### PR TITLE
Stop singularities from consuming themselves

### DIFF
--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -130,6 +130,10 @@
 	return COMPONENT_CANCEL_BLOB_ACT
 
 /datum/component/singularity/proc/consume(datum/source, atom/thing)
+	if (thing == source)
+		stack_trace("Singularity tried to consume itself.")
+		return
+
 	consume_callback?.Invoke(thing, src)
 
 /datum/component/singularity/proc/consume_attack(datum/source, mob/user)

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -130,8 +130,7 @@
 	return COMPONENT_CANCEL_BLOB_ACT
 
 /datum/component/singularity/proc/consume(datum/source, atom/thing)
-	if (thing == source)
-		stack_trace("Singularity tried to consume itself.")
+	if (thing == parent)
 		return
 
 	consume_callback?.Invoke(thing, src)

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -131,6 +131,7 @@
 
 /datum/component/singularity/proc/consume(datum/source, atom/thing)
 	if (thing == parent)
+		stack_trace("Singularity tried to consume itself.")
 		return
 
 	consume_callback?.Invoke(thing, src)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -410,6 +410,7 @@
 /obj/singularity/singularity_act()
 	var/gain = (energy/2)
 	var/dist = max((current_size - 2),1)
+	investigate_log("has been destroyed by another singularity.", INVESTIGATE_SINGULO)
 	explosion(src, devastation_range = (dist), heavy_impact_range = (dist*2), light_impact_range = (dist*4))
 	qdel(src)
 	return gain


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Singularities seem to be consuming themselves. My evidence for this is the fact that in a video I saw of it happening there was an explosion, and SM explosions are skipped, while the singularity explodes in `singularity_act`. Additionally, `singularity_act` is the one place where deletion wasn't logged (this has been addended).

~~However, I  have no idea *why*. None of the `consume` calls should be doing this. Thus, I added a `stack_trace` to help us isolate it.~~

Okay, we know why now. `COMSIG_ATOM_ENTERED` is being called on the singularity itself, making it consume itself.

## Changelog
:cl:
fix: Singularities can no longer consume themselves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
