### PR TITLE
Android sect chaplains can now trade favor for cybernetic implants

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -133,9 +133,9 @@
 	tgui_icon = "robot"
 	alignment = ALIGNMENT_NEUT
 	desired_items = list(/obj/item/stock_parts/cell = "with battery charge")
-	rites_list = list(/datum/religion_rites/synthconversion)
+	rites_list = list(/datum/religion_rites/synthconversion, /datum/religion_rites/upgrade_blessing)
 	altar_icon_state = "convertaltar-blue"
-
+	max_favor =  2500
 /datum/religion_sect/mechanical/sect_bless(mob/living/target, mob/living/chap)
 	if(iscyborg(target))
 		var/mob/living/silicon/robot/R = target

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -136,7 +136,7 @@
 	rites_list = list(/datum/religion_rites/synthconversion, /datum/religion_rites/upgrade_blessing)
 	altar_icon_state = "convertaltar-blue"
 
-	max_favor =  2500
+	max_favor = 2500
 
 /datum/religion_sect/mechanical/sect_bless(mob/living/target, mob/living/chap)
 	if(iscyborg(target))

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -135,7 +135,9 @@
 	desired_items = list(/obj/item/stock_parts/cell = "with battery charge")
 	rites_list = list(/datum/religion_rites/synthconversion, /datum/religion_rites/upgrade_blessing)
 	altar_icon_state = "convertaltar-blue"
+
 	max_favor =  2500
+
 /datum/religion_sect/mechanical/sect_bless(mob/living/target, mob/living/chap)
 	if(iscyborg(target))
 		var/mob/living/silicon/robot/R = target

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -114,7 +114,7 @@
 	desc = "Receive a blessing from the machine god to further your ascension."
 	ritual_length = 15 SECONDS
 	ritual_invocations = list("With hammer and faith our bodies were forged",
-								"Oh,Machine-god,We are your instruments of faith",
+								"Oh, Machine-god, We are your instruments of faith",
 									"Let your energy overload our iron-forged blows")
 	invoke_msg = "The end of flesh is near!"
 	favor_cost = 2500
@@ -605,5 +605,4 @@
 	user.emote("laughs")
 	new /obj/item/ritual_totem(altar_turf)
 	return TRUE
-
 

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -128,8 +128,7 @@
 					/obj/item/organ/cyberimp/eyes/hud/medical,
 					/obj/item/organ/cyberimp/mouth/breathing_tube,
 					/obj/item/organ/cyberimp/chest/thrusters,
-					/obj/item/organ/eyes/robotic/glow,
-					/obj/item/organ/cyberimp/arm/medibeam)
+					/obj/item/organ/eyes/robotic/glow)
 
 	new blessing(altar_turf)
 	return TRUE

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -109,6 +109,30 @@
 	human2borg.visible_message("<span class='notice'>[human2borg] has been converted by the rite of [name]!</span>")
 	return TRUE
 
+/datum/religion_rites/upgrade_blessing
+	name = "Receive Blessing"
+	desc = "Receive a blessing from the machine god to further your ascension."
+	ritual_length = 15 SECONDS
+	ritual_invocations = list("With hammer and faith our bodies were forged",
+								"Oh,Machine-god,We are your instruments of faith",
+									"Let your energy overload our iron-forged blows")
+	invoke_msg = "The end of flesh is near!"
+	favor_cost = 2500
+
+/datum/religion_rites/upgrade_blessing/invoke_effect(mob/living/user, atom/movable/religious_tool)
+	..()
+	var/altar_turf = get_turf(religious_tool)
+	var/blessing = pick(
+					/obj/item/organ/cyberimp/arm/surgery,
+					/obj/item/organ/cyberimp/eyes/hud/diagnostic,
+					/obj/item/organ/cyberimp/eyes/hud/medical,
+					/obj/item/organ/cyberimp/mouth/breathing_tube,
+					/obj/item/organ/cyberimp/chest/thrusters,
+					/obj/item/organ/eyes/robotic/glow,
+					/obj/item/organ/cyberimp/arm/medibeam)
+
+	new blessing(altar_turf)
+	return TRUE
 
 /**** Pyre God ****/
 


### PR DESCRIPTION

## About The Pull Request
You may now use 2500 favor to get a set of robotic implants as a chaplain, ive tried to make them as non power gamey as possible in a way where they are useful but not necessarily an advantage over people


## Why It's Good For The Game
gives the android sect another rite making it more useful then just converting people into a race and being done with it,
## Changelog
:cl:
add: Chaplains who worship the machine gods can now trade in 2500 favor to receive a random cybernetic implant
/:cl:

