### PR TITLE
Fixes a runtime in proximity_monitor/Destroy

### DIFF
--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -32,7 +32,7 @@
 	host = null
 	last_host_loc = null
 	hasprox_receiver = null
-	QDEL_LIST(checkers)
+	QDEL_LAZYLIST(checkers)
 	return ..()
 
 /datum/proximity_monitor/proc/HandleMove()
@@ -69,7 +69,7 @@
 			if(old_checkers_len)
 				pc = checkers_local[old_checkers_len]
 				--checkers_local.len
-				QDEL_LIST(checkers_local)
+				QDEL_LAZYLIST(checkers_local)
 			else
 				pc = new(loc_to_use, src)
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns QDEL_LIST -> QDEL_LAZYLIST 
checkers is a lazy list, so let's qdel it lazily yeah?
https://github.com/tgstation/tgstation/pull/58989#issuecomment-844580805
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runtiming in destroy is icky and causes harddels among other things

