### PR TITLE
Converts arrivals, aux, and cargo shuttle wall mounts

### DIFF
--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -25,9 +25,7 @@
 /area/shuttle/arrival)
 "g" = (
 /obj/effect/spawner/randomarcade,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "h" = (
@@ -47,14 +45,10 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "l" = (
-/obj/machinery/requests_console{
-	department = "Arrival shuttle";
-	name = "Arrivals Shuttle console";
-	pixel_y = 30
+/obj/machinery/requests_console/directional/north{
+	department = "Arrival shuttle"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "m" = (
@@ -72,20 +66,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
-"o" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/arrival)
 "p" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "q" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "r" = (
@@ -123,9 +110,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "x" = (
@@ -133,15 +118,12 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "y" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "z" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/machinery/light,
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "A" = (
@@ -157,7 +139,7 @@
 (1,1,1) = {"
 a
 b
-o
+d
 d
 d
 b

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -41,8 +41,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
 "h" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "i" = (
@@ -218,7 +217,7 @@
 "s" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/shuttle/arrival)
 "t" = (
@@ -296,13 +295,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/shuttle/arrival)
-"C" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/arrival)
 "D" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
@@ -321,9 +313,7 @@
 /turf/open/floor/iron,
 /area/shuttle/arrival)
 "F" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -334,6 +324,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/vending/wallmed/directional/north{
+	use_power = 0
+	},
 /turf/open/floor/iron,
 /area/shuttle/arrival)
 "G" = (
@@ -341,9 +334,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/bot,
-/obj/item/radio/intercom{
-	pixel_x = -30
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/arrival)
 "H" = (
@@ -416,9 +407,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
 "Q" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -438,9 +427,7 @@
 /turf/open/floor/iron,
 /area/shuttle/arrival)
 "S" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -563,7 +550,7 @@ w
 x
 y
 x
-C
+f
 F
 J
 O

--- a/_maps/shuttles/arrival_donut.dmm
+++ b/_maps/shuttles/arrival_donut.dmm
@@ -41,9 +41,7 @@
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "l" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/arrival)
 "m" = (
@@ -54,9 +52,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "n" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/arrival)
 "o" = (

--- a/_maps/shuttles/arrival_kilo.dmm
+++ b/_maps/shuttles/arrival_kilo.dmm
@@ -23,8 +23,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
 "f" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "g" = (
@@ -72,9 +71,7 @@
 "j" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "k" = (
@@ -85,12 +82,8 @@
 "l" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "m" = (
@@ -116,11 +109,10 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "o" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
+/obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "p" = (
@@ -159,6 +151,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/requests_console/directional/east{
+	department = "Arrivals shuttle"
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
 "t" = (
@@ -167,9 +162,7 @@
 	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "u" = (
@@ -222,7 +215,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "y" = (
@@ -240,22 +233,13 @@
 /obj/structure/window/shuttle,
 /turf/open/floor/grass,
 /area/shuttle/arrival)
-"A" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/arrival)
 "B" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/obj/machinery/light,
+/obj/machinery/status_display/evac/directional/south,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "C" = (
@@ -263,9 +247,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
+/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -356,9 +338,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "N" = (
@@ -378,6 +358,16 @@
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/arrival)
+"R" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/vending/wallmed/directional/west{
+	use_power = 0
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
@@ -449,7 +439,7 @@ f
 f
 k
 w
-A
+b
 K
 N
 f
@@ -458,7 +448,7 @@ f
 c
 l
 w
-s
+R
 K
 B
 c

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -27,9 +27,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "g" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/sign/poster/official/enlist{
 	pixel_y = 32
 	},
@@ -44,13 +42,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "j" = (
-/obj/machinery/requests_console{
-	department = "Arrival shuttle";
-	name = "Arrivals Shuttle console";
-	pixel_y = 30
-	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/light/directional/north,
+/obj/machinery/requests_console/directional/north{
+	department = "Arrivals shuttle"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
@@ -70,12 +64,11 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "m" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "arrivy";
 	name = "ship shutters"
 	},
+/obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "n" = (
@@ -102,7 +95,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "q" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "r" = (
@@ -119,18 +112,13 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "t" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -29
-	},
-/obj/machinery/light,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "u" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/machinery/light,
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "v" = (

--- a/_maps/shuttles/assault_pod_default.dmm
+++ b/_maps/shuttles/assault_pod_default.dmm
@@ -42,9 +42,7 @@
 /area/shuttle/assault_pod)
 "D" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
 "H" = (
@@ -57,7 +55,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
 "R" = (

--- a/_maps/shuttles/aux_base_default.dmm
+++ b/_maps/shuttles/aux_base_default.dmm
@@ -45,9 +45,11 @@
 /turf/open/floor/plating,
 /area/shuttle/auxiliary_base)
 "z" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating,
+/area/shuttle/auxiliary_base)
+"B" = (
+/obj/machinery/computer/auxiliary_base/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/auxiliary_base)
 "P" = (
@@ -55,7 +57,6 @@
 	dir = 2
 	},
 /obj/machinery/bluespace_beacon,
-/obj/machinery/computer/auxiliary_base,
 /turf/closed/wall,
 /area/shuttle/auxiliary_base)
 "U" = (
@@ -66,9 +67,7 @@
 /turf/open/floor/plating,
 /area/shuttle/auxiliary_base)
 "W" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/shuttle/auxiliary_base)
 "X" = (
@@ -131,7 +130,7 @@ k
 k
 X
 P
-k
+B
 k
 k
 x

--- a/_maps/shuttles/aux_base_small.dmm
+++ b/_maps/shuttles/aux_base_small.dmm
@@ -42,9 +42,7 @@
 /turf/open/floor/plating,
 /area/shuttle/auxiliary_base)
 "i" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/shuttle/auxiliary_base)
 "j" = (
@@ -52,13 +50,10 @@
 	dir = 2
 	},
 /obj/machinery/bluespace_beacon,
-/obj/machinery/computer/auxiliary_base,
 /turf/closed/wall,
 /area/shuttle/auxiliary_base)
 "k" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating,
 /area/shuttle/auxiliary_base)
 "l" = (
@@ -77,6 +72,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/turf/open/floor/plating,
+/area/shuttle/auxiliary_base)
+"O" = (
+/obj/machinery/computer/auxiliary_base/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/auxiliary_base)
 
@@ -112,7 +111,7 @@ c
 f
 h
 j
-f
+O
 f
 m
 "}

--- a/_maps/shuttles/cargo_birdboat.dmm
+++ b/_maps/shuttles/cargo_birdboat.dmm
@@ -80,22 +80,20 @@
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "p" = (
-/obj/machinery/button/door{
-	id = "QMLoaddoor2";
-	name = "Loading Doors";
-	pixel_x = 24;
-	pixel_y = 8
-	},
-/obj/machinery/button/door{
-	id = "QMLoaddoor";
-	name = "Loading Doors";
-	pixel_x = 24;
-	pixel_y = -8
-	},
 /obj/machinery/conveyor_switch/oneway{
 	id = "cargoshuttle"
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/button/door/directional/east{
+	id = "QMLoaddoor";
+	name = "Loading Doors";
+	pixel_y = -8
+	},
+/obj/machinery/button/door/directional/east{
+	id = "QMLoaddoor2";
+	name = "Loading Doors";
+	pixel_y = 8
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/supply)
 "q" = (

--- a/_maps/shuttles/cargo_birdboat.dmm
+++ b/_maps/shuttles/cargo_birdboat.dmm
@@ -95,9 +95,7 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "cargoshuttle"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/supply)
 "q" = (
@@ -151,15 +149,11 @@
 	id = "cargoshuttle";
 	name = "cargo shuttle conveyor belt"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "B" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/supply)
 "G" = (

--- a/_maps/shuttles/cargo_box.dmm
+++ b/_maps/shuttles/cargo_box.dmm
@@ -24,16 +24,14 @@
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "h" = (
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "QMLoaddoor2";
 	name = "Loading Doors";
-	pixel_x = 24;
 	pixel_y = 8
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "QMLoaddoor";
 	name = "Loading Doors";
-	pixel_x = 24;
 	pixel_y = -8
 	},
 /obj/machinery/light/directional/east,

--- a/_maps/shuttles/cargo_box.dmm
+++ b/_maps/shuttles/cargo_box.dmm
@@ -36,9 +36,7 @@
 	pixel_x = 24;
 	pixel_y = -8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "i" = (
@@ -86,15 +84,11 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/supply)
 "w" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "x" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 

--- a/_maps/shuttles/cargo_delta.dmm
+++ b/_maps/shuttles/cargo_delta.dmm
@@ -20,9 +20,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/shuttle/supply)
 "e" = (
@@ -126,9 +124,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/shuttle/supply)
 "r" = (

--- a/_maps/shuttles/cargo_delta.dmm
+++ b/_maps/shuttles/cargo_delta.dmm
@@ -100,23 +100,21 @@
 /turf/open/floor/iron,
 /area/shuttle/supply)
 "p" = (
-/obj/machinery/button/door{
-	id = "cargounload";
-	name = "Loading Doors";
-	pixel_x = -24;
-	pixel_y = 8
-	},
-/obj/machinery/button/door{
-	id = "cargoload";
-	name = "Loading Doors";
-	pixel_x = -24;
-	pixel_y = -8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "cargoload";
+	name = "Loading Doors";
+	pixel_y = -8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "cargounload";
+	name = "Loading Doors";
+	pixel_y = 8
 	},
 /turf/open/floor/iron,
 /area/shuttle/supply)

--- a/_maps/shuttles/cargo_kilo.dmm
+++ b/_maps/shuttles/cargo_kilo.dmm
@@ -154,20 +154,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "QMLoaddoor";
-	layer = 4;
 	name = "Off Ramp Toggle";
-	pixel_x = -24;
-	pixel_y = 6;
+	pixel_y = 8;
 	req_access_txt = "31"
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "QMLoaddoor2";
-	layer = 4;
 	name = "On Ramp Toggle";
-	pixel_x = -24;
-	pixel_y = -6;
+	pixel_y = -8;
 	req_access_txt = "31"
 	},
 /turf/open/floor/mineral/titanium/yellow,

--- a/_maps/shuttles/cargo_kilo.dmm
+++ b/_maps/shuttles/cargo_kilo.dmm
@@ -108,9 +108,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "m" = (

--- a/_maps/shuttles/cargo_pubby.dmm
+++ b/_maps/shuttles/cargo_pubby.dmm
@@ -4,9 +4,7 @@
 /area/shuttle/supply)
 "d" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "ShuttleLoad"
@@ -60,17 +58,13 @@
 	},
 /area/shuttle/supply)
 "o" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
 /area/shuttle/supply)
 "q" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/supply)
 "r" = (
@@ -163,9 +157,7 @@
 	},
 /area/shuttle/supply)
 "N" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},

--- a/_maps/shuttles/cargo_pubby.dmm
+++ b/_maps/shuttles/cargo_pubby.dmm
@@ -28,11 +28,9 @@
 /area/shuttle/supply)
 "g" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "cargoload";
-	name = "Loading Doors";
-	pixel_x = -24;
-	pixel_y = -8
+	name = "Loading Doors"
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/supply)
@@ -79,11 +77,9 @@
 	},
 /area/shuttle/supply)
 "t" = (
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "cargounload";
-	name = "Loading Doors";
-	pixel_x = -24;
-	pixel_y = 8
+	name = "Loading Doors"
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/supply)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the lights and wall mounts for arrivals shuttles, aux bases, and cargo shuttles to directional mounts introduced in #58809
Also changes manual grille/shuttle window placements with spawners where applicable. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When the wallening gets here, will allow us to switch the directions of all of the lights at once (which we'll need) and not have to manually set wall mount dirs. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
