### PR TITLE
Fixes defibrillator paddles and wall mounts not detecting charge changes.

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -317,9 +317,9 @@
 /obj/machinery/proc/auto_use_power()
 	if(!powered(power_channel))
 		return FALSE
-	if(use_power == 1)
+	if(use_power == IDLE_POWER_USE)
 		use_power(idle_power_usage,power_channel)
-	else if(use_power >= 2)
+	else if(use_power >= ACTIVE_POWER_USE)
 		use_power(active_power_usage,power_channel)
 	return TRUE
 

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -232,7 +232,7 @@
 	if(C.charge < C.maxcharge)
 		use_power(50 * delta_time)
 		C.give(40 * delta_time)
-		update_appearance()
+		defib.update_power()
 
 //wallframe, for attaching the mounts easily
 /obj/item/wallframe/defib_mount

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -41,6 +41,13 @@
 	update_power()
 	return
 
+/obj/item/defibrillator/examine(mob/user)
+	. = ..()
+	if(cell)
+		. += "<span class='notice'>Use a screwdriver to remove the cell.</span>"
+	else
+		. += "<span class='warning'>It has no power cell!</span>"
+
 /obj/item/defibrillator/fire_act(exposed_temperature, exposed_volume)
 	. = ..()
 	if(paddles?.loc == src)
@@ -60,6 +67,8 @@
 	else
 		powered = FALSE
 	update_appearance()
+	if(istype(loc, /obj/machinery/defibrillator_mount))
+		loc.update_appearance()
 
 /obj/item/defibrillator/update_overlays()
 	. = ..()
@@ -128,7 +137,6 @@
 			cell = W
 			to_chat(user, "<span class='notice'>You install a cell in [src].</span>")
 			update_power()
-
 	else if(W.tool_behaviour == TOOL_SCREWDRIVER)
 		if(cell)
 			cell.update_appearance()
@@ -415,8 +423,9 @@
 /obj/item/shockpaddles/attack(mob/M, mob/living/user, params)
 	if(busy)
 		return
+	defib?.update_power()
 	if(req_defib && !defib.powered)
-		user.visible_message("<span class='notice'>[defib] beeps: Unit is unpowered.</span>")
+		user.visible_message("<span class='warning'>[defib] beeps: Not enough charge!</span>")
 		playsound(src, 'sound/machines/defib_failed.ogg', 50, FALSE)
 		return
 	if(!wielded)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -192,6 +192,7 @@
 /obj/item/stock_parts/cell/empty/Initialize()
 	. = ..()
 	charge = 0
+	update_appearance()
 
 /obj/item/stock_parts/cell/crap
 	name = "\improper Nanotrasen brand rechargeable AA battery"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixed various charge-related bugs of defib and defib wall mounts, from overlays not updating to not being able to use defib paddles even if there is enough charge. Same as #59335 sans the screwdriver thing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugs are bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed defibrillator paddles and wall mounts not detecting charge changes.
qol: Examining defibrillators now tell you if there is a power cell inside and how to remove it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
