### PR TITLE
Renames the Research Director's plasmamen suit from Chief Engineer to Research Director

### DIFF
--- a/code/modules/clothing/under/jobs/Plasmaman/command.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/command.dm
@@ -37,7 +37,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 10, FIRE = 95, ACID = 95)
 
 /obj/item/clothing/under/plasmaman/research_director
-	name = "chief engineer's plasma envirosuit"
+	name = "research director's plasma envirosuit"
 	desc = "It's an envirosuit worn by those with the know-how to achieve the position of \"Research Director\"."
 	icon_state = "rd_envirosuit"
 	inhand_icon_state = "rd_envirosuit"


### PR DESCRIPTION
## About The Pull Request

Title. Probably a result from copypaste

## Why It's Good For The Game

I can't take this anymore, I'm going mental.

## Changelog
:cl:
spellcheck: The Research Director's plasmaman envirosuit is now labelled as belonging to the Research Director rather than the Chief Engineer.
/:cl: