### PR TITLE
Change the merge conflict timeout time

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -11,3 +11,4 @@ jobs:
         with:
           CONFLICT_LABEL_NAME: 'Merge Conflict'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WAIT_MS: 10000


### PR DESCRIPTION
Fetching mergable is async because idk github and bigger repos take longer to do it so this should fix timeout issues somewhat