### PR TITLE
Gives skeletons NOTRANSSTING trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -5,7 +5,12 @@
 	say_mod = "rattles"
 	sexes = 0
 	meat = /obj/item/food/meat/slab/human/mutant/skeleton
-	species_traits = list(NOBLOOD, HAS_BONE, NOEYESPRITES)
+	species_traits = list(
+		NOBLOOD,
+		HAS_BONE,
+		NOTRANSSTING,
+		NOEYESPRITES,
+	)
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_CAN_STRIP,

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -5,12 +5,7 @@
 	say_mod = "rattles"
 	sexes = 0
 	meat = /obj/item/food/meat/slab/human/mutant/skeleton
-	species_traits = list(
-		NOBLOOD,
-		HAS_BONE,
-		NOTRANSSTING,
-		NOEYESPRITES,
-	)
+	species_traits = list(NOBLOOD, HAS_BONE, NOTRANSSTING, NOEYESPRITES)
 	inherent_traits = list(
 		TRAIT_ADVANCEDTOOLUSER,
 		TRAIT_CAN_STRIP,


### PR DESCRIPTION
## About The Pull Request

NOTRANSSTING is the trait that prevents changelings from transformation stinging people from/into a certain race. Plasmamen, monkeys, synths, nightmares and zombies all have this trait, but skeletons don't.

## Why It's Good For The Game

Consistency, doesn't make sense you can't transformation sting an undead Zombie or a plasmaman, but an undead skeleton works fine.

## Changelog
:cl:
fix: You can no longer transformation sting people into Skeletons.
/:cl:
