### PR TITLE
tramstation secret documents now in cabinet instead of vault

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -38310,6 +38310,7 @@
 	dir = 8
 	},
 /obj/structure/filingcabinet,
+/obj/item/folder/documents,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "kGu" = (
@@ -50731,7 +50732,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/folder/documents,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "pEH" = (


### PR DESCRIPTION

## About The Pull Request
fixes: #59158
## Why It's Good For The Game
bugfix

## Changelog
:cl:
fix: The secret documents on tram is now inside the cabinet and not the safe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
