### PR TITLE
Wires power to Icebox Cryopod room

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -18949,6 +18949,7 @@
 "cvV" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "cvX" = (
@@ -20289,6 +20290,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
+"cLc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "cLH" = (
@@ -38305,6 +38320,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/corner,
 /area/commons/fitness/recreation)
 "eqU" = (
@@ -58926,6 +58942,21 @@
 "kgb" = (
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
+"kgn" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "kgo" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -60958,6 +60989,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -83991,6 +84023,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "qCH" = (
@@ -96119,6 +96152,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "tKS" = (
@@ -97699,6 +97733,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"ufd" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/commons/cryopods)
 "uft" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -98704,6 +98742,7 @@
 /area/security/prison)
 "uua" = (
 /obj/machinery/door/airlock/glass,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
 "uuh" = (
@@ -99553,6 +99592,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
 "uDX" = (
@@ -107191,6 +107231,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"wNc" = (
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/commons/cryopods)
 "wNi" = (
 /obj/structure/filingcabinet/medical,
 /obj/machinery/light/directional/north,
@@ -166131,7 +166182,7 @@ uhI
 uhI
 trW
 eVR
-auP
+cLc
 sUD
 wZU
 aad
@@ -166388,7 +166439,7 @@ qBh
 nzf
 qsr
 geR
-qBh
+kgn
 tEe
 wZU
 aaa
@@ -167416,7 +167467,7 @@ qBh
 xOD
 qgI
 jYD
-qBh
+kgn
 sAD
 wZU
 aad
@@ -168956,11 +169007,11 @@ cFF
 cFF
 tqX
 aaa
-wZU
+oNH
 uDP
-kgb
-gjd
-sdh
+ufd
+wNc
+wWo
 aad
 mIc
 ajr

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -7203,6 +7203,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aJB" = (
@@ -7535,6 +7536,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aMI" = (
@@ -40554,6 +40556,7 @@
 	dir = 8
 	},
 /obj/machinery/navbeacon/wayfinding,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "opx" = (
@@ -49381,6 +49384,7 @@
 	c_tag = "Dormitory South";
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "tny" = (
@@ -56042,6 +56046,16 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
+"xdS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "xeF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -89444,7 +89458,7 @@ pcX
 tHq
 pSI
 lfM
-pSI
+xdS
 tmO
 opq
 aJy

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9330,6 +9330,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"bJL" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/commons/cryopods)
 "bJO" = (
 /obj/structure/chair{
 	dir = 1
@@ -23013,6 +23017,17 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"ffb" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/commons/cryopods)
 "ffm" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -27052,6 +27067,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
 "gAH" = (
@@ -64681,6 +64697,7 @@
 /area/science/xenobiology)
 "tfr" = (
 /obj/machinery/door/airlock/glass,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/commons/cryopods)
 "tfz" = (
@@ -115236,7 +115253,7 @@ aaa
 mKd
 mbU
 jsJ
-jsJ
+ffb
 xBC
 lHs
 oMv
@@ -115493,7 +115510,7 @@ aaa
 sLD
 uBw
 owL
-owL
+bJL
 tfr
 lHu
 dUA


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The cryopod room off dorms on Icebox station was added with an APC that was not wired into the station's power grid. It now connects to the main corridor loop:
![image](https://user-images.githubusercontent.com/66576896/119066472-b7824b80-b994-11eb-8295-d32758db75ec.png)

Also does Metastation and Deltastation because I just noticed they were also given new areas with no APCs.
## Why It's Good For The Game
It'd be nice if it was usable after the first ten minutes of a round.

## Changelog
:cl:
fix: The Cryopod bays on Icebox, Metastation and Deltastation have been wired into the station's power grid
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
