### PR TITLE
Converts ferry, hunter, infiltrator, and labour wall mounts to dir

### DIFF
--- a/_maps/shuttles/ferry_base.dmm
+++ b/_maps/shuttles/ferry_base.dmm
@@ -11,11 +11,6 @@
 "c" = (
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/transport)
-"d" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/transport)
 "e" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
@@ -99,11 +94,11 @@ p
 c
 "}
 (5,1,1) = {"
-d
+e
 j
 l
 q
-d
+e
 "}
 (6,1,1) = {"
 c
@@ -149,8 +144,8 @@ c
 "}
 (12,1,1) = {"
 c
-d
+e
 m
-d
+e
 c
 "}

--- a/_maps/shuttles/ferry_fancy.dmm
+++ b/_maps/shuttles/ferry_fancy.dmm
@@ -31,9 +31,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "h" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
 "i" = (
@@ -49,7 +47,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/transport)
 "k" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
 "l" = (

--- a/_maps/shuttles/ferry_kilo.dmm
+++ b/_maps/shuttles/ferry_kilo.dmm
@@ -40,11 +40,10 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/transport)
 "i" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
+/obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/transport)
 "j" = (
@@ -59,9 +58,7 @@
 	},
 /obj/item/storage/firstaid/regular,
 /obj/item/crowbar,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/transport)
 "l" = (
@@ -90,9 +87,7 @@
 "o" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/transport)
 "p" = (
@@ -193,9 +188,7 @@
 /obj/item/radio{
 	pixel_y = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/transport)
 "w" = (
@@ -210,7 +203,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/transport)
 

--- a/_maps/shuttles/ferry_lighthouse.dmm
+++ b/_maps/shuttles/ferry_lighthouse.dmm
@@ -86,10 +86,6 @@
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/wood,
 /area/shuttle/transport)
-"aw" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/closed/wall/mineral/titanium,
-/area/shuttle/transport)
 "az" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
@@ -121,9 +117,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "aH" = (
-/obj/machinery/newscaster{
-	pixel_y = 30
-	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "aI" = (
@@ -207,10 +201,6 @@
 "aX" = (
 /obj/structure/window/fulltile,
 /turf/open/floor/mineral/titanium/blue,
-/area/shuttle/transport)
-"aY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/closed/wall/mineral/titanium,
 /area/shuttle/transport)
 "ba" = (
 /obj/machinery/conveyor{
@@ -518,7 +508,7 @@ aa
 aa
 aa
 aa
-aw
+az
 aE
 aN
 aE
@@ -536,7 +526,7 @@ aa
 aa
 aa
 aa
-aw
+az
 aE
 aE
 aE
@@ -558,7 +548,7 @@ ad
 ak
 aE
 ak
-aY
+ad
 aa
 aa
 aa
@@ -576,7 +566,7 @@ ad
 aF
 aE
 aT
-aw
+az
 aa
 aa
 aa

--- a/_maps/shuttles/ferry_meat.dmm
+++ b/_maps/shuttles/ferry_meat.dmm
@@ -71,9 +71,7 @@
 /turf/open/floor/iron/freezer,
 /area/shuttle/transport)
 "k" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/freezer,
 /area/shuttle/transport)
 "l" = (
@@ -94,8 +92,7 @@
 /turf/open/floor/iron/freezer,
 /area/shuttle/transport)
 "o" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/transport)
 "p" = (

--- a/_maps/shuttles/hunter_bounty.dmm
+++ b/_maps/shuttles/hunter_bounty.dmm
@@ -36,8 +36,7 @@
 /turf/open/floor/plating,
 /area/shuttle/hunter)
 "i" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/hunter)
 "j" = (

--- a/_maps/shuttles/hunter_russian.dmm
+++ b/_maps/shuttles/hunter_russian.dmm
@@ -65,7 +65,7 @@
 /area/shuttle/hunter)
 "o" = (
 /obj/effect/mob_spawn/human/fugitive/russian{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/hunter)
@@ -221,6 +221,10 @@
 /area/shuttle/hunter)
 "Q" = (
 /obj/item/book/manual/ripley_build_and_repair,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/hunter)
+"V" = (
+/obj/effect/mob_spawn/human/fugitive/russian,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/hunter)
 "Y" = (
@@ -449,7 +453,7 @@ a
 a
 a
 b
-o
+V
 k
 r
 z

--- a/_maps/shuttles/hunter_space_cop.dmm
+++ b/_maps/shuttles/hunter_space_cop.dmm
@@ -38,12 +38,11 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/hunter)
 "ae" = (
-/obj/machinery/button/door{
-	id = "Interpolship";
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/stripes{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/north{
+	id = "Interpolship"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/hunter)
@@ -75,6 +74,7 @@
 /obj/effect/mob_spawn/human/fugitive/spacepol{
 	dir = 1
 	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/hunter)
 "al" = (
@@ -90,23 +90,11 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/hunter)
-"gi" = (
-/obj/structure/table,
-/obj/effect/mob_spawn/human/fugitive/spacepol{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/hunter)
 "hB" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
 	},
 /turf/closed/wall/mineral/titanium,
-/area/shuttle/hunter)
-"hJ" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
 /area/shuttle/hunter)
 "ku" = (
 /turf/closed/wall/mineral/titanium,
@@ -124,6 +112,13 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "Interpolship"
 	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/hunter)
+"Am" = (
+/obj/effect/mob_spawn/human/fugitive/spacepol{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/hunter)
 "An" = (
@@ -190,20 +185,20 @@ ku
 "}
 (6,1,1) = {"
 Pq
-hJ
+An
 ag
 RO
 RO
-hJ
+An
 Pq
 "}
 (7,1,1) = {"
 Pq
-hJ
+An
 ah
 RO
 aj
-hJ
+An
 Pq
 "}
 (8,1,1) = {"
@@ -236,9 +231,9 @@ ku
 (11,1,1) = {"
 Pq
 An
-aa
-gi
+Am
 ab
+aa
 An
 Pq
 "}

--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -31,9 +31,7 @@
 /area/shuttle/syndicate/bridge)
 "ag" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
 	desc = "A bottle of whiskey. There's a label that reads 'tears' taped to the front.";
 	name = "Bottle of Tears";
@@ -60,9 +58,7 @@
 /area/shuttle/syndicate/bridge)
 "ai" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/storage/toolbox/syndicate,
 /obj/item/assembly/voice,
 /obj/item/crowbar/red,
@@ -84,9 +80,7 @@
 /area/shuttle/syndicate/bridge)
 "al" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/stack/cable_coil,
 /obj/item/crowbar/red,
 /obj/item/radio/headset/syndicate/alt,
@@ -180,10 +174,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/bridge)
 "au" = (
@@ -297,9 +288,7 @@
 	name = "tactical chair"
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -312,9 +301,7 @@
 "aG" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/paper_bin{
 	pixel_x = -4;
 	pixel_y = 4
@@ -324,9 +311,7 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/hallway)
 "aH" = (
@@ -337,9 +322,7 @@
 	name = "tactical chair"
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/airlock)
 "aJ" = (
@@ -382,9 +365,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/airlock)
 "aO" = (
@@ -398,8 +379,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/airlock)
 "aQ" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/eva)
 "aR" = (
@@ -413,9 +393,7 @@
 "aS" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/storage/fancy/cigarettes/cigpack_syndicate{
 	pixel_x = 8
 	},
@@ -543,9 +521,7 @@
 	pixel_x = 6
 	},
 /obj/item/stack/medical/ointment,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
@@ -622,9 +598,7 @@
 	},
 /obj/item/reagent_containers/glass/bottle/multiver,
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
@@ -663,15 +637,14 @@
 	id = "infiltrator_portblast";
 	name = "Infiltrator Port Hatch"
 	},
-/obj/machinery/button/door{
-	id = "infiltrator_portblast";
-	name = "Infiltrator Port Hatch Control";
-	pixel_y = 26;
-	req_access_txt = "150"
-	},
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/north{
+	id = "infiltrator_portblast";
+	name = "Infiltrator Port Hatch Control";
+	req_access_txt = "150"
+	},
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/airlock)
 "bq" = (
@@ -680,10 +653,9 @@
 	id = "infiltrator_medbay";
 	name = "Infiltrator Medical Bay"
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "infiltrator_medbay";
 	name = "Infiltrator Medical Bay Toggle";
-	pixel_x = 24;
 	req_access_txt = "150"
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -714,9 +686,7 @@
 	name = "tactical chair"
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/airlock)
 "bv" = (
@@ -882,8 +852,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
 "bQ" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/hallway)
 "bR" = (
@@ -936,10 +905,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Syndicate Radio Intercom";
-	pixel_y = 22
+/obj/item/radio/intercom/directional/north{
+	freerange = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/airlock)
@@ -1129,9 +1096,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/red,
@@ -1140,10 +1105,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
+/obj/machinery/firealarm/directional/east,
 /obj/item/clothing/suit/space/syndicate,
 /obj/item/tank/internals/oxygen/yellow,
 /obj/item/clothing/mask/gas{
@@ -1191,10 +1153,9 @@
 	id = "infiltrator_armorybay";
 	name = "Infiltrator Armoy Bay"
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "infiltrator_armorybay";
 	name = "Infiltrator Armory Bay Toggle";
-	pixel_x = -24;
 	req_access_txt = "150"
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -1355,10 +1316,7 @@
 "cU" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
+/obj/machinery/firealarm/directional/west,
 /obj/item/clothing/suit/space/syndicate/black/red,
 /obj/item/tank/internals/oxygen/yellow,
 /obj/item/clothing/mask/gas{
@@ -1393,10 +1351,9 @@
 	},
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/box,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/north{
 	id = "infiltrator_starboardblast";
 	name = "Infiltrator Starboard Hatch Control";
-	pixel_y = 26;
 	req_access_txt = "150"
 	},
 /turf/open/floor/pod/dark,
@@ -1454,7 +1411,7 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/airlock)
 "dd" = (
@@ -1579,9 +1536,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/airlock)
@@ -1610,7 +1565,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/airlock)
 "dr" = (
@@ -1680,10 +1635,8 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Syndicate Radio Intercom";
-	pixel_y = 22
+/obj/item/radio/intercom/directional/north{
+	freerange = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/airlock)
@@ -1707,9 +1660,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
@@ -1751,9 +1702,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/hallway)
 "dD" = (
-/obj/structure/mirror{
-	pixel_x = -28
-	},
+/obj/structure/mirror/directional/west,
 /obj/machinery/shower{
 	dir = 4;
 	name = "emergency shower"
@@ -1783,7 +1732,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
@@ -1829,13 +1778,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/box/corners,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/eva)
 "dK" = (
@@ -1848,9 +1792,7 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/hallway)
@@ -2004,9 +1946,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
@@ -2021,7 +1961,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/armory)
 "eb" = (
@@ -2072,7 +2012,7 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /turf/open/floor/circuit/red,
 /area/shuttle/syndicate/hallway)
@@ -2127,12 +2067,8 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
+/obj/machinery/light/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/eva)
@@ -2199,18 +2135,14 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
 	},
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/armory)
 "ep" = (
-/obj/structure/mirror{
-	pixel_y = 28
-	},
+/obj/structure/mirror/directional/north,
 /obj/structure/sink{
 	pixel_y = 24
 	},
@@ -2230,13 +2162,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
+/obj/machinery/light/directional/east,
+/obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/medical)
@@ -2244,13 +2171,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/armory)
 "et" = (
@@ -2268,10 +2190,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/armory)
 "ev" = (

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -69,9 +69,7 @@
 	pixel_x = -32
 	},
 /obj/item/clipboard,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/folder/red,
 /obj/item/toy/figure/syndie,
 /obj/effect/turf_decal/tile/neutral{
@@ -123,9 +121,7 @@
 	pixel_x = 32
 	},
 /obj/item/storage/fancy/donut_box,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -281,9 +277,7 @@
 	dir = 4;
 	name = "tactical chair"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -301,9 +295,7 @@
 	dir = 8;
 	name = "tactical chair"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -397,15 +389,12 @@
 /area/shuttle/syndicate/airlock)
 "aU" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/shuttle/syndicate/eva)
 "aV" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/hallway)
 "aW" = (
@@ -431,21 +420,13 @@
 	name = "tactical chair"
 	},
 /obj/effect/turf_decal/bot_white,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/shuttle/syndicate/airlock)
 "aY" = (
 /obj/machinery/door/poddoor{
 	id = "smindicate";
 	name = "outer blast door"
-	},
-/obj/machinery/button/door{
-	id = "smindicate";
-	name = "external door control";
-	pixel_y = 26;
-	req_access_txt = "150"
 	},
 /obj/docking_port/mobile{
 	dheight = 1;
@@ -462,6 +443,11 @@
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "smindicate";
+	name = "external door control";
+	req_access_txt = "150"
 	},
 /turf/open/floor/plating,
 /area/shuttle/syndicate/airlock)
@@ -516,13 +502,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/eva)
 "bg" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/eva)
 "bh" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/airlock)
 "bi" = (
@@ -569,9 +553,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/syndicate/medical)
 "bs" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/syndicate/medical)
 "bt" = (
@@ -618,13 +600,11 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/syndicate/medical)
 "bv" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/medical)
 "bw" = (
-/obj/structure/grille,
-/obj/structure/window/plasma/reinforced/plastitanium,
+/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/shuttle/syndicate/armory)
 "bx" = (
@@ -650,9 +630,7 @@
 /obj/item/wrench,
 /obj/item/assembly/infra,
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/syndicate/armory)
 "bA" = (
@@ -691,9 +669,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/syndicate/medical)
 "bE" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -707,9 +683,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/syndicate/hallway)
 "bF" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -994,9 +968,7 @@
 /obj/item/surgicaldrill,
 /obj/item/circular_saw,
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1014,9 +986,7 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/structure/mirror{
-	pixel_x = 30
-	},
+/obj/structure/mirror/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1034,9 +1004,7 @@
 /turf/open/floor/plating,
 /area/shuttle/syndicate/hallway)
 "cn" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -10,9 +10,7 @@
 /obj/machinery/computer/shuttle/labor{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -31
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "d" = (
@@ -37,7 +35,7 @@
 	pixel_y = -26;
 	req_access_txt = "1"
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "h" = (
@@ -73,9 +71,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 "m" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 "n" = (
@@ -89,9 +85,8 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/flasher{
-	id = "gulagshuttleflasher";
-	pixel_x = 25
+/obj/machinery/flasher/directional/east{
+	id = "gulagshuttleflasher"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)

--- a/_maps/shuttles/labour_delta.dmm
+++ b/_maps/shuttles/labour_delta.dmm
@@ -10,9 +10,7 @@
 /obj/machinery/computer/shuttle/labor{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -31
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "d" = (
@@ -28,9 +26,8 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "f" = (
-/obj/structure/grille,
 /obj/structure/cable,
-/obj/structure/window/shuttle,
+/obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/labor)
 "g" = (
@@ -43,7 +40,7 @@
 	pixel_y = -26;
 	req_access_txt = "1"
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "i" = (
@@ -97,9 +94,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/shuttle/labor)
 "p" = (
@@ -130,9 +125,8 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/obj/machinery/flasher{
-	id = "gulagshuttleflasher";
-	pixel_x = 25
+/obj/machinery/flasher/directional/east{
+	id = "gulagshuttleflasher"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6

--- a/_maps/shuttles/labour_kilo.dmm
+++ b/_maps/shuttles/labour_kilo.dmm
@@ -10,9 +10,7 @@
 /obj/machinery/computer/shuttle/labor{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -31
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
@@ -46,7 +44,7 @@
 	pixel_y = -26;
 	req_access_txt = "1"
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -124,9 +122,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "m" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -172,9 +168,8 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "q" = (
-/obj/machinery/flasher{
-	id = "gulagshuttleflasher";
-	pixel_x = 25
+/obj/machinery/flasher/directional/east{
+	id = "gulagshuttleflasher"
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the lights and wallmounts on all ferries, hunter ships, nukie infiltrators, and labour camp shuttles to directional mounts introduced in #58809
Also changes manual grille/shuttle window placements with spawners where applicable. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When the wallening gets here, will allow us to switch the directions of all of the lights at once (which we'll need) and not have to manually set wall mount dirs. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
