### PR TITLE
Run and Debug now uses dreamdaemon instead of dreamseeker

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
     {
       "type": "byond",
       "request": "launch",
-      "name": "Launch DreamSeeker",
+      "name": "Launch DreamDaemon",
       "preLaunchTask": "Build All",
       "dmb": "${workspaceFolder}/${command:CurrentDMB}",
         "dreamDaemon": true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,8 @@
       "request": "launch",
       "name": "Launch DreamSeeker",
       "preLaunchTask": "Build All",
-      "dmb": "${workspaceFolder}/${command:CurrentDMB}"
+      "dmb": "${workspaceFolder}/${command:CurrentDMB}",
+        "dreamDaemon": true
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "name": "Launch DreamDaemon",
       "preLaunchTask": "Build All",
       "dmb": "${workspaceFolder}/${command:CurrentDMB}",
-        "dreamDaemon": true
+      "dreamDaemon": true
     }
   ]
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes debug servers launch a dream daemon instead of a seeker.

## Why It's Good For The Game

There's some bad issues with seeker. It crashes randomly, and sometimes makes tgui run out of memory. Those problems aren't present when launching from daemon, so I think it's a good idea to switch over.

## Changelog

Not player facing... I really have no idea what tag to give this anyways.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
