### PR TITLE
Move Maint. Drones to the Control Interfaces category

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -860,4 +860,4 @@
 	materials = list(/datum/material/iron = 800, /datum/material/glass = 350)
 	construction_time = 150
 	build_path = /obj/effect/mob_spawn/drone
-	category = list("Misc")
+	category = list("Control Interfaces")


### PR DESCRIPTION
## About The Pull Request

Maintenance Drones were moved from the Misc category in the Mech Fabricator to the Control Interfaces category, alongside MMIs, and Positronic Brains.

I am not sure if they thematically in-universe fit in the category, but they categorically fit very well when it comes to general function.

## Why It's Good For The Game

Maint. Drones aren't printed so often, even after being researched. I hope this will help remedy that.

## Changelog
:cl: JJRcop
qol: Maintenance Drones were moved to the Control Interfaces category.
/:cl:
