### PR TITLE
Makes Microwaves turn on with Right Click

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -56,7 +56,7 @@
 /obj/machinery/microwave/examine(mob/user)
 	. = ..()
 	if(!operating)
-		. += "<span class='notice'>Alt-click [src] to turn it on.</span>"
+		. += "<span class='notice'>Right-click [src] to turn it on.</span>"
 
 	if(!in_range(user, src) && !issilicon(user) && !isobserver(user))
 		. += "<span class='warning'>You're too far away to examine [src]'s contents and display!</span>"
@@ -198,7 +198,7 @@
 
 	..()
 
-/obj/machinery/microwave/AltClick(mob/user)
+/obj/machinery/microwave/RightClick(mob/user)
 	if(user.canUseTopic(src, !issilicon(usr)))
 		cook()
 


### PR DESCRIPTION
## About The Pull Request

Changes it from Alt Click before, to Right Click. Feels way nicer to use now.
![image](https://user-images.githubusercontent.com/53777086/120085400-cc05c880-c0a5-11eb-8baf-f051e3484a13.png)

## Why It's Good For The Game

I dont see why it's still AltClick, Right click makes much more sense

## Changelog
:cl:
qol: Microwaves now use Right Click instead of Alt click to turn on.
/:cl:
