### PR TITLE
Adds a unit test for icon states on GAGS items and fixes some inhand sprites

### DIFF
--- a/code/datums/greyscale/json_configs/screwdriver.json
+++ b/code/datums/greyscale/json_configs/screwdriver.json
@@ -1,5 +1,5 @@
 {
-	"": [
+	"screwdriver_map": [
 		{
 			"type": "icon_state",
 			"icon_state": "screwdriver",

--- a/code/datums/greyscale/json_configs/screwdriver_worn.json
+++ b/code/datums/greyscale/json_configs/screwdriver_worn.json
@@ -1,5 +1,5 @@
 {
-	"": [
+	"screwdriver": [
 		{
 			"type": "icon_state",
 			"icon_state": "screwdriver",

--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -91,6 +91,8 @@
 	inhand_icon_state = "screwdriver_nuke"
 	toolspeed = 0.5
 	random_color = FALSE
+	greyscale_config_inhand_left = null
+	greyscale_config_inhand_right = null
 
 /obj/item/paper/guides/antag/nuke_instructions
 	info = "How to break into a Nanotrasen self-destruct terminal and remove its plutonium core:<br>\

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -51,7 +51,6 @@
 	if(random_color)
 		var/our_color = pick(screwdriver_colors)
 		set_greyscale(colors=list(screwdriver_colors[our_color]))
-		inhand_icon_state = null
 		colored_belt_appearance = mutable_appearance(SSgreyscale.GetColoredIconByType(/datum/greyscale_config/screwdriver_belt, greyscale_colors))
 	. = ..()
 	AddElement(/datum/element/eyestab)
@@ -71,6 +70,8 @@
 	usesound = 'sound/items/pshoom.ogg'
 	toolspeed = 0.1
 	random_color = FALSE
+	greyscale_config_inhand_left = null
+	greyscale_config_inhand_right = null
 
 /obj/item/screwdriver/abductor/get_belt_overlay()
 	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', "screwdriver_nuke")
@@ -95,6 +96,8 @@
 	usesound = 'sound/items/drill_use.ogg'
 	toolspeed = 0.7
 	random_color = FALSE
+	greyscale_config_inhand_left = null
+	greyscale_config_inhand_right = null
 
 /obj/item/screwdriver/power/examine()
 	. = ..()

--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -51,8 +51,12 @@
 	name = "rainbow shoes"
 	desc = "Very gay shoes."
 	icon_state = "rain_bow"
+
 	greyscale_colors = null
 	greyscale_config = null
+	greyscale_config_inhand_left = null
+	greyscale_config_inhand_right = null
+	greyscale_config_worn = null
 
 /obj/item/clothing/shoes/sneakers/orange
 	name = "orange shoes"

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -9,6 +9,7 @@
 	icon = 'icons/obj/clothing/under/color.dmi'
 	icon_state = "jumpsuit"
 	inhand_icon_state = "jumpsuit"
+	worn_icon_state = "jumpsuit"
 	worn_icon = 'icons/mob/clothing/under/color.dmi'
 
 /obj/item/clothing/under/color/jumpskirt

--- a/code/modules/clothing/under/jobs/civilian/curator.dm
+++ b/code/modules/clothing/under/jobs/civilian/curator.dm
@@ -31,6 +31,7 @@
 	name = "\improper NASA jumpsuit"
 	desc = "It has a NASA logo on it and is made of space-proofed materials."
 	icon_state = "jumpsuit"
+	inhand_icon_state = "jumpsuit"
 	greyscale_colors = "#3f3f3f"
 	greyscale_config = /datum/greyscale_config/jumpsuit
 	greyscale_config_inhand_left = /datum/greyscale_config/jumpsuit_inhand_left

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -197,6 +197,7 @@
 	name = "prison jumpsuit"
 	desc = "It's standardised Nanotrasen prisoner-wear. Its suit sensors are stuck in the \"Fully On\" position."
 	icon_state = "jumpsuit"
+	inhand_icon_state = "jumpsuit"
 	greyscale_colors = "#ff8300"
 	greyscale_config = /datum/greyscale_config/jumpsuit_prison
 	greyscale_config_inhand_left = /datum/greyscale_config/jumpsuit_prison_inhand_left

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -57,6 +57,7 @@
 #include "egg_glands.dm"
 #include "emoting.dm"
 #include "food_edibility_check.dm"
+#include "greyscale_config.dm"
 #include "heretic_knowledge.dm"
 #include "holidays.dm"
 #include "hydroponics_harvest.dm"

--- a/code/modules/unit_tests/greyscale_config.dm
+++ b/code/modules/unit_tests/greyscale_config.dm
@@ -1,0 +1,19 @@
+/// Makes sure items using GAGS have all the icon states needed to work
+/datum/unit_test/greyscale_item_icon_states
+
+/datum/unit_test/greyscale_item_icon_states/Run()
+	for(var/obj/item/item_path as anything in subtypesof(/obj/item))
+		var/held_icon_state = initial(item_path.inhand_icon_state) || initial(item_path.icon_state)
+
+		var/datum/greyscale_config/lefthand = SSgreyscale.configurations["[initial(item_path.greyscale_config_inhand_left)]"]
+		if(lefthand && !lefthand.icon_states[held_icon_state])
+			Fail("[lefthand.DebugName()] is missing a sprite for the held lefthand for [item_path]. Expected icon state: '[held_icon_state]'")
+
+		var/datum/greyscale_config/righthand = SSgreyscale.configurations["[initial(item_path.greyscale_config_inhand_right)]"]
+		if(righthand && !righthand.icon_states[held_icon_state])
+			Fail("[righthand.DebugName()] is missing a sprite for the held righthand for [item_path]. Expected icon state: '[held_icon_state]'")
+
+		var/datum/greyscale_config/worn = SSgreyscale.configurations["[initial(item_path.greyscale_config_worn)]"]
+		var/worn_icon_state = initial(item_path.worn_icon_state) || initial(item_path.icon_state)
+		if(worn && !worn.icon_states[worn_icon_state])
+			Fail("[worn.DebugName()] is missing a sprite for the worn overlay for [item_path]. Expected icon state: '[worn_icon_state]'")


### PR DESCRIPTION
This adds a unit test which goes through all items and makes sure all the icon states needed are in the greyscale configurations, if it has one.

The first commit intentionally fails to show the error.

:cl:
fix: Some screwdriver inhand icons have been fixed to not show an error
fix: Some prison jumpsuit inhand icons have been fixed to not show an error
/:cl: