### PR TITLE
Mannitol works on splashing and on non-failing brains, also purity matters

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -116,14 +116,17 @@
 	var/healby = 2 //heals 2 damage per unit of mannitol
 	var/pour = "carefully pour"
 	var/onto = "onto"
+	var/valid_container = TRUE
 	if(istype(O, /obj/item/reagent_containers/syringe))
 		healby = 4 //heal 4 damage because PRECISCION
 		pour = "precisely inject"
 		onto = "into"
 	else if(istype(O, /obj/item/reagent_containers/dropper))
 		healby = 4
+	else if(!O.is_drainable())
+		valid_container = FALSE // no pouring from brain burgers pls
 
-	if(O.reagents?.has_reagent(/datum/reagent/medicine/mannitol)) //attempt to heal the brain
+	if(valid_container && O.reagents?.has_reagent(/datum/reagent/medicine/mannitol)) //attempt to heal the brain
 		. = TRUE //don't do attack animation.
 		if(brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing
 			to_chat(user, "<span class='warning'>[src] is far too damaged, there's nothing else we can do for it!</span>")

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -878,14 +878,11 @@
 /datum/reagent/medicine/mannitol/expose_obj(obj/exposed_obj, reac_volume)
 	. = ..()
 	var/obj/item/organ/brain/exposed_brain = exposed_obj
-	if(!exposed_brain)
+	if(!istype(exposed_brain))
 		return
 
-	if(exposed_brain.brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing
-		to_chat(usr, "<span class='warning'>[exposed_brain] is far too damaged, there's nothing else we can do for it!</span>")
-		return
+	exposed_brain.visible_message("<span class='notice'>[exposed_brain] looks slightly better, but not much. Perhaps splashing is not a very precise method.</span>")
 
-	to_chat(usr, "<span class='notice'>[exposed_brain] looks slightly better, but not much. Perhaps splashing is not a very precise method.</span>")
 	var/healby = 1 //heals 1 damage per unit of mannitol
 	healby *= reac_volume
 	healby *= src.purity / REAGENT_STANDARD_PURITY

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -875,6 +875,22 @@
 	inverse_chem_val = 0.45
 	impure_chem = /datum/reagent/impurity/mannitol
 
+/datum/reagent/medicine/mannitol/expose_obj(obj/exposed_obj, reac_volume)
+	. = ..()
+	var/obj/item/organ/brain/exposed_brain = exposed_obj
+	if(!exposed_brain)
+		return
+
+	if(exposed_brain.brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing
+		to_chat(usr, "<span class='warning'>[exposed_brain] is far too damaged, there's nothing else we can do for it!</span>")
+		return
+
+	to_chat(usr, "<span class='notice'>[exposed_brain] looks slightly better, but not much. Perhaps splashing is not a very precise method.</span>")
+	var/healby = 1 //heals 1 damage per unit of mannitol
+	healby *= reac_volume
+	healby *= src.purity / REAGENT_STANDARD_PURITY
+	exposed_brain.applyOrganDamage(-healby) // clears the failing variable if that was up
+
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/owner, delta_time, times_fired)
 	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2 * REM * delta_time * normalise_creation_purity())
 	..()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -885,7 +885,7 @@
 
 	var/healby = 1 //heals 1 damage per unit of mannitol
 	healby *= reac_volume
-	healby *= src.purity / REAGENT_STANDARD_PURITY
+	healby *= purity / REAGENT_STANDARD_PURITY
 	exposed_brain.applyOrganDamage(-healby) // clears the failing variable if that was up
 
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/owner, delta_time, times_fired)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- mannitol heals brain on splashing (fast but ineffective)
- using mannitol with syringe or dropper is twice more effective than beaker
- can now use mannitol on non-failing brains and with any amount (even <10u)
- mannitol purity matters now
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Examining a moderately damaged brain tells you use mannitol, but you can only use mannitol on fully decayed brains. Trying to figure out why this doesn't work while the corpses are piling up in the medbay is kinda frustrating. This PR removes the annoying restrictions.
Also makes splashing brains with mannitol work, albeit with half the effect. On the other hand using a syringe doubles the effect. And the amount healed now takes purity into consideration.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Using mannitol on brains is easier now. You can use it on non-failing brains and with amounts less than 10u. Splashing now works too, but is half as effective. Use a syringe or a dropper for double effect! Also the purity of mannitol now affects the amount of damage healed.
fix: Fixed no animation and duplicated message when attacking brains
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
