### PR TITLE
Adds missing wire to Kilo Medbay Lobby

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -12561,6 +12561,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/paramedic)
 "aPo" = (
@@ -12753,6 +12754,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/landmark/start/paramedic,
 /obj/structure/chair/office/light,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/paramedic)
 "aPP" = (
@@ -12865,6 +12867,7 @@
 	pixel_x = 8;
 	pixel_y = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/paramedic)
 "aPZ" = (
@@ -14010,6 +14013,7 @@
 /obj/item/clipboard,
 /obj/item/storage/firstaid/regular,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "aSy" = (
@@ -76663,6 +76667,21 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/bar/atrium)
+"sCK" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/medical/medbay/lobby)
 "sCP" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
@@ -86190,6 +86209,7 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/box,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "wHi" = (
@@ -111986,7 +112006,7 @@ aAK
 aPn
 aPO
 aPX
-aQt
+sCK
 aQr
 aQD
 cgN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When I added a new area and APC to medbay lobby I forgot to wire the APC, oops.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Properly connected wires
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: connected the kilo medbay lobby apc to the grid
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
