### PR TITLE
Powersinks now converts power to heat

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -19,9 +19,9 @@
 	throw_speed = 1
 	throw_range = 2
 	custom_materials = list(/datum/material/iron=750)
-	var/drain_rate = 2000000 // amount of power to drain per tick
+	var/drain_rate = 2e6 // amount of power to drain per tick
 	var/power_drained = 0 // has drained this much power
-	var/max_power = 6e8 // maximum power that can be drained before exploding
+	var/max_power = 1e8 // maximum power that can be drained before exploding
 	var/mode = 0 // 0 = off, 1=clamped (off), 2=operating
 	var/admins_warned = FALSE // stop spam, only warn the admins once that we are about to boom
 
@@ -123,6 +123,8 @@
 			set_mode(CLAMPED_OFF)
 
 /obj/item/powersink/process()
+	var/old_drain = power_drained
+
 	if(!attached)
 		set_mode(DISCONNECTED)
 		return
@@ -150,6 +152,10 @@
 							A.charging = 1 // It's no longer full
 				if(drained >= drain_rate)
 					break
+
+	if(old_drain < power_drained)
+		//add heat sharing
+
 
 	if(power_drained > max_power * 0.98)
 		if (!admins_warned)

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -32,6 +32,14 @@
 	icon_state = "powersink[mode == OPERATING]"
 	return ..()
 
+/obj/item/powersink/examine(mob/user)
+	. = ..()
+	if(mode)
+		. += "\The [src] is bolted to the floor."
+	if(in_range(user, src) || isobserver(user))
+		if(internal_heat > max_heat * 0.5)
+			. += "<span class='danger'>[src] is warping the air above it. It must be very hot.</span>"
+
 /obj/item/powersink/set_anchored(anchorvalue)
 	. = ..()
 	density = anchorvalue

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -3,6 +3,8 @@
 #define OPERATING 2
 
 #define FRACTION_TO_RELEASE 50
+#define ALERT 90
+#define MINIMUM_HEAT 10000
 
 // Powersink - used to drain station power
 
@@ -36,9 +38,8 @@
 	. = ..()
 	if(mode)
 		. += "\The [src] is bolted to the floor."
-	if(in_range(user, src) || isobserver(user))
-		if(internal_heat > max_heat * 0.5)
-			. += "<span class='danger'>[src] is warping the air above it. It must be very hot.</span>"
+	if(in_range(user, src) || isobserver(user) && internal_heat > max_heat * 0.5)
+		. += "<span class='danger'>[src] is warping the air above it. It must be very hot.</span>"
 
 /obj/item/powersink/set_anchored(anchorvalue)
 	. = ..()
@@ -50,7 +51,7 @@
 	switch(value)
 		if(DISCONNECTED)
 			attached = null
-			if(mode == OPERATING && internal_heat < 1000)
+			if(mode == OPERATING && internal_heat < MINIMUM_HEAT)
 				STOP_PROCESSING(SSobj, src)
 				internal_heat = 0
 			set_anchored(FALSE)
@@ -58,7 +59,7 @@
 		if(CLAMPED_OFF)
 			if(!attached)
 				return
-			if(mode == OPERATING && internal_heat < 1000)
+			if(mode == OPERATING && internal_heat < MINIMUM_HEAT)
 				STOP_PROCESSING(SSobj, src)
 				internal_heat = 0
 			set_anchored(TRUE)
@@ -146,7 +147,7 @@
 	if(admins_warned && internal_heat < max_heat * 0.75)
 		admins_warned = FALSE
 		message_admins("Power sink at ([x],[y],[z] - <A HREF='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has cooled down and will not explode.")
-	if(mode != OPERATING && internal_heat < 1000)
+	if(mode != OPERATING && internal_heat < MINIMUM_HEAT)
 		internal_heat = 0
 		STOP_PROCESSING(SSobj, src)
 
@@ -182,10 +183,10 @@
 
 	drain_power()
 
-	if(internal_heat > max_heat * 0.90)
+	if(internal_heat > max_heat * ALERT / 100)
 		if (!admins_warned)
 			admins_warned = TRUE
-			message_admins("Power sink at ([x],[y],[z] - <A HREF='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has reached 90% of max heat. Explosion imminent.")
+			message_admins("Power sink at ([x],[y],[z] - <A HREF='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has reached [ALERT]% of max heat. Explosion imminent.")
 		playsound(src, 'sound/effects/screech.ogg', 100, TRUE, TRUE)
 
 	if(internal_heat >= max_heat)
@@ -197,3 +198,5 @@
 #undef CLAMPED_OFF
 #undef OPERATING
 #undef FRACTION_TO_RELEASE
+#undef ALERT
+#undef MINIMUM_HEAT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Powersinks now generate heat when they absorb power. Max drained per tick limit removed, explosion moved from a fixed "power drained" to a max heat limit. A power sink will get rid of 1/50 of its heat every tick, so if you stop the power drain it will cool down and be able to drain more power. Hooking one up to a network with more than 1MW available power will blow up the power sink within a few minutes if heat is not managed.
Also adds some examine text.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rebalances the powersink to reflect the removal of easy high output engines, and add benefits to doing a proper SM setup. Makes it a lot easier to blow one up by chucking more power into the powernet, and makes it a bit less set and forget than before.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
balance: Powersinks now generate heat when absorbing energy, and are a lot easier to counter with the SM than before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
