### PR TITLE
Adds a unit test to make sure the right amount of colors are supplied to GAGS configurations

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/shoes/sneakers/mime
 	name = "mime shoes"
-	greyscale_colors = "#ffffff"
+	greyscale_colors = "#ffffff#ffffff"
 
 /obj/item/clothing/shoes/combat //basic syndicate combat boots for nuke ops and mob corpses
 	name = "combat boots"

--- a/code/modules/unit_tests/greyscale_config.dm
+++ b/code/modules/unit_tests/greyscale_config.dm
@@ -22,3 +22,18 @@
 		var/belt_icon_state = initial(item_path.belt_icon_state) || initial(item_path.icon_state)
 		if(belt && !belt.icon_states[belt_icon_state])
 			Fail("[belt.DebugName()] is missing a sprite for the belt overlay for [item_path]. Expected icon state: '[belt_icon_state]'")
+
+/// Makes sure objects using greyscale configs have, if any, the correct number of colors
+/datum/unit_test/greyscale_color_count
+
+/datum/unit_test/greyscale_color_count/Run()
+	for(var/atom/thing as anything in subtypesof(/atom))
+		var/datum/greyscale_config/config = SSgreyscale.configurations["[initial(thing.greyscale_config)]"]
+		if(!config)
+			continue
+		var/list/colors = splittext(initial(thing.greyscale_colors), "#")
+		if(!length(colors))
+			continue
+		var/number_of_colors = length(colors) - 1
+		if(config.expected_colors != number_of_colors)
+			Fail("[thing] has the wrong amount of colors configured for [config.DebugName()]. Expected [config.expected_colors] but only found [number_of_colors].")


### PR DESCRIPTION
Title says it all. See the first commit for the test failing.

## Changelog
:cl:
fix: Mime shoes no longer runtime when generating their icon. This may fix some graphical oddity or do nothing at all since they get colored pure white anyway.
/:cl:
