### PR TITLE
Cargo canister purchases fixed again

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -18,7 +18,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 		"no2" = /obj/machinery/portable_atmospherics/canister/nitryl,
 		"bz" = /obj/machinery/portable_atmospherics/canister/bz,
 		"air" = /obj/machinery/portable_atmospherics/canister/air,
-		"water vapor" = /obj/machinery/portable_atmospherics/canister/water_vapor,
+		"water_vapor" = /obj/machinery/portable_atmospherics/canister/water_vapor,
 		"tritium" = /obj/machinery/portable_atmospherics/canister/tritium,
 		"hyper-noblium" = /obj/machinery/portable_atmospherics/canister/nob,
 		"stimulum" = /obj/machinery/portable_atmospherics/canister/stimulum,

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -163,10 +163,11 @@
 			if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_EXPRESSPOD_CONSOLE))
 				say("Railgun recalibrating. Stand by.")
 				return
-			var/id = text2path(params["id"])
+			var/id = params["id"]
+			id = text2path(id) || id
 			var/datum/supply_pack/pack = SSshuttle.supply_packs[id]
 			if(!istype(pack))
-				return
+				CRASH("Unknown supply pack id given by express order console ui. ID: [params["id"]]")
 			var/name = "*None Provided*"
 			var/rank = "*None Provided*"
 			var/ckey = usr.ckey

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1133,7 +1133,7 @@
 		var/name = initial(gas.name)
 		if(!initial(gas.purchaseable))
 			continue
-		var/datum/supply_pack/materials/gas_canisters/pack = new
+		var/datum/supply_pack/materials/pack = new
 		pack.name = "[name] Canister"
 		pack.desc = "Contains a canister of [name]."
 		if(initial(gas.dangerous))
@@ -1147,6 +1147,8 @@
 		pack.cost = CEILING(pack.cost, 10)
 
 		pack.contains = list(GLOB.gas_id_to_canister[initial(gas.id)])
+
+		pack.crate_type = crate_type
 
 		canister_packs += pack
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1133,7 +1133,7 @@
 		var/name = initial(gas.name)
 		if(!initial(gas.purchaseable))
 			continue
-		var/datum/supply_pack/materials/pack = new
+		var/datum/supply_pack/materials/gas_canisters/pack = new
 		pack.name = "[name] Canister"
 		pack.desc = "Contains a canister of [name]."
 		if(initial(gas.dangerous))


### PR DESCRIPTION
There were some remaining bugs with purchasing gas canisters brought to my attention.

## Changelog
:cl:
fix: Water vapor can be purchased instead of shipping an empty crate
fix: The express console can purchase gas canisters again
fix: Gas canisters come in a large crate again
/:cl:
