### PR TITLE
Fixes a bug in signal unregistration code 

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -235,6 +235,8 @@
 						target.comp_lookup = null
 						break
 			if(0)
+				if(lookup[sig] != src)
+					continue
 				lookup -= sig
 				if(!length(lookup))
 					target.comp_lookup = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This was causing unrelated objects to lose their registration in a hyper rare case.

The process went something like:
when object foo is registered to something and object bar is registered to the same object with a different
signal it will remove foo's signal only when foo is the only one registered to the object with that signal
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why it's good for the game

This was breaking #58918 when blood wasn't qdel'd post test. I'm so happy I found this.
It's a rare case, so I doubt it'll effect a lot of things, but I can trust UnregisterSignal again, which is very nice.