### PR TITLE
Fixes monkeys trying to pickpocket grass

### DIFF
--- a/code/datums/ai/monkey/monkey_behaviors.dm
+++ b/code/datums/ai/monkey/monkey_behaviors.dm
@@ -80,6 +80,10 @@
 
 	var/mob/living/victim = target.loc
 
+	if(!istype(victim))
+		finish_action(controller, FALSE)
+		return
+
 	var/mob/living/living_pawn = controller.pawn
 
 	victim.visible_message("<span class='warning'>[living_pawn] starts trying to take [target] from [victim]!</span>", "<span class='danger'>[living_pawn] tries to take [target]!</span>")


### PR DESCRIPTION
In the time between starting the goal of stealing an item and actually getting within range, the item could have been dropped or otherwise moved. This doesn't have anything player facing, just making it not runtime.