### PR TITLE
Slaughter demons use right-click to Slam rather than CtrlShiftClick

### DIFF
--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -81,7 +81,7 @@
 							Pulling a dead or unconscious mob while you enter a pool will pull them in with you, allowing you to feast and regain your health. \
 							You move quickly upon leaving a pool of blood, but the material world will soon sap your strength and leave you sluggish. \
 							You gain strength the more attacks you land on live humanoids, though this resets when you return to the blood zone. You can also \
-							launch a devastating slam attack with ctrl+shift+click, capable of smashing bones in one strike.</B>"
+							launch a devastating slam attack with right-click, capable of smashing bones in one strike.</B>"
 
 	loot = list(/obj/effect/decal/cleanable/blood, \
 				/obj/effect/decal/cleanable/blood/innards, \
@@ -110,7 +110,7 @@
 	if(bloodpool)
 		bloodpool.RegisterSignal(src, list(COMSIG_LIVING_AFTERPHASEIN,COMSIG_PARENT_QDELETING), /obj/effect/dummy/phased_mob/.proc/deleteself)
 
-/mob/living/simple_animal/hostile/imp/slaughter/CtrlShiftClickOn(atom/A)
+/mob/living/simple_animal/hostile/imp/slaughter/RightClickOn(atom/A)
 	if(!isliving(A))
 		return ..()
 

--- a/code/modules/antagonists/slaughter/slaughter_antag.dm
+++ b/code/modules/antagonists/slaughter/slaughter_antag.dm
@@ -14,7 +14,7 @@
 /datum/antagonist/slaughter/greet()
 	. = ..()
 	owner.announce_objectives()
-	to_chat(owner, "<span class='warning'>You have a powerful alt-attack that slams people backwards that you can activate by shift+ctrl+clicking your target!</span>")
+	to_chat(owner, "<span class='warning'>You have a powerful alt-attack that slams people backwards that you can activate by right-clicking your target!</span>")
 
 /datum/antagonist/slaughter/proc/forge_objectives()
 	if(summoner)


### PR DESCRIPTION
## About The Pull Request

Moves the slam function of slaughter demons to right-click rather than have it use Ctrl+shift+click.

## Why It's Good For The Game

I had a single run as a slaughter demon and realized how frustrating it was to use Ctrl+shift+click rather than something more simple like RightClick. And since the functionality allows it, might as well lessen the amounts of things pressed from 3 down to 1.

## Changelog
:cl:
qol: Slaughter demons now slam their targets with right-click rather than with ctrl+shift+click.
/:cl:
