### PR TITLE
botany research tweak

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -548,7 +548,7 @@
 	display_name = "Botanical Engineering"
 	description = "Botanical tools"
 	prereq_ids = list("adv_engi", "biotech")
-	design_ids = list("portaseeder", "flora_gun", "hydro_tray", "biogenerator", "seed_extractor")
+	design_ids = list("portaseeder", "gene_shears", "hydro_tray", "biogenerator", "seed_extractor")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
 	discount_experiments = list(/datum/experiment/scanning/random/plants/wild = 3000)
 
@@ -556,7 +556,7 @@
 	id = "exp_tools"
 	display_name = "Experimental Tools"
 	description = "Highly advanced tools."
-	design_ids = list("exwelder", "jawsoflife", "handdrill", "laserscalpel", "mechanicalpinches", "searingtool", "gene_shears")
+	design_ids = list("exwelder", "jawsoflife", "handdrill", "laserscalpel", "mechanicalpinches", "searingtool", "flora_gun")
 	prereq_ids = list("adv_engi")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	discount_experiments = list(/datum/experiment/scanning/random/material/hard/one = 5000)


### PR DESCRIPTION
## About The Pull Request

This pull request alters the research nodes of "Botanical Engineering" and "Experimental Tools" by swapping the Floral Somatoray and the Botanogenetic Shears.

## Why It's Good For The Game

The "Botanical Engineering" tech node contains items that have unique/core use to botany.  The "Experimental Tools" tech node primarily contains items that provide quality of life benefits in the form of various tools that consolidate functionality.

The Floral Somatoray(currently in Botanical Engineering) is a wonderful quality of life tool, but does not have any unique functionality.  Anything it can do can also be accomplished with fertilizer, time, autogrow mode, or a combination thereof.

The Botanogenetic Shears completely remove traits from a plant.  This isn't a quality of life function, but a unique ability without which many complex botanical projects are not feasible.

Since these items seem to be mismatched for the nodes within which they are contained, swapping them would keep the themes for the nodes more consistent.

## Changelog
:cl:
balance: swaps positions of floral somatoray and botanogenetic shears in the techweb
/:cl:
