### PR TITLE
Add workflow_dispatch to GBP collection

### DIFF
--- a/.github/workflows/gbp_collect.yml
+++ b/.github/workflows/gbp_collect.yml
@@ -3,6 +3,7 @@ name: GBP Collection
 on:
   schedule:
   - cron: "20 * * * *"
+  workflow_dispatch:
 jobs:
   gbp_collection:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Lets the action be run manually, which is useful for debugging fail cases.

https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/