### PR TITLE
Fix invisible powder breaking color blending, fixing a spurrious CI failure

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1579,7 +1579,6 @@
 	name = "Invisible Powder"
 	colorname = "invisible"
 	color = "#FFFFFF00" // white + no alpha
-	random_color_list = list(null) //because using the powder color turns things invisible
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/colorful_reagent/powder/black

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -54,6 +54,7 @@
 #include "crayons.dm"
 #include "designs.dm"
 #include "dynamic_ruleset_sanity.dm"
+#include "egg_glands.dm"
 #include "emoting.dm"
 #include "food_edibility_check.dm"
 #include "heretic_knowledge.dm"

--- a/code/modules/unit_tests/egg_glands.dm
+++ b/code/modules/unit_tests/egg_glands.dm
@@ -1,0 +1,14 @@
+/// Verifies that all glands for an egg are valid
+/datum/unit_test/egg_glands
+
+/datum/unit_test/egg_glands/Run()
+	var/obj/item/food/egg/egg = allocate(/obj/item/food/egg)
+
+	for (var/datum/reagent/reagent_type as anything in subtypesof(/datum/reagent))
+		if (!(initial(reagent_type.chemical_flags) & REAGENT_CAN_BE_SYNTHESIZED))
+			continue
+
+		try
+			mix_color_from_reagents(egg.reagents.reagent_list + list(new reagent_type))
+		catch (var/exception/exception)
+			Fail("[reagent_type] fails mixing\n[exception]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug where egg glands (eggs with a random reagent) would runtime if they combined with invisible powder.

Invisible powder was setting their color to `null`, which broke everything. This doesn't change any behavior as invisible powder hardly works anyway.