### PR TITLE
Fixes trashbags fitting in janitor wintercoats

### DIFF
--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -129,7 +129,6 @@
 		/obj/item/reagent_containers/glass/bucket,
 		/obj/item/reagent_containers/spray,
 		/obj/item/soap,
-		/obj/item/storage/bag/trash,
 	)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/janitor
 


### PR DESCRIPTION
## About The Pull Request

Long ago, #50940 happened which made trashbags unable to be equipped in an item slot. Months after, #56854 was made and the winter coat it added did not account for the months-old PR (probably because it was a port from another codebase).

## Why It's Good For The Game

Unintentionaaaaaaaaaaaaaal

## Changelog
:cl:
fix: Fixed trashbags being able to be equipped on janitor wintercoats.
/:cl: