### PR TITLE
cleans up delta incinerator 

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4675,7 +4675,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/tank/toxins,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4597,22 +4597,16 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 6
 	},
 /turf/open/floor/iron/checker,
 /area/maintenance/disposal/incinerator)
 "aGS" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -4626,6 +4620,9 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
+/obj/machinery/atmospherics/components/binary/thermomachine/heater{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "aGT" = (
@@ -4633,7 +4630,6 @@
 	c_tag = "Atmospherics - Incinerator";
 	name = "atmospherics camera"
 	},
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -4644,20 +4640,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/tank/toxins,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "aGU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency,
-/obj/item/wrench,
-/obj/item/tank/internals/emergency_oxygen/engi,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -4668,6 +4657,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "aGV" = (
@@ -4685,6 +4675,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/tank/toxins,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "aGW" = (
@@ -4705,6 +4697,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "aGY" = (
@@ -4940,9 +4933,9 @@
 "aIy" = (
 /obj/machinery/light_switch/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank/large,
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "aIH" = (
@@ -5128,9 +5121,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -14985,9 +14975,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/computer/exodrone_control_console{
-	dir = 2
-	},
+/obj/machinery/computer/exodrone_control_console,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -19263,7 +19251,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron/dark/corner,
 /area/maintenance/disposal/incinerator)
 "czq" = (
@@ -19856,7 +19843,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cGJ" = (
@@ -40452,11 +40438,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs/auxiliary)
-"eVv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "eVw" = (
 /obj/structure/table/reinforced,
 /obj/item/cartridge/quartermaster{
@@ -42001,6 +41982,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "foK" = (
@@ -44514,7 +44496,6 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden/abandoned)
 "gcW" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
@@ -46753,6 +46734,11 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/closed/wall/r_wall,
+/area/engineering/atmos)
+"gMn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "gMy" = (
 /obj/structure/cable,
@@ -58013,9 +57999,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/computer/exoscanner_control{
-	dir = 2
-	},
+/obj/machinery/computer/exoscanner_control,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -59688,6 +59672,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"kqP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall,
+/area/engineering/atmos)
 "kry" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -59856,6 +59844,20 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"kto" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "ktw" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -60138,7 +60140,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kxn" = (
@@ -68736,6 +68738,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"mKX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "mLh" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
@@ -83408,6 +83421,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "qxg" = (
@@ -84305,8 +84321,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
-	pixel_x = -7;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /obj/item/pen{
 	pixel_x = -7
@@ -94134,17 +94149,6 @@
 	dir = 1
 	},
 /area/engineering/atmos)
-"tjK" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/turf/open/floor/iron/dark/corner,
-/area/maintenance/disposal/incinerator)
 "tjO" = (
 /obj/machinery/gibber,
 /obj/machinery/light/directional/north,
@@ -94326,6 +94330,7 @@
 /turf/open/floor/iron/dark,
 /area/commons/locker)
 "tmu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "tmA" = (
@@ -95417,16 +95422,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/service/kitchen)
-"tCX" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Plasma to Turbine"
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "tDa" = (
 /obj/structure/table,
 /obj/item/rcl/pre_loaded,
@@ -105057,9 +105052,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "whq" = (
@@ -107180,23 +107173,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"wNc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Turbine"
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "wNi" = (
 /obj/structure/filingcabinet/medical,
 /obj/machinery/light/directional/north,
@@ -107642,19 +107618,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
-"wTf" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/corner,
-/area/maintenance/disposal/incinerator)
 "wTm" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -111644,9 +111607,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "yaC" = (
@@ -111910,6 +111870,10 @@
 	heat_capacity = 1e+006
 	},
 /area/science/misc_lab)
+"yde" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "ydg" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "brigprison";
@@ -134466,7 +134430,7 @@ vsT
 aad
 aFr
 aGR
-aIs
+mKX
 baL
 pCj
 bsj
@@ -134726,9 +134690,9 @@ aGS
 aIt
 ooj
 pPs
-xXs
-xXs
-xXs
+jEV
+gMn
+gMn
 kPH
 kPH
 kPH
@@ -134980,12 +134944,12 @@ qvW
 qYo
 aFr
 aGT
-tCX
+aIt
 eDo
-wTf
-xXs
+pPs
+jEV
 ipq
-ipq
+pQf
 mhy
 bgH
 fVZ
@@ -135238,10 +135202,10 @@ qYo
 aFs
 aGU
 aIt
-wNc
+baL
 who
 kxk
-pQf
+kto
 tjD
 jZK
 kfU
@@ -135497,8 +135461,8 @@ aGV
 aIv
 cGj
 czo
-xXs
-ipq
+jEV
+kto
 cdV
 uyH
 ush
@@ -135753,9 +135717,9 @@ aFr
 aGW
 aIs
 aJP
-tjK
-xXs
-ipq
+pPs
+jEV
+kto
 ohn
 slk
 vzJ
@@ -136007,11 +135971,11 @@ hLW
 cJl
 cJl
 iqM
-aFr
+yde
 aIx
 xZZ
-tjK
-eVv
+pPs
+jEV
 owj
 fbu
 qFy
@@ -136525,7 +136489,7 @@ tmu
 tmu
 foG
 tmu
-mZD
+kqP
 aWE
 rMZ
 hSV

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4676,7 +4676,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/tank/toxins,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "aGW" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -57454,13 +57454,11 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "jLK" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/status_display/ai/directional/south,
+/obj/machinery/pipedispenser,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jLY" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -99097,6 +99097,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"uzg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uzi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -106478,10 +106485,10 @@
 /turf/closed/wall/r_wall,
 /area/science/misc_lab/range)
 "wAZ" = (
-/obj/machinery/pipedispenser/disposal,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wBb" = (
@@ -138298,7 +138305,7 @@ mZD
 utn
 xqx
 wAZ
-kPE
+uzg
 jLK
 mZD
 xcs


### PR DESCRIPTION

## About The Pull Request
before
![image](https://user-images.githubusercontent.com/47158596/118223240-a19ef300-b489-11eb-80ae-aec5e37d46d2.png)
after
![image](https://user-images.githubusercontent.com/47158596/118223271-a8c60100-b489-11eb-88b8-32c876dc9f27.png)






cleans up delta incinerator 
## Why It's Good For The Game
piping has given me aids, better piping, and for some reason somone has deciced to put an EXTRA EXPLOSIVE TANK IN THE ROOM WHERE YOU OPERATE WITH BURNING GASES

## Changelog
:cl:
qol: Delta turbine has been cleaned up and changed to look easier on the eyes and give more space for atmosians to work with also adding a thermomachine for faster setup times!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
