### PR TITLE
removes the ability to see static for ai detectors and makes their other feature work for the first time in three years

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -195,7 +195,7 @@
 	user.see_invisible = SEE_INVISIBLE_LIVING //can't see ghosts through cameras
 	user.sight = SEE_TURFS | SEE_BLACKNESS
 	user.see_in_dark = 2
-	return 1
+	return TRUE
 
 /mob/camera/ai_eye/remote/Destroy()
 	if(origin && eye_user)
@@ -222,9 +222,12 @@
 			forceMove(T)
 		else
 			moveToNullspace()
+
 		update_ai_detect_hud()
-		if(use_static != FALSE)
+
+		if(use_static)
 			GLOB.cameranet.visibility(src, GetViewerClient(), null, use_static)
+
 		if(visible_icon)
 			if(eye_user.client)
 				eye_user.client.images -= user_image

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -45,8 +45,6 @@
 // Syndicate device disguised as a multitool; it will turn red when an AI camera is nearby.
 
 /obj/item/multitool/ai_detect
-	var/track_cooldown = 0
-	var/track_delay = 10 //How often it checks for proximity
 	var/detect_state = PROXIMITY_NONE
 	var/rangealert = 8 //Glows red when inside
 	var/rangewarning = 20 //Glows yellow when inside
@@ -57,12 +55,12 @@
 
 /obj/item/multitool/ai_detect/Initialize()
 	. = ..()
-	START_PROCESSING(SSobj, src)
+	START_PROCESSING(SSfastprocess, src)
 	eye = new /mob/camera/ai_eye/remote/ai_detector()
 	toggle_action = new /datum/action/item_action/toggle_multitool(src)
 
 /obj/item/multitool/ai_detect/Destroy()
-	STOP_PROCESSING(SSobj, src)
+	STOP_PROCESSING(SSfastprocess, src)
 	if(hud_on && ismob(loc))
 		remove_hud(loc)
 	QDEL_NULL(toggle_action)
@@ -82,15 +80,17 @@
 	if(hud_on)
 		remove_hud(user)
 
+/obj/item/multitool/ai_detect/update_icon_state()
+	. = ..()
+	icon_state = "[initial(icon_state)][detect_state]"
+
 /obj/item/multitool/ai_detect/process()
-	if(track_cooldown > world.time)
-		return
-	detect_state = PROXIMITY_NONE
+	var/old_detect_state = detect_state
 	if(eye.eye_user)
 		eye.setLoc(get_turf(src))
 	multitool_detect()
-	update_appearance()
-	track_cooldown = world.time + track_delay
+	if(detect_state != old_detect_state)
+		update_appearance()
 
 /obj/item/multitool/ai_detect/proc/toggle_hud(mob/user)
 	hud_on = !hud_on
@@ -123,30 +123,32 @@
 
 /obj/item/multitool/ai_detect/proc/multitool_detect()
 	var/turf/our_turf = get_turf(src)
-	for(var/mob/living/silicon/ai/AI in GLOB.ai_list)
+
+	for(var/mob/living/silicon/ai/AI as anything in GLOB.ai_list)
 		if(AI.cameraFollow == src)
 			detect_state = PROXIMITY_ON_SCREEN
-			break
+			return
 
-	if(detect_state)
-		return
-	var/datum/camerachunk/chunk = GLOB.cameranet.chunkGenerated(our_turf.x, our_turf.y, our_turf.z)
-	if(chunk?.seenby.len)
-		for(var/mob/camera/ai_eye/A in chunk.seenby)
-			if(!A.ai_detector_visible)
-				continue
-			var/turf/detect_turf = get_turf(A)
-			if(get_dist(our_turf, detect_turf) < rangealert)
-				detect_state = PROXIMITY_ON_SCREEN
-				break
-			if(get_dist(our_turf, detect_turf) < rangewarning)
-				detect_state = PROXIMITY_NEAR
-				break
+	for(var/mob/camera/ai_eye/AI_eye as anything in GLOB.aiEyes)
+		if(!AI_eye.ai_detector_visible)
+			continue
+
+		var/distance = get_dist(our_turf, get_turf(AI_eye))
+
+		if(distance == -1) //get_dist() returns -1 for distances greater than 127 (and for errors, so assume -1 is just max range)
+			continue
+
+		if(distance < rangealert) //ai should be able to see us
+			detect_state = PROXIMITY_ON_SCREEN
+			break
+		if(distance < rangewarning) //ai cant see us but is close
+			detect_state = PROXIMITY_NEAR
 
 /mob/camera/ai_eye/remote/ai_detector
 	name = "AI detector eye"
 	ai_detector_visible = FALSE
 	visible_icon = FALSE
+	use_static = FALSE
 
 /datum/action/item_action/toggle_multitool
 	name = "Toggle AI detector HUD"

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -2,7 +2,6 @@
 //
 // An invisible (no icon) mob that the AI controls to look around the station with.
 // It streams chunks as it moves around, which will show it what the AI can and cannot see.
-
 /mob/camera/ai_eye
 	name = "Inactive AI Eye"
 
@@ -39,9 +38,9 @@
 		QDEL_LIST(old_images)
 		return
 
-	if(!hud.hudusers.len)
-		//no one is watching, do not bother updating anything
-		return
+	if(!length(hud.hudusers))
+		return //no one is watching, do not bother updating anything
+
 	hud.remove_from_hud(src)
 
 	var/static/list/vis_contents_opaque = list()
@@ -86,7 +85,7 @@
 			abstract_move(T)
 		else
 			moveToNullspace()
-		if(use_static != FALSE)
+		if(use_static)
 			ai.camera_visibility(src)
 		if(ai.client && !ai.multicam_on)
 			ai.client.eye = src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ai detectors used to require camera chunks to add two vis_contents to all turfs not seen by cameras just so that ai detectors could see where static is and isnt, which is a wasteful source of maptick for a single traitor item very few people use so i removed it in #59165

then it turned out the static which blocked clicks for the ai also blocked clicks for people using ai detectors and i dont see another way to fix it without adding back the static object that ai detectors used to use, so instead i made the ai detectors actually change their appearance in response to an ai coming closer like they used to before #41108 removed it three years ago and removed the ability to see static with the ai detector entirely
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
being able to see the static is a detriment now and im not adding the transparent static back. also like i said fixes a long broken feature so the ability to see which tiles arent visible to cameras isnt much better anyways
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
remove: ai detectors no longer see ai static
fix: ai detectors now change appearance when ai's come closer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
