### PR TITLE
Fixes Icebox Sec Office not having the proper cargochat console

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -46505,11 +46505,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
 	},
-/obj/machinery/modular_computer/console/preset/cargochat/cargo{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/brown/filled/end{
 	dir = 8
+	},
+/obj/machinery/modular_computer/console/preset/cargochat/security{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/security/office)


### PR DESCRIPTION
## About The Pull Request

It had the cargo preset rather than the security preset

## Changelog
:cl:
fix: Icebox - Security Office now has the intended cargochat console.
/:cl: