### PR TITLE
Fixes heroine bud being able to be removed by drag-dropping 

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -117,6 +117,14 @@ Slimecrossing Armor
 			return
 	return ..()
 
+/obj/item/clothing/head/peaceflower/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	if(iscarbon(usr))
+		var/mob/living/carbon/C = usr
+		if(src_location == C.head)
+			to_chat(usr, "<span class='warning'>You feel at peace. <b style='color:pink'>Why would you want anything else?</b></span>")
+			return
+	return ..()
+
 /obj/item/clothing/suit/armor/heavy/adamantine
 	name = "adamantine armor"
 	desc = "A full suit of adamantine plate armor. Impressively resistant to damage, but weighs about as much as you do."

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -108,21 +108,22 @@ Slimecrossing Armor
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 1
 	throw_range = 3
-
-/obj/item/clothing/head/peaceflower/attack_hand(mob/user, list/modifiers)
+/obj/item/clothing/head/peaceflower/proc/AtPeaceCheck(mob/user)
 	if(iscarbon(user))
 		var/mob/living/carbon/C = user
 		if(src == C.head)
 			to_chat(user, "<span class='warning'>You feel at peace. <b style='color:pink'>Why would you want anything else?</b></span>")
-			return
+			return TRUE
+	return FALSE
+
+/obj/item/clothing/head/peaceflower/attack_hand(mob/user, list/modifiers)
+	if(AtPeaceCheck(user))
+		return
 	return ..()
 
 /obj/item/clothing/head/peaceflower/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
-	if(iscarbon(usr))
-		var/mob/living/carbon/C = usr
-		if(src_location == C.head)
-			to_chat(usr, "<span class='warning'>You feel at peace. <b style='color:pink'>Why would you want anything else?</b></span>")
-			return
+	if(AtPeaceCheck(usr))
+		return
 	return ..()
 
 /obj/item/clothing/suit/armor/heavy/adamantine

--- a/code/modules/research/xenobiology/crossbreeding/_clothing.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_clothing.dm
@@ -108,21 +108,21 @@ Slimecrossing Armor
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 1
 	throw_range = 3
-/obj/item/clothing/head/peaceflower/proc/AtPeaceCheck(mob/user)
+/obj/item/clothing/head/peaceflower/proc/at_peace_check(mob/user)
 	if(iscarbon(user))
-		var/mob/living/carbon/C = user
-		if(src == C.head)
+		var/mob/living/carbon/carbon_user = user
+		if(src == carbon_user.head)
 			to_chat(user, "<span class='warning'>You feel at peace. <b style='color:pink'>Why would you want anything else?</b></span>")
 			return TRUE
 	return FALSE
 
 /obj/item/clothing/head/peaceflower/attack_hand(mob/user, list/modifiers)
-	if(AtPeaceCheck(user))
+	if(at_peace_check(user))
 		return
 	return ..()
 
 /obj/item/clothing/head/peaceflower/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
-	if(AtPeaceCheck(usr))
+	if(at_peace_check(usr))
 		return
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Heroine bud can no longer be removed by drag-dropping
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #55313
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The heroine bud can no longer be removed by click-dragging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
