### PR TITLE
Takes away emag from medical borgs, and gives it to sabo borgs.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -596,7 +596,6 @@
 		/obj/item/stack/cable_coil,
 		/obj/item/pinpointer/syndicate_cyborg,
 		/obj/item/borg_chameleon,
-		/obj/item/borg/stun,
 		/obj/item/card/emag,
 		)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -558,7 +558,6 @@
 		/obj/item/scalpel,
 		/obj/item/melee/transforming/energy/sword/cyborg/saw,
 		/obj/item/roller/robo,
-		/obj/item/card/emag,
 		/obj/item/crowbar/cyborg,
 		/obj/item/extinguisher/mini,
 		/obj/item/pinpointer/syndicate_cyborg,
@@ -586,6 +585,7 @@
 		/obj/item/wrench/cyborg,
 		/obj/item/crowbar/cyborg,
 		/obj/item/wirecutters/cyborg,
+		/obj/item/analyzer,
 		/obj/item/multitool/cyborg,
 		/obj/item/stack/sheet/iron,
 		/obj/item/stack/sheet/glass,
@@ -596,6 +596,8 @@
 		/obj/item/stack/cable_coil,
 		/obj/item/pinpointer/syndicate_cyborg,
 		/obj/item/borg_chameleon,
+		/obj/item/borg/stun,
+		/obj/item/card/emag,
 		)
 
 	cyborg_base_icon = "synd_engi"


### PR DESCRIPTION
## About The Pull Request
Takes away emg from medi borgs and gives it to sabo borgs
## Why It's Good For The Game
Doesnt necessarily make sense that the borg whos supposed to heal you has a emag, but the one whos supposed to go around sabotaging stuff does not.

also for some reason sabo borgs did not have an analyzer now they do
## Changelog
:cl:
fix: Syndicate Saboteur borgs now properly come with a analyzer installed
balance: Syndicate Medical borgs no longer have an emag
balance: Syndicate Saboteur borgs now come with an emag.
/:cl:
