### PR TITLE
Fix issues I created where dynamic gives out multiple incorrect antag datums to ineligible people and gives 1 too many traitor objectives.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -214,16 +214,17 @@
 				continue
 
 		// If this ruleset has exclusive_roles set, we want to only consider players who have those
-		// job prefs enabled.
-		var/exclusive_candidate = FALSE
-		for(var/role in exclusive_roles)
-			if(role in candidate_client.prefs.job_preferences)
-				exclusive_candidate = TRUE
-				break
+		// job prefs enabled. Otherwise, continue as before.
+		if(length(exclusive_roles))
+			var/exclusive_candidate = FALSE
+			for(var/role in exclusive_roles)
+				if(role in candidate_client.prefs.job_preferences)
+					exclusive_candidate = TRUE
+					break
 
-		// If they didn't have any of the required job prefs enabled, they're not eligible for this antag type.
-		if(!exclusive_candidate)
-			candidates.Remove(candidate_player)
+			// If they didn't have any of the required job prefs enabled, they're not eligible for this antag type.
+			if(!exclusive_candidate)
+				candidates.Remove(candidate_player)
 
 /// Do your checks if the ruleset is ready to be executed here.
 /// Should ignore certain checks if forced is TRUE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -213,15 +213,17 @@
 				candidates.Remove(candidate_player)
 				continue
 
+		// If this ruleset has exclusive_roles set, we want to only consider players who have those
+		// job prefs enabled.
 		var/exclusive_candidate = FALSE
 		for(var/role in exclusive_roles)
 			if(role in candidate_client.prefs.job_preferences)
 				exclusive_candidate = TRUE
 				break
 
+		// If they didn't have any of the required job prefs enabled, they're not eligible for this antag type.
 		if(!exclusive_candidate)
 			candidates.Remove(candidate_player)
-			break
 
 /// Do your checks if the ruleset is ready to be executed here.
 /// Should ignore certain checks if forced is TRUE

--- a/code/modules/antagonists/malf_ai/datum_malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/datum_malf_ai.dm
@@ -52,7 +52,9 @@
 	var/objective_limit = CONFIG_GET(number/traitor_objectives_amount)
 	var/objective_count = length(objectives)
 
-	for(var/i = objective_count, i < objective_limit, ++i)
+	// for(in...to) loops iterate inclusively, so to reach objective_limit we need to loop to objective_limit - 1
+	// This does not give them 1 fewer objectives than intended.
+	for(var/i in objective_count to objective_limit - 1)
 		var/datum/objective/assassinate/kill_objective = new
 		kill_objective.owner = owner
 		kill_objective.find_target()

--- a/code/modules/antagonists/malf_ai/datum_malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/datum_malf_ai.dm
@@ -52,7 +52,7 @@
 	var/objective_limit = CONFIG_GET(number/traitor_objectives_amount)
 	var/objective_count = length(objectives)
 
-	for(var/i in objective_count to objective_limit)
+	for(var/i = objective_count, i < objective_limit, ++i)
 		var/datum/objective/assassinate/kill_objective = new
 		kill_objective.owner = owner
 		kill_objective.find_target()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -67,7 +67,10 @@
 		objective_count++
 
 	var/objective_limit = CONFIG_GET(number/traitor_objectives_amount)
-	for(var/i = objective_count, i < objective_limit, ++i)
+
+	// for(in...to) loops iterate inclusively, so to reach objective_limit we need to loop to objective_limit - 1
+	// This does not give them 1 fewer objectives than intended.
+	for(var/i in objective_count to objective_limit - 1)
 		forge_single_generic_objective()
 
 	if(is_hijacker)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -67,7 +67,7 @@
 		objective_count++
 
 	var/objective_limit = CONFIG_GET(number/traitor_objectives_amount)
-	for(var/i in objective_count to objective_limit)
+	for(var/i = objective_count, i < objective_limit, ++i)
 		forge_single_generic_objective()
 
 	if(is_hijacker)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #59087

An errant break noped out of the primary for loop in `/datum/dynamic_ruleset/roundstart/trim_candidates()` too early, not trimming the list of candidates properly and leaving players who should be ineligible for a role in the list of candidates. This break has been removed and a couple of comments explaining the logic have been added in its place.

Using a for(in x to y) loop is apparently x to y inclusive. As a result, `for(var/i in 0 to 2)` (where 2 is the number of traitor/malf objectives that should roll) loops 3 times when you only want it to loop twice. This meant traitors and malfs had 3 objectives + escape instead of 2. This is now fixed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Maintainerpoes goes brrrrrrr.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: You can once again no longer roll multiple antags at once or antags you have disabled in your prefs.
fix: Traitors and malf AIs no longer get 1 more objective than intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
