### PR TITLE
refactors rpg loot is now a global datum singleton and so is embedopocalypse and stickapocalypse 

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -34,6 +34,8 @@
 	#define CANCEL_PRE_RANDOM_EVENT (1<<0)
 /// a person somewhere has thrown something : (mob/living/carbon/carbon_thrower, target)
 #define COMSIG_GLOB_CARBON_THROW_THING	"!throw_thing"
+/// an obj/item is created! (obj/item/created_item)
+#define COMSIG_GLOB_NEW_ITEM "!new_item"
 
 /// signals from globally accessible objects
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1,12 +1,5 @@
 GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/effects/fire.dmi', "fire"))
 
-GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
-// if true, everyone item when created will have its name changed to be
-// more... RPG-like.
-
-GLOBAL_VAR_INIT(stickpocalypse, FALSE) // if true, all non-embeddable items will be able to harmlessly stick to people when thrown
-GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to embed in people, takes precedence over stickpocalypse
-
 /// Anything you can pick up and hold.
 /obj/item
 	name = "item"
@@ -225,6 +218,8 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 		if(damtype == BRUTE)
 			hitsound = "swing_hit"
 
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NEW_ITEM, src)
+
 /obj/item/Destroy()
 	item_flags &= ~DROPDEL //prevent reqdels
 	if(ismob(loc))
@@ -246,19 +241,6 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 
 /obj/item/ComponentInitialize()
 	. = ..()
-	// this proc says it's for initializing components, but we're initializing elements too because it's you and me against the world >:)
-	if(!LAZYLEN(embedding))
-		if(GLOB.embedpocalypse)
-			embedding = EMBED_POINTY
-			name = "pointy [name]"
-		else if(GLOB.stickpocalypse)
-			embedding = EMBED_HARMLESS
-			name = "sticky [name]"
-
-	updateEmbedding()
-
-	if(GLOB.rpg_loot_items)
-		AddComponent(/datum/component/fantasy)
 
 	if(sharpness && force > 5) //give sharp objects butchering functionality, for consistency
 		AddComponent(/datum/component/butchering, 80 * toolspeed)

--- a/code/modules/admin/verbs/highlander_datum.dm
+++ b/code/modules/admin/verbs/highlander_datum.dm
@@ -1,7 +1,6 @@
 
 GLOBAL_DATUM(highlander_controller, /datum/highlander_controller)
 
-
 /**
  * The highlander controller handles the admin highlander mode, if enabled.
  * It is first created when "there can only be one" triggers it, and it can be referenced from GLOB.highlander_controller

--- a/code/modules/events/wizard/embeddies.dm
+++ b/code/modules/events/wizard/embeddies.dm
@@ -50,11 +50,11 @@ GLOBAL_DATUM(global_funny_embedding, /datum/global_funny_embedding)
 ///signal sent by a new item being created.
 /datum/global_funny_embedding/proc/on_new_item_in_existence(datum/source, obj/item/created_item)
 	// this proc says it's for initializing components, but we're initializing elements too because it's you and me against the world >:)
-	if(LAZYLEN(embedding))
+	if(LAZYLEN(created_item.embedding))
 		return //already embeds to some degree, so whatever 🐀
 	created_item.embedding = embed_type
-	created_item.name = "[prefix] [name]"
-	updateEmbedding()
+	created_item.name = "[prefix] [created_item.name]"
+	created_item.updateEmbedding()
 
 /**
  * ### handle_current_items

--- a/code/modules/events/wizard/embeddies.dm
+++ b/code/modules/events/wizard/embeddies.dm
@@ -5,20 +5,13 @@
 	max_occurrences = 1
 	earliest_start = 0 MINUTES
 
+///behold... the only reason sticky is a subtype...
+/datum/round_event_control/wizard/embedpocalypse/canSpawnEvent(players_amt, gamemode)
+	if(GLOB.global_funny_embedding)
+		return FALSE
+
 /datum/round_event/wizard/embedpocalypse/start()
-	for(var/obj/item/I in world)
-		CHECK_TICK
-
-		if(!(I.flags_1 & INITIALIZED_1))
-			continue
-
-		if(!I.embedding || I.embedding == EMBED_HARMLESS)
-			I.embedding = EMBED_POINTY
-			I.updateEmbedding()
-			I.name = "pointy [I.name]"
-
-	GLOB.embedpocalypse = TRUE
-	GLOB.stickpocalypse = FALSE // embedpocalypse takes precedence over stickpocalypse
+	GLOB.global_funny_embedding = new /datum/global_funny_embedding/pointy
 
 /datum/round_event_control/wizard/embedpocalypse/sticky
 	name = "Make Everything Sticky"
@@ -27,20 +20,63 @@
 	max_occurrences = 1
 	earliest_start = 0 MINUTES
 
-/datum/round_event_control/wizard/embedpocalypse/sticky/canSpawnEvent(players_amt, gamemode)
-	if(GLOB.embedpocalypse)
-		return FALSE
-
 /datum/round_event/wizard/embedpocalypse/sticky/start()
-	for(var/obj/item/I in world)
+	GLOB.global_funny_embedding = new /datum/global_funny_embedding/sticky
+
+///set this to a new instance of a SUBTYPE of global_funny_embedding. The main type is a prototype and will runtime really hard
+GLOBAL_DATUM(global_funny_embedding, /datum/global_funny_embedding)
+
+/**
+ * ## global_funny_embedding!
+ *
+ * Stored in a global datum, and created when it is turned on via event or VV'ing the GLOB.embedpocalypse_controller to be a new /datum/global_funny_embedding.
+ * Gives every item in the world a prefix to their name, and...
+ * Makes every item in the world embed when thrown, but also hooks into global signals for new items created to also bless them with embed-ability(??).
+ */
+/datum/global_funny_embedding
+	var/embed_type = EMBED_POINTY
+	var/prefix = "error"
+
+/datum/global_funny_embedding/New()
+	. = ..()
+	//second operation takes MUCH longer, so lets set up signals first.
+	RegisterSignal(SSdcs, COMSIG_GLOB_NEW_ITEM, .proc/on_new_item_in_existence)
+	handle_current_items()
+
+/datum/global_funny_embedding/Destroy(force)
+	. = ..()
+	UnregisterSignal(SSdcs, COMSIG_GLOB_NEW_ITEM)
+
+///signal sent by a new item being created.
+/datum/global_funny_embedding/proc/on_new_item_in_existence(datum/source, obj/item/created_item)
+	// this proc says it's for initializing components, but we're initializing elements too because it's you and me against the world >:)
+	if(LAZYLEN(embedding))
+		return //already embeds to some degree, so whatever 🐀
+	created_item.embedding = embed_type
+	created_item.name = "[prefix] [name]"
+	updateEmbedding()
+
+/**
+ * ### handle_current_items
+ *
+ * Gives every viable item in the world the embed_type, and the prefix prefixed to the name.
+ */
+/datum/global_funny_embedding/proc/handle_current_items()
+	for(var/obj/item/embed_item in world)
 		CHECK_TICK
-
-		if(!(I.flags_1 & INITIALIZED_1))
+		if(!(embed_item.flags_1 & INITIALIZED_1))
 			continue
+		if(!embed_item.embedding)
+			embed_item.embedding = embed_type
+			embed_item.updateEmbedding()
+			embed_item.name = "[prefix] [embed_item.name]"
 
-		if(!I.embedding)
-			I.embedding = EMBED_HARMLESS
-			I.updateEmbedding()
-			I.name = "sticky [I.name]"
+///everything will be... POINTY!!!!
+/datum/global_funny_embedding/pointy
+	embed_type = EMBED_POINTY
+	prefix = "pointy"
 
-	GLOB.stickpocalypse = TRUE
+///everything will be... sticky? sure, why not
+/datum/global_funny_embedding/sticky
+	embed_type = EMBED_HARMLESS
+	prefix = "sticky"

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -6,28 +6,7 @@
 	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/rpgloot/start()
-	var/upgrade_scroll_chance = 0
-	for(var/obj/item/I in world)
-		CHECK_TICK
-
-		if(!(I.flags_1 & INITIALIZED_1) || QDELETED(I))
-			continue
-
-		I.AddComponent(/datum/component/fantasy)
-
-		if(istype(I, /obj/item/storage))
-			var/obj/item/storage/S = I
-			var/datum/component/storage/STR = S.GetComponent(/datum/component/storage)
-			if(prob(upgrade_scroll_chance) && S.contents.len < STR.max_items && !S.invisibility)
-				var/obj/item/upgradescroll/scroll = new(get_turf(S))
-				SEND_SIGNAL(S, COMSIG_TRY_STORAGE_INSERT, scroll, null, TRUE, TRUE)
-				upgrade_scroll_chance = max(0,upgrade_scroll_chance-100)
-				if(isturf(scroll.loc))
-					qdel(scroll)
-
-			upgrade_scroll_chance += 25
-
-	GLOB.rpg_loot_items = TRUE
+	GLOB.rpgloot_controller = new /datum/rpgloot_controller
 
 /obj/item/upgradescroll
 	name = "item fortification scroll"
@@ -41,14 +20,16 @@
 	var/can_backfire = TRUE
 	var/uses = 1
 
-/obj/item/upgradescroll/afterattack(obj/item/target, mob/user , proximity)
+/obj/item/upgradescroll/afterattack(obj/item/target, mob/user, proximity)
 	. = ..()
 	if(!proximity || !istype(target))
 		return
 
 	target.AddComponent(/datum/component/fantasy, upgrade_amount, null, null, can_backfire, TRUE)
 
-	if(--uses <= 0)
+	uses -= 1
+	if(!uses)
+		visible_message("<span class='warning'>[src] vanishes, its magic completely consumed from the fortification.</span>")
 		qdel(src)
 
 /obj/item/upgradescroll/unlimited
@@ -56,3 +37,59 @@
 	desc = "Somehow, this piece of paper can be applied to items to make them \"better\". This scroll is made from the tongues of dead paper wizards, and can be used an unlimited number of times, with no drawbacks."
 	uses = INFINITY
 	can_backfire = FALSE
+
+///Holds the global datum for rpgloot, so anywhere may check for its existence (it signals into whatever it needs to modify, so it shouldn't require fetching)
+GLOBAL_DATUM(rpgloot_controller, /datum/rpgloot_controller)
+
+/**
+ * ## rpgloot controller!
+ *
+ * Stored in a global datum, and created when rpgloot is turned on via event or VV'ing the GLOB.rpgloot_controller to be a new /datum/rpgloot_controller.
+ * Makes every item in the world fantasy, but also hooks into global signals for new items created to also bless them with fantasy.
+ *
+ * What do I mean by fantasy?
+ * * Items will have random qualities assigned to them
+ * * Good quality items will have positive buffs/special powers applied to them
+ * * Bad quality items will get the opposite!
+ * * All of this is reflected in a fitting name for the item
+ * * See fantasy.dm and read the component for more information :)
+ */
+/datum/rpgloot_controller
+
+/datum/rpgloot_controller/New()
+	. = ..()
+	//second operation takes MUCH longer, so lets set up signals first.
+	RegisterSignal(SSdcs, COMSIG_GLOB_NEW_ITEM, .proc/on_new_item_in_existence)
+	handle_current_items()
+
+///signal sent by a new item being created.
+/datum/rpgloot_controller/proc/on_new_item_in_existence(datum/source, obj/item/created_item)
+	created_item.AddComponent(/datum/component/fantasy)
+
+/**
+ * ### handle_current_items
+ *
+ * Gives every viable item in the world the fantasy component.
+ * If the item it is giving fantasy to is a storage item, there's a chance it'll drop in an item fortification scroll. neat!
+ */
+/datum/rpgloot_controller/proc/handle_current_items()
+	var/upgrade_scroll_chance = 0
+	for(var/obj/item/fantasy_item in world)
+		CHECK_TICK
+
+		if(!(fantasy_item.flags_1 & INITIALIZED_1) || QDELETED(fantasy_item))
+			continue
+
+		fantasy_item.AddComponent(/datum/component/fantasy)
+
+		if(istype(fantasy_item, /obj/item/storage))
+			var/obj/item/storage/storage_item = fantasy_item
+			var/datum/component/storage/storage_component = storage_item.GetComponent(/datum/component/storage)
+			if(prob(upgrade_scroll_chance) && storage_item.contents.len < storage_component.max_items && !storage_item.invisibility)
+				var/obj/item/upgradescroll/scroll = new(get_turf(storage_item))
+				SEND_SIGNAL(storage_item, COMSIG_TRY_STORAGE_INSERT, scroll, null, TRUE, TRUE)
+				upgrade_scroll_chance = max(0,upgrade_scroll_chance-100)
+				if(isturf(scroll.loc))
+					qdel(scroll)
+
+			upgrade_scroll_chance += 25


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

rpgloot is now rpgloot_controller

embedopocalypse and stickapocalypse are now subtypes of global_funny_embedding, which has the core code for applying special embedding

there is no longer a preference of embedding taking over sticking, the game simply chooses one and sticks to it

## Why It's Good For The Game

Signals are way better than every item in the game checking to see if this global var is ticked on or not

## Changelog
:cl:
refactor: rpgloot, embedopocalypse, and stickapocalypse are now datum singletons
refactor: THAT USE SIGNALS!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
