### PR TITLE
Deletes a comment that has been lying to me for months.

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -444,7 +444,7 @@
 	M.verb_whisper = initial(verb_whisper)
 	M.verb_sing = initial(verb_sing)
 	M.verb_yell = initial(verb_yell)
-	REMOVE_TRAIT(M, TRAIT_SIGN_LANG, ORGAN_TRAIT) //People who are Ahealed get "cured" of their sign language-having ways. If I knew how to make the tied tongue persist through aheals, I'd do that.
+	REMOVE_TRAIT(M, TRAIT_SIGN_LANG, ORGAN_TRAIT)
 
 //Thank you Jwapplephobia for helping me with the literal hellcode below
 


### PR DESCRIPTION
## About The Pull Request

So when I originally made #57389 I saw a comment saying that ahealing someone with the tongue-tied quirk's tongue, will cause you to lose being tongue-tied. I'm not entirely sure if the change I made in said PR fixed it, but I went back to see if I can fix it, tested it in game, and it turns out it's already fixed.

Proof here: https://youtu.be/JFN1gaO6Kk8

## Changelog
Not needed.