### PR TITLE
Prevent players who get booted back to the lobby on shiftstart from getting broken antag status on latejoin

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -386,7 +386,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 	for(var/i in GLOB.new_player_list)
 		var/mob/dead/new_player/player = i
-		if(player.ready == PLAYER_READY_TO_PLAY && player.mind)
+		if(player.ready == PLAYER_READY_TO_PLAY && player.mind && player.check_preferences())
 			roundstart_pop_ready++
 			candidates.Add(player)
 	log_game("DYNAMIC: Listing [roundstart_rules.len] round start rulesets, and [candidates.len] players ready.")

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -526,9 +526,8 @@
 		ineligible_for_roles = TRUE
 		ready = PLAYER_NOT_READY
 		if(has_antags)
-			log_admin("[src.ckey] just got booted back to lobby with no jobs, but antags enabled.")
-			message_admins("[src.ckey] just got booted back to lobby with no jobs enabled, but antag rolling enabled. Likely antag rolling abuse.")
-
+			log_admin("[src.ckey] has no jobs enabled, return to lobby if job is unavailable enabled and [client.prefs.be_special.len] antag preferences enabled. The player has been forcefully returned to the lobby.")
+			message_admins("[src.ckey] has no jobs enabled, return to lobby if job is unavailable enabled and [client.prefs.be_special.len] antag preferences enabled. This is an old antag rolling technique. The player has been asked to update their job preferences and has been forcefully returned to the lobby.")
 		return FALSE //This is the only case someone should actually be completely blocked from antag rolling as well
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The anti-antag-rolling check (player has no job prefs enabled, return to lobby if no job enabled and antags enabled) happens after Dynamic assigns antags.

See:
https://tgstation13.org/parsed-logs/manuel/data/logs/2021/05/28/round-163054/manifest.txt
`[2021-05-28 03:55:03.808] Jackraxxus \ Shoots-Her-Teammate \ Security Officer \ Heretic \ LATEJOIN`

Dynamic rulesets pick antags before this anti-antag-rolling check is performed. This leads to the weird edge case where Dynamic adds a player who should be ineligible to the candidate list, a ruleset selects them for antag, the player gets booted back to the lobby later on by SSjob.DivideOccupations() and then the ruleset gives them the antag datum while they're still in the lobby. This, naturally, runtimes in various ways as antag datums don't expect to get added to /mob/dead.

See:
https://tgstation13.org/parsed-logs/manuel/data/logs/2021/05/28/round-163054/runtime.txt
```
[2021-05-28 03:47:15.152] runtime error: bad index
 - proc name: set antag hud (/proc/set_antag_hud)
 -   source file: antag_hud.dm,38
 -   usr: (src)
 -   src: null
 -   call stack:
 - set antag hud(Jackraxxus (/mob/dead/new_player), "heretic", null)
 - Heretic (/datum/antagonist/heretic): add antag hud(25, "heretic", Jackraxxus (/mob/dead/new_player))
 - Heretic (/datum/antagonist/heretic): apply innate effects(null)
 - Heretic (/datum/antagonist/heretic): on gain()
 - Heretic (/datum/antagonist/heretic): on gain()
 - world: ImmediateInvokeAsync(Heretic (/datum/antagonist/heretic), /datum/antagonist/proc/on_gain (/datum/antagonist/proc/on_gain))
 - /datum/mind (/datum/mind): add antag datum(Heretic (/datum/antagonist/heretic), null)
 - Heretics (/datum/dynamic_ruleset/roundstart/heretics): execute()
 - dynamic mode (/datum/game_mode/dynamic): execute roundstart rule(Heretics (/datum/dynamic_ruleset/roundstart/heretics))
 - /datum/callback (/datum/callback): InvokeAsync()
 - Timer (/datum/controller/subsystem/timer): fire(0)
 - Timer (/datum/controller/subsystem/timer): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop()
 - Master (/datum/controller/master): StartProcessing(0)
```

This manifests itself as a /mob/dead with an antag datum but no antag HUD, objectives or equipment. They can even join into protected roles like Sec Officer using this method. Since admins often base a player's antag status on whether they've got an antag datum or not, this is obviously not ideal.

I've put the anti-antag-rolling logic earlier on in the Dynamic `pre_setup()` when it's creating its initial candidate lists. I've kept the logic in `DivideOccupations()` as well, there is a tick check and potential sleep between Dynamic's `pre_setup()` and `SSjob.DivideOccupations()` in which any client's prefs could theoretically change.

I've also reworded the warning a little bit to better inform admins about what is going on, including that the player has been forcefully returned to the lobby and that the game has asked them to update their job preferences.

It also doesn't immediately accuse the player of attempting to antag roll to the admins. Sometimes weird mistakes happen with players enabling roles and we block any attempts to antag roll like this anyway. Admins can decide for themselves if this was likely antag rolling or an accident.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Patch weird oversight. Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fix oversight where Dynamic can assign antag datums to the minds of players who will be forcefully returned to the lobby.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
