### PR TITLE
Fix for Nicotine Addiction.

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -107,7 +107,7 @@
 ///Minimum requirement for addiction buzz to be met. Addiction code only checks this once every two seconds, so this should generally be low
 #define MIN_ADDICTION_REAGENT_AMOUNT 1
 ///Nicotine requires much less in your system to be happy
-#define MIN_NICOTINE_ADDICTION_REAGENT_AMOUNT 0.1
+#define MIN_NICOTINE_ADDICTION_REAGENT_AMOUNT 0.01
 #define MAX_ADDICTION_POINTS 1000
 
 ///Addiction start/ends


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changed minimum Nicotine value to trigger addiction Sattisfaction as smokes only give up to 0.08333333u per tick. which was less than the 0.1u required to satisfy the addiction. Ex: Xenosmokes at 240 ticks for 20u or Cohiba 20*60 for 40u at 0.0333333


## Why It's Good For The Game
Smoking to sattisfy the addiction you are almost guaranteed to gain from smoking is nice no?


## Changelog
:cl:

fix: Smokers may now enjoy the higher quality in Supply to quench theyr addiction.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
