### PR TITLE
Fixed backpack firefighter tank nozzle refilling not working in extinguisher mode

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -133,11 +133,8 @@
 
 /obj/item/extinguisher/proc/AttemptRefill(atom/target, mob/user)
 	if(istype(target, tanktype) && target.Adjacent(user))
-		var/safety_save = safety
-		safety = TRUE
 		if(reagents.total_volume == reagents.maximum_volume)
 			to_chat(user, "<span class='warning'>\The [src] is already full!</span>")
-			safety = safety_save
 			return TRUE
 		var/obj/structure/reagent_dispensers/W = target //will it work?
 		var/transferred = W.reagents.trans_to(src, max_water, transfered_by = user)
@@ -148,7 +145,6 @@
 				R.cooling_temperature = cooling_power
 		else
 			to_chat(user, "<span class='warning'>\The [W] is empty!</span>")
-		safety = safety_save
 		return TRUE
 	else
 		return FALSE

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -268,12 +268,12 @@
 	return
 
 /obj/item/extinguisher/mini/nozzle/afterattack(atom/target, mob/user)
+	if(AttemptRefill(target, user))
+		return
 	if(nozzle_mode == EXTINGUISHER)
 		..()
 		return
 	var/Adj = user.Adjacent(target)
-	if(Adj)
-		AttemptRefill(target, user)
 	if(nozzle_mode == RESIN_LAUNCHER)
 		if(Adj)
 			return //Safety check so you don't blast yourself trying to refill your tank


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Also removed useless local var from /obj/item/extinguisher/proc/AttemptRefill

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
having to switch modes just to refill was annoying and confusing, especially when the whole station is literally on fire
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed backpack firefighter tank nozzle refilling not working in extinguisher mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
