### PR TITLE
Fix issue where Plumbing Reaction Chambers can get stuck filling

### DIFF
--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -101,7 +101,7 @@
 		var/datum/component/plumbing/supplier = A
 		if(supplier.can_give(amount, reagent, net))
 			valid_suppliers += supplier
-	// Need to ask for each in turn very carefully, making sure we get the total volume. This is to avoid a division that would always round down from becoming 0
+	// Need to ask for each in turn very carefully, making sure we get the total volume. This is to avoid a division that would always round down and become 0
 	var/targetVolume = src.reagents.total_volume + amount
 	var/suppliersLeft = valid_suppliers.len
 	for(var/A in valid_suppliers)

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -101,9 +101,14 @@
 		var/datum/component/plumbing/supplier = A
 		if(supplier.can_give(amount, reagent, net))
 			valid_suppliers += supplier
+	// Need to ask for each in turn very carefully, making sure we get the total volume. This is to avoid a division that would always round down from becoming 0
+	var/targetVolume = src.reagents.total_volume + amount
+	var/suppliersLeft = valid_suppliers.len
 	for(var/A in valid_suppliers)
 		var/datum/component/plumbing/give = A
-		give.transfer_to(src, amount / valid_suppliers.len, reagent, net)
+		var/currentRequest = (targetVolume - src.reagents.total_volume) / suppliersLeft
+		give.transfer_to(src, currentRequest, reagent, net)
+		suppliersLeft--
 
 ///returns TRUE when they can give the specified amount and reagent. called by process request
 /datum/component/plumbing/proc/can_give(amount, reagent, datum/ductnet/net)

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -102,11 +102,11 @@
 		if(supplier.can_give(amount, reagent, net))
 			valid_suppliers += supplier
 	// Need to ask for each in turn very carefully, making sure we get the total volume. This is to avoid a division that would always round down and become 0
-	var/targetVolume = src.reagents.total_volume + amount
+	var/targetVolume = reagents.total_volume + amount
 	var/suppliersLeft = valid_suppliers.len
 	for(var/A in valid_suppliers)
 		var/datum/component/plumbing/give = A
-		var/currentRequest = (targetVolume - src.reagents.total_volume) / suppliersLeft
+		var/currentRequest = (targetVolume - reagents.total_volume) / suppliersLeft
 		give.transfer_to(src, currentRequest, reagent, net)
 		suppliersLeft--
 

--- a/code/datums/components/plumbing/reaction_chamber.dm
+++ b/code/datums/components/plumbing/reaction_chamber.dm
@@ -23,7 +23,7 @@
 		for(var/datum/reagent/containg_reagent as anything in reagents.reagent_list)
 			if(required_reagent == containg_reagent.type)
 				has_reagent = TRUE
-				if(containg_reagent.volume < chamber.required_reagents[required_reagent])
+				if(containg_reagent.volume + CHEMICAL_QUANTISATION_LEVEL < chamber.required_reagents[required_reagent])
 					process_request(min(chamber.required_reagents[required_reagent] - containg_reagent.volume, MACHINE_REAGENT_TRANSFER) , required_reagent, dir)
 					return
 		if(!has_reagent)

--- a/code/modules/plumbing/plumbers/plumbing_buffer.dm
+++ b/code/modules/plumbing/plumbers/plumbing_buffer.dm
@@ -31,11 +31,11 @@
 /obj/machinery/plumbing/buffer/proc/on_reagent_change()
 	if(!buffer_net)
 		return
-	if(reagents.total_volume >= activation_volume && mode == UNREADY)
+	if(reagents.total_volume + CHEMICAL_QUANTISATION_LEVEL >= activation_volume && mode == UNREADY)
 		mode = IDLE
 		buffer_net.check_active()
 
-	else if(reagents.total_volume < activation_volume && mode != UNREADY)
+	else if(reagents.total_volume + CHEMICAL_QUANTISATION_LEVEL < activation_volume && mode != UNREADY)
 		mode = UNREADY
 		buffer_net.check_active()
 


### PR DESCRIPTION
## About The Pull Request

This Pull Requests aims to fix the issue #58993 by changing two parts of the logic I've seen the chambers get stuck on.

1. Chamber gets stuck requesting a unit that is always rounded down to 0
2. Chamber gets stuck requesting an insanely small number that gets eaten by float math

**Part 1 Explanation**
Take the example where a chamber is trying to request one unit of chemical from three synthesizers. A chamber will divide it's request amongst all suppliers who can satisfy it. In this case, `1 / 3` becomes asking each synthesizer for `0.33` (due to rounding). After one update, the chamber has `0.99` of the chemical, not `1`. On the second update, it then requires `0.01` of the chemical and asks each chamber for `0.0033`, which gets rounded down to 0. This means the chamber NEVER fills as it spends every update cycle doing the same logic and trying to transfer in parts of `0` in size.

This has been fixed by changing it from flat dividing the amount required by the number of suppliers to a more dynamic approach that looks at the target volume and how many requests it needs to make. This mean that instead of asking for `0.33` three times in the above example, it actually works out more to asking for `0.33` then `0.34` then `0.33`. Meaning it gets the whole `1` it wanted in the first update, fixing the issue.

**Part 2 Explanation**
Even with the above fix, when working with the right numbers, floats do not add as expected. Take the above example. I lied. `1/3` as a float is NOT `0.33`. `0.33` does not exist as a float, so the actual closest value is `0.32999998`, which is what the code will use, even when rounding to `0.01`. What this causes is, in some scenarios, chambers getting incredibly close to their target volume but never being able to actually reach it because `currentVolume + missingAmount` comes out as just `currentVolume`, due to the insanely small float that it's missing having no impact on the larger float when added together. Again, this is due to how floats work.

So to avoid a chamber getting stuck on `98.9999999998` when it needs `99`, I'm adding the `CHEMICAL_QUANTISATION_LEVEL` constant (used elsewhere for similar issues) to the chamber's volume when checking if it has enough. This way, the chamber will exit the filling mode even though it was short by a tiny fraction. These discrepancies seem to get handled anyway in the actual reaction code so I haven't seen any changes/problems to my outputs. For all intents and purposes, `98.9999999998` is `99` in float arithmetic when rounding as we do.

## Why It's Good For The Game

Fixes an incredibly annoying issue that plagues chemistry automation. Machines, in many scenarios, currently get stuck when they shouldn't. This means a chemist has to actively keep monitoring all their machines and then do some investigation when suddenly something stops. Eventually finding the problem chamber that is stuck on "Filling" and then plungering it. Not all Chemists know of this either and just assume it's something they have done or that it's just broken and unaware how to fix it.

Now a Chemist can move on to automating more or helping elsewhere rather than babysitting their setups.

## Changelog
:cl:
fix: fixed issue where plumbing Reaction Chambers get stuck on "Filling"
/:cl: