### PR TITLE
Fixes admin mode greyscale debug menu config selection

### DIFF
--- a/code/modules/admin/greyscale_modify_menu.dm
+++ b/code/modules/admin/greyscale_modify_menu.dm
@@ -106,7 +106,7 @@
 				"[config.type]"
 			) as anything in allowed_configs
 			new_config = allowed_configs[new_config]
-			new_config = SSgreyscale.configurations[new_config]
+			new_config = SSgreyscale.configurations[new_config] || new_config
 			if(!isnull(new_config) && config != new_config)
 				config = new_config
 				queue_refresh()


### PR DESCRIPTION
## Changelog
:cl:
fix: You can select the config again in the greyscale debug menu with admin controls enabled
/:cl:
