### PR TITLE
Makes washing machines support GAGS recoloration

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -727,31 +727,26 @@
 	. = list()
 	SEND_SIGNAL(src, COMSIG_ATOM_UPDATE_OVERLAYS, .)
 
-/// Checks if the colors given are different and if so causes a greyscale icon update
-/// The colors argument can be either a list or the full color string
-/atom/proc/set_greyscale_colors(list/colors, update=TRUE)
+/// Handles updates to greyscale value updates.
+/// The colors argument can be either a list or the full color string.
+/// Child procs should call parent last so the update happens after all changes.
+/atom/proc/set_greyscale(list/colors, new_config)
 	SHOULD_CALL_PARENT(TRUE)
 	if(istype(colors))
 		colors = colors.Join("")
-	if(greyscale_colors == colors)
-		return
-	greyscale_colors = colors
-	if(!greyscale_config)
-		return
-	if(update && greyscale_config && greyscale_colors)
-		update_greyscale()
+	if(!isnull(colors) && greyscale_colors != colors) // If you want to disable greyscale stuff then give a blank string
+		greyscale_colors = colors
 
-/// Checks if the greyscale config given is different and if so causes a greyscale icon update
-/atom/proc/set_greyscale_config(new_config, update=TRUE)
-	if(greyscale_config == new_config)
-		return
-	greyscale_config = new_config
-	if(update && greyscale_config && greyscale_colors)
-		update_greyscale()
+	if(!isnull(new_config) && greyscale_config != new_config)
+		greyscale_config = new_config
 
-/// Checks if this atom uses the GAS system and if so updates the icon
+	update_greyscale()
+
+/// Checks if this atom uses the GAGS system and if so updates the icon
 /atom/proc/update_greyscale()
-	icon = SSgreyscale.GetColoredIconByType(greyscale_config, greyscale_colors)
+	SHOULD_CALL_PARENT(TRUE)
+	if(greyscale_colors && greyscale_config)
+		icon = SSgreyscale.GetColoredIconByType(greyscale_config, greyscale_colors)
 
 /**
  * An atom we are buckled or is contained within us has tried to move

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -322,8 +322,7 @@
 					break
 
 			if(initial(pda_path.greyscale_config) && initial(pda_path.greyscale_colors))
-				stored_pda.set_greyscale_config(initial(pda_path.greyscale_config), update=FALSE)
-				stored_pda.set_greyscale_colors(initial(pda_path.greyscale_colors))
+				stored_pda.set_greyscale(initial(pda_path.greyscale_colors), initial(pda_path.greyscale_config))
 			else
 				stored_pda.icon = initial(pda_path.icon)
 			stored_pda.icon_state = initial(pda_path.icon_state)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -190,25 +190,36 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	var/dye_key_selector = dye_key_override ? dye_key_override : dying_key
 	if(undyeable)
 		return FALSE
-	if(dye_key_selector)
-		if(!GLOB.dye_registry[dye_key_selector])
-			log_runtime("Item just tried to be dyed with an invalid registry key: [dye_key_selector]")
-			return FALSE
-		var/obj/item/target_type = GLOB.dye_registry[dye_key_selector][dye_color]
-		if(target_type)
-			icon = initial(target_type.icon)
-			icon_state = initial(target_type.icon_state)
-			lefthand_file = initial(target_type.lefthand_file)
-			righthand_file = initial(target_type.righthand_file)
-			inhand_icon_state = initial(target_type.inhand_icon_state)
-			worn_icon = initial(target_type.worn_icon)
-			worn_icon_state = initial(target_type.worn_icon_state)
-			inhand_x_dimension = initial(target_type.inhand_x_dimension)
-			inhand_y_dimension = initial(target_type.inhand_y_dimension)
-			name = initial(target_type.name)
-			desc = "[initial(target_type.desc)] The colors look a little dodgy."
-			return target_type //successfully "appearance copy" dyed something; returns the target type as a hacky way of extending
-	return FALSE
+	if(!dye_key_selector)
+		return FALSE
+	if(!GLOB.dye_registry[dye_key_selector])
+		log_runtime("Item just tried to be dyed with an invalid registry key: [dye_key_selector]")
+		return FALSE
+	var/obj/item/target_type = GLOB.dye_registry[dye_key_selector][dye_color]
+	if(!target_type)
+		return FALSE
+	if(initial(target_type.greyscale_config) && initial(target_type.greyscale_colors))
+		set_greyscale(
+			colors=initial(target_type.greyscale_colors),
+			new_config=initial(target_type.greyscale_config),
+			new_worn_config=initial(target_type.greyscale_config_worn),
+			new_inhand_left=initial(target_type.greyscale_config_inhand_left),
+			new_inhand_right=initial(target_type.greyscale_config_inhand_right)
+		)
+	else
+		icon = initial(target_type.icon)
+		lefthand_file = initial(target_type.lefthand_file)
+		righthand_file = initial(target_type.righthand_file)
+		worn_icon = initial(target_type.worn_icon)
+
+	icon_state = initial(target_type.icon_state)
+	inhand_icon_state = initial(target_type.inhand_icon_state)
+	worn_icon_state = initial(target_type.worn_icon_state)
+	inhand_x_dimension = initial(target_type.inhand_x_dimension)
+	inhand_y_dimension = initial(target_type.inhand_y_dimension)
+	name = initial(target_type.name)
+	desc = "[initial(target_type.desc)] The colors look a little dodgy."
+	return target_type //successfully "appearance copy" dyed something; returns the target type as a hacky way of extending
 
 //what happens to this object when washed inside a washing machine
 /atom/movable/proc/machine_wash(obj/machinery/washing_machine/WM)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -267,7 +267,16 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 /obj/item/proc/suicide_act(mob/user)
 	return
 
-/// Checks if this atom uses the GAS system and if so updates the worn and inhand icons
+/obj/item/set_greyscale(list/colors, new_config, new_worn_config, new_inhand_left, new_inhand_right)
+	if(new_worn_config)
+		greyscale_config_worn = new_worn_config
+	if(new_inhand_left)
+		greyscale_config_inhand_left = new_inhand_left
+	if(new_inhand_right)
+		greyscale_config_inhand_right = new_inhand_right
+	return ..()
+
+/// Checks if this atom uses the GAGS system and if so updates the worn and inhand icons
 /obj/item/update_greyscale()
 	. = ..()
 	if(!greyscale_colors)

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -19,9 +19,8 @@
 	var/onstation = TRUE
 
 /obj/item/circuitboard/Initialize()
-	set_greyscale_config(/datum/greyscale_config/circuit)
-	set_greyscale_colors(greyscale_colors)
-	. = ..()
+	set_greyscale(new_config=/datum/greyscale_config/circuit)
+	return ..()
 
 /obj/item/circuitboard/proc/apply_default_parts(obj/machinery/M)
 	if(LAZYLEN(M.component_parts))

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -50,7 +50,7 @@
 /obj/item/screwdriver/Initialize()
 	if(random_color)
 		var/our_color = pick(screwdriver_colors)
-		set_greyscale_colors(list(screwdriver_colors[our_color]))
+		set_greyscale(colors=list(screwdriver_colors[our_color]))
 		inhand_icon_state = null
 		colored_belt_appearance = mutable_appearance(SSgreyscale.GetColoredIconByType(/datum/greyscale_config/screwdriver_belt, greyscale_colors))
 	. = ..()

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -6,6 +6,9 @@
 	inhand_icon_state = "cutters"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
+
+	greyscale_config = /datum/greyscale_config/wirecutters
+
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	force = 6
@@ -37,9 +40,8 @@
 
 /obj/item/wirecutters/Initialize()
 	if(random_color)
-		set_greyscale_config(/datum/greyscale_config/wirecutters)
 		var/our_color = pick(wirecutter_colors)
-		set_greyscale_colors(list(wirecutter_colors[our_color]))
+		set_greyscale(colors=list(wirecutter_colors[our_color]))
 	return ..()
 
 /obj/item/wirecutters/attack(mob/living/carbon/C, mob/user)

--- a/code/modules/admin/greyscale_modify_menu.dm
+++ b/code/modules/admin/greyscale_modify_menu.dm
@@ -231,6 +231,4 @@ This is highly likely to cause a lag spike for a few seconds."},
 	unlocked = TRUE
 
 /datum/greyscale_modify_menu/proc/DefaultApply()
-	target.set_greyscale_config(config.type, update=FALSE)
-	target.greyscale_colors = "" // We do this to force an update, in some cases it will think nothing changed when it should be refreshing
-	target.set_greyscale_colors(split_colors)
+	target.set_greyscale(split_colors, config.type)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -662,8 +662,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 					desc = initial(replacement.desc)
 					icon_state = initial(replacement.icon_state)
 					base_icon_state = icon_state
-					set_greyscale_config(initial(replacement.greyscale_config), update=FALSE)
-					set_greyscale_colors(initial(replacement.greyscale_colors))
+					set_greyscale(initial(replacement.greyscale_colors), initial(replacement.greyscale_config))
 		if("restricted")
 			restricted = !restricted
 			if(restricted)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -68,7 +68,7 @@
 /mob/living/simple_animal/hostile/carp/Initialize(mapload)
 	AddElement(/datum/element/simple_flying)
 	if(random_color)
-		set_greyscale_config(/datum/greyscale_config/carp)
+		set_greyscale(new_config=/datum/greyscale_config/carp)
 		carp_randomify(rarechance)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
@@ -92,10 +92,10 @@
 	var/our_color
 	if(prob(rarechance))
 		our_color = pick(carp_colors_rare)
-		set_greyscale_colors(list(carp_colors_rare[our_color]))
+		set_greyscale(colors=list(carp_colors_rare[our_color]))
 	else
 		our_color = pick(carp_colors)
-		set_greyscale_colors(list(carp_colors[our_color]))
+		set_greyscale(colors=list(carp_colors[our_color]))
 
 /mob/living/simple_animal/hostile/carp/revive(full_heal = FALSE, admin_revive = FALSE)
 	. = ..()

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -939,7 +939,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	playsound(src, 'sound/machines/machine_vend.ogg', 50, TRUE, extrarange = -3)
 	var/obj/item/vended_item = new R.product_path(get_turf(src))
 	if(greyscale_colors)
-		vended_item.set_greyscale_colors(greyscale_colors)
+		vended_item.set_greyscale(colors=greyscale_colors)
 	R.amount--
 	if(usr.CanReach(src) && usr.put_in_hands(vended_item))
 		to_chat(usr, "<span class='notice'>You take [R.name] out of the slot.</span>")


### PR DESCRIPTION
Washing machines needed some checks for if a sprite was generated via GAGS and to set the vars appropriately.

fixes #58811

## Changelog
:cl:
fix: Certain objects that were migrated to a new greyscale system could no longer be colored via washing machine. This has been fixed.
/:cl:
