### PR TITLE
Micro-optimize TGUI_CREATE_MESSAGE for 70% (?) speed ups

### DIFF
--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -28,7 +28,7 @@
 #define TGUI_WINDOW_INDEX(window_id) text2num(copytext(window_id, 13))
 
 /// Creates a message packet for sending via output()
-// This is {"type":type,"payload":payload}, but pre-encoded. This is 30% faster
+// This is {"type":type,"payload":payload}, but pre-encoded. This is much faster
 // than doing it the normal way.
 // To ensure this is correct, this is unit tested in tgui_create_message.
 #define TGUI_CREATE_MESSAGE(type, payload) ( \

--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -28,8 +28,9 @@
 #define TGUI_WINDOW_INDEX(window_id) text2num(copytext(window_id, 13))
 
 /// Creates a message packet for sending via output()
+// This is {"type":type,"payload":payload}, but pre-encoded. This is 30% faster
+// than doing it the normal way.
+// To ensure this is correct, this is unit tested in tgui_create_message.
 #define TGUI_CREATE_MESSAGE(type, payload) ( \
-	url_encode(json_encode(list( \
-		"type" = type, \
-		"payload" = payload, \
-	))))
+	"%7b%22type%22%3a%22[type]%22%2c%22payload%22%3a[url_encode(json_encode(payload))]%7d" \
+)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -88,6 +88,7 @@
 #include "subsystem_init.dm"
 #include "surgeries.dm"
 #include "teleporters.dm"
+#include "tgui_create_message.dm"
 #include "timer_sanity.dm"
 #include "unit_test.dm"
 #include "wizard.dm"

--- a/code/modules/unit_tests/tgui_create_message.dm
+++ b/code/modules/unit_tests/tgui_create_message.dm
@@ -1,0 +1,28 @@
+/// Test that `TGUI_CREATE_MESSAGE` is correctly implemented
+/datum/unit_test/tgui_create_message
+
+/datum/unit_test/tgui_create_message/Run()
+	var/type = "something/here"
+	var/list/payload = list(
+		"name" = "Terry McTider",
+		"heads_caved" = 100,
+		"accomplishments" = list(
+			"nothing",
+			"literally nothing",
+			list(
+				"something" = "just kidding",
+			),
+		),
+	)
+
+	var/message = TGUI_CREATE_MESSAGE(type, payload)
+
+	// Ensure consistent output to compare by performing a round-trip.
+	var/output = json_encode(json_decode(url_decode(message)))
+
+	var/expected = json_encode(list(
+		"type" = type,
+		"payload" = payload,
+	))
+
+	TEST_ASSERT_EQUAL(expected, output, "TGUI_CREATE_MESSAGE didn't round trip properly")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Disclaimer: I don't know how to do math, not sure if that number is correct.

![image](https://user-images.githubusercontent.com/35135081/118388448-68759880-b5d9-11eb-8abc-336999760e3a.png)

Hardcodes in the URL+JSON encoding of type, as it should be consistently a string.

Adds a unit test to ensure the behavior works.

## Why It's Good For The Game
`send_message` is consistently one of the hottest procs in terms of overtime and such. This change should, at least somewhat, help that. Whether or not this is the main bottleneck in `send_message`, I'm not sure.