### PR TITLE
Skittish now requires walking

### DIFF
--- a/code/datums/elements/skittish.dm
+++ b/code/datums/elements/skittish.dm
@@ -17,7 +17,7 @@
 	. = ..()
 
 /datum/element/skittish/proc/Bump(mob/living/scooby, atom/target)
-	if(scooby.stat != CONSCIOUS || scooby.m_intent != MOVE_INTENT_RUN)
+	if(scooby.stat != CONSCIOUS || scooby.m_intent != MOVE_INTENT_WALK)
 		return
 
 	if(!istype(target, /obj/structure/closet))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Skittish now requires walking so you jump into a closet or a crate. It's much more intuitive and easy to pull off than the previous shift-click before this, but skittish as it currently is is more of an annoyance than a useful quirk.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Skittish is supposed to be a positive thing. Running into crates when you're trying to push them around, or just accidentally jumping in any lockers or crates in maintenance because of a _**positive**_ trait is kinda bad. Now, it requires just simply pressing your "hold to walk" button right as you're about to dive in a closet, to actually dive into it. That way, it requires a small amount of skill to pull off, instead of constant care about not pulling it off on accident.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Skittish is now a conscious thing, requiring you to take the time to take a proper stance by walking towards a closet before diving into it!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->