### PR TITLE
fixes simple_flying element missing ELEMENT_DETACH

### DIFF
--- a/code/datums/elements/simple_flying.dm
+++ b/code/datums/elements/simple_flying.dm
@@ -5,6 +5,7 @@
  * Note: works for carbons and above, but please do something better. humans have wings got dangit!
  */
 /datum/element/simple_flying
+	element_flags = ELEMENT_DETACH
 
 /datum/element/simple_flying/Attach(datum/target)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

IT WAS SUPPOSED TO

## Why It's Good For The Game

IT DIDN'T

## Changelog
:cl:
fix: simple_flying now removes itself from a mob when the mob deletes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
