### PR TITLE
Fix blazing oil not being damaged by sprayed water

### DIFF
--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -3,7 +3,7 @@
 /obj/effect/particle_effect/water
 	name = "water"
 	icon_state = "extinguish"
-	pass_flags = PASSTABLE | PASSMACHINE | PASSSTRUCTURE | PASSGRILLE
+	pass_flags = PASSTABLE | PASSMACHINE | PASSSTRUCTURE | PASSGRILLE | PASSBLOB
 	var/life = 15
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 

--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -15,7 +15,7 @@
 	fire_based = TRUE
 
 /datum/blobstrain/reagent/blazing_oil/extinguish_reaction(obj/structure/blob/B)
-	B.take_damage(1.5, BURN, ENERGY)
+	B.take_damage(4.5, BURN, ENERGY)
 
 /datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_type == BURN && damage_flag != ENERGY)


### PR DESCRIPTION
:cl: coiax
fix: Blazing Oil blobs can now be damaged by sprayed water from fire
extinguishers, as intended.
/:cl:

Because the mechanism of how the water damages the blob has changed, the
extinguish damage has been increased, otherwise you had to empty a fire
extinguisher to kill even one single blob tile.

---

Fixes #58878