### PR TITLE
canister purchases from cargo work again

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1132,7 +1132,7 @@
 
 /datum/supply_pack/materials/bz
 	name = "BZ Canister"
-	cost = CARGO_CRATE_VALUE * 45 //bz is used for many gasses so centcomm values it
+	cost = CARGO_CRATE_VALUE * 45 //bz is used for many gasses so centcom values it
 	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
 	crate_type = /obj/structure/closet/crate/large
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1139,13 +1139,13 @@
 /datum/supply_pack/materials/carbondioxide
 	name = "Carbon Dioxide Canister"
 	cost = CARGO_CRATE_VALUE * 9
-	contains = /obj/machinery/portable_atmospherics/canister/carbon_dioxide
+	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
 	crate_type = /obj/structure/closet/crate/large
 
-	/datum/supply_pack/materials/nitrous_oxide
+/datum/supply_pack/materials/nitrous_oxide
 	name = "Nitrous Oxide Canister"
 	cost = CARGO_CRATE_VALUE * 25
-	contains = /obj/machinery/portable_atmospherics/canister/carbon_dioxide
+	contains = list(/obj/machinery/portable_atmospherics/canister/nitrous_oxide)
 	crate_type = /obj/structure/closet/crate/large
 
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1118,7 +1118,7 @@
 
 /datum/supply_pack/materials/water_vapor
 	name = "Water Vapor Canister"
-	cost = CARGO_CRATE_VALUE * 15
+	cost = CARGO_CRATE_VALUE * 15 //annoying slip gas thats cheap so people can spam it (we do a little slipping)
 	contains = list(/obj/machinery/portable_atmospherics/canister)
 	crate_type = /obj/structure/closet/crate/large
 	contains = list(/obj/machinery/portable_atmospherics/canister/water_vapor)
@@ -1132,7 +1132,7 @@
 
 /datum/supply_pack/materials/bz
 	name = "BZ Canister"
-	cost = CARGO_CRATE_VALUE * 45
+	cost = CARGO_CRATE_VALUE * 45 //bz is used for many gasses so centcomm values it
 	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
 	crate_type = /obj/structure/closet/crate/large
 
@@ -1144,7 +1144,7 @@
 
 /datum/supply_pack/materials/nitrous_oxide
 	name = "Nitrous Oxide Canister"
-	cost = CARGO_CRATE_VALUE * 25
+	cost = CARGO_CRATE_VALUE * 25 //annoying sleep gas so its worth a bit more so people cant spam it
 	contains = list(/obj/machinery/portable_atmospherics/canister/nitrous_oxide)
 	crate_type = /obj/structure/closet/crate/large
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1116,41 +1116,27 @@
 	crate_name = "water tank crate"
 	crate_type = /obj/structure/closet/crate/large
 
-/datum/supply_pack/materials/gas_canisters
-	cost = CARGO_CRATE_VALUE * 0.05
+/datum/supply_pack/materials/water_vapor
+	name = "Water Vapor Canister"
+	cost = CARGO_CRATE_VALUE * 15
 	contains = list(/obj/machinery/portable_atmospherics/canister)
 	crate_type = /obj/structure/closet/crate/large
+	contains = list(/obj/machinery/portable_atmospherics/canister/water_vapor)
 
-/datum/supply_pack/materials/gas_canisters/generate_supply_packs()
-	var/list/canister_packs = list()
+/datum/supply_pack/materials/oxygen
+	name = "Oxygen Canister"
+	cost = CARGO_CRATE_VALUE * 9
+	contains = list(/obj/machinery/portable_atmospherics/canister)
+	crate_type = /obj/structure/closet/crate/large
+	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
 
-	var/obj/machinery/portable_atmospherics/canister/fakeCanister = /obj/machinery/portable_atmospherics/canister
-	// This is the amount of moles in a default canister
-	var/moleCount = (initial(fakeCanister.maximum_pressure) * initial(fakeCanister.filled)) * initial(fakeCanister.volume) / (R_IDEAL_GAS_EQUATION * T20C)
+/datum/supply_pack/materials/bz
+	name = "BZ Canister"
+	cost = CARGO_CRATE_VALUE * 45
+	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
+	crate_type = /obj/structure/closet/crate/large
 
-	for(var/gasType in GLOB.meta_gas_info)
-		var/datum/gas/gas = gasType
-		var/name = initial(gas.name)
-		if(!initial(gas.purchaseable))
-			continue
-		var/datum/supply_pack/materials/pack = new
-		pack.name = "[name] Canister"
-		pack.desc = "Contains a canister of [name]."
-		if(initial(gas.dangerous))
-			pack.desc = "[pack.desc] Requires Atmospherics access to open."
-			pack.access = ACCESS_ATMOSPHERICS
-			pack.access_view = ACCESS_ATMOSPHERICS
-		pack.crate_name = "[name] canister crate"
-		pack.id = "[type]([name])"
 
-		pack.cost = cost + moleCount * initial(gas.base_value) * 1.6
-		pack.cost = CEILING(pack.cost, 10)
-
-		pack.contains = list(GLOB.gas_id_to_canister[initial(gas.id)])
-
-		canister_packs += pack
-
-	return canister_packs
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Medical /////////////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1136,7 +1136,17 @@
 	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
 	crate_type = /obj/structure/closet/crate/large
 
+/datum/supply_pack/materials/carbondioxide
+	name = "Carbon Dioxide Canister"
+	cost = CARGO_CRATE_VALUE * 9
+	contains = /obj/machinery/portable_atmospherics/canister/carbon_dioxide
+	crate_type = /obj/structure/closet/crate/large
 
+	/datum/supply_pack/materials/nitrous_oxide
+	name = "Nitrous Oxide Canister"
+	cost = CARGO_CRATE_VALUE * 25
+	contains = /obj/machinery/portable_atmospherics/canister/carbon_dioxide
+	crate_type = /obj/structure/closet/crate/large
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Medical /////////////////////////////////////////


### PR DESCRIPTION


## About The Pull Request
you couldnt buy canisters from cargo because it was bugged so this fixes it and changes the code a bit
## Why It's Good For The Game

bugfix and better looking code(?) i hope

## Changelog
:cl:
fix: Central Command has decided that it is no longer funny to send cargo empty gas canisters. You can now properly buy gas from cargo and they wont arrive empty
/:cl: