### PR TITLE
[READY]Updates knockoff component and adds it to prescription glasses

### DIFF
--- a/code/datums/components/knockoff.dm
+++ b/code/datums/components/knockoff.dm
@@ -11,40 +11,53 @@
 	RegisterSignal(parent, COMSIG_ITEM_DROPPED,.proc/OnDropped)
 
 	src.knockoff_chance = knockoff_chance
-	
+
 	if(zone_override)
 		target_zones = zone_override
 
 	if(slots_knockoffable)
 		src.slots_knockoffable = slots_knockoffable
 
-/datum/component/knockoff/proc/Knockoff(mob/living/attacker,zone)
+/datum/component/knockoff/proc/Knockoff(mob/living/carbon/human/wearer,mob/living/attacker,zone)
 	SIGNAL_HANDLER
 
-	var/obj/item/I = parent
-	var/mob/living/carbon/human/wearer = I.loc
+	var/obj/item/item = parent
 	if(!istype(wearer))
 		return
 	if(target_zones && !(zone in target_zones))
 		return
 	if(!prob(knockoff_chance))
 		return
-	if(!wearer.dropItemToGround(I))
+	if(!wearer.dropItemToGround(item))
 		return
+	wearer.visible_message("<span class='warning'>[attacker] knocks off [wearer]'s [item]!</span>","<span class='userdanger'>[attacker] knocks off your [item]!</span>")
 
-	wearer.visible_message("<span class='warning'>[attacker] knocks off [wearer]'s [I.name]!</span>","<span class='userdanger'>[attacker] knocks off your [I.name]!</span>")
+/datum/component/knockoff/proc/Knockoff_knockdown(mob/living/carbon/human/wearer)
+	SIGNAL_HANDLER
+
+	var/obj/item/item = parent
+	if(!istype(wearer))
+		return
+	if(!prob(knockoff_chance))
+		return
+	if(!wearer.dropItemToGround(item))
+		return
+	wearer.visible_message("<span class='warning'>[wearer]'s [item] get knocked off!</span>","<span class='userdanger'>Your [item] get knocked off!</span>")
+
 
 /datum/component/knockoff/proc/OnEquipped(datum/source, mob/living/carbon/human/H,slot)
 	SIGNAL_HANDLER
-
 	if(!istype(H))
 		return
 	if(slots_knockoffable && !(slot in slots_knockoffable))
 		UnregisterSignal(H, COMSIG_HUMAN_DISARM_HIT)
+		UnregisterSignal(H, COMSIG_LIVING_STATUS_KNOCKDOWN)
 		return
 	RegisterSignal(H, COMSIG_HUMAN_DISARM_HIT, .proc/Knockoff, TRUE)
+	RegisterSignal(H, COMSIG_LIVING_STATUS_KNOCKDOWN, .proc/Knockoff_knockdown, TRUE)
 
 /datum/component/knockoff/proc/OnDropped(datum/source, mob/living/M)
 	SIGNAL_HANDLER
 
 	UnregisterSignal(M, COMSIG_HUMAN_DISARM_HIT)
+	UnregisterSignal(M, COMSIG_LIVING_STATUS_KNOCKDOWN)

--- a/code/datums/components/knockoff.dm
+++ b/code/datums/components/knockoff.dm
@@ -1,9 +1,11 @@
-//Items with these will have a chance to get knocked off when disarming
+///Items with these will have a chance to get knocked off when disarming or being knocked down
 /datum/component/knockoff
-	var/knockoff_chance = 100 //Chance to knockoff
-	var/knockdown_threshold = 0 //  The minimum duration of a knockdown required to trigger a knockoff
-	var/list/target_zones //Aiming for these zones will cause the knockoff, null means all zones allowed
-	var/list/slots_knockoffable //Can be only knocked off from these slots, null means all slots allowed
+	///Chance to knockoff
+	var/knockoff_chance = 100
+	///Aiming for these zones will cause the knockoff, null means all zones allowed
+	var/list/target_zones
+	///Can be only knocked off from these slots, null means all slots allowed
+	var/list/slots_knockoffable
 
 /datum/component/knockoff/Initialize(knockoff_chance,zone_override,slots_knockoffable)
 	if(!isitem(parent))
@@ -19,6 +21,7 @@
 	if(slots_knockoffable)
 		src.slots_knockoffable = slots_knockoffable
 
+///Tries to knockoff the item when disarmed
 /datum/component/knockoff/proc/Knockoff(mob/living/carbon/human/wearer,mob/living/attacker,zone)
 	SIGNAL_HANDLER
 
@@ -33,19 +36,18 @@
 		return
 	wearer.visible_message("<span class='warning'>[attacker] knocks off [wearer]'s [item]!</span>","<span class='userdanger'>[attacker] knocks off your [item]!</span>")
 
+///Tries to knockoff the item when user is knocked down
 /datum/component/knockoff/proc/Knockoff_knockdown(mob/living/carbon/human/wearer,amount)
 	SIGNAL_HANDLER
 
 	var/obj/item/item = parent
 	if(!istype(wearer))
 		return
-	if(knockdown_threshold <= amount)
-		return
 	if(!prob(knockoff_chance))
 		return
 	if(!wearer.dropItemToGround(item))
 		return
-	wearer.visible_message("<span class='warning'>[wearer]'s [item] get knocked off!</span>","<span class='userdanger'>Your [item] get knocked off!</span>")
+	wearer.visible_message("<span class='warning'>[wearer]'s [item] gets knocked off!</span>","<span class='userdanger'>Your [item] was knocked off!</span>")
 
 
 /datum/component/knockoff/proc/OnEquipped(datum/source, mob/living/carbon/human/H,slot)

--- a/code/datums/components/knockoff.dm
+++ b/code/datums/components/knockoff.dm
@@ -1,6 +1,7 @@
 //Items with these will have a chance to get knocked off when disarming
 /datum/component/knockoff
 	var/knockoff_chance = 100 //Chance to knockoff
+	var/knockdown_threshold = 0 //  The minimum duration of a knockdown required to trigger a knockoff
 	var/list/target_zones //Aiming for these zones will cause the knockoff, null means all zones allowed
 	var/list/slots_knockoffable //Can be only knocked off from these slots, null means all slots allowed
 
@@ -32,11 +33,13 @@
 		return
 	wearer.visible_message("<span class='warning'>[attacker] knocks off [wearer]'s [item]!</span>","<span class='userdanger'>[attacker] knocks off your [item]!</span>")
 
-/datum/component/knockoff/proc/Knockoff_knockdown(mob/living/carbon/human/wearer)
+/datum/component/knockoff/proc/Knockoff_knockdown(mob/living/carbon/human/wearer,amount)
 	SIGNAL_HANDLER
 
 	var/obj/item/item = parent
 	if(!istype(wearer))
+		return
+	if(knockdown_threshold <= amount)
 		return
 	if(!prob(knockoff_chance))
 		return

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -237,7 +237,7 @@
 /datum/quirk/nearsighted //t. errorage
 	name = "Nearsighted"
 	desc = "You are nearsighted without prescription glasses, but spawn with a pair."
-	value = -1
+	value = -4
 	gain_text = "<span class='danger'>Things far away from you start looking blurry.</span>"
 	lose_text = "<span class='notice'>You start seeing faraway things normally again.</span>"
 	medical_record_text = "Patient requires prescription glasses in order to counteract nearsightedness."

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -150,7 +150,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		reagents.add_reagent_list(list_reagents)
 	if(starts_lit)
 		light()
-	AddComponent(/datum/component/knockoff,90,list(BODY_ZONE_PRECISE_MOUTH),list(ITEM_SLOT_MASK))//90% to knock off when wearing a mask
+	AddComponent(/datum/component/knockoff,90,15,list(BODY_ZONE_PRECISE_MOUTH),list(ITEM_SLOT_MASK))//90% to knock off when wearing a mask
 
 /obj/item/clothing/mask/cigarette/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -150,7 +150,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		reagents.add_reagent_list(list_reagents)
 	if(starts_lit)
 		light()
-	AddComponent(/datum/component/knockoff,90,15,list(BODY_ZONE_PRECISE_MOUTH),list(ITEM_SLOT_MASK))//90% to knock off when wearing a mask
+	AddComponent(/datum/component/knockoff,90,list(BODY_ZONE_PRECISE_MOUTH),list(ITEM_SLOT_MASK))//90% to knock off when wearing a mask
 
 /obj/item/clothing/mask/cigarette/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -204,19 +204,22 @@
 
 /obj/item/clothing/glasses/regular/Initialize()
 	. = ..()
-	AddComponent(/datum/component/knockoff,30,25,list(BODY_ZONE_PRECISE_EYES),list(ITEM_SLOT_EYES))
+	AddComponent(/datum/component/knockoff,25,list(BODY_ZONE_PRECISE_EYES),list(ITEM_SLOT_EYES))
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = .proc/on_entered,
 	)
 	AddElement(/datum/element/connect_loc, src, loc_connections)
 
 
-/obj/item/clothing/glasses/regular/proc/on_entered(datum/source, atom/movable/AM)
+/obj/item/clothing/glasses/regular/proc/on_entered(datum/source, atom/movable/movable)
 	SIGNAL_HANDLER
-	if(isliving(AM))
-		var/mob/living/L = AM
-		if(L.m_intent != MOVE_INTENT_WALK || !(L.movement_type & (FLYING|FLOATING)) || L.buckled)
+	if(damaged_clothes == CLOTHING_SHREDDED)
+		return
+	if(isliving(movable))
+		var/mob/living/crusher = movable
+		if(crusher.m_intent != MOVE_INTENT_WALK || !(crusher.movement_type & (FLYING|FLOATING)) || crusher.buckled)
 			playsound(src, 'sound/effects/glass_step.ogg', 30, TRUE)
+			visible_message("<span class='warning'>[crusher] steps on [src], damaging it!</span>")
 			take_damage(100, sound_effect = FALSE)
 
 /obj/item/clothing/glasses/regular/obj_destruction(damage_flag)

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -204,8 +204,7 @@
 
 /obj/item/clothing/glasses/regular/Initialize()
 	. = ..()
-	AddComponent(/datum/component/knockoff,30,list(BODY_ZONE_PRECISE_EYES),list(ITEM_SLOT_EYES))
-	AddElement(/datum/element/caltrop, min_damage = 5)
+	AddComponent(/datum/component/knockoff,30,25,list(BODY_ZONE_PRECISE_EYES),list(ITEM_SLOT_EYES))
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = .proc/on_entered,
 	)
@@ -216,20 +215,21 @@
 	SIGNAL_HANDLER
 	if(isliving(AM))
 		var/mob/living/L = AM
-		if(!(L.movement_type & (FLYING|FLOATING)) || L.buckled || L.m_intent == MOVE_INTENT_WALK)
+		if(L.m_intent != MOVE_INTENT_WALK || !(L.movement_type & (FLYING|FLOATING)) || L.buckled)
 			playsound(src, 'sound/effects/glass_step.ogg', 30, TRUE)
 			take_damage(100, sound_effect = FALSE)
 
 /obj/item/clothing/glasses/regular/obj_destruction(damage_flag)
 	. = ..()
 	vision_correction = FALSE
-	name = "broken [initial(name)]"
 
 /obj/item/clothing/glasses/regular/welder_act(mob/living/user, obj/item/I)
 	. = ..()
-	if(!W.tool_start_check(user, amount=1))
+	if(damaged_clothes == CLOTHING_PRISTINE)
 		return
-	if(W.use_tool(src, user, 10, volume=30, amount=1))
+	if(!I.tool_start_check(user, amount=1))
+		return
+	if(I.use_tool(src, user, 10, volume=30, amount=1))
 		user.visible_message("<span class='notice'>[user] welds [src] back together.</span>",\
 					"<span class='notice'>You weld [src] back together.</span>")
 		repair()

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -202,6 +202,44 @@
 	inhand_icon_state = "glasses"
 	vision_correction = TRUE //corrects nearsightedness
 
+/obj/item/clothing/glasses/regular/Initialize()
+	. = ..()
+	AddComponent(/datum/component/knockoff,30,list(BODY_ZONE_PRECISE_EYES),list(ITEM_SLOT_EYES))
+	AddElement(/datum/element/caltrop, min_damage = 5)
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_ENTERED = .proc/on_entered,
+	)
+	AddElement(/datum/element/connect_loc, src, loc_connections)
+
+
+/obj/item/clothing/glasses/regular/proc/on_entered(datum/source, atom/movable/AM)
+	SIGNAL_HANDLER
+	if(isliving(AM))
+		var/mob/living/L = AM
+		if(!(L.movement_type & (FLYING|FLOATING)) || L.buckled || L.m_intent == MOVE_INTENT_WALK)
+			playsound(src, 'sound/effects/glass_step.ogg', 30, TRUE)
+			take_damage(100, sound_effect = FALSE)
+
+/obj/item/clothing/glasses/regular/obj_destruction(damage_flag)
+	. = ..()
+	vision_correction = FALSE
+	name = "broken [initial(name)]"
+
+/obj/item/clothing/glasses/regular/welder_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(!W.tool_start_check(user, amount=1))
+		return
+	if(W.use_tool(src, user, 10, volume=30, amount=1))
+		user.visible_message("<span class='notice'>[user] welds [src] back together.</span>",\
+					"<span class='notice'>You weld [src] back together.</span>")
+		repair()
+		return TRUE
+
+/obj/item/clothing/glasses/regular/repair()
+	. = ..()
+	vision_correction = TRUE
+	name = initial(name)
+
 /obj/item/clothing/glasses/regular/jamjar
 	name = "jamjar glasses"
 	desc = "Also known as Virginity Protectors."

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -241,7 +241,6 @@
 /obj/item/clothing/glasses/regular/repair()
 	. = ..()
 	vision_correction = TRUE
-	name = initial(name)
 
 /obj/item/clothing/glasses/regular/jamjar
 	name = "jamjar glasses"

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -217,7 +217,7 @@
 		return
 	if(isliving(movable))
 		var/mob/living/crusher = movable
-		if(crusher.m_intent != MOVE_INTENT_WALK || !(crusher.movement_type & (FLYING|FLOATING)) || crusher.buckled)
+		if(crusher.m_intent != MOVE_INTENT_WALK && (!(crusher.movement_type & (FLYING|FLOATING)) || crusher.buckled))
 			playsound(src, 'sound/effects/glass_step.ogg', 30, TRUE)
 			visible_message("<span class='warning'>[crusher] steps on [src], damaging it!</span>")
 			take_damage(100, sound_effect = FALSE)


### PR DESCRIPTION
Fixes #58957

![1uC](https://user-images.githubusercontent.com/38563876/117591069-ea297a00-b132-11eb-8465-94803245a4a3.gif)

## About The Pull Request
First of all I fixed the knockoff component that's been broken for a while and did a bit of cleanup and documentation.
The knockoff component may also trigger whenever the wearer is knocked down. I've added the component to prescription glasses.
Prescription glasses will get damaged whenever someone steps on them, step on them one too many times (that's twice, currently) and they'll be unusable until repaired. 

## Why It's Good For The Game
At first I wanted to just increase the point cost of nearsighted but I decided to make it a lot more interesting instead! 
Losing your eye slot is a pretty big deal but it didn't really add any particularly interesting gameplay interactions, so I wanted to change that.
This should make wearing glasses a more quirky experience and open up for some uuuuh interesting experiences with your fellow crew members, whether accidentally or not...

## Changelog
:cl:
fix: you can knock cigarettes out of people's mouths again, hooray!
balance: objects that can be knocked off now have a chance to fall whenever the wearer is knocked down
balance: Prescription glasses can now be knocked off. Careful where you step, those things are fragile!
balance: Broken prescription glasses can be repaired using cloth or a welding tool
balance: Increased point cost of Nearsighted quirk from -1 to -4
/:cl:
