### PR TITLE
Converts emergency shuttle wall mounts (part 2)

### DIFF
--- a/_maps/shuttles/emergency_medisim.dmm
+++ b/_maps/shuttles/emergency_medisim.dmm
@@ -16,9 +16,7 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "cc" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "cL" = (
@@ -268,15 +266,11 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/template_noop,
 /area/shuttle/escape)
 "kS" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "lg" = (
@@ -302,9 +296,7 @@
 /obj/structure/table/reinforced,
 /obj/item/surgicaldrill,
 /obj/item/cautery,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/escape)
 "ls" = (
@@ -485,9 +477,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/template_noop,
 /area/shuttle/escape)
 "uG" = (
@@ -632,8 +622,8 @@
 	dispense_type = /obj/item/binoculars;
 	end_create_message = "dispenses a pair of binoculars.";
 	glass_cost = 0;
-	maximum_idle = 1;
 	iron_cost = 0;
+	maximum_idle = 1;
 	name = "binoculars fabricator";
 	power_used = 0;
 	starting_amount = 25000
@@ -644,9 +634,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "CM" = (
@@ -685,9 +673,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Eo" = (
@@ -706,9 +692,7 @@
 /turf/template_noop,
 /area/template_noop)
 "EV" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "EZ" = (
@@ -833,9 +817,7 @@
 "HE" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/escape)
 "HR" = (
@@ -1077,9 +1059,7 @@
 /obj/item/clothing/suit/fire/firefighter,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/head/hardhat/red,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "Sf" = (
@@ -1157,9 +1137,7 @@
 	pixel_x = -3;
 	pixel_y = 2
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "TE" = (
@@ -1204,12 +1182,8 @@
 /turf/template_noop,
 /area/shuttle/escape)
 "Vn" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/west,
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "Vv" = (
@@ -1250,7 +1224,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "WN" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "WQ" = (
@@ -1351,9 +1325,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "YC" = (

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -69,15 +69,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "as" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_y = 27
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "at" = (
@@ -192,14 +186,8 @@
 /obj/item/restraints/handcuffs{
 	pixel_y = 3
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"az" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "aA" = (
 /obj/structure/tank_dispenser/oxygen{
@@ -244,17 +232,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"aI" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
-"aJ" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
 "aL" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -262,11 +239,8 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aN" = (
-/obj/machinery/status_display/evac{
-	dir = 8;
-	pixel_x = 32
-	},
 /obj/machinery/holopad,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aO" = (
@@ -292,30 +266,21 @@
 	pixel_x = -2;
 	pixel_y = 8
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -31
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aR" = (
 /obj/structure/table,
 /obj/item/folder/blue,
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_y = -27
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aS" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -31
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aT" = (
@@ -323,9 +288,7 @@
 /obj/item/stack/medical/gauze,
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/ointment,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aW" = (
@@ -421,9 +384,7 @@
 "bo" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bp" = (
@@ -441,10 +402,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
-"bt" = (
-/obj/structure/reagent_dispensers/peppertank,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/escape)
 "bu" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/epinephrine{
@@ -510,9 +467,8 @@
 "bz" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bA" = (
@@ -535,10 +491,7 @@
 	pixel_x = -4;
 	pixel_y = 2
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -31
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = -4;
 	pixel_y = 4
@@ -583,10 +536,7 @@
 	},
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -27
-	},
+/obj/item/radio/intercom/directional/west,
 /obj/item/surgicaldrill,
 /obj/item/cautery,
 /turf/open/floor/mineral/titanium,
@@ -613,10 +563,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"bL" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
 "bM" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen/red,
@@ -630,10 +576,7 @@
 /area/shuttle/escape)
 "bN" = (
 /obj/machinery/space_heater,
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_y = -27
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -682,10 +625,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bQ" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -31
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -699,13 +639,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/shuttle/escape)
-"bS" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
 "bT" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
@@ -714,9 +647,7 @@
 /area/shuttle/escape/brig)
 "bV" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bW" = (
@@ -798,41 +729,32 @@
 /obj/structure/closet/crate{
 	name = "lifejackets"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bX" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bY" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ca" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "cb" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "cc" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -840,13 +762,55 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
+/obj/structure/reagent_dispensers/peppertank/directional/east,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
+"qi" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/vending/wallmed/directional/north{
+	use_power = 0
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"sd" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"tZ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"Lk" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
 "LY" = (
 /turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Sb" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/vending/wallmed/directional/south{
+	use_power = 0
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"TZ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
 /area/shuttle/escape)
 "Vs" = (
 /turf/open/floor/mineral/titanium/white,
@@ -909,8 +873,8 @@ aF
 aL
 aO
 aP
-aJ
-bd
+ad
+TZ
 bd
 bd
 bC
@@ -967,16 +931,16 @@ ac
 (8,1,1) = {"
 ad
 ad
-az
+ad
 ad
 aH
 ad
-az
 ad
 ad
 ad
 ad
-az
+ad
+ad
 ad
 ad
 "}
@@ -992,7 +956,7 @@ ap
 ad
 bh
 bh
-bh
+tZ
 bD
 ad
 "}
@@ -1033,8 +997,8 @@ af
 LY
 LY
 aE
-aI
-ar
+ad
+qi
 LY
 aE
 ad
@@ -1055,8 +1019,8 @@ LY
 aS
 ad
 ad
-bt
-az
+ad
+ad
 ad
 ad
 "}
@@ -1064,8 +1028,8 @@ ad
 af
 LY
 LY
-aE
-aJ
+Lk
+ad
 ar
 LY
 aE
@@ -1129,8 +1093,8 @@ ac
 ar
 LY
 aE
-bL
-ar
+ad
+sd
 LY
 aE
 ba
@@ -1160,8 +1124,8 @@ ad
 ah
 LY
 LY
-aE
-bS
+Sb
+ad
 ar
 LY
 aE
@@ -1180,8 +1144,8 @@ aE
 ac
 ar
 LY
-aE
-aJ
+Lk
+ad
 bo
 be
 be

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -53,15 +53,12 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "k" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "l" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 28
+/obj/machinery/vending/wallmed/directional/east{
+	use_power = 0
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -69,9 +66,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "n" = (
@@ -102,15 +97,17 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "t" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "u" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
 	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"w" = (
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "x" = (
@@ -123,24 +120,15 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"z" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed"
-	},
-/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "A" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "B" = (
@@ -168,16 +156,12 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "E" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "G" = (
 /obj/structure/table/optable,
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"H" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "I" = (
 /obj/machinery/door/airlock/command/glass{
@@ -199,10 +183,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "L" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 24
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "M" = (
@@ -349,8 +330,8 @@ K
 K
 K
 f
-r
-H
+w
+b
 t
 f
 R
@@ -367,7 +348,7 @@ t
 x
 n
 n
-z
+b
 n
 n
 R

--- a/_maps/shuttles/emergency_monastery.dmm
+++ b/_maps/shuttles/emergency_monastery.dmm
@@ -32,7 +32,7 @@
 /turf/open/space,
 /area/shuttle/escape)
 "aF" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -84,11 +84,7 @@
 /turf/open/space/basic,
 /area/shuttle/escape)
 "bb" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Monastery Docking Bay APC";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/dark,
@@ -97,9 +93,7 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "bd" = (
@@ -108,9 +102,7 @@
 /turf/open/space,
 /area/shuttle/escape)
 "be" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
@@ -142,14 +134,8 @@
 /turf/open/space/basic,
 /area/shuttle/escape)
 "bn" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Library APC";
-	pixel_x = 24
-	},
+/obj/machinery/light/small/directional/east,
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -239,9 +225,7 @@
 "cu" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/item/flashlight/lantern,
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
@@ -254,10 +238,8 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "cL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/machinery/light/small,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/light/small/directional/south,
 /obj/machinery/camera{
 	c_tag = "Monastery Dock";
 	dir = 1;
@@ -279,10 +261,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "cP" = (
-/obj/item/radio/intercom{
-	pixel_x = 27
-	},
-/obj/machinery/light/small,
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -331,6 +311,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "dn" = (
@@ -343,14 +324,8 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Library Lounge APC";
-	pixel_x = 24
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -404,9 +379,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "dJ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/camera{
 	c_tag = "Monastery Dining Room";
 	dir = 8;
@@ -492,20 +465,15 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/light/dim{
-	dir = 1
-	},
+/obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "eu" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light/small,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/light/small/directional/south,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "eA" = (
@@ -657,9 +625,7 @@
 "fT" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/camera,
 /turf/open/floor/iron/dark,
@@ -678,9 +644,7 @@
 /turf/open/space/basic,
 /area/shuttle/escape)
 "gL" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/door/window/northright{
 	dir = 2;
 	name = "Curator Desk Door";
@@ -765,9 +729,7 @@
 /turf/open/space,
 /area/shuttle/escape)
 "iB" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/photocopier,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -784,18 +746,12 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "iI" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "iJ" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Chapel Office APC";
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -841,9 +797,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "iW" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/sand,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -855,9 +809,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "jd" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/item/storage/box/lights/bulbs,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -946,9 +898,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "ki" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/camera{
 	c_tag = "Chapel Crematorium";
 	network = list("ss13","monastery")
@@ -956,9 +906,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "kn" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "ko" = (
@@ -1012,9 +960,7 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -1069,9 +1015,7 @@
 	},
 /area/shuttle/escape)
 "lE" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "lP" = (
@@ -1164,9 +1108,7 @@
 /area/shuttle/escape)
 "mQ" = (
 /obj/machinery/hydroponics/soil,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/item/seeds/watermelon/holy,
 /turf/open/floor/grass,
 /area/shuttle/escape)
@@ -1183,9 +1125,7 @@
 /turf/open/floor/iron/chapel,
 /area/shuttle/escape)
 "nl" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/computer/pod/old/mass_driver_controller/chapelgun{
 	pixel_x = 24
 	},
@@ -1242,9 +1182,7 @@
 /turf/open/space,
 /area/shuttle/escape)
 "ov" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/camera{
 	c_tag = "Chapel Starboard";
 	dir = 8;
@@ -1295,27 +1233,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
-"oO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/shuttle/escape)
 "oS" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -1349,9 +1266,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "pa" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1381,9 +1296,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "pv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/black,
 /area/shuttle/escape)
 "pw" = (
@@ -1457,13 +1370,10 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "qr" = (
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/obj/machinery/requests_console{
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/requests_console/directional/west{
 	department = "Chapel";
-	departmentType = 2;
-	pixel_x = -32
+	departmentType = 2
 	},
 /obj/structure/closet,
 /obj/item/storage/backpack/cultpack,
@@ -1509,9 +1419,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "qU" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/camera{
 	c_tag = "Chapel Port Access";
 	network = list("ss13","monastery")
@@ -1519,18 +1427,13 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "rb" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "rk" = (
 /obj/structure/chair/wood,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "ru" = (
@@ -1540,9 +1443,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "rw" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "rF" = (
@@ -1663,9 +1564,7 @@
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "sz" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/camera{
 	c_tag = "Chapel Starboard Access";
 	network = list("ss13","monastery")
@@ -1675,9 +1574,7 @@
 /area/shuttle/escape)
 "sC" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1695,7 +1592,7 @@
 /obj/structure/sign/painting/library_secure{
 	pixel_y = -32
 	},
-/obj/machinery/light/dim,
+/obj/machinery/light/dim/directional/south,
 /obj/item/reagent_containers/food/drinks/trophy{
 	pixel_y = 10
 	},
@@ -1753,13 +1650,13 @@
 	pixel_x = -3;
 	pixel_y = 8
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "tz" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/fancy/candle_box,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "tT" = (
@@ -1767,11 +1664,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "tV" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Monastery APC";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1805,9 +1698,7 @@
 /area/shuttle/escape)
 "uc" = (
 /obj/structure/bookcase/random/religion,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "un" = (
@@ -1821,7 +1712,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "ux" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/carpet/black,
 /area/shuttle/escape)
 "uC" = (
@@ -1867,7 +1758,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "vk" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -2040,9 +1931,7 @@
 /turf/open/floor/plating/asteroid,
 /area/shuttle/escape)
 "wM" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/camera{
 	c_tag = "Monastery Cloister Fore";
 	network = list("ss13","monastery")
@@ -2094,10 +1983,7 @@
 	dir = 8;
 	pixel_y = -4
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/iron/showroomfloor,
 /area/shuttle/escape)
@@ -2172,9 +2058,7 @@
 /area/shuttle/escape)
 "xZ" = (
 /obj/structure/cable,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -2204,7 +2088,7 @@
 /area/shuttle/escape)
 "yr" = (
 /obj/structure/closet,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/item/storage/book/bible,
 /obj/item/storage/book/bible,
 /obj/item/storage/book/bible,
@@ -2269,14 +2153,12 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "yS" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "yZ" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -2301,9 +2183,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "zj" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/door/window/northright{
 	base_state = "left";
 	dir = 2;
@@ -2338,17 +2218,13 @@
 /area/shuttle/escape)
 "zp" = (
 /obj/item/storage/bag/plants,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/storage/bag/plants/portaseeder,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "zr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2372,9 +2248,7 @@
 /area/shuttle/escape)
 "zF" = (
 /obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/item/storage/crayons,
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
@@ -2384,9 +2258,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "zQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -2494,7 +2366,7 @@
 	pixel_y = 6;
 	throwforce = 8
 	},
-/obj/machinery/light/dim,
+/obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "BQ" = (
@@ -2530,7 +2402,7 @@
 /area/shuttle/escape)
 "Cg" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "Cn" = (
@@ -2547,7 +2419,7 @@
 /area/shuttle/escape)
 "CJ" = (
 /obj/structure/bookcase/random/adult,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "CM" = (
@@ -2568,14 +2440,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Dc" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Garden APC";
-	pixel_x = -25
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/light/small/directional/west,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/cable,
 /turf/open/floor/grass,
@@ -2655,10 +2521,7 @@
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
 "DW" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "DY" = (
@@ -2715,13 +2578,9 @@
 "Ew" = (
 /obj/structure/table,
 /obj/machinery/microwave,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/cobweb,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "Ex" = (
@@ -2744,9 +2603,7 @@
 "EU" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/wheat,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "Fa" = (
@@ -2757,9 +2614,7 @@
 /area/shuttle/escape)
 "Ff" = (
 /obj/structure/flora/ausbushes/genericbush,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "Fh" = (
@@ -2846,9 +2701,7 @@
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "Gu" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/easel,
 /obj/item/canvas/twentythree_nineteen,
 /turf/open/floor/iron/grimy,
@@ -2997,10 +2850,7 @@
 	c_tag = "Monastery Archives Fore";
 	network = list("ss13","monastery")
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "IM" = (
@@ -3016,9 +2866,7 @@
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "IT" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/camera{
 	c_tag = "Monastery Cloister Starboard";
 	dir = 8;
@@ -3085,9 +2933,7 @@
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "Jy" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -3156,9 +3002,7 @@
 /turf/closed/mineral,
 /area/shuttle/escape)
 "Kd" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -3173,9 +3017,7 @@
 /area/shuttle/escape)
 "Kl" = (
 /obj/machinery/chem_master/condimaster,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "Km" = (
@@ -3199,13 +3041,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "KE" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "KH" = (
@@ -3238,17 +3075,12 @@
 /obj/structure/toilet{
 	pixel_y = 8
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/shuttle/escape)
 "La" = (
 /obj/structure/cable,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -3262,9 +3094,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Lq" = (
@@ -3288,9 +3118,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "LC" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/camera{
 	c_tag = "Chapel Port";
 	dir = 4;
@@ -3340,7 +3168,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "LV" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/machinery/camera{
 	c_tag = "Monastery Cloister Aft";
 	dir = 1;
@@ -3367,9 +3195,7 @@
 /area/shuttle/escape)
 "Mb" = (
 /obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/item/instrument/violin,
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
@@ -3381,9 +3207,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Md" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/camera{
 	c_tag = "Monastery Archives Starboard";
 	dir = 8;
@@ -3401,7 +3225,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Mi" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -3453,9 +3277,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "ML" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -3523,7 +3345,7 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /obj/item/kitchen/rollingpin,
 /obj/item/kitchen/knife,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "Ng" = (
@@ -3587,9 +3409,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "NS" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "NX" = (
@@ -3640,9 +3460,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Oi" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
 	},
@@ -3831,9 +3649,7 @@
 	dir = 8
 	},
 /obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Qq" = (
@@ -3908,7 +3724,7 @@
 /area/shuttle/escape)
 "Rd" = (
 /obj/machinery/hydroponics/soil,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/item/seeds/poppy,
 /turf/open/floor/grass,
 /area/shuttle/escape)
@@ -3919,9 +3735,7 @@
 /area/shuttle/escape)
 "Rs" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -3940,17 +3754,12 @@
 /obj/item/canvas/nineteen_nineteen,
 /obj/item/canvas/nineteen_nineteen,
 /obj/item/wirecutters,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Rx" = (
 /obj/item/storage/toolbox/mechanical,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -3961,9 +3770,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "RA" = (
@@ -3973,9 +3780,7 @@
 /area/shuttle/escape)
 "RG" = (
 /obj/structure/bookcase/random/nonfiction,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "RJ" = (
@@ -3993,16 +3798,12 @@
 "RZ" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/sugarcane,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "Sb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/dim{
-	dir = 4
-	},
+/obj/machinery/light/dim/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Sc" = (
@@ -4044,9 +3845,7 @@
 	},
 /obj/item/toy/crayon/spraycan,
 /obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -4069,9 +3868,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Ss" = (
-/obj/machinery/light/dim{
-	dir = 8
-	},
+/obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Su" = (
@@ -4106,17 +3903,13 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "SK" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "SQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/item/stack/rods/fifty,
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
@@ -4249,15 +4042,8 @@
 	pixel_y = 4
 	},
 /obj/structure/table/wood,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Monastery Art Gallery APC";
-	pixel_y = 23
-	},
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -4290,9 +4076,7 @@
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "UJ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/camera{
 	c_tag = "Monastery Archives Port";
 	dir = 4;
@@ -4390,9 +4174,7 @@
 /obj/structure/sign/painting/library_private{
 	pixel_x = 32
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "VA" = (
@@ -4465,10 +4247,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Wp" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Ws" = (
@@ -4482,9 +4261,7 @@
 /area/shuttle/escape)
 "WF" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "WG" = (
@@ -4494,9 +4271,7 @@
 /area/shuttle/escape)
 "WH" = (
 /obj/structure/cable,
-/obj/machinery/light/dim{
-	dir = 8
-	},
+/obj/machinery/light/dim/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -4513,9 +4288,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "WO" = (
-/obj/machinery/light/dim{
-	dir = 4
-	},
+/obj/machinery/light/dim/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "WQ" = (
@@ -4603,12 +4376,8 @@
 	},
 /area/shuttle/escape)
 "XP" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -4674,9 +4443,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "YC" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "YD" = (
@@ -4738,10 +4505,9 @@
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "Zl" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/libraryscanner,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Zn" = (
@@ -4753,11 +4519,7 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "Zr" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Monastery Maintenance APC";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -4767,15 +4529,6 @@
 "ZA" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/photo_album,
-/turf/open/floor/carpet,
-/area/shuttle/escape)
-"ZF" = (
-/obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "ZM" = (
@@ -6994,7 +6747,7 @@ RA
 Up
 RA
 XL
-ZF
+RA
 RA
 ZU
 KR
@@ -7081,7 +6834,7 @@ ZZ
 Eu
 dl
 dU
-oO
+dU
 PN
 eU
 Oc

--- a/_maps/shuttles/emergency_narnar.dmm
+++ b/_maps/shuttles/emergency_narnar.dmm
@@ -70,16 +70,11 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/cult,
 /area/shuttle/escape)
 "o" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/cult,
 /area/shuttle/escape)
 "p" = (
@@ -96,10 +91,6 @@
 "r" = (
 /obj/machinery/door/airlock/cult/unruned/glass/friendly,
 /turf/open/floor/cult,
-/area/shuttle/escape)
-"s" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/cult,
 /area/shuttle/escape)
 "t" = (
 /obj/structure/closet/emcloset,
@@ -168,9 +159,7 @@
 /turf/open/floor/cult,
 /area/shuttle/escape)
 "G" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/item/extinguisher{
 	safety = 0
 	},
@@ -207,9 +196,7 @@
 /turf/open/floor/cult,
 /area/shuttle/escape)
 "M" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/cult,
 /area/shuttle/escape)
 "N" = (
@@ -231,9 +218,7 @@
 	pixel_y = 3
 	},
 /obj/item/crowbar,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/item/stack/sheet/iron,
 /turf/open/floor/cult,
 /area/shuttle/escape)
@@ -261,6 +246,14 @@
 "V" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"X" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/cult,
+/area/shuttle/escape)
+"Y" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/cult,
 /area/shuttle/escape)
 "Z" = (
 /obj/machinery/stasis,
@@ -403,8 +396,8 @@ j
 C
 z
 j
-j
-s
+Y
+b
 b
 b
 b
@@ -440,8 +433,8 @@ c
 g
 k
 k
-s
-j
+b
+X
 j
 A
 D

--- a/_maps/shuttles/emergency_nature.dmm
+++ b/_maps/shuttles/emergency_nature.dmm
@@ -88,19 +88,14 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -31
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "dP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dT" = (
@@ -160,9 +155,7 @@
 /obj/item/storage/toolbox/emergency{
 	pixel_y = 3
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "fD" = (
@@ -200,11 +193,7 @@
 	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle,
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_y = 27
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "gj" = (
@@ -244,12 +233,8 @@
 	dir = 9
 	},
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 28
-	},
+/obj/machinery/light/directional/west,
+/obj/structure/reagent_dispensers/peppertank/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape/brig)
 "hC" = (
@@ -301,9 +286,7 @@
 /obj/item/restraints/handcuffs{
 	pixel_y = 3
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "iF" = (
@@ -360,6 +343,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"kT" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/chair/comfy/shuttle,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
 /area/shuttle/escape)
 "lo" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -483,9 +474,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "qD" = (
@@ -572,10 +561,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/shuttle/escape)
-"ui" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
 "ur" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -583,9 +568,8 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "uI" = (
@@ -623,9 +607,7 @@
 /obj/item/storage/box/handcuffs{
 	pixel_y = 5
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape/brig)
 "wg" = (
@@ -640,7 +622,7 @@
 /area/shuttle/escape)
 "wX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "xA" = (
@@ -731,10 +713,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/status_display/evac{
-	dir = 8;
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "AM" = (
@@ -807,9 +786,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
@@ -821,9 +798,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
@@ -858,9 +833,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/vending/snack/green,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
@@ -1195,9 +1168,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
@@ -1357,7 +1328,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 3
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
@@ -1391,9 +1362,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "ZL" = (
@@ -1408,9 +1377,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 
@@ -1650,7 +1617,7 @@ Yu
 Yu
 VI
 VI
-ui
+Yu
 Yu
 Db
 Co
@@ -1850,8 +1817,8 @@ iD
 og
 WL
 Zg
-ui
-Co
+Yu
+kT
 Zt
 VI
 VI

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -15,12 +15,8 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "ae" = (
@@ -31,18 +27,13 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = 24
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "ag" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -102,12 +93,8 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "al" = (
@@ -159,9 +146,7 @@
 "ap" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -299,9 +284,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "aB" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -316,10 +299,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_x = 26
-	},
+/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -327,9 +307,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -461,29 +439,18 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
-/area/shuttle/escape)
-"aL" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"aM" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
-/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "aN" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/light/small/directional/west,
+/obj/machinery/vending/wallmed/directional/west{
+	use_power = 0
 	},
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -515,11 +482,12 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "aR" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "aS" = (
@@ -528,9 +496,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -543,10 +509,6 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/shuttle/escape)
-"aU" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "aV" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -599,18 +561,18 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "ba" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = -26;
-	use_power = 0
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed/directional/west{
+	use_power = 0
+	},
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "bb" = (
@@ -623,10 +585,7 @@
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "bc" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_x = 26
-	},
+/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -638,14 +597,10 @@
 /area/shuttle/escape)
 "bd" = (
 /obj/machinery/recharge_station,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "be" = (
@@ -702,12 +657,8 @@
 	pixel_y = 3
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -726,10 +677,7 @@
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_x = -32
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom";
-	pixel_y = -26
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -760,9 +708,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 24
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -781,9 +727,7 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
 /obj/structure/table/reinforced,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -857,6 +801,28 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"eA" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"qt" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/vending/wallmed/directional/east{
+	use_power = 0
+	},
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"sY" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -866,9 +832,9 @@ aq
 ac
 ay
 aa
-ab
-ab
-ab
+sY
+sY
+sY
 aa
 aP
 ac
@@ -884,7 +850,7 @@ aa
 ad
 ak
 al
-ab
+sY
 az
 aD
 aJ
@@ -892,7 +858,7 @@ aJ
 aJ
 aD
 az
-ab
+sY
 az
 bd
 bj
@@ -901,7 +867,7 @@ br
 bv
 "}
 (3,1,1) = {"
-ab
+sY
 ae
 al
 al
@@ -917,28 +883,28 @@ aT
 aW
 be
 bk
-ab
+sY
 bs
 bv
 "}
 (4,1,1) = {"
-ab
+sY
 ae
 al
 al
-ab
+sY
 aA
 aF
 aK
 aF
-aF
+qt
 aF
 aQ
 aT
 aX
 bf
 bl
-ab
+sY
 bt
 bv
 "}
@@ -947,15 +913,15 @@ aa
 af
 al
 ar
-ab
+sY
 aA
 aG
-aL
+aZ
 aI
-aM
+aZ
 aG
 aQ
-ab
+sY
 aY
 bg
 bm
@@ -967,7 +933,7 @@ bv
 ac
 ab
 am
-ab
+sY
 aw
 aB
 aH
@@ -976,9 +942,9 @@ aO
 aI
 aH
 aR
-aU
 aZ
-ab
+aZ
+sY
 aZ
 aZ
 br
@@ -989,15 +955,15 @@ aa
 ag
 an
 as
-ab
+sY
 aA
 aI
-aM
+aZ
 aG
-aL
+aZ
 aI
 aQ
-ab
+sY
 ba
 bh
 bn
@@ -1006,7 +972,7 @@ bt
 bv
 "}
 (8,1,1) = {"
-ab
+sY
 ah
 ao
 an
@@ -1015,19 +981,19 @@ aA
 aJ
 aN
 aJ
-aJ
+eA
 aJ
 aQ
 aV
 bb
 bb
 bo
-ab
+sY
 bt
 bv
 "}
 (9,1,1) = {"
-ab
+sY
 ai
 an
 at
@@ -1043,12 +1009,12 @@ aV
 bb
 bb
 bp
-ab
+sY
 bt
 bv
 "}
 (10,1,1) = {"
-ab
+sY
 aj
 ap
 au
@@ -1060,7 +1026,7 @@ aF
 aF
 aF
 aS
-ab
+sY
 bc
 bi
 bq
@@ -1070,16 +1036,16 @@ bv
 "}
 (11,1,1) = {"
 aa
-ab
-ab
+sY
+sY
 aa
 ac
 aa
-ab
-ab
-ab
-ab
-ab
+sY
+sY
+sY
+sY
+sY
 aa
 ac
 aa

--- a/_maps/shuttles/emergency_pod.dmm
+++ b/_maps/shuttles/emergency_pod.dmm
@@ -9,8 +9,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "c" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "d" = (
@@ -30,9 +29,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "i" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "j" = (
@@ -45,9 +42,7 @@
 /obj/machinery/computer/emergency_shuttle{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "m" = (

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -60,9 +60,7 @@
 /area/shuttle/escape)
 "ap" = (
 /obj/structure/chair/comfy,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -84,9 +82,7 @@
 /turf/open/floor/carpet/black,
 /area/shuttle/escape)
 "as" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
 	pixel_x = -3;
@@ -207,12 +203,8 @@
 /area/shuttle/escape)
 "aE" = (
 /obj/structure/chair/comfy,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -240,9 +232,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/food/butterdog,
 /obj/item/food/cakeslice/apple,
 /obj/item/food/cakeslice/brioche,
@@ -279,7 +269,7 @@
 /obj/structure/chair/comfy{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -378,9 +368,7 @@
 /area/shuttle/escape)
 "aT" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -432,7 +420,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -441,9 +429,7 @@
 /area/shuttle/escape)
 "aZ" = (
 /obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/storage/firstaid/regular,
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -455,8 +441,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/vending/wallmed{
-	pixel_y = 30
+/obj/machinery/vending/wallmed/directional/north{
+	use_power = 0
 	},
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
@@ -557,7 +543,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -576,7 +562,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "br" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/chair/office{
 	dir = 8
 	},
@@ -586,7 +572,7 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "bt" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/chair/office{
 	dir = 4
 	},
@@ -599,8 +585,7 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bv" = (
-/obj/structure/window/plasma/reinforced/plastitanium,
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "bw" = (
@@ -659,17 +644,15 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "bH" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bI" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bK" = (

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -181,10 +181,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/light,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/ai/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -218,10 +216,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/light,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "aG" = (
@@ -248,10 +244,7 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
 /obj/item/wrench,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -31
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/item/restraints/handcuffs,
 /obj/item/food/chocolatebar,
 /obj/item/assembly/flash,
@@ -312,13 +305,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aR" = (
@@ -342,12 +331,8 @@
 	},
 /area/shuttle/escape)
 "aU" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
 /turf/open/floor/iron/white/side{
@@ -386,9 +371,7 @@
 	pixel_y = 3
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
@@ -474,9 +457,7 @@
 	pixel_y = 4
 	},
 /obj/item/storage/lockbox/loyalty,
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
+/obj/item/radio/intercom/directional/west,
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
@@ -535,7 +516,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "bn" = (
@@ -580,17 +561,14 @@
 /area/shuttle/escape)
 "bq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
+/obj/item/radio/intercom/directional/east,
 /obj/machinery/stasis,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
 /area/shuttle/escape)
 "br" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "bs" = (
@@ -731,9 +709,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "bI" = (
@@ -856,10 +832,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 23
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "bS" = (
@@ -926,9 +899,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "bZ" = (
@@ -1069,9 +1040,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "cq" = (
@@ -1127,9 +1096,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "cw" = (
@@ -1165,9 +1132,7 @@
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "cA" = (
@@ -1209,9 +1174,7 @@
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "cD" = (
@@ -1236,10 +1199,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	dir = 8;
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
@@ -1254,10 +1214,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	dir = 8;
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "cH" = (
@@ -1266,9 +1223,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "cI" = (
@@ -1279,9 +1234,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "cJ" = (
@@ -1302,7 +1255,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "cL" = (
@@ -1594,9 +1547,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -1720,9 +1671,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "dq" = (
@@ -1769,11 +1718,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/light,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -28
-	},
+/obj/machinery/light/directional/south,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "dt" = (
@@ -1790,9 +1736,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "du" = (
@@ -1885,10 +1829,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dE" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -1906,18 +1847,14 @@
 "dI" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dJ" = (
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dK" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dL" = (
@@ -1948,9 +1885,7 @@
 "dQ" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dR" = (

--- a/_maps/shuttles/emergency_rollerdome.dmm
+++ b/_maps/shuttles/emergency_rollerdome.dmm
@@ -93,15 +93,11 @@
 /turf/template_noop,
 /area/template_noop)
 "pI" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "qU" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "ss" = (
@@ -299,7 +295,7 @@
 /obj/structure/table/wood/poker,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "Zo" = (

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -73,7 +73,6 @@
 "ao" = (
 /obj/machinery/button/flasher{
 	id = "cockpit_flasher";
-	pixel_x = 6;
 	pixel_y = -24
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -82,12 +81,9 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "ap" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aq" = (
@@ -112,10 +108,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"as" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/rust,
-/area/shuttle/escape)
 "at" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Glorious Leaders";
@@ -135,10 +127,8 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aw" = (
-/obj/machinery/flasher{
-	id = "cockpit_flasher";
-	pixel_x = 6;
-	pixel_y = 24
+/obj/machinery/flasher/directional/north{
+	id = "cockpit_flasher"
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape)
@@ -164,6 +154,7 @@
 /area/shuttle/escape)
 "aC" = (
 /obj/item/kitchen/knife,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/engine,
 /area/shuttle/escape)
 "aD" = (
@@ -173,20 +164,10 @@
 /turf/closed/wall/r_wall/rust,
 /area/shuttle/escape)
 "aF" = (
-/obj/machinery/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -24;
-	pixel_y = 6
+/obj/machinery/flasher/directional/west{
+	id = "shuttle_flasher"
 	},
-/obj/machinery/button/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -24;
-	pixel_y = -6
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aG" = (
@@ -285,10 +266,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aX" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape)
 "aY" = (
@@ -423,15 +401,11 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "bs" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape)
 "bt" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/open/floor/mineral/plastitanium,
@@ -441,10 +415,6 @@
 	name = "Emergency Shuttle Cargo"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
-"bv" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
 /area/shuttle/escape)
 "bw" = (
 /obj/machinery/door/airlock/security/glass{
@@ -460,9 +430,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "bz" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "bA" = (
@@ -475,14 +443,9 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bC" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -537,42 +500,32 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "bM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/engine,
 /area/shuttle/escape)
 "bN" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape)
 "bO" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "bP" = (
 /obj/structure/kitchenspike,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "bQ" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape)
 "bR" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "iJ" = (
@@ -587,6 +540,19 @@
 /obj/structure/table/optable,
 /turf/open/floor/iron,
 /area/shuttle/escape)
+"wM" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/button/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"Jl" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
 
 (1,1,1) = {"
 aa
@@ -618,7 +584,7 @@ aa
 aa
 aa
 ab
-av
+wM
 aF
 aH
 ad
@@ -641,8 +607,8 @@ aa
 aa
 aa
 aa
-as
-av
+ad
+Jl
 aG
 aP
 ad
@@ -773,7 +739,7 @@ ax
 ax
 ax
 bQ
-bv
+ab
 ad
 ad
 ad
@@ -857,7 +823,7 @@ aa
 ad
 ab
 ad
-as
+ad
 aC
 aK
 bM

--- a/_maps/shuttles/emergency_scrapheap.dmm
+++ b/_maps/shuttles/emergency_scrapheap.dmm
@@ -65,20 +65,16 @@
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "an" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "ao" = (
 /obj/machinery/button/flasher{
 	id = "cockpit_flasher";
-	pixel_x = 6;
 	pixel_y = -24
 	},
 /obj/structure/table/wood/poker,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "ap" = (
@@ -113,14 +109,12 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "au" = (
-/obj/machinery/flasher{
-	id = "cockpit_flasher";
-	pixel_x = 6;
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
+	},
+/obj/machinery/flasher/directional/north{
+	id = "cockpit_flasher"
 	},
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -135,20 +129,15 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "ax" = (
-/obj/machinery/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -24;
-	pixel_y = 6
+/obj/machinery/flasher/directional/west{
+	id = "shuttle_flasher"
 	},
 /obj/machinery/button/flasher{
 	id = "shuttle_flasher";
 	pixel_x = -24;
 	pixel_y = -6
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "ay" = (
@@ -177,9 +166,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape/brig)
 "aD" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/table,
 /obj/item/extinguisher,
 /obj/item/crowbar,
@@ -208,10 +195,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 23
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aJ" = (
@@ -277,9 +261,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aU" = (
@@ -312,9 +294,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ba" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -326,16 +306,12 @@
 	dir = 4
 	},
 /obj/structure/barricade/wooden,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/shuttle/escape)
-"bc" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium,
 /area/shuttle/escape)
 "bd" = (
 /obj/machinery/door/airlock{
@@ -347,12 +323,8 @@
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "bf" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "bg" = (
@@ -377,16 +349,12 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "bk" = (
 /obj/machinery/recharge_station,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/freezer,
 /area/shuttle/escape)
 "bl" = (
@@ -412,19 +380,23 @@
 /area/shuttle/escape)
 "bo" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bp" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light{
+/obj/machinery/light/directional/north,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Fs" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -539,8 +511,8 @@ aG
 aw
 aL
 ac
-av
-bc
+Fs
+ab
 be
 ab
 ab

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -268,9 +268,7 @@
 	anchored = 1
 	},
 /obj/item/clothing/glasses/meson/engine,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bj" = (
@@ -278,27 +276,21 @@
 	anchored = 1
 	},
 /obj/item/clothing/glasses/meson/engine,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "bl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "hD" = (

--- a/_maps/shuttles/emergency_tram.dmm
+++ b/_maps/shuttles/emergency_tram.dmm
@@ -52,9 +52,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "al" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/shuttle/escape)
 "am" = (
@@ -64,9 +62,7 @@
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/escape)
 "ao" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/shuttle/escape)
 "ap" = (
@@ -97,25 +93,15 @@
 /obj/machinery/computer/crew{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -31
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/shuttle/escape)
 "au" = (
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	dir = 4;
-	pixel_y = -27
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/mineral/titanium/tiled/white,
-/area/shuttle/escape)
-"av" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "aw" = (
 /obj/machinery/door/airlock/public/glass{
@@ -128,15 +114,12 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/glass/reinforced,
 /area/shuttle/escape)
 "ay" = (
 /obj/machinery/button/flasher{
 	id = "cockpit_flasher";
-	pixel_x = 6;
 	pixel_y = -24
 	},
 /turf/open/floor/glass/reinforced,
@@ -149,16 +132,12 @@
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/glass/reinforced,
 /area/shuttle/escape)
 "aB" = (
 /obj/structure/chair/comfy/shuttle,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/north,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aC" = (
@@ -166,10 +145,8 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aD" = (
-/obj/machinery/flasher{
-	id = "cockpit_flasher";
-	pixel_x = -24;
-	pixel_y = 24
+/obj/machinery/flasher/directional/west{
+	id = "cockpit_flasher"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
@@ -177,32 +154,24 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aF" = (
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = 32;
+/obj/machinery/vending/wallmed/directional/north{
 	use_power = 0
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aG" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aH" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/button/flasher{
 	id = "shuttle_flasher";
 	pixel_x = -24;
 	pixel_y = -6
 	},
-/obj/machinery/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -24;
-	pixel_y = 6
+/obj/machinery/flasher/directional/west{
+	id = "shuttle_flasher"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
@@ -251,9 +220,7 @@
 /turf/closed/wall/mineral/titanium/interior,
 /area/shuttle/escape)
 "aP" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aQ" = (
@@ -268,10 +235,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "aR" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -5;
-	pixel_y = 30
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aS" = (
@@ -290,12 +254,8 @@
 /turf/open/openspace/airless,
 /area/template_noop)
 "aV" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
+/obj/machinery/light/directional/east,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aW" = (
@@ -323,18 +283,14 @@
 /obj/machinery/shower{
 	pixel_y = 18
 	},
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = 32;
+/obj/machinery/vending/wallmed/directional/north{
 	use_power = 0
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bb" = (
 /obj/machinery/stasis,
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bc" = (
@@ -369,9 +325,7 @@
 	pixel_x = 2;
 	pixel_y = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bd" = (
@@ -381,13 +335,8 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/toxin,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/machinery/light/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "be" = (
@@ -426,9 +375,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/glass/reinforced,
 /area/shuttle/escape)
 "bk" = (
@@ -440,10 +387,33 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
-/obj/machinery/light/small{
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/glass/reinforced,
+/area/shuttle/escape)
+"uu" = (
+/obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/turf/open/floor/glass/reinforced,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/shuttle/escape)
+"Ej" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/shuttle/escape)
+"WP" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/shuttle/escape)
+"WZ" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -520,8 +490,8 @@ ab
 af
 al
 aq
-aq
-av
+Ej
+ak
 ax
 ak
 aC
@@ -529,8 +499,8 @@ aI
 aN
 aO
 aR
-aS
-av
+uu
+ak
 ax
 ak
 aF
@@ -538,8 +508,8 @@ aK
 aK
 aK
 aK
-aE
-av
+WZ
+ak
 ax
 ak
 aY
@@ -656,8 +626,8 @@ ab
 af
 ao
 ar
-ar
-av
+WP
+ak
 aA
 ak
 aF
@@ -665,8 +635,8 @@ aL
 aL
 aL
 aL
-aE
-av
+WZ
+ak
 aA
 ak
 aR
@@ -674,8 +644,8 @@ aL
 aL
 aL
 aL
-aE
-av
+WZ
+ak
 aA
 ak
 ba

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -91,6 +91,10 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
+/obj/machinery/button/flasher{
+	id = "shuttle_flasher";
+	pixel_x = -24
+	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "al" = (
@@ -132,18 +136,11 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "at" = (
-/obj/machinery/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -24;
-	pixel_y = 6
-	},
-/obj/machinery/button/flasher{
-	id = "shuttle_flasher";
-	pixel_x = -24;
-	pixel_y = -6
-	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
+	},
+/obj/machinery/flasher/directional/west{
+	id = "shuttle_flasher"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
@@ -213,9 +210,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes{
 	pixel_x = 3;
@@ -253,9 +248,7 @@
 /area/shuttle/escape)
 "aM" = (
 /obj/machinery/chem_dispenser,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "aN" = (
@@ -454,7 +447,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "bi" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -468,51 +461,32 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "bj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "bk" = (
 /obj/structure/chair/wood,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/cult,
 /area/shuttle/escape)
 "bl" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"bm" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "bn" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bo" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bp" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "ji" = (
@@ -570,7 +544,7 @@ at
 al
 as
 aq
-bm
+bo
 aI
 aI
 aq
@@ -670,7 +644,7 @@ aq
 aq
 aq
 bn
-aH
+ab
 ab
 ab
 ab

--- a/_maps/shuttles/escape_pod_default.dmm
+++ b/_maps/shuttles/escape_pod_default.dmm
@@ -6,9 +6,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/machinery/computer/shuttle/pod{
 	pixel_x = -32
 	},
@@ -31,15 +29,11 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_x = 25
-	},
+/obj/item/radio/intercom/directional/east,
 /obj/item/storage/pod{
 	pixel_x = -26
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "Z" = (

--- a/_maps/shuttles/escape_pod_large.dmm
+++ b/_maps/shuttles/escape_pod_large.dmm
@@ -12,17 +12,14 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "u" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/pod_1)
 "A" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_x = 30
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "B" = (
@@ -30,9 +27,7 @@
 /area/shuttle/pod_1)
 "C" = (
 /obj/machinery/computer/shuttle/monastery_shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "H" = (
@@ -45,9 +40,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "L" = (
@@ -60,9 +53,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "O" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the lights and wallmounts on all emergency shuttles from the medisim to the two escape pods (including wall flashers, extinguisher cabinets, nanomeds, and peppertanks) to directional mounts introduced in #58809
Also changes manual grille/shuttle window placements with spawners where applicable. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When the wallening gets here, will allow us to switch the directions of all of the lights at once (which we'll need) and not have to manually set wall mount dirs. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
