### PR TITLE
Converts emergency shuttle wall mounts (part 1)

### DIFF
--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -5,11 +5,6 @@
 "ac" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"ad" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ae" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
@@ -97,11 +92,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aF" = (
@@ -115,9 +106,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "aH" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aI" = (
@@ -145,10 +134,7 @@
 /area/shuttle/escape)
 "aM" = (
 /obj/structure/closet/emcloset,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 23
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aN" = (
@@ -185,9 +171,7 @@
 /obj/structure/chair/office/light{
 	name = "Captain"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aV" = (
@@ -197,15 +181,8 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aW" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 23
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"aX" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aY" = (
 /obj/structure/chair/comfy/shuttle{
@@ -293,9 +270,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bn" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bp" = (
@@ -327,9 +302,7 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/structure/mirror{
-	pixel_x = -30
-	},
+/obj/structure/mirror/directional/west,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bu" = (
@@ -346,19 +319,14 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bx" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "by" = (
@@ -370,14 +338,13 @@
 /area/shuttle/escape)
 "bz" = (
 /obj/machinery/stasis,
+/obj/machinery/vending/wallmed/directional/east{
+	use_power = 0
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bC" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bD" = (
@@ -388,9 +355,7 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bF" = (
@@ -414,35 +379,34 @@
 /obj/item/surgical_drapes,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"bI" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "bJ" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bK" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bM" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bN" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bP" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"hJ" = (
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Id" = (
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "Jx" = (
 /turf/open/floor/mineral/titanium/white,
@@ -461,9 +425,9 @@ aa
 ac
 am
 ac
-ad
-ad
-bI
+ah
+ah
+ah
 ac
 am
 ac
@@ -516,7 +480,7 @@ ac
 ac
 "}
 (5,1,1) = {"
-ad
+ah
 ap
 aq
 bJ
@@ -528,7 +492,7 @@ ac
 bN
 bu
 bE
-ad
+ah
 "}
 (6,1,1) = {"
 ae
@@ -546,7 +510,7 @@ ac
 ac
 "}
 (7,1,1) = {"
-ad
+ah
 ar
 aq
 aq
@@ -558,7 +522,7 @@ ac
 Jx
 bu
 bE
-ad
+ah
 "}
 (8,1,1) = {"
 ac
@@ -566,9 +530,9 @@ ac
 ac
 aG
 ac
-aX
+ac
 bg
-bi
+ac
 az
 bu
 az
@@ -581,9 +545,9 @@ ac
 ac
 aH
 at
+hJ
 at
-at
-at
+Id
 at
 at
 ac
@@ -653,7 +617,7 @@ aa
 (14,1,1) = {"
 aa
 aa
-ad
+ah
 aK
 at
 aZ
@@ -661,14 +625,14 @@ ah
 aK
 at
 aZ
-ad
+ah
 aa
 aa
 "}
 (15,1,1) = {"
 aa
 aa
-ad
+ah
 aK
 at
 at
@@ -676,14 +640,14 @@ at
 at
 at
 aZ
-ad
+ah
 aa
 aa
 "}
 (16,1,1) = {"
 aa
 aa
-ad
+ah
 aK
 at
 aZ
@@ -691,7 +655,7 @@ ah
 aK
 at
 aZ
-ad
+ah
 aa
 aa
 "}
@@ -774,13 +738,13 @@ aa
 ac
 ac
 ac
-ad
+ah
 aP
-ad
+ah
 bi
-ad
+ah
 br
-ad
+ah
 ac
 ac
 ac
@@ -807,13 +771,13 @@ aw
 aw
 aw
 aw
-ad
+ah
 Jx
 Jx
 Jx
 Jx
 bG
-ad
+ah
 "}
 (25,1,1) = {"
 ac
@@ -835,11 +799,11 @@ ac
 ac
 ac
 ac
-ad
+ah
 aP
 ac
 bq
-ad
+ah
 JM
 ac
 ac
@@ -852,7 +816,7 @@ ac
 ac
 aQ
 aw
-ad
+ah
 Jx
 bs
 ac
@@ -866,9 +830,9 @@ aa
 aa
 ac
 ac
-ad
+ah
 ac
-ad
+ah
 ac
 ac
 aa

--- a/_maps/shuttles/emergency_backup.dmm
+++ b/_maps/shuttles/emergency_backup.dmm
@@ -3,6 +3,7 @@
 /obj/machinery/computer/emergency_shuttle{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape/backup)
 "c" = (
@@ -24,10 +25,6 @@
 "p" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/backup)
-"q" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape/backup)
 "u" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -35,9 +32,11 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape/backup)
 "x" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
+"A" = (
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape/backup)
 "F" = (
@@ -45,10 +44,12 @@
 /obj/item/paper/fluff/stations/centcom/broken_evac,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape/backup)
+"L" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape/backup)
 "P" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape/backup)
 
@@ -63,14 +64,14 @@ m
 m
 "}
 (2,1,1) = {"
-q
-g
+m
+A
 g
 g
 x
 g
-g
-q
+L
+m
 "}
 (3,1,1) = {"
 m
@@ -113,14 +114,14 @@ g
 m
 "}
 (7,1,1) = {"
-q
+m
 a
 F
 f
 P
 g
-g
-q
+L
+m
 "}
 (8,1,1) = {"
 m

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -59,12 +59,8 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "ak" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "al" = (
@@ -101,19 +97,14 @@
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "ar" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "as" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "at" = (
@@ -125,7 +116,7 @@
 /obj/structure/table/wood/poker,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "au" = (
@@ -141,28 +132,20 @@
 	},
 /turf/open/floor/carpet,
 /area/shuttle/escape)
-"aA" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
 "aC" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aD" = (
-/obj/machinery/flasher{
-	id = "cockpit_flasher";
-	pixel_x = 6;
-	pixel_y = 24
+/obj/machinery/flasher/directional/north{
+	id = "cockpit_flasher"
 	},
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -189,20 +172,15 @@
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
 "aH" = (
-/obj/machinery/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -24;
-	pixel_y = 6
+/obj/machinery/flasher/directional/west{
+	id = "shuttle_flasher"
 	},
 /obj/machinery/button/flasher{
 	id = "shuttle_flasher";
 	pixel_x = -24;
 	pixel_y = -6
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aI" = (
@@ -227,9 +205,7 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aM" = (
@@ -278,9 +254,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "aS" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/table,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/food/drinks/bottle/lizardwine,
@@ -316,9 +290,6 @@
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
 "aX" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -328,6 +299,7 @@
 /area/shuttle/escape)
 "aY" = (
 /obj/machinery/vending/boozeomat,
+/obj/machinery/light/directional/east,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aZ" = (
@@ -397,7 +369,6 @@
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "bn" = (
-/obj/effect/spawner/structure/window/shuttle,
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
@@ -441,26 +412,19 @@
 "bw" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bx" = (
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "by" = (
 /obj/machinery/recharge_station,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "bz" = (
@@ -484,10 +448,6 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"bF" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/iron/freezer,
-/area/shuttle/escape)
 "bG" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -498,6 +458,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bH" = (
@@ -564,9 +525,7 @@
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
 "bR" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -615,15 +574,11 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
 "bX" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -631,9 +586,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bY" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -641,7 +594,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bZ" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -649,26 +602,28 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "ca" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/machinery/vending/wallmed/directional/south{
+	use_power = 0
+	},
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "cb" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/stasis,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"Yn" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
+"EL" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -783,8 +738,8 @@ bK
 bH
 bK
 bH
-aE
-aA
+EL
+ab
 bp
 ab
 ab
@@ -832,7 +787,7 @@ aN
 aN
 aE
 ca
-Yn
+ae
 ab
 ab
 ab
@@ -844,7 +799,7 @@ ac
 ai
 ao
 ao
-aA
+ab
 bG
 aE
 aO
@@ -904,7 +859,7 @@ bN
 be
 bT
 bk
-bF
+ac
 br
 cb
 bU

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -1,15 +1,15 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
+"aa" = (
 /turf/template_noop,
 /area/template_noop)
-"b" = (
+"ab" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
-"c" = (
+"ac" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"d" = (
+"ad" = (
 /obj/structure/table,
 /obj/item/scalpel,
 /obj/item/retractor{
@@ -18,7 +18,7 @@
 /obj/item/hemostat,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"e" = (
+"ae" = (
 /obj/structure/table,
 /obj/item/cautery,
 /obj/item/surgicaldrill,
@@ -27,99 +27,88 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"f" = (
+"af" = (
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"g" = (
+"ag" = (
 /obj/structure/shuttle/engine/propulsion/right{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"h" = (
+"ah" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
-"i" = (
+"ai" = (
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"j" = (
+"aj" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"k" = (
+"ak" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"l" = (
+"al" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
-"m" = (
+"am" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
-"n" = (
+"an" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"o" = (
-/obj/machinery/light{
-	dir = 4
-	},
+"ao" = (
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"p" = (
+"ap" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"q" = (
+"aq" = (
 /obj/machinery/computer/communications{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"r" = (
+"ar" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"s" = (
+"as" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "bridge door";
 	req_access_txt = "19"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"t" = (
+"at" = (
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
-"u" = (
+"au" = (
 /obj/structure/shuttle/engine/propulsion/left{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
-"v" = (
-/obj/machinery/light,
+"av" = (
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"w" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"x" = (
+"ax" = (
 /obj/structure/table,
 /obj/machinery/recharger{
 	active_power_usage = 0;
@@ -129,58 +118,56 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
-"y" = (
+"ay" = (
 /obj/structure/table,
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
-"z" = (
+"az" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "security airlock";
 	req_access_txt = "63"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
-"A" = (
+"aA" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"B" = (
+"aB" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"C" = (
+"aC" = (
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"D" = (
+"aD" = (
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"E" = (
+"aE" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"F" = (
+"aF" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"G" = (
+"aG" = (
 /obj/machinery/door/airlock/titanium,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"H" = (
+"aH" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"I" = (
+"aI" = (
 /obj/structure/table,
 /obj/item/food/spaghetti/boiledspaghetti{
 	name = "pasghetti";
@@ -189,11 +176,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"J" = (
-/obj/machinery/light/small,
+"aJ" = (
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"K" = (
+"aK" = (
 /obj/machinery/door/airlock/titanium,
 /obj/docking_port/mobile/emergency{
 	dir = 8;
@@ -205,33 +192,31 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"L" = (
+"aL" = (
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"M" = (
+"aM" = (
 /obj/structure/table,
 /obj/item/food/chocolatebar,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"N" = (
+"aN" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"O" = (
+"aO" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"P" = (
+"aP" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -239,13 +224,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"Q" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
+"aQ" = (
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"R" = (
+"aR" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/fire{
 	pixel_x = 5;
@@ -254,343 +237,345 @@
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"S" = (
+"aS" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"T" = (
+"aT" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"U" = (
+"aU" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/brute{
 	pixel_x = 5;
 	pixel_y = 5
 	},
 /obj/item/storage/firstaid/brute,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"V" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
+"aV" = (
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"W" = (
+"aW" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"X" = (
+"aX" = (
 /obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"Y" = (
+"aY" = (
 /obj/structure/table/glass,
 /obj/item/defibrillator/loaded,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"Z" = (
+"aZ" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "bridge door";
 	req_access_txt = "19"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape/brig)
+"iP" = (
+/obj/machinery/vending/wallmed/directional/south{
+	use_power = 0
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 
 (1,1,1) = {"
-a
-a
-b
-b
-c
-b
-c
-c
-c
-c
-c
-b
-a
-a
+aa
+aa
+ab
+ab
+ac
+ab
+ac
+ac
+ac
+ac
+ac
+ab
+aa
+aa
 "}
 (2,1,1) = {"
-a
-b
-h
-q
-k
-c
-B
-H
-H
-H
-B
-h
-b
-a
+aa
+ab
+ah
+aq
+ak
+ac
+aB
+aH
+aH
+aH
+aB
+ah
+ab
+aa
 "}
 (3,1,1) = {"
-a
-b
-i
-r
-C
-s
-C
-C
-C
-C
-C
-S
-b
-a
+aa
+ab
+ai
+ar
+aC
+as
+aC
+aC
+aC
+aC
+aC
+aS
+ab
+aa
 "}
 (4,1,1) = {"
-a
-c
-j
-C
-v
-b
-D
-D
-L
-C
-C
-S
-b
-a
+aa
+ac
+aj
+aC
+av
+ab
+aD
+aD
+aL
+aC
+aC
+aS
+ab
+aa
 "}
 (5,1,1) = {"
-a
-c
-j
-C
-V
-b
-E
-E
-M
-C
-C
-S
-b
-a
+aa
+ac
+aj
+aC
+aV
+ab
+aE
+aE
+aM
+aC
+aC
+aS
+ab
+aa
 "}
 (6,1,1) = {"
-a
-b
-k
-C
-k
-b
-F
-I
-L
-C
-C
-T
-h
-b
+aa
+ab
+ak
+aC
+ak
+ab
+aF
+aI
+aL
+aC
+aC
+aT
+ah
+ab
 "}
 (7,1,1) = {"
-a
-b
-b
-Z
-c
-b
-C
-C
-C
-C
-C
-C
-B
-b
+aa
+ab
+ab
+aZ
+ac
+ab
+aC
+aC
+aC
+aC
+aC
+aC
+aB
+ab
 "}
 (8,1,1) = {"
-a
-b
-l
-t
-t
-c
-B
-C
-C
-C
-C
-C
-V
-b
+aa
+ab
+al
+at
+at
+ac
+aB
+aC
+aC
+aC
+aC
+aC
+aV
+ab
 "}
 (9,1,1) = {"
-a
-b
-l
-t
-t
-z
-C
-C
-N
-P
-C
-C
-W
-c
+aa
+ab
+al
+at
+at
+az
+aC
+aC
+aN
+aP
+aC
+aC
+aW
+ac
 "}
 (10,1,1) = {"
-a
-b
-m
-t
-t
-c
-C
-C
-N
-P
-C
-C
-W
-c
+aa
+ab
+am
+at
+at
+ac
+aC
+aC
+aN
+aP
+aC
+aC
+aW
+ac
 "}
 (11,1,1) = {"
-a
-b
-l
-t
-x
-b
-C
-C
-N
-P
-C
-C
-W
-c
+aa
+ab
+al
+at
+ax
+ab
+aC
+aC
+aN
+aP
+aC
+aC
+aW
+ac
 "}
 (12,1,1) = {"
-a
-b
-l
-t
-y
-b
-C
-C
-O
-P
-C
-C
-B
-b
+aa
+ab
+al
+at
+ay
+ab
+aC
+aC
+aO
+aP
+aC
+aC
+aB
+ab
 "}
 (13,1,1) = {"
-b
-b
-b
-b
-b
-h
-C
-C
-w
-b
-A
-c
-b
-b
+ab
+ab
+ab
+ab
+ab
+ah
+aC
+iP
+ah
+ab
+aA
+ac
+ab
+ab
 "}
 (14,1,1) = {"
-b
-d
-n
-f
-f
-A
-C
-C
-A
-Q
-f
-f
-X
-b
+ab
+ad
+an
+af
+af
+aA
+aC
+aC
+aA
+aQ
+af
+af
+aX
+ab
 "}
 (15,1,1) = {"
-b
-e
-f
-f
-f
-A
-C
-C
-A
-f
-f
-f
-f
-b
+ab
+ae
+af
+af
+af
+aA
+aC
+aC
+aA
+af
+af
+af
+af
+ab
 "}
 (16,1,1) = {"
-b
-f
-o
-f
-b
-b
-G
-G
-b
-b
-R
-U
-Y
-b
+ab
+af
+ao
+af
+ab
+ab
+aG
+aG
+ab
+ab
+aR
+aU
+aY
+ab
 "}
 (17,1,1) = {"
-b
-b
-b
-b
-b
-b
-C
-J
-b
-b
-b
-b
-b
-b
+ab
+ab
+ab
+ab
+ab
+ab
+aC
+aJ
+ab
+ab
+ab
+ab
+ab
+ab
 "}
 (18,1,1) = {"
-b
-g
-p
-u
-b
-b
-G
-K
-b
-b
-g
-p
-u
-b
+ab
+ag
+ap
+au
+ab
+ab
+aG
+aK
+ab
+ab
+ag
+ap
+au
+ab
 "}

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -74,16 +74,11 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "as" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "at" = (
@@ -92,7 +87,7 @@
 	pixel_x = 6;
 	pixel_y = -24
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "au" = (
@@ -108,23 +103,15 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"az" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
 "aA" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aB" = (
-/obj/machinery/flasher{
-	id = "cockpit_flasher";
-	pixel_x = 6;
-	pixel_y = 24
+/obj/machinery/flasher/directional/north{
+	id = "cockpit_flasher"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aC" = (
@@ -145,19 +132,14 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aF" = (
-/obj/machinery/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -24;
-	pixel_y = 6
-	},
 /obj/machinery/button/flasher{
 	id = "shuttle_flasher";
 	pixel_x = -24;
 	pixel_y = -6
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/machinery/light/small/directional/west,
+/obj/machinery/flasher/directional/west{
+	id = "shuttle_flasher"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
@@ -202,19 +184,12 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aR" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aS" = (
@@ -242,9 +217,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aX" = (
@@ -263,9 +236,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bd" = (
@@ -280,12 +251,8 @@
 	pixel_y = 3
 	},
 /obj/item/crowbar,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bf" = (
@@ -304,10 +271,6 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "bj" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "bk" = (
@@ -315,54 +278,51 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "bl" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bm" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bn" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bo" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bp" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bq" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "br" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bs" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "ga" = (
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Dk" = (
+/obj/machinery/vending/wallmed/directional/north{
+	use_power = 0
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Nt" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "XC" = (
 /obj/structure/closet/emcloset,
@@ -475,7 +435,7 @@ ac
 aH
 ac
 bj
-aC
+Dk
 aT
 aT
 aT
@@ -506,7 +466,7 @@ aC
 aC
 aC
 bp
-az
+ad
 ad
 ad
 ad
@@ -542,8 +502,8 @@ ac
 ai
 ao
 ao
-az
-an
+ad
+Nt
 aC
 aM
 aM

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -16,9 +16,7 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /obj/item/crowbar,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -118,9 +116,7 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/o2,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -423,10 +419,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -436,23 +429,18 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "aN" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "aO" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "aP" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -489,17 +477,13 @@
 /area/shuttle/escape/brig)
 "aT" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aU" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aV" = (
@@ -545,10 +529,8 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/flasher{
-	id = "shuttle_flasher";
-	pixel_x = 24;
-	pixel_y = 6
+/obj/machinery/flasher/directional/east{
+	id = "shuttle_flasher"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
@@ -586,10 +568,8 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -24;
-	pixel_y = 6
+/obj/machinery/flasher/directional/west{
+	id = "shuttle_flasher"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
@@ -604,12 +584,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -630,9 +605,7 @@
 	dir = 1
 	},
 /obj/structure/closet,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -725,11 +698,7 @@
 "bG" = (
 /obj/structure/table,
 /obj/item/storage/box/cups,
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_y = 27
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -791,9 +760,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -821,6 +788,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bN" = (
@@ -851,9 +819,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bR" = (
@@ -879,11 +845,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bU" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_y = 27
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bV" = (
@@ -892,9 +854,7 @@
 	pixel_x = 2;
 	pixel_y = 3
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bW" = (
@@ -942,9 +902,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "bZ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "ca" = (
@@ -961,7 +919,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "cc" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -971,9 +929,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "cd" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -996,18 +952,14 @@
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "cf" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "cg" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "ch" = (
@@ -1127,9 +1079,7 @@
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "cu" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -1138,6 +1088,9 @@
 	dir = 4
 	},
 /obj/machinery/stasis,
+/obj/machinery/vending/wallmed/directional/north{
+	use_power = 0
+	},
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "cv" = (
@@ -1176,7 +1129,9 @@
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "cz" = (
-/obj/effect/spawner/randomarcade,
+/obj/effect/spawner/randomarcade{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1190,9 +1145,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "cA" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -1384,10 +1337,7 @@
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "cM" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -1406,9 +1356,7 @@
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "cO" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1447,9 +1395,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "cT" = (
@@ -1475,9 +1421,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "cV" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/computer/monitor/secret,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -1503,15 +1447,11 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
+/obj/structure/mirror/directional/west,
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "cY" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "cZ" = (
@@ -1572,15 +1512,11 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "df" = (
-/obj/structure/urinal{
-	pixel_y = -32
-	},
+/obj/structure/urinal/directional/south,
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "dg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
@@ -1639,10 +1575,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "dm" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -1658,7 +1591,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "do" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -1666,9 +1599,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "dp" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -1686,9 +1617,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ds" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dt" = (
@@ -1729,13 +1658,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/shuttle/escape)
-"pf" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -2558,7 +2480,7 @@ ac
 ac
 ab
 ab
-pf
+ad
 cu
 cy
 cD

--- a/_maps/shuttles/emergency_clown.dmm
+++ b/_maps/shuttles/emergency_clown.dmm
@@ -74,22 +74,18 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "ap" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/item/toy/snappop/phoenix,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "aq" = (
 /obj/item/toy/snappop/phoenix,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "ar" = (
@@ -104,17 +100,11 @@
 	},
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
-"at" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
 "au" = (
 /turf/open/chasm,
 /area/shuttle/escape)
 "av" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "ay" = (
@@ -155,18 +145,12 @@
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aF" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "aG" = (
 /obj/structure/table,
 /obj/item/toy/sword,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aH" = (
@@ -191,17 +175,12 @@
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "aK" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/item/toy/snappop/phoenix,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "aL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/item/toy/snappop/phoenix,
 /obj/machinery/light/small{
 	dir = 4
@@ -249,9 +228,7 @@
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
 "aS" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/item/toy/snappop/phoenix,
 /turf/open/floor/bluespace,
 /area/shuttle/escape)
@@ -271,9 +248,7 @@
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "aX" = (
@@ -301,9 +276,7 @@
 	pixel_y = 3
 	},
 /obj/item/crowbar,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -339,6 +312,22 @@
 "bg" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"lT" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"ns" = (
+/obj/item/toy/snappop/phoenix,
+/obj/machinery/light/directional/south,
+/turf/open/floor/bluespace,
+/area/shuttle/escape)
+"RX" = (
+/obj/item/toy/snappop/phoenix,
+/obj/machinery/vending/wallmed/directional/north{
+	use_power = 0
+	},
+/turf/open/floor/bluespace,
 /area/shuttle/escape)
 "Zf" = (
 /obj/structure/closet/emcloset,
@@ -452,7 +441,7 @@ ac
 aA
 ac
 aF
-ak
+RX
 aO
 aO
 aO
@@ -470,7 +459,7 @@ bg
 ac
 ag
 ak
-aq
+ns
 ab
 av
 ak
@@ -483,7 +472,7 @@ ak
 ak
 ak
 aq
-at
+ab
 ab
 ab
 ab
@@ -519,8 +508,8 @@ ac
 ah
 al
 al
-at
-aV
+ab
+lT
 ak
 aE
 aH

--- a/_maps/shuttles/emergency_cramped.dmm
+++ b/_maps/shuttles/emergency_cramped.dmm
@@ -33,9 +33,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
 /obj/item/book/manual/random,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "h" = (
@@ -103,18 +101,14 @@
 /obj/structure/closet/crate/secure/weapon,
 /obj/effect/spawner/lootdrop/armory_contraband,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "s" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "t" = (
@@ -130,9 +124,7 @@
 /area/shuttle/escape)
 "v" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "w" = (

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -106,9 +106,7 @@
 /obj/item/clipboard,
 /obj/item/folder/white,
 /obj/item/pen/blue,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "dR" = (
@@ -236,9 +234,7 @@
 /obj/item/clipboard,
 /obj/item/folder/red,
 /obj/item/pen/red,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "jT" = (
@@ -362,9 +358,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "mv" = (
@@ -402,13 +396,11 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "oo" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "oH" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "oZ" = (
@@ -432,9 +424,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "qd" = (
@@ -527,9 +517,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "rt" = (
@@ -577,9 +565,7 @@
 /area/shuttle/escape)
 "si" = (
 /obj/structure/table/wood/fancy,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "sv" = (
@@ -626,7 +612,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "ut" = (
@@ -843,9 +829,7 @@
 /area/shuttle/escape)
 "BB" = (
 /obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "Cw" = (
@@ -854,7 +838,7 @@
 /area/shuttle/escape)
 "CK" = (
 /obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "CR" = (
@@ -888,9 +872,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "Dq" = (
@@ -915,9 +897,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "EC" = (
@@ -928,9 +908,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "FR" = (
@@ -1039,9 +1017,7 @@
 /area/shuttle/escape)
 "Iu" = (
 /obj/machinery/computer/slot_machine,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "IL" = (
@@ -1096,16 +1072,12 @@
 	max_integrity = 2500;
 	name = "seraph mech exhibit"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "Kc" = (
 /obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "Ki" = (
@@ -1241,9 +1213,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "On" = (
@@ -1335,15 +1305,11 @@
 	max_integrity = 2500;
 	name = "marauder mech exhibit"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "Pr" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "So" = (
@@ -1467,7 +1433,7 @@
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "UJ" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "UN" = (
@@ -1490,9 +1456,7 @@
 /area/shuttle/escape)
 "Vv" = (
 /obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "VQ" = (
@@ -1615,9 +1579,7 @@
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "YZ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "ZL" = (

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -178,6 +178,7 @@
 	},
 /obj/item/surgicaldrill,
 /obj/item/cautery,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "an" = (
@@ -215,18 +216,12 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/shuttle/escape)
-"aq" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "ar" = (
 /obj/item/reagent_containers/glass/bottle/epinephrine{
@@ -260,34 +255,19 @@
 	pixel_y = 8
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "as" = (
 /obj/structure/chair/office/light{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/shuttle/escape)
-"at" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_x = 26;
-	pixel_y = 58
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -381,14 +361,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
-"aC" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"aD" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
 "aE" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -419,10 +391,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_x = -26
-	},
+/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -445,10 +414,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
-"aK" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
 "aL" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -468,9 +433,7 @@
 "aN" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -521,9 +484,7 @@
 /area/shuttle/escape)
 "aU" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "aV" = (
@@ -556,9 +517,7 @@
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "aY" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/shieldgen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -584,10 +543,7 @@
 /area/shuttle/escape)
 "ba" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_x = -26
-	},
+/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -672,13 +628,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/shuttle/escape)
-"bj" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
 "bk" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Emergency Shuttle Cargo"
@@ -695,9 +644,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/head/hardhat/red,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bm" = (
@@ -720,11 +667,10 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bp" = (
-/obj/machinery/flasher{
-	id = "shuttleflash";
-	pixel_y = -26
+/obj/machinery/flasher/directional/south{
+	id = "shuttleflash"
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -826,10 +772,8 @@
 /area/shuttle/escape)
 "bD" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bE" = (
@@ -845,12 +789,8 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -861,17 +801,6 @@
 /area/shuttle/escape)
 "bI" = (
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/shuttle/escape)
-"bJ" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 58
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bK" = (
@@ -893,9 +822,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bN" = (
@@ -918,9 +845,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bQ" = (
-/obj/structure/fireaxecabinet{
-	pixel_x = 32
-	},
+/obj/structure/fireaxecabinet/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -952,10 +877,7 @@
 "bV" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/zipties,
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = -26
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bW" = (
@@ -1010,9 +932,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1071,24 +991,6 @@
 "cf" = (
 /obj/structure/chair/office{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/shuttle/escape)
-"cg" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_x = 26;
-	pixel_y = 58
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1313,9 +1215,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "cy" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1330,9 +1230,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1348,9 +1246,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "cC" = (
@@ -1358,14 +1254,14 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "cF" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "cG" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "cH" = (
@@ -1373,9 +1269,83 @@
 /obj/machinery/light/small,
 /turf/open/floor/iron,
 /area/shuttle/escape)
+"hg" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/shuttle/escape)
 "hB" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"jH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"no" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"nB" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"qn" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21";
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"yb" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"TK" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/wallmed/directional/east{
+	use_power = 0
+	},
+/turf/open/floor/iron,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -1480,13 +1450,13 @@ ao
 aw
 aw
 aw
-aw
+hg
 aw
 ao
 aw
+hg
 aw
-aw
-aw
+nB
 aw
 ao
 bo
@@ -1509,15 +1479,15 @@ af
 ai
 ao
 ax
-aC
+ae
 aI
-aK
+ae
 ax
 ao
 aX
-aK
+ae
 be
-aD
+ae
 aX
 ao
 bo
@@ -1540,7 +1510,7 @@ af
 cy
 ao
 av
-av
+yb
 av
 av
 av
@@ -1602,15 +1572,15 @@ af
 cy
 ao
 aw
+nB
 aw
-aw
-aw
+hg
 aw
 ao
 aw
 aw
 aw
-aw
+TK
 aw
 ao
 bo
@@ -1619,8 +1589,8 @@ bz
 bF
 bP
 bW
-aq
-cc
+af
+jH
 cc
 cl
 cs
@@ -1633,15 +1603,15 @@ hB
 ai
 ao
 ax
-aD
+ae
 aI
-aK
+ae
 ax
 ao
 aX
-aC
+ae
 be
-bj
+ae
 aX
 ao
 bo
@@ -1670,7 +1640,7 @@ av
 av
 ao
 av
-av
+yb
 av
 av
 av
@@ -1712,9 +1682,9 @@ bA
 bG
 bQ
 bI
-aq
+af
+jH
 cc
-cg
 cl
 cv
 hB
@@ -1744,7 +1714,7 @@ af
 af
 bY
 af
-cb
+qn
 ch
 ch
 cw
@@ -1755,7 +1725,7 @@ ab
 ad
 af
 af
-aq
+af
 ag
 aF
 aF
@@ -1848,7 +1818,7 @@ ab
 ad
 hB
 al
-at
+aR
 aA
 ao
 ao
@@ -1863,8 +1833,8 @@ bh
 bn
 br
 af
-bC
-bJ
+no
+bo
 ai
 bZ
 hB

--- a/_maps/shuttles/emergency_discoinferno.dmm
+++ b/_maps/shuttles/emergency_discoinferno.dmm
@@ -70,7 +70,7 @@
 /obj/structure/table/wood/poker,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/gold,
 /area/shuttle/escape)
 "o" = (
@@ -142,9 +142,7 @@
 /area/shuttle/escape)
 "C" = (
 /obj/machinery/computer/slot_machine,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "D" = (
@@ -175,9 +173,7 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/coin/plasma,
 /obj/item/coin/plasma,
 /turf/open/floor/wood,

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -18,9 +18,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "af" = (
@@ -42,9 +40,7 @@
 "aj" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ak" = (
@@ -117,10 +113,8 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aw" = (
-/obj/machinery/flasher{
-	id = "cockpit_flasher";
-	pixel_x = 6;
-	pixel_y = 24
+/obj/machinery/flasher/directional/north{
+	id = "cockpit_flasher"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -148,10 +142,8 @@
 /area/shuttle/escape/brig)
 "aB" = (
 /obj/structure/chair,
-/obj/machinery/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -6;
-	pixel_y = 24
+/obj/machinery/flasher/directional/north{
+	id = "shuttle_flasher"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
@@ -166,9 +158,7 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aE" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aF" = (
@@ -181,9 +171,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aH" = (
@@ -198,15 +186,16 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aJ" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
+/obj/machinery/vending/wallmed/directional/south{
+	use_power = 0
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aK" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/north,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aL" = (
@@ -221,13 +210,6 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"aN" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
-/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aO" = (
 /obj/structure/chair/comfy/shuttle{
@@ -264,21 +246,18 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"aT" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
 "aU" = (
-/obj/machinery/light,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/light/directional/south,
+/obj/machinery/light/directional/north,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/vending/wallmed/directional/south{
+	use_power = 0
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aV" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aW" = (
@@ -357,7 +336,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bi" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -392,7 +371,7 @@
 	},
 /obj/item/lazarus_injector,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /mob/living/simple_animal/bot/medbot{
 	name = "\improper emergency medibot";
 	pixel_x = -3;
@@ -439,7 +418,7 @@
 	pixel_x = 2;
 	pixel_y = 8
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bo" = (
@@ -463,7 +442,7 @@
 "bq" = (
 /obj/structure/table,
 /obj/item/defibrillator/loaded,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "br" = (
@@ -655,11 +634,11 @@ ab
 ak
 am
 aJ
-aN
+ab
 ac
 ab
 ac
-aT
+ab
 aV
 aW
 aX
@@ -829,17 +808,17 @@ ak
 ak
 ak
 aJ
-aN
+ab
 ac
 ab
 ac
-aT
+ab
 aU
-aN
+ab
 ac
 ab
 ac
-aT
+ab
 aV
 aW
 aX

--- a/_maps/shuttles/emergency_goon.dmm
+++ b/_maps/shuttles/emergency_goon.dmm
@@ -41,10 +41,24 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"l" = (
-/obj/machinery/vending/wallmed,
-/turf/closed/wall/mineral/titanium,
+"i" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed/directional/west{
+	use_power = 0
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"j" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed/directional/south{
+	use_power = 0
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
 "m" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
@@ -65,7 +79,9 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "q" = (
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "r" = (
@@ -84,9 +100,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "v" = (
@@ -129,7 +143,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "E" = (
@@ -183,35 +197,29 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "Q" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "R" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "S" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "T" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "V" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "W" = (
@@ -236,6 +244,12 @@
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"Z" = (
+/obj/machinery/vending/wallmed/directional/north{
+	use_power = 0
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -279,15 +293,15 @@ Y
 "}
 (4,1,1) = {"
 d
-l
-n
+d
+Z
 n
 R
 d
 T
 J
-H
-l
+j
+d
 d
 "}
 (5,1,1) = {"
@@ -296,7 +310,7 @@ d
 d
 w
 f
-l
+d
 f
 K
 d
@@ -309,7 +323,7 @@ d
 s
 r
 s
-s
+i
 s
 r
 s

--- a/_maps/shuttles/emergency_imfedupwiththisworld.dmm
+++ b/_maps/shuttles/emergency_imfedupwiththisworld.dmm
@@ -2,10 +2,6 @@
 "a" = (
 /turf/closed/wall/mineral/wood,
 /area/shuttle/escape)
-"b" = (
-/obj/machinery/light_switch,
-/turf/closed/wall/mineral/wood,
-/area/shuttle/escape)
 "c" = (
 /obj/docking_port/mobile/emergency{
 	dwidth = 1;
@@ -20,9 +16,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "e" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "f" = (
@@ -50,9 +44,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "k" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/vending/boozeomat{
 	req_access = null
 	},
@@ -125,9 +117,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "u" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "v" = (
@@ -140,9 +130,7 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/mob_spawn/human/corpse,
 /obj/item/gun/ballistic/automatic/pistol/m1911,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/item/food/cakeslice/birthday,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
@@ -167,7 +155,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "B" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -187,6 +175,10 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/wood,
 /area/shuttle/escape)
+"K" = (
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/wood,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 a
@@ -200,8 +192,8 @@ a
 a
 "}
 (2,1,1) = {"
-b
-d
+a
+K
 d
 d
 d

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -154,12 +154,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = -24
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/keycard_auth/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "au" = (
@@ -187,18 +183,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = 24
-	},
+/obj/machinery/light/directional/east,
+/obj/machinery/keycard_auth/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "aw" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/mineral/plastitanium,
@@ -271,9 +261,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aD" = (
@@ -465,9 +453,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aT" = (
@@ -556,9 +542,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "bb" = (
@@ -762,9 +746,7 @@
 /obj/structure/sign/departments/security{
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium,
@@ -793,9 +775,7 @@
 /obj/structure/sign/departments/engineering{
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium,
@@ -953,17 +933,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"bN" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
+/obj/machinery/light/directional/east,
+/obj/machinery/vending/wallmed/directional/east{
 	use_power = 0
 	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bO" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -981,10 +955,6 @@
 /obj/structure/window/shuttle,
 /turf/open/floor/grass,
 /area/shuttle/escape)
-"bQ" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
 "bR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -996,9 +966,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bS" = (
@@ -1098,10 +1067,8 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/obj/machinery/light,
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "ca" = (
@@ -1330,9 +1297,6 @@
 /area/shuttle/escape)
 "cu" = (
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/stasis,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
@@ -1340,9 +1304,6 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -1367,21 +1328,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cy" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/stasis,
-/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "cz" = (
 /obj/effect/turf_decal/delivery,
@@ -1427,9 +1377,7 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "cE" = (
@@ -1437,23 +1385,13 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"cF" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -1464,27 +1402,17 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"cH" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "cI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 11
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -1521,9 +1449,7 @@
 	},
 /obj/structure/closet/crate/internals,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "cK" = (
@@ -1538,9 +1464,7 @@
 "cM" = (
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "cN" = (
@@ -1588,9 +1512,7 @@
 	pixel_y = 16
 	},
 /obj/item/hemostat,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "cS" = (
@@ -1677,6 +1599,23 @@
 /obj/structure/shuttle/engine/propulsion/right,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"NC" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/vending/wallmed/directional/east{
+	use_power = 0
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -1773,7 +1712,7 @@ ac
 bt
 br
 bK
-bN
+as
 bu
 bD
 bK
@@ -1854,14 +1793,14 @@ bn
 bw
 bE
 bK
-bQ
+as
 bu
 bT
 ca
 bC
 cn
 cv
-cF
+cb
 cO
 cX
 ac
@@ -1881,7 +1820,7 @@ aO
 bx
 bF
 bL
-bL
+NC
 bL
 bU
 cb
@@ -1908,14 +1847,14 @@ bo
 bt
 br
 bK
-bN
+as
 bu
 bV
 cc
 bG
 cn
 cx
-cH
+cb
 cP
 cZ
 ac
@@ -1941,7 +1880,7 @@ bD
 bK
 ci
 cm
-cy
+cu
 cI
 cQ
 da
@@ -1989,7 +1928,7 @@ ac
 bw
 bE
 bK
-bQ
+as
 bu
 bD
 bK

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -18,7 +18,7 @@
 /obj/machinery/door/airlock/silver{
 	name = "First Class"
 	},
-/turf/open/floor/carpet/orange,
+/turf/open/floor/carpet/blue,
 /area/shuttle/escape/luxury)
 "ae" = (
 /obj/docking_port/mobile/emergency{
@@ -34,7 +34,7 @@
 /obj/machinery/door/airlock/silver{
 	name = "First Class"
 	},
-/turf/open/floor/carpet/orange,
+/turf/open/floor/carpet/blue,
 /area/shuttle/escape/luxury)
 "af" = (
 /obj/machinery/door/airlock/security/glass{
@@ -50,14 +50,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/ore_box,
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/shuttle/escape/luxury)
-"ai" = (
-/turf/closed/indestructible/riveted/plastinum,
-/area/shuttle/escape)
 "aj" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/large,
@@ -70,18 +65,9 @@
 "al" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape/luxury)
-"am" = (
-/turf/open/floor/carpet/orange,
-/area/shuttle/escape/luxury)
 "ao" = (
 /turf/open/floor/carpet/blue,
 /area/shuttle/escape/luxury)
-"ap" = (
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/turf/open/floor/mineral/diamond,
-/area/shuttle/escape)
 "aq" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/reagent_dispensers/fueltank,
@@ -126,9 +112,7 @@
 /area/shuttle/escape/luxury)
 "ax" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/shuttle/escape/luxury)
 "ay" = (
@@ -144,7 +128,6 @@
 /obj/machinery/button/door{
 	id = "ohnopoors";
 	name = "window shutters";
-	pixel_x = -5;
 	pixel_y = 26
 	},
 /turf/open/floor/carpet/blue,
@@ -257,10 +240,7 @@
 /turf/open/floor/carpet/red,
 /area/shuttle/escape/luxury)
 "aR" = (
-/obj/structure/mirror{
-	pixel_x = -23;
-	pixel_y = -2
-	},
+/obj/structure/mirror/directional/west,
 /obj/structure/sink/greyscale{
 	dir = 4;
 	pixel_x = -12
@@ -362,15 +342,11 @@
 /area/shuttle/escape/luxury)
 "bj" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bk" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/carpet/blue,
 /area/shuttle/escape/luxury)
 "bl" = (
@@ -385,7 +361,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
+/area/shuttle/escape/luxury)
 "bn" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/engineering/electrical,
@@ -505,11 +481,9 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bE" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
+/area/shuttle/escape/luxury)
 "bF" = (
 /obj/item/bikehorn/rubberducky,
 /obj/item/bikehorn/rubberducky,
@@ -582,9 +556,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape/luxury)
 "bQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/holofloor/beach/water,
 /area/shuttle/escape/luxury)
 "bR" = (
@@ -636,9 +608,6 @@
 /area/shuttle/escape/luxury)
 "bZ" = (
 /obj/machinery/vending/boozeomat,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/carpet/green,
 /area/shuttle/escape/luxury)
 "ca" = (
@@ -668,9 +637,7 @@
 /turf/open/floor/carpet/cyan,
 /area/shuttle/escape/luxury)
 "ce" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 26;
+/obj/machinery/vending/wallmed/directional/east{
 	use_power = 0
 	},
 /turf/open/floor/carpet/cyan,
@@ -722,9 +689,7 @@
 /area/shuttle/escape/luxury)
 "ck" = (
 /obj/item/stack/tile/iron/base,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/escape/luxury)
 "cl" = (
@@ -794,9 +759,7 @@
 /obj/structure/toilet{
 	pixel_y = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape/luxury)
 "cv" = (
@@ -828,7 +791,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape/luxury)
 "cz" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape/luxury)
 "cA" = (
@@ -849,29 +812,21 @@
 /obj/structure/frame/machine,
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/escape/luxury)
 "cE" = (
 /obj/structure/chair/comfy/brown,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/carpet/orange,
 /area/shuttle/escape/luxury)
 "cF" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/carpet/green,
 /area/shuttle/escape/luxury)
 "cG" = (
 /obj/machinery/stasis,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/carpet/cyan,
 /area/shuttle/escape/luxury)
 "cH" = (
@@ -905,20 +860,16 @@
 	pixel_x = 3;
 	pixel_y = -2
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/carpet/cyan,
 /area/shuttle/escape/luxury)
 "cI" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/carpet/blue,
 /area/shuttle/escape/luxury)
 "cJ" = (
 /obj/item/stack/tile/iron/base,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/shuttle/escape/luxury)
 "cK" = (
@@ -928,20 +879,18 @@
 	},
 /obj/item/hatchet,
 /obj/item/kitchen/knife,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/shuttle/escape/luxury)
 "cL" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/carpet/orange,
 /area/shuttle/escape/luxury)
 "cM" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape/luxury)
 "cN" = (
@@ -954,9 +903,7 @@
 /obj/structure/toilet{
 	pixel_y = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape/luxury)
 "Lt" = (
@@ -1274,7 +1221,7 @@ ag
 "}
 (20,1,1) = {"
 ag
-am
+ao
 ao
 ao
 bO
@@ -1305,7 +1252,7 @@ cM
 ag
 "}
 (22,1,1) = {"
-ai
+ag
 bm
 aw
 aw
@@ -1321,7 +1268,7 @@ aS
 ag
 "}
 (23,1,1) = {"
-ai
+ag
 bE
 aw
 aw
@@ -1337,8 +1284,8 @@ aS
 ag
 "}
 (24,1,1) = {"
-ai
-ap
+ag
+aM
 aM
 aM
 aM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the lights and wallmounts on all emergency shuttles up to the luxury shuttle (including wall flashers, extinguisher cabinets, nanomeds, and peppertanks) to directional mounts introduced in #58809
Also changes manual grille/shuttle window placements with spawners where applicable. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When the wallening gets here, will allow us to switch the directions of all of the lights at once (which we'll need) and not have to manually set wall mount dirs. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
