### PR TITLE
Fixes human burgers not naming after the donor

### DIFF
--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -70,6 +70,9 @@
 	var/atom/original_object = parent
 	var/atom/grilled_result = new cook_result(original_object.loc)
 
+	if(original_object.custom_materials)
+		grilled_result.set_custom_materials(original_object.custom_materials, 1)
+
 	grilled_result.pixel_x = original_object.pixel_x
 	grilled_result.pixel_y = original_object.pixel_y
 

--- a/code/datums/materials/meat.dm
+++ b/code/datums/materials/meat.dm
@@ -34,12 +34,24 @@
 
 /datum/material/meat/mob_meat
 	init_flags = MATERIAL_INIT_BESPOKE
+	var/subjectname = ""
+	var/subjectjob = null
 
 /datum/material/meat/mob_meat/Initialize(_id, mob/living/source)
 	if(!istype(source))
 		return FALSE
 
 	name = "[source?.name ? "[source.name]'s" : "mystery"] [initial(name)]"
+
+	if(source.real_name)
+		subjectname = source.real_name
+	else if(source.name)
+		subjectname = source.name
+
+	if(ishuman(source))
+		var/mob/living/carbon/human/human_source = source
+		subjectjob = human_source.job
+
 	return ..()
 
 /datum/material/meat/species_meat

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1435,8 +1435,13 @@
 		var/list/atom/created_atoms = list()
 		for(var/i = 1 to chosen_option[TOOL_PROCESSING_AMOUNT])
 			var/atom/created_atom = new atom_to_create(drop_location())
-			created_atom.pixel_x = rand(-8, 8)
-			created_atom.pixel_y = rand(-8, 8)
+			if(custom_materials)
+				created_atom.set_custom_materials(custom_materials, 1 / chosen_option[TOOL_PROCESSING_AMOUNT])
+			created_atom.pixel_x = pixel_x
+			created_atom.pixel_y = pixel_y
+			if(i > 1)
+				created_atom.pixel_x += rand(-8,8)
+				created_atom.pixel_y += rand(-8,8)
 			SEND_SIGNAL(created_atom, COMSIG_ATOM_CREATEDBY_PROCESSING, src, chosen_option)
 			created_atom.OnCreatedFromProcessing(user, I, chosen_option, src)
 			to_chat(user, "<span class='notice'>You manage to create [chosen_option[TOOL_PROCESSING_AMOUNT]] [initial(atom_to_create.name)]\s from [src].</span>")

--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -34,22 +34,17 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/protein = 6, /datum/reagent/consumable/nutriment/vitamin = 5)
 	tastes = list("bun" = 2, "long pig" = 4)
 	foodtypes = MEAT | GRAIN | GROSS
-	var/subjectname = ""
-	var/subjectjob = null
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/burger/human/CheckParts(list/parts_list)
 	..()
-	var/obj/item/food/meat/M = locate(/obj/item/food/meat/steak/plain/human) in contents
-	if(M)
-		subjectname = M.subjectname
-		subjectjob = M.subjectjob
-		if(subjectname)
-			name = "[subjectname] burger"
-		else if(subjectjob)
-			name = "[subjectjob] burger"
-		qdel(M)
-
+	var/obj/item/food/patty/human/human_patty = locate(/obj/item/food/patty/human) in contents
+	if(LAZYLEN(human_patty.custom_materials))
+		for(var/datum/material/meat/mob_meat/mob_meat_material in human_patty.custom_materials)
+			if(mob_meat_material.subjectname)
+				name = "[mob_meat_material.subjectname] burger"
+			else if(mob_meat_material.subjectjob)
+				name = "[mob_meat_material.subjectjob] burger"
 
 /obj/item/food/burger/corgi
 	name = "corgi burger"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Instead of human burgers always being called human burgers they'll try to name themselves after the donor or their job title again.

In the process, does the following:
- Adds name and job of meat source to mob_meat material 
- Transfers custom materials to the results of processed atoms
- Transfers custom materials to the results of grilling


Also makes processed atoms have the same pixel offsets as their source while randomising any subsequent ones.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Human burgers are a staple of SS13 cuisine and this returns them to their former glory.

If you use a rolling pin on a meatball the resulting patty won't have moved randomly.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
fix: Human burgers can name themselves after their ingredient sources again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
