### PR TITLE
Fixed not being able to add telecomms frequency filters

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -123,14 +123,13 @@
 			if(params["value"])
 				tempfreq = text2num(params["value"]) * 10
 		if("freq")
-			var/newfreq = tempfreq * 10
-			if(newfreq == FREQ_SYNDICATE)
-				to_chat(operator, "<span class='warning'>Error: Interference preventing filtering frequency: \"[newfreq / 10] GHz\"</span>")
+			if(tempfreq == FREQ_SYNDICATE)
+				to_chat(operator, "<span class='warning'>Error: Interference preventing filtering frequency: \"[tempfreq / 10] kHz\"</span>")
 				playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 			else
-				if(!(newfreq in freq_listening) && newfreq < 10000)
-					freq_listening.Add(newfreq)
-					log_game("[key_name(operator)] added frequency [newfreq] for [src] at [AREACOORD(src)].")
+				if(!(tempfreq in freq_listening))
+					freq_listening.Add(tempfreq)
+					log_game("[key_name(operator)] added frequency [tempfreq] for [src] at [AREACOORD(src)].")
 					. = TRUE
 		if("delete")
 			freq_listening.Remove(params["value"])

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -330,6 +330,9 @@ em {
   color: #88ff88;
 }
 
+/* RADIO COLORS */
+/* IF YOU CHANGE THIS KEEP IT IN SYNC WITH TGUI CONSTANTS */
+
 .radio {
   color: #1ecc43;
 }

--- a/tgui/packages/tgui/constants.js
+++ b/tgui/packages/tgui/constants.js
@@ -59,11 +59,12 @@ export const CSS_COLORS = [
   'label',
 ];
 
+/* IF YOU CHANGE THIS KEEP IT IN SYNC WITH CHAT CSS */
 export const RADIO_CHANNELS = [
   {
     name: 'Syndicate',
     freq: 1213,
-    color: '#a52a2a',
+    color: '#8f4a4b',
   },
   {
     name: 'Red Team',
@@ -83,7 +84,7 @@ export const RADIO_CHANNELS = [
   {
     name: 'Yellow Team',
     freq: 1221,
-    color: '#d1ba22',
+    color: '#fdfd34',
   },
   {
     name: 'CentCom',
@@ -108,7 +109,7 @@ export const RADIO_CHANNELS = [
   {
     name: 'Command',
     freq: 1353,
-    color: '#5177ff',
+    color: '#fcdf03',
   },
   {
     name: 'Medical',

--- a/tgui/packages/tgui/interfaces/Telecomms.js
+++ b/tgui/packages/tgui/interfaces/Telecomms.js
@@ -99,7 +99,7 @@ export const Telecomms = (props, context) => {
                     </Table.Cell>
                     <NumberInput
                       animate
-                      unit="GHz"
+                      unit="kHz"
                       step={0.2}
                       stepPixelSize={10}
                       minValue={minfreq / 10}
@@ -153,7 +153,7 @@ export const Telecomms = (props, context) => {
                 {frequencies.map(entry => (
                   <Table.Row key={frequencies.i} className="candystripe">
                     <Table.Cell bold>
-                      {entry/10} GHz
+                      {entry/10} kHz
                     </Table.Cell>
                     <Table.Cell>
                       {RADIO_CHANNELS
@@ -202,7 +202,7 @@ export const Telecomms = (props, context) => {
                     <Table.Cell>
                       <NumberInput
                         animate
-                        unit="GHz"
+                        unit="kHz"
                         step={0.2}
                         stepPixelSize={10}
                         minValue={minfreq / 10}


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- fixed not being able to add telecomms frequency filters
- changed GHz to hHz in telecomms GUI to be consistent with headset GUI
- changed color of command frequency from blue to yellow to match chat color
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Freq filters were broken since new tcomms UI. Also command chat was changed to yellow, but command frequency was still blue, this PR updates it.
 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed not being able to add telecomms frequency filters
fix: Changed the color of command frequency in telecomms and headset GUI from blue to yellow to match chat color
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
