### PR TITLE
Brings Cryopods up to /tg/ codebase standards, makes it drop all items on player deletion & can only be self-used unless your target is catatonic.

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -290,7 +290,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 			to_chat(user, "<span class='danger'>You can't put [target] into [src]. [target.p_theyre(capitalized = TRUE)] conscious.</span>")
 		return
 
-	if(target == user && (tgalert(target, "Would you like to enter cryosleep?", "Enter Cryopod?", "Yes", "No") == "No"))
+	if(target == user && (tgalert(target, "Would you like to enter cryosleep?", "Enter Cryopod?", "Yes", "No") != "Yes"))
 		return
 
 	if(target == user)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -1,3 +1,5 @@
+#define AHELP_FIRST_MESSAGE "Please adminhelp before leaving the round, even if there are no administrators online!"
+
 /*
  * Cryogenic refrigeration unit. Basically a despawner.
  * Stealing a lot of concepts/code from sleepers due to massive laziness.
@@ -22,11 +24,9 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 	// Used for logging people entering cryosleep and important items they are carrying.
 	var/list/frozen_crew = list()
-	var/list/frozen_items = list()
 
 	var/storage_type = "crewmembers"
 	var/storage_name = "Cryogenic Oversight Control"
-	var/allow_items = TRUE
 
 /obj/machinery/computer/cryopod/Initialize()
 	. = ..()
@@ -56,12 +56,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 /obj/machinery/computer/cryopod/ui_data(mob/user)
 	var/list/data = list()
-	data["allow_items"] = allow_items
 	data["frozen_crew"] = frozen_crew
-	data["frozen_items"] = list()
-
-	if(allow_items)
-		data["frozen_items"] = frozen_items
 
 	var/obj/item/card/id/id_card
 	var/datum/bank_account/current_user
@@ -74,50 +69,6 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		data["account_name"] = current_user.account_holder
 
 	return data
-
-/obj/machinery/computer/cryopod/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
-
-	var/mob/user = usr
-
-	add_fingerprint(user)
-
-	switch(action)
-		if("one_item")
-			if(!allowed(user))
-				to_chat(user, "<span class='warning'>Access Denied.</span>")
-				return
-
-			if(!allow_items) return
-
-			if(!params["item"])
-				return
-
-			var/obj/item/item = frozen_items[text2num(params["item"])]
-			if(!item)
-				to_chat(user, "<span class='notice'>[item] is no longer in storage.</span>")
-				return
-
-			visible_message("<span class='notice'>[src] beeps happily as it disgorges [item].</span>")
-			item.forceMove(get_turf(src))
-			frozen_items -= item
-
-		if("all_items")
-			if(!allowed(user))
-				to_chat(user, "<span class='warning'>Access Denied.</span>")
-				return
-
-			if(!allow_items) return
-
-			visible_message("<span class='notice'>[src] beeps happily as it disgorges the desired objects.</span>")
-
-			for(var/obj/item/item in frozen_items)
-				item.forceMove(get_turf(src))
-				frozen_items -= item
-
-	return TRUE
 
 // Cryopods themselves.
 /obj/machinery/cryopod
@@ -132,10 +83,10 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	var/on_store_message = "has entered long-term storage."
 	var/on_store_name = "Cryogenic Oversight"
 
-	// 3 minutes-ish safe period before being despawned.
-	var/time_till_despawn = 3 MINUTES // This is reduced to 30 seconds if a player manually enters cryo
-	var/fast_despawn = 30 SECONDS
-	var/despawn_world_time = null // Used to keep track of the safe period.
+	/// Time until despawn when a mob enters a cryopod. You cannot other people in pods unless they're catatonic.
+	var/time_till_despawn = 30 SECONDS
+	/// Cooldown for when it's now safe to try an despawn the player.
+	COOLDOWN_DECLARE(despawn_world_time)
 
 	var/obj/machinery/computer/cryopod/control_computer
 	COOLDOWN_DECLARE(last_no_computer_message)
@@ -154,7 +105,6 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	return ..()
 
 /obj/machinery/cryopod/proc/find_control_computer(urgent = FALSE)
-
 	for(var/cryo_console as anything in GLOB.cryopod_computers)
 		var/obj/machinery/computer/cryopod/console = cryo_console
 		if(get_area(console) == get_area(src))
@@ -170,18 +120,16 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 	return control_computer != null
 
-/obj/machinery/cryopod/close_machine(mob/user)
+/obj/machinery/cryopod/close_machine(atom/movable/target)
 	if(!control_computer)
 		find_control_computer(TRUE)
-	if((isnull(user) || istype(user)) && state_open && !panel_open)
-		..(user)
+	if((isnull(target) || isliving(target)) && state_open && !panel_open)
+		..(target)
 		var/mob/living/mob_occupant = occupant
 		if(mob_occupant && mob_occupant.stat != DEAD)
 			to_chat(occupant, "<span class='notice'><b>You feel cool air surround you. You go numb as your senses turn inward.</b></span>")
-		if(mob_occupant.client || !mob_occupant.key) // Self cryos and SSD
-			despawn_world_time = world.time + (fast_despawn) // This gives them 30 seconds
-		else
-			despawn_world_time = world.time + time_till_despawn
+
+		COOLDOWN_START(src, despawn_world_time, time_till_despawn)
 	icon_state = "cryopod"
 
 /obj/machinery/cryopod/open_machine()
@@ -203,19 +151,14 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		return
 
 	var/mob/living/mob_occupant = occupant
-	if(mob_occupant)
-		// Eject dead people
-		if(mob_occupant.stat == DEAD)
-			open_machine()
+	if(mob_occupant.stat == DEAD)
+		open_machine()
 
-		if(world.time <= despawn_world_time)
-			return
+	if(!mob_occupant.client && COOLDOWN_FINISHED(src, despawn_world_time))
+		if(!control_computer)
+			find_control_computer(urgent = TRUE)
 
-		if(!mob_occupant.client && mob_occupant.stat <= SOFT_CRIT) // Occupant is living and has no client.
-			if(!control_computer)
-				find_control_computer(urgent = TRUE) // better hope you found it this time
-
-			despawn_occupant()
+		despawn_occupant()
 
 /obj/machinery/cryopod/proc/handle_objectives()
 	var/mob/living/mob_occupant = occupant
@@ -283,6 +226,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 			mob_occupant.mind.special_role = null
 	else
 		crew_member["job"] = "N/A"
+
 	// Delete them from datacore.
 	var/announce_rank = null
 	for(var/datum/data/record/medical_record as anything in GLOB.data_core.medical)
@@ -305,22 +249,15 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 	visible_message("<span class='notice'>[src] hums and hisses as it moves [mob_occupant.real_name] into storage.</span>")
 
-	for(var/obj/item/item in mob_occupant.GetAllContents())
-		if(item.loc.loc && (item.loc.loc == loc || item.loc.loc == control_computer))
-			continue // means we already moved whatever this thing was in
-			// I'm a professional, okay
-
-		if(!should_preserve_item(item))
+#if MIN_COMPILER_VERSION >= 514
+	#warn Please replace the loop below this warning with an `as anything` loop.
+#endif
+	for(var/mob_content in mob_occupant)
+		var/obj/item/item_content = mob_content
+		if(!istype(item_content))
 			continue
 
-		if(control_computer && control_computer.allow_items)
-			control_computer.frozen_items += item
-			mob_occupant.transferItemToLoc(item, control_computer, TRUE)
-		else
-			mob_occupant.transferItemToLoc(item, loc, TRUE)
-
-	var/list/contents = mob_occupant.GetAllContents()
-	QDEL_LIST(contents)
+		mob_occupant.transferItemToLoc(item_content, drop_location(), force = TRUE, silent = TRUE)
 
 	// Ghost and delete the mob.
 	if(!mob_occupant.get_ghost(TRUE))
@@ -328,6 +265,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 			mob_occupant.ghostize(FALSE) // Players despawned too early may not re-enter the game
 		else
 			mob_occupant.ghostize(TRUE)
+
 	handle_objectives()
 	QDEL_NULL(occupant)
 	open_machine()
@@ -345,52 +283,50 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		to_chat(user, "<span class='notice'>Dead people can not be put into cryo.</span>")
 		return
 
-	if(target.client && user != target)
+	if(target.key && user != target)
 		if(iscyborg(target))
 			to_chat(user, "<span class='danger'>You can't put [target] into [src]. [target.p_theyre(capitalized = TRUE)] online.</span>")
 		else
 			to_chat(user, "<span class='danger'>You can't put [target] into [src]. [target.p_theyre(capitalized = TRUE)] conscious.</span>")
 		return
-	else if(target.client)
-		if(alert(target,"Would you like to enter cryosleep?",,"Yes","No") == "No")
-			return
 
-	var/generic_plsnoleave_message = " Please adminhelp before leaving the round, even if there are no administrators online!"
+	if(target == user && (tgalert(target, "Would you like to enter cryosleep?", "Enter Cryopod?", "Yes", "No") == "No"))
+		return
 
-	if(target == user && COOLDOWN_FINISHED(target.client, cryo_warned))
-		var/caught = FALSE
+	if(target == user)
 		var/datum/antagonist/antag = target.mind.has_antag_datum(/datum/antagonist)
+
 		var/datum/job/target_job = SSjob.GetJob(target.mind.assigned_role)
-		if(target_job.req_admin_notify)
-			alert("You're an important role![generic_plsnoleave_message]")
-			caught = TRUE
+
+		if(target_job && target_job.req_admin_notify)
+			tgalert(target, "You're an important role! [AHELP_FIRST_MESSAGE]")
 		if(antag)
-			alert("You're \a [antag.name]![generic_plsnoleave_message]")
-			caught = TRUE
-		if(caught)
-			COOLDOWN_START(target.client, cryo_warned, 5 MINUTES)
-			return
+			tgalert(target, "You're \a [antag.name]! [AHELP_FIRST_MESSAGE]")
 
 	if(!istype(target) || !can_interact(user) || !target.Adjacent(user) || !ismob(target) || isanimal(target) || !istype(user.loc, /turf) || target.buckled)
 		return
 		// rerun the checks in case of shenanigans
+
+	if(occupant)
+		to_chat(user, "<span class='notice'>[src] is already occupied!</span>")
+		return
 
 	if(target == user)
 		visible_message("<span class='infoplain'>[user] starts climbing into the cryo pod.</span>")
 	else
 		visible_message("<span class='infoplain'>[user] starts putting [target] into the cryo pod.</span>")
 
-	if(occupant)
-		to_chat(user, "<span class='notice'>[src] is in use.</span>")
-		return
-	close_machine(target)
+	to_chat(target, "<span class='warning'><b>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</b></span>")
 
-	to_chat(target, "<span class='notice'><b>If you ghost, log out or close your client now, your character will shortly be permanently removed from the round.</b></span>")
-	name = "[name] ([occupant.name])"
 	log_admin("[key_name(target)] entered a stasis pod.")
 	message_admins("[key_name_admin(target)] entered a stasis pod. [ADMIN_JMP(src)]")
 	add_fingerprint(target)
 
+	close_machine(target)
+	name = "[name] ([target.name])"
+
 // Attacks/effects.
 /obj/machinery/cryopod/blob_act()
 	return // Sorta gamey, but we don't really want these to be destroyed.
+
+#undef AHELP_FIRST_MESSAGE

--- a/tgui/packages/tgui/interfaces/CryopodConsole.js
+++ b/tgui/packages/tgui/interfaces/CryopodConsole.js
@@ -1,24 +1,21 @@
 import { useBackend } from '../backend';
-import { Stack, Button, Section, NoticeBox, LabeledList, Collapsible } from '../components';
+import { Collapsible, LabeledList, NoticeBox, Section } from '../components';
 import { Window } from '../layouts';
 
 export const CryopodConsole = (props, context) => {
   const { data } = useBackend(context);
-  const { account_name, allow_items } = data;
+  const { account_name } = data;
 
   const welcomeTitle = `Hello, ${account_name || '[REDACTED]'}!`;
 
   return (
     <Window title="Cryopod Console" width={400} height={480}>
       <Window.Content>
-        <Stack vertical>
-          <Section title={welcomeTitle}>
-            This automated cryogenic freezing unit will safely store your
-            corporeal form until your next assignment.
-          </Section>
-          <CrewList />
-          {!!allow_items && <ItemList />}
-        </Stack>
+        <Section title={welcomeTitle}>
+          This automated cryogenic freezing unit will safely store your
+          corporeal form until your next assignment.
+        </Section>
+        <CrewList />
       </Window.Content>
     </Window>
   );
@@ -42,53 +39,6 @@ const CrewList = (props, context) => {
             ))}
           </LabeledList>
         </Section>
-      )}
-    </Collapsible>
-  );
-};
-
-const ItemList = (props, context) => {
-  const { act, data } = useBackend(context);
-  const { frozen_items } = data;
-
-  const replaceItemName = (item) => {
-    let itemName = item.toString();
-    if (itemName.startsWith('the')) {
-      itemName = itemName.slice(4, itemName.length);
-    }
-    return itemName.replace(/^\w/, (c) => c.toUpperCase());
-  };
-
-  return (
-    <Collapsible title="Stored Items">
-      {!frozen_items.length ? (
-        <NoticeBox>No stored items!</NoticeBox>
-      ) : (
-        <>
-          <Section height={12} fill scrollable>
-            <LabeledList>
-              {frozen_items.map((item, index) => (
-                <LabeledList.Item
-                  key={item}
-                  label={replaceItemName(item)}
-                  buttons={
-                    <Button
-                      icon="arrow-down"
-                      content="Drop"
-                      mr={1}
-                      onClick={() => act('one_item', { item: index + 1 })}
-                    />
-                  }
-                />
-              ))}
-            </LabeledList>
-          </Section>
-          <Button
-            content="Drop All Items"
-            color="red"
-            onClick={() => act('all_items')}
-          />
-        </>
       )}
     </Collapsible>
   );

--- a/tgui/packages/tgui/interfaces/CryopodConsole.js
+++ b/tgui/packages/tgui/interfaces/CryopodConsole.js
@@ -30,7 +30,7 @@ const CrewList = (props, context) => {
       {!frozen_crew.length ? (
         <NoticeBox>No stored crew!</NoticeBox>
       ) : (
-        <Section height={10} fill scrollable>
+        <Section height={"100%"} scrollable>
           <LabeledList>
             {frozen_crew.map((person) => (
               <LabeledList.Item key={person} label={person.name}>

--- a/tgui/packages/tgui/interfaces/CryopodConsole.js
+++ b/tgui/packages/tgui/interfaces/CryopodConsole.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Collapsible, LabeledList, NoticeBox, Section } from '../components';
+import { Box, LabeledList, NoticeBox, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 export const CryopodConsole = (props, context) => {
@@ -11,11 +11,17 @@ export const CryopodConsole = (props, context) => {
   return (
     <Window title="Cryopod Console" width={400} height={480}>
       <Window.Content>
-        <Section title={welcomeTitle}>
-          This automated cryogenic freezing unit will safely store your
-          corporeal form until your next assignment.
-        </Section>
-        <CrewList />
+        <Stack vertical fill>
+          <Stack.Item>
+            <Section title={welcomeTitle}>
+              This automated cryogenic freezing unit will safely store your
+              corporeal form until your next assignment.
+            </Section>
+          </Stack.Item>
+          <Stack.Item grow>
+            <CrewList />
+          </Stack.Item>
+        </Stack>
       </Window.Content>
     </Window>
   );
@@ -26,20 +32,20 @@ const CrewList = (props, context) => {
   const { frozen_crew } = data;
 
   return (
-    <Collapsible title="Stored Crew">
-      {!frozen_crew.length ? (
-        <NoticeBox>No stored crew!</NoticeBox>
-      ) : (
-        <Section height={"100%"} scrollable>
-          <LabeledList>
-            {frozen_crew.map((person) => (
-              <LabeledList.Item key={person} label={person.name}>
-                {person.job}
-              </LabeledList.Item>
-            ))}
-          </LabeledList>
-        </Section>
-      )}
-    </Collapsible>
+    frozen_crew.length && (
+      <Section
+        fill
+        scrollable>
+        <LabeledList>
+          {frozen_crew.map((person) => (
+            <LabeledList.Item key={person} label={person.name}>
+              {person.job}
+            </LabeledList.Item>
+          ))}
+        </LabeledList>
+      </Section>
+    ) || (
+      <NoticeBox>No stored crew!</NoticeBox>
+    )
   );
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The code has overall had a minor touch-up with a few renamed vars here and there for consistency's sake. The message template for informing the admins before you log out has been hoisted up to a #define.

You can no longer put other players into cryopods unless they're catatonic. This is because cryopods actually ROUND REMOVE people and going SSD is not permanent. An SSD player is free to return to the game at any time and has full metaprotections against being killed while SSD as if they were still living.

![image](https://user-images.githubusercontent.com/24975989/118209492-9edbd800-b460-11eb-9e82-dd082760ae66.png)
![image](https://user-images.githubusercontent.com/24975989/118209540-b3b86b80-b460-11eb-893d-8f042c7dedc7.png)

With this removed, the only way to enter pods when a body has a ckey associated with it is of your own volition. As a result, the 3 minute timer is no longer necessary and the only timer is 30 seconds. After this point, you will be round removed if you go SSD or ghost yourself. This timer now uses our COOLDOWN_ macros.

The alerts now use tgalert.
![vJxCMESklA](https://user-images.githubusercontent.com/24975989/118208244-4dcae480-b45e-11eb-8992-04910c4e190a.gif)

These alerts for vital station crew and antags now always show if you're going to try and cryopod yourself, there was no point giving you a 5 minute cooldown where the alerts don't appear.

If you have a mind.assigned_role that doesn't have a job datum assigned to it, the pod no longer runtimes and you can successfully cryo yourself. Useful for getting rid of your Centcom intern hordes after you've successfully besieged the station.

All items you had equipped (and maybe even some you didn't have equipped) are dumped to the floor when the machine vores you. Items are no longer destroyed, including any special objectives. The cryo console no longer has the functionality to store items inside it, as this functionality has been replaced by the classic floordump. This fixes #58402

![EnkGInYnCs](https://user-images.githubusercontent.com/24975989/118208992-a5b61b00-b45f-11eb-94be-9063d4a1522e.gif)

Because the item functionality is no longer needed/supported, the tgui interface has has this section removed. It now just shows a list of all stored crew.

![image](https://user-images.githubusercontent.com/24975989/118302432-1e5abd00-b4dc-11eb-949e-1a5c7d318133.png)
![image](https://user-images.githubusercontent.com/24975989/118302467-29155200-b4dc-11eb-86b2-025bb3c1c284.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Aligns cryopods more with the standards and expectations of the tg codebase. They are now far simpler and perform their job as an RP way of leaving the shift that doesn't involve suicide. They no longer delete traitor items or items in general. They can no longer be used to round remove SSD people without leaving a trail of logs behind.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cryopods can no longer be used to round remove other SSD players.
fix: Cryopods no longer delete traitor objectives under certain edge cases, and can no longer be used to metagame the existence of traitors with steal objectives.
balance: Cryopods now vomit out all the items of players who get vored by them, like beautiful loot pinatas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
