### PR TITLE
Fix regal rat runtime with target being deleted

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -96,7 +96,12 @@
 /mob/living/simple_animal/hostile/regalrat/AttackingTarget()
 	if (DOING_INTERACTION(src, "regalrat"))
 		return
+
 	. = ..()
+
+	if (QDELETED(target))
+		return
+
 	if (target.reagents && target.is_injectable(src, allowmobs = TRUE))
 		src.visible_message("<span class='warning'>[src] starts licking [target] passionately!</span>","<span class='notice'>You start licking [target]...</span>")
 		if (do_mob(src, target, 2 SECONDS, interaction_key = "regalrat"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The target was being deleted by the attack_animal call. What was actually being deleted and why it's only happening now, I don't know and I'm too tired to care.