### PR TITLE
Lowers the cold temperature activation threshold for fire alarms/firelocks

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -51,7 +51,7 @@
 	update_appearance()
 	myarea = get_area(src)
 	LAZYADD(myarea.firealarms, src)
-	
+
 	AddElement(/datum/element/atmos_sensitive, mapload)
 	RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, .proc/check_security_level)
 
@@ -125,7 +125,7 @@
 	playsound(src, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 
 /obj/machinery/firealarm/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	return (exposed_temperature > T0C + 200 || exposed_temperature < BODYTEMP_COLD_DAMAGE_LIMIT) && !(obj_flags & EMAGGED) && !machine_stat
+	return (exposed_temperature > T0C + 200 || exposed_temperature < BODYTEMP_COLD_DAMAGE_LIMIT - 30) && !(obj_flags & EMAGGED) && !machine_stat
 
 /obj/machinery/firealarm/atmos_expose(datum/gas_mixture/air, exposed_temperature)
 	if(!detecting)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fire alarms and firelocks currently activate when the temperature drops below 270 K. This PR changes that value to 240 K.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A lot of players have been complaining about how often firelocks activate after recent atmos changes (https://tgstation13.org/phpBB/viewtopic.php?f=10&t=29086, https://tgstation13.org/phpBB/viewtopic.php?f=9&t=28353). In my experience most of these "firelock gridlock" situations happen after a hull breach has occurred and been fixed, but pockets of air in locked-down areas remain cold enough to trigger the fire alarms (but not cold enough to actually harm players - if players notice that they're taking cold damage, they usually try to warm up the area). Based on my testing, humans won't take cold damage until temperature reaches 235 K or lower, so lowering the activation temperature to just above that should reduce the number of "false positive" firelock activations without hampering the system's ability to respond to actual atmos incidents.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The cold temperature activation point for firelocks has been reduced from -3°C to -33°C
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
