### PR TITLE
Makes timer subsystems available as a new subsystem type

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -66,6 +66,13 @@
 }\
 /datum/controller/subsystem/##X
 
+#define TIMER_DEF(X) GLOBAL_REAL(SS##X, /datum/controller/subsystem/timer/##X);\
+/datum/controller/subsystem/timer/##X/New(){\
+	NEW_SS_GLOBAL(SS##X);\
+	PreInit();\
+}\
+/datum/controller/subsystem/timer/##X
+
 #define PROCESSING_SUBSYSTEM_DEF(X) GLOBAL_REAL(SS##X, /datum/controller/subsystem/processing/##X);\
 /datum/controller/subsystem/processing/##X/New(){\
 	NEW_SS_GLOBAL(SS##X);\

--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -66,7 +66,7 @@
 }\
 /datum/controller/subsystem/##X
 
-#define TIMER_DEF(X) GLOBAL_REAL(SS##X, /datum/controller/subsystem/timer/##X);\
+#define TIMER_SUBSYSTEM_DEF(X) GLOBAL_REAL(SS##X, /datum/controller/subsystem/timer/##X);\
 /datum/controller/subsystem/timer/##X/New(){\
 	NEW_SS_GLOBAL(SS##X);\
 	PreInit();\

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -189,6 +189,7 @@
 #define FIRE_PRIORITY_OVERLAYS 500
 #define FIRE_PRIORITY_EXPLOSIONS 666
 #define FIRE_PRIORITY_TIMER 700
+#define FIRE_PRIORITY_SOUND_LOOPS 800
 #define FIRE_PRIORITY_INPUT 1000 // This must always always be the max highest priority. Player input must never be lost.
 
 

--- a/code/controllers/subsystem/sound_loops.dm
+++ b/code/controllers/subsystem/sound_loops.dm
@@ -1,0 +1,3 @@
+TIMER_DEF(sound_loops)
+	name = "Sound Loops"
+	priority = FIRE_PRIORITY_SOUND_LOOPS

--- a/code/controllers/subsystem/sound_loops.dm
+++ b/code/controllers/subsystem/sound_loops.dm
@@ -1,3 +1,3 @@
-TIMER_DEF(sound_loops)
+TIMER_SUBSYSTEM_DEF(sound_loops)
 	name = "Sound Loops"
 	priority = FIRE_PRIORITY_SOUND_LOOPS

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -64,7 +64,7 @@
 	if(!timerid)
 		return
 	on_stop()
-	deltimer(timerid)
+	deltimer(timerid, SStimer)
 	timerid = null
 
 /datum/looping_sound/proc/sound_loop(starttime)
@@ -74,7 +74,7 @@
 	if(!chance || prob(chance))
 		play(get_sound(starttime))
 	if(!timerid)
-		timerid = addtimer(CALLBACK(src, .proc/sound_loop, world.time), mid_length, TIMER_CLIENT_TIME | TIMER_STOPPABLE | TIMER_LOOP)
+		timerid = addtimer(CALLBACK(src, .proc/sound_loop, world.time), mid_length, TIMER_CLIENT_TIME | TIMER_STOPPABLE | TIMER_LOOP, SSsound_loops)
 
 /datum/looping_sound/proc/play(soundfile, volume_override)
 	var/list/atoms_cache = output_atoms
@@ -99,7 +99,7 @@
 	if(start_sound)
 		play(start_sound, start_volume)
 		start_wait = start_length
-	addtimer(CALLBACK(src, .proc/sound_loop), start_wait, TIMER_CLIENT_TIME)
+	addtimer(CALLBACK(src, .proc/sound_loop), start_wait, TIMER_CLIENT_TIME, SSsound_loops)
 
 /datum/looping_sound/proc/on_stop()
 	if(end_sound)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -346,6 +346,7 @@
 #include "code\controllers\subsystem\server_maint.dm"
 #include "code\controllers\subsystem\shuttle.dm"
 #include "code\controllers\subsystem\skills.dm"
+#include "code\controllers\subsystem\sound_loops.dm"
 #include "code\controllers\subsystem\sounds.dm"
 #include "code\controllers\subsystem\spacedrift.dm"
 #include "code\controllers\subsystem\statpanel.dm"


### PR DESCRIPTION
After some discussion with @MrStonedOne we decided that the current timer subsystem is too big and subtypes were merited so we could properly prioritize timers instead of throwing them all into one subsystem. This gives us the capability to deal with some of the stranger symptoms of lag that happen when the timer subsystem is unable to keep up by slowing down less important timers first. For now this is just sound loops.
