### PR TITLE
Converts Tramstation wall mounts to dirs

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -12,9 +12,7 @@
 /area/maintenance/central)
 "aad" = (
 /obj/structure/bed/dogbed/lia,
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -41,9 +39,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "aaj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -65,9 +61,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 9
 	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/port)
@@ -145,7 +139,7 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/port)
 "aax" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/machinery/camera{
 	c_tag = "Science - Genetics Pen";
@@ -170,9 +164,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/port)
 "aaz" = (
@@ -181,33 +173,28 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aaA" = (
-/obj/machinery/button/door{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_x = -24;
-	pixel_y = 10;
-	req_access_txt = "24"
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for secure storage.";
-	id = "Secure Storage";
-	name = "Engineering Secure Storage";
-	pixel_x = -24;
-	req_access_txt = "11"
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_x = -24;
-	pixel_y = -10;
-	req_access_txt = "10"
-	},
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
 /mob/living/simple_animal/parrot/poly,
+/obj/machinery/button/door/directional/west{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_y = 8;
+	req_access_txt = "24"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	req_access_txt = "11"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_y = -8;
+	req_access_txt = "10"
+	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "aaB" = (
@@ -273,12 +260,10 @@
 "aaP" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "private_e";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
@@ -365,9 +350,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 5
 	},
@@ -385,9 +368,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 9
 	},
@@ -461,9 +442,7 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "abu" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -533,7 +512,7 @@
 /area/security/prison)
 "abF" = (
 /obj/structure/table/wood,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -561,9 +540,7 @@
 "abK" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/assistant,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
 /area/service/library)
 "abL" = (
@@ -641,9 +618,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "acg" = (
@@ -944,9 +919,7 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "adi" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/service/kitchen)
@@ -1083,9 +1056,7 @@
 /area/hallway/primary/port)
 "adG" = (
 /obj/structure/displaycase/trophy,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "adH" = (
@@ -1097,9 +1068,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/service/bar)
@@ -1176,7 +1145,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/computer/arcade/battle{
 	dir = 8
 	},
@@ -1224,12 +1193,10 @@
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /obj/effect/landmark/start/assistant,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "private_a";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
@@ -1239,9 +1206,7 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aej" = (
@@ -1529,9 +1494,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "afw" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/freezer,
 /area/service/bar)
 "afx" = (
@@ -1566,9 +1529,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "afB" = (
@@ -1712,9 +1673,7 @@
 /area/security/courtroom)
 "afR" = (
 /obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
+/obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/wood,
 /area/service/library)
 "afU" = (
@@ -1762,9 +1721,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "aga" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "agb" = (
@@ -1790,9 +1747,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "agg" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "agh" = (
@@ -1936,7 +1891,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
 /area/service/library)
 "agM" = (
@@ -1952,9 +1907,7 @@
 /area/cargo/miningdock)
 "agN" = (
 /obj/structure/table,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/item/folder/white{
 	pixel_y = 4
 	},
@@ -2118,9 +2071,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -2136,9 +2087,7 @@
 /area/service/kitchen)
 "ahF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/light_construct{
-	dir = 1
-	},
+/obj/structure/light_construct/directional/north,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
@@ -2292,9 +2241,7 @@
 /turf/open/floor/engine/cult,
 /area/service/library)
 "aib" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/openspace,
 /area/hallway/primary/port)
 "aid" = (
@@ -2458,9 +2405,7 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "aiD" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/openspace,
 /area/hallway/primary/port)
 "aiE" = (
@@ -2520,10 +2465,7 @@
 /obj/item/stack/cable_coil{
 	amount = 15
 	},
-/obj/machinery/light_switch{
-	pixel_x = -24;
-	pixel_y = -8
-	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "aiQ" = (
@@ -2537,7 +2479,7 @@
 	c_tag = "Arrivals Escape Pod 1";
 	dir = 8
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aiS" = (
@@ -2570,9 +2512,7 @@
 /turf/open/floor/plating,
 /area/commons/vacant_room/commissary)
 "aiX" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "aiZ" = (
@@ -2644,9 +2584,7 @@
 /area/command/gateway)
 "ajj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/commons/vacant_room/commissary)
@@ -2703,9 +2641,7 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "ajt" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 32
-	},
+/obj/item/storage/secure/safe/directional/east,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
@@ -2719,9 +2655,7 @@
 	pixel_y = 3
 	},
 /obj/item/storage/fancy/candle_box,
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/chapel,
 /area/service/chapel)
 "ajv" = (
@@ -2770,9 +2704,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
@@ -2789,12 +2721,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
-/obj/machinery/button/door{
-	id = "aux_base_shutters";
-	name = "Public Shutters Control";
-	pixel_y = -28;
-	req_one_access_txt = "72"
-	},
 /obj/structure/rack,
 /obj/item/electronics/airlock,
 /obj/item/electronics/airlock,
@@ -2807,6 +2733,11 @@
 /obj/item/wallframe/camera,
 /obj/item/wallframe/camera,
 /obj/item/assault_pod/mining,
+/obj/machinery/button/door/directional/south{
+	id = "aux_base_shutters";
+	name = "Public Shutters Control";
+	req_access_txt = "72"
+	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "ajF" = (
@@ -2875,9 +2806,7 @@
 	dir = 1
 	},
 /obj/item/kirbyplants/random,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/hallway/primary/port)
@@ -2943,9 +2872,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "aki" = (
-/obj/structure/urinal{
-	pixel_y = 32
-	},
+/obj/structure/urinal/directional/north,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -2976,9 +2903,7 @@
 	c_tag = "Civilian - Vacant Commissary";
 	dir = 8
 	},
-/obj/item/storage/secure/safe{
-	pixel_x = 32
-	},
+/obj/item/storage/secure/safe/directional/east,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "akn" = (
@@ -3045,16 +2970,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -3148,15 +3069,13 @@
 "akL" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/button/door/directional/east{
 	id = "private_b";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "akM" = (
@@ -3167,9 +3086,7 @@
 /area/hallway/secondary/entry)
 "akN" = (
 /obj/machinery/computer/rdservercontrol,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/server)
@@ -3229,9 +3146,7 @@
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/service/bar)
@@ -3239,9 +3154,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "akZ" = (
@@ -3278,13 +3191,12 @@
 "ale" = (
 /obj/item/kirbyplants/dead,
 /obj/structure/cable,
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	announcementConsole = 1;
 	department = "Research Director's Desk";
 	departmentType = 5;
-	name = "Research Director RC";
-	pixel_x = 28;
-	pixel_y = 30;
+	name = "Research Director's Requests Console";
+	pixel_x = 30;
 	receive_ore_updates = 1
 	},
 /obj/machinery/airalarm/directional/north,
@@ -3318,10 +3230,7 @@
 /area/commons/dorms)
 "alh" = (
 /obj/structure/table/reinforced,
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 32
-	},
+/obj/structure/noticeboard/directional/east,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3375,9 +3284,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
@@ -3386,9 +3293,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "alq" = (
@@ -3404,7 +3309,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -3483,6 +3388,7 @@
 	pixel_y = 6
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/keycard_auth/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "alC" = (
@@ -3507,9 +3413,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "alI" = (
@@ -3521,9 +3425,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/commons/storage/art)
@@ -3538,9 +3440,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "alP" = (
@@ -3572,7 +3472,7 @@
 "alX" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "alZ" = (
@@ -3693,15 +3593,13 @@
 "amr" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/button/door/directional/west{
 	id = "private_l";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "amv" = (
@@ -3783,9 +3681,7 @@
 /area/hallway/primary/port)
 "amI" = (
 /obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "amJ" = (
@@ -3869,9 +3765,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/requests_console{
-	department = "Law office";
-	pixel_y = 32
+/obj/machinery/requests_console/directional/north{
+	department = "Nanite Lab";
+	name = "Nanite Lab Requests Console"
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
@@ -3901,9 +3797,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "ann" = (
@@ -3963,9 +3857,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "anv" = (
@@ -4118,10 +4010,7 @@
 /area/security/brig)
 "anR" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/bounty_board{
-	dir = 1;
-	pixel_y = -32
-	},
+/obj/machinery/bounty_board/directional/south,
 /turf/open/floor/iron,
 /area/security/brig)
 "anT" = (
@@ -4138,9 +4027,7 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/bodybags,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "anV" = (
@@ -4151,9 +4038,7 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/bar)
@@ -4162,9 +4047,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "anX" = (
@@ -4236,7 +4119,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "aoh" = (
@@ -4329,10 +4212,9 @@
 	},
 /obj/item/storage/box/deputy,
 /obj/item/radio/intercom/directional/west,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "HOSOffice";
 	name = "Emergency Blast Doors";
-	pixel_x = -24;
 	pixel_y = -8;
 	req_access_txt = "3"
 	},
@@ -4372,9 +4254,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/wood,
 /area/service/library)
 "aoG" = (
@@ -4428,9 +4308,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
@@ -4456,9 +4334,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Security - Warden's Office";
 	dir = 6;
@@ -4497,12 +4373,11 @@
 	id = "Cell 3";
 	name = "Cell 3 Locker"
 	},
-/obj/machinery/flasher{
-	id = "Cell 3";
-	pixel_y = -28
-	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/flasher/directional/south{
+	id = "Cell 3"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "aoY" = (
@@ -4584,9 +4459,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -4748,10 +4621,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_x = -4;
-	pixel_y = 24
-	},
+/obj/machinery/light_switch/directional/north,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -4899,15 +4769,13 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/machinery/button/door{
-	id = "commissaryshutter";
-	name = "Commissary Shutter Control";
-	pixel_x = 6;
-	pixel_y = -26
-	},
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/button/door/directional/south{
+	id = "commissaryshutter";
+	name = "Commissary Shutter Control"
+	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "apY" = (
@@ -4936,7 +4804,7 @@
 /obj/effect/turf_decal/trimline/red/arrow_cw{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Security - Temporary Holding Cell";
@@ -4951,9 +4819,7 @@
 /area/security/brig)
 "aqf" = (
 /obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/wood,
 /area/service/library)
 "aqg" = (
@@ -5012,9 +4878,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "aqp" = (
@@ -5047,9 +4911,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/item/clothing/mask/whistle,
@@ -5351,13 +5213,10 @@
 /obj/machinery/computer/communications{
 	dir = 8
 	},
-/obj/machinery/keycard_auth{
-	pixel_x = 24;
-	pixel_y = 24
+/obj/machinery/keycard_auth/directional/north{
+	pixel_x = 26
 	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
@@ -5376,9 +5235,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -5447,9 +5304,7 @@
 /area/commons/toilet/restrooms)
 "arm" = (
 /obj/structure/filingcabinet,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
 /area/service/library)
@@ -5487,9 +5342,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/east,
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/security/checkpoint)
@@ -5682,9 +5535,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
@@ -5712,9 +5563,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "arX" = (
-/obj/structure/mirror{
-	pixel_y = 28
-	},
+/obj/structure/mirror/directional/north,
 /obj/structure/sink{
 	pixel_y = 20
 	},
@@ -5952,9 +5801,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/paper_bin{
 	pixel_x = -5;
 	pixel_y = 3
@@ -5989,7 +5836,7 @@
 /area/medical/pharmacy)
 "asK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "asL" = (
@@ -6017,9 +5864,7 @@
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
 /obj/item/pen,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
@@ -6036,9 +5881,7 @@
 "asQ" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
@@ -6176,7 +6019,7 @@
 /area/medical/psychology)
 "atl" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -6207,9 +6050,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/gun/syringe,
@@ -6269,9 +6110,7 @@
 /area/medical/treatment_center)
 "atz" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
@@ -6359,12 +6198,10 @@
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /obj/effect/landmark/start/assistant,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "private_f";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
@@ -6723,12 +6560,12 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "auP" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
 "auU" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/openspace,
 /area/commons/dorms)
 "auW" = (
@@ -6775,7 +6612,7 @@
 	dir = 4;
 	pixel_y = -40
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw,
 /obj/structure/sign/directions/vault{
 	dir = 4;
@@ -6817,7 +6654,7 @@
 	dir = 4;
 	pixel_y = -40
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_cw,
 /obj/structure/sign/directions/upload{
 	dir = 4;
@@ -6835,9 +6672,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "avk" = (
@@ -6845,9 +6680,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/filled/corner,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -6903,7 +6736,7 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "avs" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
@@ -6925,9 +6758,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "avy" = (
@@ -6949,9 +6780,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
@@ -6967,7 +6796,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
 	},
@@ -6994,12 +6823,10 @@
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /obj/effect/landmark/start/assistant,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "private_k";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
@@ -7028,7 +6855,7 @@
 	dir = 1;
 	pixel_y = -40
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw,
 /obj/structure/sign/directions/vault{
 	dir = 1;
@@ -7070,7 +6897,7 @@
 /obj/structure/sign/directions/engineering{
 	pixel_y = -40
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_cw,
 /obj/structure/sign/directions/upload{
 	dir = 4;
@@ -7082,9 +6909,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
@@ -7094,7 +6919,7 @@
 /turf/open/floor/plating,
 /area/hallway/primary/tram/right)
 "avZ" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/right)
@@ -7102,9 +6927,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
@@ -7158,7 +6981,7 @@
 	dir = 8;
 	pixel_y = -40
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw,
 /obj/structure/sign/directions/vault{
 	dir = 8;
@@ -7232,7 +7055,7 @@
 	dir = 8;
 	pixel_y = -40
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_cw,
 /obj/structure/sign/directions/upload{
 	pixel_y = -22
@@ -7421,9 +7244,7 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "awX" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "awY" = (
@@ -7510,9 +7331,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
@@ -7569,11 +7388,10 @@
 "axB" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "private_i";
 	name = "Privacy Bolts";
-	pixel_x = 24;
-	pixel_y = -8;
+	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
@@ -7782,9 +7600,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Port"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -7829,7 +7645,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/computer/arcade/battle{
 	dir = 4
 	},
@@ -7919,9 +7735,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ayE" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -7957,15 +7771,13 @@
 "ayH" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/button/door/directional/east{
 	id = "private_j";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "ayI" = (
@@ -8006,9 +7818,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "ayQ" = (
@@ -8058,9 +7868,7 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron,
 /area/service/bar)
 "ayX" = (
@@ -8237,7 +8045,7 @@
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
 "azD" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
@@ -8302,9 +8110,7 @@
 /area/commons/storage/primary)
 "azK" = (
 /obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "azM" = (
@@ -8403,9 +8209,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -8445,9 +8249,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -8456,9 +8258,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Service - Hydroponics";
 	dir = 6
@@ -8480,9 +8280,7 @@
 	pixel_y = 3
 	},
 /obj/item/food/grown/harebell,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/chapel{
 	dir = 4
 	},
@@ -8491,9 +8289,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -8508,9 +8304,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
@@ -8587,9 +8381,6 @@
 	},
 /obj/item/screwdriver{
 	pixel_y = 16
-	},
-/obj/machinery/light_switch{
-	pixel_y = 28
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
@@ -8928,9 +8719,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/lawyer,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/service/lawoffice)
@@ -9011,11 +8800,10 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	department = "Hydroponics";
 	departmentType = 2;
-	name = "Hydroponics RC";
-	pixel_y = 32
+	name = "Hydroponics Requests Console"
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
@@ -9113,9 +8901,7 @@
 /area/command/gateway)
 "aCz" = (
 /obj/structure/bed/dogbed/ian,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/machinery/firealarm/directional/east,
 /mob/living/simple_animal/pet/dog/corgi/ian,
 /turf/open/floor/wood,
@@ -9184,9 +8970,7 @@
 /area/hallway/secondary/entry)
 "aCI" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,
@@ -9235,16 +9019,14 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/west{
 	department = "Tool Storage";
-	pixel_x = -30
+	name = "Tool Storage Requests Console"
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aCP" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
 "aCR" = (
@@ -9254,9 +9036,25 @@
 /obj/machinery/button/ticket_machine{
 	pixel_x = 32
 	},
-/obj/machinery/keycard_auth{
-	pixel_x = 26;
-	pixel_y = -26
+/obj/machinery/keycard_auth/directional/south{
+	pixel_x = 26
+	},
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 6;
+	pixel_y = -36
+	},
+/obj/machinery/button/door/directional/south{
+	id = "hop";
+	name = "Privacy Shutters Control";
+	pixel_x = -8;
+	req_access_txt = "28"
+	},
+/obj/machinery/button/door/directional/south{
+	id = "hopqueue";
+	name = "Queue Shutters Control";
+	pixel_x = -8;
+	pixel_y = -34;
+	req_access_txt = "28"
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
@@ -9275,23 +9073,19 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "aDa" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
-	id = "private_f";
+/obj/effect/landmark/start/hangover,
+/obj/machinery/button/door/directional/west{
+	id = "private_g";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "aDk" = (
@@ -9317,9 +9111,7 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "aDm" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
@@ -9327,15 +9119,17 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/button/door/directional/east{
+	id = "kanyewest";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aDo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -9345,9 +9139,7 @@
 /obj/structure/chair/comfy/beige{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
 "aDq" = (
@@ -9395,9 +9187,7 @@
 	dir = 1;
 	pixel_y = 40
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_cw{
 	dir = 1
 	},
@@ -9535,9 +9325,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "aDX" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
@@ -9592,9 +9380,7 @@
 	dir = 8;
 	pixel_y = 40
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_cw{
 	dir = 1
 	},
@@ -9649,9 +9435,7 @@
 	dir = 8;
 	pixel_y = 40
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw{
 	dir = 1
 	},
@@ -9692,18 +9476,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "aEo" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "aEp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -9833,9 +9613,7 @@
 /turf/closed/wall,
 /area/construction/mining/aux_base)
 "aEK" = (
-/obj/machinery/newscaster{
-	pixel_y = -28
-	},
+/obj/machinery/newscaster/security_unit/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
 /turf/open/floor/iron,
@@ -9936,6 +9714,7 @@
 	pixel_y = 7
 	},
 /obj/item/taperecorder,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "aEW" = (
@@ -10272,12 +10051,10 @@
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /obj/effect/landmark/start/assistant,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "private_d";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
@@ -10307,9 +10084,7 @@
 	dir = 1
 	},
 /obj/structure/chair/stool,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron,
 /area/service/bar)
 "aGh" = (
@@ -10327,10 +10102,9 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aGk" = (
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/south{
 	department = "Law Office";
-	name = "'Law Office RC";
-	pixel_y = -32
+	name = "Law Office Requests Console"
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
@@ -10344,15 +10118,11 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
@@ -10363,9 +10133,7 @@
 	dir = 1
 	},
 /obj/structure/chair/stool,
-/obj/structure/noticeboard{
-	pixel_y = -27
-	},
+/obj/structure/noticeboard/directional/south,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/bar)
@@ -10403,9 +10171,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "aGt" = (
@@ -10443,7 +10209,7 @@
 /obj/structure/chair/sofa/corner{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aGC" = (
@@ -10461,15 +10227,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/detective,
-/obj/machinery/button/door{
-	id = "kanyewest";
-	name = "Privacy Shutters";
-	pixel_x = 24;
-	pixel_y = -24
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aGE" = (
@@ -10626,9 +10384,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "aHg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Civilian - Upper Power Hatch";
@@ -10775,9 +10531,7 @@
 /area/maintenance/port/fore)
 "aHF" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aHG" = (
@@ -10811,9 +10565,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
@@ -10825,9 +10577,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aHO" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -10851,7 +10601,7 @@
 /area/medical/treatment_center)
 "aHR" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
@@ -11000,9 +10750,7 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "aIo" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
@@ -11019,10 +10767,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
-/obj/machinery/light_switch{
-	pixel_x = 27;
-	pixel_y = -5
-	},
+/obj/machinery/light_switch/directional/east,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/nanite)
@@ -11095,7 +10840,7 @@
 /area/engineering/engine_smes)
 "aIH" = (
 /obj/structure/displaycase/labcage,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
@@ -11206,18 +10951,15 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "aJd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Medical - Main South-West";
@@ -11245,9 +10987,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
@@ -11415,9 +11155,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/bar)
@@ -11430,9 +11168,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "aKQ" = (
@@ -11444,10 +11180,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
-/obj/machinery/light_switch{
-	pixel_x = 28;
-	pixel_y = -8
-	},
+/obj/machinery/light_switch/directional/east,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
@@ -11494,10 +11227,7 @@
 	dir = 5
 	},
 /obj/machinery/vending/cigarette,
-/obj/machinery/light_switch{
-	pixel_x = 28;
-	pixel_y = -8
-	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "aLs" = (
@@ -11586,9 +11316,7 @@
 /area/service/bar)
 "aLP" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -11768,7 +11496,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "aNe" = (
@@ -11782,9 +11510,7 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
 "aNj" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
@@ -11854,7 +11580,7 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -12011,9 +11737,7 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "aOD" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -12058,7 +11782,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aOO" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
@@ -12156,9 +11880,7 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aPg" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aPh" = (
@@ -12182,9 +11904,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/cult,
 /area/service/library)
 "aPr" = (
@@ -12211,7 +11931,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aPw" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
@@ -12392,9 +12112,7 @@
 /area/commons/lounge)
 "aQS" = (
 /obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/power/apc/auto_name/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -12473,9 +12191,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aRm" = (
@@ -12537,10 +12253,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/requests_console{
-	department = "Chemistry";
+/obj/machinery/requests_console/directional/west{
+	department = "Pharmacy";
 	departmentType = 2;
-	pixel_x = -30;
+	name = "Pharmacy Requests Console";
 	receive_ore_updates = 1
 	},
 /obj/item/book/manual/wiki/chemistry{
@@ -12658,23 +12374,19 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aSa" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/button/door/directional/east{
 	id = "private_h";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "aSb" = (
@@ -12690,9 +12402,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/service/library)
@@ -12731,9 +12441,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aSk" = (
@@ -12832,9 +12540,7 @@
 	amount = 10
 	},
 /obj/item/stack/rods/fifty,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "aTh" = (
@@ -12882,7 +12588,7 @@
 	},
 /area/service/chapel)
 "aTI" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -12986,9 +12692,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "aUr" = (
@@ -13003,15 +12707,13 @@
 "aUv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/button/door/directional/west{
 	id = "private_n";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "aUy" = (
@@ -13020,9 +12722,7 @@
 	dir = 8
 	},
 /obj/structure/dresser,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/service/theater)
 "aUB" = (
@@ -13131,13 +12831,6 @@
 /obj/item/canvas/twentythree_twentythree,
 /turf/open/floor/iron,
 /area/commons/storage/art)
-"aVo" = (
-/obj/machinery/light_switch{
-	pixel_x = 28;
-	pixel_y = -8
-	},
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "aVt" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -13160,12 +12853,8 @@
 /area/maintenance/central)
 "aVz" = (
 /obj/structure/filingcabinet/employment,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "aVB" = (
@@ -13190,9 +12879,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "aVF" = (
-/obj/structure/urinal{
-	pixel_y = 32
-	},
+/obj/structure/urinal/directional/north,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -13324,10 +13011,10 @@
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "aWI" = (
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/south{
 	department = "Janitorial";
 	departmentType = 1;
-	pixel_y = -29
+	name = "Janitorial Requests Console"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -13400,21 +13087,15 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
 "aXN" = (
-/obj/machinery/light/small,
-/obj/machinery/button/door{
+/obj/machinery/light/small/directional/south,
+/obj/machinery/button/door/directional/east{
 	id = "restroom_3";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = 8;
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
-"aXR" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/hallway/secondary/exit/departure_lounge)
 "aXX" = (
 /obj/structure/closet/secure_closet/bar{
 	req_access_txt = "25"
@@ -13601,20 +13282,16 @@
 "aZk" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "private_c";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "aZo" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
@@ -13686,12 +13363,10 @@
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /obj/effect/landmark/start/assistant,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "private_m";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8;
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
@@ -13792,9 +13467,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "baJ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "baK" = (
@@ -13856,13 +13529,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "bbT" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/central)
@@ -13890,9 +13561,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -14215,9 +13884,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
@@ -14227,10 +13894,8 @@
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
 "bid" = (
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
@@ -14537,9 +14202,7 @@
 /obj/machinery/computer/monitor{
 	dir = 8
 	},
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bpR" = (
@@ -14640,14 +14303,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "right_tram_lower";
-	pixel_x = -24;
-	pixel_y = 4;
 	req_access_txt = "12"
 	},
 /turf/open/floor/iron,
@@ -14755,9 +14414,7 @@
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
@@ -14868,9 +14525,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "buP" = (
@@ -14895,9 +14550,7 @@
 /area/command/heads_quarters/captain/private)
 "bvF" = (
 /obj/structure/rack,
-/obj/machinery/status_display/ai{
-	pixel_y = 31
-	},
+/obj/machinery/status_display/ai/directional/north,
 /obj/effect/spawner/lootdrop/techstorage/medical,
 /obj/effect/turf_decal/trimline/white/filled/line,
 /turf/open/floor/iron/dark,
@@ -14943,10 +14596,10 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bwG" = (
 /obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Chapel Office";
-	name = "Chapel RC";
-	pixel_y = 32
+/obj/machinery/requests_console/directional/north{
+	department = "Chapel";
+	departmentType = 1;
+	name = "Chapel Requests Console"
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Chaplain's Office";
@@ -15015,45 +14668,37 @@
 "byg" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"byo" = (
-/obj/machinery/light,
-/turf/closed/wall,
-/area/maintenance/central/secondary)
 "byy" = (
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/west{
 	freerange = 1;
+	listening = 0;
 	name = "Common Channel";
-	pixel_x = -27;
-	pixel_y = -7
+	pixel_y = -8
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/south{
+	freerange = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
+/obj/item/radio/intercom/directional/east{
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_y = -27
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_x = 27;
-	pixel_y = -7
+	pixel_y = -8
 	},
 /obj/effect/landmark/start/ai,
-/obj/machinery/button/door{
+/obj/structure/cable,
+/obj/machinery/button/door/directional/south{
 	id = "AI Core shutters";
-	name = "AI Core shutters control";
+	name = "AI Core Shutters Control";
 	pixel_x = 24;
-	pixel_y = -22;
 	req_access_txt = "16"
 	},
-/obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "byD" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "byG" = (
@@ -15061,16 +14706,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
 	},
-/obj/machinery/newscaster{
-	pixel_y = -28
-	},
+/obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "byJ" = (
 /obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
@@ -15384,9 +15025,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "bFr" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/science/cytology)
@@ -15511,10 +15150,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bIL" = (
-/obj/machinery/light_switch{
-	pixel_x = -27;
-	pixel_y = -28
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -15566,9 +15201,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -16012,9 +15645,7 @@
 /obj/structure/sign/directions/engineering{
 	pixel_y = 40
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw{
 	dir = 1
 	},
@@ -16083,16 +15714,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "bRI" = (
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	pixel_x = 30;
-	pixel_y = 30
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
+/obj/machinery/firealarm/directional/west,
 /obj/machinery/power/solar_control{
 	id = "aicore";
 	name = "AI Core Solar Control"
@@ -16138,19 +15760,23 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
 	department = "Chief Medical Officer's Desk";
 	departmentType = 5;
-	name = "Chief Medical Officer's RC";
-	pixel_x = 32
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = 24;
-	pixel_y = -20
+	name = "Chief Medical Officer's Requests Console"
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
+"bTb" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "bTr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/disposalpipe/segment,
@@ -16356,9 +15982,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
@@ -16475,11 +16099,9 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/east{
 	department = "Genetics";
-	dir = 8;
-	name = "Genetics Requests Console";
-	pixel_x = 30
+	name = "Genetics Requests Console"
 	},
 /turf/open/floor/iron/dark,
 /area/science/genetics)
@@ -16523,9 +16145,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "bZB" = (
@@ -16564,9 +16184,7 @@
 /obj/machinery/suit_storage_unit/ce,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/ce)
 "caY" = (
@@ -16699,9 +16317,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_y = -28
-	},
+/obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cdu" = (
@@ -16778,7 +16394,7 @@
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cec" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
 /area/maintenance/central)
 "cel" = (
@@ -16804,9 +16420,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "ceW" = (
@@ -16824,10 +16438,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_x = 22;
-	pixel_y = 24
-	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cfh" = (
@@ -16956,9 +16567,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
-/obj/machinery/light_switch{
-	pixel_x = 20
-	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/command/gateway)
 "cix" = (
@@ -16978,7 +16587,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorms South";
 	dir = 1
@@ -16998,9 +16607,7 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "cjP" = (
-/obj/structure/mirror{
-	pixel_y = 28
-	},
+/obj/structure/mirror/directional/north,
 /obj/structure/sink{
 	pixel_y = 15
 	},
@@ -17020,7 +16627,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -17031,7 +16638,7 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ckj" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ckA" = (
@@ -17261,9 +16868,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/green/corner{
@@ -17361,11 +16966,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"cqH" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small{
+"cqG" = (
+/obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/item/radio/intercom/directional/south{
+	freerange = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
+/turf/open/floor/glass/reinforced,
+/area/ai_monitored/turret_protected/aisat/hallway)
+"cqH" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
@@ -17412,12 +17028,10 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "crg" = (
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "restroom_6";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = 8;
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/freezer,
@@ -17430,7 +17044,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Cargo - Lobby";
 	dir = 9;
@@ -17497,7 +17111,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
@@ -17649,7 +17263,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "cxs" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -17658,12 +17272,6 @@
 	},
 /turf/open/floor/plating,
 /area/service/hydroponics)
-"cxt" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/construction/mining/aux_base)
 "cxx" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -17854,9 +17462,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -18090,9 +17696,7 @@
 	},
 /obj/structure/table/wood,
 /obj/machinery/recharger,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 30
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
 "cGo" = (
@@ -18140,9 +17744,7 @@
 /turf/open/floor/iron,
 /area/security/office)
 "cHW" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "cIh" = (
@@ -18183,9 +17785,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "cIN" = (
@@ -18290,7 +17890,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "cKE" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /obj/machinery/modular_computer/console/preset/engineering{
@@ -18314,7 +17914,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "cKT" = (
@@ -18546,7 +18146,7 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "cQS" = (
@@ -18574,13 +18174,11 @@
 /area/science/robotics/lab)
 "cRi" = (
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "cRs" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=8-TunnelMidBottom";
@@ -18607,9 +18205,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "cRH" = (
-/obj/structure/urinal{
-	pixel_y = 32
-	},
+/obj/structure/urinal/directional/north,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -18703,9 +18299,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "cSQ" = (
@@ -18759,9 +18353,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Secure - AI Upper Ring West";
 	dir = 9;
@@ -18782,7 +18374,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "cTY" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 2
@@ -19151,9 +18743,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "dbJ" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /obj/structure/chair/office{
 	dir = 1
 	},
@@ -19205,7 +18795,7 @@
 /area/maintenance/tram/left)
 "ddu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -19395,9 +18985,7 @@
 	pixel_x = 3;
 	pixel_y = 4
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -30
-	},
+/obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "dhQ" = (
@@ -19435,9 +19023,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Security - Medical Center";
 	dir = 5;
@@ -19499,9 +19085,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "dku" = (
@@ -19511,9 +19095,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "dkx" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -19631,10 +19213,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "dnG" = (
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/trimline/yellow/warning,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -19694,9 +19274,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/science/research)
 "doq" = (
@@ -19717,9 +19295,7 @@
 /area/hallway/secondary/entry)
 "doA" = (
 /obj/structure/reagent_dispensers/cooking_oil,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Service - Kitchen Freezer";
 	dir = 6
@@ -19819,19 +19395,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "dqd" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = -6;
-	pixel_y = -22
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -19843,9 +19414,8 @@
 /area/command/bridge)
 "dqs" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/flasher{
-	id = "hopflash";
-	pixel_x = 28
+/obj/machinery/flasher/directional/east{
+	id = "hopflash"
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -19873,9 +19443,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "dqG" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
@@ -20140,9 +19708,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/paper_bin,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
@@ -20331,12 +19897,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"dzg" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/closed/wall/r_wall,
-/area/science/robotics/lab)
 "dzo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -20446,9 +20006,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "dBF" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
+/obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -20519,9 +20077,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "dCn" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/research)
@@ -20603,9 +20159,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "dDU" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/hangover/closet,
@@ -20618,9 +20172,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/processing)
 "dFh" = (
@@ -20768,10 +20320,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/security/office)
 "dHF" = (
@@ -20784,9 +20333,7 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "dHK" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 4
 	},
@@ -21203,9 +20750,7 @@
 	id = "Cell 1";
 	name = "Cell 1 Locker"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 8
@@ -21295,9 +20840,7 @@
 "dPU" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Security - Equipment Room";
 	dir = 6;
@@ -21383,9 +20926,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -21451,9 +20992,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/sign/poster/official/science{
 	pixel_x = 32
 	},
@@ -21513,9 +21052,7 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -21525,7 +21062,7 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
 "dVz" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/openspace,
 /area/science/xenobiology)
 "dWa" = (
@@ -21573,11 +21110,10 @@
 "dXN" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "miningdorm2";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 25;
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
@@ -21667,9 +21203,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dZO" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Upload";
 	dir = 5;
@@ -21802,7 +21336,7 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
@@ -22029,9 +21563,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -22048,7 +21580,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Arrivals - Central Docking Wing";
 	dir = 1
@@ -22127,6 +21659,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/freezer,
 /area/medical/coldroom)
 "eji" = (
@@ -22237,9 +21770,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "elX" = (
@@ -22278,9 +21809,7 @@
 "emw" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Security - Prison Laundromat";
 	dir = 6;
@@ -22296,9 +21825,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "emO" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Civilian - Library Back Room";
@@ -22307,13 +21834,11 @@
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "emS" = (
-/obj/machinery/light/small,
-/obj/machinery/button/door{
+/obj/machinery/light/small/directional/south,
+/obj/machinery/button/door/directional/west{
 	id = "restroom_5";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = 8;
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/freezer,
@@ -22479,9 +22004,7 @@
 	dir = 8
 	},
 /obj/item/storage/box/donkpockets,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
@@ -22749,9 +22272,7 @@
 "eue" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/science/mixing)
 "euK" = (
@@ -22853,9 +22374,7 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "ewL" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -22905,9 +22424,7 @@
 /area/command/heads_quarters/rd)
 "exv" = (
 /obj/structure/table,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -23102,9 +22619,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/science/research)
 "eCj" = (
@@ -23147,9 +22662,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Medical - Main North-West";
 	dir = 9;
@@ -23276,9 +22789,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "eGr" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
@@ -23323,9 +22834,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "eHP" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/camera{
@@ -23360,9 +22869,7 @@
 /area/maintenance/starboard/central)
 "eIm" = (
 /obj/machinery/field/generator,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Secure Storage";
 	dir = 6;
@@ -23394,7 +22901,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "eJt" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "eJC" = (
@@ -23576,7 +23083,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "eOc" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/portable_atmospherics/pump,
@@ -23697,9 +23204,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "eRS" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -23711,9 +23216,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eRW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "eSp" = (
@@ -23798,7 +23301,7 @@
 /area/science/server)
 "eTg" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
 	},
@@ -23869,9 +23372,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "eUu" = (
-/obj/structure/mirror{
-	pixel_y = 28
-	},
+/obj/structure/mirror/directional/north,
 /obj/structure/sink{
 	pixel_y = 20
 	},
@@ -24124,7 +23625,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bedsheet/red,
 /obj/machinery/camera{
@@ -24142,14 +23643,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "left_tram_lower";
-	pixel_x = -24;
-	pixel_y = 4;
 	req_access_txt = "12"
 	},
 /turf/open/floor/iron,
@@ -24170,9 +23667,7 @@
 /area/maintenance/starboard/secondary)
 "fat" = (
 /obj/effect/spawner/randomcolavend,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
@@ -24184,9 +23679,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "faK" = (
@@ -24762,16 +24255,13 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter)
 "fmj" = (
-/obj/machinery/button/door{
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/button/door/directional/south{
 	id = "xenobiobottomright";
-	layer = 3.3;
 	name = "Xenobio Bottom Right Blast Door Toggle";
-	pixel_x = 8;
-	pixel_y = -24;
 	req_access_txt = "55"
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "fmk" = (
@@ -24834,10 +24324,10 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "packageSort2"
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_y = 30
+	name = "Cargo Bay Requests Console"
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -24885,9 +24375,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -25016,6 +24504,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "fsL" = (
@@ -25055,9 +24544,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -25083,9 +24570,6 @@
 	dir = 6
 	},
 /obj/effect/landmark/event_spawn,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/medical/coldroom)
@@ -25344,9 +24828,7 @@
 /area/hallway/primary/port)
 "fAM" = (
 /obj/structure/table/wood,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/east,
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
@@ -25367,10 +24849,6 @@
 /obj/structure/closet/crate/goldcrate,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"fBd" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/tcommsat/computer)
 "fBx" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/escape)
@@ -25417,9 +24895,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "fCb" = (
@@ -25555,9 +25031,7 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "fEk" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron/freezer,
 /area/service/bar)
@@ -25682,9 +25156,7 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "fGF" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -25778,15 +25250,11 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "fIp" = (
@@ -25794,6 +25262,15 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating,
 /area/mine/explored)
+"fJp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "fJq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -25913,9 +25390,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
@@ -26304,9 +25779,7 @@
 /area/security/prison)
 "fRN" = (
 /obj/structure/table/reinforced,
-/obj/machinery/keycard_auth{
-	pixel_y = -28
-	},
+/obj/machinery/keycard_auth/directional/south,
 /obj/item/rcl/pre_loaded,
 /obj/machinery/computer/security/telescreen/ce{
 	dir = 4;
@@ -26338,23 +25811,15 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Hallway - Upper Right Command";
 	dir = 5
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"fSu" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter)
 "fSv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -26397,7 +25862,7 @@
 "fSR" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/closet/secure_closet/brig,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "fSY" = (
@@ -26409,9 +25874,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "fTg" = (
@@ -26440,9 +25903,7 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "fTt" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 4
 	},
@@ -26615,11 +26076,9 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "atmos";
 	name = "Atmospherics Lockdown";
-	pixel_x = 24;
-	pixel_y = 4;
 	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
@@ -26682,9 +26141,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 30
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "gap" = (
@@ -26731,9 +26188,7 @@
 /obj/machinery/porta_turret/ai{
 	dir = 4
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "gch" = (
@@ -26764,11 +26219,10 @@
 	dir = 6;
 	network = list("aicore","ss13")
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/north{
 	freerange = 1;
 	frequency = 1447;
-	name = "Private Channel";
-	pixel_y = 28
+	name = "Private Channel"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
@@ -26859,9 +26313,7 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "geU" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
@@ -26875,12 +26327,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/science/research)
 "gfd" = (
@@ -26904,9 +26352,7 @@
 /area/engineering/atmos)
 "gfh" = (
 /obj/structure/table,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/machinery/camera{
 	c_tag = "Secure - AI Minisat Entry";
 	dir = 5;
@@ -27024,9 +26470,7 @@
 /area/medical/medbay/central)
 "ghY" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27290,7 +26734,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -27312,10 +26756,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 32
-	},
+/obj/structure/noticeboard/directional/east,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "gpM" = (
@@ -27345,9 +26786,7 @@
 /obj/structure/chair/pew/right{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Civilian - Chapel North";
 	dir = 6
@@ -27368,9 +26807,7 @@
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -27430,9 +26867,7 @@
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "grq" = (
@@ -27525,7 +26960,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "gtx" = (
@@ -27646,10 +27080,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = 22;
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -27666,9 +27096,7 @@
 /area/command/bridge)
 "gvN" = (
 /obj/machinery/stasis,
-/obj/machinery/defibrillator_mount{
-	pixel_y = 32
-	},
+/obj/machinery/defibrillator_mount/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
@@ -27691,10 +27119,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/bounty_board{
-	dir = 1;
-	pixel_y = -32
-	},
+/obj/machinery/bounty_board/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "gwP" = (
@@ -27733,9 +27158,7 @@
 	},
 /obj/item/stack/medical/mesh,
 /obj/item/stack/medical/gauze,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "gxp" = (
@@ -27773,11 +27196,10 @@
 /obj/machinery/computer/station_alert{
 	dir = 8
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/east{
 	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_x = 30
+	departmentType = 3;
+	name = "Atmospherics Requests Console"
 	},
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Atmospherics Front Desk";
@@ -27854,7 +27276,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -27915,9 +27337,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "gBA" = (
@@ -27932,9 +27352,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -27947,9 +27365,7 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_y = 32
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
@@ -27975,9 +27391,7 @@
 /obj/machinery/conveyor{
 	id = "packageSort2"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/cargo/sorting)
 "gBX" = (
@@ -27992,9 +27406,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "gCm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "gCq" = (
@@ -28191,9 +27603,7 @@
 /area/cargo/miningdock)
 "gGN" = (
 /obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/manipulator,
 /obj/item/stock_parts/micro_laser,
@@ -28480,9 +27890,7 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "gLR" = (
@@ -28609,9 +28017,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "gOj" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Maintenance - Escape Pod";
@@ -28660,7 +28066,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/loading_area,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "gPh" = (
@@ -28864,7 +28270,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -28882,12 +28288,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/light,
-/obj/item/radio/intercom{
+/obj/machinery/light/directional/south,
+/obj/item/radio/intercom/directional/south{
 	freerange = 1;
 	frequency = 1447;
-	name = "Private Channel";
-	pixel_y = -28
+	listening = 0;
+	name = "Private Channel"
 	},
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -29057,9 +28463,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "gYh" = (
@@ -29076,6 +28480,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "gYs" = (
@@ -29357,12 +28762,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/white,
 /area/science/research)
 "hdc" = (
@@ -29471,7 +28872,7 @@
 /obj/item/seeds/watermelon,
 /obj/structure/table/glass,
 /obj/item/seeds/tower,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "hft" = (
@@ -29489,9 +28890,7 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "hfu" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 10
 	},
@@ -29535,7 +28934,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/science/mixing)
 "hgK" = (
@@ -29654,7 +29053,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/commons/lounge)
@@ -29932,9 +29331,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "hlV" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Secure - AI Upper Ring South";
 	dir = 6;
@@ -30098,7 +29495,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "hod" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -30281,9 +29678,7 @@
 /obj/machinery/computer/security/telescreen/vault{
 	pixel_y = 30
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
 "hrp" = (
@@ -30324,21 +29719,15 @@
 	pixel_y = 6
 	},
 /obj/item/reagent_containers/dropper,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "hrY" = (
 /obj/structure/displaycase/captain{
 	pixel_y = 5
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/item/storage/secure/safe{
-	pixel_x = -24
-	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/item/storage/secure/safe/directional/west,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "hsm" = (
@@ -30404,10 +29793,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = 24
-	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "htW" = (
@@ -30428,9 +29813,7 @@
 	dir = 4;
 	pixel_y = 40
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw{
 	dir = 1
 	},
@@ -30456,9 +29839,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/science/research)
 "huJ" = (
@@ -30518,9 +29899,7 @@
 	},
 /area/science/breakroom)
 "hvU" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/openspace,
 /area/science/xenobiology)
 "hvZ" = (
@@ -30557,7 +29936,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/cable,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/science/explab)
@@ -30635,9 +30014,7 @@
 	dir = 4;
 	pixel_y = 40
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/arrow_cw{
 	dir = 1
 	},
@@ -30656,9 +30033,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/stool/bar{
 	dir = 1
@@ -30942,9 +30317,7 @@
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
 	name = "medical bed"
 	},
-/obj/machinery/defibrillator_mount{
-	pixel_y = -32
-	},
+/obj/machinery/defibrillator_mount/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
@@ -31082,16 +30455,12 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "left_tram_lower";
-	pixel_x = 24;
-	pixel_y = 4;
 	req_access_txt = "12"
 	},
 /turf/open/floor/iron,
@@ -31137,7 +30506,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "hKB" = (
@@ -31312,7 +30681,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "hNl" = (
@@ -31325,18 +30694,14 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "hNR" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31375,9 +30740,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "hPt" = (
@@ -31404,9 +30767,7 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "hPX" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -31836,15 +31197,11 @@
 "iby" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/vending/wallmed{
-	pixel_y = -32
-	},
+/obj/machinery/vending/wallmed/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "ibN" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/camera{
 	c_tag = "Hallway - Bar West Restroom";
@@ -31928,16 +31285,13 @@
 /area/security/prison)
 "iep" = (
 /obj/structure/cable,
-/obj/machinery/button/door{
-	id = "xenobiotopleft";
-	layer = 3.3;
-	name = "Xenobio Top Left Blast Door Toggle";
-	pixel_x = -8;
-	pixel_y = 24;
-	req_access_txt = "55"
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "xenobiotopleft";
+	name = "Xenobio Top Left Blast Door";
+	req_access_txt = "55"
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -32054,9 +31408,7 @@
 "igu" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/camera{
 	c_tag = "Civilian - Bar Backroom";
 	dir = 6
@@ -32078,9 +31430,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "igT" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -32277,9 +31627,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -32351,7 +31699,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "inR" = (
@@ -32445,9 +31793,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "ipa" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "ipr" = (
@@ -32475,7 +31821,7 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ipX" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ipY" = (
@@ -32544,6 +31890,7 @@
 /obj/item/stack/sheet/plasteel{
 	amount = 15
 	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "isF" = (
@@ -32671,7 +32018,7 @@
 "ivk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/bed/roller,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Medical - Lobby";
 	dir = 1;
@@ -32799,9 +32146,7 @@
 	dir = 6;
 	network = list("ss13","science")
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron/white,
 /area/science/research)
 "ixJ" = (
@@ -32938,9 +32283,7 @@
 /obj/structure/transit_tube/horizontal{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "izU" = (
@@ -33079,9 +32422,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/motion{
 	c_tag = "Security - Armory";
@@ -33141,9 +32482,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "iCR" = (
@@ -33270,9 +32609,7 @@
 	id = "publicElevator";
 	pixel_x = 25
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -33291,9 +32628,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "iGa" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -33317,7 +32652,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
 	},
@@ -33434,10 +32769,7 @@
 /area/science/mixing)
 "iJx" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -27
-	},
+/obj/structure/noticeboard/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -33479,9 +32811,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "iKQ" = (
@@ -33540,10 +32870,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -31
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "iLW" = (
@@ -33576,16 +32903,15 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "kitchencounter";
-	name = "Kitchen Counter Shutters";
-	pixel_x = -8;
-	pixel_y = -26;
-	req_access_txt = "28"
-	},
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 11
+	},
+/obj/machinery/button/door/directional/south{
+	id = "kitchencounter";
+	name = "Kitchen Counter Shutters";
+	pixel_x = -8;
+	req_access_txt = "28"
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
@@ -33663,7 +32989,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "iNy" = (
@@ -33795,12 +33121,15 @@
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/spawner/lootdrop/armory_contraband/metastation,
 /obj/effect/spawner/lootdrop/maintenance/three,
+/obj/machinery/button/door/directional/east{
+	id = "armory";
+	name = "Armory Shutters";
+	req_access_txt = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "iPj" = (
-/obj/structure/mirror{
-	pixel_y = 28
-	},
+/obj/structure/mirror/directional/north,
 /obj/structure/sink{
 	pixel_y = 17
 	},
@@ -33830,9 +33159,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark,
@@ -33843,9 +33170,7 @@
 	dir = 1
 	},
 /obj/machinery/vending/cigarette,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera{
 	c_tag = "Cargo - Mining Break Room";
@@ -33975,10 +33300,6 @@
 "iUt" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
-	},
-/obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = 26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -34276,18 +33597,14 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/science/research)
 "jaO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
 	dir = 6
 	},
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
+/obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
@@ -34676,9 +33993,7 @@
 	dir = 6;
 	network = list("ss13","science")
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/folder/white,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
@@ -34866,9 +34181,7 @@
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "joH" = (
-/obj/item/radio/intercom{
-	pixel_y = -26
-	},
+/obj/item/radio/intercom/directional/south,
 /obj/structure/bed/dogbed/renault,
 /mob/living/simple_animal/pet/fox/renault,
 /turf/open/floor/carpet,
@@ -35059,7 +34372,7 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "jtb" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -35116,7 +34429,7 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "juo" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
@@ -35256,9 +34569,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/slot_machine,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/service/bar)
 "jxN" = (
@@ -35342,9 +34653,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Hallway - Upper Left Command";
 	dir = 9
@@ -35422,9 +34731,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -35468,10 +34775,9 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "jBG" = (
-/obj/machinery/flasher{
+/obj/machinery/flasher/directional/south{
 	id = "AI";
-	pixel_x = 23;
-	pixel_y = -23
+	pixel_x = 20
 	},
 /obj/structure/cable,
 /obj/machinery/door/window{
@@ -35692,9 +34998,7 @@
 /area/service/library)
 "jGL" = (
 /obj/machinery/telecomms/processor/preset_two,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "jGO" = (
@@ -35736,9 +35040,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "jIg" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
 /turf/open/floor/plating,
@@ -35795,19 +35097,17 @@
 	dir = 8
 	},
 /obj/item/hand_labeler,
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_y = 30
+	name = "Cargo Bay Requests Console"
 	},
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jIX" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
@@ -35890,9 +35190,7 @@
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "jKu" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
@@ -35921,12 +35219,11 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "jKG" = (
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	announcementConsole = 1;
 	department = "Head of Personnel's Desk";
 	departmentType = 5;
-	name = "Head of Personnel RC";
-	pixel_y = 30
+	name = "Head of Personnel's Requests Console"
 	},
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase,
@@ -35934,9 +35231,7 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "jKR" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 6
 	},
@@ -36005,14 +35300,12 @@
 /obj/machinery/computer/security{
 	dir = 4
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/west{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = -30
+	name = "Security Requests Console"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "jNk" = (
@@ -36030,7 +35323,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "jNr" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "jNJ" = (
@@ -36046,11 +35339,10 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "miningdorm1";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 25;
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
@@ -36097,16 +35389,13 @@
 /area/engineering/supermatter/room)
 "jPc" = (
 /obj/structure/cable,
-/obj/machinery/button/door{
-	id = "xenobiotopright";
-	layer = 3.3;
-	name = "Xenobio Top Right Blast Door Toggle";
-	pixel_x = 8;
-	pixel_y = 24;
-	req_access_txt = "55"
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "xenobiotopright";
+	name = "Xenobio Top right Blast Door";
+	req_access_txt = "55"
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -36150,9 +35439,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
-/obj/structure/fireaxecabinet{
-	pixel_y = 32
-	},
+/obj/structure/fireaxecabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "jQP" = (
@@ -36275,9 +35562,7 @@
 	c_tag = "Command - Bridge South";
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_y = -28
-	},
+/obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/carpet,
 /area/command/bridge)
 "jTk" = (
@@ -36288,9 +35573,7 @@
 "jTP" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
 	},
@@ -36437,19 +35720,16 @@
 /area/science/research)
 "jVY" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "jWc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/requests_console{
+/obj/machinery/light/directional/east,
+/obj/machinery/requests_console/directional/east{
 	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC";
-	pixel_x = 30
-	},
-/obj/machinery/light{
-	dir = 4
+	departmentType = 3;
+	name = "Atmospherics Requests Console"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -36457,11 +35737,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -25;
-	pixel_y = -2;
+/obj/item/radio/intercom/directional/west{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
 	prison_radio = 1
 	},
 /turf/open/floor/iron,
@@ -36579,7 +35857,7 @@
 /area/science/xenobiology)
 "jYp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "jYw" = (
@@ -36597,9 +35875,7 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "jZu" = (
@@ -36675,9 +35951,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Medical - Main North-East";
@@ -36772,9 +36046,7 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "kbY" = (
-/obj/structure/mirror{
-	pixel_y = 28
-	},
+/obj/structure/mirror/directional/north,
 /obj/structure/sink{
 	pixel_y = 15
 	},
@@ -36836,16 +36108,15 @@
 /obj/machinery/computer/apc_control{
 	dir = 1
 	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 3;
-	name = "Chief Engineer RC";
-	pixel_y = -32
-	},
 /obj/machinery/computer/security/telescreen/ce{
 	dir = 4;
 	pixel_x = -24
+	},
+/obj/machinery/requests_console/directional/south{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	name = "Chief Engineer's Request Console"
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
@@ -36915,9 +36186,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bedsheet/red,
 /obj/effect/spawner/lootdrop/prison_contraband,
@@ -37034,14 +36303,13 @@
 /obj/structure/filingcabinet/chestdrawer{
 	pixel_y = 2
 	},
-/obj/machinery/button/door{
-	id = "hop";
-	name = "Privacy Shutters Control";
-	pixel_y = 25;
-	req_access_txt = "28"
-	},
 /obj/structure/sign/poster/official/love_ian{
 	pixel_x = -32
+	},
+/obj/machinery/button/door/directional/north{
+	id = "hop";
+	name = "Privacy Shutters Control";
+	req_access_txt = "28"
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hop)
@@ -37149,11 +36417,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	department = "Medbay";
 	departmentType = 1;
-	name = "Medbay RC";
-	pixel_y = 32
+	name = "Medbay Requests Console"
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
@@ -37194,7 +36461,7 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "khJ" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -37264,7 +36531,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "kke" = (
@@ -37282,9 +36549,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "kkn" = (
@@ -37569,7 +36834,7 @@
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "koZ" = (
@@ -37681,9 +36946,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/secondary)
 "kqy" = (
@@ -37759,9 +37022,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/prisoner/management,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 30
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "krp" = (
@@ -37839,9 +37100,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "ksf" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Security - Escape Pod";
@@ -37944,7 +37203,7 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "kua" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -38187,9 +37446,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "kzn" = (
 /obj/machinery/teleport/station,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -38334,9 +37591,7 @@
 /area/commons/storage/primary)
 "kBI" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "kBV" = (
@@ -38356,7 +37611,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
@@ -38401,9 +37656,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "kDm" = (
@@ -38627,9 +37880,7 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "kHC" = (
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/structure/chair/office{
 	dir = 1
 	},
@@ -38756,9 +38007,7 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
+/obj/structure/mirror/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -38766,9 +38015,7 @@
 /area/service/bar)
 "kKK" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38808,9 +38055,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bedsheet/red,
 /obj/effect/spawner/lootdrop/prison_contraband,
@@ -38855,9 +38100,8 @@
 /obj/machinery/computer/upload/ai{
 	dir = 8
 	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 24
+/obj/machinery/flasher/directional/east{
+	id = "AI"
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -39356,9 +38600,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "kXD" = (
@@ -39627,10 +38869,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_x = 22;
-	pixel_y = 24
-	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "lcH" = (
@@ -39783,10 +39022,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
-/obj/machinery/flasher{
+/obj/machinery/flasher/directional/west{
 	id = "AI";
-	pixel_x = -25;
-	pixel_y = -25
+	pixel_y = -26
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -39868,9 +39106,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
@@ -40037,9 +39273,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "lka" = (
@@ -40131,11 +39365,9 @@
 	dir = 1;
 	name = "Gas to Chamber"
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "cytologysecure";
-	name = "Secure Pen Lockdown";
-	pixel_x = 24;
-	pixel_y = 8
+	name = "Secure Pen Lockdown"
 	},
 /turf/open/floor/iron/white,
 /area/science/cytology)
@@ -40145,9 +39377,8 @@
 /area/mine/explored)
 "lmw" = (
 /obj/structure/cable,
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_y = 24
+/obj/machinery/flasher/directional/north{
+	id = "AI"
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -40223,9 +39454,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/engineering/main)
 "lnr" = (
@@ -40248,9 +39477,7 @@
 	dir = 1
 	},
 /obj/structure/filingcabinet,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "lnC" = (
@@ -40469,9 +39696,7 @@
 /area/maintenance/tram/right)
 "lsF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/landmark/start/cyborg,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -40808,9 +40033,8 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_x = -28
+/obj/machinery/flasher/directional/west{
+	id = "Cell 1"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/red/corner{
@@ -40869,16 +40093,14 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "lzM" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -40944,18 +40166,16 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
-/obj/machinery/light,
-/obj/machinery/button/door{
-	id = "cmoprivacy";
-	name = "CMO Privacy Shutters";
-	pixel_x = -7;
-	pixel_y = -26;
-	req_access_txt = "40"
-	},
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Medical - Chief Medical Officer's Office";
 	dir = 1;
 	network = list("ss13","medbay")
+	},
+/obj/machinery/button/door/directional/south{
+	id = "cmoprivacy";
+	name = "CMO Privacy Shutters";
+	req_access_txt = "40"
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
@@ -41013,11 +40233,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/west{
 	department = "Engineering";
 	departmentType = 4;
-	name = "Engineering RC";
-	pixel_x = -28
+	name = "Engineering Requests Console"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -41169,9 +40388,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "lDd" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "lDe" = (
@@ -41193,9 +40410,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "lEo" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 8
 	},
@@ -41210,9 +40425,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -41477,19 +40690,16 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "cargowarehouse";
-	pixel_x = 24;
-	pixel_y = -4
+/obj/machinery/light/directional/east,
+/obj/machinery/button/door/directional/east{
+	id = "cargowarehouse"
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "lMb" = (
 /obj/structure/punching_bag,
 /obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "lMy" = (
@@ -41592,9 +40802,7 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "lOl" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
@@ -41766,9 +40974,7 @@
 	id = "Cell 4";
 	name = "Cell 4 Locker"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -41795,9 +41001,7 @@
 /area/command/bridge)
 "lSQ" = (
 /obj/machinery/telecomms/bus/preset_four,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "lSU" = (
@@ -41834,9 +41038,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/security/processing)
 "lTE" = (
@@ -41928,6 +41130,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "lVv" = (
@@ -41961,9 +41164,7 @@
 /area/science/genetics)
 "lWG" = (
 /obj/machinery/stasis,
-/obj/machinery/defibrillator_mount{
-	pixel_y = 32
-	},
+/obj/machinery/defibrillator_mount/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
@@ -42135,7 +41336,7 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "mdk" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/closet/firecloset,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/plating,
@@ -42187,9 +41388,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "mfy" = (
@@ -42594,9 +41793,7 @@
 /obj/item/stack/medical/gauze{
 	pixel_x = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "mmz" = (
@@ -42813,16 +42010,12 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "right_tram_lower";
-	pixel_x = 24;
-	pixel_y = 4;
 	req_access_txt = "12"
 	},
 /turf/open/floor/iron,
@@ -42842,9 +42035,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
@@ -42911,9 +42102,7 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "msT" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/table,
 /obj/item/food/grown/banana,
 /obj/item/food/grown/banana{
@@ -42943,9 +42132,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/sign/poster/contraband/d_day_promo{
 	pixel_x = 32
 	},
@@ -42955,9 +42142,7 @@
 "mtW" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "muj" = (
@@ -43161,7 +42346,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
@@ -43206,9 +42391,7 @@
 "myU" = (
 /obj/machinery/power/shieldwallgen,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Secure - Teleporter";
 	dir = 6
@@ -43414,9 +42597,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/east,
 /obj/machinery/camera{
 	c_tag = "Science - Security Outpost";
 	dir = 9;
@@ -43549,10 +42730,7 @@
 /turf/open/floor/plating,
 /area/commons/lounge)
 "mHN" = (
-/obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = -8
-	},
+/obj/machinery/light_switch/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
 	dir = 6
 	},
@@ -43793,9 +42971,7 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "mOj" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -43882,10 +43058,6 @@
 /obj/machinery/bluespace_vendor/north,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
-"mOU" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/engineering/main)
 "mOW" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8
@@ -43999,9 +43171,7 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
 "mRn" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
 "mRN" = (
@@ -44121,9 +43291,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/security,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 30
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "mVj" = (
@@ -44199,9 +43367,7 @@
 /turf/open/floor/iron,
 /area/security/office)
 "mWF" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -44276,9 +43442,8 @@
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "mXj" = (
-/obj/machinery/sparker{
-	id = "Xenobio";
-	pixel_x = -25
+/obj/machinery/sparker/directional/west{
+	id = "Xenobio"
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -44382,9 +43547,7 @@
 /turf/closed/wall,
 /area/cargo/miningdock)
 "naC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -44424,9 +43587,7 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
+/obj/structure/mirror/directional/west,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/landmark/xeno_spawn,
 /obj/effect/landmark/start/hangover,
@@ -44527,14 +43688,14 @@
 /area/commons/storage/art)
 "ndT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "neu" = (
 /obj/structure/chair/sofa/corner{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/camera{
 	c_tag = "Service - Kitchen Dining Area";
@@ -44686,9 +43847,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Science - Main Upper Left";
 	dir = 9;
@@ -44713,9 +43872,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "nhO" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "niO" = (
@@ -44738,9 +43895,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "njM" = (
@@ -44754,9 +43909,7 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "njO" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -44831,9 +43984,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "nlt" = (
@@ -44938,9 +44089,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
 "npC" = (
@@ -45112,9 +44261,7 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "nss" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/openspace,
 /area/hallway/primary/tram/right)
 "nsx" = (
@@ -45174,6 +44321,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "ntr" = (
@@ -45279,9 +44427,7 @@
 /area/tcommsat/server)
 "nuQ" = (
 /obj/machinery/recharge_station,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -45302,9 +44448,7 @@
 "nvm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
-/obj/machinery/vending/wallmed{
-	pixel_y = -32
-	},
+/obj/machinery/vending/wallmed/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "nvY" = (
@@ -45403,7 +44547,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
@@ -45617,7 +44761,7 @@
 /turf/open/floor/plating,
 /area/medical/pharmacy)
 "nBD" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/openspace,
 /area/hallway/primary/tram/right)
 "nBH" = (
@@ -45736,24 +44880,6 @@
 "nFe" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/head_of_personnel,
-/obj/machinery/light_switch{
-	pixel_x = 38;
-	pixel_y = -35
-	},
-/obj/machinery/button/door{
-	id = "hopqueue";
-	name = "Queue Shutters Control";
-	pixel_x = 25;
-	pixel_y = -36;
-	req_access_txt = "28"
-	},
-/obj/machinery/button/door{
-	id = "hop";
-	name = "Privacy Shutters Control";
-	pixel_x = 25;
-	pixel_y = -26;
-	req_access_txt = "28"
-	},
 /obj/machinery/button/flasher{
 	id = "hopflash";
 	pixel_x = 38;
@@ -45805,13 +44931,11 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "nGo" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "nGD" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/openspace,
 /area/hallway/primary/tram/left)
 "nGG" = (
@@ -45856,9 +44980,7 @@
 	dir = 8;
 	name = "Judge"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Civilian - Courtroom";
 	dir = 9
@@ -45926,9 +45048,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "nJk" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
 "nJo" = (
@@ -45983,10 +45103,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = -25;
-	pixel_y = -25
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -46036,9 +45152,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
 "nML" = (
@@ -46234,9 +45348,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Atmospherics Distribution Loop";
 	dir = 6;
@@ -46333,9 +45445,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
@@ -46352,9 +45462,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -22
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 26
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -46412,9 +45521,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/science/research)
 "nUi" = (
@@ -46535,9 +45642,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/obj/machinery/light_switch{
-	pixel_x = 12;
-	pixel_y = 25
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 12
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -46662,6 +45768,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/main)
 "nZR" = (
@@ -46672,7 +45779,7 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/freezer,
 /area/science/research)
 "oad" = (
@@ -46710,9 +45817,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	name = "sorting disposal pipe (Head of Personnel's Office)";
@@ -46730,6 +45835,7 @@
 	dir = 9
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "obu" = (
@@ -46788,7 +45894,7 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
 "ocW" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -46945,9 +46051,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "ofx" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -46977,14 +46081,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ofV" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "restroom_2";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = 8;
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/freezer,
@@ -47057,9 +46159,7 @@
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
 "ohm" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47122,9 +46222,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "ois" = (
@@ -47283,25 +46381,20 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "ola" = (
-/obj/machinery/button/door{
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/button/door/directional/south{
 	id = "xenobiobottomleft";
-	layer = 3.3;
 	name = "Xenobio Bottom Left Blast Door Toggle";
-	pixel_x = -8;
-	pixel_y = -24;
 	req_access_txt = "55"
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "old" = (
+/obj/machinery/light/directional/north,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/item/storage/firstaid/regular{
 	pixel_x = 6;
@@ -47414,7 +46507,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "omK" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
@@ -47433,17 +46526,15 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/blue,
 /obj/machinery/camera{
 	c_tag = "Secure - EVA Main";
 	dir = 6
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	department = "EVA";
-	pixel_y = 32
+	name = "EVA Requests Console"
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
@@ -47506,11 +46597,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/west{
 	department = "Robotics";
-	departmentType = 5;
-	name = "Robotics RC";
-	pixel_x = -30;
+	departmentType = 2;
+	name = "Robotics Requests Console";
 	receive_ore_updates = 1
 	},
 /turf/open/floor/iron/dark,
@@ -47579,9 +46669,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -47727,9 +46815,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -47913,6 +46999,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/sorting)
+"owU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "oxe" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
@@ -47923,9 +47015,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/line,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "oxt" = (
@@ -47949,7 +47039,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "oxX" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "oyh" = (
@@ -48032,9 +47122,7 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "ozW" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/button/elevator{
 	id = "publicElevator";
 	pixel_x = 25
@@ -48095,9 +47183,7 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "oBl" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "oBB" = (
@@ -48307,9 +47393,7 @@
 /obj/machinery/porta_turret/ai{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "oEG" = (
@@ -48417,6 +47501,7 @@
 	dir = 6;
 	network = list("ss13","science")
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "oHI" = (
@@ -48438,13 +47523,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "armory";
-	name = "Armory Shutters";
-	pixel_x = 26;
-	pixel_y = -26;
-	req_access_txt = "3"
 	},
 /obj/structure/chair/office{
 	dir = 4
@@ -48476,7 +47554,7 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "oIG" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/openspace,
 /area/science/xenobiology)
 "oIH" = (
@@ -48699,9 +47777,7 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
 "oMq" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin{
@@ -48727,14 +47803,16 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "oMJ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "oMP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
+	},
+/obj/machinery/button/door/directional/west{
+	id = "cytologylockdown";
+	name = "Cytology Lockdown"
 	},
 /turf/open/floor/iron/white,
 /area/science/cytology)
@@ -48748,9 +47826,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "oNk" = (
@@ -48789,9 +47865,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "oOk" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "oOP" = (
@@ -48904,9 +47978,7 @@
 	anchored = 1
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
@@ -48920,9 +47992,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Filter"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "oRk" = (
@@ -49118,9 +48188,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "oUw" = (
@@ -49140,7 +48208,7 @@
 	pixel_x = 5
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "oUz" = (
@@ -49184,7 +48252,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/prisoner,
 /obj/effect/landmark/event_spawn,
@@ -49209,9 +48277,7 @@
 /area/engineering/supermatter/room)
 "oVw" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "oVG" = (
@@ -49276,11 +48342,18 @@
 /area/science/genetics)
 "oXj" = (
 /obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/science/research)
+"oXr" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "oXu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
 	dir = 4
@@ -49434,7 +48507,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark,
@@ -49610,9 +48683,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Arrivals - North Docking Wing";
 	dir = 6
@@ -49683,9 +48754,7 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "pfK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "pfS" = (
@@ -49793,10 +48862,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
+	departmentType = 3;
+	name = "Security Requests Console"
 	},
 /turf/open/floor/iron,
 /area/security/office)
@@ -49894,9 +48963,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "pjU" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4
 	},
@@ -49941,11 +49008,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/requests_console{
-	department = "Science";
+/obj/machinery/requests_console/directional/north{
+	department = "Toxins";
 	departmentType = 2;
-	name = "Science Requests Console";
-	pixel_y = 30;
+	name = "Toxins Requests Console";
 	receive_ore_updates = 1
 	},
 /turf/open/floor/iron,
@@ -50020,7 +49086,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Security Outpost";
 	dir = 1;
@@ -50101,9 +49167,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -30
-	},
+/obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron,
 /area/security/office)
 "pom" = (
@@ -50191,9 +49255,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
 	},
@@ -50527,12 +49589,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "pwh" = (
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
 	department = "Captain's Desk";
 	departmentType = 5;
-	name = "Captain RC";
-	pixel_x = 32
+	name = "Captain's Requests Console"
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
@@ -50607,9 +49668,7 @@
 	},
 /obj/item/aicard,
 /obj/item/multitool,
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "pxY" = (
@@ -50693,9 +49752,7 @@
 "pzh" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/science/mixing)
 "pzD" = (
@@ -50708,9 +49765,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "pzR" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -50724,12 +49779,11 @@
 /area/maintenance/central)
 "pAr" = (
 /obj/machinery/computer/secure_data,
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	announcementConsole = 1;
 	department = "Head of Security's Desk";
 	departmentType = 5;
-	name = "Head of Security RC";
-	pixel_y = 30
+	name = "Head of Security's Requests Console"
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
@@ -50774,7 +49828,7 @@
 /turf/open/floor/carpet,
 /area/cargo/qm)
 "pBl" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
@@ -50850,9 +49904,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
@@ -50863,7 +49915,7 @@
 /area/hallway/primary/tram/right)
 "pCR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/science/research)
 "pDd" = (
@@ -51025,7 +50077,7 @@
 /obj/structure/chair/pew/left{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Civilian - Chapel South";
 	dir = 1
@@ -51087,9 +50139,7 @@
 "pHb" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/south,
 /obj/item/radio/off,
 /obj/item/screwdriver{
 	pixel_y = 10
@@ -51223,10 +50273,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "pKF" = (
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "ceprivacy";
-	name = "Privacy Shutters Control";
-	pixel_x = 24
+	name = "Privacy Shutters Control"
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
@@ -51306,9 +50355,7 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "pMQ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -51366,9 +50413,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "pOv" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
+/obj/machinery/light_switch/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
@@ -51638,6 +50683,10 @@
 /obj/effect/turf_decal/caution,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
+"pSu" = (
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "pSw" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -51743,9 +50792,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Secure - AI Upper Ring East";
 	dir = 5;
@@ -51770,18 +50817,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "pWN" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/suit/hazardvest,
@@ -51888,9 +50931,7 @@
 	dir = 8
 	},
 /obj/structure/railing/corner,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/space/basic,
 /area/space/nearstation)
 "pYX" = (
@@ -51932,9 +50973,7 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
 "pZW" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -51943,12 +50982,9 @@
 /area/security/prison)
 "qab" = (
 /obj/structure/cable,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/light_switch{
-	pixel_x = 12;
-	pixel_y = 26
+/obj/machinery/newscaster/security_unit/directional/north,
+/obj/machinery/light_switch/directional/north{
+	pixel_x = 12
 	},
 /turf/open/floor/iron/cafeteria{
 	dir = 5
@@ -52040,9 +51076,7 @@
 /obj/item/radio/intercom/chapel{
 	pixel_y = 27
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "qcw" = (
@@ -52136,9 +51170,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "qeg" = (
@@ -52194,7 +51226,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "qgs" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
 "qgz" = (
@@ -52293,9 +51325,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "qiW" = (
@@ -52353,7 +51383,7 @@
 "qka" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qkj" = (
@@ -52547,9 +51577,7 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 3
 	},
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_x = 32
-	},
+/obj/structure/reagent_dispensers/virusfood/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "qpf" = (
@@ -52600,9 +51628,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "qqd" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
 /area/science/explab)
 "qqf" = (
@@ -52627,12 +51653,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
 	department = "Bridge";
 	departmentType = 5;
-	name = "Bridge RC";
-	pixel_x = -32
+	name = "Bridge Requests Console"
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -52773,11 +51798,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/north{
 	id = "mechbay";
 	name = "Mech Bay Shutters Control";
-	pixel_x = 26;
-	pixel_y = 24;
 	req_access_txt = "29"
 	},
 /turf/open/floor/iron,
@@ -52787,9 +51810,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "qvE" = (
@@ -52951,9 +51972,7 @@
 /obj/machinery/porta_turret/ai{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "qxK" = (
@@ -53173,9 +52192,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "qBv" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 1
 	},
@@ -53230,6 +52247,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "qCF" = (
@@ -53301,9 +52319,7 @@
 /area/maintenance/central)
 "qDt" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -53415,9 +52431,7 @@
 	dir = 1
 	},
 /obj/item/kirbyplants/random,
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "qEY" = (
@@ -53504,9 +52518,7 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
+/obj/structure/mirror/directional/east,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/freezer,
@@ -53559,9 +52571,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -30
-	},
+/obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "qHK" = (
@@ -54030,9 +53040,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/science/mixing)
 "qUf" = (
@@ -54059,12 +53067,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"qUE" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/turf/closed/mineral/random/stationside/asteroid,
-/area/mine/explored)
 "qUI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -54097,13 +53099,11 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/requests_console{
+/obj/machinery/light/directional/west,
+/obj/machinery/requests_console/directional/west{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = -30
+	name = "Cargo Bay Requests Console"
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Quartermaster's Office";
@@ -54174,7 +53174,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "qWH" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
 	},
@@ -54229,9 +53229,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "qYl" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/food_packaging,
 /turf/open/floor/plating,
@@ -54387,9 +53385,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -54569,9 +53565,7 @@
 /area/engineering/storage/tech)
 "rei" = (
 /obj/machinery/duct,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "rej" = (
@@ -54784,23 +53778,23 @@
 /area/engineering/break_room)
 "riW" = (
 /obj/effect/landmark/start/ai/secondary,
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/north{
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_y = 28
+	pixel_x = 6
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/east{
 	freerange = 1;
-	name = "Common Channel";
-	pixel_x = 27;
-	pixel_y = 5
+	listening = 0;
+	name = "Common Channel"
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/south{
 	freerange = 1;
 	frequency = 1447;
+	listening = 0;
 	name = "Private Channel";
-	pixel_y = -25
+	pixel_x = 6
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -54832,9 +53826,7 @@
 	},
 /obj/structure/closet/secure_closet/captains,
 /obj/item/reagent_containers/food/drinks/shaker,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/machinery/camera{
 	c_tag = "Command - Captain's Quarters"
 	},
@@ -55070,9 +54062,7 @@
 /obj/structure/rack,
 /obj/item/electronics/apc,
 /obj/item/electronics/airlock,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/camera{
 	c_tag = "Civilian - Aux Tool Storage";
@@ -55333,7 +54323,7 @@
 /area/science/mixing)
 "rum" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -55482,6 +54472,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "rwL" = (
@@ -55645,9 +54636,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "rzp" = (
@@ -55871,9 +54860,7 @@
 /area/security/brig)
 "rDu" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56090,9 +55077,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "rIU" = (
@@ -56195,9 +55180,7 @@
 /area/maintenance/tram/left)
 "rKJ" = (
 /obj/structure/table,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/item/paper_bin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -56229,9 +55212,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "rLA" = (
@@ -56278,7 +55259,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "rLX" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "rMa" = (
@@ -56335,9 +55316,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_x = 32
@@ -56479,7 +55458,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "rQq" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
 "rQy" = (
@@ -56560,9 +55539,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "rSb" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
+/obj/machinery/light_switch/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -56928,15 +55905,11 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
 "sbk" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sbm" = (
@@ -57025,23 +55998,23 @@
 /area/medical/virology)
 "scX" = (
 /obj/effect/landmark/start/ai/secondary,
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/north{
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_y = 28
+	pixel_x = -6
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/west{
 	freerange = 1;
-	name = "Common Channel";
-	pixel_x = -27;
-	pixel_y = 5
+	listening = 0;
+	name = "Common Channel"
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/south{
 	freerange = 1;
 	frequency = 1447;
+	listening = 0;
 	name = "Private Channel";
-	pixel_y = -25
+	pixel_x = -6
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -57129,9 +56102,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -57244,7 +56215,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/cable,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Science - Experimentor Lab";
 	dir = 1;
@@ -57354,9 +56325,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57615,7 +56584,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "sov" = (
@@ -57625,16 +56594,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "right_tram_lower";
-	pixel_x = -24;
-	pixel_y = -4;
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment{
@@ -57888,9 +56853,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/machinery/light_switch{
-	pixel_x = -25
-	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "ssw" = (
@@ -58005,9 +56968,7 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/wrench,
 /obj/item/assembly/signaler,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "stP" = (
@@ -58025,9 +56986,7 @@
 "stX" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "suF" = (
@@ -58165,9 +57124,7 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "sxN" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "sxO" = (
@@ -58196,13 +57153,11 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "syo" = (
-/obj/machinery/light/small,
-/obj/machinery/button/door{
+/obj/machinery/light/small/directional/south,
+/obj/machinery/button/door/directional/west{
 	id = "restroom_4";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = 8;
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/freezer,
@@ -58234,9 +57189,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/lighter,
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
+/obj/item/radio/intercom/directional/east,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/service/bar)
@@ -58329,9 +57282,7 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/space/nearstation)
 "sBn" = (
-/obj/structure/fireaxecabinet{
-	pixel_x = -32
-	},
+/obj/structure/fireaxecabinet/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -58382,7 +57333,7 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "sCS" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/openspace,
 /area/hallway/primary/tram/left)
 "sCW" = (
@@ -58401,9 +57352,7 @@
 /area/command/heads_quarters/rd)
 "sDt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -58429,9 +57378,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Medical - Main South-East";
 	dir = 4;
@@ -58478,9 +57425,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "sEy" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
@@ -58507,10 +57452,9 @@
 /area/science/robotics/mechbay)
 "sFj" = (
 /obj/structure/cable,
-/obj/machinery/flasher{
+/obj/machinery/flasher/directional/east{
 	id = "AI";
-	pixel_x = 25;
-	pixel_y = 25
+	pixel_y = 26
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -58644,9 +57588,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Science - Main Upper Right";
 	dir = 5;
@@ -58730,7 +57672,7 @@
 	pixel_x = -10;
 	pixel_y = -1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "sLq" = (
@@ -58842,9 +57784,7 @@
 	pixel_y = 6
 	},
 /obj/item/reagent_containers/dropper,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "sOv" = (
@@ -58902,9 +57842,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "sPO" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
@@ -59023,14 +57961,12 @@
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/ce)
 "sSd" = (
+/obj/machinery/button/door/directional/east{
+	id = "pharmacy_shutters_2";
+	name = "Pharmacy Privacy Shutters Toggle"
+	},
 /obj/structure/window/reinforced{
 	pixel_y = 2
-	},
-/obj/machinery/button/door{
-	id = "pharmacy_shutters_2";
-	name = "Pharmacy Privacy Shutters Toggle";
-	pixel_x = 24;
-	pixel_y = 8
 	},
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
@@ -59105,10 +58041,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
+	departmentType = 3;
+	name = "Security Requests Console"
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
@@ -59173,13 +58109,11 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/requests_console{
+/obj/machinery/light/directional/north,
+/obj/machinery/requests_console/directional/north{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_y = 30
+	name = "Cargo Bay Requests Console"
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -59251,10 +58185,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = -27;
-	pixel_y = -8
-	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "sWR" = (
@@ -59347,9 +58278,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -59367,7 +58296,7 @@
 "sYd" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "sYh" = (
@@ -59499,9 +58428,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "tcT" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
@@ -59575,9 +58502,7 @@
 	dir = 5
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "tet" = (
@@ -59623,9 +58548,7 @@
 /obj/item/radio/intercom/chapel{
 	pixel_y = 27
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "tfC" = (
@@ -59653,9 +58576,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -59712,9 +58633,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -59860,6 +58779,7 @@
 	c_tag = "Departures - West Main";
 	dir = 9
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "tib" = (
@@ -59932,9 +58852,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 30
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "tiG" = (
@@ -60143,9 +59061,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
 "tmA" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -60384,9 +59300,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -60426,10 +59340,8 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "tqz" = (
+/obj/machinery/light/small/directional/east,
 /obj/structure/cable/multilayer/multiz,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32
 	},
@@ -60473,7 +59385,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "trk" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
@@ -60481,7 +59393,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "trB" = (
@@ -60606,9 +59518,7 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ttX" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -60751,7 +59661,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -60799,9 +59709,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "txp" = (
@@ -60881,9 +59789,7 @@
 /area/maintenance/tram/mid)
 "txZ" = (
 /obj/machinery/power/apc/auto_name/north,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -60966,7 +59872,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/cargo/office)
 "tzu" = (
@@ -61065,7 +59971,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "tCn" = (
@@ -61168,16 +60074,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "tES" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -61198,9 +60100,7 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
 "tFo" = (
@@ -61382,9 +60282,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
@@ -61470,9 +60368,7 @@
 "tKp" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/science/mixing)
 "tKK" = (
@@ -61629,9 +60525,7 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "tNC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
 "tND" = (
@@ -61797,16 +60691,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "tQo" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -62101,9 +60991,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
@@ -62135,10 +61023,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
-/obj/machinery/bounty_board{
-	dir = 1;
-	pixel_y = -32
-	},
+/obj/machinery/bounty_board/directional/south,
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -62310,7 +61195,7 @@
 /area/maintenance/port/central)
 "tYf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "tYk" = (
@@ -62764,9 +61649,7 @@
 /area/science/xenobiology)
 "uga" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "ugp" = (
@@ -62774,25 +61657,22 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_x = 8;
-	pixel_y = -28;
-	req_access_txt = "10"
-	},
 /obj/item/paper_bin{
 	pixel_x = 1;
 	pixel_y = 9
 	},
 /obj/item/pen,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/south{
 	id = "atmos";
 	name = "Atmospherics Lockdown";
-	pixel_x = -8;
-	pixel_y = -28;
+	pixel_x = -6;
 	req_access_txt = "24"
+	},
+/obj/machinery/button/door/directional/south{
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_x = 6;
+	req_access_txt = "10"
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
@@ -62813,9 +61693,7 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
+/obj/structure/mirror/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -62841,9 +61719,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron,
@@ -62855,14 +61731,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "uht" = (
@@ -62912,9 +61784,7 @@
 	},
 /obj/structure/closet/crate,
 /obj/item/stack/ore/silver,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "uiK" = (
@@ -62957,7 +61827,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Security - Prison Outpost";
 	dir = 1;
@@ -62993,7 +61863,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "ujH" = (
@@ -63006,15 +61876,13 @@
 	dir = 6;
 	network = list("ss13","cargo")
 	},
-/obj/machinery/button/door{
-	id = "QMLoaddoor2";
-	pixel_x = 8;
-	pixel_y = 24
-	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/north{
 	id = "QMLoaddoor";
-	pixel_x = -8;
-	pixel_y = 24
+	pixel_x = -6
+	},
+/obj/machinery/button/door/directional/north{
+	id = "QMLoaddoor2";
+	pixel_x = 6
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -63022,11 +61890,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/west{
 	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmospherics RC";
-	pixel_x = -28
+	departmentType = 3;
+	name = "Atmospherics Requests Console"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -63338,9 +62205,7 @@
 /area/tcommsat/computer)
 "urC" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
@@ -63416,7 +62281,7 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "usv" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "usA" = (
@@ -63440,9 +62305,7 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "usV" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "usX" = (
@@ -63510,13 +62373,11 @@
 /obj/item/paper/guides/jobs/medical/morgue{
 	pixel_x = -4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "uuz" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/engineering/main)
 "uuB" = (
@@ -63562,9 +62423,7 @@
 /turf/open/floor/wood,
 /area/service/library)
 "uxk" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "uxw" = (
@@ -63584,21 +62443,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "left_tram_lower";
-	pixel_x = -24;
-	pixel_y = -4;
-	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/button/door/directional/west,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "uya" = (
@@ -63633,16 +62485,14 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uyS" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
 "uyV" = (
@@ -63659,9 +62509,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -63670,7 +62518,7 @@
 /area/maintenance/tram/mid)
 "uzj" = (
 /obj/effect/turf_decal/stripes/white/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "uzM" = (
@@ -63681,6 +62529,7 @@
 /area/security/interrogation)
 "uzN" = (
 /obj/machinery/vending/boozeomat,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "uAb" = (
@@ -63697,9 +62546,7 @@
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "uAn" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "uAx" = (
@@ -63817,7 +62664,7 @@
 /area/tcommsat/server)
 "uDs" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Medical - Main South";
 	dir = 1;
@@ -63933,9 +62780,7 @@
 /obj/machinery/porta_turret/ai{
 	dir = 4
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "uHL" = (
@@ -63944,7 +62789,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "uIa" = (
@@ -64196,9 +63041,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron/white,
 /area/science/lab)
 "uLZ" = (
@@ -64362,18 +63205,14 @@
 /area/service/bar)
 "uOf" = (
 /obj/effect/turf_decal/bot,
-/obj/item/radio/intercom{
-	pixel_y = 21
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "uOF" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
 "uOY" = (
@@ -64414,9 +63253,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "uPC" = (
@@ -64479,9 +63316,7 @@
 	c_tag = "Secure - Telecomms Control Room";
 	dir = 6
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "uQB" = (
@@ -64529,13 +63364,10 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "uRd" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "uRw" = (
@@ -64605,11 +63437,11 @@
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 9
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/south{
 	freerange = 1;
 	frequency = 1447;
-	name = "Private Channel";
-	pixel_y = -28
+	listening = 0;
+	name = "Private Channel"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -64669,9 +63501,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "uUH" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -64924,9 +63754,7 @@
 	dir = 8
 	},
 /obj/structure/closet/l3closet/scientist,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "uZt" = (
@@ -64934,9 +63762,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -65027,9 +63853,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "vbG" = (
@@ -65146,10 +63970,7 @@
 /area/hallway/secondary/command)
 "ves" = (
 /obj/machinery/suit_storage_unit/hos,
-/obj/machinery/keycard_auth{
-	pixel_x = 24;
-	pixel_y = 10
-	},
+/obj/machinery/keycard_auth/directional/east,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "veB" = (
@@ -65175,9 +63996,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "vfl" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/circuit/green,
 /area/science/nanite)
 "vfo" = (
@@ -65222,9 +64041,7 @@
 	pixel_x = -6;
 	pixel_y = -3
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "vgg" = (
@@ -65335,14 +64152,12 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "vhE" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "restroom_1";
 	name = "Privacy Bolts";
 	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = 8;
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/freezer,
@@ -65351,9 +64166,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
 "vio" = (
@@ -65578,12 +64391,8 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/newscaster/security_unit/directional/west,
 /obj/machinery/camera{
 	c_tag = "Medical - Security Outpost";
 	dir = 4;
@@ -65611,9 +64420,7 @@
 /area/mine/explored)
 "vlZ" = (
 /obj/machinery/porta_turret/ai,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
@@ -65643,16 +64450,12 @@
 /obj/machinery/computer/operating{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "vnm" = (
 /obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/science/research)
 "vnt" = (
@@ -65669,10 +64472,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -20;
-	pixel_y = -24
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -65900,9 +64699,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/secondary)
 "vux" = (
@@ -66084,9 +64881,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "vAW" = (
@@ -66240,9 +65035,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "vDR" = (
@@ -66301,9 +65094,7 @@
 /area/science/research)
 "vEx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
 "vEG" = (
@@ -66352,9 +65143,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/corner,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "vFb" = (
@@ -66460,16 +65249,15 @@
 	id = "Cell 2";
 	name = "Cell 2 Locker"
 	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_y = -28
-	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Security - Cell 2";
 	dir = 1;
 	network = list("ss13","Security")
+	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 2"
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -66585,18 +65373,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "vIB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Medical - Main East";
 	dir = 8;
@@ -66727,10 +65511,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	department = "Security";
-	departmentType = 5;
-	pixel_y = 30
+	departmentType = 3;
+	name = "Security Requests Console"
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/depsec/supply,
@@ -66814,7 +65598,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "vMl" = (
@@ -66922,9 +65706,7 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "vNX" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
@@ -67026,9 +65808,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/science/research)
 "vQd" = (
@@ -67099,26 +65879,15 @@
 	id = "AI Core shutters";
 	name = "AI core shutters"
 	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = -26;
-	pixel_y = 3
-	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "Station Intercom (AI Private)";
-	pixel_x = 28
+/obj/machinery/flasher/directional/west{
+	id = "AI"
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "vRm" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/cargo/storage)
@@ -67155,15 +65924,14 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/flasher{
-	id = "Cell 4";
-	pixel_x = 28
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/flasher/directional/east{
+	id = "Cell 4"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "vRM" = (
@@ -67220,9 +65988,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "vSA" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8
 	},
@@ -67742,9 +66508,7 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "wdg" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Civilian - Disposals";
@@ -67767,19 +66531,14 @@
 /obj/item/storage/toolbox/electrical,
 /obj/item/clothing/head/welding,
 /obj/item/clothing/glasses/welding,
-/obj/machinery/newscaster{
-	pixel_x = -4;
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "wdJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "wdO" = (
@@ -67813,9 +66572,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "weC" = (
@@ -67866,7 +66623,7 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "wfn" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=10-TunnelLeftBottom";
@@ -67899,9 +66656,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "wfN" = (
@@ -68200,10 +66955,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"wmy" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter)
 "wmA" = (
 /obj/item/plate,
 /obj/effect/decal/cleanable/dirt,
@@ -68346,7 +67097,7 @@
 /area/hallway/primary/tram/center)
 "woW" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -68358,9 +67109,7 @@
 /area/maintenance/disposal/incinerator)
 "wpl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
 "wpm" = (
@@ -68432,9 +67181,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "wrn" = (
@@ -68480,9 +67227,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "wrS" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "wsh" = (
@@ -68510,7 +67255,7 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "wsA" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/closet/emcloset,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/plating,
@@ -68542,11 +67287,10 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "miningdorm3";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
-	pixel_x = 25;
 	specialfunctions = 4
 	},
 /turf/open/floor/carpet,
@@ -68696,20 +67440,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "right_tram_lower";
-	pixel_x = 24;
-	pixel_y = -4;
-	req_access_txt = "12"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/button/door/directional/east{
+	id = "right_tram_lower";
+	req_access_txt = "12"
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
@@ -68795,9 +67535,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
 "wws" = (
@@ -68851,9 +67589,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Arrivals - South Docking Wing";
 	dir = 6
@@ -68879,9 +67615,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "wxC" = (
@@ -68913,9 +67647,7 @@
 /area/cargo/storage)
 "wxW" = (
 /obj/structure/chair/stool,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -68993,12 +67725,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/requests_console{
-	department = "Kitchen";
-	name = "Kitchen RC";
-	pixel_y = 32
-	},
 /obj/machinery/grill,
+/obj/machinery/requests_console/directional/north{
+	department = "Kitchen";
+	name = "Kithen Requests Console"
+	},
 /turf/open/floor/iron,
 /area/service/kitchen)
 "wzc" = (
@@ -69471,9 +68202,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/east,
 /obj/structure/rack,
 /obj/item/restraints/handcuffs,
 /turf/open/floor/iron,
@@ -69542,9 +68271,7 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "wIj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/hangover/closet,
@@ -69619,9 +68346,7 @@
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
 	name = "medical bed"
 	},
-/obj/machinery/defibrillator_mount{
-	pixel_y = -32
-	},
+/obj/machinery/defibrillator_mount/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
@@ -69650,19 +68375,16 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	announcementConsole = 1;
 	department = "Telecomms Admin";
 	departmentType = 5;
-	name = "Telecomms RC";
-	pixel_y = 30
+	name = "Telecomms Requests Console"
 	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "wJT" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "wJV" = (
@@ -69829,7 +68551,7 @@
 "wMq" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "wMv" = (
@@ -69895,12 +68617,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -25
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/light/directional/west,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Material Storage";
 	dir = 5;
@@ -69959,14 +68677,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "wPO" = (
+/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
-	},
-/obj/machinery/light/small{
-	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -70039,7 +68755,7 @@
 /area/security/detectives_office)
 "wRf" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "wRg" = (
@@ -70082,13 +68798,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
 	dir = 1
 	},
-/obj/machinery/button/door{
+/obj/structure/cable,
+/obj/machinery/button/door/directional/south{
 	id = "engsm";
 	name = "Radiation Shutters Control";
-	pixel_y = -24;
 	req_access_txt = "10"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "wSA" = (
@@ -70101,9 +68816,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "wTg" = (
@@ -70252,9 +68965,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/science/research)
 "wWR" = (
@@ -70272,7 +68983,7 @@
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "wXy" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -70338,10 +69049,9 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/syringes,
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/east{
 	department = "Virology";
 	name = "Virology Requests Console";
-	pixel_x = 32;
 	receive_ore_updates = 1
 	},
 /turf/open/floor/iron/white,
@@ -70396,9 +69106,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
 "wZS" = (
@@ -70424,9 +69132,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "xao" = (
@@ -70523,9 +69229,7 @@
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
 "xdC" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden{
 	dir = 4
 	},
@@ -70566,10 +69270,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
-/obj/machinery/button/door{
-	id = "cargowarehouse";
-	pixel_x = -24;
-	pixel_y = -4
+/obj/machinery/button/door/directional/west{
+	id = "cargowarehouse"
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -70593,9 +69295,7 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "xev" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "xeC" = (
@@ -70732,9 +69432,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/ai,
 /obj/effect/turf_decal/trimline/white/filled/line,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "xgp" = (
@@ -70781,9 +69479,7 @@
 	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /obj/machinery/camera{
 	c_tag = "Civilian - Lounge South";
 	dir = 6
@@ -70808,9 +69504,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 1
 	},
-/obj/machinery/ticket_machine{
-	pixel_y = 32
-	},
+/obj/machinery/ticket_machine/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "xiC" = (
@@ -70833,9 +69527,7 @@
 /turf/open/space/basic,
 /area/space)
 "xiS" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/sign/poster/ripped{
 	pixel_x = -32
 	},
@@ -70868,9 +69560,7 @@
 "xjz" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/wood,
-/obj/item/radio/intercom{
-	pixel_x = 27
-	},
+/obj/item/radio/intercom/directional/east,
 /obj/item/reagent_containers/food/drinks/flask/gold,
 /obj/item/hand_tele,
 /turf/open/floor/wood,
@@ -70887,9 +69577,7 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "xjN" = (
@@ -71052,9 +69740,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/white,
 /area/science/research)
 "xmJ" = (
@@ -71140,9 +69826,7 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "xnN" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/sign/painting/library{
 	pixel_y = 32
 	},
@@ -71173,9 +69857,7 @@
 /area/cargo/miningdock)
 "xox" = (
 /obj/machinery/computer/security/hos,
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 30
-	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /obj/machinery/camera{
 	c_tag = "Security - Head of Security's Office";
 	dir = 6;
@@ -71273,6 +69955,15 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
+"xrN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/structure/cable,
+/obj/machinery/status_display/ai/directional/east,
+/turf/open/floor/engine,
+/area/engineering/supermatter/room)
 "xrY" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -71291,12 +69982,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "cytologylockdown";
-	name = "Cytology Lockdown";
-	pixel_x = -24;
-	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
@@ -71414,9 +70099,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "xuH" = (
@@ -71512,9 +70195,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "xxm" = (
@@ -71597,9 +70278,7 @@
 /area/hallway/secondary/entry)
 "xyX" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -71676,9 +70355,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/secure_data,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera{
 	c_tag = "Departures - Security Outpost";
@@ -71707,9 +70384,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "xAu" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -71943,9 +70618,7 @@
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xFN" = (
@@ -72103,7 +70776,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/landmark/start/cyborg,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/computer/security/telescreen{
@@ -72135,6 +70808,11 @@
 	pixel_y = 3
 	},
 /obj/structure/cable,
+/obj/machinery/requests_console/directional/north{
+	department = "AI";
+	departmentType = 5;
+	name = "AI Requests Console"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "xIL" = (
@@ -72224,32 +70902,30 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "xKn" = (
-/obj/machinery/button/door{
-	id = "rnd2";
-	name = "Research Lab Shutter Control";
-	pixel_x = 6;
-	pixel_y = -25;
-	req_access_txt = "47"
-	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/south{
 	id = "Biohazard";
 	name = "Biohazard Shutter Control";
 	pixel_x = -6;
-	pixel_y = -25;
 	req_access_txt = "47"
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/south{
+	id = "rnd2";
+	name = "Research Lab Shutter Control";
+	pixel_x = 6;
+	req_access_txt = "47"
+	},
+/obj/machinery/button/door/directional/south{
+	id = "xenobiomain";
+	name = "Xenobiology Containmenr Blast Door";
+	pixel_x = -6;
+	pixel_y = -34;
+	req_access_txt = "55"
+	},
+/obj/machinery/button/door/directional/south{
 	id = "misclab";
 	name = "Test Chamber Blast Doors";
 	pixel_x = 6;
-	pixel_y = -38;
-	req_access_txt = "55"
-	},
-/obj/machinery/button/door{
-	id = "xenobiomain";
-	name = "Xenobiology Containment Blast Doors";
-	pixel_x = -6;
-	pixel_y = -38;
+	pixel_y = -34;
 	req_access_txt = "55"
 	},
 /turf/open/floor/iron/cafeteria,
@@ -72263,9 +70939,7 @@
 /area/security/prison)
 "xKv" = (
 /obj/item/food/grown/banana,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/grass,
 /area/medical/virology)
 "xKB" = (
@@ -72335,9 +71009,7 @@
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "xLE" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
 "xLP" = (
@@ -72388,9 +71060,7 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "xMx" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/security/prison)
@@ -72409,9 +71079,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "xNa" = (
@@ -72537,20 +71205,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "left_tram_lower";
-	pixel_x = 24;
-	pixel_y = -4;
-	req_access_txt = "12"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/machinery/button/door/directional/east{
+	id = "left_tram_lower";
+	req_access_txt = "12"
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
@@ -72675,7 +71339,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Command - Bridge Left Airlock";
@@ -72728,9 +71392,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xSo" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Core South";
 	dir = 6;
@@ -73089,10 +71751,11 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/east{
+	announcementConsole = 1;
 	department = "Research Lab";
-	name = "Research RC";
-	pixel_x = 32;
+	departmentType = 5;
+	name = "Research Requests Console";
 	receive_ore_updates = 1
 	},
 /obj/machinery/airalarm/directional/north,
@@ -73328,7 +71991,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -73365,9 +72028,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ydE" = (
@@ -73481,9 +72142,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "yhw" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -73517,9 +72176,7 @@
 /area/science/research)
 "yhS" = (
 /obj/structure/toilet,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/freezer,
@@ -73579,9 +72236,7 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "yjj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
 "yjp" = (
@@ -100364,7 +99019,7 @@ qrK
 btM
 oTx
 qrK
-fBd
+siu
 qrK
 qrK
 gUw
@@ -102945,7 +101600,7 @@ tLr
 aTB
 svf
 svf
-svf
+xrN
 eel
 svf
 mQb
@@ -103201,12 +101856,12 @@ cjg
 tLr
 hAq
 xKC
-usj
-fSu
+bTb
+wKG
 fbD
 fmi
 fbD
-wmy
+wKG
 ntj
 oXu
 mAL
@@ -104724,7 +103379,7 @@ duN
 bhR
 bhR
 bhR
-mOU
+lpV
 nZO
 xjN
 xjN
@@ -105257,12 +103912,12 @@ cjg
 ckA
 xEu
 hLp
-jGh
-wmy
+oXr
+wKG
 osV
 hCQ
 wTk
-fSu
+wKG
 fsF
 lOO
 eiA
@@ -105515,11 +104170,11 @@ jDY
 nxw
 ncZ
 ncZ
-ncZ
+fJp
 jOX
 jOX
 jOX
-jOX
+owU
 sgc
 aZx
 cOZ
@@ -109603,7 +108258,7 @@ aJo
 hjW
 hjW
 aJo
-byo
+aJo
 aJo
 fVf
 iYt
@@ -154036,8 +152691,8 @@ aEJ
 aEJ
 aEJ
 aEJ
-cxt
-cxt
+aEJ
+aEJ
 aEJ
 aEJ
 aEJ
@@ -164564,7 +163219,7 @@ aYq
 afQ
 aig
 afp
-aVo
+aAL
 nSw
 gLR
 avp
@@ -173592,7 +172247,7 @@ cMw
 uus
 aGK
 vnu
-irj
+pSu
 eVQ
 hag
 adW
@@ -176934,7 +175589,7 @@ hDp
 aae
 aae
 aae
-qUE
+aae
 aae
 aae
 aae
@@ -177191,7 +175846,7 @@ aae
 aae
 dyg
 dyg
-dzg
+dyg
 dyg
 dyg
 dyg
@@ -184964,7 +183619,7 @@ mLq
 leZ
 leZ
 xyC
-eEo
+cqG
 uoZ
 lve
 dtL
@@ -186942,7 +185597,7 @@ eHH
 eHH
 pQf
 ujA
-aXR
+gBY
 arf
 eHH
 cZO


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the lights and wallmounts on Tramstation to directional mounts introduced in #58809
Also removed a couple of wall mounts hidden in asteroid (fire extinguisher cabinet and light switch).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When the wallening gets here, will allow us to switch the directions of all of the lights at once (which we'll need) and not have to manually set wall mount dirs. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
