### PR TITLE
Adds balloon messages when holding firelocks open

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -141,7 +141,7 @@
 
 	if(density)
 		being_held_open = TRUE
-		user.visible_message("<span class='danger'>[user] holds [src] open.</span>", "<span class='notice'>You hold [src] open.</span>")
+		user.balloon_alert_to_viewers("holding [src] open", "holding [src] open")
 		open()
 		if(QDELETED(user))
 			being_held_open = FALSE
@@ -175,7 +175,7 @@
 	UnregisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION)
 	UnregisterSignal(user, COMSIG_PARENT_QDELETING)
 	if(user)
-		user.visible_message("<span class='danger'>[user] stops holding [src] open.</span>", "<span class='notice'>You stop holding [src] open.</span>")
+		user.balloon_alert_to_viewers("released [src]", "released [src]")
 
 /obj/machinery/door/firedoor/attack_ai(mob/user)
 	add_fingerprint(user)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -36,8 +36,8 @@
 		. += "<span class='notice'>It is open, but could be <b>pried</b> closed.</span>"
 	else if(!welded)
 		. += "<span class='notice'>It is closed, but could be <b>pried</b> open.</span>"
-		. += "<span class='notice'>Hold the door open by prying it with <i>left-click</i> and standing next to it.</span>"
-		. += "<span class='notice'>Prying by <i>right-clicking</i> the door will simply open it.</span>"
+		. += "<span class='notice'>Hold the firelock temporarily open by prying it with <i>left-click</i> and standing next to it.</span>"
+		. += "<span class='notice'>Prying by <i>right-clicking</i> the firelock will open it permanently.</span>"
 		. += "<span class='notice'>Deconstruction would require it to be <b>welded</b> shut.</span>"
 	else if(boltslocked)
 		. += "<span class='notice'>It is <i>welded</i> shut. The floor bolts have been locked by <b>screws</b>.</span>"
@@ -130,7 +130,7 @@
 	user.visible_message("<span class='notice'>[user] starts [welded ? "unwelding" : "welding"] [src].</span>", "<span class='notice'>You start welding [src].</span>")
 	if(W.use_tool(src, user, DEFAULT_STEP_TIME, volume=50))
 		welded = !welded
-		to_chat(user, "<span class='danger'>[user] [welded?"welds":"unwelds"] [src].</span>", "<span class='notice'>You [welded ? "weld" : "unweld"] [src].</span>")
+		user.visible_message("<span class='danger'>[user] [welded?"welds":"unwelds"] [src].</span>", "<span class='notice'>You [welded ? "weld" : "unweld"] [src].</span>")
 		log_game("[key_name(user)] [welded ? "welded":"unwelded"] firedoor [src] with [W] at [AREACOORD(src)]")
 		update_appearance()
 
@@ -141,6 +141,7 @@
 
 	if(density)
 		being_held_open = TRUE
+		user.visible_message("<span class='danger'>[user] holds [src] open.</span>", "<span class='notice'>You hold [src] open.</span>")
 		open()
 		if(QDELETED(user))
 			being_held_open = FALSE
@@ -165,22 +166,16 @@
 /obj/machinery/door/firedoor/proc/handle_held_open_adjacency(mob/user)
 	SIGNAL_HANDLER
 
-	//Handle qdeletion here
-	if(QDELETED(user))
-		being_held_open = FALSE
-		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
-		UnregisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION)
-		UnregisterSignal(user, COMSIG_PARENT_QDELETING)
-		return
-
 	var/mob/living/living_user = user
-	if(Adjacent(user) && isliving(user) && (living_user.body_position == STANDING_UP))
+	if(!QDELETED(user) && Adjacent(user) && isliving(user) && (living_user.body_position == STANDING_UP))
 		return
 	being_held_open = FALSE
 	INVOKE_ASYNC(src, .proc/close)
 	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 	UnregisterSignal(user, COMSIG_LIVING_SET_BODY_POSITION)
 	UnregisterSignal(user, COMSIG_PARENT_QDELETING)
+	if(user)
+		user.visible_message("<span class='danger'>[user] stops holding [src] open.</span>", "<span class='notice'>You stop holding [src] open.</span>")
 
 /obj/machinery/door/firedoor/attack_ai(mob/user)
 	add_fingerprint(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds balloon messages when a player is starts or ends holding a firelock open. Changes the examine text of a closed firelock to explain that right-click opens it permanently and left-click opens it temporarily 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Holding firelocks open behavior introduced in #57943 is very confusing. It just looks like an annoying bug, until you examine the firelock to learn that it's actually a feature. This change makes it less confusing by telling the player wtf is happening.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Made the action of holding firelocks open by left clicking with a crowbar less confusing by adding balloon messages describing what is happening. Changed the firelock examine text to explain that right-click opens it permanently and left-click opens it temporarily
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
