### PR TITLE
Ensure a consistent working directory in build.bat

### DIFF
--- a/BUILD.bat
+++ b/BUILD.bat
@@ -1,2 +1,2 @@
-@call tools\build\build
+@call "%~dp0\tools\build\build"
 @pause


### PR DESCRIPTION
When doubleclicking a file in windows explorer, working directory is in some situations different than what's expected.