### PR TITLE
More GAGS debug and color select improvement

### DIFF
--- a/code/controllers/subsystem/greyscale.dm
+++ b/code/controllers/subsystem/greyscale.dm
@@ -27,9 +27,13 @@ SUBSYSTEM_DEF(greyscale)
 		configurations[i].Refresh(TRUE)
 
 /datum/controller/subsystem/greyscale/proc/GetColoredIconByType(type, list/colors)
+	if(!ispath(type, /datum/greyscale_config))
+		CRASH("An invalid greyscale configuration was given to `GetColoredIconByType()`: [type]")
 	type = "[type]"
 	if(istype(colors)) // It's the color list format
 		colors = colors.Join()
+	else if(!istext(colors))
+		CRASH("Invalid colors were given to `GetColoredIconByType()`: [colors]")
 	return configurations[type].Generate(colors)
 
 /datum/controller/subsystem/greyscale/proc/ParseColorString(color_string)

--- a/code/datums/greyscale/layer.dm
+++ b/code/datums/greyscale/layer.dm
@@ -35,6 +35,8 @@
 			processed_colors += i
 	return InternalGenerate(processed_colors, render_steps)
 
+/// Override this to implement layers.
+/// The colors var will only contain colors that this layer is configured to use.
 /datum/greyscale_layer/proc/InternalGenerate(list/colors, list/render_steps)
 
 ////////////////////////////////////////////////////////
@@ -49,7 +51,8 @@
 /datum/greyscale_layer/icon_state/New(icon_file, list/json_data)
 	. = ..()
 	var/icon_state = json_data["icon_state"]
-	if(!(icon_state in icon_states(icon_file)))
+	var/list/icon_states = icon_states(icon_file)
+	if(!(icon_state in icon_states))
 		CRASH("Configured icon state \[[icon_state]\] was not found in [icon_file]. Double check your json configuration.")
 	icon = new(icon_file, json_data["icon_state"])
 
@@ -77,4 +80,7 @@
 		CRASH("An unknown greyscale configuration was given to a reference layer: [json_data["reference_type"]]")
 
 /datum/greyscale_layer/reference/InternalGenerate(list/colors, list/render_steps)
-	return icon(reference_config.Generate(colors.Join(), render_steps), icon_state)
+	if(render_steps)
+		return reference_config.GenerateBundle(colors, render_steps)
+	else
+		return reference_config.Generate(colors.Join())

--- a/code/modules/admin/greyscale_modify_menu.dm
+++ b/code/modules/admin/greyscale_modify_menu.dm
@@ -146,6 +146,16 @@
 				split_colors[group] = new_color
 				queue_refresh()
 
+		if("random_color")
+			var/group = text2num(params["color_index"])
+			randomize_color(group)
+			queue_refresh()
+
+		if("random_all_colors")
+			for(var/i in 1 to length(split_colors))
+				randomize_color(i)
+			queue_refresh()
+
 		if("select_icon_state")
 			var/new_icon_state = params["new_icon_state"]
 			if(!config.icon_states[new_icon_state])
@@ -183,6 +193,12 @@ This is highly likely to cause a lag spike for a few seconds."},
 	for(var/i in 2 to length(raw_colors))
 		split_colors += "#[raw_colors[i]]"
 
+/datum/greyscale_modify_menu/proc/randomize_color(color_index)
+	var/new_color = "#"
+	for(var/i in 1 to 3)
+		new_color += num2hex(rand(0, 255), 2)
+	split_colors[color_index] = new_color
+
 /datum/greyscale_modify_menu/proc/queue_refresh()
 	refreshing = TRUE
 	addtimer(CALLBACK(src, .proc/refresh_preview), 1 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
@@ -205,24 +221,30 @@ This is highly likely to cause a lag spike for a few seconds."},
 			icon_state = pick(generated_icon_states)
 
 	var/image/finished
+	var/time_spent = TICK_USAGE
 	if(!generate_full_preview)
 		finished = image(config.GenerateBundle(used_colors), icon_state=icon_state)
+		time_spent = TICK_USAGE - time_spent
 	else
 		var/list/data = config.GenerateDebug(used_colors.Join())
+		time_spent = TICK_USAGE - time_spent
 		finished = image(data["icon"], icon_state=icon_state)
 		var/list/steps = list()
 		sprite_data["steps"] = steps
 		for(var/step in data["steps"])
 			CHECK_TICK
-			var/image/layer = image(data["steps"][step])
-			var/image/result = image(step)
+			var/list/step_data = data["steps"][step]
+			var/image/layer = image(step)
+			var/image/result = step_data["result"]
 			steps += list(
 				list(
 					"layer"=icon2html(layer, user, dir=sprite_dir, sourceonly=TRUE),
-					"result"=icon2html(result, user, dir=sprite_dir, sourceonly=TRUE)
+					"result"=icon2html(result, user, dir=sprite_dir, sourceonly=TRUE),
+					"config_name"=step_data["config_name"]
 				)
 			)
 
+	sprite_data["time_spent"] = TICK_DELTA_TO_MS(time_spent)
 	sprite_data["finished"] = icon2html(finished, user, dir=sprite_dir, sourceonly=TRUE)
 	refreshing = FALSE
 

--- a/tgui/packages/tgui/interfaces/GreyscaleModifyMenu.tsx
+++ b/tgui/packages/tgui/interfaces/GreyscaleModifyMenu.tsx
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Box, Button, ColorBox, Flex, Stack, Icon, Input, LabeledList, Section, Table } from '../components';
+import { Box, Button, ColorBox, Flex, Stack, Icon, Input, LabeledList, Section, Table, Divider } from '../components';
 import { Window } from '../layouts';
 
 type ColorEntry = {
@@ -11,11 +11,13 @@ type SpriteData = {
   icon_states: string[];
   finished: string;
   steps: SpriteEntry[];
+  time_spent: Number;
 }
 
 type SpriteEntry = {
   layer: string;
   result: string;
+  config_name: string;
 }
 
 type GreyscaleMenuData = {
@@ -79,6 +81,11 @@ const ColorDisplay = (props, context) => {
       <LabeledList>
         <LabeledList.Item
           label="Full Color String">
+          <Button
+            icon="dice"
+            onClick={() => act("random_all_colors")}
+            tooltip="Randomizes all color groups."
+          />
           <Input
             value={colors.map(item => item.value).join('')}
             onChange={(_, value) => act("recolor_from_string", { color_string: value })}
@@ -97,9 +104,16 @@ const ColorDisplay = (props, context) => {
             <Button
               icon="palette"
               onClick={() => act("pick_color", { color_index: item.index })}
+              tooltip="Brings up a color pick window to replace this color group."
+            />
+            <Button
+              icon="dice"
+              onClick={() => act("random_color", { color_index: item.index })}
+              tooltip="Randomizes the color for this color group."
             />
             <Input
               value={item.value}
+              width={7}
               onChange={(_, value) => act("recolor", { color_index: item.index, new_color: value })}
             />
           </LabeledList.Item>
@@ -145,6 +159,7 @@ const SingleDirection = (props, context) => {
     <Flex.Item grow={1} basis={0}>
       <Button
         content={DirectionAbbreviation[dir]}
+        tooltip={`Sets the direction of the preview sprite to ${dir}`}
         disabled={`${dir}` === data.sprites_dir ? true : false}
         textAlign="center"
         onClick={() => act("change_dir", { new_sprite_dir: dir })}
@@ -205,6 +220,11 @@ const PreviewDisplay = (props, context) => {
         </Table.Row>
       </Table>
       {
+        !!data.generate_full_preview
+          && `Time Spent: ${data.sprites.time_spent}ms`
+      }
+      <Divider />
+      {
         !data.refreshing
           && (
             <Table>
@@ -212,8 +232,9 @@ const PreviewDisplay = (props, context) => {
                 !!data.generate_full_preview && data.sprites.steps !== null
                   && (
                     <Table.Row header>
-                      <Table.Cell textAlign="center">Step Layer</Table.Cell>
-                      <Table.Cell textAlign="center">Step Result</Table.Cell>
+                      <Table.Cell width="50%" textAlign="center">Layer Source</Table.Cell>
+                      <Table.Cell width="25%" textAlign="center">Step Layer</Table.Cell>
+                      <Table.Cell width="25%" textAlign="center">Step Result</Table.Cell>
                     </Table.Row>
                   )
               }
@@ -221,8 +242,13 @@ const PreviewDisplay = (props, context) => {
                 !!data.generate_full_preview && data.sprites.steps !== null
                   && data.sprites.steps.map(item => (
                     <Table.Row key={`${item.result}|${item.layer}`}>
-                      <Table.Cell width="50%"><SingleSprite source={item.result} /></Table.Cell>
-                      <Table.Cell width="50%"><SingleSprite source={item.layer} /></Table.Cell>
+                      <Table.Cell verticalAlign="middle">{item.config_name}</Table.Cell>
+                      <Table.Cell>
+                        <SingleSprite source={item.layer} />
+                      </Table.Cell>
+                      <Table.Cell>
+                        <SingleSprite source={item.result} />
+                      </Table.Cell>
                     </Table.Row>
                   ))
               }


### PR DESCRIPTION
## About The Pull Request
Overall this pr adds some more error handling and explanation in a few different places in GAGS code. Also adds a bit of performance tracking so you can be aware if your sprite generation is expensive for some reason. All the current configurations were under 10ms, at least on my computer. Also some additional features were added to the configuration menu.

## Changelog
:cl:
qol: Additional information was added to the greyscale configuration menu in the form of tooltips.
qol: You can now randomize the colors in the greyscale configuration menu.
qol: The configuration that a layer is from is now displayed in the full version of the greyscale configuration menu.
fix: The full version of the greyscale configuration menu now properly displays all layer steps again.
/:cl:
