### PR TITLE
Fixes Sentience Fun Balloons not being interactive

### DIFF
--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -57,6 +57,8 @@
 /obj/effect/fun_balloon/sentience/ui_status(mob/user)
 	if(popped)
 		return UI_CLOSE
+	if(isAdminObserver(user)) // ignore proximity if we're an admin
+		return UI_INTERACTIVE
 	return ..()
 
 /obj/effect/fun_balloon/sentience/ui_act(action, list/params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When I changed sentience fun balloons to TGUI I accidentally made it so they can't be edited or popped unless you were next to them or had AI interact turned on. This allows admins to pop them at any range. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #59136
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: sentience fun balloons now work consistently again!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
