### PR TITLE
Large Energy Crossbows Now Sound Like Energy Crossbows

### DIFF
--- a/code/modules/projectiles/ammunition/energy/ebow.dm
+++ b/code/modules/projectiles/ammunition/energy/ebow.dm
@@ -2,7 +2,7 @@
 	projectile_type = /obj/projectile/energy/bolt
 	select_name = "bolt"
 	e_cost = 500
-	fire_sound = 'sound/weapons/genhit.ogg'
+	fire_sound = 'sound/weapons/gun/general/heavy_shot_suppressed.ogg' // Even for non-suppressed crossbows, this is the most appropriate sound
 
 /obj/item/ammo_casing/energy/bolt/halloween
 	projectile_type = /obj/projectile/energy/bolt/halloween


### PR DESCRIPTION
## About The Pull Request

Replaces the base energy crossbow projectile's unused fire sound with the sound one traditionally attributes to energy crossbows. I did this because the large energy crossbow is not suppressed, causing it to use the extremely ill-fitting genhit.ogg fire_sound. Replacing the fire sound in this way allows the large energy crossbow to remain un-suppressed while still sounding like the base crossbow, instead of sounding like you pushed a wall.

## Why It's Good For The Game

Large energy crossbow now sounds like an energy crossbow, while retaining the PKA recharge sound effect from being un-suppressed

## Changelog
:cl:
fix: Large energy crossbow now sounds like an energy crossbow
/:cl:
