### PR TITLE
CONTRIBUTING.md has a new code standard about naming arguments passed to vars

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -643,6 +643,37 @@ Proc variables, static variables, and global variables are resolved at compile t
 
 Note: While there has historically been a strong impulse to use associated lists for caching of computed values, this is the easy way out and leaves a lot of hidden overhead. Please keep this in mind when designing core/root systems that are intended for use by other code/coders. It's normally better for consumers of such systems to handle their own caching using vars and number indexed lists, than for you to do it using associated lists.
 
+### When passing vars through New() or Initialize()'s arguments, use src.var
+Using src.var + naming the arguments the same as the var is the most readable and intuitive way to pass arguments into a new instance's vars. The main benefit is that you do not need to give arguments odd names with prefixes and suffixes that are easily forgotten in `new()` when sending named args.
+
+
+This is bad:
+```DM
+var/atom/thing
+	var/is_red
+
+var/atom/thing/Initialize(mapload, _is_red)
+	is_red = _is_red
+
+/proc/make_red_thing()
+	new /atom/thing(null, _is_red = TRUE)
+```
+
+`_is_red` is being used to set `is_red` and yet means a random '_' needs to be appended to the front of the arg, same as all other setter args.
+
+This is good:
+```DM
+var/atom/thing
+	var/is_red
+
+var/atom/thing/Initialize(mapload, is_red)
+	src.is_red = is_red
+
+/proc/make_red_thing()
+	new /atom/thing(null, is_red = TRUE)
+```
+
+setting `is_red` in args is simple, and directly names the variable the argument sets.
 
 ### Other Notes
 * Code should be modular where possible; if you are working on a new addition, then strongly consider putting it in its own file unless it makes sense to put it with similar ones (i.e. a new tool would go in the "tools.dm" file)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -651,7 +651,7 @@ This is very bad:
 /atom/thing
 	var/is_red
 
-var/atom/thing/Initialize(mapload, enable_red)
+/atom/thing/Initialize(mapload, enable_red)
 	is_red = enable_red
 
 /proc/make_red_thing()
@@ -665,7 +665,7 @@ This is bad:
 /atom/thing
 	var/is_red
 
-var/atom/thing/Initialize(mapload, _is_red)
+/atom/thing/Initialize(mapload, _is_red)
 	is_red = _is_red
 
 /proc/make_red_thing()
@@ -679,7 +679,7 @@ This is good:
 /atom/thing
 	var/is_red
 
-var/atom/thing/Initialize(mapload, is_red)
+/atom/thing/Initialize(mapload, is_red)
 	src.is_red = is_red
 
 /proc/make_red_thing()

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -648,7 +648,7 @@ Using src.var + naming the arguments the same as the var is the most readable an
 
 This is very bad:
 ```DM
-var/atom/thing
+/atom/thing
 	var/is_red
 
 var/atom/thing/Initialize(mapload, enable_red)
@@ -662,7 +662,7 @@ Future coders using this code will have to remember two differently named variab
 
 This is bad:
 ```DM
-var/atom/thing
+/atom/thing
 	var/is_red
 
 var/atom/thing/Initialize(mapload, _is_red)
@@ -676,7 +676,7 @@ var/atom/thing/Initialize(mapload, _is_red)
 
 This is good:
 ```DM
-var/atom/thing
+/atom/thing
 	var/is_red
 
 var/atom/thing/Initialize(mapload, is_red)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -646,6 +646,19 @@ Note: While there has historically been a strong impulse to use associated lists
 ### When passing vars through New() or Initialize()'s arguments, use src.var
 Using src.var + naming the arguments the same as the var is the most readable and intuitive way to pass arguments into a new instance's vars. The main benefit is that you do not need to give arguments odd names with prefixes and suffixes that are easily forgotten in `new()` when sending named args.
 
+This is very bad:
+```DM
+var/atom/thing
+	var/is_red
+
+var/atom/thing/Initialize(mapload, enable_red)
+	is_red = enable_red
+
+/proc/make_red_thing()
+	new /atom/thing(null, enable_red = TRUE)
+```
+
+Future coders using this code will have to remember two differently named variables which are near-synonyms of eachother. One of them is only used in Initialize for one line.
 
 This is bad:
 ```DM
@@ -659,7 +672,7 @@ var/atom/thing/Initialize(mapload, _is_red)
 	new /atom/thing(null, _is_red = TRUE)
 ```
 
-`_is_red` is being used to set `is_red` and yet means a random '_' needs to be appended to the front of the arg, same as all other setter args.
+`_is_red` is being used to set `is_red` and yet means a random '_' needs to be appended to the front of the arg, same as all other args like this.
 
 This is good:
 ```DM
@@ -673,7 +686,7 @@ var/atom/thing/Initialize(mapload, is_red)
 	new /atom/thing(null, is_red = TRUE)
 ```
 
-setting `is_red` in args is simple, and directly names the variable the argument sets.
+Setting `is_red` in args is simple, and directly names the variable the argument sets.
 
 ### Other Notes
 * Code should be modular where possible; if you are working on a new addition, then strongly consider putting it in its own file unless it makes sense to put it with similar ones (i.e. a new tool would go in the "tools.dm" file)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request & Why It's Good For The Game

Title. There has been some really hideous arg names for this situation of passing it into a var, for example:

`/datum/element/decal/Attach(atom/target, _icon, _icon_state, _dir, _cleanable=FALSE, _color, _layer=TURF_LAYER, _description, _alpha=255, mutable_appearance/_pic)`

Some of which aren't even matching the format of var = _arg...

![image](https://user-images.githubusercontent.com/40974010/120048567-4feb8200-bfcc-11eb-852a-862cf04c4088.png)

## Changelog
Not player facing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
