### PR TITLE
Fixes drone tools being accepted by machines

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -388,6 +388,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_NODROP "nodrop"
 /// cannot be inserted in a storage.
 #define TRAIT_NO_STORAGE_INSERT "no_storage_insert"
+/// cannot be inserted into a machine which has storage (currently anything using component/material_container, experimentor and destructive analyser)
+#define TRAIT_NO_MACHINE_INSERT "no_machine_insert"
 /// Visible on t-ray scanners if the atom/var/level == 1
 #define TRAIT_T_RAY_VISIBLE "t-ray-visible"
 #define TRAIT_FOOD_GRILLED "food_grilled"
@@ -483,6 +485,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define ROUNDSTART_TRAIT "roundstart"
 #define JOB_TRAIT "job"
 #define CYBORG_ITEM_TRAIT "cyborg-item"
+#define DRONE_ITEM_TRAIT "drone-item"
 /// (B)admins only.
 #define ADMIN_TRAIT "admin"
 #define CHANGELING_TRAIT "changeling"

--- a/code/datums/components/holderloving.dm
+++ b/code/datums/components/holderloving.dm
@@ -38,6 +38,7 @@
 		COMSIG_STORAGE_ENTERED,
 		COMSIG_STORAGE_EXITED,
 	), .proc/check_my_loc)
+	ADD_TRAIT(parent, TRAIT_NO_MACHINE_INSERT, DRONE_ITEM_TRAIT)
 
 /datum/component/holderloving/UnregisterFromParent()
 	UnregisterSignal(holder, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
@@ -47,6 +48,7 @@
 		COMSIG_STORAGE_ENTERED,
 		COMSIG_STORAGE_EXITED,
 	))
+	REMOVE_TRAIT(parent, TRAIT_NO_MACHINE_INSERT, DRONE_ITEM_TRAIT)
 
 /datum/component/holderloving/PostTransfer()
 	if(!isitem(parent))

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -114,7 +114,7 @@
 	var/list/tc = allowed_item_typecache
 	if(!(mat_container_flags & MATCONTAINER_ANY_INTENT) && user.combat_mode)
 		return
-	if(I.item_flags & ABSTRACT)
+	if(I.item_flags & ABSTRACT || HAS_TRAIT(I, TRAIT_NO_MACHINE_INSERT))
 		return
 	if((I.flags_1 & HOLOGRAM_1) || (I.item_flags & NO_MAT_REDEMPTION) || (tc && !is_type_in_typecache(I, tc)))
 		if(!(mat_container_flags & MATCONTAINER_SILENT))

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -31,6 +31,8 @@ Note: Must be placed within 3 tiles of the R&D Console
 		. = 1
 		if(!is_insertion_ready(user))
 			return
+		if(HAS_TRAIT(O, TRAIT_NO_MACHINE_INSERT))
+			return
 		if(!user.transferItemToLoc(O, src))
 			to_chat(user, "<span class='warning'>\The [O] is stuck to your hand, you cannot put it in the [src.name]!</span>")
 			return

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -113,6 +113,8 @@
 		. = 1
 		if(!is_insertion_ready(user))
 			return
+		if(HAS_TRAIT(O, TRAIT_NO_MACHINE_INSERT))
+			return
 		if(!user.transferItemToLoc(O, src))
 			return
 		loaded_item = O


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Prevents drone tools being eaten up by machines such as the autolathe. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #59358 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Drones cannot put their tools in the autolathe or destructive analyzer or experimentor now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
