### PR TITLE
Fixes layering for piggyback rides

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -78,8 +78,10 @@
 
 #define BELOW_MOB_LAYER 3.7
 #define LYING_MOB_LAYER 3.8
+#define MOB_BELOW_PIGGYBACK_LAYER 3.94
 //#define MOB_LAYER 4 //For easy recordkeeping; this is a byond define
 #define MOB_SHIELD_LAYER 4.01
+#define MOB_ABOVE_PIGGYBACK_LAYER 4.06
 #define ABOVE_MOB_LAYER 4.1
 #define WALL_OBJ_LAYER 4.25
 #define EDGED_TURF_LAYER 4.3

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -73,6 +73,9 @@
 		living_parent.log_message("is no longer being ridden by [former_rider]", LOG_ATTACK, color="pink")
 		former_rider.log_message("is no longer riding [living_parent]", LOG_ATTACK, color="pink")
 	remove_abilities(former_rider)
+	// We gotta reset those layers at some point, don't we?
+	former_rider.layer = MOB_LAYER
+	living_parent.layer = MOB_LAYER
 	return ..()
 
 /datum/component/riding/creature/driver_move(atom/movable/movable_parent, mob/living/user, direction)
@@ -210,14 +213,14 @@
 
 	if(!AM.buckle_lying) // rider is vertical, must be piggybacking
 		if(dir == SOUTH)
-			AM.layer = ABOVE_MOB_LAYER
+			AM.layer = MOB_ABOVE_PIGGYBACK_LAYER
 		else
-			AM.layer = OBJ_LAYER
+			AM.layer = MOB_BELOW_PIGGYBACK_LAYER
 	else  // laying flat, we must be firemanning the rider
 		if(dir == NORTH)
-			AM.layer = OBJ_LAYER
+			AM.layer = MOB_BELOW_PIGGYBACK_LAYER
 		else
-			AM.layer = ABOVE_MOB_LAYER
+			AM.layer = MOB_ABOVE_PIGGYBACK_LAYER
 
 /datum/component/riding/creature/human/get_offsets(pass_index)
 	var/mob/living/carbon/human/H = parent
@@ -251,9 +254,9 @@
 /datum/component/riding/creature/cyborg/handle_vehicle_layer(dir)
 	var/atom/movable/robot_parent = parent
 	if(dir == SOUTH)
-		robot_parent.layer = ABOVE_MOB_LAYER
+		robot_parent.layer = MOB_ABOVE_PIGGYBACK_LAYER
 	else
-		robot_parent.layer = OBJ_LAYER
+		robot_parent.layer = MOB_BELOW_PIGGYBACK_LAYER
 
 /datum/component/riding/creature/cyborg/get_offsets(pass_index) // list(dir = x, y, layer)
 	return list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(-6, 3), TEXT_WEST = list( 6, 3))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Did you know that getting off of someone while they were giving you a piggyback ride would never reset your layer back to MOB_LAYER, so that if you were behind them, you'd stay on OBJ_LAYER instead? You probably didn't, but it becomes annoying, especially for the downstreams where controlling the layers is possible, because the difference between MOB_LAYER and OBJ_LAYER is massive.

Thus, I created two defines especially for piggyback riding, to make it easier to handle and so the layer differences wouldn't be as abysmal as they currently are.

Also, I fixed the code so it would actually reset both the ridden and the rider's layer back to MOB_LAYER upon unbuckling, so you're not going to be stuck in OBJ_LAYER anymore.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Objects belong to OBJ_LAYER, not living beings.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:GoldenAlpharex
fix: You no longer get on the object layer when you're riding someone's back, and your layer now gets successfully reset upon unbuckling.
qol: The layer difference between the person at the front and at the back (layer-wise) during a piggyback ride isn't abysmal anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
