### PR TITLE
You can now pick up Sloths in your hand.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/sloth.dm
+++ b/code/modules/mob/living/simple_animal/friendly/sloth.dm
@@ -10,6 +10,7 @@
 	emote_see = list("dozes off.", "looks around sleepily.")
 	speak_chance = 1
 	turns_per_move = 5
+	can_be_held = TRUE
 	butcher_results = list(/obj/item/food/meat/slab = 3)
 	response_help_continuous = "pets"
 	response_help_simple = "pet"


### PR DESCRIPTION
## About The Pull Request

This allows Sloths to be picked up in your hand, though they still do not fit in pet carriers. I thought this was an oversight, though I can't find any PRs mentioning them ever being able to get picked up.

![image](https://user-images.githubusercontent.com/53777086/120023730-3b9f8900-bfbc-11eb-8bf7-97620156e362.png)

## Why It's Good For The Game

They have the sprites for it in game, but isnt used, and Paperwork/Citrus is the only pet that has no way to be picked up (Poly cannot be picked up, but fits in a pet carrier)

## Changelog
:cl:
qol: Sloths can now be picked up.
/:cl: