### PR TITLE
Modifies the "No ERP" poster

### DIFF
--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -616,7 +616,7 @@
 
 /obj/structure/sign/poster/official/no_erp
 	name = "No ERP"
-	desc = "This poster reminds the crew that saying the initialism \"ERP\" out loud makes you look like \"total fucking loser\" who is \"not welcome on Nanotrasen stations\"."
+	desc = "This poster reminds the crew that saying the acronym \"ERP\" out loud makes you look like \"total fucking loser\" who is \"not welcome on Nanotrasen stations\"."
 	icon_state = "poster34_legit"
 
 /obj/structure/sign/poster/official/wtf_is_co2

--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -616,7 +616,7 @@
 
 /obj/structure/sign/poster/official/no_erp
 	name = "No ERP"
-	desc = "This poster reminds the crew that Eroticism, Rape and Pornography are banned on Nanotrasen stations."
+	desc = "This poster reminds the crew that saying the initialism \"ERP\" out loud makes you look like \"total fucking loser\" who is \"not welcome on Nanotrasen stations\"."
 	icon_state = "poster34_legit"
 
 /obj/structure/sign/poster/official/wtf_is_co2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
There have been lots of arguments between players and admins about whether it's acceptable to use the term "ERP" in-character or if it constitutes netspeak, and inevitably this poster gets brought up as justification for it being IC. This PR defuses the argument entirely by changing the poster to be about how stupid saying ERP makes you sound.

Really though I just think this joke is funnier
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives a new coat of paint to an old joke
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
spellcheck: Nanotrasen has modified its previous "No ERP" ad campaign to encourage people to stop saying "ERP"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
