### PR TITLE
Prevents players from exploting the pricetag component on bounty cubes.

### DIFF
--- a/code/datums/components/pricetag.dm
+++ b/code/datums/components/pricetag.dm
@@ -20,7 +20,8 @@
 
 /datum/component/pricetag/proc/Unwrapped()
 	SIGNAL_HANDLER
-
+	if(istype(parent, /obj/item/bounty_cube))
+		return
 	qdel(src) //Once it leaves it's wrapped container, the object in question should lose it's pricetag component.
 
 /datum/component/pricetag/proc/split_profit(item_value)

--- a/code/datums/components/pricetag.dm
+++ b/code/datums/components/pricetag.dm
@@ -1,4 +1,5 @@
 /datum/component/pricetag
+	dupe_mode = COMPONENT_DUPE_UNIQUE
 	///Payee gets 100% of the value if no ratio has been set.
 	var/default_profit_ratio = 1
 	///List of bank accounts this pricetag pays out to. Format is payees[bank_account] = profit_ratio.

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -241,7 +241,7 @@
 ///Upon completion of a civilian bounty, one of these is created. It is sold to cargo to give the cargo budget bounty money, and the person who completed it cash.
 /obj/item/bounty_cube
 	name = "bounty cube"
-	desc = "A bundle of compressed hardlight data, containing a completed bounty. Sell this on the cargo shuttle to claim it!"
+	desc = "A bundle of compressed hardlight data, containing a completed bounty. Sell this on the cargo shuttle to claim it! Wrapping and tagging is unnecessary."
 	icon = 'icons/obj/economy.dmi'
 	icon_state = "bounty_cube"
 	///Value of the bounty that this bounty cube sells for.


### PR DESCRIPTION

## About The Pull Request

So, I was convinced that this had been fixed at some point, and it would appear that either it unfixed itself, never got fixed in the first place, or got reverted at some point, so this is the official fix for this.

By wrapping up bounty cubes and placing a new pricetag on the cube, players were able to effectively overwrite the price tag built in for cargo bounties and get up to 50% payout instead of the intended cut mean for you and cargo. This was not and is not intented. Instead, this gives the pricetag component COMPONENT_DUPE_UNIQUE, preventing it from being overwritten via price tags while wrapped. The only intentional way to remove a pricetag component remains unwrapping it from a package, which bounty cubes have been made exempt from as well.

The ONLY processing you are expected to perform on a bounty cube is JUST shipping it out.

## Why It's Good For The Game

This was absolutely an unintended exploit capable of both stealing from players (Removing the pricetag for solo-cargo civilian bounties), and getting much higher civilian payouts by the time of sale (replacing player cut to 50% profit.)

## Changelog
:cl:
fix: An exploit with civilian bounty cubes, allowing you to rewrap and re-pricetag cubes for higher profits has been fixed.
/:cl:
