### PR TITLE
Minebot Fixes

### DIFF
--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -284,6 +284,7 @@
 		return
 	M.melee_damage_lower += 7
 	M.melee_damage_upper += 7
+	to_chat(user, "<span class='notice'>You increase the close-quarter combat abilities of [M.name].")
 	qdel(src)
 
 //Health
@@ -297,6 +298,7 @@
 		return
 	M.maxHealth += 45
 	M.updatehealth()
+	to_chat(user, "<span class='notice'>You reinforce the armor of [M.name].")
 	qdel(src)
 
 //AI

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -43,9 +43,9 @@
 
 /mob/living/simple_animal/hostile/mining_drone/Initialize()
 	. = ..()
-	
+
 	AddComponent(/datum/component/footstep, FOOTSTEP_OBJ_ROBOT, 1, -6, vary = TRUE)
-	
+
 	stored_gun = new(src)
 	var/datum/action/innate/minedrone/toggle_light/toggle_light_action = new()
 	toggle_light_action.Grant(src)
@@ -116,7 +116,7 @@
 	..()
 
 /mob/living/simple_animal/hostile/mining_drone/death()
-	DropOre(0)
+	DropOre()
 	if(stored_gun)
 		for(var/obj/item/borg/upgrade/modkit/M in stored_gun.modkits)
 			M.uninstall(stored_gun)
@@ -280,7 +280,7 @@
 
 /obj/item/mine_bot_upgrade/proc/upgrade_bot(mob/living/simple_animal/hostile/mining_drone/M, mob/user)
 	if(M.melee_damage_upper != initial(M.melee_damage_upper))
-		to_chat(user, "<span class='warning'>[src] already has a combat upgrade installed!</span>")
+		to_chat(user, "<span class='warning'>[M.name] already has a combat upgrade installed!</span>")
 		return
 	M.melee_damage_lower += 7
 	M.melee_damage_upper += 7
@@ -293,7 +293,7 @@
 
 /obj/item/mine_bot_upgrade/health/upgrade_bot(mob/living/simple_animal/hostile/mining_drone/M, mob/user)
 	if(M.maxHealth != initial(M.maxHealth))
-		to_chat(user, "<span class='warning'>[src] already has reinforced armor!</span>")
+		to_chat(user, "<span class='warning'>[M.name] already has reinforced armor!</span>")
 		return
 	M.maxHealth += 45
 	M.updatehealth()

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -321,8 +321,7 @@
 		minebot.melee_damage_lower = initial(minebot.melee_damage_lower) + base_damage_add
 		minebot.melee_damage_upper = initial(minebot.melee_damage_upper) + base_damage_add
 		minebot.move_to_delay = initial(minebot.move_to_delay) + base_speed_add
-		if(minebot.stored_gun)
-			minebot.stored_gun.overheat_time += base_cooldown_add
+		minebot.stored_gun?.overheat_time += base_cooldown_add
 
 #undef MINEDRONE_COLLECT
 #undef MINEDRONE_ATTACK

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -312,13 +312,14 @@
 	var/base_cooldown_add = 10 //base cooldown isn't reset to normal, it's just added on, since it's not practical to disable the cooldown module
 
 /obj/item/slimepotion/slime/sentience/mining/after_success(mob/living/user, mob/living/simple_animal/simple_mob)
-	if(istype(simple_mob, /mob/living/simple_animal/hostile/mining_drone))
-		var/mob/living/simple_animal/hostile/mining_drone/minebot = simple_mob
-		minebot.maxHealth = initial(minebot.maxHealth) + base_health_add
-		minebot.melee_damage_lower = initial(minebot.melee_damage_lower) + base_damage_add
-		minebot.melee_damage_upper = initial(minebot.melee_damage_upper) + base_damage_add
-		minebot.move_to_delay = initial(minebot.move_to_delay) + base_speed_add
-		minebot.stored_gun?.overheat_time += base_cooldown_add
+	if(!istype(simple_mob, /mob/living/simple_animal/hostile/mining_drone))
+		return
+	var/mob/living/simple_animal/hostile/mining_drone/minebot = simple_mob
+	minebot.maxHealth = initial(minebot.maxHealth) + base_health_add
+	minebot.melee_damage_lower = initial(minebot.melee_damage_lower) + base_damage_add
+	minebot.melee_damage_upper = initial(minebot.melee_damage_upper) + base_damage_add
+	minebot.move_to_delay = initial(minebot.move_to_delay) + base_speed_add
+	minebot.stored_gun?.overheat_time += base_cooldown_add
 
 #undef MINEDRONE_COLLECT
 #undef MINEDRONE_ATTACK

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -86,8 +86,7 @@
 	Field repairs can be done with a welder."}
 	if(stored_gun?.max_mod_capacity)
 		. += "<b>[stored_gun.get_remaining_mod_capacity()]%</b> mod capacity remaining."
-		for(var/upgrade in stored_gun.modkits)
-			var/obj/item/borg/upgrade/modkit/modkit = upgrade
+		for(var/obj/item/borg/upgrade/modkit/modkit as anything in stored_gun.modkits)
 			. += "<span class='notice'>There is \a [modkit] installed, using <b>[modkit.cost]%</b> capacity.</span>"
 
 /mob/living/simple_animal/hostile/mining_drone/welder_act(mob/living/user, obj/item/welder)
@@ -118,7 +117,7 @@
 /mob/living/simple_animal/hostile/mining_drone/death()
 	DropOre()
 	if(stored_gun)
-		for(var/obj/item/borg/upgrade/modkit/modkit in stored_gun.modkits)
+		for(var/obj/item/borg/upgrade/modkit/modkit as anything in stored_gun.modkits)
 			modkit.uninstall(stored_gun)
 	deathmessage = "blows apart!"
 	..()
@@ -141,10 +140,8 @@
 	if(istype(object, /obj/projectile/kinetic))
 		var/obj/projectile/kinetic/projectile = object
 		if(projectile.kinetic_gun)
-			for(var/upgrade in projectile.kinetic_gun.modkits)
-				var/obj/item/borg/upgrade/modkit/modkit = upgrade
-				if(istype(modkit, /obj/item/borg/upgrade/modkit/minebot_passthrough))
-					return TRUE
+			if (locate(/obj/item/borg/upgrade/modkit/minebot_passthrough) in projectile.kinetic_gun.modkits)
+				return TRUE
 	if(istype(object, /obj/projectile/destabilizer))
 		return TRUE
 

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -280,11 +280,11 @@
 
 /obj/item/mine_bot_upgrade/proc/upgrade_bot(mob/living/simple_animal/hostile/mining_drone/M, mob/user)
 	if(M.melee_damage_upper != initial(M.melee_damage_upper))
-		to_chat(user, "<span class='warning'>[M.name] already has a combat upgrade installed!</span>")
+		to_chat(user, "<span class='warning'>[M] already has a combat upgrade installed!</span>")
 		return
 	M.melee_damage_lower += 7
 	M.melee_damage_upper += 7
-	to_chat(user, "<span class='notice'>You increase the close-quarter combat abilities of [M.name].")
+	to_chat(user, "<span class='notice'>You increase the close-quarter combat abilities of [M].")
 	qdel(src)
 
 //Health
@@ -294,11 +294,11 @@
 
 /obj/item/mine_bot_upgrade/health/upgrade_bot(mob/living/simple_animal/hostile/mining_drone/M, mob/user)
 	if(M.maxHealth != initial(M.maxHealth))
-		to_chat(user, "<span class='warning'>[M.name] already has reinforced armor!</span>")
+		to_chat(user, "<span class='warning'>[M] already has reinforced armor!</span>")
 		return
 	M.maxHealth += 45
 	M.updatehealth()
-	to_chat(user, "<span class='notice'>You reinforce the armor of [M.name].")
+	to_chat(user, "<span class='notice'>You reinforce the armor of [M].")
 	qdel(src)
 
 //AI

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -86,11 +86,11 @@
 	Field repairs can be done with a welder."}
 	if(stored_gun?.max_mod_capacity)
 		. += "<b>[stored_gun.get_remaining_mod_capacity()]%</b> mod capacity remaining."
-		for(var/A in stored_gun.modkits)
-			var/obj/item/borg/upgrade/modkit/M = A
-			. += "<span class='notice'>There is \a [M] installed, using <b>[M.cost]%</b> capacity.</span>"
+		for(var/upgrade in stored_gun.modkits)
+			var/obj/item/borg/upgrade/modkit/modkit = upgrade
+			. += "<span class='notice'>There is \a [modkit] installed, using <b>[modkit.cost]%</b> capacity.</span>"
 
-/mob/living/simple_animal/hostile/mining_drone/welder_act(mob/living/user, obj/item/I)
+/mob/living/simple_animal/hostile/mining_drone/welder_act(mob/living/user, obj/item/welder)
 	..()
 	. = TRUE
 	if(mode == MINEDRONE_ATTACK)
@@ -101,25 +101,25 @@
 		to_chat(user, "<span class='info'>[src] is at full integrity.</span>")
 		return
 
-	if(I.use_tool(src, user, 0, volume=40))
+	if(welder.use_tool(src, user, 0, volume=40))
 		adjustBruteLoss(-15)
 		to_chat(user, "<span class='info'>You repair some of the armor on [src].</span>")
 
-/mob/living/simple_animal/hostile/mining_drone/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/mining_scanner) || istype(I, /obj/item/t_scanner/adv_mining_scanner))
+/mob/living/simple_animal/hostile/mining_drone/attackby(obj/item/item_used, mob/user, params)
+	if(istype(item_used, /obj/item/mining_scanner) || istype(item_used, /obj/item/t_scanner/adv_mining_scanner))
 		to_chat(user, "<span class='info'>You instruct [src] to drop any collected ore.</span>")
 		DropOre()
 		return
-	if(I.tool_behaviour == TOOL_CROWBAR || istype(I, /obj/item/borg/upgrade/modkit))
-		I.melee_attack_chain(user, stored_gun, params)
+	if(item_used.tool_behaviour == TOOL_CROWBAR || istype(item_used, /obj/item/borg/upgrade/modkit))
+		item_used.melee_attack_chain(user, stored_gun, params)
 		return
 	..()
 
 /mob/living/simple_animal/hostile/mining_drone/death()
 	DropOre()
 	if(stored_gun)
-		for(var/obj/item/borg/upgrade/modkit/M in stored_gun.modkits)
-			M.uninstall(stored_gun)
+		for(var/obj/item/borg/upgrade/modkit/modkit in stored_gun.modkits)
+			modkit.uninstall(stored_gun)
 	deathmessage = "blows apart!"
 	..()
 
@@ -136,16 +136,16 @@
 				to_chat(user, "<span class='info'>[src] has been set to attack hostile wildlife.</span>")
 		return
 
-/mob/living/simple_animal/hostile/mining_drone/CanAllowThrough(atom/movable/O)
+/mob/living/simple_animal/hostile/mining_drone/CanAllowThrough(atom/movable/object)
 	. = ..()
-	if(istype(O, /obj/projectile/kinetic))
-		var/obj/projectile/kinetic/K = O
-		if(K.kinetic_gun)
-			for(var/A in K.kinetic_gun.modkits)
-				var/obj/item/borg/upgrade/modkit/M = A
-				if(istype(M, /obj/item/borg/upgrade/modkit/minebot_passthrough))
+	if(istype(object, /obj/projectile/kinetic))
+		var/obj/projectile/kinetic/projectile = object
+		if(projectile.kinetic_gun)
+			for(var/upgrade in projectile.kinetic_gun.modkits)
+				var/obj/item/borg/upgrade/modkit/modkit = upgrade
+				if(istype(modkit, /obj/item/borg/upgrade/modkit/minebot_passthrough))
 					return TRUE
-	if(istype(O, /obj/projectile/destabilizer))
+	if(istype(object, /obj/projectile/destabilizer))
 		return TRUE
 
 /mob/living/simple_animal/hostile/mining_drone/proc/SetCollectBehavior()
@@ -178,10 +178,10 @@
 		SetOffenseBehavior()
 	return ..()
 
-/mob/living/simple_animal/hostile/mining_drone/OpenFire(atom/A)
-	if(CheckFriendlyFire(A))
+/mob/living/simple_animal/hostile/mining_drone/OpenFire(atom/target)
+	if(CheckFriendlyFire(target))
 		return
-	stored_gun.afterattack(A, src) //of the possible options to allow minebots to have KA mods, would you believe this is the best?
+	stored_gun.afterattack(target, src) //of the possible options to allow minebots to have KA mods, would you believe this is the best?
 
 /mob/living/simple_animal/hostile/mining_drone/proc/CollectOre()
 	for(var/obj/item/stack/ore/O in range(1, src))
@@ -272,19 +272,19 @@
 	icon_state = "door_electronics"
 	icon = 'icons/obj/module.dmi'
 
-/obj/item/mine_bot_upgrade/afterattack(mob/living/simple_animal/hostile/mining_drone/M, mob/user, proximity)
+/obj/item/mine_bot_upgrade/afterattack(mob/living/simple_animal/hostile/mining_drone/minebot, mob/user, proximity)
 	. = ..()
-	if(!istype(M) || !proximity)
+	if(!istype(minebot) || !proximity)
 		return
-	upgrade_bot(M, user)
+	upgrade_bot(minebot, user)
 
-/obj/item/mine_bot_upgrade/proc/upgrade_bot(mob/living/simple_animal/hostile/mining_drone/M, mob/user)
-	if(M.melee_damage_upper != initial(M.melee_damage_upper))
-		to_chat(user, "<span class='warning'>[M] already has a combat upgrade installed!</span>")
+/obj/item/mine_bot_upgrade/proc/upgrade_bot(mob/living/simple_animal/hostile/mining_drone/minebot, mob/user)
+	if(minebot.melee_damage_upper != initial(minebot.melee_damage_upper))
+		to_chat(user, "<span class='warning'>[minebot] already has a combat upgrade installed!</span>")
 		return
-	M.melee_damage_lower += 7
-	M.melee_damage_upper += 7
-	to_chat(user, "<span class='notice'>You increase the close-quarter combat abilities of [M].")
+	minebot.melee_damage_lower += 7
+	minebot.melee_damage_upper += 7
+	to_chat(user, "<span class='notice'>You increase the close-quarter combat abilities of [minebot].")
 	qdel(src)
 
 //Health
@@ -292,13 +292,13 @@
 /obj/item/mine_bot_upgrade/health
 	name = "minebot armor upgrade"
 
-/obj/item/mine_bot_upgrade/health/upgrade_bot(mob/living/simple_animal/hostile/mining_drone/M, mob/user)
-	if(M.maxHealth != initial(M.maxHealth))
-		to_chat(user, "<span class='warning'>[M] already has reinforced armor!</span>")
+/obj/item/mine_bot_upgrade/health/upgrade_bot(mob/living/simple_animal/hostile/mining_drone/minebot, mob/user)
+	if(minebot.maxHealth != initial(minebot.maxHealth))
+		to_chat(user, "<span class='warning'>[minebot] already has reinforced armor!</span>")
 		return
-	M.maxHealth += 45
-	M.updatehealth()
-	to_chat(user, "<span class='notice'>You reinforce the armor of [M].")
+	minebot.maxHealth += 45
+	minebot.updatehealth()
+	to_chat(user, "<span class='notice'>You reinforce the armor of [minebot].")
 	qdel(src)
 
 //AI
@@ -314,15 +314,15 @@
 	var/base_speed_add = 1
 	var/base_cooldown_add = 10 //base cooldown isn't reset to normal, it's just added on, since it's not practical to disable the cooldown module
 
-/obj/item/slimepotion/slime/sentience/mining/after_success(mob/living/user, mob/living/simple_animal/SM)
-	if(istype(SM, /mob/living/simple_animal/hostile/mining_drone))
-		var/mob/living/simple_animal/hostile/mining_drone/M = SM
-		M.maxHealth = initial(M.maxHealth) + base_health_add
-		M.melee_damage_lower = initial(M.melee_damage_lower) + base_damage_add
-		M.melee_damage_upper = initial(M.melee_damage_upper) + base_damage_add
-		M.move_to_delay = initial(M.move_to_delay) + base_speed_add
-		if(M.stored_gun)
-			M.stored_gun.overheat_time += base_cooldown_add
+/obj/item/slimepotion/slime/sentience/mining/after_success(mob/living/user, mob/living/simple_animal/simple_mob)
+	if(istype(simple_mob, /mob/living/simple_animal/hostile/mining_drone))
+		var/mob/living/simple_animal/hostile/mining_drone/minebot = simple_mob
+		minebot.maxHealth = initial(minebot.maxHealth) + base_health_add
+		minebot.melee_damage_lower = initial(minebot.melee_damage_lower) + base_damage_add
+		minebot.melee_damage_upper = initial(minebot.melee_damage_upper) + base_damage_add
+		minebot.move_to_delay = initial(minebot.move_to_delay) + base_speed_add
+		if(minebot.stored_gun)
+			minebot.stored_gun.overheat_time += base_cooldown_add
 
 #undef MINEDRONE_COLLECT
 #undef MINEDRONE_ATTACK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Did you know that minebots are currently worse than an ore box, for they just _delete_ the ores they contain when they die? Pretty dumb, I know, that's why I'm fixing it.

Also fixed some weird mistakes in some user feedback on the upgrades.

Also adds some chat feedback when the upgrades are successfully applied. Yay!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Minebots are no longer ore trashcans.

Also, less of "minebot armor upgrade already has reinforced armor!"

Also, less guessing whether or not the upgrades were successfully applied.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:GoldenAlpharex
fix: Minebots now drop their ores on death, they no longer bring them with themselves in the grave.
spellcheck: less "minebot armor upgrade already has reinforced armor!"
qol: Minebot upgrades now tell the user when they've been successfully applied.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
