### PR TITLE
Fix jatum

### DIFF
--- a/code/__HELPERS/jatum.dm
+++ b/code/__HELPERS/jatum.dm
@@ -80,15 +80,13 @@
 		// Serialize all lists as dicts, list("a") and list("a" = null) can't be differentiated in DM
 		var/list_contents = list()
 		for(var/key in value)
-			var/got_l_value
 			var/l_value
 			try
 				l_value = value[key]
-				got_l_value = TRUE
 			catch
 				// Expected, indicates a flat list
 
-			if(got_l_value)
+			if(l_value)
 				list_contents += list(list(
 					"key" = _jatum_serialize_value(key, seen_references),
 					"value" = _jatum_serialize_value(l_value, seen_references)

--- a/code/__HELPERS/jatum.dm
+++ b/code/__HELPERS/jatum.dm
@@ -86,7 +86,7 @@
 			catch
 				// Expected, indicates a flat list
 
-			if(l_value)
+			if(!isnull(l_value))
 				list_contents += list(list(
 					"key" = _jatum_serialize_value(key, seen_references),
 					"value" = _jatum_serialize_value(l_value, seen_references)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Jatum was not hanling non assoc list very well, due to a try not throwing an error like it should. This fixes that

Note that jatum still cannot be 100% trusted with datum serialisation, as it bugs out in this specific case:

datum/a
      var/datum/b/a_datum
      var/list/datum/b/a_list_of_datum_b

if a_datum is in a_list_of_datum_b, jatum will not correctly deserialise the full list (as the reference is already seen)

The fix was tested for : https://github.com/tgstation/TerraGov-Marine-Corps/pull/6599

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Jatum handles better non-assoc list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
