### PR TITLE
Converts Deltastation wall mounts to dirs

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -152,9 +152,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/clothing/head/welding,
 /obj/effect/turf_decal/bot,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -186,7 +184,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "aaI" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -234,9 +232,7 @@
 /area/space/nearstation)
 "abp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -247,12 +243,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "abq" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "abs" = (
@@ -273,20 +268,6 @@
 	},
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
-"abx" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/newscaster/security_unit/directional/west,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai)
 "aby" = (
 /obj/machinery/turretid{
 	icon_state = "control_stun";
@@ -316,20 +297,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "abz" = (
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	name = "AI RC";
-	pixel_x = 30;
-	pixel_y = 30
-	},
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/flasher{
+/obj/machinery/flasher/directional/south{
 	id = "AI";
-	pixel_x = 23;
-	pixel_y = -23
+	pixel_x = 26
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -363,6 +336,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/requests_console/directional/north{
+	department = "AI";
+	departmentType = 5;
+	name = "AI Requests Console"
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "abC" = (
@@ -379,9 +357,7 @@
 /area/hallway/secondary/entry)
 "abE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -395,9 +371,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "abG" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -443,9 +417,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "abR" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/closet/emcloset/anchored,
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
@@ -469,19 +441,14 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/bounty_board{
-	dir = 4;
-	pixel_x = -32
-	},
+/obj/machinery/bounty_board/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "abY" = (
-/obj/machinery/bounty_board{
-	pixel_y = 32
-	},
+/obj/machinery/bounty_board/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -547,10 +514,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "acg" = (
-/obj/machinery/bounty_board{
-	dir = 4;
-	pixel_x = -32
-	},
+/obj/machinery/bounty_board/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -611,9 +575,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
 "act" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -633,9 +595,7 @@
 	c_tag = "Solar - Fore Starboard";
 	name = "solar camera"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/machinery/power/terminal{
 	dir = 8
@@ -767,12 +727,8 @@
 /turf/open/floor/plating,
 /area/maintenance/space_hut/observatory)
 "acV" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -782,24 +738,16 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "acX" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "acY" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Arrivals Shuttle - Fore Port";
 	dir = 8;
@@ -822,12 +770,8 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "adb" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Arrivals Shuttle - Fore Starboard";
 	dir = 4;
@@ -839,12 +783,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "adc" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -859,9 +799,7 @@
 	dir = 4;
 	name = "engineering camera"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -872,9 +810,7 @@
 /area/construction/mining/aux_base)
 "adf" = (
 /obj/structure/closet/secure_closet/miner/unlocked,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -918,9 +854,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "ado" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -996,17 +930,13 @@
 	name = "Test Site Materials Crate";
 	req_access_txt = "63"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -36
+/obj/machinery/light/small/directional/west,
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -38
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
+/obj/machinery/firealarm/directional/north{
+	pixel_x = -26
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
@@ -1040,9 +970,7 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "adZ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1122,9 +1050,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
@@ -1151,16 +1077,7 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"aeB" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/construction/mining/aux_base)
 "aeC" = (
-/obj/machinery/requests_console{
-	department = "Construction";
-	name = "Construction RC";
-	pixel_y = 32
-	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -1170,6 +1087,10 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/requests_console/directional/north{
+	department = "Construction";
+	name = "Construction Requests Console"
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
@@ -1198,9 +1119,7 @@
 /area/construction/mining/aux_base)
 "aeS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -1208,9 +1127,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aeV" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -1218,9 +1135,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aeX" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -1229,9 +1144,7 @@
 /area/hallway/secondary/entry)
 "afb" = (
 /obj/effect/spawner/randomsnackvend,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -1262,9 +1175,7 @@
 /area/construction/mining/aux_base)
 "afs" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1669,12 +1580,8 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "ahS" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Arrivals Shuttle - Aft Port";
 	dir = 8;
@@ -1950,9 +1857,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/hallway/secondary/entry)
 "ajK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -2098,6 +2003,7 @@
 	icon_state = "plant-21"
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "akK" = (
@@ -2124,6 +2030,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "akO" = (
@@ -2169,6 +2076,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/keycard_auth/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "alv" = (
@@ -2183,10 +2091,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "alw" = (
-/obj/machinery/keycard_auth{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -2196,16 +2100,9 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
-"alx" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
-/area/hallway/secondary/entry)
-"aly" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/hallway/secondary/entry)
 "alA" = (
 /obj/structure/table/reinforced,
 /obj/item/crowbar,
@@ -2223,9 +2120,7 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/radio,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/east,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -2236,9 +2131,7 @@
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "alW" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -2282,10 +2175,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "aml" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -2314,6 +2203,7 @@
 	c_tag = "Arrivals - Center";
 	name = "arrivals camera"
 	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
 "amp" = (
@@ -2332,6 +2222,7 @@
 "ams" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
 "amx" = (
@@ -2393,9 +2284,7 @@
 /obj/machinery/computer/crew{
 	dir = 4
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -2456,9 +2345,7 @@
 /obj/machinery/computer/prisoner/management{
 	dir = 8
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/machinery/camera{
 	c_tag = "Security Post - Arrivals";
 	dir = 8
@@ -2533,9 +2420,7 @@
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Arrivals Customs";
 	dir = 4;
@@ -2624,9 +2509,7 @@
 /turf/closed/wall,
 /area/maintenance/disposal)
 "aoW" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoY" = (
@@ -2637,9 +2520,7 @@
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -2709,9 +2590,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -2748,9 +2627,7 @@
 /obj/machinery/mass_driver/trash{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2824,6 +2701,7 @@
 "aqm" = (
 /obj/structure/table/wood,
 /obj/item/food/chips,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
 "aqn" = (
@@ -2836,7 +2714,7 @@
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
 "aqo" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -2854,6 +2732,7 @@
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/entry)
 "aqs" = (
@@ -2899,9 +2778,7 @@
 	req_access_txt = "12"
 	},
 /obj/structure/chair/stool,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -2947,9 +2824,7 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "aqT" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -3122,9 +2997,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "arL" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -3137,6 +3010,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "arN" = (
@@ -3169,12 +3043,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "arR" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -3193,16 +3066,11 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "arU" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "ase" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/conveyor{
 	dir = 9;
 	id = "garbage"
@@ -3264,15 +3132,13 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "asr" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/machinery/camera{
 	c_tag = "Bridge - E.V.A. Aft";
 	dir = 1;
 	name = "command camera"
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -3658,9 +3524,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "avY" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -3725,9 +3589,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "awp" = (
-/obj/structure/mirror{
-	pixel_x = -28
-	},
+/obj/structure/mirror/directional/west,
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/suit/toggle/suspenders,
@@ -3961,7 +3823,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ayU" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -3988,7 +3850,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "ayW" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/autodrobe/all_access,
 /obj/effect/turf_decal/tile/red{
@@ -4032,7 +3894,7 @@
 /obj/item/storage/crayons,
 /obj/item/storage/crayons,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -4177,6 +4039,10 @@
 	},
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
+"aAA" = (
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/white,
+/area/service/kitchen)
 "aAR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -4185,6 +4051,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
+"aAS" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "garbage"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "aAU" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/delivery,
@@ -4222,11 +4103,14 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "aBC" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "custodialshutters";
+	name = "Custodial Shutters";
+	req_access_txt = "26"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -4416,9 +4300,7 @@
 /area/hallway/secondary/service)
 "aDF" = (
 /obj/structure/bed,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/item/bedsheet/clown,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/service)
@@ -4440,9 +4322,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/service)
 "aDM" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -4520,6 +4400,7 @@
 /obj/effect/spawner/randomarcade{
 	dir = 1
 	},
+/obj/machinery/light/dim/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aFb" = (
@@ -4601,12 +4482,10 @@
 "aFT" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "AuxCabinA";
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 7;
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/grimy,
@@ -4617,7 +4496,7 @@
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/service)
 "aFV" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/iron/grimy,
 /area/hallway/secondary/service)
@@ -4665,23 +4544,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "aGu" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/radio,
-/obj/machinery/button/door{
-	desc = "A remote control switch.";
-	id = "cardoor";
-	name = "Cargo Cell Control";
-	normaldoorcontrol = 1;
-	pixel_x = -36;
-	pixel_y = -7
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -4691,12 +4558,17 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/button/door/directional/west{
+	id = "cardoor";
+	name = "Cargo Cell Control";
+	normaldoorcontrol = 1;
+	pixel_x = -34;
+	pixel_y = -6
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "aGH" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4738,9 +4610,7 @@
 /turf/open/floor/iron/checker,
 /area/maintenance/disposal/incinerator)
 "aGS" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral{
@@ -5058,9 +4928,7 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "aIx" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/oil,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -5070,10 +4938,7 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "aIy" = (
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = 24
-	},
+/obj/machinery/light_switch/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank/large,
 /obj/effect/turf_decal/bot,
@@ -5103,9 +4968,7 @@
 /area/hallway/secondary/service)
 "aIP" = (
 /obj/structure/bed,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/item/bedsheet/mime,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
@@ -5422,12 +5285,8 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aLd" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/computer/atmos_control/incinerator{
@@ -5462,12 +5321,10 @@
 "aLC" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/west{
 	id = "AuxCabinB";
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 7;
 	specialfunctions = 4
 	},
 /turf/open/floor/wood,
@@ -5477,7 +5334,7 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "aLE" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
@@ -5515,9 +5372,7 @@
 /area/security/checkpoint/supply)
 "aLV" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Security Post - Cargo";
 	dir = 8
@@ -5533,9 +5388,7 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "aMa" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -5573,19 +5426,16 @@
 /area/security/prison)
 "aMm" = (
 /obj/structure/chair/stool,
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/west{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -30;
+	name = "prison intercom";
 	prison_radio = 1
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "aMq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
@@ -5615,9 +5465,7 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aMs" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
@@ -5676,6 +5524,7 @@
 /obj/effect/spawner/randomarcade{
 	dir = 1
 	},
+/obj/machinery/light/dim/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aMZ" = (
@@ -5723,9 +5572,7 @@
 "aNH" = (
 /obj/structure/table,
 /obj/item/trash/popcorn,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "aNJ" = (
@@ -5737,9 +5584,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "aNM" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /mob/living/simple_animal/mouse/white,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
@@ -5899,9 +5744,7 @@
 	name = "Queue Shutters"
 	},
 /obj/effect/landmark/event_spawn,
-/obj/machinery/ticket_machine{
-	pixel_y = 32
-	},
+/obj/machinery/ticket_machine/directional/north,
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
@@ -5927,15 +5770,11 @@
 /area/security/prison/safe)
 "aPk" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "aPn" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/item/clothing/suit/caution,
 /obj/structure/sign/poster/official/no_erp{
 	pixel_x = -30
@@ -6162,9 +6001,7 @@
 /obj/structure/table/glass,
 /obj/item/folder/blue,
 /obj/item/healthanalyzer,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -6245,9 +6082,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "aRF" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -6328,19 +6163,16 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aSH" = (
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/north{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_y = 24;
+	name = "prison intercom";
 	prison_radio = 1
 	},
 /turf/open/floor/iron,
 /area/security/prison)
 "aSI" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/item/reagent_containers/glass/bottle/morphine{
 	pixel_x = 7;
 	pixel_y = 7
@@ -6371,17 +6203,16 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aSJ" = (
-/obj/machinery/button/door{
-	id = "visitation";
-	name = "Visitation Shutters";
-	pixel_x = 6;
-	pixel_y = 25;
-	req_access_txt = "2"
-	},
 /obj/machinery/button/flasher{
 	id = "visitorflash";
 	pixel_x = -6;
 	pixel_y = 24
+	},
+/obj/machinery/button/door/directional/north{
+	id = "visitation";
+	name = "Visitation Shutters";
+	pixel_x = 6;
+	req_access_txt = "2"
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -6390,28 +6221,14 @@
 /obj/machinery/button/ignition{
 	id = "justicespark";
 	pixel_x = 7;
-	pixel_y = 26;
+	pixel_y = 24;
 	req_access_txt = "63"
 	},
 /obj/machinery/button/flasher{
 	id = "justiceflash";
-	pixel_x = 7;
-	pixel_y = 38;
+	pixel_x = 6;
+	pixel_y = 34;
 	req_access_txt = "63"
-	},
-/obj/machinery/button/door{
-	id = "justiceblast";
-	name = "Justice Shutters Control";
-	pixel_x = -7;
-	pixel_y = 26;
-	req_access_txt = "63"
-	},
-/obj/machinery/button/door{
-	id = "justicechamber";
-	name = "Justice Chamber Control";
-	pixel_x = -7;
-	pixel_y = 38;
-	req_access_txt = "3"
 	},
 /obj/item/folder/red{
 	pixel_x = 3
@@ -6423,6 +6240,19 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "justiceblast";
+	name = "Justice Shutters Control";
+	pixel_x = -6;
+	req_access_txt = "63"
+	},
+/obj/machinery/button/door/directional/north{
+	id = "justicechamber";
+	name = "Justice Chamber Control";
+	pixel_x = -6;
+	pixel_y = 34;
+	req_access_txt = "3"
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
@@ -6534,9 +6364,7 @@
 /area/engineering/atmos)
 "aUv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -6560,14 +6388,10 @@
 /area/security/prison/safe)
 "aUD" = (
 /obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /obj/item/electropack,
 /obj/item/assembly/signaler,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/clothing/head/helmet/sec,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -6695,7 +6519,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "aWe" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6748,10 +6572,7 @@
 /area/security/prison)
 "aWl" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light_switch{
-	pixel_x = -7;
-	pixel_y = -26
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/item/flashlight/lamp,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -6764,9 +6585,7 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aWm" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "aWq" = (
@@ -6874,9 +6693,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
+/obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/commons/toilet/auxiliary)
@@ -6939,9 +6756,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "aYB" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -7050,9 +6865,7 @@
 	},
 /area/security/prison)
 "aZN" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -7099,9 +6912,7 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "baG" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -7155,7 +6966,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "bbp" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
@@ -7399,12 +7210,8 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -32
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/south,
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -7460,12 +7267,8 @@
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
 	},
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/status_display/ai/directional/south,
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -7499,9 +7302,7 @@
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -7606,9 +7407,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -7651,6 +7450,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bdT" = (
@@ -7682,9 +7482,7 @@
 "bes" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -7720,9 +7518,7 @@
 /area/hallway/secondary/command)
 "beK" = (
 /obj/structure/closet/firecloset,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
@@ -8024,9 +7820,7 @@
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bhH" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -8037,9 +7831,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "bhJ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -8097,6 +7889,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"bia" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "bib" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -8157,11 +7954,7 @@
 /obj/structure/bed,
 /obj/machinery/iv_drip,
 /obj/item/bedsheet/medical,
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_y = 26;
-	use_power = 0
-	},
+/obj/machinery/vending/wallmed/directional/north,
 /obj/machinery/camera{
 	c_tag = "Security - Medbay"
 	},
@@ -8511,7 +8304,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "blJ" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -8546,9 +8339,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -8593,7 +8384,7 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "bme" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -8726,10 +8517,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"bnx" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/hallway/primary/fore)
 "bnz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -8800,6 +8587,7 @@
 	c_tag = "Holodeck - Fore 2";
 	name = "holodeck camera"
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
 	},
@@ -8923,9 +8711,7 @@
 /area/security/execution/transfer)
 "bpf" = (
 /obj/machinery/computer/shuttle/labor,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -8952,9 +8738,7 @@
 /area/security/execution/transfer)
 "bph" = (
 /obj/machinery/computer/secure_data,
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /obj/machinery/camera{
 	c_tag = "Security - Transfer Centre"
 	},
@@ -8972,9 +8756,7 @@
 "bpi" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
+/obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -9043,9 +8825,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -9154,7 +8934,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bqz" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Locker Room - Aft";
 	dir = 1;
@@ -9171,6 +8951,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/commons/locker)
 "bqG" = (
@@ -9194,9 +8975,7 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bre" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
 	},
@@ -9269,6 +9048,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "brL" = (
@@ -9505,13 +9285,9 @@
 /area/commons/fitness/recreation)
 "bua" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/toy/katana,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -9782,10 +9558,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"bwn" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai)
 "bwo" = (
 /obj/item/kirbyplants/random,
 /obj/structure/cable,
@@ -9887,9 +9659,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bxw" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -9900,6 +9670,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bxy" = (
@@ -9998,9 +9769,7 @@
 /area/security/execution/transfer)
 "byG" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/folder/red,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/effect/turf_decal/tile/red{
@@ -10036,9 +9805,7 @@
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "byK" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -10173,6 +9940,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/medical/virology)
+"bzS" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron,
+/area/engineering/main)
 "bzW" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -10249,10 +10024,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/command/gateway)
-"bAx" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai)
 "bAy" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -10267,6 +10038,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bAz" = (
@@ -10552,21 +10324,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/button/door{
-	desc = "A remote control switch.";
-	id = "gulagdoor";
-	name = "Transfer Door Control";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = -8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -32;
-	pixel_y = 6
+/obj/machinery/firealarm/directional/west{
+	pixel_x = -38
+	},
+/obj/machinery/button/door/directional/west{
+	id = "gulagdoor";
+	name = "Transfer Door Control";
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/iron,
 /area/security/execution/transfer)
@@ -10629,9 +10396,7 @@
 /area/security/execution/transfer)
 "bEb" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -10653,24 +10418,21 @@
 	req_access_txt = "16"
 	},
 /obj/effect/landmark/start/ai/secondary,
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/north{
 	freerange = 1;
 	listening = 0;
-	name = "Custom Channel";
-	pixel_x = -10;
-	pixel_y = 22
+	name = "Custom Channel"
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/west{
 	freerange = 1;
-	name = "Common Channel";
-	pixel_x = -27
+	listening = 0;
+	name = "Common Channel"
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/south{
 	freerange = 1;
 	frequency = 1447;
-	name = "Private Channel";
-	pixel_x = -10;
-	pixel_y = -25
+	listening = 0;
+	name = "Private Channel"
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
@@ -10720,24 +10482,21 @@
 	req_access_txt = "16"
 	},
 /obj/effect/landmark/start/ai/secondary,
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/north{
 	freerange = 1;
 	listening = 0;
-	name = "Custom Channel";
-	pixel_x = 10;
-	pixel_y = 22
+	name = "Custom Channel"
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/east{
 	freerange = 1;
-	name = "Common Channel";
-	pixel_x = 27
+	listening = 0;
+	name = "Common Channel"
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/south{
 	freerange = 1;
 	frequency = 1447;
-	name = "Private Channel";
-	pixel_x = 10;
-	pixel_y = -25
+	listening = 0;
+	name = "Private Channel"
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
@@ -10884,9 +10643,7 @@
 /area/security/execution/transfer)
 "bFK" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -10914,9 +10671,7 @@
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -10970,39 +10725,36 @@
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "bFT" = (
-/obj/machinery/button/door{
-	id = "aicorewindow";
-	name = "AI Core Shutters";
-	pixel_x = 24;
-	pixel_y = -22;
-	req_access_txt = "16"
-	},
-/obj/machinery/button/door{
-	id = "aicoredoor";
-	name = "AI Chamber Access Control";
-	pixel_x = -23;
-	pixel_y = -23;
-	req_access_txt = "16"
-	},
 /obj/effect/landmark/start/ai,
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/west{
 	freerange = 1;
+	listening = 0;
 	name = "Common Channel";
-	pixel_x = -27;
-	pixel_y = -7
+	pixel_y = -8
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/south{
+	freerange = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
+/obj/item/radio/intercom/directional/east{
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_y = -27
+	pixel_y = -8
 	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_x = 27;
-	pixel_y = -7
+/obj/machinery/button/door/directional/south{
+	id = "aicoredoor";
+	name = "AI Chamber Access Control";
+	pixel_x = -24;
+	req_access_txt = "16"
+	},
+/obj/machinery/button/door/directional/south{
+	id = "aicorewindow";
+	name = "AI Core Shutters";
+	pixel_x = 24;
+	req_access_txt = "16"
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
@@ -11081,9 +10833,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard";
 	dir = 8;
@@ -11184,9 +10934,7 @@
 	id = "brig1";
 	name = "Cell 1 Locker"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -11199,10 +10947,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "bHy" = (
-/obj/machinery/flasher{
-	id = "brig1";
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -11211,6 +10955,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/flasher/directional/north{
+	id = "brig1"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "bHG" = (
@@ -11312,6 +11059,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bHZ" = (
@@ -11354,7 +11102,7 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/package_wrap,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
@@ -11481,6 +11229,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "bJh" = (
@@ -11571,9 +11320,7 @@
 /area/security/detectives_office)
 "bJm" = (
 /obj/machinery/photocopier,
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -11584,6 +11331,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/peppertank/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "bJn" = (
@@ -11696,7 +11444,7 @@
 /area/security/warden)
 "bJE" = (
 /obj/machinery/suit_storage_unit/security,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -11824,6 +11572,21 @@
 "bKH" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
+"bKJ" = (
+/obj/machinery/porta_turret/ai,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "bKW" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Auxiliary Tool Storage Maintenance";
@@ -11861,10 +11624,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
 	},
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
@@ -11978,6 +11737,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bLF" = (
@@ -12040,9 +11800,7 @@
 /area/security/checkpoint/engineering)
 "bMx" = (
 /obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/paper_bin,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12075,6 +11833,7 @@
 	name = "telecomms camera";
 	network = list("ss13","tcomms")
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
 "bMD" = (
@@ -12093,9 +11852,7 @@
 /area/tcommsat/computer)
 "bMF" = (
 /obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/flashlight/lamp,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12135,9 +11892,7 @@
 /turf/closed/wall,
 /area/security/detectives_office)
 "bMX" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Detective's Office";
 	dir = 4
@@ -12192,10 +11947,9 @@
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/east{
 	department = "Detective's Office";
-	name = "Detective RC";
-	pixel_x = 30
+	name = "Detective's Requests Console"
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
@@ -12217,9 +11971,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -12239,11 +11991,11 @@
 /area/security/brig)
 "bNm" = (
 /obj/machinery/computer/crew,
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	department = "Security";
-	name = "Security RC";
-	pixel_x = -32;
-	pixel_y = 32
+	departmentType = 3;
+	name = "Security Requests Console";
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -12414,7 +12166,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bNA" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -12514,9 +12266,7 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bOi" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/closet/secure_closet/brig{
 	id = "engcell";
 	name = "Engineering Cell Locker"
@@ -12566,9 +12316,7 @@
 /area/hallway/primary/central/fore)
 "bOG" = (
 /obj/machinery/announcement_system,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -12610,9 +12358,7 @@
 /obj/machinery/computer/telecomms/monitor{
 	dir = 8
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -12626,10 +12372,7 @@
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "bOP" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -12699,12 +12442,8 @@
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/light/directional/east,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bPl" = (
@@ -12729,9 +12468,7 @@
 	id = "brig2";
 	name = "Cell 2 Locker"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -12744,10 +12481,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "bPp" = (
-/obj/machinery/flasher{
-	id = "brig2";
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -12756,6 +12489,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/flasher/directional/north{
+	id = "brig2"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "bPr" = (
@@ -12851,9 +12587,7 @@
 /area/ai_monitored/security/armory)
 "bPA" = (
 /obj/structure/closet/secure_closet/contraband/armory,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -12869,16 +12603,8 @@
 "bPC" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
-"bPD" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat_interior)
 "bPH" = (
 /obj/structure/sign/plaques/kiddie,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat_interior)
-"bPI" = (
-/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPV" = (
@@ -12980,6 +12706,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
+/obj/machinery/button/door/directional/west{
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	req_access_txt = "10"
+	},
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "bQG" = (
@@ -13040,9 +12771,7 @@
 /area/tcommsat/computer)
 "bRd" = (
 /obj/structure/bodycontainer/morgue,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -13103,17 +12832,6 @@
 /area/security/detectives_office)
 "bRk" = (
 /obj/structure/table/wood,
-/obj/machinery/button/door{
-	id = "detectivewindows";
-	name = "Privacy Shutters";
-	pixel_x = 26;
-	pixel_y = -26;
-	req_access_txt = "4"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 38;
-	pixel_y = -26
-	},
 /obj/structure/disposalpipe/segment,
 /obj/item/flashlight/lamp,
 /obj/item/reagent_containers/food/drinks/flask/det,
@@ -13121,10 +12839,17 @@
 /area/security/detectives_office)
 "bRl" = (
 /obj/structure/table/wood,
-/obj/item/storage/secure/safe{
-	pixel_x = 32
-	},
+/obj/item/storage/secure/safe/directional/east,
 /obj/machinery/computer/security/wooden_tv,
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 8
+	},
+/obj/machinery/button/door/directional/south{
+	id = "detectivewindows";
+	name = "Privacy Shutters";
+	pixel_x = -6;
+	req_access_txt = "4"
+	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "bRm" = (
@@ -13266,12 +12991,8 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/ai/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -13362,12 +13083,8 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bRL" = (
 /obj/machinery/teleport/station,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -13576,9 +13293,7 @@
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/toy/figure/warden,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -13664,9 +13379,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/storage/secure/safe{
-	pixel_x = 32
-	},
+/obj/item/storage/secure/safe/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -14045,6 +13758,9 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/security_unit/directional/west,
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -42
+	},
 /turf/open/floor/iron,
 /area/security/warden)
 "bVn" = (
@@ -14207,9 +13923,7 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bWz" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -14296,9 +14010,7 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "bWW" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -14336,9 +14048,7 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "bXb" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -14764,9 +14474,7 @@
 /obj/machinery/computer/station_alert{
 	dir = 1
 	},
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -14775,7 +14483,7 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bYF" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/computer/security{
 	dir = 1
 	},
@@ -14799,12 +14507,8 @@
 /area/security/checkpoint/engineering)
 "bYH" = (
 /obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -32
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/south,
+/obj/machinery/status_display/evac/directional/east,
 /obj/machinery/recharger,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -14813,9 +14517,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = -32
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 32
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
@@ -14861,7 +14564,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bYP" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -14978,9 +14681,7 @@
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "bZY" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -14995,9 +14696,7 @@
 /area/ai_monitored/security/armory)
 "caa" = (
 /obj/machinery/recharge_station,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -15007,24 +14706,21 @@
 /obj/machinery/computer/monitor{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
+/obj/item/radio/intercom/directional/south{
+	freerange = 1;
 	frequency = 1447;
 	listening = 0;
-	name = "AI Intercom";
-	pixel_y = -26
+	name = "Private Channel"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cac" = (
 /obj/machinery/recharge_station,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -15044,7 +14740,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "cae" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -15091,7 +14787,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "cai" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -15122,9 +14818,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "cak" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
+/obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -15140,9 +14834,7 @@
 "cal" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -15160,7 +14852,7 @@
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/toy/figure/borg,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -15171,12 +14863,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
+/obj/item/radio/intercom/directional/south{
+	freerange = 1;
 	frequency = 1447;
 	listening = 0;
-	name = "AI Intercom";
-	pixel_y = -26
+	name = "Private Channel"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -15187,9 +14878,7 @@
 	pixel_y = 3
 	},
 /obj/item/folder/yellow,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/item/aicard,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -15327,9 +15016,7 @@
 /turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
 "caY" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -15418,18 +15105,12 @@
 /area/security/brig)
 "cbD" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light_switch{
-	pixel_x = -38;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -26;
-	pixel_y = -26
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -26
 	},
 /turf/open/floor/iron,
 /area/security/warden)
@@ -15463,16 +15144,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/button/door/directional/south{
+	id = "armouryaccess";
+	name = "Armoury Access";
+	req_access_txt = "3"
+	},
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "cbI" = (
-/obj/machinery/button/door{
-	id = "armouryaccess";
-	name = "Armoury Access";
-	pixel_x = -26;
-	pixel_y = -26;
-	req_access_txt = "3"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -15502,9 +15181,7 @@
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "cbL" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/east,
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/gas/sechailer{
 	pixel_x = -3;
@@ -15683,9 +15360,7 @@
 /area/hallway/primary/central/aft)
 "ccU" = (
 /obj/effect/spawner/randomsnackvend,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -15782,12 +15457,8 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "cdd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
+/obj/machinery/light/directional/north,
+/obj/structure/reagent_dispensers/peppertank/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -15805,6 +15476,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "cdg" = (
@@ -15876,10 +15548,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = -7
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "cdq" = (
@@ -15932,10 +15601,6 @@
 "cdt" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
-"cdu" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai_upload)
 "cdv" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral{
@@ -15952,9 +15617,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "cdw" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -15998,6 +15661,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cdH" = (
@@ -16277,20 +15941,6 @@
 	pixel_y = 7;
 	req_access_txt = "63"
 	},
-/obj/machinery/button/door{
-	id = "brigfront";
-	name = "Brig Access Control";
-	pixel_x = 26;
-	pixel_y = -7;
-	req_access_txt = "63"
-	},
-/obj/machinery/button/door{
-	id = "brigwindows";
-	name = "Cell Window Control";
-	pixel_x = 38;
-	pixel_y = -7;
-	req_access_txt = "63"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -16298,13 +15948,24 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/button/door/directional/east{
+	id = "brigfront";
+	name = "Brig Access Control";
+	pixel_y = -6;
+	req_access_txt = "63"
+	},
+/obj/machinery/button/door/directional/east{
+	id = "brigwindows";
+	name = "Cell Window Control";
+	pixel_x = 36;
+	pixel_y = -6;
+	req_access_txt = "63"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "cfe" = (
 /obj/structure/chair,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -16366,6 +16027,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "cfs" = (
@@ -16393,6 +16055,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cft" = (
@@ -16439,6 +16102,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cfR" = (
@@ -16501,9 +16165,7 @@
 /area/tcommsat/server)
 "cgz" = (
 /obj/structure/table,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -16643,25 +16305,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"cha" = (
-/obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32;
-	pixel_y = -64
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "chb" = (
 /obj/effect/landmark/start/security_officer,
 /obj/structure/cable,
@@ -16720,18 +16363,10 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "chg" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32;
-	pixel_y = 32
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 32;
-	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -16976,7 +16611,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "cig" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -17041,9 +16676,7 @@
 "ciz" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/item/pen,
 /obj/structure/sign/poster/official/enlist{
 	pixel_y = -32
@@ -17075,12 +16708,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -26;
-	pixel_y = -26
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -26
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/security/brig)
 "ciJ" = (
@@ -17114,9 +16746,7 @@
 /area/security/brig)
 "ciL" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -17130,7 +16760,7 @@
 "ciM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -17161,9 +16791,7 @@
 /area/security/brig)
 "ciP" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -17359,16 +16987,12 @@
 /turf/open/floor/iron,
 /area/maintenance/central/secondary)
 "ckd" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/machinery/camera{
 	c_tag = "Courtroom - Center";
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -17395,45 +17019,12 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai_upload)
-"cko" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ckp" = (
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
-/area/ai_monitored/turret_protected/ai_upload)
-"cks" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ckt" = (
 /obj/structure/table/reinforced,
@@ -17449,6 +17040,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ckJ" = (
@@ -17461,9 +17053,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "ckK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -17610,9 +17200,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/security/range)
@@ -17638,9 +17226,7 @@
 /turf/open/floor/plating,
 /area/security/range)
 "clL" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -17660,12 +17246,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "clN" = (
-/obj/machinery/flasher{
-	pixel_x = -26;
-	pixel_y = -26
+/obj/machinery/flasher/directional/south{
+	id = "AI";
+	pixel_x = -26
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -17681,9 +17268,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "clP" = (
-/obj/machinery/flasher{
-	pixel_x = 26;
-	pixel_y = -26
+/obj/machinery/flasher/directional/south{
+	id = "AI";
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -17714,6 +17301,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "clR" = (
@@ -17959,7 +17547,7 @@
 /area/security/range)
 "cnu" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -18010,7 +17598,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "cny" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -18049,9 +17637,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cnV" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Bar - Aft";
 	dir = 4;
@@ -18323,7 +17909,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Security - Shooting Range";
@@ -18347,9 +17933,7 @@
 /turf/open/floor/plating,
 /area/security/range)
 "coW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -18450,9 +18034,7 @@
 /area/maintenance/aft)
 "cpV" = (
 /obj/structure/table,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
@@ -18659,9 +18241,7 @@
 /area/security/courtroom)
 "crj" = (
 /obj/machinery/vending/cigarette,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Courtroom - Aft";
 	dir = 8
@@ -18684,9 +18264,7 @@
 /area/security/courtroom)
 "crl" = (
 /obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/neutral{
@@ -18850,9 +18428,7 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "csa" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -19077,7 +18653,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ctV" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -19127,7 +18703,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "cub" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -19182,7 +18758,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "cuj" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
@@ -19197,7 +18773,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "cup" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Center Starboard";
 	dir = 1;
@@ -19248,7 +18824,6 @@
 /obj/item/clothing/under/rank/security/officer,
 /obj/item/restraints/handcuffs,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plating,
@@ -19257,6 +18832,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/loot_site_spawner,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cuI" = (
@@ -19265,9 +18841,7 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "cuK" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/south,
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/box/flashes,
@@ -19662,7 +19236,7 @@
 /area/maintenance/starboard)
 "czd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -19704,6 +19278,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"czv" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "czw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/delivery,
@@ -19840,9 +19425,7 @@
 /area/maintenance/port)
 "cAY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/effect/loot_site_spawner,
 /turf/open/floor/iron,
@@ -19874,6 +19457,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"cBV" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "cCe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -20045,9 +19646,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cDC" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -20143,6 +19742,7 @@
 	c_tag = "Holodeck - Fore 1";
 	name = "holodeck camera"
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
 	},
@@ -20172,9 +19772,7 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden/abandoned)
 "cFL" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/airalarm/unlocked{
 	dir = 4;
 	pixel_x = -23
@@ -20278,12 +19876,8 @@
 /area/maintenance/port/aft)
 "cGO" = (
 /obj/structure/chair/stool,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -20304,9 +19898,7 @@
 	},
 /area/maintenance/port)
 "cHk" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -20358,7 +19950,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -20407,10 +19999,6 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central/fore)
 "cHS" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
@@ -20435,10 +20023,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cHY" = (
+/obj/machinery/newscaster/directional/north,
 /obj/structure/table/wood,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20478,14 +20064,12 @@
 "cIp" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/maintenance/port)
 "cIt" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -20674,10 +20258,6 @@
 	heat_capacity = 1e+006
 	},
 /area/maintenance/port)
-"cJW" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/service/hydroponics)
 "cJX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -20692,9 +20272,7 @@
 	},
 /area/maintenance/port)
 "cKc" = (
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood,
 /area/service/theater/abandoned)
 "cKJ" = (
@@ -20737,7 +20315,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "cLK" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle,
 /obj/effect/decal/cleanable/dirt,
@@ -20754,7 +20332,7 @@
 "cMf" = (
 /obj/item/storage/belt,
 /obj/item/radio,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20804,9 +20382,7 @@
 /area/maintenance/aft)
 "cMn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -20874,9 +20450,7 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "cNa" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
@@ -20905,9 +20479,7 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "cNe" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Cell 1";
 	name = "xenobiology camera";
@@ -20926,9 +20498,7 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "cNg" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Cell 3";
 	name = "xenobiology camera";
@@ -20960,9 +20530,7 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/science/xenobiology)
 "cNi" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Killroom Chamber";
 	name = "xenobiology camera";
@@ -21027,10 +20595,6 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
-"cNB" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
 /area/medical/medbay/central)
 "cND" = (
 /obj/structure/sign/departments/medbay/alt,
@@ -21107,10 +20671,10 @@
 "cNP" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/requests_console{
-	department = "Medbay Storage";
-	name = "Medbay Storage RC";
-	pixel_y = 28
+/obj/machinery/requests_console/directional/north{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay Requests Console"
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/airalarm/directional/east,
@@ -21195,6 +20759,13 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port)
+"cOm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cOn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -21248,9 +20819,7 @@
 /area/maintenance/department/electrical)
 "cOv" = (
 /obj/machinery/power/port_gen/pacman,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -21261,18 +20830,14 @@
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "cOy" = (
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
+/obj/machinery/light_switch/directional/north,
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "cOz" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -3;
@@ -21372,12 +20937,8 @@
 /turf/closed/wall,
 /area/science/research)
 "cPj" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -21497,7 +21058,7 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/crowbar/red,
 /obj/item/wrench,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -21611,9 +21172,7 @@
 /area/science/xenobiology)
 "cQz" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/science/research)
@@ -21629,9 +21188,7 @@
 /area/security/checkpoint/science/research)
 "cQE" = (
 /obj/structure/closet/secure_closet/security/science,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -21641,19 +21198,19 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = 32
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_x = -32
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -38
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "cQF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -21667,12 +21224,8 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/radio,
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
+/obj/structure/reagent_dispensers/peppertank/directional/east,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -21818,15 +21371,14 @@
 /turf/closed/wall,
 /area/medical/storage)
 "cRf" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/effect/turf_decal/stripes/box,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/medical/storage)
 "cRg" = (
@@ -21903,9 +21455,7 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "cRD" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/suit/hazardvest,
@@ -21913,15 +21463,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
-"cRE" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/maintenance/department/electrical)
 "cRF" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cRG" = (
@@ -21967,9 +21514,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cRQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -21991,9 +21536,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "cRT" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Port";
 	name = "xenobiology camera";
@@ -22005,13 +21548,12 @@
 /area/science/xenobiology)
 "cRV" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "cRW" = (
@@ -22127,10 +21669,6 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
 "cSm" = (
-/obj/machinery/light_switch{
-	pixel_x = -38;
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -22175,39 +21713,16 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "cSM" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/radio,
-/obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = 24
-	},
-/obj/machinery/button/door{
-	desc = "A remote control switch.";
-	id = "meddoor";
-	name = "Medical Cell Control";
-	normaldoorcontrol = 1;
-	pixel_x = -36;
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -22217,14 +21732,24 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/button/door/directional/north{
+	id = "meddoor";
+	name = "Medical Cell Control";
+	normaldoorcontrol = 1;
+	pixel_x = -36
+	},
+/obj/machinery/button/door/directional/north{
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -24
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "cSN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -22235,10 +21760,8 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "cSO" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/machinery/light_switch{
+/obj/machinery/status_display/ai/directional/north,
+/obj/machinery/light_switch/directional/east{
 	pixel_x = 38
 	},
 /obj/structure/closet/secure_closet/security/med,
@@ -22249,9 +21772,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/airalarm{
-	pixel_x = 32;
-	pixel_y = 23
+/obj/machinery/airalarm/directional/north{
+	pixel_x = 32
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
@@ -22312,9 +21834,7 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -22352,6 +21872,7 @@
 	dir = 1;
 	name = "holodeck camera"
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
 	},
@@ -22361,9 +21882,7 @@
 /obj/item/extinguisher/mini,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/mask/breath,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -22378,9 +21897,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "cTm" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -22530,6 +22047,7 @@
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "cTI" = (
@@ -22562,9 +22080,7 @@
 	name = "Containment Control";
 	req_access_txt = "55"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/xenobiology)
@@ -22770,9 +22286,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -22783,18 +22297,14 @@
 	},
 /area/medical/medbay/central)
 "cUT" = (
-/obj/structure/mirror{
-	pixel_x = 26
-	},
+/obj/structure/mirror/directional/east,
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 11
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit/old,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/landmark/blobstart,
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_y = 32
@@ -22859,9 +22369,7 @@
 /turf/open/floor/iron/dark/corner,
 /area/maintenance/department/electrical)
 "cVs" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/table/reinforced,
 /obj/item/crowbar/red,
 /obj/item/wrench,
@@ -22873,6 +22381,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "cVu" = (
@@ -22911,9 +22420,7 @@
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "cVA" = (
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
+/obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
@@ -22944,6 +22451,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
 "cVR" = (
@@ -22968,13 +22476,10 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "cVT" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/requests_console{
-	department = "Xenobiology Lab";
-	name = "Xenobiology RC";
-	pixel_x = 32;
+/obj/machinery/light/directional/east,
+/obj/machinery/requests_console/directional/east{
+	department = "Xenobiology";
+	name = "Xenobiology Requests Console";
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -23090,9 +22595,7 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/item/gun/syringe,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -23119,9 +22622,7 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
@@ -23258,9 +22759,7 @@
 	name = "xenobiology camera";
 	network = list("ss13","xeno","rd")
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -23386,9 +22885,7 @@
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 8
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/circuit/green,
 /area/science/xenobiology)
 "cXn" = (
@@ -23410,14 +22907,6 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/obj/machinery/button/door{
-	desc = "A remote control switch.";
-	id = "scidoor";
-	name = "Science Cell Control";
-	normaldoorcontrol = 1;
-	pixel_x = -36;
-	pixel_y = -7
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -23431,6 +22920,12 @@
 	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/effect/landmark/start/depsec/science,
+/obj/machinery/button/door/directional/west{
+	id = "scidoor";
+	name = "Science Cell Control";
+	normaldoorcontrol = 1;
+	pixel_y = -12
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "cXp" = (
@@ -23443,9 +22938,7 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "cXq" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Security Post - Science";
@@ -23671,9 +23164,7 @@
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "cYy" = (
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -23699,19 +23190,15 @@
 /area/maintenance/department/electrical)
 "cYE" = (
 /obj/machinery/power/smes,
-/obj/machinery/light/small,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/light/small/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cYF" = (
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -23722,10 +23209,8 @@
 /area/maintenance/department/electrical)
 "cYH" = (
 /obj/machinery/power/smes,
-/obj/machinery/light/small,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/light/small/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23981,9 +23466,7 @@
 /turf/closed/wall/r_wall,
 /area/science/lab)
 "cZr" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -23991,9 +23474,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cZA" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -24012,9 +23493,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -24074,9 +23553,7 @@
 /obj/item/wirecutters,
 /obj/effect/turf_decal/bot,
 /obj/item/crowbar,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "dal" = (
@@ -24143,7 +23620,7 @@
 	name = "Containment Control";
 	req_access_txt = "55"
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -24167,7 +23644,7 @@
 	name = "Containment Control";
 	req_access_txt = "55"
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -24176,9 +23653,7 @@
 /area/science/xenobiology)
 "daB" = (
 /obj/machinery/processor/slime,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/xenobiology)
@@ -24247,9 +23722,7 @@
 /turf/open/floor/iron,
 /area/science/research)
 "daM" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -24295,13 +23768,9 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "daS" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -24434,11 +23903,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
-/area/medical/pharmacy)
-"dbi" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
 /area/medical/pharmacy)
 "dbr" = (
 /obj/machinery/door/firedoor,
@@ -24452,9 +23918,7 @@
 /area/medical/medbay/central)
 "dbv" = (
 /obj/structure/chair/stool,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -24479,12 +23943,8 @@
 /area/medical/medbay/central)
 "dbz" = (
 /obj/effect/spawner/randomcolavend,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -24526,7 +23986,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "dcb" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -24647,9 +24107,7 @@
 /area/science/xenobiology)
 "dcp" = (
 /obj/machinery/smartfridge/extract/preloaded,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
+/obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/xenobiology)
@@ -24685,9 +24143,7 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
 /obj/item/pen,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/storage/box/monkeycubes,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -24846,12 +24302,8 @@
 /turf/open/floor/iron,
 /area/science/lab)
 "dcK" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/status_display/ai/directional/east,
+/obj/machinery/light/directional/east,
 /obj/machinery/rnd/production/protolathe/department/science,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -24878,9 +24330,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -25164,9 +24614,7 @@
 "ddU" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/xenobiology)
@@ -25204,7 +24652,7 @@
 /turf/open/floor/iron,
 /area/science/research)
 "dea" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/research)
@@ -25361,11 +24809,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/white,
-/area/medical/pharmacy)
-"der" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
 /area/medical/pharmacy)
 "dew" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -25642,10 +25087,11 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "dfu" = (
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/east{
+	announcementConsole = 1;
 	department = "Research Lab";
-	name = "Research RC";
-	pixel_x = 32;
+	departmentType = 5;
+	name = "Research Requests Console";
 	receive_ore_updates = 1
 	},
 /obj/machinery/camera{
@@ -25662,25 +25108,21 @@
 /turf/closed/wall,
 /area/medical/pharmacy)
 "dfw" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "chemistbot";
-	name = "Chemistry Shutter Control";
-	pixel_x = -26;
-	pixel_y = -7;
-	req_access_txt = "69"
-	},
-/obj/machinery/button/door{
-	id = "chemisttop";
-	name = "Chemistry Shutter Control";
-	pixel_x = -26;
-	pixel_y = 7;
-	req_access_txt = "69"
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "chemisttop";
+	name = "Pharmacy Top Shutter Control";
+	pixel_y = 6;
+	req_access_txt = "69"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "chemistbot";
+	name = "Pharmacy Bottom Shutter Control";
+	pixel_y = -6;
+	req_access_txt = "69"
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
@@ -25704,9 +25146,7 @@
 	},
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/reagent_containers/dropper,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Medbay - Pharmacy";
 	dir = 8;
@@ -25817,7 +25257,7 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "dgt" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Cell 6";
 	dir = 1;
@@ -26046,9 +25486,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dht" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/sign/departments/medbay/alt{
 	pixel_x = -32
 	},
@@ -26104,9 +25542,7 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "dhV" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -26588,6 +26024,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "djh" = (
@@ -26642,9 +26079,7 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "djx" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -26873,16 +26308,15 @@
 /area/science/lab)
 "djY" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/cell_charger,
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -25
+	},
 /turf/open/floor/iron,
 /area/science/lab)
 "djZ" = (
@@ -26903,9 +26337,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -26930,25 +26362,23 @@
 /area/science/lab)
 "dkd" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/button/door{
-	id = "rndlab1";
-	name = "Primary Research Shutters Control";
-	pixel_x = -7;
-	pixel_y = -23;
-	req_access_txt = "7"
-	},
-/obj/machinery/button/door{
-	id = "rndlab2";
-	name = "Secondary Research Shutters Control";
-	pixel_x = 7;
-	pixel_y = -23;
-	req_access_txt = "7"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/machinery/button/door/directional/south{
+	id = "rndlab1";
+	name = "Primary Research Shutters Control";
+	pixel_x = -8;
+	req_access_txt = "7"
+	},
+/obj/machinery/button/door/directional/south{
+	id = "rndlab2";
+	name = "Secondary Research Shutters Control";
+	pixel_x = 8;
+	req_access_txt = "7"
 	},
 /turf/open/floor/iron,
 /area/science/lab)
@@ -26996,14 +26426,13 @@
 /area/medical/pharmacy)
 "dkh" = (
 /obj/machinery/chem_heater/withbuffer,
-/obj/machinery/requests_console{
-	department = "Pharmacy";
-	name = "Pharmacy RC";
-	pixel_y = -32;
-	receive_ore_updates = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/machinery/requests_console/directional/south{
+	department = "Pharmacy";
+	name = "Pharmacy Requests Console";
+	receive_ore_updates = 1
 	},
 /turf/open/floor/iron,
 /area/medical/pharmacy)
@@ -27038,7 +26467,7 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "dkJ" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/kirbyplants/random,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -27049,9 +26478,7 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "dkK" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/structure/closet/secure_closet/psychology,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -27086,9 +26513,7 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "dkN" = (
-/obj/structure/noticeboard{
-	pixel_y = -32
-	},
+/obj/structure/noticeboard/directional/south,
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop{
 	dir = 1;
@@ -27107,9 +26532,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/vending/wallmed{
-	pixel_x = -32
-	},
+/obj/machinery/vending/wallmed/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -27232,9 +26655,7 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "dlr" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/landmark/start/geneticist,
 /obj/structure/chair/office/light{
 	dir = 1;
@@ -27280,12 +26701,8 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "dlv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
+/obj/machinery/light/directional/east,
+/obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
@@ -27345,17 +26762,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"dlS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -24;
-	pixel_y = -24
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "dlU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -27390,10 +26796,6 @@
 "dma" = (
 /turf/closed/wall,
 /area/medical/surgery)
-"dmb" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/medical/surgery)
 "dmd" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -27426,9 +26828,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = -32
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 26
 	},
 /obj/machinery/newscaster/security_unit/directional/east,
 /turf/open/floor/iron/dark,
@@ -27610,9 +27011,7 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/cell_charger,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/airalarm/directional/west,
@@ -27649,9 +27048,7 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "dnf" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 32
 	},
@@ -27676,9 +27073,7 @@
 /area/medical/chemistry)
 "dnh" = (
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -27693,9 +27088,7 @@
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -27898,9 +27291,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "dnE" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -28051,9 +27442,7 @@
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
 "doh" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -28078,9 +27467,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "dol" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
@@ -28120,7 +27507,7 @@
 /area/science/research)
 "doR" = (
 /obj/structure/rack,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/item/aicard,
 /obj/item/storage/secure/briefcase,
 /obj/effect/turf_decal/tile/neutral{
@@ -28133,6 +27520,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "doT" = (
@@ -28190,6 +27578,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mechpad,
 /obj/effect/turf_decal/bot,
+/obj/machinery/button/door/directional/east{
+	id = "mechbay";
+	name = "Mech Bay Shutters Control";
+	req_access_txt = "29"
+	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "dpe" = (
@@ -28201,6 +27594,11 @@
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "mechbay";
+	name = "Mech Bay Shutters Control";
+	req_access_txt = "29"
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -28227,7 +27625,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dpm" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -28319,9 +27717,7 @@
 /area/medical/surgery)
 "dpD" = (
 /obj/structure/chair,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -28346,9 +27742,7 @@
 /area/maintenance/starboard/aft)
 "dpF" = (
 /obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/item/crowbar/red,
 /obj/item/wrench,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -28363,9 +27757,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/construction)
 "dpI" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -28523,9 +27915,7 @@
 /area/medical/virology)
 "dqL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
+/obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
@@ -28556,12 +27946,6 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
 	name = "Mech Bay Shutters"
-	},
-/obj/machinery/button/door{
-	id = "mechbay";
-	name = "Mech Bay Shutters Control";
-	pixel_y = 26;
-	req_access_txt = "29"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -28705,15 +28089,13 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "drF" = (
-/obj/machinery/light_switch{
-	pixel_x = 36
-	},
 /obj/machinery/vending/assist,
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "drG" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -28825,12 +28207,8 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "drO" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/light/directional/east,
+/obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/loading_area,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -28884,9 +28262,7 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "dsc" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
@@ -28977,9 +28353,7 @@
 "dsw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/directional/east,
 /obj/item/storage/toolbox/emergency,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -29146,6 +28520,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/mirror/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dsT" = (
@@ -29242,10 +28617,7 @@
 /area/science/mixing)
 "dtm" = (
 /obj/structure/closet/bombcloset,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
+/obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -29308,9 +28680,7 @@
 /area/science/research)
 "dtw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
@@ -29367,9 +28737,7 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dtQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -29418,10 +28786,6 @@
 /turf/open/floor/iron,
 /area/medical/surgery)
 "dtU" = (
-/obj/structure/mirror{
-	pixel_x = 26;
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -29481,9 +28845,7 @@
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "dum" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/science/research/abandoned)
@@ -29515,9 +28877,7 @@
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "dur" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/mecha_part_fabricator/maint,
 /turf/open/floor/iron,
@@ -29653,14 +29013,8 @@
 /area/science/robotics/mechbay)
 "duZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -38
-	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24;
+/obj/machinery/firealarm/directional/east{
 	pixel_y = -26
 	},
 /turf/open/floor/iron,
@@ -29741,9 +29095,6 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "dvR" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
@@ -29790,11 +29141,6 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "dwd" = (
-/obj/machinery/requests_console{
-	department = "Medbay Storage";
-	name = "Genetics Lab RC";
-	pixel_y = -32
-	},
 /obj/machinery/camera{
 	c_tag = "Research Division - Genetics Lab";
 	dir = 4;
@@ -29811,10 +29157,14 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/requests_console/directional/south{
+	department = "Genetics";
+	name = "Genetics Requests console"
+	},
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "dwe" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/landmark/start/geneticist,
 /obj/structure/chair/office/light{
 	dir = 8
@@ -29903,10 +29253,9 @@
 "dwC" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/bot,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "dwD" = (
@@ -30026,18 +29375,14 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/item/gun/syringe,
 /obj/item/clothing/glasses/eyepatch,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dxl" = (
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
+/obj/machinery/light_switch/directional/west,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12
@@ -30060,18 +29405,14 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dxp" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dxr" = (
 /obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/item/storage/toolbox/emergency{
 	pixel_x = -3;
 	pixel_y = 3
@@ -30102,9 +29443,7 @@
 /area/hallway/secondary/construction)
 "dxw" = (
 /obj/structure/table,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/item/clipboard,
 /obj/item/folder/yellow,
 /obj/item/electronics/firealarm,
@@ -30118,6 +29457,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "dxA" = (
@@ -30177,16 +29517,12 @@
 /area/science/research/abandoned)
 "dxO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
+/obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "dxP" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -32
 	},
@@ -30295,9 +29631,7 @@
 /obj/machinery/computer/crew{
 	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -30319,9 +29653,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "dyH" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -30360,9 +29692,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "dyJ" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/machinery/smartfridge/organ,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -30378,11 +29708,7 @@
 /area/medical/surgery)
 "dyK" = (
 /obj/structure/closet/crate/freezer/blood,
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	pixel_x = 26;
-	use_power = 0
-	},
+/obj/machinery/vending/wallmed/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -30545,9 +29871,7 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "dzx" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
 	},
@@ -30607,9 +29931,7 @@
 /obj/structure/rack,
 /obj/item/book/manual/wiki/robotics_cyborgs,
 /obj/item/storage/belt/utility/full,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/circuitboard/mecha/ripley/main,
 /obj/item/circuitboard/mecha/ripley/peripherals,
 /obj/effect/turf_decal/bot,
@@ -30624,18 +29946,13 @@
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/toy/figure/roboticist,
-/obj/machinery/button/door{
+/obj/effect/turf_decal/bot,
+/obj/machinery/button/door/directional/north{
 	id = "roboticsprivacy";
-	name = "Robotics Privacy Control";
-	pixel_x = 26;
-	pixel_y = 26;
+	name = "Robotics Privacy Controls";
+	pixel_x = 24;
 	req_access_txt = "29"
 	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 38
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "dzL" = (
@@ -30720,9 +30037,7 @@
 /area/maintenance/solars/starboard/aft)
 "dAm" = (
 /obj/machinery/power/smes,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -30795,13 +30110,14 @@
 	amount = 15
 	},
 /obj/item/wrench,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/clothing/glasses/welding,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -38
+	},
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "dAK" = (
@@ -30910,9 +30226,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "dBo" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed/directional/north,
 /obj/structure/table/glass,
 /obj/item/stack/medical/gauze,
 /obj/effect/turf_decal/tile/blue{
@@ -30944,9 +30258,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -31201,10 +30513,6 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
 /obj/structure/table/reinforced,
-/obj/machinery/light_switch{
-	pixel_x = -38;
-	pixel_y = 26
-	},
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
@@ -31250,9 +30558,7 @@
 /area/medical/chemistry)
 "dCF" = (
 /obj/machinery/vending/cart,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "dCO" = (
@@ -31262,16 +30568,14 @@
 /area/medical/surgery/room_b)
 "dCP" = (
 /obj/structure/table/optable,
-/obj/machinery/button/door{
-	id = "surgeryb";
-	name = "Privacy Shutters Control";
-	pixel_x = 26;
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/button/door/directional/east{
+	id = "surgeryb";
+	name = "Privacy Shutters Control"
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "dDb" = (
@@ -31317,7 +30621,7 @@
 /turf/open/floor/plating,
 /area/science/research/abandoned)
 "dDh" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -31341,7 +30645,7 @@
 /area/science/research/abandoned)
 "dDk" = (
 /obj/structure/frame/machine,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/item/stack/sheet/glass,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -31370,9 +30674,7 @@
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -31419,9 +30721,7 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "dDw" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
@@ -31434,10 +30734,7 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "dDF" = (
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 32
-	},
+/obj/structure/noticeboard/directional/east,
 /obj/machinery/camera{
 	c_tag = "Science - Robotics Lab";
 	dir = 8;
@@ -31478,10 +30775,7 @@
 	},
 /obj/item/reagent_containers/dropper,
 /obj/structure/table/glass,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 6
-	},
+/obj/machinery/light_switch/directional/east,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -31501,16 +30795,12 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/mask/surgical,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/vending/wallmed{
-	pixel_y = 32
-	},
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dDP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -31546,9 +30836,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 2
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -31588,6 +30876,7 @@
 	pixel_y = 2
 	},
 /obj/item/pushbroom,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -31709,11 +30998,10 @@
 	pixel_x = 5
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/west{
 	department = "Toxins Lab";
-	name = "Toxins RC";
-	pixel_x = -32;
-	receive_ore_updates = 1
+	departmentType = 5;
+	name = "Toxins Requests Console"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -31732,9 +31020,7 @@
 /area/science/mixing)
 "dEv" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -31759,9 +31045,7 @@
 /area/science/storage)
 "dEz" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/crowbar,
 /obj/item/wrench,
@@ -31903,11 +31187,10 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/machinery/requests_console{
-	department = "Chemistry Lab";
-	name = "Chemistry RC";
-	pixel_y = -32;
-	receive_ore_updates = 1
+/obj/machinery/requests_console/directional/south{
+	department = "Chemistry";
+	departmentType = 1;
+	name = "Chemistry Requests Console"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -32023,9 +31306,7 @@
 /area/security/detectives_office/private_investigators_office)
 "dFv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/plating,
 /area/security/detectives_office/private_investigators_office)
 "dFw" = (
@@ -32076,9 +31357,7 @@
 "dFB" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/item/crowbar,
 /obj/item/wrench,
 /obj/item/clothing/mask/gas,
@@ -32087,9 +31366,7 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/misc_lab)
@@ -32112,6 +31389,9 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/light_switch/directional/east{
+	pixel_y = 26
+	},
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "dFI" = (
@@ -32131,16 +31411,12 @@
 	pixel_y = -2
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/science/mixing)
 "dFL" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Science - Toxins Mixing Lab Aft";
 	dir = 8;
@@ -32186,10 +31462,6 @@
 "dFR" = (
 /obj/machinery/computer/rdservercontrol{
 	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -28;
-	pixel_y = -26
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -32273,10 +31545,6 @@
 /turf/open/floor/iron,
 /area/medical/morgue)
 "dGv" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -32334,9 +31602,7 @@
 /area/maintenance/starboard/aft)
 "dGL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/item/kirbyplants/random,
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
@@ -32420,9 +31686,7 @@
 /area/science/misc_lab)
 "dHe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -32459,9 +31723,7 @@
 /turf/open/floor/iron,
 /area/science/storage)
 "dHp" = (
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
+/obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -32502,9 +31764,7 @@
 	},
 /obj/item/multitool,
 /obj/item/clothing/head/welding,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
@@ -32556,12 +31816,8 @@
 /obj/structure/table/reinforced,
 /obj/item/retractor,
 /obj/item/hemostat,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/light/directional/east,
+/obj/machinery/status_display/ai/directional/east,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
@@ -32806,7 +32062,7 @@
 /obj/machinery/computer/operating{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
@@ -32816,9 +32072,7 @@
 "dIR" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
@@ -32831,9 +32085,7 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
+/obj/structure/mirror/directional/east,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
@@ -32868,7 +32120,7 @@
 /area/hallway/primary/aft)
 "dIW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
@@ -32946,7 +32198,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -32962,6 +32214,7 @@
 /obj/structure/table,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/plating,
 /area/medical/morgue)
 "dJo" = (
@@ -33028,9 +32281,7 @@
 /area/security/detectives_office/private_investigators_office)
 "dJF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/item/kirbyplants/random,
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_x = 32
@@ -33072,14 +32323,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = -32
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = -26
 	},
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "dJK" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -33110,7 +32360,7 @@
 /area/science/misc_lab)
 "dJQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -33125,6 +32375,7 @@
 "dJT" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/bot,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/science/mixing)
 "dJU" = (
@@ -33132,7 +32383,7 @@
 /obj/item/clothing/suit/fire/firefighter,
 /obj/item/clothing/head/hardhat/red,
 /obj/item/clothing/mask/gas,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
@@ -33464,9 +32715,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
@@ -33593,12 +32842,8 @@
 "dLw" = (
 /obj/structure/frame/computer,
 /obj/item/circuitboard/computer/secure_data,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/light/small/directional/west,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office/private_investigators_office)
 "dLx" = (
@@ -33771,13 +33016,9 @@
 /turf/open/floor/iron,
 /area/science/storage)
 "dMb" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
+/obj/structure/urinal/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/landmark/xeno_spawn,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -33863,7 +33104,7 @@
 /area/maintenance/port/aft)
 "dMt" = (
 /obj/structure/closet/firecloset,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -34147,9 +33388,7 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
+/obj/structure/mirror/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/tile/neutral{
@@ -34165,9 +33404,7 @@
 /turf/open/floor/iron,
 /area/science/research)
 "dOs" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -34209,9 +33446,7 @@
 /area/science/research)
 "dOz" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -34227,16 +33462,13 @@
 /area/security/checkpoint/customs/auxiliary)
 "dOB" = (
 /obj/machinery/photocopier,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32;
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs/auxiliary)
 "dOC" = (
@@ -34249,12 +33481,11 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs/auxiliary)
 "dOD" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/machinery/camera{
 	c_tag = "Departures Hallway - Aft";
 	dir = 4;
@@ -34286,9 +33517,7 @@
 /area/hallway/primary/aft)
 "dOH" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/delivery,
@@ -34395,9 +33624,7 @@
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -34482,9 +33709,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "dPJ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
@@ -34527,7 +33752,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -34551,10 +33776,8 @@
 /area/science/research)
 "dPQ" = (
 /obj/effect/spawner/randomcolavend,
-/obj/machinery/light,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -34715,6 +33938,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dQj" = (
@@ -34741,15 +33965,11 @@
 "dQm" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32;
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north,
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dQn" = (
@@ -34769,9 +33989,7 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dQp" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32;
 	pixel_y = 32
@@ -34781,6 +33999,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dQA" = (
@@ -34824,9 +34043,7 @@
 /obj/machinery/computer/crew{
 	dir = 4
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -34862,9 +34079,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = -32
+/obj/machinery/newscaster/directional/east{
+	pixel_y = -28
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs/auxiliary)
@@ -34881,9 +34097,7 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
+/obj/structure/mirror/directional/west,
 /obj/machinery/shower{
 	dir = 8;
 	name = "emergency shower"
@@ -34958,9 +34172,7 @@
 /turf/open/floor/iron,
 /area/medical/virology)
 "dQZ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -35004,10 +34216,6 @@
 /turf/open/floor/iron,
 /area/medical/virology)
 "dRc" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -35113,9 +34321,7 @@
 	dir = 8;
 	pixel_y = 1
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -35158,9 +34364,7 @@
 /area/maintenance/port/aft)
 "dRP" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/crowbar,
 /obj/item/radio,
 /obj/structure/sign/poster/official/do_not_question{
@@ -35232,9 +34436,7 @@
 /area/hallway/primary/aft)
 "dRX" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -35254,7 +34456,7 @@
 /area/medical/virology)
 "dSa" = (
 /obj/structure/closet/l3closet/virology,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
@@ -35268,9 +34470,7 @@
 /turf/open/floor/iron,
 /area/medical/virology)
 "dSd" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -35304,12 +34504,8 @@
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "dSo" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/light/directional/east,
+/obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -35446,9 +34642,7 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "dTj" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -35512,6 +34706,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "dTR" = (
@@ -35535,9 +34730,7 @@
 	},
 /area/service/chapel/main)
 "dTU" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = -32
 	},
@@ -35558,9 +34751,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "dTV" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -35728,9 +34919,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "dUO" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = -32
-	},
+/obj/machinery/vending/wallmed/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -35813,18 +35002,17 @@
 /area/medical/virology)
 "dVu" = (
 /obj/structure/table/glass,
-/obj/machinery/requests_console{
-	department = "Virology Lab";
-	name = "Virology RC";
-	pixel_y = 32;
-	receive_ore_updates = 1
-	},
 /obj/item/folder/white,
 /obj/item/pen/red,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 5
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/requests_console/directional/north{
+	department = "Virology";
+	name = "Virology Requests Console";
+	receive_ore_updates = 1
+	},
 /turf/open/floor/iron,
 /area/medical/virology)
 "dVv" = (
@@ -35841,12 +35029,8 @@
 /turf/open/floor/iron,
 /area/medical/virology)
 "dVx" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -35893,9 +35077,7 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dVE" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -35908,9 +35090,7 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dVG" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -36054,9 +35234,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "dWg" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -36078,9 +35256,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "dWm" = (
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_x = -32
-	},
+/obj/structure/reagent_dispensers/virusfood/directional/west,
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
 	desc = "Used to grind things up into raw materials and liquids.";
@@ -36343,8 +35519,9 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "dXN" = (
@@ -36352,6 +35529,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "dXR" = (
@@ -36382,9 +35560,7 @@
 	pixel_x = -3;
 	pixel_y = 2
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36505,10 +35681,6 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
-"dYF" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/hallway/secondary/exit/departure_lounge)
 "dYG" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -36516,10 +35688,6 @@
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit/departure_lounge)
-"dYH" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "dYI" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -36613,10 +35781,8 @@
 /turf/open/floor/iron,
 /area/medical/virology)
 "dYT" = (
-/obj/machinery/light,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -36631,9 +35797,8 @@
 /area/medical/virology)
 "dYV" = (
 /obj/structure/closet/secure_closet/medical1,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/east,
@@ -36641,9 +35806,7 @@
 /turf/open/floor/iron,
 /area/medical/virology)
 "dYW" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
@@ -36690,9 +35853,7 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hop)
 "dZn" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -36709,6 +35870,7 @@
 /obj/item/folder,
 /obj/item/pen,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "dZq" = (
@@ -36719,6 +35881,7 @@
 	name = "departures camera"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "dZr" = (
@@ -36933,9 +36096,7 @@
 /area/maintenance/solars/port/aft)
 "eaS" = (
 /obj/machinery/power/smes,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36985,12 +36146,6 @@
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "eaZ" = (
-/obj/machinery/button/door{
-	id = "evashutters2";
-	name = "E.V.A. Shutters";
-	pixel_x = 26;
-	req_access_txt = "19"
-	},
 /obj/machinery/door/poddoor/shutters{
 	id = "evashutters2";
 	name = "E.V.A. Storage Shutters"
@@ -37020,9 +36175,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/port/aft)
 "ebk" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/spawner/randomsnackvend,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -37033,12 +36186,14 @@
 	},
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "ebm" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "ebp" = (
@@ -37072,10 +36227,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/virology)
-"ebx" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
 /area/medical/virology)
 "ebz" = (
 /obj/machinery/iv_drip,
@@ -37193,19 +36344,20 @@
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "ebO" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/kirbyplants/random,
+/obj/machinery/button/door/directional/north{
+	id = "evashutters2";
+	name = "E.V.A. Shutters";
+	req_access_txt = "19"
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ebQ" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/folder/yellow,
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ebR" = (
@@ -37391,16 +36543,16 @@
 /area/hallway/secondary/exit/departure_lounge)
 "ecG" = (
 /obj/structure/chair,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "ecH" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "ecI" = (
@@ -37827,10 +36979,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
-"eee" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/security/checkpoint/escape)
 "eej" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
@@ -37873,9 +37021,7 @@
 /area/maintenance/port/aft)
 "eeq" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -37884,9 +37030,7 @@
 /area/maintenance/port/aft)
 "eer" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ees" = (
@@ -37914,16 +37058,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "eeG" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "eeH" = (
 /obj/structure/filingcabinet/security,
-/obj/machinery/light_switch{
-	pixel_x = -26;
+/obj/machinery/light_switch/directional/west{
 	pixel_y = 26
 	},
 /obj/machinery/camera{
@@ -37977,6 +37118,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "eeN" = (
@@ -38109,9 +37251,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "efu" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/crowbar,
 /obj/item/wrench,
 /obj/item/radio,
@@ -38295,9 +37435,7 @@
 /obj/machinery/computer/security{
 	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -38309,7 +37447,7 @@
 /area/security/checkpoint/escape)
 "egm" = (
 /obj/structure/closet/secure_closet/security,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -38324,7 +37462,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/sign/poster{
 	icon_state = "poster22_legit";
 	pixel_y = -32
@@ -38364,7 +37502,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Security - Departures Starboard";
 	dir = 1
@@ -38570,11 +37708,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
-"eiZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/small{
+"eiK" = (
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"eiZ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small/directional/north,
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
@@ -38662,9 +37805,7 @@
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/folder,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "ekq" = (
@@ -38685,7 +37826,7 @@
 /area/cargo/qm)
 "ekw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -38702,12 +37843,8 @@
 /area/commons/toilet/restrooms)
 "ekx" = (
 /obj/structure/bed,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /obj/item/bedsheet/dorms,
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -38726,6 +37863,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "ekM" = (
@@ -38992,10 +38130,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"enP" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/engineering/main)
 "eok" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Surgery Maintenance";
@@ -39040,18 +38174,17 @@
 	pixel_x = 25;
 	pixel_y = 7
 	},
-/obj/machinery/button/door{
-	id = "permashut2";
-	name = "Cell Lockdown Button";
-	pixel_x = 25;
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/door/directional/east{
+	id = "permashut2";
+	name = "Cell Lockdown Button";
+	pixel_y = -6;
+	req_access_txt = "2"
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "eph" = (
@@ -39225,7 +38358,7 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "esn" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Medbay - Starboard";
 	dir = 1;
@@ -39365,7 +38498,7 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "euP" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/command/meeting_room/council)
@@ -39411,9 +38544,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ewa" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/suit_storage_unit/captain,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -39547,6 +38678,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "eyc" = (
@@ -39635,7 +38767,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
 	dir = 4
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "ezU" = (
@@ -39667,7 +38799,7 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "eAA" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -39940,10 +39072,6 @@
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den/secondary)
 "eEK" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -39976,9 +39104,8 @@
 /area/engineering/atmos)
 "eEX" = (
 /obj/structure/chair/stool,
-/obj/machinery/flasher{
-	id = "visitorflash";
-	pixel_y = 28
+/obj/machinery/flasher/directional/north{
+	id = "visitorflash"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -40021,9 +39148,7 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "eFq" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -40179,10 +39304,6 @@
 /area/science/xenobiology)
 "eHv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 32
-	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
@@ -40198,9 +39319,7 @@
 /area/engineering/main)
 "eHx" = (
 /obj/structure/displaycase/labcage,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
@@ -40225,11 +39344,12 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "eHP" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -40273,9 +39393,7 @@
 /area/cargo/storage)
 "eIs" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Medbay - Chief Medical Officer's Office";
 	dir = 8;
@@ -40296,16 +39414,14 @@
 /area/command/heads_quarters/cmo)
 "eIy" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/clothing/suit/jacket{
 	desc = "All the class of a trenchcoat without the security fibers.";
 	icon_state = "greydet";
 	name = "trenchcoat"
 	},
 /obj/item/clothing/suit/toggle/lawyer/black,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/item/clothing/head/fedora,
 /obj/item/clothing/under/dress/redeveninggown,
 /obj/item/clothing/head/rabbitears,
@@ -40382,7 +39498,7 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "eJG" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/closet/crate/goldcrate,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -40398,10 +39514,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "eJR" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/service/kitchen)
@@ -40419,9 +39531,7 @@
 /area/service/chapel/office)
 "eKl" = (
 /obj/structure/filingcabinet/filingcabinet,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -40499,9 +39609,8 @@
 "eLb" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
 "eLv" = (
@@ -40523,15 +39632,14 @@
 /area/security/range)
 "eLz" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
 "eLA" = (
@@ -40545,15 +39653,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"eLE" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/commons/fitness/recreation)
 "eLK" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
+/obj/machinery/light_switch/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -40721,9 +39823,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eND" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral{
@@ -40787,7 +39887,7 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "eOt" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -40938,9 +40038,7 @@
 	desc = "A replica hat of a Central Commander's attire. It has a small tag on it saying, 'It's good to be emperor.'";
 	name = "Replica CentCom hat"
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/command/corporate_showroom)
@@ -40970,9 +40068,7 @@
 /area/hallway/primary/central/aft)
 "eQk" = (
 /obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/camera{
@@ -40995,10 +40091,9 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/command/nuke_storage)
 "eQB" = (
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/north{
 	department = "Kitchen";
-	name = "Kitchen RC";
-	pixel_y = 32
+	name = "Kitchen Requests Console"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -41140,16 +40235,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eSH" = (
-/obj/machinery/button/door{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
 	id = "Dorm2";
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 7;
 	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
@@ -41197,7 +40290,7 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "eTx" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Medbay - Port";
 	dir = 1;
@@ -41246,9 +40339,7 @@
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "eTQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/wood,
 /area/service/library)
 "eTS" = (
@@ -41285,9 +40376,7 @@
 /turf/open/floor/glass,
 /area/maintenance/space_hut/observatory)
 "eUp" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/mapping_helpers/ianbirthday,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood,
@@ -41310,9 +40399,7 @@
 /area/commons/storage/primary)
 "eUH" = (
 /obj/machinery/vending/autodrobe,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -41412,9 +40499,7 @@
 /area/medical/medbay/central)
 "eVC" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -41468,6 +40553,21 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"eWf" = (
+/obj/machinery/porta_turret/ai,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai_upload)
 "eWj" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=engi2";
@@ -41498,9 +40598,7 @@
 /area/commons/dorms)
 "eWx" = (
 /obj/structure/window/reinforced,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -41841,10 +40939,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"fay" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter)
 "faE" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -41977,12 +41071,8 @@
 "fbt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/disposal/bin,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/light_switch/directional/west,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -42050,14 +41140,15 @@
 /area/engineering/main)
 "fcl" = (
 /obj/structure/dresser,
-/obj/structure/mirror{
-	pixel_x = 26
-	},
+/obj/structure/mirror/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/light_switch/directional/north{
+	pixel_x = -8
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
@@ -42116,13 +41207,12 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "fcG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
 	},
@@ -42267,7 +41357,7 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "ffh" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plating,
 /area/commons/toilet/auxiliary)
@@ -42469,9 +41559,7 @@
 /area/hallway/primary/port)
 "fiJ" = (
 /obj/structure/dresser,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -42524,12 +41612,8 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_x = 26
-	},
+/obj/machinery/light/directional/east,
+/obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -42544,9 +41628,7 @@
 /area/security/checkpoint)
 "fjo" = (
 /obj/structure/table/wood,
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/item/stack/sheet/glass,
@@ -42584,6 +41666,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/service/theater/abandoned)
+"fjO" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "fjP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -42597,6 +41686,14 @@
 "fjU" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/light_switch/directional/north{
+	pixel_x = -8
+	},
+/obj/machinery/button/door/directional/north{
+	id = "lawyerprivacy";
+	name = "Lawyer's Privacy Control";
+	pixel_x = 6
+	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "fjV" = (
@@ -42636,9 +41733,7 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "fkP" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -42986,9 +42081,7 @@
 /turf/open/floor/iron,
 /area/science/research)
 "fpv" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
@@ -43029,12 +42122,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "fqj" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -43108,10 +42197,7 @@
 /area/maintenance/starboard/fore)
 "fqV" = (
 /obj/structure/closet/radiation,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
 "fqW" = (
@@ -43147,9 +42233,7 @@
 /area/engineering/gravity_generator)
 "frl" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/storage)
@@ -43205,9 +42289,7 @@
 /area/service/janitor)
 "ftc" = (
 /obj/machinery/libraryscanner,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "ftf" = (
@@ -43238,9 +42320,7 @@
 /area/engineering/atmos)
 "ftB" = (
 /obj/structure/closet/emcloset/anchored,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/bot,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
@@ -43403,22 +42483,18 @@
 /area/medical/chemistry)
 "fvG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "fvN" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fvP" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -43487,9 +42563,7 @@
 /area/hallway/primary/central/fore)
 "fwB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/stripes/line,
 /obj/item/radio/intercom/directional/north,
@@ -43603,19 +42677,13 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "fyM" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
+/obj/machinery/status_display/ai/directional/north,
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/light_switch/directional/east{
 	pixel_x = 38
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 32
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -43662,15 +42730,13 @@
 	},
 /area/engineering/atmos)
 "fzO" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "fAd" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/command/meeting_room/council)
@@ -43864,9 +42930,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -43893,9 +42957,7 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "fDt" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -43980,9 +43042,7 @@
 "fFv" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/yellow,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -44008,20 +43068,6 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "fFU" = (
-/obj/machinery/button/door{
-	id = "cargounload";
-	layer = 4;
-	name = "Loading Doors";
-	pixel_x = 24;
-	pixel_y = 8
-	},
-/obj/machinery/button/door{
-	id = "cargoload";
-	layer = 4;
-	name = "Loading Doors";
-	pixel_x = 24;
-	pixel_y = -8
-	},
 /obj/machinery/computer/cargo{
 	dir = 8
 	},
@@ -44030,17 +43076,26 @@
 	dir = 8;
 	name = "cargo camera"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/bot,
+/obj/machinery/button/door/directional/east{
+	id = "cargounload";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_y = 6
+	},
+/obj/machinery/button/door/directional/east{
+	id = "cargoload";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_y = -6
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fGb" = (
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/south{
 	department = "Mining";
-	name = "Mining Dock RC";
-	pixel_y = -32
+	name = "Mining Requests Console"
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Mining Dock";
@@ -44105,9 +43160,7 @@
 	},
 /obj/item/stack/cable_coil,
 /obj/item/healthanalyzer,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -44153,9 +43206,7 @@
 "fHm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -44219,9 +43270,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fIt" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -44247,6 +43296,7 @@
 "fIF" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "fIN" = (
@@ -44386,18 +43436,14 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "fKX" = (
-/obj/structure/mirror{
-	pixel_x = -28
-	},
+/obj/structure/mirror/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
 "fLT" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -44411,9 +43457,7 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "fMb" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4
 	},
@@ -44431,7 +43475,7 @@
 /area/service/kitchen)
 "fMD" = (
 /obj/machinery/vending/cigarette,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/commons/toilet/auxiliary)
@@ -44522,13 +43566,9 @@
 /area/medical/treatment_center)
 "fOk" = (
 /obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/storage/lockbox/loyalty,
-/obj/item/storage/secure/safe{
-	pixel_x = 32
-	},
+/obj/item/storage/secure/safe/directional/east,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "fOo" = (
@@ -44547,9 +43587,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "fOJ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/cable,
@@ -44563,6 +43601,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "fOP" = (
@@ -44570,12 +43609,8 @@
 /turf/open/space,
 /area/engineering/atmos/upper)
 "fOX" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/light/small/directional/west,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
@@ -44759,7 +43794,7 @@
 /turf/closed/wall,
 /area/hallway/primary/central/aft)
 "fSA" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 1
@@ -44784,9 +43819,7 @@
 /area/medical/virology)
 "fSE" = (
 /obj/structure/closet/athletic_mixed,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -44835,9 +43868,7 @@
 /area/maintenance/starboard/fore)
 "fTP" = (
 /obj/machinery/vending/cigarette,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -44881,10 +43912,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "fUl" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -44988,9 +44015,7 @@
 /area/commons/storage/primary)
 "fVy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/structure/reagent_dispensers/fueltank/large,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -45006,9 +44031,7 @@
 	dir = 8;
 	name = "engineering camera"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/storage)
@@ -45033,9 +44056,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "fVZ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -45054,19 +44075,15 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "fWi" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/light/small/directional/north,
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/service/electronic_marketing_den)
@@ -45148,9 +44165,7 @@
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
 "fXn" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
@@ -45172,17 +44187,13 @@
 /obj/machinery/computer/robotics{
 	dir = 8
 	},
-/obj/machinery/light,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/keycard_auth/directional/south{
+	pixel_x = -5
 	},
-/obj/machinery/keycard_auth{
-	pixel_x = -5;
-	pixel_y = -26
-	},
-/obj/machinery/light_switch{
-	pixel_x = 5;
-	pixel_y = -26
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 8
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -45212,6 +44223,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 10
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -45250,9 +44262,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -45312,9 +44322,7 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "fZA" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -45476,23 +44484,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
-"gbE" = (
-/obj/machinery/button/door{
-	id = "teleportershutters";
-	name = "Teleporter Shutters";
-	pixel_x = -26;
-	req_access_txt = "19"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "teleportershutters";
-	name = "Teleporter Shutters"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/command/teleporter)
 "gbL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -45582,10 +44573,9 @@
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "gep" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "geA" = (
@@ -45696,17 +44686,13 @@
 /obj/structure/table/wood,
 /obj/item/clothing/suit/cardborg,
 /obj/item/clothing/head/cardborg,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/service/theater/abandoned)
 "gho" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -45788,6 +44774,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"giT" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark,
+/area/service/chapel/office)
 "giV" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron/grimy,
@@ -45838,10 +44839,8 @@
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
 "gjl" = (
-/obj/machinery/light,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /obj/machinery/camera{
 	c_tag = "Engineering - Gravity Generator";
 	dir = 1;
@@ -45907,13 +44906,8 @@
 /turf/open/floor/carpet,
 /area/command/meeting_room/council)
 "gkn" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 8
-	},
+/obj/machinery/light/directional/east,
+/obj/machinery/light_switch/directional/east,
 /obj/machinery/camera{
 	c_tag = "Hydroponics";
 	dir = 8;
@@ -46071,16 +45065,15 @@
 /area/maintenance/port/fore)
 "gmi" = (
 /obj/structure/rack,
-/obj/machinery/button/door{
-	id = "kitchenwindows";
-	name = "Kitchen Privacy Control";
-	pixel_y = -26;
-	req_access_txt = "28"
-	},
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/item/storage/box/donkpockets,
 /obj/item/clothing/head/chefhat,
 /obj/effect/turf_decal/bot,
+/obj/machinery/button/door/directional/south{
+	id = "kitchenwindow";
+	name = "Kitchen Privacy Control";
+	req_access_txt = "28"
+	},
 /turf/open/floor/iron,
 /area/service/kitchen)
 "gmN" = (
@@ -46152,9 +45145,8 @@
 	name = "MiniSat Upload";
 	req_access_txt = "16"
 	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = -26
+/obj/machinery/flasher/directional/west{
+	id = "AI"
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -46200,16 +45192,14 @@
 "gnW" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
-/obj/machinery/button/door{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
 	id = "Dorm3";
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 7;
 	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -46226,9 +45216,7 @@
 /area/hallway/primary/aft)
 "goy" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -46239,10 +45227,6 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"goO" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/engineering/atmos)
 "goP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -46495,9 +45479,7 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "grO" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -46553,10 +45535,18 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
-"gsr" = (
-/obj/machinery/light{
+"gsq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron/grimy,
+/area/service/chapel/main)
+"gsr" = (
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "gsx" = (
@@ -46582,7 +45572,7 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "gsX" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -46610,11 +45600,9 @@
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "gta" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "gtr" = (
@@ -46731,6 +45719,7 @@
 	dir = 8
 	},
 /obj/structure/displaycase/forsale/kitchen,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "guW" = (
@@ -46806,9 +45795,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "gvH" = (
-/obj/structure/mirror{
-	pixel_x = -28
-	},
+/obj/structure/mirror/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -46830,6 +45817,11 @@
 "gwr" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/button/door/directional/south{
+	id = "evashutters";
+	name = "E.V.A. Shutters";
+	req_access_txt = "19"
+	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "gxd" = (
@@ -46864,9 +45856,7 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "gxm" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
 "gxo" = (
@@ -46919,16 +45909,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"gxN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/open/floor/iron/white/corner,
-/area/hallway/secondary/entry)
 "gxR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -47039,7 +46019,7 @@
 /turf/open/floor/wood,
 /area/service/electronic_marketing_den)
 "gzU" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Aft Starboard";
 	dir = 1;
@@ -47117,7 +46097,7 @@
 "gBt" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/harebell,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden/abandoned)
@@ -47158,9 +46138,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "gBU" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/structure/closet/wardrobe/mixed,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47267,12 +46245,8 @@
 "gDC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
+/obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -47446,9 +46420,7 @@
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 8
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
@@ -47498,7 +46470,7 @@
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
 "gHK" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -47539,6 +46511,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/theater/abandoned)
 "gIm" = (
@@ -47571,7 +46544,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "gJq" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Cell 8";
 	dir = 1;
@@ -47692,9 +46665,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -47730,9 +46701,7 @@
 "gLe" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/ce)
 "gLm" = (
@@ -47833,9 +46802,7 @@
 /area/service/theater/abandoned)
 "gNK" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/service/library)
 "gNS" = (
@@ -47877,12 +46844,8 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "gOL" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Arrivals Dock - Aft";
 	dir = 8;
@@ -48000,9 +46963,7 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/fore)
 "gPC" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "gPM" = (
@@ -48050,10 +47011,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "gQQ" = (
-/obj/machinery/light,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /obj/machinery/vending/dinnerware,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -48080,7 +47039,7 @@
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "gRN" = (
@@ -48184,12 +47143,11 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "gSY" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "gTa" = (
@@ -48438,9 +47396,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -48461,7 +47417,7 @@
 /area/security/detectives_office)
 "gWX" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
@@ -48599,7 +47555,7 @@
 /area/service/lawoffice)
 "gYD" = (
 /obj/structure/rack,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/item/storage/toolbox/emergency,
 /obj/item/wrench,
 /obj/effect/turf_decal/tile/neutral{
@@ -48612,6 +47568,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "gYQ" = (
@@ -48811,6 +47768,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "hbT" = (
@@ -48820,9 +47778,7 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "hbW" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -48861,19 +47817,16 @@
 /area/engineering/supermatter)
 "hdj" = (
 /obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "hdp" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "hdq" = (
@@ -49007,12 +47960,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/flask/gold,
 /obj/item/razor,
-/obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Captain's Intercom";
-	pixel_x = -26
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
 "hfC" = (
@@ -49147,9 +48095,7 @@
 /area/engineering/supermatter/room)
 "hia" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -49185,15 +48131,11 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -26;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
 "hiG" = (
@@ -49463,10 +48405,6 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "hnn" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/effect/landmark/start/head_of_personnel,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -49728,9 +48666,7 @@
 /area/hallway/primary/starboard)
 "hpY" = (
 /obj/structure/cable,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -49807,9 +48743,7 @@
 /area/service/abandoned_gambling_den)
 "hra" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
+/obj/machinery/light_switch/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -49824,9 +48758,7 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "hrt" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
 "hrI" = (
@@ -49906,6 +48838,13 @@
 	},
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
+"hsR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/central/fore)
 "htp" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library Access"
@@ -49950,14 +48889,13 @@
 /turf/open/floor/iron,
 /area/engineering/storage)
 "htS" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "htZ" = (
@@ -50039,10 +48977,6 @@
 /area/science/mixing)
 "hvd" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_x = 24;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -50053,12 +48987,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "hvp" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -50131,9 +49064,7 @@
 /area/maintenance/starboard/aft)
 "hwU" = (
 /obj/structure/window/reinforced,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -50147,9 +49078,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "hwV" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -50344,9 +49273,7 @@
 	dir = 1;
 	name = "Jury"
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -50362,19 +49289,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"hzE" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
 "hAc" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -50612,9 +49526,7 @@
 /turf/open/floor/circuit/green,
 /area/engineering/gravity_generator)
 "hDb" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/structure/frame/computer,
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
@@ -50630,9 +49542,8 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "hDe" = (
-/obj/machinery/light_switch{
-	pixel_x = 10;
-	pixel_y = -26
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 8
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow,
@@ -50642,9 +49553,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_x = -4;
-	pixel_y = -26
+/obj/item/radio/intercom/directional/south{
+	pixel_x = -4
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
@@ -50654,10 +49564,6 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/solars/port/fore)
 "hDA" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -50845,6 +49751,7 @@
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "hGg" = (
@@ -51029,9 +49936,7 @@
 /area/maintenance/starboard/fore)
 "hIq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -51062,10 +49967,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hJb" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
@@ -51102,9 +50003,7 @@
 /area/maintenance/port)
 "hJA" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -51295,9 +50194,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "hNd" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -51464,6 +50361,7 @@
 /area/security/prison)
 "hQk" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "hQn" = (
@@ -51754,7 +50652,7 @@
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/tower,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden/abandoned)
@@ -51842,16 +50740,12 @@
 /area/space/nearstation)
 "hUq" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "hUr" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -52013,9 +50907,7 @@
 /turf/open/floor/iron,
 /area/science/research)
 "hVE" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -52026,12 +50918,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
-"hVS" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/turf/closed/wall,
-/area/service/bar/atrium)
 "hVW" = (
 /obj/structure/window/plasma/reinforced/spawner/west{
 	dir = 4
@@ -52080,10 +50966,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"hWe" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/service/kitchen)
 "hWj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -52115,6 +50997,10 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/machinery/flasher/directional/east{
+	id = "justiceflash";
+	req_access_txt = "63"
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
@@ -52151,7 +51037,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "hXe" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
@@ -52293,17 +51179,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"hYS" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/command/heads_quarters/captain/private)
 "hZg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -52419,10 +51294,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/research)
-"iaV" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/cargo/qm)
 "ibh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/structure/window/reinforced,
@@ -52491,6 +51362,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"ibS" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron/dark/corner,
+/area/engineering/atmos)
 "ibV" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
@@ -52552,7 +51433,7 @@
 /obj/structure/sign/departments/chemistry{
 	pixel_y = -32
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Medbay - Waiting Room";
 	dir = 1;
@@ -52618,7 +51499,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -52690,9 +51571,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "idv" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
+/obj/structure/urinal/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
@@ -52825,23 +51704,23 @@
 /obj/structure/table/glass,
 /obj/item/clipboard,
 /obj/item/toy/figure/md,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/sign/poster/official/ian{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
 "ifj" = (
 /obj/structure/dresser,
-/obj/item/storage/secure/safe{
-	pixel_x = 32
-	},
+/obj/item/storage/secure/safe/directional/east,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "ifv" = (
@@ -52922,6 +51801,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "iga" = (
@@ -52930,17 +51810,6 @@
 	},
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
-"igb" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 58
-	},
-/turf/open/floor/iron/grimy,
-/area/command/heads_quarters/hos)
 "igc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -52965,20 +51834,26 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "igq" = (
-/obj/machinery/button/door{
-	id = "Dorm4";
-	name = "Dormitory Door Lock";
-	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 7;
-	specialfunctions = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/button/door/directional/west{
+	id = "Dorm4";
+	name = "Dormitory Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
 /turf/open/floor/wood,
 /area/commons/dorms)
+"igB" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "igV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -53119,11 +51994,12 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "iiL" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/grimy,
 /area/command/corporate_showroom)
@@ -53149,9 +52025,7 @@
 /area/command/heads_quarters/captain/private)
 "ijk" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 32
 	},
@@ -53206,7 +52080,7 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -53371,10 +52245,6 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "imN" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -53416,6 +52286,7 @@
 	dir = 4
 	},
 /obj/item/paper_bin,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/grimy,
 /area/command/bridge)
 "inw" = (
@@ -53586,9 +52457,7 @@
 /area/command/heads_quarters/rd)
 "ioR" = (
 /obj/structure/closet/secure_closet/bar,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -53604,9 +52473,7 @@
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "ioU" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -53643,9 +52510,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "ipn" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -53912,10 +52777,9 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/west{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -30;
+	name = "prison intercom";
 	prison_radio = 1
 	},
 /turf/open/floor/iron,
@@ -53975,9 +52839,7 @@
 /area/engineering/storage/tech)
 "itL" = (
 /obj/structure/table/wood,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/item/coin/adamantine{
 	pixel_x = -4;
 	pixel_y = 4
@@ -53992,7 +52854,7 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden/abandoned)
 "itR" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -54211,9 +53073,8 @@
 /turf/closed/wall,
 /area/engineering/main)
 "ixI" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "ixL" = (
@@ -54226,9 +53087,7 @@
 /turf/open/space/basic,
 /area/engineering/atmos/upper)
 "iyg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -54280,9 +53139,7 @@
 /obj/effect/spawner/randomarcade{
 	dir = 8
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/machinery/camera{
 	c_tag = "Permabrig - Hall";
 	dir = 8;
@@ -54422,9 +53279,7 @@
 	},
 /area/commons/toilet/auxiliary)
 "iAW" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/storage/pod{
 	pixel_x = 8;
 	pixel_y = 32
@@ -54462,6 +53317,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iBB" = (
@@ -54579,9 +53435,7 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "iDb" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
@@ -54855,15 +53709,11 @@
 /area/security/checkpoint/escape)
 "iHq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -55000,9 +53850,7 @@
 /area/maintenance/port/fore)
 "iKi" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -55085,9 +53933,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "iLD" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -55242,11 +54088,8 @@
 	icon_state = "curator"
 	},
 /obj/item/clothing/under/rank/civilian/curator/treasure_hunter,
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/machinery/airalarm/directional/north,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "iMR" = (
@@ -55268,11 +54111,9 @@
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "iNf" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/dresser,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -55298,7 +54139,7 @@
 "iNs" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Cargo - Mining Office";
 	dir = 8;
@@ -55336,9 +54177,7 @@
 "iOi" = (
 /obj/machinery/cell_charger,
 /obj/structure/table/reinforced,
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /obj/item/stock_parts/cell/high,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55358,9 +54197,7 @@
 /area/command/heads_quarters/ce)
 "iOm" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -55386,9 +54223,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "iOz" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/lawoffice)
@@ -55496,10 +54331,6 @@
 /turf/open/floor/iron/grimy,
 /area/tcommsat/computer)
 "iQb" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -55551,18 +54382,17 @@
 	pixel_x = 25;
 	pixel_y = 7
 	},
-/obj/machinery/button/door{
-	id = "permashut4";
-	name = "Cell Lockdown Button";
-	pixel_x = 25;
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/door/directional/east{
+	id = "permashut4";
+	name = "Cell Lockdown Button";
+	pixel_y = -6;
+	req_access_txt = "2"
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "iQv" = (
@@ -55747,7 +54577,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "iTd" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -55878,9 +54708,7 @@
 /area/command/meeting_room/council)
 "iVH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -55935,9 +54763,7 @@
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 8
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -55985,9 +54811,7 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "iYA" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
@@ -56099,10 +54923,7 @@
 "jam" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
-/obj/machinery/bounty_board{
-	dir = 1;
-	pixel_y = -32
-	},
+/obj/machinery/bounty_board/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -56184,13 +55005,6 @@
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 11
-	},
-/obj/machinery/requests_console{
-	department = "Hydroponics";
-	departmentType = 2;
-	name = "Hydroponics RC";
-	pixel_x = 32;
-	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -56448,17 +55262,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
-"jgC" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/xenobiology)
 "jgH" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -56496,7 +55299,7 @@
 	},
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/closet,
 /turf/open/floor/iron/dark,
 /area/service/bar)
@@ -56650,17 +55453,16 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/bot,
-/obj/machinery/button/door{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/button/door/directional/south{
 	id = "AuxToilet2";
 	name = "Lock Control";
 	normaldoorcontrol = 1;
-	pixel_y = -25;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/commons/toilet/auxiliary)
 "jiW" = (
@@ -56739,19 +55541,24 @@
 /area/ai_monitored/command/storage/eva)
 "jjx" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/button/door{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = 24;
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/button/door/directional/north{
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = 24
+	},
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
+"jjB" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "jjI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -56838,6 +55645,10 @@
 "jkE" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
+/obj/machinery/requests_console/directional/south{
+	department = "Law Office";
+	name = "Law Office Requests Console"
+	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "jkF" = (
@@ -56850,6 +55661,12 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon,
 /obj/item/stamp/hop,
+/obj/machinery/requests_console/directional/north{
+	announcementConsole = 1;
+	department = "Head of Personnel's Desk";
+	departmentType = 5;
+	name = "Head of Personnel's Requests Console"
+	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "jkT" = (
@@ -56892,9 +55709,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jmr" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -57037,16 +55852,11 @@
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
 	},
-/obj/machinery/keycard_auth{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
 	department = "Captain's Desk";
 	departmentType = 5;
-	name = "Captain RC";
-	pixel_x = -32
+	name = "Captain's Requests Console"
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
@@ -57058,9 +55868,7 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "jpo" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -57208,6 +56016,13 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
+"jrC" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron/white/corner,
+/area/hallway/secondary/entry)
 "jrR" = (
 /obj/structure/sign/poster/ripped{
 	pixel_y = -32
@@ -57235,19 +56050,11 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "jsg" = (
-/obj/machinery/light_switch{
-	pixel_x = -7;
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "jsh" = (
@@ -57282,13 +56089,11 @@
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
 "jsB" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/cargo/warehouse)
 "jsQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -57367,9 +56172,7 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Turbine Access";
 	dir = 1;
@@ -57532,9 +56335,7 @@
 /area/science/server)
 "jwc" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/item/stack/package_wrap,
 /obj/item/crowbar,
 /obj/item/hand_labeler,
@@ -57557,9 +56358,6 @@
 /area/space/nearstation)
 "jwE" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
 	dir = 8
 	},
@@ -57608,18 +56406,17 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/bot,
-/obj/machinery/button/door{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/button/door/directional/south{
 	id = "Toilet3";
 	name = "Lock Control";
 	normaldoorcontrol = 1;
-	pixel_y = -25;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
 "jxA" = (
@@ -57629,7 +56426,7 @@
 /turf/open/floor/iron/dark,
 /area/service/electronic_marketing_den)
 "jxD" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -57643,9 +56440,7 @@
 /turf/closed/wall,
 /area/cargo/storage)
 "jxO" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -57674,10 +56469,6 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "jyi" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57696,10 +56487,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = -24;
-	pixel_y = -24
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -26
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
@@ -57719,10 +56508,6 @@
 /turf/open/floor/iron,
 /area/maintenance/aft)
 "jzg" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -57938,9 +56723,7 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "jCf" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -57956,13 +56739,6 @@
 /area/ai_monitored/turret_protected/ai)
 "jCg" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/button/door{
-	id = "ceblast";
-	name = "Lockdown Control";
-	pixel_x = 26;
-	pixel_y = 26;
-	req_access_txt = "56"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -57977,6 +56753,12 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/button/door/directional/north{
+	id = "ceblast";
+	name = "Lockdown Control";
+	pixel_x = 24;
+	req_access_txt = "56"
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "jCj" = (
@@ -58009,10 +56791,8 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "jCE" = (
-/obj/machinery/light,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/ai/directional/south,
 /obj/machinery/camera{
 	c_tag = "Security - Office Aft";
 	dir = 1
@@ -58024,10 +56804,10 @@
 /turf/open/floor/iron,
 /area/security/office)
 "jCF" = (
-/obj/machinery/button/door{
-	id = "teleporterhubshutters";
+/obj/machinery/button/door/directional/north{
+	id = "teleportershutters";
 	name = "Teleporter Shutters";
-	pixel_y = 26
+	req_access_txt = "19"
 	},
 /obj/machinery/bluespace_beacon,
 /obj/structure/disposalpipe/segment{
@@ -58043,16 +56823,12 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/flashlight,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/main)
 "jDc" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -58110,10 +56886,6 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "jEi" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 21
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -58196,9 +56968,7 @@
 /obj/item/folder/yellow,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -58206,9 +56976,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 32
+/obj/structure/extinguisher_cabinet/directional/north{
+	pixel_x = 32
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
@@ -58463,9 +57232,7 @@
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "jIv" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -58486,9 +57253,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Port";
 	dir = 4;
@@ -58528,6 +57293,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "jJq" = (
@@ -58588,7 +57354,6 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "jJW" = (
-/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/engineering/storage_shared)
@@ -58611,7 +57376,7 @@
 /area/maintenance/port)
 "jKg" = (
 /obj/machinery/vending/autodrobe,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
@@ -58672,9 +57437,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "jLf" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -58712,6 +57475,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jLY" = (
@@ -58806,9 +57570,7 @@
 /area/service/kitchen)
 "jNq" = (
 /obj/structure/dresser,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/ce)
 "jNs" = (
@@ -58831,9 +57593,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -59077,9 +57837,6 @@
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -59090,6 +57847,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "jQY" = (
@@ -59108,6 +57866,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer/on,
+/obj/machinery/light_switch/directional/east{
+	pixel_x = 21
+	},
 /turf/open/floor/iron/dark,
 /area/science/server)
 "jRs" = (
@@ -59429,9 +58190,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "jVX" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = -28
-	},
+/obj/structure/fireaxecabinet/directional/south,
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -59458,6 +58217,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
 /area/command/meeting_room/council)
 "jWm" = (
@@ -59585,9 +58345,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 26
+/obj/item/radio/intercom/directional/east{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
@@ -59680,10 +58441,6 @@
 /turf/open/floor/iron/dark,
 /area/commons/locker)
 "jZU" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59707,10 +58464,6 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "kaB" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -59734,10 +58487,7 @@
 	pixel_y = 3
 	},
 /obj/item/reagent_containers/syringe/multiver,
-/obj/machinery/vending/wallmed{
-	name = "Emergency NanoMed";
-	use_power = 0
-	},
+/obj/machinery/vending/wallmed/directional/west,
 /obj/machinery/camera{
 	c_tag = "Bridge - Gateway Atrium";
 	dir = 4;
@@ -59866,9 +58616,7 @@
 /turf/open/floor/iron,
 /area/security/office)
 "kcH" = (
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/structure/table/wood,
 /obj/item/storage/briefcase{
 	pixel_x = 3;
@@ -59885,9 +58633,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "kcZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -59905,7 +58651,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kdD" = (
-/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -60037,9 +58782,7 @@
 	},
 /area/commons/dorms)
 "ken" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Chapel Crematorium";
 	dir = 8;
@@ -60119,14 +58862,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/fore)
-"kfo" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/grimy,
-/area/command/heads_quarters/hos)
 "kfv" = (
 /obj/structure/table/wood,
 /obj/item/phone{
@@ -60255,24 +58990,18 @@
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/pen/blue,
-/obj/machinery/button/door{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
 	id = "Dorm6";
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 7;
 	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "khr" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32;
-	pixel_y = 32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -60340,10 +59069,7 @@
 "kip" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = 26
-	},
+/obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -60352,7 +59078,7 @@
 /area/commons/toilet/restrooms)
 "kiw" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32;
 	pixel_y = -32
@@ -60371,6 +59097,7 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "kiz" = (
@@ -60394,10 +59121,10 @@
 "kiB" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/south{
 	department = "Engineering";
-	name = "Engineering RC";
-	pixel_y = -32
+	departmentType = 3;
+	name = "Engineering Requests Console"
 	},
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_x = 32
@@ -60425,13 +59152,10 @@
 /area/command/corporate_showroom)
 "kjh" = (
 /obj/structure/closet/firecloset,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/bot,
-/obj/machinery/firealarm{
-	pixel_x = -32;
-	pixel_y = 24
+/obj/machinery/firealarm/directional/north{
+	pixel_x = -26
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
@@ -60440,23 +59164,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/abandoned_gambling_den)
-"kjo" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "kjp" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -60597,14 +59304,12 @@
 /turf/open/floor/wood,
 /area/service/electronic_marketing_den)
 "kms" = (
-/obj/machinery/button/door{
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/button/door/directional/south{
 	id = "idquarters";
 	name = "Privacy Control";
-	pixel_x = -26;
-	pixel_y = -26;
 	req_access_txt = "30"
 	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "kmR" = (
@@ -60664,9 +59369,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "knJ" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Locker Room - Fore";
 	name = "dormitories camera"
@@ -60677,6 +59380,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -60718,9 +59422,7 @@
 "koH" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -60771,31 +59473,9 @@
 "kpk" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Personnel's Desk";
-	departmentType = 5;
-	name = "Head of Personnel RC";
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/obj/machinery/light_switch{
+/obj/machinery/light_switch/directional/west{
 	pixel_x = -38;
-	pixel_y = 7
-	},
-/obj/machinery/button/door{
-	id = "hopline";
-	name = "Queue Shutters Control";
-	pixel_x = -26;
-	pixel_y = -7;
-	req_access_txt = "57"
-	},
-/obj/machinery/button/door{
-	id = "hopblast";
-	name = "Lockdown Blast doors";
-	pixel_x = -26;
-	pixel_y = 7;
-	req_access_txt = "57"
+	pixel_y = 8
 	},
 /obj/machinery/button/flasher{
 	id = "hopflash";
@@ -60804,7 +59484,7 @@
 	req_access_txt = "28"
 	},
 /obj/machinery/button/ticket_machine{
-	pixel_y = 40
+	pixel_y = 22
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -60816,7 +59496,21 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/item/radio/intercom/directional/north{
+	pixel_y = 30
+	},
+/obj/machinery/button/door/directional/west{
+	id = "hopblast";
+	name = "Lockdown Blast Doors";
+	pixel_y = 6;
+	req_access_txt = "57"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "hopline";
+	name = "Queue Shutters Control";
+	pixel_y = -6;
+	req_access_txt = "57"
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hop)
 "kpm" = (
@@ -60914,7 +59608,7 @@
 /area/maintenance/starboard/fore)
 "kqi" = (
 /obj/structure/table/wood,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/newscaster/directional/south,
@@ -61069,9 +59763,7 @@
 /area/command/heads_quarters/rd)
 "ksk" = (
 /obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/stack/rods{
 	amount = 23
 	},
@@ -61167,9 +59859,7 @@
 "ktw" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/carpet,
 /area/service/chapel/office)
 "ktN" = (
@@ -61196,12 +59886,11 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "ktT" = (
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
 	department = "Chief Engineer's Desk";
-	departmentType = 5;
-	name = "Chief Engineer's RC";
-	pixel_x = -32
+	departmentType = 3;
+	name = "Chief Engineer's Requests Console"
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Chief Engineer's Office";
@@ -61313,6 +60002,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/cargo/office)
 "kvn" = (
@@ -61359,12 +60049,8 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "kvK" = (
@@ -61458,9 +60144,7 @@
 "kxn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/light_switch{
-	pixel_x = 23
-	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/plating,
 /area/cargo/warehouse)
 "kxv" = (
@@ -61637,7 +60321,7 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "kAc" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -61670,16 +60354,11 @@
 	pixel_y = 3
 	},
 /obj/item/camera_film,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "kAl" = (
-/obj/machinery/button/door{
-	id = "construction";
-	name = "Auxiliary Construction Shutters";
-	pixel_x = -26;
-	req_access_txt = "72"
-	},
-/obj/machinery/light_switch{
+/obj/machinery/light_switch/directional/west{
 	pixel_x = -38
 	},
 /obj/machinery/camera{
@@ -61694,6 +60373,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/button/door/directional/west{
+	id = "construction";
+	name = "Auxiliary Construction Shutters";
+	req_access_txt = "72"
+	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "kAm" = (
@@ -61708,23 +60392,20 @@
 	pixel_x = 25;
 	pixel_y = 7
 	},
-/obj/machinery/button/door{
-	id = "permashut1";
-	name = "Cell Lockdown Button";
-	pixel_x = 25;
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/door/directional/east{
+	id = "permashut1";
+	name = "Cell Lockdown Button";
+	pixel_y = -6;
+	req_access_txt = "2"
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "kAu" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -61793,21 +60474,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
-"kBU" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
-	},
-/turf/open/floor/iron,
-/area/science/xenobiology)
 "kBX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -62078,19 +60744,13 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "kGC" = (
-/obj/machinery/light,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = -26
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/hos)
@@ -62180,9 +60840,7 @@
 	},
 /area/service/electronic_marketing_den)
 "kHw" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/table/wood,
 /obj/item/grown/log,
 /obj/item/grown/log,
@@ -62269,12 +60927,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "atmoslock";
-	name = "Atmospherics Lockdown Control";
-	pixel_x = -38;
-	req_access_txt = "24"
-	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the Engine.";
 	dir = 4;
@@ -62591,10 +61243,6 @@
 /turf/open/floor/iron,
 /area/tcommsat/server)
 "kMn" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -62713,7 +61361,7 @@
 	dir = 4;
 	name = "emergency shower"
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -62805,6 +61453,7 @@
 	network = list("rd","minisat");
 	pixel_y = 2
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "kQi" = (
@@ -62908,6 +61557,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"kRh" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "kRj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -62959,6 +61614,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/north{
+	id = "evashutters";
+	name = "E.V.A. Shutters";
+	req_access_txt = "19"
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
@@ -63046,19 +61706,8 @@
 /turf/open/floor/iron,
 /area/security/office)
 "kTm" = (
-/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/primary/central/aft)
-"kTo" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
 "kTp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/brown{
@@ -63110,15 +61759,7 @@
 /area/command/bridge)
 "kUs" = (
 /obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Bar Counter";
-	name = "Bar RC";
-	pixel_y = 32;
-	receive_ore_updates = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/reagent_containers/glass/rag,
@@ -63131,6 +61772,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/requests_console/directional/north{
+	department = "Bar";
+	name = "Bar Requests Console";
+	receive_ore_updates = 1
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
@@ -63152,9 +61798,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -63286,6 +61930,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
 "kWr" = (
@@ -63359,9 +62004,7 @@
 /area/command/teleporter)
 "kWS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/mirror{
-	pixel_x = -26
-	},
+/obj/structure/mirror/directional/west,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12
@@ -63396,9 +62039,7 @@
 /area/science/research)
 "kWY" = (
 /obj/structure/bed/dogbed/runtime,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -63559,9 +62200,7 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/landmark/start/captain,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 6
@@ -63664,7 +62303,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "laF" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -63732,14 +62371,9 @@
 "lbJ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/machinery/button/door{
-	id = "gatewayshutters";
-	name = "Gateway Shutters";
-	pixel_x = -26;
-	pixel_y = -26
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/command/gateway)
 "lbK" = (
@@ -63812,26 +62446,23 @@
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "lcu" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "kitchencounter";
-	name = "Kitchen Counter Shutters";
-	pixel_x = 26;
-	pixel_y = 8;
-	req_access_txt = "28"
-	},
-/obj/machinery/button/door{
-	id = "kitchenside";
-	name = "Kitchen Side Shutters";
-	pixel_x = 26;
-	pixel_y = -8;
-	req_access_txt = "28"
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/button/door/directional/east{
+	id = "kitchencounter";
+	name = "Kitchen Counter Shutters";
+	pixel_y = 6;
+	req_access_txt = "28"
+	},
+/obj/machinery/button/door/directional/east{
+	id = "kitchenside";
+	name = "Kitchen Side Shutters";
+	pixel_y = -6;
+	req_access_txt = "28"
+	},
 /turf/open/floor/iron,
 /area/service/kitchen)
 "lcv" = (
@@ -63880,9 +62511,7 @@
 	},
 /area/maintenance/department/electrical)
 "lcG" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
+/obj/structure/urinal/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -64195,10 +62824,7 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/lootdrop/prison_contraband,
 /obj/item/toy/figure/syndie,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating,
 /area/security/prison)
 "lgA" = (
@@ -64215,6 +62841,7 @@
 /area/maintenance/starboard/fore)
 "lgC" = (
 /obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "lgR" = (
@@ -64426,10 +63053,7 @@
 /area/security/prison)
 "lkw" = (
 /obj/structure/table/glass,
-/obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = -24
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -64480,9 +63104,7 @@
 	},
 /area/maintenance/port/aft)
 "lkV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -64600,28 +63222,6 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "lmb" = (
-/obj/machinery/button/door{
-	id = "bridgedoors";
-	name = "Bridge Access Blast doors";
-	pixel_x = 7;
-	pixel_y = -26;
-	req_access_txt = "19"
-	},
-/obj/machinery/button/door{
-	id = "bridgewindows";
-	name = "Bridge View Blast doors";
-	pixel_x = -7;
-	pixel_y = -26;
-	req_access_txt = "19"
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Bridge";
-	departmentType = 5;
-	name = "Bridge RC";
-	pixel_x = -32;
-	pixel_y = -32
-	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Command Chair";
 	dir = 1;
@@ -64630,12 +63230,25 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/button/door/directional/south{
+	id = "bridgewindows";
+	name = "Bridge View Blast Doors";
+	pixel_x = -6;
+	req_access_txt = "19"
+	},
+/obj/machinery/button/door/directional/south{
+	id = "bridgedoors";
+	name = "Bridge Access Blast Doors";
+	pixel_x = 6;
+	req_access_txt = "19"
+	},
 /turf/open/floor/carpet,
 /area/command/bridge)
 "lmi" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/remains/human,
+/obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -64690,6 +63303,14 @@
 "lmL" = (
 /turf/closed/wall,
 /area/engineering/supermatter/room)
+"lmO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/central/aft)
 "lmX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -64815,9 +63436,7 @@
 /area/medical/surgery/room_b)
 "lom" = (
 /obj/item/kirbyplants/random,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/south,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -64825,11 +63444,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24;
-	pixel_y = -26
-	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "loE" = (
@@ -64945,7 +63560,7 @@
 /obj/item/instrument/harmonica,
 /obj/item/storage/pill_bottle/dice,
 /obj/item/toy/cards/deck/tarot,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "lqq" = (
@@ -65014,9 +63629,7 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "lrk" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/machinery/camera{
 	c_tag = "Recreation - Center";
 	dir = 4;
@@ -65036,10 +63649,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"lrr" = (
-/obj/machinery/computer/security/telescreen/entertainment,
-/turf/closed/wall/r_wall,
-/area/command/heads_quarters/captain)
 "lrw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/virology{
@@ -65080,9 +63689,7 @@
 "lsd" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/lights/mixed,
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
+/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -65100,7 +63707,7 @@
 	dir = 1;
 	name = "service camera"
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -65170,17 +63777,13 @@
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
 "ltx" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/grimy,
 /area/service/abandoned_gambling_den/secondary)
 "ltH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -65220,9 +63823,7 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "luH" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/machinery/camera{
 	c_tag = "Security - Head of Security's Office"
 	},
@@ -65237,6 +63838,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "lvk" = (
@@ -65374,6 +63976,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/button/door/directional/north{
+	id = "brigprison";
+	name = "Prison Lockdown";
+	req_access_txt = "63"
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "lwN" = (
@@ -65508,6 +64115,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/checker,
 /area/engineering/atmos)
 "lyE" = (
@@ -65522,9 +64130,7 @@
 "lyK" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole,
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "lyN" = (
@@ -65729,9 +64335,7 @@
 /turf/open/floor/iron/grimy,
 /area/command/corporate_showroom)
 "lBd" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "lBf" = (
@@ -65794,6 +64398,12 @@
 	dir = 8
 	},
 /obj/item/storage/fancy/donut_box,
+/obj/machinery/requests_console/directional/south{
+	announcementConsole = 1;
+	department = "Bridge";
+	departmentType = 5;
+	name = "Bridge Requests Console"
+	},
 /turf/open/floor/iron/grimy,
 /area/command/bridge)
 "lBN" = (
@@ -65833,9 +64443,7 @@
 /area/maintenance/port/fore)
 "lCm" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/microwave{
 	desc = "Cooks and boils stuff, somehow.";
 	pixel_x = -3;
@@ -65917,14 +64525,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/storage)
-"lEA" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
-/area/command/bridge)
-"lEF" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/cargo/office)
 "lEK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/station_engineer,
@@ -65942,9 +64542,7 @@
 /area/engineering/main)
 "lEN" = (
 /obj/machinery/photocopier,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "lEQ" = (
@@ -65958,9 +64556,7 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "lET" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -66051,24 +64647,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"lGZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/xenobiology)
 "lHa" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/soda_cans/cola,
@@ -66119,9 +64697,7 @@
 /area/hallway/primary/fore)
 "lHU" = (
 /obj/machinery/seed_extractor,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -66141,9 +64717,7 @@
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/pen/fourcolor,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
 "lIF" = (
@@ -66185,6 +64759,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -66200,10 +64775,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = -26
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "lJj" = (
@@ -66216,9 +64787,7 @@
 "lJt" = (
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 32
-	},
+/obj/structure/reagent_dispensers/peppertank/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -66235,12 +64804,6 @@
 	},
 /area/service/chapel/main)
 "lJZ" = (
-/obj/machinery/button/door{
-	id = "evashutters";
-	name = "E.V.A. Shutters";
-	pixel_x = 26;
-	req_access_txt = "19"
-	},
 /obj/machinery/door/poddoor/shutters{
 	id = "evashutters";
 	name = "E.V.A. Storage Shutters"
@@ -66431,10 +64994,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "lMJ" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -66469,9 +65028,7 @@
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den/secondary)
 "lNK" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -66590,9 +65147,7 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den/secondary)
 "lOE" = (
-/obj/structure/mirror{
-	pixel_x = 28
-	},
+/obj/structure/mirror/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/service/theater/abandoned)
@@ -66684,7 +65239,7 @@
 	},
 /area/maintenance/port/aft)
 "lQc" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -66748,6 +65303,11 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/requests_console/directional/east{
+	department = "Hydroponics";
+	departmentType = 2;
+	name = "Hydroponics Requests Console"
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "lQQ" = (
@@ -66864,9 +65424,7 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "lSL" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/oil,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -66948,10 +65506,7 @@
 /area/cargo/miningoffice)
 "lTK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/iron,
@@ -66973,9 +65528,7 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "lUe" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
 	},
@@ -67022,9 +65575,7 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/structure/mirror{
-	pixel_x = 26
-	},
+/obj/structure/mirror/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -67055,7 +65606,7 @@
 /area/service/library/abandoned)
 "lVl" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
@@ -67174,14 +65725,6 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "lXe" = (
-/obj/machinery/button/door{
-	desc = "A remote control switch.";
-	id = "engdoor";
-	name = "Engineering Cell Control";
-	normaldoorcontrol = 1;
-	pixel_x = 7;
-	pixel_y = 36
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -67194,6 +65737,12 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/effect/landmark/start/depsec/engineering,
+/obj/machinery/button/door/directional/north{
+	id = "engdoor";
+	name = "Engineering Cell Control";
+	normaldoorcontrol = 1;
+	pixel_y = 36
+	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "lXf" = (
@@ -67214,9 +65763,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "lXF" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/computer/atmos_control/toxinsmix{
 	dir = 8
 	},
@@ -67295,9 +65842,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "lYg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
@@ -67396,14 +65941,12 @@
 /obj/structure/table/wood,
 /obj/item/storage/crayons,
 /obj/item/storage/crayons,
-/obj/machinery/requests_console{
-	department = "Chapel Office";
-	name = "Chapel RC";
-	pixel_y = -32
+/obj/machinery/requests_console/directional/south{
+	department = "Chapel";
+	departmentType = 2;
+	name = "Chapel Requests Console"
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
 	dir = 1;
@@ -67426,9 +65969,7 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "lZk" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/machinery/camera{
 	c_tag = "Engineering - Power Monitoring";
 	dir = 1;
@@ -67447,11 +65988,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
-	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "lZn" = (
@@ -67468,12 +66004,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "lZo" = (
-/obj/machinery/button/door{
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_y = -24;
-	req_access_txt = "10"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -67487,12 +66017,8 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "lZt" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
 /area/service/electronic_marketing_den)
 "lZv" = (
@@ -67514,9 +66040,7 @@
 /area/hallway/primary/central/aft)
 "lZN" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron/dark,
@@ -67578,10 +66102,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"maT" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/engineering/break_room)
 "maY" = (
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
@@ -67657,9 +66177,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mbW" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Security Hallway";
 	dir = 4;
@@ -67722,9 +66240,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "mcF" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "mcZ" = (
@@ -67749,6 +66266,7 @@
 /obj/item/chisel{
 	pixel_y = 7
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "mda" = (
@@ -67804,9 +66322,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "mdG" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -67857,10 +66373,8 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "mfb" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/obj/machinery/light,
+/obj/machinery/status_display/evac/directional/south,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -67880,9 +66394,7 @@
 /area/science/xenobiology)
 "mfP" = (
 /obj/machinery/vending/autodrobe,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/service/theater/abandoned)
 "mfQ" = (
@@ -67967,10 +66479,7 @@
 /area/commons/toilet/restrooms)
 "mgU" = (
 /obj/structure/closet/secure_closet/security,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -68073,10 +66582,8 @@
 /obj/item/clothing/head/welding,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
+/obj/machinery/firealarm/directional/west{
+	pixel_y = -26
 	},
 /turf/open/floor/iron,
 /area/engineering/storage)
@@ -68154,9 +66661,7 @@
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "mjA" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
+/obj/structure/urinal/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
@@ -68178,10 +66683,9 @@
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "mkl" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/layer_manifold/green/visible,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "mkm" = (
@@ -68239,9 +66743,7 @@
 	},
 /area/commons/fitness/recreation)
 "mkY" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -68323,11 +66825,6 @@
 	},
 /area/maintenance/port/fore)
 "mlw" = (
-/obj/machinery/flasher{
-	id = "brigflashdoor";
-	pixel_x = 26;
-	pixel_y = -26
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -68338,10 +66835,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/flasher/directional/south{
+	id = "brigflashdoor";
+	pixel_x = 26
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "mlx" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -68445,12 +66946,8 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
 "mmR" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -68538,9 +67035,7 @@
 	pixel_y = 3
 	},
 /obj/item/food/grown/poppy,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "mnS" = (
@@ -68645,9 +67140,8 @@
 	id = "aicoredoor";
 	name = "AI Core Access"
 	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = -26
+/obj/machinery/flasher/directional/west{
+	id = "AI"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -68661,13 +67155,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "AI Intercom";
-	pixel_x = 28
-	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mpy" = (
@@ -68740,9 +67227,7 @@
 /area/engineering/atmos)
 "mqj" = (
 /obj/structure/chair/wood,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron{
 	icon_state = "chapel"
@@ -68782,26 +67267,11 @@
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/pen,
-/obj/machinery/button/door{
-	id = "hosprivacy";
-	name = "Privacy Control";
-	pixel_x = 26;
-	pixel_y = 7;
-	req_access_txt = "58"
-	},
-/obj/machinery/button/door{
-	id = "hosspace";
-	name = "Space Shutters Control";
-	pixel_x = 26;
-	pixel_y = -7;
-	req_access_txt = "58"
-	},
-/obj/machinery/light_switch{
+/obj/machinery/light_switch/directional/east{
 	pixel_x = 38
 	},
-/obj/machinery/keycard_auth{
-	pixel_x = 26;
-	pixel_y = 26
+/obj/machinery/keycard_auth/directional/north{
+	pixel_x = 26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -68813,12 +67283,23 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/ai/directional/north,
+/obj/machinery/button/door/directional/east{
+	id = "hosprivacy";
+	name = "Privacy Control";
+	pixel_y = 6;
+	req_access_txt = "58"
+	},
+/obj/machinery/button/door/directional/east{
+	id = "hosspace";
+	name = "Space Shutters Control";
+	pixel_y = -6;
+	req_access_txt = "58"
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "mqA" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -68838,7 +67319,7 @@
 /area/service/electronic_marketing_den)
 "mqR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -69125,10 +67606,6 @@
 /turf/open/floor/iron/grimy,
 /area/command/corporate_showroom)
 "mui" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -69323,9 +67800,7 @@
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = -32
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -69432,9 +67907,7 @@
 	},
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
@@ -69544,9 +68017,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "mzQ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -69885,7 +68356,7 @@
 /area/medical/virology)
 "mFe" = (
 /obj/structure/closet/radiation,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -70033,9 +68504,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "mHY" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -70237,9 +68706,7 @@
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "mKA" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron,
@@ -70270,9 +68737,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "mLh" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -70341,18 +68806,9 @@
 /area/security/brig)
 "mLS" = (
 /obj/structure/table,
-/obj/item/storage/secure/safe{
-	pixel_y = 32
-	},
+/obj/item/storage/secure/safe/directional/north,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/button/door{
-	id = "commissaryshutters";
-	name = "Commissary Shutters Control";
-	pixel_x = 26;
-	pixel_y = -5;
-	req_access_txt = null
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -70360,6 +68816,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/button/door/directional/east{
+	id = "commissaryshutters";
+	name = "Commissary Shutters Control"
+	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "mMg" = (
@@ -70410,9 +68870,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "mMT" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -70436,10 +68894,11 @@
 	dir = 1;
 	name = "engineering camera"
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/storage_shared)
 "mNo" = (
@@ -70448,9 +68907,7 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "mNs" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -70603,7 +69060,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "mPM" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -70643,9 +69100,7 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -70656,6 +69111,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "mQK" = (
@@ -70716,10 +69172,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/space_hut/observatory)
-"mRe" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/service/bar)
 "mRh" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
@@ -70829,9 +69281,7 @@
 /area/ai_monitored/aisat/exterior)
 "mSD" = (
 /obj/machinery/pdapainter,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "mST" = (
@@ -70965,9 +69415,7 @@
 "mVf" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/machinery/camera{
 	c_tag = "Security - Head of Security's Quarters"
 	},
@@ -71069,9 +69517,7 @@
 	name = "Containment Control";
 	req_access_txt = "55"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/xenobiology)
@@ -71102,15 +69548,18 @@
 /area/medical/medbay/central)
 "mWO" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/requests_console/directional/east{
+	department = "Cargo Bay";
+	departmentType = 2;
+	name = "Cargo Bay Requests Console"
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
@@ -71129,9 +69578,7 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/multitool,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -71320,7 +69767,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "naF" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -71541,10 +69988,9 @@
 /area/commons/dorms)
 "nca" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/requests_console{
-	department = "Primary Tool Storage";
-	name = "Primary Tool Storage RC";
-	pixel_y = 32
+/obj/machinery/requests_console/directional/north{
+	department = "Tool Storage";
+	name = "Tool Storage Requests Console"
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/bot,
@@ -71590,9 +70036,7 @@
 /turf/open/floor/glass,
 /area/maintenance/space_hut/observatory)
 "ncE" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -71679,9 +70123,7 @@
 /area/commons/fitness/recreation)
 "ndz" = (
 /obj/structure/closet/secure_closet/research_director,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -71730,9 +70172,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ndT" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -71860,9 +70300,7 @@
 /area/engineering/atmos)
 "nfs" = (
 /obj/machinery/computer/slot_machine,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
 	},
@@ -71970,9 +70408,7 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "ngz" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
@@ -72036,9 +70472,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -72059,6 +70493,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"nhp" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai)
 "nhx" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 1
@@ -72263,15 +70714,12 @@
 /area/hallway/secondary/entry)
 "nkf" = (
 /obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/requests_console{
+/obj/machinery/light/directional/north,
+/obj/machinery/requests_console/directional/north{
 	announcementConsole = 1;
 	department = "Head of Security's Desk";
 	departmentType = 5;
-	name = "Head of Security RC";
-	pixel_y = 32
+	name = "Head of Security's Requests Console"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -72282,6 +70730,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/item/radio/intercom/directional/north{
+	pixel_x = 32
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
@@ -72294,7 +70745,7 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "nkB" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -72350,10 +70801,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"nll" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/command/bridge)
 "nlw" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -72440,9 +70887,7 @@
 /area/engineering/atmos)
 "nmR" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -72472,9 +70917,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/fireaxecabinet{
-	pixel_x = -32
-	},
+/obj/structure/fireaxecabinet/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -72511,9 +70954,7 @@
 /area/hallway/primary/aft)
 "noK" = (
 /obj/structure/bookcase,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -72568,10 +71009,9 @@
 	dir = 8;
 	name = "motion-sensitive command camera"
 	},
-/obj/machinery/requests_console{
-	department = "E.V.A. Storage";
-	name = "E.V.A. RC";
-	pixel_x = 32
+/obj/machinery/requests_console/directional/east{
+	department = "EVA";
+	name = "EVA Requests Console"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -72587,11 +71027,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = 25;
-	pixel_y = -2;
+/obj/item/radio/intercom/directional/east{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
 	prison_radio = 1
 	},
 /turf/open/floor/iron,
@@ -72601,6 +71039,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "nqe" = (
@@ -72707,7 +71146,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Science - Waiting Room";
 	dir = 1;
@@ -72938,9 +71377,7 @@
 /turf/open/floor/iron/dark,
 /area/service/electronic_marketing_den)
 "nuU" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -73360,9 +71797,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "nzn" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
 /area/service/library)
@@ -73410,30 +71845,8 @@
 /obj/structure/chair/office,
 /turf/open/floor/wood,
 /area/service/library)
-"nAh" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
 "nAl" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -73634,19 +72047,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/theater)
-"nDd" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
 "nDe" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -73938,18 +72338,14 @@
 /obj/structure/sign/poster/contraband/ambrosia_vulgaris{
 	pixel_x = -30
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/security/prison)
 "nFS" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Kitchen";
 	dir = 4;
@@ -74180,9 +72576,7 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "nIF" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/folder/white,
@@ -74356,9 +72750,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
 "nKF" = (
@@ -74479,9 +72871,7 @@
 /area/hallway/primary/central/fore)
 "nMv" = (
 /obj/structure/frame/computer,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/wood,
 /area/service/electronic_marketing_den)
 "nMS" = (
@@ -74536,6 +72926,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "nNO" = (
@@ -74686,10 +73077,7 @@
 /turf/closed/wall,
 /area/service/chapel/office)
 "nPC" = (
-/obj/machinery/light_switch{
-	pixel_x = -7;
-	pixel_y = -26
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/machinery/camera{
 	c_tag = "Bridge - Teleporter";
 	dir = 1;
@@ -74705,11 +73093,6 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = -26;
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -74719,6 +73102,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/flasher/directional/north{
+	id = "AI";
+	pixel_x = -26
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
@@ -74844,15 +73231,13 @@
 /turf/open/floor/plating,
 /area/commons/fitness/recreation)
 "nSi" = (
-/obj/machinery/button/door{
+/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/obj/machinery/button/door/directional/west{
 	id = "Dorm1";
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 7;
 	specialfunctions = 4
 	},
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "nSn" = (
@@ -74881,14 +73266,6 @@
 /obj/item/stack/cable_coil/five,
 /obj/item/wrench,
 /obj/item/screwdriver,
-/obj/machinery/button/door{
-	id = "commissarydoor";
-	name = "Commissary Door Lock";
-	normaldoorcontrol = 1;
-	pixel_x = -5;
-	pixel_y = -26;
-	specialfunctions = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -74898,12 +73275,16 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/newscaster/directional/east,
+/obj/machinery/button/door/directional/south{
+	id = "commissarydoor";
+	name = "Commissary Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "nSt" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -75079,9 +73460,7 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "nUd" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/reflector/single,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
@@ -75293,9 +73672,7 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "nWl" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral{
@@ -75311,9 +73688,7 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "nWu" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -75334,9 +73709,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "nXv" = (
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/portable_atmospherics/canister/water_vapor,
@@ -75360,9 +73733,7 @@
 /area/ai_monitored/command/storage/eva)
 "nXD" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
+/obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -75370,12 +73741,10 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
-	},
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -26
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "nXJ" = (
@@ -75431,10 +73800,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = -32
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -26
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
@@ -75527,7 +73894,7 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -75592,9 +73959,7 @@
 /turf/open/floor/plating,
 /area/cargo/warehouse)
 "oay" = (
-/obj/machinery/bounty_board{
-	pixel_y = 32
-	},
+/obj/machinery/bounty_board/directional/north,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -75928,15 +74293,7 @@
 /area/engineering/atmos)
 "odR" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	id = "atmoslock";
-	name = "Atmospherics Lockdown Control";
-	pixel_x = -26;
-	req_access_txt = "24"
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -75947,16 +74304,15 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/button/door/directional/west{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Control";
+	req_access_txt = "24"
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "odU" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/button/door{
-	id = "transitlock";
-	name = "Transit Tube Lockdown Control";
-	pixel_y = 26;
-	req_access_txt = "19"
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -75968,6 +74324,11 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/button/door/directional/north{
+	id = "transitlock";
+	name = "Transit Tube Lockdown Control";
+	req_access_txt = "19"
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "oej" = (
@@ -76099,9 +74460,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ogz" = (
@@ -76180,6 +74539,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "oha" = (
@@ -76346,9 +74706,7 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "ojz" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron{
 	dir = 8;
@@ -76366,16 +74724,14 @@
 /turf/open/floor/plating,
 /area/cargo/qm)
 "ojK" = (
-/obj/machinery/button/door{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
 	id = "Dorm5";
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
-	pixel_x = -26;
-	pixel_y = 7;
 	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -76421,10 +74777,6 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "okc" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -76435,10 +74787,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -38;
-	pixel_y = -24
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -32
+	},
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -20
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
@@ -76567,9 +74920,7 @@
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "ole" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -76649,7 +75000,7 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "olH" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/processor,
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -76665,16 +75016,14 @@
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = 32
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/security/prison/safe)
 "olS" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/storage)
@@ -76753,9 +75102,7 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "omM" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -76827,9 +75174,7 @@
 	name = "Cell 1";
 	pixel_x = -32
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Security - Brig Center";
 	dir = 4
@@ -77028,7 +75373,7 @@
 /turf/open/floor/wood,
 /area/service/library/abandoned)
 "oqq" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -77037,9 +75382,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "oqI" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -77139,29 +75482,23 @@
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "osF" = (
-/obj/machinery/button/door{
-	id = "evastorage";
-	name = "E.V.A. Shutters";
-	pixel_x = 7;
-	pixel_y = -26;
-	req_access_txt = "19"
-	},
-/obj/machinery/button/door{
-	id = "teleportershutters";
-	name = "Teleporter Shutters";
-	pixel_x = -7;
-	pixel_y = -26
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = -7;
+/obj/machinery/keycard_auth/directional/south{
 	pixel_y = -38
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = -26
+/obj/machinery/button/door/directional/south{
+	id = "teleportershutters";
+	name = "Teleporter Shutters";
+	pixel_x = -6;
+	req_access_txt = "19"
+	},
+/obj/machinery/button/door/directional/south{
+	id = "evastorage";
+	name = "E.V.A. Shutters";
+	pixel_x = 6;
+	req_access_txt = "19"
 	},
 /turf/open/floor/carpet,
 /area/command/bridge)
@@ -77213,6 +75550,7 @@
 "otq" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "otC" = (
@@ -77241,9 +75579,7 @@
 /area/maintenance/port)
 "otK" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_x = 22
-	},
+/obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/storage_shared)
@@ -77310,7 +75646,7 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "ovo" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -77338,9 +75674,7 @@
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
 "ovG" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/structure/transit_tube/station/reverse/flipped,
 /obj/structure/transit_tube_pod{
 	dir = 8
@@ -77439,7 +75773,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "owE" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -77490,15 +75824,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24;
-	pixel_y = 32
-	},
 /turf/open/floor/iron,
 /area/service/bar)
 "oxk" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -77888,10 +76217,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "oCe" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -78078,6 +76403,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"oEL" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/engineering/break_room)
 "oEW" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -78180,9 +76510,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
 "oGa" = (
@@ -78194,9 +76522,7 @@
 /turf/open/floor/carpet,
 /area/command/meeting_room/council)
 "oGt" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -78220,13 +76546,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "oGA" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
+/obj/structure/urinal/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
 /area/commons/toilet/auxiliary)
@@ -78248,7 +76570,7 @@
 /turf/open/floor/iron,
 /area/science/research)
 "oGK" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -78262,6 +76584,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "oGL" = (
@@ -78351,12 +76674,11 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/engineering/storage)
 "oHx" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -78376,9 +76698,7 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "oHB" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -78562,9 +76882,7 @@
 /area/commons/storage/primary)
 "oJi" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -78659,10 +76977,8 @@
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
-/obj/machinery/light,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /obj/item/paicard,
 /turf/open/floor/wood,
 /area/commons/dorms)
@@ -78691,18 +77007,11 @@
 /area/engineering/main)
 "oLa" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "oLd" = (
-/obj/machinery/button/door{
-	id = "brigprison";
-	name = "Prison Lockdown";
-	pixel_x = 26;
-	pixel_y = 26;
-	req_access_txt = "63"
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -78817,9 +77126,7 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "oMA" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -78911,9 +77218,7 @@
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
 "oNS" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -78977,13 +77282,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/obj/machinery/requests_console{
-	department = "Atmospherics Office";
-	name = "Atmospherics RC";
-	pixel_x = 30
+/obj/machinery/status_display/evac/directional/south,
+/obj/machinery/requests_console/directional/east{
+	department = "Atmospherics";
+	departmentType = 3;
+	name = "Atmospherics Requests Console"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -78991,9 +77294,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = -32
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 26
 	},
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
@@ -79270,10 +77572,9 @@
 /obj/item/assembly/igniter,
 /obj/item/assembly/igniter,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "oSd" = (
@@ -79479,6 +77780,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "oVm" = (
@@ -79622,9 +77924,7 @@
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
 "oWZ" = (
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/plasteel/twenty,
 /obj/item/wrench,
@@ -79674,13 +77974,14 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "oXH" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Library - Aft";
 	dir = 1;
 	name = "library camera"
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/wood,
 /area/service/library)
 "oXW" = (
@@ -79742,11 +78043,28 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/engineering/storage)
-"oYy" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
+"oYv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai)
+"oYy" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -79761,10 +78079,7 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "oYB" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/food/chococoin,
@@ -79958,10 +78273,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26;
-	pixel_y = -32
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = -26
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "pbl" = (
@@ -80110,22 +78425,10 @@
 "pdv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/ce,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/ce)
-"pdJ" = (
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/command/bridge)
 "pdK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80139,10 +78442,10 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/structure/table/reinforced,
-/obj/machinery/requests_console{
-	department = "Robotics Lab";
-	name = "Robotics RC";
-	pixel_y = 32;
+/obj/machinery/requests_console/directional/north{
+	department = "Robotics";
+	departmentType = 2;
+	name = "Robotics Requests Console";
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -80238,15 +78541,28 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"pft" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/peppertank/directional/east,
+/turf/open/floor/iron,
+/area/security/brig)
 "pfD" = (
-/obj/structure/noticeboard{
-	desc = "A board for remembering the fallen of the station.";
-	dir = 1;
-	name = "memorial board";
-	pixel_y = -32
+/obj/structure/noticeboard/directional/south{
+	name = "memorial board"
 	},
 /obj/machinery/holopad,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Chapel - Aft";
 	dir = 1;
@@ -80310,6 +78626,20 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"pgz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "pgZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -80339,21 +78669,10 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "phx" = (
-/obj/machinery/button/door{
-	id = "hosroom";
-	name = "Privacy Control";
-	pixel_x = 64;
-	pixel_y = -26;
-	req_access_txt = "58"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hos)
 "phH" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -80489,12 +78808,8 @@
 /area/engineering/atmos)
 "pkT" = (
 /obj/structure/closet/secure_closet/bar,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -80629,9 +78944,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "plV" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -80695,13 +79008,6 @@
 /turf/open/floor/iron/dark,
 /area/science/server)
 "pms" = (
-/obj/machinery/button/door{
-	id = "brigprison";
-	name = "Prison Lockdown";
-	pixel_x = 26;
-	pixel_y = 26;
-	req_access_txt = "63"
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -80719,9 +79025,7 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -80737,9 +79041,7 @@
 /area/ai_monitored/aisat/exterior)
 "pmL" = (
 /obj/effect/landmark/start/hangover,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
 "pmQ" = (
@@ -80801,7 +79103,7 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/construction/plumbing,
 /obj/item/construction/plumbing,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
@@ -80926,9 +79228,7 @@
 	pixel_x = -3
 	},
 /obj/item/wrench,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -80983,9 +79283,7 @@
 /turf/closed/wall/r_wall,
 /area/engineering/storage_shared)
 "pqs" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -80993,9 +79291,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "pqt" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -81274,9 +79570,7 @@
 	dir = 1;
 	name = "Jury"
 	},
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -81649,9 +79943,8 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "pBK" = (
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_y = 26
+/obj/machinery/flasher/directional/north{
+	id = "AI"
 	},
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral{
@@ -81730,17 +80023,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
-"pCo" = (
-/obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "pCr" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -81882,9 +80164,7 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "pDW" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -81912,7 +80192,7 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "pES" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -81928,12 +80208,8 @@
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
 "pFe" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -81970,24 +80246,21 @@
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/toy/figure/rd,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Research Director's Desk";
-	departmentType = 5;
-	name = "Research Director's RC";
-	pixel_x = -32;
-	receive_ore_updates = 1
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/requests_console/directional/west{
+	announcementConsole = 1;
+	department = "Research Director's Desk";
+	departmentType = 5;
+	name = "Research Director's Requests Console";
+	receive_ore_updates = 1
+	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "pGi" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/sign/warning/radiation{
 	pixel_x = -32
 	},
@@ -82016,6 +80289,7 @@
 	dir = 8
 	},
 /mob/living/simple_animal/pet/fox/renault,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "pGD" = (
@@ -82074,9 +80348,7 @@
 	pixel_y = 3
 	},
 /obj/item/storage/fancy/candle_box,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet,
 /area/service/chapel/office)
@@ -82507,18 +80779,14 @@
 /area/commons/fitness/recreation)
 "pNB" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/delivery,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "pND" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -82533,9 +80801,7 @@
 /turf/open/space,
 /area/engineering/atmos)
 "pNL" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82550,9 +80816,7 @@
 /area/command/heads_quarters/captain)
 "pOb" = (
 /obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/stack/package_wrap,
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/hand_labeler,
@@ -82562,7 +80826,7 @@
 "pOd" = (
 /obj/machinery/disposal/bin,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -82578,6 +80842,11 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/button/door/directional/south{
+	id = "custodialshutters";
+	name = "Custodial Shutters";
+	req_access_txt = "26"
+	},
 /turf/open/floor/iron,
 /area/service/janitor)
 "pOh" = (
@@ -82609,7 +80878,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "pOm" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -82645,7 +80914,7 @@
 "pOJ" = (
 /obj/structure/closet/wardrobe/miner,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/storage/backpack/satchel/explorer,
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/south,
@@ -82741,9 +81010,7 @@
 /turf/open/floor/iron,
 /area/engineering/storage)
 "pQQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -82815,9 +81082,7 @@
 	dir = 4;
 	pixel_x = -11
 	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
+/obj/structure/mirror/directional/west,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/medical/morgue)
@@ -82869,10 +81134,6 @@
 	},
 /area/hallway/secondary/entry)
 "pSs" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -83078,6 +81339,8 @@
 "pUY" = (
 /obj/structure/kitchenspike,
 /obj/effect/turf_decal/bot,
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "pVf" = (
@@ -83107,14 +81370,12 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "pVq" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/photocopier,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "pVu" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -83239,9 +81500,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pWT" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -83277,9 +81536,7 @@
 /area/security/prison)
 "pXd" = (
 /obj/structure/filingcabinet/security,
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
+/obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -83289,6 +81546,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "pXj" = (
@@ -83300,16 +81558,6 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"pXt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "pXL" = (
 /turf/open/floor/iron/grimy,
 /area/command/corporate_showroom)
@@ -83430,10 +81678,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
+/obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -83551,9 +81796,7 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "qak" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Bridge Port";
@@ -83614,9 +81857,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "qaJ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/machinery/camera{
 	c_tag = "Technology Storage - Secure";
 	dir = 8;
@@ -83627,9 +81868,6 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "qaK" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/conveyor{
 	dir = 5;
 	id = "garbage"
@@ -83695,16 +81933,15 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/light/small,
-/obj/machinery/button/door{
+/obj/machinery/light/small/directional/south,
+/obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/button/door/directional/south{
 	id = "Toilet1";
 	name = "Lock Control";
 	normaldoorcontrol = 1;
-	pixel_y = -25;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
 /area/commons/toilet/restrooms)
 "qbV" = (
@@ -83715,10 +81952,6 @@
 	},
 /area/service/theater/abandoned)
 "qbZ" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -83733,9 +81966,7 @@
 /area/command/heads_quarters/rd)
 "qcr" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/item/clipboard,
 /obj/item/toy/figure/janitor,
 /obj/effect/turf_decal/tile/neutral{
@@ -83836,7 +82067,7 @@
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "qdO" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/table/reinforced,
 /obj/item/hfr_box/core,
 /obj/item/hfr_box/corner,
@@ -83921,7 +82152,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "qfq" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -83948,6 +82179,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/vending/wallmed/directional/south,
 /turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
 "qfw" = (
@@ -84436,23 +82668,19 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/prisoner,
 /obj/structure/cable,
-/obj/machinery/flasher{
-	id = "Cell 5";
-	pixel_y = -25
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 5"
+	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "qlz" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
+/obj/machinery/light/directional/east,
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -84641,9 +82869,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "qoK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -84757,13 +82983,23 @@
 /turf/open/floor/plating,
 /area/service/chapel/main)
 "qrd" = (
-/obj/machinery/airalarm{
-	pixel_y = 22
-	},
+/obj/machinery/airalarm/directional/north,
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"qrf" = (
+/obj/structure/table/optable,
+/obj/machinery/button/door/directional/east{
+	id = "surgeryb";
+	name = "Privacy Shutters Control"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/medical/surgery/room_b)
 "qrg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84821,6 +83057,10 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
+"qrD" = (
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/wood,
+/area/command/meeting_room/council)
 "qrM" = (
 /turf/closed/wall,
 /area/command/teleporter)
@@ -84908,9 +83148,7 @@
 /area/engineering/break_room)
 "qst" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -84925,10 +83163,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"qsK" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "qsP" = (
 /turf/open/floor/iron,
 /area/service/hydroponics/garden/abandoned)
@@ -85093,6 +83327,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "qvC" = (
@@ -85131,9 +83366,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -85280,6 +83513,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "qyh" = (
@@ -85303,6 +83537,14 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"qyj" = (
+/obj/machinery/power/smes/engineering{
+	charge = 2e+006
+	},
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/circuit/green,
+/area/engineering/main)
 "qyu" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -85371,10 +83613,6 @@
 /area/commons/fitness/recreation)
 "qzb" = (
 /obj/structure/table/wood,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/item/storage/box/beanbag,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -85394,9 +83632,7 @@
 	pixel_y = 3
 	},
 /obj/item/food/grown/harebell,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "qzr" = (
@@ -85619,15 +83855,14 @@
 /area/science/storage)
 "qBp" = (
 /obj/effect/landmark/start/prisoner,
-/obj/machinery/flasher{
-	id = "Cell 3";
-	pixel_y = -25
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 3"
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -85780,16 +84015,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "qDD" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/machinery/button/door{
-	id = "lawyerprivacy";
-	name = "Lawyer's Privacy Control";
-	pixel_x = 38;
-	pixel_y = 25
-	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "qDK" = (
@@ -85802,9 +84027,7 @@
 /area/medical/treatment_center)
 "qDN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/mirror{
-	pixel_x = -26
-	},
+/obj/structure/mirror/directional/west,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12
@@ -85897,10 +84120,10 @@
 /area/security/prison)
 "qFt" = (
 /obj/structure/closet/l3closet/janitor,
-/obj/machinery/requests_console{
-	department = "Custodial Closet";
-	name = "Custodial RC";
-	pixel_y = 32
+/obj/machinery/requests_console/directional/north{
+	department = "Janitorial";
+	departmentType = 1;
+	name = "Janitorial Requests Console"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
@@ -85950,13 +84173,11 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/fore)
 "qFS" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
 "qFT" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "qFV" = (
@@ -86004,12 +84225,8 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "qGj" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Arrivals Shuttle - Aft Starboard";
 	dir = 4;
@@ -86023,9 +84240,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "qGs" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Port";
 	dir = 4;
@@ -86053,9 +84268,7 @@
 "qGH" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -86140,13 +84353,11 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "qHt" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
 "qHH" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32;
 	pixel_y = 32
@@ -86196,7 +84407,7 @@
 /area/service/library/abandoned)
 "qIO" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -86272,12 +84483,6 @@
 	id = "custodialshutters";
 	name = "Custodial Closet Shutters"
 	},
-/obj/machinery/button/door{
-	id = "custodialshutters";
-	name = "Custodial Shutters";
-	pixel_x = 26;
-	req_access_txt = "26"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -86347,9 +84552,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "qLa" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
 	},
@@ -86372,9 +84575,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qLu" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -86598,33 +84799,31 @@
 /obj/machinery/computer/crew{
 	dir = 8
 	},
-/obj/machinery/button/door{
-	id = "cmoshutter";
-	name = "CMO Office Shutters";
-	pixel_x = 7;
-	pixel_y = -26;
-	req_access_txt = "40"
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = 7;
+/obj/machinery/keycard_auth/directional/south{
+	pixel_x = 8;
 	pixel_y = -38
 	},
-/obj/machinery/light_switch{
-	pixel_x = -7;
-	pixel_y = -26
-	},
-/obj/machinery/requests_console{
+/obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
 	department = "Chief Medical Officer's Desk";
 	departmentType = 5;
-	name = "Chief Medical Officer's RC";
-	pixel_x = 32
+	name = "Chief Medical Officer's Requests Console"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -8
+	},
+/obj/machinery/button/door/directional/south{
+	id = "cmoshutter";
+	name = "CMO Office Shutters";
+	pixel_x = 6;
+	pixel_y = -26;
+	req_access_txt = "40"
 	},
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
@@ -86686,28 +84885,23 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/bot,
-/obj/machinery/button/door{
-	id = "Toilet2";
-	name = "Lock control";
-	normaldoorcontrol = 1;
-	pixel_y = -25;
-	specialfunctions = 4
-	},
 /obj/effect/landmark/start/hangover,
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/button/door/directional/south{
+	id = "Toilet2";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
 "qPd" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/bed,
 /obj/item/bedsheet/rd,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -86789,15 +84983,14 @@
 /area/hallway/secondary/exit/departure_lounge)
 "qPM" = (
 /obj/structure/table,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "qPN" = (
 /obj/structure/rack,
 /obj/item/airlock_painter,
 /obj/item/toner,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/item/storage/box/shipping,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -87024,9 +85217,7 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "qTG" = (
-/obj/structure/mirror{
-	pixel_x = -28
-	},
+/obj/structure/mirror/directional/west,
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/orange,
 /obj/item/reagent_containers/spray/cleaner{
@@ -87230,9 +85421,7 @@
 /area/solars/port/fore)
 "qVt" = (
 /obj/effect/landmark/secequipment,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -87344,7 +85533,7 @@
 /turf/closed/wall,
 /area/service/electronic_marketing_den)
 "qVY" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -87367,6 +85556,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -87436,10 +85626,6 @@
 /turf/closed/wall/r_wall,
 /area/engineering/break_room)
 "qXE" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -87572,6 +85758,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "qZr" = (
@@ -87693,9 +85880,7 @@
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/storage/toolbox/electrical,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -87758,10 +85943,6 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "rch" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32;
-	pixel_y = -32
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/storage_shared)
 "rcu" = (
@@ -87773,16 +85954,12 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "rcv" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "rcz" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -87817,7 +85994,7 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -87927,6 +86104,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/button/door/directional/north{
+	id = "teleportershutters";
+	name = "Teleporter Shutters";
+	req_access_txt = "19"
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -88079,9 +86261,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "rfF" = (
-/obj/machinery/bounty_board{
-	pixel_y = 32
-	},
+/obj/machinery/bounty_board/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -88160,7 +86340,30 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"rgx" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai)
 "rgz" = (
+/obj/machinery/keycard_auth/directional/south{
+	pixel_x = 6
+	},
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -8
+	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "rgA" = (
@@ -88205,7 +86408,7 @@
 "rgU" = (
 /obj/machinery/disposal/bin,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
@@ -88242,10 +86445,9 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/west{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = -30;
+	name = "prison intercom";
 	prison_radio = 1
 	},
 /turf/open/floor/iron,
@@ -88311,9 +86513,7 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "rib" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
 /obj/effect/landmark/start/captain,
@@ -88369,7 +86569,7 @@
 /turf/open/floor/plating,
 /area/medical/treatment_center)
 "rjq" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -88494,9 +86694,7 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "rkL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
@@ -88574,7 +86772,7 @@
 /turf/open/floor/plating,
 /area/commons/dorms)
 "rmn" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -88597,6 +86795,7 @@
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/command/gateway)
 "rmA" = (
@@ -88615,9 +86814,7 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "rmR" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/ai/directional/east,
 /obj/structure/frame/computer,
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
@@ -88633,6 +86830,12 @@
 /obj/machinery/suit_storage_unit/hos,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/button/door/directional/east{
+	id = "hosroom";
+	name = "Privacy Control";
+	req_access_txt = "58"
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/hos)
@@ -88695,9 +86898,7 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
 "row" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "roK" = (
@@ -88748,11 +86949,8 @@
 "rpy" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -32
-	},
+/obj/machinery/light/directional/south,
+/obj/structure/noticeboard/directional/south,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/storage)
@@ -88864,9 +87062,7 @@
 /area/maintenance/starboard/fore)
 "rru" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/wrench,
 /obj/item/clothing/mask/gas,
 /obj/effect/turf_decal/tile/yellow{
@@ -88957,21 +87153,28 @@
 /obj/machinery/bluespace_vendor/west,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"rtI" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/iron,
+/area/medical/medbay/central)
 "rtJ" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteen_nineteen,
 /obj/item/canvas/twentythree_twentythree,
 /obj/item/canvas/twentythree_twentythree,
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "rtM" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -89009,9 +87212,7 @@
 /area/service/chapel/main)
 "ruy" = (
 /obj/machinery/power/smes,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -89019,7 +87220,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "ruK" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -89034,9 +87235,7 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -89310,7 +87509,7 @@
 /area/service/kitchen)
 "rzc" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/storage)
@@ -89370,9 +87569,7 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "rzT" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = 32
@@ -89495,17 +87692,16 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/vomit,
-/obj/machinery/button/door{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/button/door/directional/south{
 	id = "AuxToilet1";
 	name = "Lock Control";
 	normaldoorcontrol = 1;
-	pixel_y = -25;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
 /area/commons/toilet/auxiliary)
 "rCa" = (
@@ -89550,6 +87746,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "rCO" = (
@@ -89611,9 +87808,7 @@
 /area/command/meeting_room/council)
 "rDG" = (
 /obj/structure/closet/toolcloset,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -89621,11 +87816,10 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "rDI" = (
-/obj/machinery/flasher{
-	id = "Cell 6";
-	pixel_y = -25
+/obj/machinery/flasher/directional/south{
+	id = "Cell 6"
 	},
-/obj/machinery/light/small/broken,
+/obj/machinery/light/small/broken/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -89642,7 +87836,7 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "rDX" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -89732,23 +87926,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"rFn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/turf/open/floor/iron,
-/area/service/bar/atrium)
 "rFD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
 	dir = 4
@@ -89993,23 +88170,7 @@
 /turf/open/floor/carpet,
 /area/service/library)
 "rIR" = (
-/obj/machinery/keycard_auth{
-	pixel_x = -26
-	},
-/obj/machinery/button/door{
-	id = "engstorage";
-	name = "Engineering Secure Storage Control";
-	pixel_x = -38;
-	pixel_y = 8;
-	req_access_txt = "11"
-	},
-/obj/machinery/button/door{
-	id = "transitlock";
-	name = "Transit Tube Lockdown Control";
-	pixel_x = -38;
-	pixel_y = -8;
-	req_access_txt = "19"
-	},
+/obj/machinery/keycard_auth/directional/west,
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4
 	},
@@ -90023,6 +88184,18 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/button/door/directional/west{
+	id = "engstorage";
+	name = "Engineering Secure Storage Control";
+	pixel_y = 10;
+	req_access_txt = "11"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "transitlock";
+	name = "Transit Tube Lockdown Control";
+	pixel_y = -10;
+	req_access_txt = "19"
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "rIW" = (
@@ -90034,12 +88207,8 @@
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
 "rIY" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -90050,9 +88219,7 @@
 "rJj" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -90103,14 +88270,8 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"rJT" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/commons/storage/primary)
 "rJU" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -90337,7 +88498,7 @@
 /area/science/mixing)
 "rMk" = (
 /obj/machinery/portable_atmospherics/canister/bz,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -90520,9 +88681,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "rPb" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -90545,9 +88704,7 @@
 /turf/open/floor/plating,
 /area/service/library/abandoned)
 "rPv" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -90709,11 +88866,9 @@
 /area/service/theater/abandoned)
 "rRw" = (
 /obj/machinery/autolathe,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -23
+/obj/machinery/light/directional/west,
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -20
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -90841,9 +88996,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "rTO" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
 "rTT" = (
@@ -91077,9 +89230,7 @@
 /area/cargo/storage)
 "rWm" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -91125,10 +89276,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/cmo)
-"rXo" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/cargo/sorting)
 "rXs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -91643,9 +89790,7 @@
 "seV" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -91668,9 +89813,7 @@
 /area/engineering/atmos)
 "sfb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -91784,7 +89927,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden{
 	dir = 10
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos/upper)
@@ -91923,9 +90066,7 @@
 	},
 /area/service/abandoned_gambling_den/secondary)
 "sin" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "sip" = (
@@ -91946,6 +90087,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light/dim/directional/north,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/fore)
 "siG" = (
@@ -91976,9 +90118,7 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hop)
 "sjE" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/vending/modularpc,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -91986,6 +90126,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
 "sjF" = (
@@ -92235,9 +90376,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
 "sni" = (
@@ -92270,12 +90409,8 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
+/obj/machinery/light/directional/east,
+/obj/machinery/status_display/ai/directional/east,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -92629,12 +90764,8 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "srX" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "srY" = (
@@ -92876,9 +91007,7 @@
 "suL" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "suN" = (
@@ -93102,7 +91231,7 @@
 /area/solars/port/fore)
 "syV" = (
 /obj/structure/closet/toolcloset,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/machinery/camera{
 	c_tag = "Engineering - Engine Foyer";
 	dir = 1;
@@ -93164,9 +91293,7 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "szF" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Theater Stage";
 	name = "service camera"
@@ -93180,18 +91307,17 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/bot,
-/obj/machinery/button/door{
+/obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/button/door/directional/south{
 	id = "AuxToilet3";
 	name = "Lock Control";
 	normaldoorcontrol = 1;
-	pixel_y = -25;
 	specialfunctions = 4
 	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/commons/toilet/auxiliary)
 "sAj" = (
@@ -93220,9 +91346,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "sAm" = (
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
+/obj/machinery/light_switch/directional/east,
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/psychologist,
 /obj/effect/turf_decal/tile/blue{
@@ -93232,9 +91356,7 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "sAn" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
@@ -93274,9 +91396,7 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "sAB" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -93366,9 +91486,7 @@
 /area/commons/locker)
 "sBb" = (
 /obj/machinery/vending/assist,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
@@ -93590,9 +91708,7 @@
 /area/engineering/main)
 "sDw" = (
 /obj/structure/chair/stool/bar,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
@@ -93662,7 +91778,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "sEo" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -93719,6 +91835,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"sES" = (
+/obj/machinery/porta_turret/ai,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "sFf" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -93730,9 +91861,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "sFr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/structure/chair/office/light,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
@@ -93745,6 +91874,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "sFw" = (
@@ -93873,7 +92003,7 @@
 /area/engineering/main)
 "sGK" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/storage/secure/briefcase,
 /obj/item/taperecorder,
 /obj/effect/turf_decal/bot,
@@ -93970,7 +92100,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sHo" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
@@ -94012,9 +92142,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "sIg" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -94084,10 +92212,7 @@
 /area/command/bridge)
 "sJx" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_x = 22;
-	pixel_y = -10
-	},
+/obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -94130,9 +92255,7 @@
 /area/command/corporate_showroom)
 "sKr" = (
 /obj/structure/chair/office,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/service/library/abandoned)
 "sKy" = (
@@ -94142,17 +92265,13 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/syringes,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "sKJ" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
+/obj/structure/urinal/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
@@ -94177,19 +92296,18 @@
 	pixel_x = 25;
 	pixel_y = 7
 	},
-/obj/machinery/button/door{
-	id = "permashut3";
-	name = "Cell Lockdown Button";
-	pixel_x = 25;
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/button/door/directional/east{
+	id = "permashut3";
+	name = "Cell Lockdown Button";
+	pixel_y = -6;
+	req_access_txt = "2"
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -94362,9 +92480,7 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "sMV" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -94445,10 +92561,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/bag/books,
 /obj/item/taperecorder,
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 32
-	},
+/obj/structure/noticeboard/directional/east,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "sPf" = (
@@ -94506,9 +92619,7 @@
 /area/engineering/storage/tech)
 "sPE" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom/directional/east,
@@ -94535,9 +92646,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "sQk" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -94550,21 +92659,18 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "sQr" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_y = -25
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 2"
 	},
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "sQV" = (
 /obj/structure/closet/radiation,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -94629,9 +92735,7 @@
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sRX" = (
-/obj/structure/mirror{
-	pixel_x = -26
-	},
+/obj/structure/mirror/directional/west,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12
@@ -94773,9 +92877,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "sTA" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "sTC" = (
@@ -95121,9 +93223,7 @@
 /area/service/library/abandoned)
 "sXr" = (
 /obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/item/flashlight/lamp/green,
 /obj/machinery/camera{
 	c_tag = "Bridge - Captain's Office";
@@ -95173,9 +93273,7 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "sXL" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -95184,7 +93282,7 @@
 /area/commons/toilet/auxiliary)
 "sXO" = (
 /obj/structure/cable,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
@@ -95398,9 +93496,7 @@
 /obj/structure/rack,
 /obj/item/crowbar,
 /obj/item/storage/toolbox/mechanical,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -95485,15 +93581,30 @@
 	},
 /area/service/library/abandoned)
 "tbj" = (
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
+/obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
+"tbk" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/blue,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai)
 "tbn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/loot_site_spawner,
@@ -95580,7 +93691,7 @@
 /area/security/checkpoint/escape)
 "tcl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -95647,9 +93758,7 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "tdE" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "teo" = (
@@ -95770,10 +93879,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
-"tfu" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/service/library)
 "tfy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -95814,15 +93919,14 @@
 /area/science/xenobiology)
 "tgb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/flasher{
-	id = "Cell 1";
-	pixel_y = -25
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 1"
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
@@ -95837,14 +93941,8 @@
 /turf/open/floor/plating,
 /area/maintenance/space_hut/observatory)
 "tgL" = (
-/obj/machinery/requests_console{
-	department = "Quartermaster's Desk";
-	name = "Quartermaster RC";
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/machinery/light_switch{
-	pixel_x = 23
+/obj/machinery/light_switch/directional/east{
+	pixel_x = 22
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -95862,7 +93960,7 @@
 	name = "emergency shower"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -95929,10 +94027,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "thX" = (
-/obj/machinery/light_switch{
-	pixel_x = -7;
-	pixel_y = -26
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -96051,9 +94146,7 @@
 /area/maintenance/disposal/incinerator)
 "tjO" = (
 /obj/machinery/gibber,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -96086,6 +94179,20 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/security/office)
+"tku" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/south{
+	id = "evashutters2";
+	name = "E.V.A. Shutters";
+	req_access_txt = "19"
+	},
+/turf/open/floor/iron,
+/area/maintenance/port/aft)
 "tkH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase/random/adult,
@@ -96188,9 +94295,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/structure/easel,
 /obj/item/canvas/twentythree_twentythree,
 /obj/item/canvas/twentythree_twentythree,
@@ -96202,10 +94307,6 @@
 /obj/item/wrench,
 /obj/item/clothing/glasses/meson/engine,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/storage)
@@ -96269,9 +94370,7 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "tni" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -96341,9 +94440,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "tof" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/machinery/camera{
 	c_tag = "Cargo - Quartermaster's Quarters";
 	dir = 8;
@@ -96362,9 +94459,7 @@
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -96555,9 +94650,7 @@
 /area/commons/fitness/recreation)
 "tro" = (
 /obj/structure/closet/secure_closet/hydroponics,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -96611,9 +94704,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "tsl" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
+/obj/structure/urinal/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
@@ -96670,9 +94761,7 @@
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
 "tsY" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /obj/effect/turf_decal/bot,
@@ -96713,9 +94802,7 @@
 /obj/item/electronics/firelock,
 /obj/item/electronics/firealarm,
 /obj/item/electronics/firealarm,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -97160,9 +95247,7 @@
 /turf/open/floor/iron/white/corner,
 /area/engineering/atmos)
 "tAv" = (
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
+/obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -97194,9 +95279,7 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/fore)
 "tBg" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airlock_sensor/incinerator_atmos{
 	pixel_y = 24
@@ -97398,9 +95481,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "tDT" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -97415,6 +95496,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "tDV" = (
@@ -97463,9 +95545,7 @@
 /area/solars/starboard/fore)
 "tEy" = (
 /obj/machinery/photocopier,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/machinery/camera{
 	c_tag = "Lawyer's Office";
 	dir = 8
@@ -97480,9 +95560,7 @@
 /area/engineering/storage/tech)
 "tEM" = (
 /obj/structure/table/wood,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/item/book/manual/wiki/engineering_hacking,
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
@@ -97764,10 +95842,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
-"tIq" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
-/area/command/heads_quarters/hop)
 "tIE" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -97909,13 +95983,7 @@
 /area/commons/dorms)
 "tJH" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/light_switch{
-	pixel_x = -38;
-	pixel_y = -8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -98078,26 +96146,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
-"tLc" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel/office)
 "tLg" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -98201,9 +96249,7 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "tLY" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /obj/machinery/lapvend,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -98257,7 +96303,7 @@
 /area/service/chapel/main)
 "tME" = (
 /obj/effect/spawner/randomsnackvend,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
@@ -98380,9 +96426,7 @@
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /obj/item/camera,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -98506,9 +96550,7 @@
 /area/commons/dorms)
 "tOT" = (
 /obj/item/kirbyplants/random,
-/obj/item/storage/secure/safe{
-	pixel_x = 32
-	},
+/obj/item/storage/secure/safe/directional/east,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
 "tOW" = (
@@ -98712,10 +96754,6 @@
 /turf/open/floor/plating,
 /area/engineering/break_room)
 "tSn" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -98735,10 +96773,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
-"tSy" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/commons/locker)
 "tSz" = (
 /obj/effect/landmark/start/chaplain,
 /obj/structure/cable,
@@ -98776,9 +96810,7 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "tSS" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/wood,
 /area/service/library)
@@ -98855,7 +96887,7 @@
 /obj/structure/musician/piano{
 	icon_state = "piano"
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/landmark/start/hangover,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/grimy,
@@ -99059,7 +97091,7 @@
 /turf/open/floor/iron/dark,
 /area/service/library)
 "tVL" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Recreation - Aft";
 	dir = 1;
@@ -99084,10 +97116,10 @@
 "tVP" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
-/obj/machinery/requests_console{
-	department = "Cargo Office";
-	name = "Cargo Office RC";
-	pixel_y = 32
+/obj/machinery/requests_console/directional/north{
+	department = "Cargo Bay";
+	departmentType = 2;
+	name = "Cargo Bay Requests Console"
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Office";
@@ -99121,9 +97153,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "tWP" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "tXb" = (
@@ -99152,9 +97182,7 @@
 /area/medical/chemistry)
 "tXm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -99168,7 +97196,7 @@
 /obj/structure/table/reinforced,
 /obj/item/assembly/timer,
 /obj/item/assembly/timer,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
@@ -99394,9 +97422,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "ubA" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -99424,11 +97450,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/item/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	name = "Prison Intercom (General)";
-	pixel_x = 25;
-	pixel_y = -2;
+/obj/item/radio/intercom/directional/east{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
 	prison_radio = 1
 	},
 /turf/open/floor/iron,
@@ -99467,9 +97491,7 @@
 	pixel_y = 3
 	},
 /obj/item/camera_film,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -99492,9 +97514,7 @@
 /area/maintenance/port/aft)
 "ucu" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden/abandoned)
@@ -99541,9 +97561,7 @@
 /area/engineering/supermatter/room)
 "ude" = (
 /obj/structure/table/wood,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/item/clipboard,
 /obj/item/toy/figure/bartender,
 /obj/item/holosign_creator/robot_seat/bar,
@@ -99584,9 +97602,7 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "udD" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -99614,6 +97630,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "ueh" = (
@@ -99622,7 +97639,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ueo" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
@@ -99766,24 +97783,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"uhF" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "gatewayshutters";
-	name = "Gateway Chamber Shutters"
-	},
-/obj/machinery/button/door{
-	id = "gatewayshutters";
-	name = "Gateway Shutters";
-	pixel_x = -26;
-	req_access_txt = "19"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/command/gateway)
 "uhH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -99866,9 +97865,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -99922,6 +97919,15 @@
 	dir = 1
 	},
 /area/engineering/atmos)
+"ujM" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "ujO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -100051,9 +98057,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/machinery/camera{
 	c_tag = "AI Satellite - Transit Tube";
 	name = "ai camera";
@@ -100077,9 +98081,7 @@
 /area/engineering/transit_tube)
 "ulm" = (
 /obj/machinery/teleport/station,
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -100194,9 +98196,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "unk" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/service/library/abandoned)
 "unv" = (
@@ -100344,7 +98344,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/south,
+/obj/item/radio/intercom/directional/south{
+	frequency = 1423;
+	name = "Interrogation Intercom"
+	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "upL" = (
@@ -100412,9 +98415,7 @@
 	pixel_y = 3
 	},
 /obj/item/newspaper,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -100479,9 +98480,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "uqQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -100617,6 +98616,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "utp" = (
@@ -100699,6 +98699,17 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
+"uuh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 4
+	},
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron/dark/corner,
+/area/engineering/atmos)
 "uup" = (
 /obj/structure/table,
 /obj/item/toy/gun,
@@ -100792,7 +98803,7 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 1
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -100979,9 +98990,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "uym" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -101039,6 +99048,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/command/heads_quarters/hos)
 "uyP" = (
@@ -101263,12 +99273,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "uBh" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/light/directional/east,
 /obj/machinery/camera{
 	c_tag = "Arrivals Dock - Fore";
 	dir = 8;
@@ -101284,6 +99290,9 @@
 /area/hallway/secondary/entry)
 "uBn" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/light_switch/directional/north{
+	pixel_x = -8
+	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "uBs" = (
@@ -101554,9 +99563,7 @@
 /area/engineering/main)
 "uEl" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/wrench,
 /obj/item/assembly/timer,
 /obj/item/assembly/signaler,
@@ -101637,9 +99644,7 @@
 /turf/open/floor/iron/grimy,
 /area/service/library/abandoned)
 "uFq" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -101679,7 +99684,7 @@
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "uGj" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -101689,6 +99694,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uGv" = (
@@ -101756,9 +99762,7 @@
 "uHf" = (
 /obj/structure/table/reinforced,
 /obj/item/aicard,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -101925,7 +99929,7 @@
 /area/service/chapel/office)
 "uJL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /turf/open/floor/iron,
@@ -101941,12 +99945,8 @@
 	pixel_y = 5
 	},
 /obj/item/radio,
-/obj/machinery/light_switch{
-	pixel_x = 26
-	},
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light_switch/directional/east,
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
@@ -101999,14 +99999,8 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"uKP" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/engineering/transit_tube)
 "uKR" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/machinery/newscaster/directional/north,
@@ -102153,9 +100147,7 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/storage/toolbox/electrical,
 /obj/item/multitool,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -102222,9 +100214,7 @@
 /turf/open/floor/iron/grimy,
 /area/command/corporate_showroom)
 "uOU" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -102350,10 +100340,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "uRT" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -102529,9 +100515,7 @@
 /area/engineering/atmos/upper)
 "uTr" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/item/stack/sheet/iron{
 	amount = 30
 	},
@@ -102628,9 +100612,7 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "uVx" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
@@ -102806,10 +100788,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
-"uZi" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/hallway/primary/central/fore)
 "uZm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -102861,9 +100839,7 @@
 /area/maintenance/port/aft)
 "vat" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/computer/security/telescreen/ce{
 	dir = 4;
 	pixel_x = -30
@@ -102898,12 +100874,8 @@
 "vaH" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cmo,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/light/directional/east,
+/obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -102976,10 +100948,7 @@
 	pixel_y = 3
 	},
 /obj/item/stamp,
-/obj/machinery/bounty_board{
-	dir = 8;
-	pixel_x = 32
-	},
+/obj/machinery/bounty_board/directional/east,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -103095,15 +101064,14 @@
 	id = "atmoslock";
 	name = "Atmospherics Lockdown Blast door"
 	},
-/obj/machinery/button/door{
-	id = "atmoslock";
-	name = "Atmospherics Lockdown Control";
-	pixel_x = 26;
-	req_access_txt = "24"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/button/door/directional/east{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Control";
+	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -103170,6 +101138,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vep" = (
@@ -103300,9 +101269,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "vgr" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/closet/crate/silvercrate,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -103366,9 +101333,6 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hop)
 "vgM" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -103379,6 +101343,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "vgX" = (
@@ -103480,7 +101445,7 @@
 "vhK" = (
 /obj/item/clipboard,
 /obj/item/folder/yellow,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/table/reinforced,
 /obj/item/gps,
 /obj/item/gps,
@@ -103511,10 +101476,6 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "vhT" = (
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -103689,9 +101650,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "vkA" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Medbay Aft";
 	name = "hallway camera"
@@ -103746,7 +101705,7 @@
 /turf/open/floor/iron/grimy,
 /area/command/bridge)
 "vlo" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -103762,9 +101721,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "vlp" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -103850,9 +101807,7 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "vnd" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/ai/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -104128,10 +102083,8 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "vrZ" = (
-/obj/machinery/light,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -104274,9 +102227,7 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
 "vtF" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -104393,7 +102344,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "vwa" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -104471,9 +102422,7 @@
 /area/command/bridge)
 "vxk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/machinery/conveyor/inverted{
 	dir = 10;
 	id = "cargoload"
@@ -104665,6 +102614,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/library)
 "vzJ" = (
@@ -104749,9 +102699,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "vBj" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
@@ -104761,9 +102709,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "vBN" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
+/obj/structure/urinal/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -104784,6 +102730,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/library)
+"vCj" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/wood,
+/area/command/heads_quarters/hop)
 "vCl" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced,
@@ -104869,9 +102820,7 @@
 /area/engineering/supermatter)
 "vDG" = (
 /obj/machinery/meter,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -104897,7 +102846,7 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
@@ -104911,9 +102860,7 @@
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/pen,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -105029,20 +102976,18 @@
 /area/commons/vacant_room/commissary)
 "vFU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/flasher{
-	id = "Cell 4";
-	pixel_y = -25
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 4"
+	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "vGx" = (
-/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -105087,18 +103032,16 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "vGQ" = (
-/obj/machinery/button/door{
-	id = "corporatelounge";
-	name = "Corporate Lounge Shutters";
-	pixel_x = -7;
-	pixel_y = -26
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = -26
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 6
 	},
 /obj/item/kirbyplants/random,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
+/obj/machinery/button/door/directional/south{
+	id = "corporatelounge";
+	name = "Corporate Lounge Shutters";
+	pixel_x = -6
+	},
 /turf/open/floor/iron/grimy,
 /area/command/corporate_showroom)
 "vHf" = (
@@ -105190,7 +103133,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "vHY" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/table/wood,
 /obj/item/reagent_containers/blood/random,
 /obj/item/reagent_containers/syringe{
@@ -105275,9 +103218,7 @@
 	},
 /area/maintenance/port)
 "vIJ" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -105315,9 +103256,7 @@
 /turf/open/space,
 /area/engineering/atmos)
 "vJj" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
 /turf/open/floor/iron,
@@ -105379,14 +103318,14 @@
 /turf/open/floor/plating,
 /area/commons/storage/tools)
 "vJW" = (
-/obj/machinery/button/door{
-	id = "councilblast";
-	name = "Council Blast doors";
-	pixel_x = -26;
-	pixel_y = -26
-	},
 /obj/structure/bookcase/random,
-/obj/item/radio/intercom/directional/south,
+/obj/item/radio/intercom/directional/south{
+	pixel_y = -38
+	},
+/obj/machinery/button/door/directional/south{
+	id = "councilblast";
+	name = "Council Blast Doors"
+	},
 /turf/open/floor/wood,
 /area/command/meeting_room/council)
 "vKa" = (
@@ -105448,9 +103387,7 @@
 /area/security/office)
 "vKD" = (
 /obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/iron/dark,
@@ -105581,12 +103518,8 @@
 /area/hallway/primary/central/fore)
 "vMb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -105977,9 +103910,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vSm" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "vSn" = (
@@ -106015,22 +103946,17 @@
 /area/science/xenobiology)
 "vSw" = (
 /obj/structure/closet/secure_closet/engineering_chief,
-/obj/machinery/button/door{
-	id = "ceprivacy";
-	name = "Privacy Control";
-	pixel_x = 26;
-	req_access_txt = "56"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Chief Engineer's Quarters";
 	name = "engineering camera"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/button/door/directional/east{
+	id = "ceprivacy";
+	name = "Privacy Control";
+	req_access_txt = "56"
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
@@ -106185,9 +104111,7 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hos)
 "vTH" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -106294,10 +104218,7 @@
 /area/hallway/primary/central/fore)
 "vVF" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -106436,6 +104357,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
 "vXh" = (
@@ -106474,9 +104396,7 @@
 /turf/closed/wall,
 /area/security/prison/safe)
 "vXB" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/break_room)
@@ -106647,6 +104567,7 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/bot,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "vZQ" = (
@@ -106735,7 +104656,7 @@
 "wbb" = (
 /obj/structure/table/wood,
 /obj/item/camera,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
 	},
@@ -106759,9 +104680,7 @@
 "wbv" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_y = 26
-	},
+/obj/machinery/light_switch/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -106927,9 +104846,7 @@
 /area/science/xenobiology)
 "wdC" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -106942,10 +104859,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"wdM" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
-/area/hallway/primary/central/fore)
 "wdO" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -107062,10 +104975,9 @@
 /area/service/electronic_marketing_den)
 "wfK" = (
 /obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Theater Backstage";
-	name = "Theater RC";
-	pixel_x = -32
+/obj/machinery/requests_console/directional/west{
+	department = "Theater";
+	name = "Theater Requests Console"
 	},
 /obj/item/lipstick/random{
 	pixel_x = 3;
@@ -107206,9 +105118,7 @@
 "wiy" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/item/crowbar/red,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 20
@@ -107433,6 +105343,25 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"wka" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "wke" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -107637,7 +105566,7 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "wof" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
 /area/service/electronic_marketing_den)
 "woh" = (
@@ -107716,9 +105645,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "wpu" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/structure/closet/wardrobe/mixed,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -107765,9 +105692,7 @@
 /area/hallway/primary/central/fore)
 "wqv" = (
 /obj/structure/table/wood,
-/obj/machinery/keycard_auth{
-	pixel_x = -26
-	},
+/obj/machinery/keycard_auth/directional/west,
 /obj/item/flashlight/lamp,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -107815,9 +105740,7 @@
 /area/engineering/main)
 "wrg" = (
 /obj/machinery/vending/boozeomat,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "wrv" = (
@@ -107836,10 +105759,6 @@
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "wrG" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 64;
-	pixel_y = 32
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -107948,9 +105867,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
 	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -107984,7 +105901,7 @@
 	dir = 1;
 	layer = 2.9
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/space,
 /area/ai_monitored/aisat/exterior)
 "wtx" = (
@@ -108037,6 +105954,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/button/door/directional/north{
+	id = "gatewayshutters";
+	name = "Gateway Shutters";
+	req_access_txt = "19"
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "wuB" = (
@@ -108058,7 +105980,7 @@
 /obj/item/stack/spacecash/c500,
 /obj/item/stack/spacecash/c500,
 /obj/item/stack/spacecash/c500,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/item/gun/ballistic/automatic/pistol/deagle,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -108104,12 +106026,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/radio/intercom{
+/obj/item/radio/intercom/directional/south{
 	broadcasting = 1;
 	frequency = 1423;
 	listening = 0;
-	name = "Interrogation Intercom";
-	pixel_y = -24
+	name = "Interrogation Intercom"
 	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
@@ -108199,9 +106120,7 @@
 "wvB" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -108235,9 +106154,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wvH" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
 	dir = 4;
@@ -108374,10 +106291,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/engineering/main)
-"wyo" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/commons/vacant_room/office)
 "wyv" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency{
@@ -108387,9 +106300,7 @@
 /obj/item/storage/toolbox/emergency,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/light_switch{
-	pixel_x = -26
-	},
+/obj/machinery/light_switch/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -108399,6 +106310,19 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
+"wyK" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "brigprison";
+	name = "Prison Blast door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/button/door/directional/east{
+	id = "brigprison";
+	name = "Prison Lockdown";
+	req_access_txt = "63"
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "wyU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -108483,11 +106407,8 @@
 /obj/item/clothing/suit/toggle/lawyer,
 /obj/item/clothing/under/costume/kilt,
 /obj/item/clothing/head/beret,
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /obj/machinery/airalarm/directional/north,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "wzW" = (
@@ -108540,9 +106461,7 @@
 /turf/open/floor/iron,
 /area/service/abandoned_gambling_den/secondary)
 "wAi" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -108589,9 +106508,7 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "wBS" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
@@ -108629,7 +106546,7 @@
 "wCo" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain/private)
 "wCM" = (
@@ -108656,6 +106573,9 @@
 /obj/item/kirbyplants/random,
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 32
+	},
+/obj/machinery/light_switch/directional/east{
+	pixel_x = 21
 	},
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
@@ -108699,16 +106619,12 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/upper)
 "wEb" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "wEc" = (
 /obj/structure/bookcase,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/structure/sign/plaques/kiddie/badger{
 	pixel_y = 32
 	},
@@ -108808,7 +106724,7 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "wFe" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -108950,6 +106866,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
 "wHc" = (
@@ -108975,7 +106892,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
 	},
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -109026,10 +106943,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
 "wIy" = (
-/obj/machinery/flasher{
-	id = "hopflash";
-	pixel_y = 58
-	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
@@ -109101,9 +107014,7 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "wJo" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -109166,16 +107077,9 @@
 	},
 /turf/open/floor/iron,
 /area/commons/locker)
-"wKz" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/turf/open/floor/iron/grimy,
-/area/command/heads_quarters/hos)
 "wKG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -109261,19 +107165,18 @@
 	pixel_x = 25;
 	pixel_y = 7
 	},
-/obj/machinery/button/door{
-	id = "permashut5";
-	name = "Cell Lockdown Button";
-	pixel_x = 25;
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/door/directional/east{
+	id = "permashut5";
+	name = "Cell Lockdown Button";
+	pixel_y = -6;
+	req_access_txt = "2"
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "wNc" = (
@@ -109295,9 +107198,8 @@
 /area/maintenance/disposal/incinerator)
 "wNi" = (
 /obj/structure/filingcabinet/medical,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hop)
 "wNq" = (
@@ -109488,9 +107390,7 @@
 /area/hallway/primary/central/aft)
 "wPU" = (
 /obj/machinery/photocopier,
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -109503,9 +107403,7 @@
 /obj/machinery/computer/communications{
 	dir = 4
 	},
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "wQf" = (
@@ -109513,11 +107411,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clipboard,
 /obj/item/toy/figure/miner,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = -38
+/obj/machinery/light/directional/north,
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -42
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/west,
@@ -109542,10 +107438,9 @@
 /area/security/prison)
 "wQx" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/flasher{
+/obj/machinery/flasher/directional/south{
 	id = "AI";
-	pixel_x = -26;
-	pixel_y = -26
+	pixel_x = -26
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -109605,17 +107500,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"wRa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = 26
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/medical/morgue)
 "wRg" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -109707,7 +107591,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wSK" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -109776,7 +107660,7 @@
 /area/engineering/supermatter/room)
 "wTo" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = -32
 	},
@@ -109843,9 +107727,8 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/lights/mixed,
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -20
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -109869,10 +107752,6 @@
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/pen,
-/obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = -32
-	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "wUj" = (
@@ -109916,9 +107795,7 @@
 "wUz" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/item/crowbar/red,
 /obj/item/wrench,
@@ -109941,9 +107818,7 @@
 	c_tag = "Vacant Commissary";
 	dir = 1
 	},
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -109964,7 +107839,7 @@
 /area/service/kitchen)
 "wVf" = (
 /obj/structure/table/wood,
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
 /obj/machinery/computer/security/telescreen/vault{
@@ -110038,9 +107913,7 @@
 /area/engineering/supermatter/room)
 "wWh" = (
 /obj/structure/chair/wood,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron{
 	dir = 8;
 	icon_state = "chapel"
@@ -110467,6 +108340,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -110635,15 +108509,7 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "xeK" = (
-/obj/machinery/light_switch{
-	pixel_x = -8;
-	pixel_y = -24
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_x = 32;
-	pixel_y = -24
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
@@ -110657,7 +108523,7 @@
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "xeU" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "xfl" = (
@@ -110713,6 +108579,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
 "xhe" = (
@@ -110890,11 +108757,6 @@
 /area/engineering/atmos)
 "xjq" = (
 /obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Law Office";
-	name = "'Law Office RC";
-	pixel_y = -64
-	},
 /obj/item/folder/blue{
 	pixel_x = 3;
 	pixel_y = 3
@@ -111062,9 +108924,7 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "xmf" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -111146,7 +109006,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/transit_tube)
 "xnj" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/machinery/computer/station_alert{
 	dir = 1
 	},
@@ -111160,6 +109020,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "xno" = (
@@ -111172,9 +109033,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "xnH" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/machinery/disposal/bin,
 /obj/structure/sign/plaques/kiddie/library{
 	pixel_x = -32
@@ -111199,13 +109058,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
-"xnI" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/open/floor/iron/grimy,
-/area/command/heads_quarters/hos)
 "xnL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -111335,11 +109187,7 @@
 /area/maintenance/starboard)
 "xpx" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light/small,
-/obj/machinery/light_switch{
-	pixel_x = 26;
-	pixel_y = -26
-	},
+/obj/machinery/light/small/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -111488,6 +109336,7 @@
 	desc = "Used to grind things up into raw materials and liquids.";
 	pixel_y = 5
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "xrw" = (
@@ -111553,7 +109402,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/canvas/twentythree_twentythree,
 /obj/item/canvas/twentythree_twentythree,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/service/library/abandoned)
 "xtg" = (
@@ -111635,10 +109484,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
 "xtC" = (
-/obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = -32
-	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
@@ -111662,12 +109507,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
+/obj/machinery/light/directional/north,
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -111695,9 +109536,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "xuj" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -111723,10 +109562,8 @@
 /area/engineering/atmos)
 "xuD" = (
 /obj/structure/bed,
-/obj/machinery/light,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /obj/item/bedsheet/dorms,
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -111852,9 +109689,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "xwQ" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -111882,9 +109717,7 @@
 /area/command/heads_quarters/hop)
 "xxb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/service/library/abandoned)
 "xxj" = (
@@ -111900,9 +109733,7 @@
 /area/service/library/abandoned)
 "xxr" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Engineering - Foyer";
@@ -111938,10 +109769,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"xxP" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
-/area/engineering/atmos)
 "xyb" = (
 /obj/machinery/camera{
 	c_tag = "Cargo - Quartermaster's Office";
@@ -111981,6 +109808,10 @@
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
+/obj/machinery/button/door/directional/south{
+	id = "gatewayshutters";
+	name = "Gateway Shutters"
+	},
 /turf/open/floor/iron,
 /area/command/gateway)
 "xzc" = (
@@ -112092,10 +109923,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
-"xAy" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/service/chapel/main)
 "xAE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -112138,9 +109965,7 @@
 /area/security/office)
 "xBe" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/bot,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
@@ -112172,10 +109997,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "xCb" = (
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = 26
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -112220,9 +110041,7 @@
 /area/hallway/primary/central/aft)
 "xCx" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -112300,7 +110119,7 @@
 /turf/open/floor/plating,
 /area/engineering/transit_tube)
 "xDZ" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -112369,22 +110188,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
-"xEP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_switch{
-	pixel_x = -26;
-	pixel_y = -26
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "xET" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -112439,9 +110242,7 @@
 "xFl" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
@@ -112686,7 +110487,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/mop,
 /obj/item/mop,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = -32
 	},
@@ -112933,7 +110734,7 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "xNJ" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /obj/structure/table/wood,
 /obj/item/folder,
 /obj/item/laser_pointer{
@@ -113021,7 +110822,7 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hos)
 "xOo" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -113158,10 +110959,8 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/hos)
 "xQg" = (
-/obj/machinery/light,
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
+/obj/machinery/light/directional/south,
+/obj/machinery/light_switch/directional/south,
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -113256,9 +111055,7 @@
 /area/service/theater)
 "xRQ" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/light_switch{
-	pixel_y = -26
-	},
+/obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
@@ -113284,9 +111081,7 @@
 /area/service/abandoned_gambling_den/secondary)
 "xSk" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -113356,9 +111151,7 @@
 /area/command/bridge)
 "xTw" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -113442,10 +111235,8 @@
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "xVh" = (
-/obj/machinery/sparker{
-	dir = 1;
-	id = "justicespark";
-	pixel_x = -22
+/obj/machinery/sparker/directional/west{
+	id = "justicespark"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -113520,6 +111311,7 @@
 	dir = 1;
 	name = "holodeck camera"
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
 	},
@@ -113666,9 +111458,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 26
+/obj/item/radio/intercom/directional/east{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
 	},
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
@@ -113680,9 +111473,7 @@
 /turf/open/floor/iron/grimy,
 /area/command/heads_quarters/captain)
 "xYr" = (
-/obj/machinery/light_switch{
-	pixel_x = -22
-	},
+/obj/machinery/light_switch/directional/west,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -113883,16 +111674,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"yaW" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_x = -32;
-	pixel_y = 24
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "ybg" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Center";
@@ -113994,10 +111775,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 26
-	},
 /turf/open/floor/iron,
 /area/security/office)
 "ycm" = (
@@ -114005,9 +111782,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 26
+/obj/item/radio/intercom/directional/east{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	prison_radio = 1
 	},
 /turf/open/floor/carpet,
 /area/commons/dorms)
@@ -114016,7 +111794,7 @@
 /turf/closed/wall,
 /area/engineering/atmos/upper)
 "ycz" = (
-/obj/machinery/light,
+/obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/service/library)
 "ycA" = (
@@ -114059,9 +111837,7 @@
 /turf/open/floor/iron,
 /area/medical/surgery/room_b)
 "ycC" = (
-/obj/machinery/light{
-	dir = 4
-	},
+/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -114077,9 +111853,7 @@
 /area/command/heads_quarters/ce)
 "ycI" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
+/obj/machinery/status_display/evac/directional/north,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -114105,9 +111879,7 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "ycV" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -114152,9 +111924,7 @@
 /area/security/prison)
 "ydq" = (
 /obj/structure/frame/machine,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "yds" = (
@@ -114181,9 +111951,6 @@
 /area/engineering/atmos)
 "ydF" = (
 /obj/structure/dresser,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -114219,9 +111986,8 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/depsec/medical,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = -32
+/obj/structure/extinguisher_cabinet/directional/south{
+	pixel_x = 26
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
@@ -114241,6 +112007,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "yew" = (
@@ -114386,9 +112153,7 @@
 /area/service/bar)
 "ygx" = (
 /obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/machinery/newscaster/directional/west,
@@ -114570,9 +112335,7 @@
 "yjE" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "yjF" = (
@@ -114648,9 +112411,7 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -114688,6 +112449,7 @@
 	pixel_y = 3
 	},
 /obj/item/camera_film,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "ylt" = (
@@ -114705,7 +112467,7 @@
 /area/science/xenobiology)
 "ylX" = (
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
@@ -114715,9 +112477,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "yma" = (
@@ -121570,13 +119330,13 @@ aad
 btH
 btH
 btH
-bAx
 btH
 btH
 btH
-bwn
 btH
-bAx
+btH
+btH
+btH
 btH
 bPC
 bRB
@@ -121827,11 +119587,11 @@ btH
 btH
 btH
 byS
-bAy
+rgx
 btH
 bEf
 btH
-bAy
+nhp
 bAG
 bLx
 btH
@@ -122085,7 +119845,7 @@ btH
 bxv
 byT
 bAz
-abx
+bCq
 bEg
 bCq
 bCq
@@ -122099,7 +119859,7 @@ yeH
 bPC
 bPC
 bPC
-cdu
+cdt
 cfs
 chj
 cdv
@@ -122338,7 +120098,7 @@ gUo
 brN
 aaa
 btH
-bwn
+btH
 bxw
 bCu
 mFB
@@ -122349,18 +120109,18 @@ abJ
 bcG
 abJ
 bNA
-bPD
-bRE
+bPC
+bKJ
 bYa
 nAo
 bYa
 bRE
 bRD
-cdv
+eWf
 cft
 cho
 ciR
-cko
+cft
 clM
 cdt
 cdt
@@ -123376,9 +121136,9 @@ btH
 btH
 brB
 abJ
-bCq
+oYv
 bPC
-caf
+wka
 bYe
 eFb
 bYe
@@ -123880,7 +121640,7 @@ gUo
 brN
 aaa
 btH
-bwn
+btH
 bxw
 bCu
 nnp
@@ -123891,8 +121651,8 @@ abJ
 orN
 abJ
 bNA
-bPI
-bRE
+bPC
+sES
 bYg
 nAo
 bYg
@@ -123902,7 +121662,7 @@ cdA
 cft
 cho
 ciX
-cks
+cft
 clQ
 cdt
 cdt
@@ -124155,7 +121915,7 @@ qQH
 bPC
 bPC
 bPC
-cdu
+cdt
 cfz
 chq
 cdv
@@ -124397,7 +122157,7 @@ btH
 btH
 btH
 bzc
-bAG
+tbk
 btH
 bEm
 btH
@@ -124654,13 +122414,13 @@ aad
 btH
 btH
 btH
-bAx
 btH
 btH
 btH
-bwn
 btH
-bAx
+btH
+btH
+btH
 btH
 bPC
 bRK
@@ -134957,11 +132717,11 @@ vNO
 vzm
 rNb
 idx
-fay
+qzf
 tKt
 inC
 tKt
-fay
+qzf
 wHb
 nLn
 dqi
@@ -135477,7 +133237,7 @@ hVW
 hVW
 qzf
 qzf
-fay
+qzf
 htS
 mKr
 lhy
@@ -135711,7 +133471,7 @@ qTO
 npf
 mLw
 pIZ
-uKP
+xKG
 ocA
 xKG
 pIZ
@@ -136505,7 +134265,7 @@ tSQ
 qzf
 qzf
 qzf
-fay
+qzf
 hdp
 miV
 ren
@@ -136517,9 +134277,9 @@ jJY
 cMO
 cMO
 cQj
-cRE
+cMO
 cQj
-cRE
+cMO
 cQj
 cMO
 cMO
@@ -137013,7 +134773,7 @@ sbI
 xPF
 aCW
 lAe
-fay
+qzf
 vDy
 lZo
 qzf
@@ -139026,14 +136786,14 @@ gpG
 iZY
 qkN
 vzJ
-kqH
-xxP
+uuh
+mZD
 vem
 kKi
 kKi
 kKi
 iBb
-goO
+mZD
 fYs
 xgR
 vSa
@@ -139049,8 +136809,8 @@ jTi
 jTi
 qfT
 prq
-rXD
-maT
+oEL
+jTi
 npZ
 prq
 rXD
@@ -139814,7 +137574,7 @@ bHn
 qhK
 glG
 yjF
-qsK
+kPH
 iiI
 dCh
 ooT
@@ -140568,14 +138328,14 @@ qxS
 iYd
 hQJ
 byL
-xox
-goO
+ibS
+mZD
 utn
 xqx
 wAZ
 kPE
 jLK
-xxP
+mZD
 xcs
 pMc
 bnz
@@ -140609,7 +138369,7 @@ evr
 mqC
 hBy
 evr
-evr
+bzS
 evr
 sAL
 unj
@@ -140866,7 +138626,7 @@ gVf
 tGh
 njR
 sKS
-enP
+hMk
 phR
 sGJ
 noM
@@ -142401,7 +140161,7 @@ bUi
 bWy
 bYH
 bQg
-gOY
+qyj
 eHv
 lIU
 oVk
@@ -142639,7 +140399,7 @@ aRx
 kPH
 kPH
 ndO
-qsK
+kPH
 xao
 wGx
 eqa
@@ -142687,7 +140447,7 @@ cNd
 cNd
 sUE
 cTH
-kBU
+ftI
 cXa
 cYQ
 cTG
@@ -142896,7 +140656,7 @@ aRx
 alf
 bqm
 bug
-bug
+eiK
 bvs
 fiE
 bug
@@ -143203,7 +140963,7 @@ cRY
 cTJ
 tUy
 rvL
-jgC
+cYU
 xGe
 dch
 ddR
@@ -144743,7 +142503,7 @@ cNd
 cQv
 dcj
 cTJ
-lGZ
+tab
 cXf
 cYU
 xGe
@@ -145560,7 +143320,7 @@ uIr
 sev
 ert
 nbF
-eap
+tku
 dLY
 ebO
 ecr
@@ -146054,7 +143814,7 @@ dDn
 dEq
 dFI
 dHh
-xEP
+bpL
 dJT
 drP
 dLT
@@ -146508,8 +144268,8 @@ hoS
 dLb
 qLe
 tXr
-rJT
-sVj
+tst
+cBV
 bWC
 bWC
 nJo
@@ -146525,7 +144285,7 @@ sHr
 hzg
 ybZ
 oXH
-tfu
+nJo
 mcZ
 ocw
 lOk
@@ -147196,7 +144956,7 @@ wav
 abe
 abp
 abC
-dlS
+abC
 abZ
 abC
 abC
@@ -147870,7 +145630,7 @@ wjX
 tSz
 ipa
 kTD
-ipa
+giT
 nPB
 ekH
 uJK
@@ -148067,7 +145827,7 @@ kBt
 tIV
 kBt
 hQk
-tfu
+nJo
 vzF
 eTH
 tNO
@@ -148127,7 +145887,7 @@ ofJ
 jHF
 vGL
 eFq
-nAh
+xCb
 awf
 xCb
 rfm
@@ -148547,7 +146307,7 @@ jQY
 gJO
 vHS
 qZr
-cJW
+qZr
 vhQ
 nHT
 jiK
@@ -148556,7 +146316,7 @@ qZr
 qZr
 wWP
 tst
-rJT
+tst
 fVr
 fVr
 scZ
@@ -148813,7 +146573,7 @@ lqP
 poj
 lPY
 lqP
-lqP
+hsR
 hfl
 hfl
 tvS
@@ -149388,7 +147148,7 @@ xih
 tfn
 kRs
 uGB
-kTo
+sjF
 qcg
 hVF
 uBG
@@ -149423,7 +147183,7 @@ nlB
 uBK
 nPB
 tDT
-tLc
+uRT
 ujV
 nPB
 aad
@@ -149594,14 +147354,14 @@ wEA
 wEA
 lRN
 wpW
-wdM
+vPh
 bOF
 twc
 twc
 twc
 twc
 aPg
-uZi
+vPh
 wpW
 wpW
 wpW
@@ -149815,14 +147575,14 @@ wcz
 rAw
 aXI
 aXI
-hVS
+ncV
 kIC
 khK
 imN
 qvB
 yhE
 pbj
-hWe
+kEi
 pUY
 eJR
 oJG
@@ -149932,8 +147692,8 @@ qEv
 mhj
 jtP
 hPv
-gSp
-xAy
+gsq
+nlB
 ixI
 iGq
 xsm
@@ -150085,7 +147845,7 @@ sGZ
 pLf
 rmH
 kEi
-reI
+aAA
 nHt
 omF
 kEi
@@ -150111,7 +147871,7 @@ wpW
 wpW
 erd
 iIt
-tIq
+wpW
 iIt
 nDx
 iIt
@@ -150303,8 +148063,8 @@ aad
 aad
 aaO
 tRN
-ajV
-wyo
+jrC
+ldY
 eLb
 xNl
 ewj
@@ -151097,7 +148857,7 @@ aXI
 heA
 gje
 heA
-mRe
+aXI
 aXI
 aXI
 wTb
@@ -151363,7 +149123,7 @@ ofO
 ofO
 ofO
 bDy
-rFn
+ofO
 cnV
 sRg
 qhd
@@ -151644,7 +149404,7 @@ qJA
 oOD
 hZw
 hML
-nYj
+qrD
 nYj
 gqP
 nYj
@@ -151661,7 +149421,7 @@ ocD
 wVo
 iYA
 reS
-hhG
+vCj
 wpW
 lpc
 oaQ
@@ -151887,11 +149647,11 @@ fGQ
 qrQ
 jTU
 olH
-hWe
+kEi
 xha
 pRf
 djc
-uZi
+vPh
 aad
 aad
 aad
@@ -152496,12 +150256,12 @@ dUx
 dVZ
 dUx
 dXM
-dYF
-dZo
+dST
+kRh
 vIQ
 dUx
 ebl
-dYF
+dST
 ecG
 dUx
 kQA
@@ -152619,11 +150379,11 @@ lET
 anm
 lAM
 abZ
-yaW
+anm
 anm
 aol
 api
-api
+bia
 abZ
 arL
 tXb
@@ -152908,7 +150668,7 @@ ofO
 ofO
 vIJ
 utc
-hWe
+kEi
 lcu
 gVj
 fMv
@@ -152928,7 +150688,7 @@ fec
 skj
 vxf
 doR
-nll
+too
 bKH
 bMy
 bOH
@@ -153010,16 +150770,16 @@ ecY
 dVZ
 dUx
 dXN
-dYH
+dST
 dZp
 vIQ
 dUx
 ebm
-dYH
+dST
 ecH
 dUx
 gER
-eee
+edY
 eeM
 efz
 egm
@@ -153132,13 +150892,13 @@ aaO
 qQv
 akf
 akJ
-alx
+abf
 amo
 ann
 aom
 ufw
 aqm
-aly
+abf
 arM
 fcn
 aum
@@ -153524,12 +151284,12 @@ dUz
 dWd
 dWV
 dXM
-dYF
+dST
 dZq
 vIQ
 dUx
-dXL
-dYF
+igB
+dST
 ecG
 dUx
 gER
@@ -154160,13 +151920,13 @@ aaO
 tRN
 aco
 akN
-aly
+abf
 ams
 mIm
 aom
 apn
 aqq
-alx
+abf
 arQ
 fcn
 aup
@@ -154470,7 +152230,7 @@ iDp
 bIW
 tLO
 gYD
-lEA
+too
 bKH
 bME
 bON
@@ -154929,7 +152689,7 @@ aad
 aad
 aaO
 tRN
-gxN
+hxG
 akP
 akP
 lXL
@@ -154980,7 +152740,7 @@ aaa
 khQ
 fny
 uEl
-kjo
+wQK
 nzz
 oOD
 gdT
@@ -155212,7 +152972,7 @@ vLs
 wjV
 uhJ
 kuv
-kuv
+ujM
 flz
 hyF
 fmd
@@ -155291,7 +153051,7 @@ dgX
 dis
 mCn
 dlU
-pCo
+fYL
 dpi
 dcO
 dcO
@@ -155469,7 +153229,7 @@ jtJ
 xuZ
 xaj
 oFV
-rXo
+iZZ
 vbX
 iZZ
 iZZ
@@ -155478,18 +153238,18 @@ vTt
 rqC
 llC
 kvl
-lEF
+unx
 bdS
 bfo
 iUE
 bfo
 mam
 blJ
-bnx
+bdN
 xha
 bkA
 djc
-uZi
+vPh
 aad
 aad
 aad
@@ -156021,7 +153781,7 @@ lxe
 cqC
 pSs
 aVP
-hYS
+hmb
 dKL
 ktU
 wCo
@@ -156045,7 +153805,7 @@ eEK
 kqG
 tnm
 plg
-xCi
+lmO
 kTm
 eLz
 jPm
@@ -156199,19 +153959,19 @@ adc
 abD
 abD
 abD
-abD
+cOm
 abD
 lQQ
 abD
 abD
-abD
+cOm
 kjD
 abD
 ahz
 adc
 abD
 abD
-pXt
+aiU
 aji
 aju
 bOP
@@ -156269,7 +154029,7 @@ nqS
 fec
 pzs
 stn
-lrr
+glH
 mcF
 gaN
 qPs
@@ -156311,9 +154071,9 @@ pzC
 hVx
 ici
 pxG
-dbi
 pxG
-der
+pxG
+pxG
 pxG
 dhb
 diu
@@ -156456,12 +154216,12 @@ abi
 abi
 abi
 abi
-aeB
+abi
 afc
 tzF
 abi
 abi
-aeB
+abi
 qCZ
 aht
 abi
@@ -156545,7 +154305,7 @@ qrM
 fxe
 faH
 oSn
-gbE
+srY
 oSi
 cup
 vZj
@@ -156782,7 +154542,7 @@ fFy
 iLS
 nzz
 oOD
-pdJ
+thX
 glH
 omM
 xYd
@@ -157070,7 +154830,7 @@ eND
 myM
 nOD
 mLk
-uhF
+wnW
 rWa
 irp
 xCi
@@ -158386,7 +156146,7 @@ dyw
 dri
 poe
 vxF
-wRa
+vdc
 ePK
 nGs
 iBZ
@@ -158888,7 +156648,7 @@ dfD
 dbr
 diE
 oGK
-cNB
+cPy
 cNz
 dbr
 dbr
@@ -159414,7 +157174,7 @@ qgk
 qnO
 kdN
 qgk
-nDd
+qgk
 kct
 qgk
 wTq
@@ -159846,8 +157606,8 @@ sWJ
 rEc
 uOw
 nYU
-iaV
-xOr
+oBs
+jjB
 wTy
 wnk
 eID
@@ -159930,7 +157690,7 @@ sgL
 grl
 fuv
 kct
-hzE
+qgk
 oLE
 ubA
 ivY
@@ -160430,7 +158190,7 @@ riX
 dho
 diM
 uGj
-cNB
+cPy
 cNz
 dbr
 dbr
@@ -160590,7 +158350,7 @@ aig
 aad
 aoE
 qaK
-aqE
+aAS
 aqE
 ase
 atB
@@ -160687,7 +158447,7 @@ riX
 cPv
 diJ
 bLm
-qZb
+rtI
 lQF
 xkU
 xkU
@@ -160849,7 +158609,7 @@ aoF
 qVV
 aoF
 aoF
-asf
+czv
 atC
 pZn
 aoF
@@ -161972,8 +159732,8 @@ ovU
 cPv
 diM
 mWI
-dmb
-dnD
+dma
+pgz
 dnD
 drn
 dsK
@@ -162754,7 +160514,7 @@ dxl
 dyG
 dma
 dBs
-dCP
+qrf
 dEg
 rLD
 xNr
@@ -163484,7 +161244,7 @@ fof
 plV
 coK
 fAX
-tSy
+fAX
 knJ
 yfe
 oRC
@@ -163494,7 +161254,7 @@ ffY
 mDs
 oEu
 bqz
-tSy
+fAX
 fAX
 vbb
 vbb
@@ -164322,7 +162082,7 @@ kbC
 dZE
 dQl
 eaO
-ebx
+dQl
 dQl
 dPq
 aad
@@ -165082,7 +162842,7 @@ aad
 dPq
 dRl
 phH
-dYb
+fjO
 dTZ
 dPq
 dPq
@@ -166273,7 +164033,7 @@ xjZ
 aZo
 whb
 bcN
-beq
+wyK
 oLd
 bhc
 biF
@@ -167075,7 +164835,7 @@ jcC
 cbE
 cdq
 iZC
-cha
+chc
 ciJ
 bgZ
 clG
@@ -168873,7 +166633,7 @@ bXR
 bZY
 cbL
 bLs
-cfr
+pft
 chg
 cfr
 bgZ
@@ -169362,7 +167122,7 @@ aad
 aad
 frV
 luH
-xnI
+ybi
 ybi
 fUR
 ybi
@@ -170390,11 +168150,11 @@ aad
 aad
 frV
 nkf
-igb
+ybi
 ybi
 gjC
 oIN
-kfo
+oIN
 kiw
 frV
 aaa
@@ -171164,7 +168924,7 @@ frV
 cCv
 ybi
 xPU
-wKz
+ybi
 uyO
 frV
 aad
@@ -174546,7 +172306,7 @@ ajr
 aaa
 ajr
 aad
-eLE
+oNH
 lIP
 pwR
 gtA


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the lights and wallmounts on Deltastation to directional mounts introduced in #58809
The final one... I've seen too much.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
When the wallening gets here, will allow us to switch the directions of all of the lights at once (which we'll need) and not have to manually set wall mount dirs. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
