### PR TITLE
The tralezab's entire afternoon rabbit hole: Improves chainsaw code to actually use twohanded component properly, butchering no longer codifies using getComponent, and more refactoring everywhere

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -923,6 +923,13 @@
 ///sent from mecha action buttons to the mecha they're linked to
 #define COMSIG_MECHA_ACTION_TRIGGER "mecha_action_activate"
 
+// /obj/item/mecha_parts/mecha_equipment signals, sorted close to mecha signals so you can find it easier
+
+///from base of /obj/item/mecha_parts/mecha_equipment/proc/attach(): (mecha)
+#define COMSIG_MECHA_EQUIPMENT_ATTACHED "mecha_equipment_attached"
+///from base of /obj/item/mecha_parts/mecha_equipment/proc/detach(): ()
+#define COMSIG_MECHA_EQUIPMENT_DETACHED "mecha_equipment_detached"
+
 
 // /mob/living/carbon/human signals
 

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -6,17 +6,28 @@
  */
 /datum/component/two_handed
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS // Only one of the component can exist on an item
-	var/wielded = FALSE /// Are we holding the two handed item properly
-	var/force_multiplier = 0 /// The multiplier applied to force when wielded, does not work with force_wielded, and force_unwielded
-	var/force_wielded = 0 /// The force of the item when weilded
-	var/force_unwielded = 0 /// The force of the item when unweilded
-	var/wieldsound = FALSE /// Play sound when wielded
-	var/unwieldsound = FALSE /// Play sound when unwielded
-	var/attacksound = FALSE /// Play sound on attack when wielded
-	var/require_twohands = FALSE /// Does it have to be held in both hands
-	var/icon_wielded = FALSE /// The icon that will be used when wielded
-	var/obj/item/offhand/offhand_item = null /// Reference to the offhand created for the item
-	var/sharpened_increase = 0 /// The amount of increase recived from sharpening the item
+	/// Are we holding the two handed item properly
+	var/wielded = FALSE
+	/// The multiplier applied to force when wielded, does not work with force_wielded, and force_unwielded
+	var/force_multiplier
+	/// The force of the item when weilded
+	var/force_wielded
+	/// The force of the item when unweilded
+	var/force_unwielded
+	/// Play sound when wielded
+	var/wieldsound
+	/// Play sound when unwielded
+	var/unwieldsound
+	/// Play sound on attack when wielded
+	var/attacksound
+	/// Does it have to be held in both hands
+	var/require_twohands = FALSE
+	/// The icon that will be used when wielded
+	var/icon_wielded = FALSE
+	/// Reference to the offhand created for the item
+	var/obj/item/offhand/offhand_item = null
+	/// The amount of increase recived from sharpening the item
+	var/sharpened_increase = 0
 /**
 
  * Two Handed component
@@ -31,7 +42,7 @@
  * * force_unwielded (optional) The force setting when the item is unwielded, do not use with force_multiplier
  * * icon_wielded (optional) The icon to be used when wielded
  */
-/datum/component/two_handed/Initialize(require_twohands=FALSE, wieldsound=FALSE, unwieldsound=FALSE, attacksound=FALSE, \
+/datum/component/two_handed/Initialize(require_twohands=FALSE, wieldsound, unwieldsound, attacksound, \
 										force_multiplier=0, force_wielded=0, force_unwielded=0, icon_wielded=FALSE)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -118,6 +129,12 @@
 		unwield(user)
 	else if(user.is_holding(parent))
 		wield(user)
+		user.update_inv_hands()
+
+	if(isitem(parent))
+		var/obj/item/butchering_tool = parent
+		for(var/datum/action/action as anything in butchering_tool.actions)
+			action.UpdateButtonIcon()
 
 /**
  * Wield the two handed item in both hands

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -132,8 +132,8 @@
 		user.update_inv_hands()
 
 	if(isitem(parent))
-		var/obj/item/butchering_tool = parent
-		for(var/datum/action/action as anything in butchering_tool.actions)
+		var/obj/item/two_handed_item = parent
+		for(var/datum/action/action as anything in two_handed_item.actions)
 			action.UpdateButtonIcon()
 
 /**

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -10,9 +10,9 @@
 	var/wielded = FALSE
 	/// The multiplier applied to force when wielded, does not work with force_wielded, and force_unwielded
 	var/force_multiplier
-	/// The force of the item when weilded
+	/// The force of the item when wielded
 	var/force_wielded
-	/// The force of the item when unweilded
+	/// The force of the item when unwielded
 	var/force_unwielded
 	/// Play sound when wielded
 	var/wieldsound

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -224,6 +224,22 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 			hitsound = 'sound/items/welder.ogg'
 		if(damtype == BRUTE)
 			hitsound = "swing_hit"
+	if(!LAZYLEN(embedding))
+		if(GLOB.embedpocalypse)
+			embedding = EMBED_POINTY
+			name = "pointy [name]"
+		else if(GLOB.stickpocalypse)
+			embedding = EMBED_HARMLESS
+			name = "sticky [name]"
+
+	updateEmbedding()
+
+	if(GLOB.rpg_loot_items)
+		AddComponent(/datum/component/fantasy)
+
+	if(sharpness && force > 5) //give sharp objects butchering functionality, for consistency
+		var/speed = 8 SECONDS * toolspeed
+		AddComponent(/datum/component/butchering, speed)
 
 /obj/item/Destroy()
 	item_flags &= ~DROPDEL //prevent reqdels
@@ -243,25 +259,6 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 /obj/item/blob_act(obj/structure/blob/B)
 	if(B && B.loc == loc)
 		obj_destruction(MELEE)
-
-/obj/item/ComponentInitialize()
-	. = ..()
-	// this proc says it's for initializing components, but we're initializing elements too because it's you and me against the world >:)
-	if(!LAZYLEN(embedding))
-		if(GLOB.embedpocalypse)
-			embedding = EMBED_POINTY
-			name = "pointy [name]"
-		else if(GLOB.stickpocalypse)
-			embedding = EMBED_HARMLESS
-			name = "sticky [name]"
-
-	updateEmbedding()
-
-	if(GLOB.rpg_loot_items)
-		AddComponent(/datum/component/fantasy)
-
-	if(sharpness && force > 5) //give sharp objects butchering functionality, for consistency
-		AddComponent(/datum/component/butchering, 80 * toolspeed)
 
 /**Makes cool stuff happen when you suicide with an item
  *

--- a/code/game/objects/items/chainsaw.dm
+++ b/code/game/objects/items/chainsaw.dm
@@ -8,7 +8,6 @@
 	righthand_file = 'icons/mob/inhands/weapons/chainsaw_righthand.dmi'
 	flags_1 = CONDUCT_1
 	force = 13
-	var/force_on = 24
 	w_class = WEIGHT_CLASS_HUGE
 	throwforce = 13
 	throw_speed = 2
@@ -21,33 +20,71 @@
 	actions_types = list(/datum/action/item_action/startchainsaw)
 	tool_behaviour = TOOL_SAW
 	toolspeed = 0.5
-	var/on = FALSE
+	// used as a component arg for how much force the chainsaw has while on
+	var/force_on = 24
 	var/wielded = FALSE // track wielded status on item
 
 /obj/item/chainsaw/Initialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, .proc/on_wield)
 	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, .proc/on_unwield)
-
-/obj/item/chainsaw/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/butchering, 30, 100, 0, 'sound/weapons/chainsawhit.ogg', TRUE)
-	AddComponent(/datum/component/two_handed, require_twohands=TRUE)
+	//some clarified arguments
+	var/speed = 3 SECONDS
+	var/effectiveness = 100
+	var/bonus_modifier = 0
+	var/butcher_sound = 'sound/effects/butcher.ogg'
+	var/can_be_blunt = TRUE
+	var/butchering_enabled = FALSE
+	var/enable_butchering_signals = list(COMSIG_TWOHANDED_WIELD)
+	var/disable_butchering_signals = list(COMSIG_TWOHANDED_UNWIELD)
+	AddComponent(\
+		/datum/component/butchering,\
+		speed,\
+		effectiveness,\
+		bonus_modifier,\
+		butcher_sound,\
+		can_be_blunt,\
+		butchering_enabled,\
+		enable_butchering_signals,\
+		disable_butchering_signals\
+	)
+	//same here for twohands
+	var/require_twohands = TRUE
+	var/unwieldsound = null
+	var/wieldsound = null
+	var/attacksound = 'sound/weapons/chainsawhit.ogg'
+	var/force_multiplier = 0
+	var/force_wielded = force_on
+	var/force_unwielded = 13
+	var/icon_wielded = "chainsaw_on"
+	AddComponent(
+		/datum/component/two_handed,\
+		require_twohands,\
+		unwieldsound,\
+		wieldsound,\
+		attacksound,\
+		force_multiplier,\
+		force_wielded,\
+		force_unwielded,\
+		icon_wielded\
+	)
 
 /// triggered on wield of two handed item
 /obj/item/chainsaw/proc/on_wield(obj/item/source, mob/user)
 	SIGNAL_HANDLER
 
+	to_chat(user, "As you pull the starting cord dangling from [src], it begins to whirr.")
 	wielded = TRUE
 
 /// triggered on unwield of two handed item
 /obj/item/chainsaw/proc/on_unwield(obj/item/source, mob/user)
 	SIGNAL_HANDLER
 
+	to_chat(user, "As you pull the starting cord dangling from [src], the chain stops moving.")
 	wielded = FALSE
 
 /obj/item/chainsaw/suicide_act(mob/living/carbon/user)
-	if(on)
+	if(wielded)
 		user.visible_message("<span class='suicide'>[user] begins to tear [user.p_their()] head off with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 		playsound(src, 'sound/weapons/chainsawhit.ogg', 100, TRUE)
 		var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
@@ -57,26 +94,6 @@
 		user.visible_message("<span class='suicide'>[user] smashes [src] into [user.p_their()] neck, destroying [user.p_their()] esophagus! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 		playsound(src, 'sound/weapons/genhit1.ogg', 100, TRUE)
 	return(BRUTELOSS)
-
-/obj/item/chainsaw/attack_self(mob/user)
-	on = !on
-	to_chat(user, "As you pull the starting cord dangling from [src], [on ? "it begins to whirr." : "the chain stops moving."]")
-	force = on ? force_on : initial(force)
-	throwforce = on ? force_on : initial(force)
-	icon_state = "chainsaw_[on ? "on" : "off"]"
-	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
-	butchering.butchering_enabled = on
-
-	if(on)
-		hitsound = 'sound/weapons/chainsawhit.ogg'
-	else
-		hitsound = "swing_hit"
-
-	if(src == user.get_active_held_item()) //update inhands
-		user.update_inv_hands()
-	for(var/X in actions)
-		var/datum/action/A = X
-		A.UpdateButtonIcon()
 
 /obj/item/chainsaw/doomslayer
 	name = "THE GREAT COMMUNICATOR"

--- a/code/game/objects/items/chainsaw.dm
+++ b/code/game/objects/items/chainsaw.dm
@@ -20,53 +20,40 @@
 	actions_types = list(/datum/action/item_action/startchainsaw)
 	tool_behaviour = TOOL_SAW
 	toolspeed = 0.5
-	// used as a component arg for how much force the chainsaw has while on
+	///butchering component added to this object, only used for deletion which is why this is acceptable.
+	var/datum/component/butchering/butcher_component
+	///used as a component arg for how much force the chainsaw has while on
 	var/force_on = 24
-	var/wielded = FALSE // track wielded status on item
+	///track wielded status on item
+	var/wielded = FALSE
 
 /obj/item/chainsaw/Initialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, .proc/on_wield)
 	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, .proc/on_unwield)
+	add_butcher_component()
+	AddComponent(
+		/datum/component/two_handed,\
+		require_twohands = TRUE,\
+		attacksound = 'sound/weapons/chainsawhit.ogg',\
+		force_wielded = force_on,\
+		force_unwielded = 13,\
+		icon_wielded = "chainsaw_on"\
+	)
+
+///wrapper for adding the butcher component to it is cleaner to add and remove it in multiple places
+/obj/item/chainsaw/proc/add_butcher_component()
 	//some clarified arguments
 	var/speed = 3 SECONDS
 	var/effectiveness = 100
 	var/bonus_modifier = 0
 	var/butcher_sound = 'sound/effects/butcher.ogg'
-	var/can_be_blunt = TRUE
-	var/butchering_enabled = FALSE
-	var/enable_butchering_signals = list(COMSIG_TWOHANDED_WIELD)
-	var/disable_butchering_signals = list(COMSIG_TWOHANDED_UNWIELD)
-	AddComponent(\
+	butcher_component = AddComponent(\
 		/datum/component/butchering,\
 		speed,\
 		effectiveness,\
 		bonus_modifier,\
 		butcher_sound,\
-		can_be_blunt,\
-		butchering_enabled,\
-		enable_butchering_signals,\
-		disable_butchering_signals\
-	)
-	//same here for twohands
-	var/require_twohands = TRUE
-	var/unwieldsound = null
-	var/wieldsound = null
-	var/attacksound = 'sound/weapons/chainsawhit.ogg'
-	var/force_multiplier = 0
-	var/force_wielded = force_on
-	var/force_unwielded = 13
-	var/icon_wielded = "chainsaw_on"
-	AddComponent(
-		/datum/component/two_handed,\
-		require_twohands,\
-		unwieldsound,\
-		wieldsound,\
-		attacksound,\
-		force_multiplier,\
-		force_wielded,\
-		force_unwielded,\
-		icon_wielded\
 	)
 
 /// triggered on wield of two handed item
@@ -74,6 +61,7 @@
 	SIGNAL_HANDLER
 
 	to_chat(user, "As you pull the starting cord dangling from [src], it begins to whirr.")
+	add_butcher_component()
 	wielded = TRUE
 
 /// triggered on unwield of two handed item
@@ -81,6 +69,7 @@
 	SIGNAL_HANDLER
 
 	to_chat(user, "As you pull the starting cord dangling from [src], the chain stops moving.")
+	qdel(butcher_component)
 	wielded = FALSE
 
 /obj/item/chainsaw/suicide_act(mob/living/carbon/user)

--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -30,19 +30,18 @@
 
 /obj/item/fireaxe/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/butchering, 100, 80, 0 , hitsound) //axes are not known for being precision butchering tools
-	AddComponent(/datum/component/two_handed, force_unwielded=5, force_wielded=24, icon_wielded="[base_icon_state]1")
+	//axes are not known for being precision butchering tools
+	AddComponent(/datum/component/butchering, speed = 10 SECONDS, effectiveness = 80, bonus_modifier = 0, butcher_sound = hitsound)
+	AddComponent(/datum/component/two_handed, force_unwielded = 5, force_wielded = 24, icon_wielded = "[base_icon_state]1")
 
 /// triggered on wield of two handed item
 /obj/item/fireaxe/proc/on_wield(obj/item/source, mob/user)
 	SIGNAL_HANDLER
-
 	wielded = TRUE
 
 /// triggered on unwield of two handed item
 /obj/item/fireaxe/proc/on_unwield(obj/item/source, mob/user)
 	SIGNAL_HANDLER
-
 	wielded = FALSE
 
 /obj/item/fireaxe/update_icon_state()

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -468,7 +468,7 @@
 
 /obj/item/nullrod/scythe/Initialize()
 	. = ..()
-	AddComponent(/datum/component/butchering, 70, 110) //the harvest gives a high bonus chance
+	AddComponent(/datum/component/butchering, speed = 7 SECONDS, effectiveness = 110) //the harvest gives a high bonus chance
 
 /obj/item/nullrod/scythe/vibro
 	icon_state = "hfrequency0"
@@ -593,7 +593,7 @@
 /obj/item/nullrod/chainsaw/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
-	AddComponent(/datum/component/butchering, 30, 100, 0, hitsound)
+	AddComponent(/datum/component/butchering, speed = 3 SECONDS, effectiveness = 100, hitsound)
 
 /obj/item/nullrod/clown
 	name = "clown dagger"
@@ -679,7 +679,7 @@
 /obj/item/nullrod/armblade/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
-	AddComponent(/datum/component/butchering, 80, 70)
+	AddComponent(/datum/component/butchering, effectiveness = 70)
 
 /obj/item/nullrod/armblade/tentacle
 	name = "unholy blessing"
@@ -744,7 +744,7 @@
 /obj/item/nullrod/tribal_knife/Initialize(mapload)
 	. = ..()
 	START_PROCESSING(SSobj, src)
-	AddComponent(/datum/component/butchering, 50, 100)
+	AddComponent(/datum/component/butchering, speed = 5 SECONDS, effectiveness = 100)
 
 /obj/item/nullrod/tribal_knife/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -110,7 +110,7 @@
 
 ///Adds the butchering component, used to override stats for special cases
 /obj/item/kitchen/knife/proc/set_butchering()
-	AddComponent(/datum/component/butchering, 80 - force, 100, force - 10) //bonus chance increases depending on force
+	AddComponent(/datum/component/butchering, speed = 80 - force, effectiveness = 100, bonus_modifier = force - 10) //bonus chance increases depending on force
 
 /obj/item/kitchen/knife/suicide_act(mob/user)
 	user.visible_message(pick("<span class='suicide'>[user] is slitting [user.p_their()] wrists with the [src.name]! It looks like [user.p_theyre()] trying to commit suicide.</span>", \
@@ -197,7 +197,7 @@
 	icon_state = "huntingknife"
 
 /obj/item/kitchen/knife/hunting/set_butchering()
-	AddComponent(/datum/component/butchering, 80 - force, 100, force + 10)
+	AddComponent(/datum/component/butchering, speed = 80 - force, effectiveness = 100, bonus_modifier = force + 10)
 
 /obj/item/kitchen/knife/combat
 	name = "combat knife"

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -26,7 +26,7 @@
 
 /obj/item/spear/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/butchering, 100, 70) //decent in a pinch, but pretty bad.
+	AddComponent(/datum/component/butchering, speed = 10 SECONDS, effectiveness = 70) //decent in a pinch, but pretty bad.
 	AddComponent(/datum/component/jousting)
 	AddComponent(/datum/component/two_handed, force_unwielded=10, force_wielded=18, icon_wielded="[icon_prefix]1")
 	update_appearance()

--- a/code/modules/ruins/icemoonruin_code/wrath.dm
+++ b/code/modules/ruins/icemoonruin_code/wrath.dm
@@ -7,37 +7,29 @@
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+	///butchering component added to this object, only used for deletion which is why this is acceptable.
+	var/datum/component/butchering/butcher_component
 
-/obj/item/clothing/gloves/butchering/Initialize()
+/obj/item/clothing/gloves/butchering/equipped(mob/user, slot, initial = FALSE)
 	. = ..()
 	//some clarified arguments
 	var/speed = 0.5 SECONDS
 	var/effectiveness = 125
 	var/bonus_modifier = 0
 	var/butcher_sound = 'sound/effects/butcher.ogg'
-	var/can_be_blunt = TRUE
-	var/butchering_enabled = FALSE
-	var/enable_butchering_signals = list(COMSIG_ITEM_EQUIPPED)
-	var/disable_butchering_signals = list(COMSIG_ITEM_PRE_UNEQUIP)
-	AddComponent(
+	butcher_component = AddComponent(
 		/datum/component/butchering,\
 		speed,\
 		effectiveness,\
 		bonus_modifier,\
-		butcher_sound,\
-		can_be_blunt,\
-		butchering_enabled,\
-		enable_butchering_signals,\
-		disable_butchering_signals\
+		butcher_sound\
 	)
-
-/obj/item/clothing/gloves/butchering/equipped(mob/user, slot, initial = FALSE)
-	. = ..()
 	RegisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK, .proc/butcher_target)
 
 /obj/item/clothing/gloves/butchering/dropped(mob/user, silent = FALSE)
 	. = ..()
 	UnregisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK)
+	qdel(butcher_component)
 
 /obj/item/clothing/gloves/butchering/proc/butcher_target(mob/user, atom/target, proximity)
 	if(!isliving(target))

--- a/code/modules/ruins/icemoonruin_code/wrath.dm
+++ b/code/modules/ruins/icemoonruin_code/wrath.dm
@@ -10,19 +10,34 @@
 
 /obj/item/clothing/gloves/butchering/Initialize()
 	. = ..()
-	AddComponent(/datum/component/butchering, 5, 125, null, null, TRUE, TRUE)
+	//some clarified arguments
+	var/speed = 0.5 SECONDS
+	var/effectiveness = 125
+	var/bonus_modifier = 0
+	var/butcher_sound = 'sound/effects/butcher.ogg'
+	var/can_be_blunt = TRUE
+	var/butchering_enabled = FALSE
+	var/enable_butchering_signals = list(COMSIG_ITEM_EQUIPPED)
+	var/disable_butchering_signals = list(COMSIG_ITEM_PRE_UNEQUIP)
+	AddComponent(
+		/datum/component/butchering,\
+		speed,\
+		effectiveness,\
+		bonus_modifier,\
+		butcher_sound,\
+		can_be_blunt,\
+		butchering_enabled,\
+		enable_butchering_signals,\
+		disable_butchering_signals\
+	)
 
 /obj/item/clothing/gloves/butchering/equipped(mob/user, slot, initial = FALSE)
 	. = ..()
 	RegisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK, .proc/butcher_target)
-	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
-	butchering.butchering_enabled = TRUE
 
 /obj/item/clothing/gloves/butchering/dropped(mob/user, silent = FALSE)
 	. = ..()
 	UnregisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK)
-	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
-	butchering.butchering_enabled = FALSE
 
 /obj/item/clothing/gloves/butchering/proc/butcher_target(mob/user, atom/target, proximity)
 	if(!isliving(target))

--- a/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
+++ b/code/modules/vehicles/mecha/equipment/mecha_equipment.dm
@@ -118,24 +118,24 @@
 		return TRUE
 	return FALSE
 
-/obj/item/mecha_parts/mecha_equipment/proc/attach(obj/vehicle/sealed/mecha/M)
-	LAZYADD(M.equipment, src)
-	chassis = M
-	forceMove(M)
+/obj/item/mecha_parts/mecha_equipment/proc/attach(obj/vehicle/sealed/mecha/mecha)
+	LAZYADD(mecha.equipment, src)
+	chassis = mecha
+	forceMove(mecha)
+	SEND_SIGNAL(src, COMSIG_MECHA_EQUIPMENT_ATTACHED, mecha)
 	log_message("[src] initialized.", LOG_MECHA)
 	update_chassis_page()
-	return
 
-/obj/item/mecha_parts/mecha_equipment/proc/detach(atom/moveto=null)
+/obj/item/mecha_parts/mecha_equipment/proc/detach(atom/moveto = null)
 	moveto = moveto || get_turf(chassis)
 	if(src.Move(moveto))
+		SEND_SIGNAL(src, COMSIG_MECHA_EQUIPMENT_DETACHED)
 		LAZYREMOVE(chassis.equipment, src)
 		if(chassis.selected == src)
 			chassis.selected = null
 		update_chassis_page()
 		log_message("[src] removed from equipment.", LOG_MECHA)
 		chassis = null
-	return
 
 
 /obj/item/mecha_parts/mecha_equipment/Topic(href,href_list)

--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -22,7 +22,26 @@
 
 /obj/item/mecha_parts/mecha_equipment/drill/Initialize()
 	. = ..()
-	AddComponent(/datum/component/butchering, 50, 100, null, null, TRUE)
+	//some clarified arguments
+	var/speed = 5 SECONDS
+	var/effectiveness = 100
+	var/bonus_modifier = 0
+	var/butcher_sound = 'sound/effects/butcher.ogg'
+	var/can_be_blunt = TRUE
+	var/butchering_enabled = FALSE
+	var/enable_butchering_signals = list(COMSIG_MECHA_EQUIPMENT_ATTACHED)
+	var/disable_butchering_signals = list(COMSIG_MECHA_EQUIPMENT_DETACHED)
+	AddComponent(\
+		/datum/component/butchering,\
+		speed,\
+		effectiveness,\
+		bonus_modifier,\
+		butcher_sound,\
+		can_be_blunt,\
+		butchering_enabled,\
+		enable_butchering_signals,\
+		disable_butchering_signals\
+	)
 
 /obj/item/mecha_parts/mecha_equipment/drill/action(mob/source, atom/target, params)
 	// Check if we can even use the equipment to begin with.
@@ -111,16 +130,6 @@
 		if(istype(M, /obj/vehicle/sealed/mecha/working) || istype(M, /obj/vehicle/sealed/mecha/combat))
 			return TRUE
 	return FALSE
-
-/obj/item/mecha_parts/mecha_equipment/drill/attach(obj/vehicle/sealed/mecha/M)
-	..()
-	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
-	butchering.butchering_enabled = TRUE
-
-/obj/item/mecha_parts/mecha_equipment/drill/detach(atom/moveto)
-	..()
-	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
-	butchering.butchering_enabled = FALSE
 
 /obj/item/mecha_parts/mecha_equipment/drill/proc/drill_mob(mob/living/target, mob/living/user)
 	target.visible_message("<span class='danger'>[chassis] is drilling [target] with [src]!</span>", \

--- a/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/mining_tools.dm
@@ -16,32 +16,30 @@
 	range = MECHA_MELEE
 	tool_behaviour = TOOL_DRILL
 	toolspeed = 0.9
+	mech_flags = EXOSUIT_MODULE_WORKING | EXOSUIT_MODULE_COMBAT
 	var/drill_delay = 7
 	var/drill_level = DRILL_BASIC
-	mech_flags = EXOSUIT_MODULE_WORKING | EXOSUIT_MODULE_COMBAT
+	///butchering component added to this object, only used for deletion which is why this is acceptable.
+	var/datum/component/butchering/butcher_component
 
-/obj/item/mecha_parts/mecha_equipment/drill/Initialize()
-	. = ..()
+/obj/item/mecha_parts/mecha_equipment/drill/attach(obj/vehicle/sealed/mecha/M)
+	..()
 	//some clarified arguments
 	var/speed = 5 SECONDS
 	var/effectiveness = 100
 	var/bonus_modifier = 0
 	var/butcher_sound = 'sound/effects/butcher.ogg'
-	var/can_be_blunt = TRUE
-	var/butchering_enabled = FALSE
-	var/enable_butchering_signals = list(COMSIG_MECHA_EQUIPMENT_ATTACHED)
-	var/disable_butchering_signals = list(COMSIG_MECHA_EQUIPMENT_DETACHED)
-	AddComponent(\
+	butcher_component = AddComponent(\
 		/datum/component/butchering,\
 		speed,\
 		effectiveness,\
 		bonus_modifier,\
 		butcher_sound,\
-		can_be_blunt,\
-		butchering_enabled,\
-		enable_butchering_signals,\
-		disable_butchering_signals\
 	)
+
+/obj/item/mecha_parts/mecha_equipment/drill/detach(atom/moveto)
+	..()
+	qdel(butcher_component)
 
 /obj/item/mecha_parts/mecha_equipment/drill/action(mob/source, atom/target, params)
 	// Check if we can even use the equipment to begin with.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### just, you're gonna have to accept that this is a flow of consciousness onto the pr body. sorry :^(

removes /obj/item/ComponentInitialize(), ComponentInitialize is deprecated

butchering now has logging

fixes #59028

Chainsaw code had many problems and barely used the twohanded component, rathering doing everything itself. Moved off, yadda yadda

twohanded now correctly DMdocs

Any use of getComponent to toggle the ability to butcher has been moved to signals

butchering now uses register and unregister signal procs, no longer has checks for whether the thing is an item for subtypes as subtypes can now override the signal procs

instances of butchering component now use clarified arguments on their component

brought anywhere I touched up to code standards of the repo (no single letter vars, etc

## Why It's Good For The Game

Code improvement? more like code improv

## Changelog
:cl:
code: chainsaw now actually uses its twohanded component correctly
refactor: butchercomponent brought up to modern standards
refactor: AND NO MORE GETCOMPONENT REQUIRED TO USE IT
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
