### PR TITLE
Attempts to track AI lawsets randomly and silently returning to Asimov

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -18,7 +18,10 @@
 
 /datum/ai_laws/Destroy()
 	if(!QDELETED(owner)) //Stopgap to help with laws randomly being lost. This stack_trace will hopefully help find the real issues.
-		stack_trace("AI law datum for [owner] has ignored Destroy() call; the owner variable must be cleared first.")
+		if(force) //Unless we're forced...
+			stack_trace("AI law datum for [owner] has been forcefully destroyed incorrectly; the owner variable should be cleared first!")
+			return ..()
+		stack_trace("AI law datum for [owner] has ignored Destroy() call; the owner variable must be cleared first!")
 		return QDEL_HINT_LETMELIVE
 	owner = null
 	return ..()

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -17,7 +17,7 @@
 	var/id = DEFAULT_AI_LAWID
 
 /datum/ai_laws/Destroy()
-	if(owner && !QDELETED(owner)) //Stopgap to help with laws randomly being lost. This stack_trace will hopefully help find the real issues.
+	if(!QDELETED(owner)) //Stopgap to help with laws randomly being lost. This stack_trace will hopefully help find the real issues.
 		stack_trace("AI law datum for [owner] has ignored Destroy() call; the owner variable must be cleared first.")
 		return QDEL_HINT_LETMELIVE
 	owner = null

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -17,6 +17,9 @@
 	var/id = DEFAULT_AI_LAWID
 
 /datum/ai_laws/Destroy()
+	if(owner && !QDELETED(owner)) //Stopgap to help with laws randomly being lost. This stack_trace will hopefully help find the real issues.
+		stack_trace("AI law datum for [owner] has ignored Destroy() call; the owner variable must be cleared first.")
+		return QDEL_HINT_LETMELIVE
 	owner = null
 	return ..()
 

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -16,7 +16,7 @@
 	var/mob/living/silicon/owner
 	var/id = DEFAULT_AI_LAWID
 
-/datum/ai_laws/Destroy()
+/datum/ai_laws/Destroy(force=FALSE, ...)
 	if(!QDELETED(owner)) //Stopgap to help with laws randomly being lost. This stack_trace will hopefully help find the real issues.
 		if(force) //Unless we're forced...
 			stack_trace("AI law datum for [owner] has been forcefully destroyed incorrectly; the owner variable should be cleared first!")

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -65,6 +65,7 @@
 	QDEL_NULL(aicamera)
 	QDEL_NULL(builtInCamera)
 	QDEL_NULL(aiPDA)
+	laws?.owner = null //Laws will refuse to die otherwise.
 	QDEL_NULL(laws)
 	GLOB.silicon_mobs -= src
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a check in the ai_laws datum's `Destroy()` proc, returning `QDEL_HINT_LETMELIVE` if an owner is still set and not qdeleted. Makes silicons clear the owner variable from their law datum before calling `Destroy` on it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Under rare conditions, AI law datums are being deleted, which leads to a new default (Asimov) lawset being created anew. This causes confusion for Malf AIs (where law 0 is now missing) and also can cause strange inconsistencies where AIs just randomly become Asimov again.

The source of this issue is not yet known, so I have added a check to (hopefully) ensure that ai_law datums are only deleted from silicons when done through the proper channel (silicon itself being deleted too), and a stack trace to help track down the root cause.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: AIs should no longer occasionally have their lawset randomly and silently returned to Asimov.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
