### PR TITLE
Rename cyborg modules to cyborg components

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -2,7 +2,7 @@
 // Contains various borg upgrades.
 
 /obj/item/borg/upgrade
-	name = "borg upgrade module."
+	name = "borg upgrade component."
 	desc = "Protected by FRM."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cyborg_upgrade"
@@ -23,7 +23,7 @@
 		return FALSE
 	if(model_type && !is_type_in_list(R.model, model_type))
 		to_chat(R, "<span class='alert'>Upgrade mounting error! No suitable hardpoint detected.</span>")
-		to_chat(user, "<span class='warning'>There's no mounting point for the module!</span>")
+		to_chat(user, "<span class='warning'>There's no mounting point for the component!</span>")
 		return FALSE
 	return TRUE
 
@@ -55,14 +55,14 @@
 		log_game("[key_name(user)] have used a cyborg reclassification board to rename [oldkeyname] to [key_name(R)] at [loc_name(user)]")
 
 /obj/item/borg/upgrade/restart
-	name = "cyborg emergency reboot module"
+	name = "cyborg emergency reboot component"
 	desc = "Used to force a reboot of a disabled-but-repaired cyborg, bringing it back online."
 	icon_state = "cyborg_upgrade1"
 	one_use = TRUE
 
 /obj/item/borg/upgrade/restart/action(mob/living/silicon/robot/R, user = usr)
 	if(R.health < 0)
-		to_chat(user, "<span class='warning'>You have to repair the cyborg before using this module!</span>")
+		to_chat(user, "<span class='warning'>You have to repair the cyborg before using this component!</span>")
 		return FALSE
 
 	if(R.mind)
@@ -74,7 +74,7 @@
 	R.logevent("System brought online.")
 
 /obj/item/borg/upgrade/disablercooler
-	name = "cyborg rapid disabler cooling module"
+	name = "cyborg rapid disabler cooling component"
 	desc = "Used to cool a mounted disabler, increasing the potential current in it and thus its recharge rate."
 	icon_state = "cyborg_upgrade3"
 	require_model = TRUE
@@ -158,7 +158,7 @@
 
 /obj/item/borg/upgrade/soh
 	name = "mining cyborg satchel of holding"
-	desc = "A satchel of holding replacement for mining cyborg's ore satchel module."
+	desc = "A satchel of holding replacement for mining cyborg's ore satchel component."
 	icon_state = "cyborg_upgrade3"
 	require_model = TRUE
 	model_type = list(/obj/item/robot_model/miner)
@@ -262,7 +262,7 @@
 			R.model.remove_module(P, TRUE)
 
 /obj/item/borg/upgrade/syndicate
-	name = "illegal equipment module"
+	name = "illegal equipment component"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg."
 	icon_state = "cyborg_upgrade3"
 	require_model = TRUE
@@ -304,8 +304,8 @@
 		LAZYREMOVE(R.weather_immunities, "lava")
 
 /obj/item/borg/upgrade/selfrepair
-	name = "self-repair module"
-	desc = "This module will repair the cyborg over time."
+	name = "self-repair component"
+	desc = "This component will repair the cyborg over time."
 	icon_state = "cyborg_upgrade5"
 	require_model = TRUE
 	var/repair_amount = -1
@@ -322,7 +322,7 @@
 	if(.)
 		var/obj/item/borg/upgrade/selfrepair/U = locate() in R
 		if(U)
-			to_chat(user, "<span class='warning'>This unit is already equipped with a self-repair module!</span>")
+			to_chat(user, "<span class='warning'>This unit is already equipped with a self-repair component!</span>")
 			return FALSE
 
 		icon_state = "selfrepair_off"
@@ -338,10 +338,10 @@
 
 /obj/item/borg/upgrade/selfrepair/ui_action_click()
 	if(on)
-		to_chat(toggle_action.owner, "<span class='notice'>You deactivate the self-repair module.</span>")
+		to_chat(toggle_action.owner, "<span class='notice'>You deactivate the self-repair component.</span>")
 		deactivate_sr()
 	else
-		to_chat(toggle_action.owner, "<span class='notice'>You activate the self-repair module.</span>")
+		to_chat(toggle_action.owner, "<span class='notice'>You activate the self-repair component.</span>")
 		activate_sr()
 
 
@@ -370,12 +370,12 @@
 
 	if(istype(cyborg) && (cyborg.stat != DEAD) && on)
 		if(!cyborg.cell)
-			to_chat(cyborg, "<span class='alert'>Self-repair module deactivated. Please insert power cell.</span>")
+			to_chat(cyborg, "<span class='alert'>Self-repair component deactivated. Please insert power cell.</span>")
 			deactivate_sr()
 			return
 
 		if(cyborg.cell.charge < powercost * 2)
-			to_chat(cyborg, "<span class='alert'>Self-repair module deactivated. Please recharge.</span>")
+			to_chat(cyborg, "<span class='alert'>Self-repair component deactivated. Please recharge.</span>")
 			deactivate_sr()
 			return
 
@@ -540,7 +540,7 @@
 		R.model.remove_module(SP, TRUE)
 
 /obj/item/borg/upgrade/ai
-	name = "B.O.R.I.S. module"
+	name = "B.O.R.I.S. component"
 	desc = "Bluespace Optimized Remote Intelligence Synchronization. An uplink device which takes the place of an MMI in cyborg endoskeletons, creating a robotic shell controlled by an AI."
 	icon_state = "boris"
 
@@ -573,7 +573,7 @@
 	if(.)
 
 		if(R.hasExpanded)
-			to_chat(usr, "<span class='warning'>This unit already has an expand module installed!</span>")
+			to_chat(usr, "<span class='warning'>This unit already has an expand component installed!</span>")
 			return FALSE
 
 		R.notransform = TRUE
@@ -618,7 +618,7 @@
 
 		var/obj/item/storage/part_replacer/cyborg/RPED = locate() in R
 		if(RPED)
-			to_chat(user, "<span class='warning'>This unit is already equipped with a RPED module!</span>")
+			to_chat(user, "<span class='warning'>This unit is already equipped with a RPED component!</span>")
 			return FALSE
 
 		RPED = new(R.model)
@@ -634,7 +634,7 @@
 
 /obj/item/borg/upgrade/pinpointer
 	name = "medical cyborg crew pinpointer"
-	desc = "A crew pinpointer module for the medical cyborg. Permits remote access to the crew monitor."
+	desc = "A crew pinpointer component for the medical cyborg. Permits remote access to the crew monitor."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "pinpointer_crew"
 	require_model = TRUE
@@ -648,7 +648,7 @@
 
 		var/obj/item/pinpointer/crew/PP = locate() in R.model
 		if(PP)
-			to_chat(user, "<span class='warning'>This unit is already equipped with a pinpointer module!</span>")
+			to_chat(user, "<span class='warning'>This unit is already equipped with a pinpointer component!</span>")
 			return FALSE
 
 		PP = new(R.model)

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -613,7 +613,7 @@
 	build_path = /obj/item/borg/upgrade/rename
 	materials = list(/datum/material/iron = 5000)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_restart
 	name = "Cyborg Upgrade (Emergency Reboot Board)"
@@ -622,7 +622,7 @@
 	build_path = /obj/item/borg/upgrade/restart
 	materials = list(/datum/material/iron = 20000 , /datum/material/glass = 5000)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_thrusters
 	name = "Cyborg Upgrade (Ion Thrusters)"
@@ -631,16 +631,16 @@
 	build_path = /obj/item/borg/upgrade/thrusters
 	materials = list(/datum/material/iron = 10000, /datum/material/glass = 6000, /datum/material/plasma = 5000, /datum/material/uranium = 6000)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Component")
 
 /datum/design/borg_upgrade_disablercooler
-	name = "Cyborg Upgrade (Rapid Disabler Cooling Module)"
+	name = "Cyborg Upgrade (Rapid Disabler Cooling Component)"
 	id = "borg_upgrade_disablercooler"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/disablercooler
 	materials = list(/datum/material/iron = 20000 , /datum/material/glass = 6000, /datum/material/gold = 2000, /datum/material/diamond = 2000)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_diamonddrill
 	name = "Cyborg Upgrade (Diamond Drill)"
@@ -649,7 +649,7 @@
 	build_path = /obj/item/borg/upgrade/ddrill
 	materials = list(/datum/material/iron=10000, /datum/material/glass = 6000, /datum/material/diamond = 2000)
 	construction_time = 80
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_holding
 	name = "Cyborg Upgrade (Ore Satchel of Holding)"
@@ -658,7 +658,7 @@
 	build_path = /obj/item/borg/upgrade/soh
 	materials = list(/datum/material/iron = 10000, /datum/material/gold = 2000, /datum/material/uranium = 1000)
 	construction_time = 40
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_lavaproof
 	name = "Cyborg Upgrade (Lavaproof Tracks)"
@@ -667,16 +667,16 @@
 	build_path = /obj/item/borg/upgrade/lavaproof
 	materials = list(/datum/material/iron = 10000, /datum/material/plasma = 4000, /datum/material/titanium = 5000)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_syndicate_module
-	name = "Cyborg Upgrade (Illegal Modules)"
+	name = "Cyborg Upgrade (Illegal Components)"
 	id = "borg_syndicate_module"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/syndicate
 	materials = list(/datum/material/iron = 15000, /datum/material/glass = 15000, /datum/material/diamond = 10000)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_transform_clown
 	name = "Cyborg Upgrade (Clown Model)"
@@ -685,7 +685,7 @@
 	build_path = /obj/item/borg/upgrade/transform/clown
 	materials = list(/datum/material/iron = 15000, /datum/material/glass = 15000, /datum/material/bananium = 1000)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_selfrepair
 	name = "Cyborg Upgrade (Self-repair)"
@@ -694,7 +694,7 @@
 	build_path = /obj/item/borg/upgrade/selfrepair
 	materials = list(/datum/material/iron = 15000, /datum/material/glass = 15000)
 	construction_time = 80
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_expandedsynthesiser
 	name = "Cyborg Upgrade (Hypospray Expanded Synthesiser)"
@@ -703,7 +703,7 @@
 	build_path = /obj/item/borg/upgrade/hypospray/expanded
 	materials = list(/datum/material/iron = 15000, /datum/material/glass = 15000, /datum/material/plasma = 8000, /datum/material/uranium = 8000)
 	construction_time = 80
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_piercinghypospray
 	name = "Cyborg Upgrade (Piercing Hypospray)"
@@ -712,7 +712,7 @@
 	build_path = /obj/item/borg/upgrade/piercing_hypospray
 	materials = list(/datum/material/iron = 15000, /datum/material/glass = 15000, /datum/material/titanium = 5000, /datum/material/diamond = 3000)
 	construction_time = 80
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_defibrillator
 	name = "Cyborg Upgrade (Defibrillator)"
@@ -721,7 +721,7 @@
 	build_path = /obj/item/borg/upgrade/defib
 	materials = list(/datum/material/iron = 8000, /datum/material/glass = 5000, /datum/material/silver = 4000, /datum/material/gold = 3000)
 	construction_time = 80
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_surgicalprocessor
 	name = "Cyborg Upgrade (Surgical Processor)"
@@ -730,7 +730,7 @@
 	build_path = /obj/item/borg/upgrade/processor
 	materials = list(/datum/material/iron = 5000, /datum/material/glass = 4000, /datum/material/silver = 4000)
 	construction_time = 40
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_trashofholding
 	name = "Cyborg Upgrade (Trash Bag of Holding)"
@@ -739,7 +739,7 @@
 	build_path = /obj/item/borg/upgrade/tboh
 	materials = list(/datum/material/gold = 2000, /datum/material/uranium = 1000)
 	construction_time = 40
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_advancedmop
 	name = "Cyborg Upgrade (Advanced Mop)"
@@ -748,7 +748,7 @@
 	build_path = /obj/item/borg/upgrade/amop
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 2000)
 	construction_time = 40
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_prt
 	name = "Cyborg Upgrade (Plating Repair Tool)"
@@ -757,7 +757,7 @@
 	build_path = /obj/item/borg/upgrade/prt
 	materials = list(/datum/material/iron = 2500, /datum/material/glass = 750) //same price as a cautery
 	construction_time = 40
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_expand
 	name = "Cyborg Upgrade (Expand)"
@@ -766,10 +766,10 @@
 	build_path = /obj/item/borg/upgrade/expand
 	materials = list(/datum/material/iron = 200000, /datum/material/titanium = 5000)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/boris_ai_controller
-	name = "B.O.R.I.S. AI-Cyborg Remote Control Module"
+	name = "B.O.R.I.S. AI-Cyborg Remote Control Component"
 	id = "borg_ai_control"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/ai
@@ -785,7 +785,7 @@
 	build_path = /obj/item/borg/upgrade/rped
 	materials = list(/datum/material/iron = 10000, /datum/material/glass = 5000)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_circuit_app
 	name = "Cyborg Upgrade (Circuit Manipulator)"
@@ -794,7 +794,7 @@
 	build_path = /obj/item/borg/upgrade/circuit_app
 	materials = list(/datum/material/iron = 2000, /datum/material/titanium = 500)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_beaker_app
 	name = "Cyborg Upgrade (Beaker Storage)"
@@ -803,7 +803,7 @@
 	build_path = /obj/item/borg/upgrade/beaker_app
 	materials = list(/datum/material/iron = 2000, /datum/material/glass = 2250) //Need glass for the new beaker too
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_pinpointer
 	name = "Cyborg Upgrade (Crew pinpointer)"
@@ -812,7 +812,7 @@
 	build_path = /obj/item/borg/upgrade/pinpointer
 	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 /datum/design/borg_upgrade_broomer
 	name = "Cyborg Upgrade (Experimental Push Broom)"
@@ -821,7 +821,7 @@
 	build_path = /obj/item/borg/upgrade/broomer
 	materials = list(/datum/material/iron = 4000, /datum/material/glass = 500)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Components")
 
 //Misc
 /datum/design/mecha_tracking

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -24,7 +24,7 @@
 	id = "cyborg"
 	starting_node = TRUE
 	display_name = "Cyborg Construction"
-	description = "Sapient robots with preloaded tool modules and programmable laws."
+	description = "Sapient robots with preloaded tool components and programmable laws."
 	design_ids = list("robocontrol", "sflash", "borg_suit", "borg_head", "borg_chest", "borg_r_arm", "borg_l_arm", "borg_r_leg", "borg_l_leg", "borgupload",
 					"cyborgrecharger", "borg_upgrade_restart", "borg_upgrade_rename")
 


### PR DESCRIPTION
## About The Pull Request

Renames all cyborg upgrade modules to cyborg components.

## Why It's Good For The Game

Cyborg Modules can easily be confused with Mech Modules, so they have been renamed for clarity.

## Changelog
:cl:
qol: Cyborg Modules renamed to Cyborg Components to prevent confusion with Mech Modules.
/:cl: