### PR TITLE
Fix proximity checkers not being destroyed

### DIFF
--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -118,7 +118,8 @@
 	return
 
 /obj/effect/abstract/proximity_checker/Destroy()
-	monitor.checkers -= src
+	if (monitor.checkers)
+		monitor.checkers -= src
 	monitor = null
 	return ..()
 

--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -118,8 +118,7 @@
 	return
 
 /obj/effect/abstract/proximity_checker/Destroy()
-	if (monitor.checkers)
-		monitor.checkers -= src
+	LAZYREMOVE(monitor.checkers, src)
 	monitor = null
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
`monitor.checkers` is a lazy list, this was runtiming.

lol bee code

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![vlc_2021-05-09T01-38-09](https://user-images.githubusercontent.com/35135081/117565934-bd109500-b068-11eb-9248-b852107fe7b4.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Proximity checkers, used in the peacekeeper borg module, will now properly destroy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
