### PR TITLE
Hauberoaches will no longer try to squish themselves

### DIFF
--- a/code/datums/elements/squashable.dm
+++ b/code/datums/elements/squashable.dm
@@ -33,6 +33,9 @@
 /datum/component/squashable/proc/on_entered(turf/source_turf, atom/movable/crossing_movable)
 	SIGNAL_HANDLER
 
+	if(parent == crossing_movable)
+		return
+
 	var/mob/living/parent_as_living = parent
 
 	if(squash_flags & SQUASHED_SHOULD_BE_DOWN && parent_as_living.body_position != LYING_DOWN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Due to recent changes with connect_loc replacing crossed with entered, the squashable component would try triggering on the parent mob whenever it moved. This only manifests in bad behavior with the hauberoach class of cockroaches, causing them to constantly print messages about stepping on themselves, but there's no reason for something to squash itself so here's the check. Kyler will presumably fix the entered signal being called by atoms on themselves later on, but this is still a good check.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less roach spam
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Hauberoaches will no longer spam messages about trying to squish themselves every time they move
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
