### PR TITLE
Issue #29019 medical borgs on skateboards look weird

### DIFF
--- a/code/datums/components/riding/riding.dm
+++ b/code/datums/components/riding/riding.dm
@@ -48,7 +48,7 @@
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
 
-	handle_specials()
+	handle_specials(riding_mob)
 	riding_mob.updating_glide_size = FALSE
 	ride_check_flags |= buckle_mob_flags
 

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -140,7 +140,7 @@
 	if(iscyborg(riding_mob))
 		set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0), TEXT_SOUTH = list(0), TEXT_EAST = list(0), TEXT_WEST = list(2)))
 	else
-		set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list( 2), TEXT_SOUTH = list(-2), TEXT_EAST = list(0), TEXT_WEST = list( 2)))
+		set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(2), TEXT_SOUTH = list(-2), TEXT_EAST = list(0), TEXT_WEST = list(2)))
 
 /datum/component/riding/vehicle/scooter/skateboard
 	vehicle_move_delay = 1.5

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -137,7 +137,7 @@
 
 /datum/component/riding/vehicle/scooter/handle_specials(mob/living/riding_mob)
 	. = ..()
-	if(istype(riding_mob, obj/item/robot_model/medical))
+	if(iscyborg(riding_mob))
 		set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0), TEXT_SOUTH = list(0), TEXT_EAST = list(0), TEXT_WEST = list( 2)))
 	else
 		set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list( 2), TEXT_SOUTH = list(-2), TEXT_EAST = list(0), TEXT_WEST = list( 2)))

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -137,7 +137,7 @@
 
 /datum/component/riding/vehicle/scooter/handle_specials(mob/living/riding_mob)
 	. = ..()
-	if(iscyborg(riding_mob) && istype(riding_mob, /mob/living/silicon/robot/medical))
+	if(istype(riding_mob, obj/item/robot_model/medical))
 		set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0), TEXT_SOUTH = list(0), TEXT_EAST = list(0), TEXT_WEST = list( 2)))
 	else
 		set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list( 2), TEXT_SOUTH = list(-2), TEXT_EAST = list(0), TEXT_WEST = list( 2)))

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -135,9 +135,12 @@
 /datum/component/riding/vehicle/scooter
 	ride_check_flags = RIDER_NEEDS_LEGS | RIDER_NEEDS_ARMS | UNBUCKLE_DISABLED_RIDER
 
-/datum/component/riding/vehicle/scooter/handle_specials()
+/datum/component/riding/vehicle/scooter/handle_specials(mob/living/riding_mob)
 	. = ..()
-	set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0), TEXT_SOUTH = list(-2), TEXT_EAST = list(0), TEXT_WEST = list( 2)))
+	if(iscyborg(riding_mob) && istype(riding_mob, /mob/living/silicon/robot/medical))
+		set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0), TEXT_SOUTH = list(0), TEXT_EAST = list(0), TEXT_WEST = list( 2)))
+	else
+		set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list( 2), TEXT_SOUTH = list(-2), TEXT_EAST = list(0), TEXT_WEST = list( 2)))
 
 /datum/component/riding/vehicle/scooter/skateboard
 	vehicle_move_delay = 1.5

--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -138,7 +138,7 @@
 /datum/component/riding/vehicle/scooter/handle_specials(mob/living/riding_mob)
 	. = ..()
 	if(iscyborg(riding_mob))
-		set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0), TEXT_SOUTH = list(0), TEXT_EAST = list(0), TEXT_WEST = list( 2)))
+		set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0), TEXT_SOUTH = list(0), TEXT_EAST = list(0), TEXT_WEST = list(2)))
 	else
 		set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list( 2), TEXT_SOUTH = list(-2), TEXT_EAST = list(0), TEXT_WEST = list( 2)))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the cyborgs consistent on scooters and its skateboard subtypes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the vehicle_specials() proc aware of what the rider is.
Fixes #29019

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed cyborgs using the carbon's offset on scooters and skateboards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
