### PR TITLE
Reduce default Maint. Drone playtime requirement

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -410,7 +410,7 @@
 	config_entry_value = "Silicon"
 
 /datum/config_entry/number/drone_role_playtime
-	config_entry_value = 40
+	config_entry_value = 14
 	min_val = 0
 	integer = FALSE // It is in hours, but just in case one wants to specify minutes.
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -569,7 +569,7 @@ MAXFINE 2000
 #DRONE_REQUIRED_ROLE Silicon
 
 ## How many played hours of DRONE_REQUIRED_ROLE required to be a Maintenance Done
-#DRONE_ROLE_PLAYTIME 40
+#DRONE_ROLE_PLAYTIME 14
 
 ## Uncomment to enable SDQL spells
 ## Warning: SDQL is a powerful tool and can break many things or expose security sensitive information.


### PR DESCRIPTION
## About The Pull Request

I have reduced the default Drone hours requirement from 40 to 14. This PR shouldn't be merged until DRONE_ROLE_PLAYTIME is set to 40 on the live game configs (currently unset), or a reasonable amount of time has passed and it is still unset.

I have no intention of slipping this behind anyone's back, and want to give ample notice to current admins.

## Why It's Good For The Game

I think it is a more reasonable default than 40, if even still on the higher side. 40 is a bit more of a nuclear setting based on fear from drones' previous incarnation.

## Changelog
:cl: JJRcop
server: Default Drone hours without config set reduced from 40 to 14. Please set DRONE_ROLE_PLAYTIME to 40 if you wish to retain old behavior.
/:cl:
