### PR TITLE
Fixes geysers being unplungerable

### DIFF
--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -65,6 +65,8 @@
 		start_chemming()
 
 /obj/structure/geyser/attackby(obj/item/item, mob/user, params)
+	. = ..()
+
 	if(!istype(item, /obj/item/mining_scanner) && !istype(item, /obj/item/t_scanner/adv_mining_scanner))
 		return
 

--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -65,10 +65,8 @@
 		start_chemming()
 
 /obj/structure/geyser/attackby(obj/item/item, mob/user, params)
-	. = ..()
-
 	if(!istype(item, /obj/item/mining_scanner) && !istype(item, /obj/item/t_scanner/adv_mining_scanner))
-		return
+		return ..() //this runs the plunger code
 
 	if(discovered)
 		to_chat(user, "<span class='warning'>This geyser has already been discovered!</span>")


### PR DESCRIPTION
closes #59084 

:cl:
fix: geysers are now ACTUALLY plungerable
/:cl:

I never actually bothered to check if geysers were still plungerable, why would I? Plunger act is checked in the attack_by chain and I forgot to call it when adding scanner interactions