### PR TITLE
Makes the surgery mask, the muzzle breathmask, not block surgeries.

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -22,6 +22,7 @@
 	desc = "To silence those pesky patients before putting them under."
 	icon_state = "breathmuzzle"
 	inhand_icon_state = "breathmuzzle"
+	body_parts_covered = FALSE
 	clothing_flags = MASKINTERNALS | BLOCKS_SPEECH
 	gas_transfer_coefficient = 0.1
 	permeability_coefficient = 0.01

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -22,7 +22,7 @@
 	desc = "To silence those pesky patients before putting them under."
 	icon_state = "breathmuzzle"
 	inhand_icon_state = "breathmuzzle"
-	body_parts_covered = FALSE
+	body_parts_covered = NONE
 	clothing_flags = MASKINTERNALS | BLOCKS_SPEECH
 	gas_transfer_coefficient = 0.1
 	permeability_coefficient = 0.01


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The surgery mask introduced in https://github.com/tgstation/tgstation/pull/58330 now doesn't block surgeries done on the head.

I'm tagging this as a QoL PR, and not a balance PR, as I don't see this as meaningfully affecting the balance of the game all too much. The item is such a niche in terms of pure mechanical gameplay, I strongly doubt this will have any effect out of roleplaying out surgery.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
kinda a shit surgery mask if you can't do any surgery with it on
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: FlamingLily
qol: Surgery masks no longer block surgery.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
