### PR TITLE
CONTRIBUTING.md now has isnull checks on the iconstate2appearance example

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -568,9 +568,13 @@ Bad:
 Good:
 ```dm
 /obj/machine/update_overlays(var/blah)
-	var/static/on_overlay = iconstate2appearance(icon, "on")
-	var/static/off_overlay = iconstate2appearance(icon, "off")
-	var/static/broken_overlay = icon2appearance(broken_icon)
+	var/static/on_overlay
+	var/static/off_overlay
+	var/static/broken_overlay
+	if(isnull(on_overlay)) //static vars initialize with global variables, meaning src is null and this won't pass integration tests unless you check.
+		on_overlay = iconstate2appearance(icon, "on")
+		off_overlay = iconstate2appearance(icon, "off")
+		broken_overlay = icon2appearance(broken_icon)
 	if (stat & broken)
 		add_overlay(broken_overlay) 
 		return
@@ -591,7 +595,9 @@ Associated lists that could instead be variables or statically defined number in
 Bad:
 ```dm
 /obj/machine/update_overlays(var/blah)
-	var/static/our_overlays = list("on" = iconstate2appearance(overlay_icon, "on"), "off" = iconstate2appearance(overlay_icon, "off"), "broken" = iconstate2appearance(overlay_icon, "broken"))
+	var/static/our_overlays
+	if(isnull(our_overlays)
+		our_overlays = list("on" = iconstate2appearance(overlay_icon, "on"), "off" = iconstate2appearance(overlay_icon, "off"), "broken" = iconstate2appearance(overlay_icon, "broken"))
 	if (stat & broken)
 		add_overlay(our_overlays["broken"]) 
 		return
@@ -603,8 +609,10 @@ Good:
 #define OUR_ON_OVERLAY 1
 #define OUR_OFF_OVERLAY 2
 #define OUR_BROKEN_OVERLAY 3
-/obj/machine/update_overlays(var/blah)
-	var/static/our_overlays = list(iconstate2appearance(overlay_icon, "on"), iconstate2appearance(overlay_icon, "off"), iconstate2appearance(overlay_icon, "broken"))
+/obj/machine/update_overlays(var/blah
+	var/static/our_overlays
+	if(isnull(our_overlays)
+		our_overlays = list(iconstate2appearance(overlay_icon, "on"), iconstate2appearance(overlay_icon, "off"), iconstate2appearance(overlay_icon, "broken"))
 	if (stat & broken)
 		add_overlay(our_overlays[OUR_BROKEN_OVERLAY])
 		return
@@ -619,9 +627,13 @@ Storing these in a flat (non-associated) list saves on memory, and using defines
 Also good:
 ```dm
 /obj/machine/update_overlays(var/blah)
-	var/static/on_overlay = iconstate2appearance(overlay_icon, "on")
-	var/static/off_overlay = iconstate2appearance(overlay_icon, "off")
-	var/static/broken_overlay = iconstate2appearance(overlay_icon, "broken")
+	var/static/on_overlay
+	var/static/off_overlay
+	var/static/broken_overlay
+	if(isnull(on_overlay))
+		on_overlay = iconstate2appearance(overlay_icon, "on")
+		off_overlay = iconstate2appearance(overlay_icon, "off")
+		broken_overlay = iconstate2appearance(overlay_icon, "broken")
 	if (stat & broken)
 		add_overlay(broken_overlay)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The static variables are now null, and the nullness is checked before setting the statics in the example.

## Why It's Good For The Game

See https://github.com/tgstation/tgstation/pull/58910#discussion_r626989067.

Without isnull checks, the statics try to initialize with global variables (actually mentioned later in the file) and by that time src is still null, meaning src's icon is null, meaning iconstate2appearance doesn't work.

@MrStonedOne You should take a look at this as it is your work i'm editing here, if you think there is a nicer way to do this, i'm more than willing to change the file to however that is.

## Changelog
:cl:
fix: CONTRIBUTING.md's example on static overlays passes integration tests now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
