### PR TITLE
[The reconnect bug is maybe fixed] Queue stat panel commands, ideally fixing another source of the reconnect bug

### DIFF
--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -322,13 +322,43 @@ var statcontentdiv = document.getElementById('statcontent');
 var storedimages = [];
 var split_admin_tabs = false;
 
+var connected = false;
+var commandQueue = [];
+
+// Any BYOND verb call must go through this, as if a verb is sent during reconnect then
+// it will cause the reconnect to fail.
+// This function will either call immediately, or queue until
+// BYOND confirms we are connected.
+function send_byond_command(command) {
+	var href = "byond://winset?command=" + command;
+
+	if (connected) {
+		window.location.href = href;
+	} else {
+		commandQueue.push(href);
+	}
+}
+
 // Any BYOND commands that could result in the client's focus changing go through this
 // to ensure that when we relinquish our focus, we don't do it after the result of
 // a command has already taken focus for itself.
-function send_byond_focus_command(url) {
-	setTimeout(function() {
-		window.location.href = url;
-	}, 0);
+function run_after_focus(callback) {
+	setTimeout(callback, 0);
+}
+
+function connected_to_server() {
+	if (connected) {
+		return;
+	}
+
+	connected = true;
+
+	for (var index = 0; index < commandQueue.length; index++) {
+		// TODO: This is just setting it a lot, is this not going to cancel?
+		window.location.href = commandQueue[index];
+	}
+
+	commandQueue = [];
 }
 
 function update_split_admin_tabs(status) {
@@ -497,7 +527,7 @@ function wipe_verbs() {
 
 function update_verbs() {
 	wipe_verbs();
-	window.location.href = "byond://winset?command=Update-Verbs";
+	send_byond_command("Update-Verbs");
 }
 
 function add_verb_list(v) {
@@ -544,6 +574,7 @@ function remove_verb_list(v) {
 // passes a 2D list of (verbcategory, verbname) creates tabs and adds verbs to respective list
 // example (IC, Say)
 function init_verbs(c, v) {
+	connected_to_server();
 	wipe_verbs(); // remove all verb categories so we can replace them
 	checkStatusTab(); // remove all status tabs
 	verb_tabs = JSON.parse(c);
@@ -576,12 +607,12 @@ function SendTabsToByond(){
 }
 
 function SendTabToByond(tab) {
-	window.location.href = "byond://winset?command=Send-Tabs " + tab;
+	send_byond_command("Send-Tabs " + tab);
 }
 
 //Byond can't have this tab anymore since we're removing it
 function TakeTabFromByond(tab) {
-	window.location.href = "byond://winset?command=Remove-Tabs " + tab;
+	send_byond_command("Remove-Tabs " + tab);
 }
 
 function update(global_data, ping_entry, other_entries) {
@@ -697,8 +728,9 @@ function tab_change(tab) {
 }
 
 function set_byond_tab(tab){
-	window.location.href = "byond://winset?command=Set-Tab " + tab;
+	send_byond_command("Set-Tab " + tab);
 }
+
 function draw_debug() {
 	statcontentdiv[textContentKey] = "";
 	var wipeverbstabs = document.createElement("div");
@@ -788,7 +820,7 @@ function draw_status() {
 	}
 	if(verb_tabs.length == 0 || !verbs)
 	{
-		window.location.href = "byond://winset?command=Fix-Stat-Panel";
+		send_byond_command("Fix-Stat-Panel");
 	}
 }
 
@@ -1094,7 +1126,9 @@ function draw_spells(cat) {
 
 function make_verb_onclick(command) {
 	return function() {
-		send_byond_focus_command("byond://winset?command=" + command);
+		run_after_focus(function() {
+			send_byond_command(command);
+		});
 	};
 }
 
@@ -1182,7 +1216,9 @@ function set_style_sheet(sheet) {
 }
 
 function restoreFocus() {
-	send_byond_focus_command("byond://winset?map.focus=true")
+	run_after_focus(function() {
+		window.location.href = "byond://winset?map.focus=true";
+	});
 }
 
 document[addEventListenerKey]("mouseup", restoreFocus);

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -354,7 +354,7 @@ function connected_to_server() {
 	connected = true;
 
 	for (var index = 0; index < commandQueue.length; index++) {
-		// TODO: This is just setting it a lot, is this not going to cancel?
+		// This is just setting it a lot, is this not going to cancel?
 		window.location.href = commandQueue[index];
 	}
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #59226, ideally.

It's hard to test this, but this queues any `?command` until `init_verbs`, in which case we have confirmed to be connected. The only one it does not is the one in `onload`, as that didn't seem to appear in my logs and I suspect is only called once we're connected to the server, which helps.

## Changelog
:cl:
fix: Fixed another source to the bug preventing reconnect.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
