### PR TITLE
fixes recyclers eating themselves roundstart

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -18,20 +18,25 @@
 	var/item_recycle_sound = 'sound/items/welder.ogg'
 
 /obj/machinery/recycler/Initialize()
-	AddComponent(/datum/component/butchering/recycler, 1, amount_produced,amount_produced/5)
-	var/list/allowed_materials = list(/datum/material/iron,
-									/datum/material/glass,
-									/datum/material/silver,
-									/datum/material/plasma,
-									/datum/material/gold,
-									/datum/material/diamond,
-									/datum/material/plastic,
-									/datum/material/uranium,
-									/datum/material/bananium,
-									/datum/material/titanium,
-									/datum/material/bluespace
-									)
+	var/list/allowed_materials = list(
+	/datum/material/iron,
+	/datum/material/glass,
+	/datum/material/silver,
+	/datum/material/plasma,
+	/datum/material/gold,
+	/datum/material/diamond,
+	/datum/material/plastic,
+	/datum/material/uranium,
+	/datum/material/bananium,
+	/datum/material/titanium,
+	/datum/material/bluespace
+	)
 	AddComponent(/datum/component/material_container, allowed_materials, INFINITY, MATCONTAINER_NO_INSERT|BREAKDOWN_FLAGS_RECYCLER)
+	AddComponent(/datum/component/butchering/recycler, 1, amount_produced,amount_produced/5)
+	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/recycler/LateInitialize()
 	. = ..()
 	update_appearance(UPDATE_ICON)
 	req_one_access = SSid_access.get_region_access_list(list(REGION_ALL_STATION, REGION_CENTCOM))

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -19,17 +19,17 @@
 
 /obj/machinery/recycler/Initialize()
 	var/list/allowed_materials = list(
-	/datum/material/iron,
-	/datum/material/glass,
-	/datum/material/silver,
-	/datum/material/plasma,
-	/datum/material/gold,
-	/datum/material/diamond,
-	/datum/material/plastic,
-	/datum/material/uranium,
-	/datum/material/bananium,
-	/datum/material/titanium,
-	/datum/material/bluespace
+		/datum/material/iron,
+		/datum/material/glass,
+		/datum/material/silver,
+		/datum/material/plasma,
+		/datum/material/gold,
+		/datum/material/diamond,
+		/datum/material/plastic,
+		/datum/material/uranium,
+		/datum/material/bananium,
+		/datum/material/titanium,
+		/datum/material/bluespace
 	)
 	AddComponent(/datum/component/material_container, allowed_materials, INFINITY, MATCONTAINER_NO_INSERT|BREAKDOWN_FLAGS_RECYCLER)
 	AddComponent(/datum/component/butchering/recycler, 1, amount_produced,amount_produced/5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #59115
turfs call Entered() on all of their contents in Initialize(), since recyclers are set to recycle things that enter their tile with connect_loc, they will vore themselves. now it doesnt do that since they use LateInitialize() to register for Entered signal. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Recyclers dont vore themselves the moment the world is created anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
