### PR TITLE
Re-add the debug controller verb

### DIFF
--- a/code/controllers/admin.dm
+++ b/code/controllers/admin.dm
@@ -71,7 +71,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/statclick)
 		return
 	
 	var/list/controllers = list()
-	var/list/controller_choices
+	var/list/controller_choices = list()
 	
 	for (var/datum/controller/controller in world)
 		if (istype(controller, /datum/controller/subsystem))

--- a/code/controllers/admin.dm
+++ b/code/controllers/admin.dm
@@ -61,3 +61,30 @@ INITIALIZE_IMMEDIATE(/obj/effect/statclick)
 			SSblackbox.record_feedback("tally", "admin_verb", 1, "Restart Failsafe Controller")
 
 	message_admins("Admin [key_name_admin(usr)] has restarted the [controller] controller.")
+
+/client/proc/debug_controller()
+	set category = "Debug"
+	set name = "Debug Controller"
+	set desc = "Debug the various periodic loop controllers for the game (be careful!)"
+
+	if(!holder)
+		return
+	
+	var/list/controllers = list()
+	var/list/controller_choices
+	
+	for (var/datum/controller/controller in world)
+		if (istype(controller, /datum/controller/subsystem))
+			continue
+		controllers["[controller] (controller.type)"] = controller //we use an associated list to ensure clients can't hold references to controllers
+		controller_choices += "[controller] (controller.type)"
+	
+	var/datum/controller/controller_string = input("Select controller to debug", "Debug Controller") as null|anything in controller_choices
+	var/datum/controller/controller = controllers[controller_string]
+	
+	if (!istype(controller))
+		return
+	debug_variables(controller)
+	
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Restart Failsafe Controller")
+	message_admins("Admin [key_name_admin(usr)] is debugging the [controller] controller.")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -137,6 +137,7 @@ GLOBAL_PROTECT(admin_verbs_debug)
 /world/proc/AVerbsDebug()
 	return list(
 	/client/proc/restart_controller,
+	/client/proc/debug_controller,
 	/client/proc/cmd_admin_list_open_jobs,
 	/client/proc/Debug2,
 	/client/proc/cmd_debug_make_powernets,


### PR DESCRIPTION
So that we can use it if the verb panel isn't working.

I made this find and generate a list of all controllers (san subsystems), so it should work without snowflake if we add more controllers. (the old verb was a big switch chain)

yolo webedit!