### PR TITLE
big connect_loc fix. teleporters dont cause runtimes and movables registered to things entering their turf no longer have themselves entering their turf sent to them

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -384,8 +384,6 @@
 	#define COMPONENT_MOVABLE_BLOCK_PRE_MOVE (1<<0)
 ///from base of atom/movable/Moved(): (/atom, dir)
 #define COMSIG_MOVABLE_MOVED "movable_moved"
-///from base of atom/movable/update_loc(): (/atom/oldloc)
-#define COMSIG_MOVABLE_LOCATION_CHANGE "location_changed"
 ///from base of atom/movable/Cross(): (/atom/movable)
 #define COMSIG_MOVABLE_CROSS "movable_cross"
 ///from base of atom/movable/Move(): (/atom/movable)

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -82,9 +82,7 @@
 
 /datum/element/connect_loc/proc/on_moved(atom/movable/tracked, atom/old_loc)
 	SIGNAL_HANDLER
-	//loc1 -> loc2 -> loc3, but Moved(loc2) (when loc == loc3) happens before Moved(loc1) (when loc == loc2)
-	//it needs to somehow only update the second Moved() (at loc == loc3)
-	//so the actual Moved() that updates connect_loc should be Moved(loc1) (at loc == loc3)
+
 	var/datum/listener = targets[old_loc][tracked]
 	unregister_signals(listener, tracked, old_loc)
 	update_signals(listener, tracked)

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -24,7 +24,7 @@
 
 	src.connections = connections
 
-	RegisterSignal(tracked, COMSIG_MOVABLE_LOCATION_CHANGE, .proc/on_moved, override=TRUE)
+	RegisterSignal(tracked, COMSIG_MOVABLE_MOVED, .proc/on_moved)
 	update_signals(listener, tracked)
 
 /datum/element/connect_loc/Detach(datum/listener, atom/movable/tracked, list/connections)
@@ -82,7 +82,9 @@
 
 /datum/element/connect_loc/proc/on_moved(atom/movable/tracked, atom/old_loc)
 	SIGNAL_HANDLER
-
+	//loc1 -> loc2 -> loc3, but Moved(loc2) (when loc == loc3) happens before Moved(loc1) (when loc == loc2)
+	//it needs to somehow only update the second Moved() (at loc == loc3)
+	//so the actual Moved() that updates connect_loc should be Moved(loc1) (at loc == loc3)
 	var/datum/listener = targets[old_loc][tracked]
 	unregister_signals(listener, tracked, old_loc)
 	update_signals(listener, tracked)

--- a/code/datums/elements/connect_loc.dm
+++ b/code/datums/elements/connect_loc.dm
@@ -24,7 +24,7 @@
 
 	src.connections = connections
 
-	RegisterSignal(tracked, COMSIG_MOVABLE_MOVED, .proc/on_moved)
+	RegisterSignal(tracked, COMSIG_MOVABLE_MOVED, .proc/on_moved, override = TRUE)
 	update_signals(listener, tracked)
 
 /datum/element/connect_loc/Detach(datum/listener, atom/movable/tracked, list/connections)
@@ -34,7 +34,7 @@
 		unregister_all(listener)
 	else if(targets[tracked.loc]) // Detach can happen multiple times due to qdel
 		unregister_signals(listener, tracked, tracked.loc)
-		UnregisterSignal(tracked, COMSIG_MOVABLE_LOCATION_CHANGE)
+		UnregisterSignal(tracked, COMSIG_MOVABLE_MOVED)
 
 /datum/element/connect_loc/proc/update_signals(datum/listener, atom/movable/tracked)
 	var/existing = length(targets[tracked.loc])
@@ -62,7 +62,7 @@
 				unregister_signals(listener, tracked, location)
 			else
 				continue
-			UnregisterSignal(tracked, COMSIG_MOVABLE_LOCATION_CHANGE)
+			UnregisterSignal(tracked, COMSIG_MOVABLE_MOVED)
 
 /datum/element/connect_loc/proc/unregister_signals(datum/listener, atom/movable/tracked, atom/old_loc)
 	if (length(targets[old_loc]) <= 1)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -366,16 +366,6 @@
 	loc = new_loc
 	Moved(old_loc)
 
-/**
- * meant to be used for all location changes. any instances of setting loc directly (for movables) should instead use this
- * do NOT use this directly, use either Move() or abstract_move() or forceMove()
- */
-/atom/movable/proc/update_loc(atom/new_loc)
-	SHOULD_NOT_OVERRIDE(TRUE)
-	var/old_loc = loc
-	loc = new_loc
-	SEND_SIGNAL(src, COMSIG_MOVABLE_LOCATION_CHANGE, old_loc)
-
 ////////////////////////////////////////
 // Here's where we rewrite how byond handles movement except slightly different
 // To be removed on step_ conversion

--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -8,7 +8,7 @@
 /obj/effect/temp_visual/point/Initialize(mapload, set_invis = 0)
 	. = ..()
 	var/atom/old_loc = loc
-	update_loc(get_turf(src))
+	abstract_move(get_turf(src))
 	pixel_x = old_loc.pixel_x
 	pixel_y = old_loc.pixel_y
 	invisibility = set_invis

--- a/code/modules/buildmode/effects/line.dm
+++ b/code/modules/buildmode/effects/line.dm
@@ -4,7 +4,7 @@
 
 /obj/effect/buildmode_line/New(client/C, atom/atom_a, atom/atom_b, linename)
 	name = linename
-	update_loc(get_turf(atom_a))
+	abstract_move(get_turf(atom_a))
 	I = image('icons/misc/mark.dmi', src, "line", 19.0)
 	var/x_offset = ((atom_b.x * 32) + atom_b.pixel_x) - ((atom_a.x * 32) + atom_a.pixel_x)
 	var/y_offset = ((atom_b.y * 32) + atom_b.pixel_y) - ((atom_a.y * 32) + atom_a.pixel_y)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -105,7 +105,7 @@ All ShuttleMove procs go here
 	if(loc != oldT) // This is for multi tile objects
 		return
 
-	update_loc(newT)
+	abstract_move(newT)
 
 	return TRUE
 
@@ -385,7 +385,7 @@ All ShuttleMove procs go here
 	if(loc != oldT) // This is for multi tile objects
 		return
 
-	update_loc(newT)
+	abstract_move(newT)
 
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #59080

title, also removes update_loc() and COMSIG_MOVABLE_LOCATION_CHANGE and makes connect_loc register to COMSIG_MOVABLE_MOVED (Moved() is also now in the father atom/movable/Move() proc instead of its child so its called for all tile movements)

the problem is that if you move onto a portal, but connect_loc registers and deregisters on Moved() instead of update_loc() (so that you dont get sent yourself moving onto the tile)

Move() will be called from loc1 moving to loc2 (where the portal is)
loc = loc2
loc2.Entered() will be called
now the COMSIG_ATOM_ENTERED signal is sent to loc2, which the portal is registered to
    portal/on_entered() calls do_teleport()
    do_teleport() calls forceMove() from loc2 to loc3 (the location of the second portal the first is linked to)
    loc = loc3
    loc3.Entered()
    THEN Moved(OldLoc = loc2) is called, but the Moved() from the first Move() call was never reached yet, so when connect_loc
    tries to update your location all it has stored is loc1 in the targets list, so it will runtime
    
the forceMove() call ends and youve teleported to loc3,
now Moved(OldLoc = loc1) is called in the original Move() proc
connect_loc now updates where its stored your position from loc1 to loc3

so to fix this i made Moved() not call if (number of times a movement proc started in this call stack) - (number of times Moved() has been called in this callstack) > 0, so connect_loc will only update on the very last Moved() call in a single callstack
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
this issue might be contributing to the CI errors we're getting but definitely contributes to like 5 errors at least from the Crossed refactor related to things interacting with themselves when moving (like singularities eating themselves)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: singularities will no longer eat themselves, among other things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
