### PR TITLE
enable expression evaluation for auxtools debug server

### DIFF
--- a/code/__DEFINES/spaceman_dmm.dm
+++ b/code/__DEFINES/spaceman_dmm.dm
@@ -31,6 +31,9 @@
 /proc/auxtools_stack_trace(msg)
 	CRASH(msg)
 
+/proc/auxtools_expr_stub()
+	CRASH("auxtools not loaded")
+
 /proc/enable_debugging(mode, port)
 	CRASH("auxtools not loaded")
 


### PR DESCRIPTION
this proc has to exist to allow evaluation in the debug console, watch window, and for conditional breakpoints.