### PR TITLE
Fixes a ci error caused by adding an element to something that'd being deleted

### DIFF
--- a/code/datums/components/fantasy/prefixes.dm
+++ b/code/datums/components/fantasy/prefixes.dm
@@ -100,7 +100,7 @@
 
 /datum/fantasy_affix/ugly/remove(datum/component/fantasy/comp)
 	var/obj/item/master = comp.parent
-	master.AddElement(/datum/element/beauty, min(comp.quality, -1) * 250)
+	master.RemoveElement(/datum/element/beauty, min(comp.quality, -1) * 250)
 
 /datum/fantasy_affix/venomous
 	name = "<poisonname>-laced (picked from small pool of toxins)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title, the beauty component used to be very dumb, it is now an element and slightly less dumb, but someone forgot to change this line when cleaning all the shit up

## Why It's Good For The Game

So that's why mythril coins kept harddeleting.
Man I'm glad I added an error on adding elements to qdeleted objects.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
