### PR TITLE
Stops giving you organ damage messages if you arent conscious

### DIFF
--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -217,14 +217,15 @@
 		return
 	if(DT_PROB(65, delta_time))
 		return
-	var/obj/item/organ/organ = pick(affected_carbon.internal_organs)
-	if(organ.low_threshold)
-		to_chat(affected_carbon, organ.low_threshold_passed)
-		return
-	else if (organ.high_threshold_passed)
-		to_chat(affected_carbon, organ.high_threshold_passed)
-		return
-	to_chat(affected_carbon, "<span class='warning'>You feel a dull pain in your [organ.name].</span>")
+	if(affected_carbon.stat <= SOFT_CRIT)
+		var/obj/item/organ/organ = pick(affected_carbon.internal_organs)
+		if(organ.low_threshold)
+			to_chat(affected_carbon, organ.low_threshold_passed)
+			return
+		else if (organ.high_threshold_passed)
+			to_chat(affected_carbon, organ.high_threshold_passed)
+			return
+		to_chat(affected_carbon, "<span class='warning'>You feel a dull pain in your [organ.name].</span>")
 
 /datum/addiction/medicine/end_withdrawal(mob/living/carbon/affected_carbon)
 	. = ..()

--- a/code/modules/reagents/withdrawal/generic_addictions.dm
+++ b/code/modules/reagents/withdrawal/generic_addictions.dm
@@ -217,15 +217,17 @@
 		return
 	if(DT_PROB(65, delta_time))
 		return
-	if(affected_carbon.stat <= SOFT_CRIT)
-		var/obj/item/organ/organ = pick(affected_carbon.internal_organs)
-		if(organ.low_threshold)
-			to_chat(affected_carbon, organ.low_threshold_passed)
-			return
-		else if (organ.high_threshold_passed)
-			to_chat(affected_carbon, organ.high_threshold_passed)
-			return
-		to_chat(affected_carbon, "<span class='warning'>You feel a dull pain in your [organ.name].</span>")
+	if(affected_carbon.stat >= SOFT_CRIT)
+		return
+
+	var/obj/item/organ/organ = pick(affected_carbon.internal_organs)
+	if(organ.low_threshold)
+		to_chat(affected_carbon, organ.low_threshold_passed)
+		return
+	else if (organ.high_threshold_passed)
+		to_chat(affected_carbon, organ.high_threshold_passed)
+		return
+	to_chat(affected_carbon, "<span class='warning'>You feel a dull pain in your [organ.name].</span>")
 
 /datum/addiction/medicine/end_withdrawal(mob/living/carbon/affected_carbon)
 	. = ..()

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -172,7 +172,7 @@
 	damage = clamp(damage + damage_amount, 0, maximum)
 	var/mess = check_damage_thresholds(owner)
 	prev_damage = damage
-	if(mess && owner)
+	if(mess && owner.stat <= SOFT_CRIT)
 		to_chat(owner, mess)
 
 ///SETS an organ's damage to the amount "damage_amount", and in doing so clears or sets the failing flag, good for when you have an effect that should fix an organ if broken


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For instance, if you stay in your body as a ghost you will currently be getting warnings in chat about your organs failing. This adds a stat check for those if you are not soft crit or above.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gets rid of some noise, and doesnt give you information about things happening while you wouldnt be able to know.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Skoglol
fix: Organ damage messages are now only sent if you are conscious.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
