### PR TITLE
Converts misc map wall mounts to dir

### DIFF
--- a/_maps/map_files/CTF/downtown.dmm
+++ b/_maps/map_files/CTF/downtown.dmm
@@ -1474,10 +1474,9 @@
 /turf/open/floor/iron,
 /area/ctf)
 "BW" = (
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/north{
 	id = "flag1";
 	name = "Flag Shutters";
-	pixel_y = 28;
 	resistance_flags = 64
 	},
 /obj/effect/turf_decal/tile/red{
@@ -1643,10 +1642,9 @@
 /turf/open/floor/iron,
 /area/ctf)
 "EB" = (
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/south{
 	id = "flag1";
 	name = "Flag Shutters";
-	pixel_y = -28;
 	resistance_flags = 64
 	},
 /obj/effect/turf_decal/tile/red,
@@ -1817,17 +1815,16 @@
 /turf/open/floor/iron,
 /area/ctf)
 "Il" = (
-/obj/machinery/button/door{
-	id = "flag2";
-	name = "Flag Shutters";
-	pixel_y = 28;
-	resistance_flags = 64
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "flag2";
+	name = "Flag Shutters";
+	resistance_flags = 64
 	},
 /turf/open/floor/iron,
 /area/ctf)
@@ -2669,10 +2666,9 @@
 /turf/open/floor/iron/dark,
 /area/ctf)
 "YL" = (
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/south{
 	id = "flag2";
 	name = "Flag Shutters";
-	pixel_y = -28;
 	resistance_flags = 64
 	},
 /obj/effect/turf_decal/tile/blue{

--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -125,9 +125,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "aG" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -205,9 +203,7 @@
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "aY" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "aZ" = (
@@ -278,7 +274,7 @@
 	dir = 8;
 	pixel_x = -25
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/table,
 /obj/item/analyzer,
 /obj/item/wrench,
@@ -310,7 +306,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "bo" = (
@@ -321,7 +317,7 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "bp" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/storage/box/lights/mixed,
 /obj/item/lightreplacer,
 /turf/open/floor/plating,
@@ -365,9 +361,7 @@
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
 "bz" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "bA" = (
@@ -485,9 +479,7 @@
 	},
 /area/hallway/secondary/entry)
 "bV" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron{
 	dir = 1
@@ -534,29 +526,25 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "co" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cp" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron{
 	dir = 10
 	},
 /area/command/bridge)
 "cr" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron{
 	dir = 6
 	},
 /area/command/bridge)
 "ct" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cv" = (
@@ -585,9 +573,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cB" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -616,9 +602,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron{
 	dir = 1
@@ -661,7 +645,7 @@
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/rods/fifty,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "cL" = (
@@ -758,9 +742,7 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "de" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "dk" = (
@@ -773,9 +755,7 @@
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "dm" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -785,24 +765,18 @@
 /turf/open/floor/plating,
 /area/construction)
 "do" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/construction)
 "dp" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "dx" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "dy" = (
@@ -892,7 +866,7 @@
 /area/commons/storage/primary)
 "dO" = (
 /obj/structure/table,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/fireaxe,
 /obj/item/extinguisher,
 /turf/open/floor/iron,
@@ -906,7 +880,7 @@
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/tubes,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "dR" = (
@@ -960,9 +934,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "em" = (
@@ -995,9 +967,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "ez" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron{
 	dir = 8
 	},
@@ -1013,9 +983,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "eE" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "eF" = (
@@ -1023,9 +991,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "eH" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
 	},
@@ -1053,13 +1019,11 @@
 /obj/effect/turf_decal/stripes/asteroid/corner{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "eN" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "eO" = (
@@ -1092,9 +1056,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "fo" = (
@@ -1220,15 +1182,11 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "lm" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
@@ -1265,9 +1223,7 @@
 /turf/open/openspace,
 /area/space/nearstation)
 "nz" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "nF" = (
@@ -1292,18 +1248,14 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "on" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "oA" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "oJ" = (
@@ -1311,9 +1263,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "pi" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/openspace,
 /area/hallway/secondary/service)
 "qo" = (
@@ -1335,9 +1285,7 @@
 /turf/open/floor/plating,
 /area/engineering/storage)
 "rd" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/openspace,
 /area/engineering/storage)
 "rN" = (
@@ -1398,9 +1346,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "vF" = (
@@ -1434,7 +1380,7 @@
 /turf/open/floor/plating,
 /area/engineering/storage)
 "xI" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "xK" = (
@@ -1503,9 +1449,7 @@
 /turf/closed/wall/r_wall,
 /area/engineering/storage)
 "AI" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -1522,9 +1466,7 @@
 /turf/open/openspace,
 /area/space/nearstation)
 "Bm" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -1556,15 +1498,11 @@
 /turf/open/floor/plating,
 /area/construction)
 "Dm" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "DG" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/engineering/storage)
 "DK" = (
@@ -1673,7 +1611,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "KM" = (
@@ -1700,7 +1638,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "ME" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "Ob" = (
@@ -1725,9 +1663,7 @@
 /turf/open/floor/plating,
 /area/engineering/storage)
 "Pz" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating,
 /area/engineering/storage)
 "Qo" = (
@@ -1805,9 +1741,7 @@
 /turf/open/floor/plating,
 /area/construction)
 "WN" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "XN" = (

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -152,9 +152,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "aG" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -163,9 +161,7 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "aH" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/main)
 "aI" = (
@@ -263,9 +259,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "aY" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "ba" = (
@@ -291,10 +285,7 @@
 /obj/item/weldingtool/experimental,
 /obj/item/inducer,
 /obj/item/storage/belt/utility/chief/full,
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -311,11 +302,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Gravity Generator APC";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
@@ -365,7 +352,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "bp" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -373,7 +360,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/telecomms/allinone{
 	network = "tcommsat"
 	},
@@ -445,10 +432,7 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -528,10 +512,7 @@
 /area/medical/chemistry)
 "bR" = (
 /obj/machinery/camera/autoname,
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
 /obj/machinery/chem_heater/debug,
 /turf/open/floor/iron/dark,
@@ -551,10 +532,7 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -568,9 +546,7 @@
 	},
 /area/medical/medbay)
 "bV" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -670,14 +646,12 @@
 /turf/open/floor/iron,
 /area/medical/medbay)
 "co" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/ore_silo,
 /turf/open/floor/iron,
 /area/science)
 "cp" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/closet/secure_closet/engineering_chief{
 	locked = 0
 	},
@@ -699,7 +673,7 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "cr" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/closet/secure_closet/hos{
 	locked = 0
 	},
@@ -713,9 +687,7 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "ct" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/medical/chemistry)
 "cu" = (
@@ -755,9 +727,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -824,10 +794,7 @@
 	},
 /area/medical/medbay)
 "cI" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -841,7 +808,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/medical/medbay)
 "cK" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -888,10 +855,7 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -932,10 +896,7 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -959,9 +920,7 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "dj" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "dk" = (
@@ -976,9 +935,7 @@
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "dm" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -988,18 +945,14 @@
 /turf/open/floor/plating,
 /area/construction)
 "do" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/construction)
 "dp" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "dq" = (
@@ -1045,9 +998,7 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "dx" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "dy" = (
@@ -1134,7 +1085,7 @@
 /area/commons/storage/primary)
 "dO" = (
 /obj/structure/table,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/storage/firstaid/regular,
 /obj/item/healthanalyzer/advanced,
 /turf/open/floor/iron,
@@ -1147,13 +1098,11 @@
 /area/hallway/secondary/entry)
 "dQ" = (
 /obj/structure/table,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "dR" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/brig)
 "dS" = (
@@ -1193,9 +1142,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/construction)
 "dY" = (
@@ -1265,9 +1212,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ej" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ek" = (
@@ -1370,15 +1315,13 @@
 /turf/open/space/basic,
 /area/space)
 "eF" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "eG" = (
 /obj/machinery/airalarm/unlocked{
+	dir = 4;
 	pixel_x = -32
 	},
 /turf/open/floor/iron,
@@ -1407,7 +1350,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "eM" = (
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/airalarm/unlocked{
+	dir = 8;
+	pixel_x = 23
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "eN" = (
@@ -1418,10 +1364,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "eP" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -1476,9 +1419,7 @@
 /turf/open/floor/iron,
 /area/medical/medbay)
 "eV" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "eW" = (
@@ -1535,24 +1476,22 @@
 /turf/closed/wall/r_wall,
 /area/construction)
 "fe" = (
-/obj/machinery/button/door{
-	id = "cargounload";
-	layer = 4;
-	name = "Loading Doors";
-	pixel_x = 24;
-	pixel_y = 8
-	},
-/obj/machinery/button/door{
-	id = "cargoload";
-	layer = 4;
-	name = "Loading Doors";
-	pixel_x = 24;
-	pixel_y = -8
-	},
 /obj/machinery/computer/cargo{
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/button/door/directional/east{
+	id = "cargounload";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_y = 8
+	},
+/obj/machinery/button/door/directional/east{
+	id = "cargoload";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_y = -8
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ff" = (
@@ -1630,9 +1569,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fr" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/computer/cargo/express{
 	dir = 4
 	},
@@ -1670,9 +1607,7 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "fy" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/plaque{
 	icon_state = "L3"
 	},
@@ -1717,9 +1652,7 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "fD" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/plaque{
 	icon_state = "L11"
@@ -1796,12 +1729,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "fP" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/keycard_auth{
-	pixel_y = 28
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/keycard_auth/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "fQ" = (
@@ -1818,10 +1747,7 @@
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "fS" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -1866,9 +1792,7 @@
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "fY" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -1923,11 +1847,9 @@
 /turf/open/floor/plating,
 /area/commons/storage/primary)
 "gi" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/machinery/airalarm/unlocked{
+	dir = 8;
 	pixel_x = 32
 	},
 /obj/structure/cable,
@@ -1986,47 +1908,41 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "gv" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "gw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "gx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "gy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/construction)
 "gz" = (
 /obj/structure/table,
 /obj/item/card/id/advanced/gold/captains_spare,
-/obj/machinery/keycard_auth{
-	pixel_y = 28
-	},
+/obj/machinery/keycard_auth/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "gA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -2034,18 +1950,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "gC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "gD" = (
@@ -2072,9 +1984,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/construction)
 "gH" = (
@@ -2086,9 +1996,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "gI" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera/autoname,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -2115,9 +2023,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/construction)
 "jb" = (
@@ -2142,9 +2048,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "kn" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "kp" = (
@@ -2157,10 +2061,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -2291,9 +2192,7 @@
 /turf/open/floor/engine,
 /area/hallway/secondary/entry)
 "un" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -2303,9 +2202,7 @@
 /obj/structure/closet/secure_closet/atmospherics{
 	locked = 0
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "uO" = (
@@ -2315,9 +2212,7 @@
 /area/commons/storage/primary)
 "uQ" = (
 /obj/machinery/nanite_programmer,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "vm" = (
@@ -2346,9 +2241,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -2425,7 +2318,7 @@
 /turf/open/floor/iron,
 /area/science)
 "CQ" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -2443,9 +2336,7 @@
 /turf/open/floor/iron,
 /area/medical/chemistry)
 "Df" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /mob/living/carbon/human,
 /turf/open/floor/iron/dark,
 /area/science/nanite)
@@ -2464,18 +2355,14 @@
 /turf/open/floor/iron,
 /area/construction)
 "EB" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 27
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/medical/medbay)
 "EG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = 20
-	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/construction)
 "EI" = (
@@ -2548,7 +2435,7 @@
 /obj/structure/table,
 /obj/item/analyzer,
 /obj/item/wrench,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "Ly" = (
@@ -2649,9 +2536,7 @@
 /turf/open/floor/iron/white/corner,
 /area/medical/medbay)
 "Td" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -2677,7 +2562,7 @@
 /turf/open/floor/iron,
 /area/medical/medbay)
 "Vg" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -2728,9 +2613,7 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "Xg" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/vending/syndichem{
 	onstation = 0;
 	req_access = null
@@ -2738,7 +2621,7 @@
 /turf/open/floor/iron,
 /area/medical/chemistry)
 "Xp" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/tank_dispenser{
 	pixel_x = -1
 	},
@@ -2768,9 +2651,7 @@
 /area/engineering/atmos)
 "XU" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "XZ" = (
@@ -2783,9 +2664,7 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "Yy" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/rnd/production/circuit_imprinter/department,
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,

--- a/_maps/templates/hilbertshotel.dmm
+++ b/_maps/templates/hilbertshotel.dmm
@@ -21,9 +21,7 @@
 "f" = (
 /obj/structure/table/wood,
 /obj/structure/showcase/machinery/tv,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "g" = (
@@ -36,12 +34,7 @@
 /area/hilbertshotel)
 "i" = (
 /obj/structure/table/wood/fancy,
-/obj/structure/mirror{
-	pixel_y = 24
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/structure/mirror/directional/north,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "j" = (
@@ -53,9 +46,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "l" = (
@@ -66,9 +57,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "n" = (
@@ -102,9 +91,7 @@
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "t" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "u" = (
@@ -112,9 +99,7 @@
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "v" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "w" = (
@@ -133,9 +118,7 @@
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "A" = (
-/obj/structure/mirror{
-	pixel_x = -32
-	},
+/obj/structure/mirror/directional/west,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12;
@@ -154,9 +137,7 @@
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "D" = (
-/obj/machinery/light_switch{
-	pixel_x = 32
-	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "E" = (
@@ -174,9 +155,7 @@
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "G" = (
-/obj/machinery/light_switch{
-	pixel_x = -32
-	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "H" = (
@@ -188,46 +167,36 @@
 /turf/closed/indestructible/hoteldoor,
 /area/hilbertshotel)
 "J" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "K" = (
 /obj/structure/closet/crate/bin,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "L" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "M" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "N" = (
 /obj/structure/table/reinforced,
 /obj/item/soap/deluxe,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "O" = (
 /obj/item/bikehorn/rubberducky,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "P" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "Q" = (
@@ -264,12 +233,17 @@
 /obj/structure/sink/kitchen{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "V" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/three_course_meal,
+/turf/open/indestructible/hotelwood,
+/area/hilbertshotel)
+"Z" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/light/small/directional/north,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 
@@ -463,7 +437,7 @@ a
 (12,1,1) = {"
 a
 b
-h
+Z
 d
 d
 d

--- a/_maps/templates/hilbertshotellore.dmm
+++ b/_maps/templates/hilbertshotellore.dmm
@@ -7,14 +7,9 @@
 /area/hilbertshotel)
 "ac" = (
 /obj/structure/table/wood/fancy,
-/obj/structure/mirror{
+/obj/structure/mirror/directional/north{
 	broken = 1;
-	desc = "Oh no, seven years of bad luck!";
-	icon_state = "mirror_broke";
-	pixel_y = 24
-	},
-/obj/machinery/light/small{
-	dir = 1
+	icon_state = "mirror_broke"
 	},
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
@@ -28,9 +23,7 @@
 "af" = (
 /obj/structure/table/wood,
 /obj/structure/showcase/machinery/tv,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "ag" = (
@@ -55,9 +48,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "al" = (
@@ -68,15 +59,11 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "an" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "ap" = (
@@ -102,13 +89,11 @@
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "au" = (
-/obj/machinery/light_switch{
-	pixel_x = -32
-	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "av" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "aw" = (
@@ -124,9 +109,7 @@
 /area/hilbertshotel)
 "ay" = (
 /obj/structure/closet/crate/bin,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "az" = (
@@ -138,18 +121,14 @@
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "aB" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "aC" = (
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "aD" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "aE" = (
@@ -170,9 +149,7 @@
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "aI" = (
-/obj/structure/mirror{
-	pixel_x = -32
-	},
+/obj/structure/mirror/directional/west,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12;
@@ -224,9 +201,7 @@
 /area/hilbertshotel)
 "aP" = (
 /obj/item/bikehorn/rubberducky,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "aQ" = (
@@ -250,7 +225,7 @@
 /obj/structure/sink/kitchen{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "aU" = (
@@ -260,7 +235,7 @@
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "aV" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "aW" = (
@@ -270,10 +245,8 @@
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "aX" = (
-/obj/machinery/light_switch{
-	pixel_x = 32
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch/directional/east,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "aY" = (
@@ -293,9 +266,7 @@
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "bb" = (
-/obj/structure/mirror{
-	pixel_x = -32
-	},
+/obj/structure/mirror/directional/west,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12;
@@ -316,9 +287,7 @@
 /turf/open/indestructible/hoteltile,
 /area/hilbertshotel)
 "be" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
@@ -329,17 +298,13 @@
 /area/hilbertshotel)
 "bg" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 "bh" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/item/soap/homemade{
 	name = "used soap"
 	},
@@ -364,6 +329,11 @@
 "bl" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/crumpled/bloody/docsdeathnote,
+/turf/open/indestructible/hotelwood,
+/area/hilbertshotel)
+"Mn" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/light/small/directional/north,
 /turf/open/indestructible/hotelwood,
 /area/hilbertshotel)
 
@@ -557,7 +527,7 @@ aa
 (12,1,1) = {"
 aa
 ab
-ah
+Mn
 ad
 aL
 ad

--- a/_maps/templates/shelter_2.dmm
+++ b/_maps/templates/shelter_2.dmm
@@ -103,10 +103,7 @@
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "s" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#DDFFD3"
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	pixel_x = 7;
@@ -173,7 +170,7 @@
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "z" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "A" = (

--- a/_maps/templates/shelter_3.dmm
+++ b/_maps/templates/shelter_3.dmm
@@ -76,9 +76,7 @@
 	req_one_access = 0;
 	req_one_access_txt = "25;48"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/pod/dark,
 /area/survivalpod)
 "n" = (
@@ -213,9 +211,7 @@
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "G" = (
-/obj/structure/urinal{
-	pixel_y = 24
-	},
+/obj/structure/urinal/directional/north,
 /turf/open/floor/pod/light,
 /area/survivalpod)
 "H" = (
@@ -226,9 +222,7 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/pod/light,
 /area/survivalpod)
 "J" = (
@@ -248,16 +242,14 @@
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "M" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "N" = (
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/pod/light,
 /area/survivalpod)
 "O" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the lights and wall mounts for all of the debug maps (multi-z and runtime), a couple of templates (survival pods and hotel rooms), and one CTF map to directional mounts introduced in #58809
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When the wallening gets here, will allow us to switch the directions of all of the lights at once (which we'll need) and not have to manually set wall mount dirs. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
