### PR TITLE
Dead people can no longer offer items

### DIFF
--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -168,6 +168,10 @@
 		to_chat(src, "<span class='warning'>You're not holding anything to give!</span>")
 		return
 
+	if(IS_DEAD_OR_INCAP(src))
+		to_chat(src, "<span class='warning'>You're unable to offer anything in your current state!</span>")
+		return
+
 	if(istype(receiving, /obj/item/slapper))
 		offer_high_five(receiving)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
@Mothblocks mentioned to me that a dead mime was being very rude and continually offering them a circle hand. This PR makes it so the dead and incapacitated can no longer offer things to people even if they somehow have something in their hands.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If a dead mime offers you something, say no
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Dead and incapacitated people can no longer offer items
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
