### PR TITLE
Dynamic no longer creates malf humans.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -222,7 +222,7 @@
 		if(length(exclusive_roles))
 			var/exclusive_candidate = FALSE
 			for(var/role in exclusive_roles)
-				if((role in candidate_client.prefs.job_preferences) && !SSjob.is_banned_from(candidate_player.ckey, role))
+				if((role in candidate_client.prefs.job_preferences) && !is_banned_from(candidate_player.ckey, role))
 					exclusive_candidate = TRUE
 					break
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -218,15 +218,16 @@
 				continue
 
 		// If this ruleset has exclusive_roles set, we want to only consider players who have those
-		// job prefs enabled. Otherwise, continue as before.
+		// job prefs enabled and aren't role banned from that job. Otherwise, continue as before.
 		if(length(exclusive_roles))
 			var/exclusive_candidate = FALSE
 			for(var/role in exclusive_roles)
-				if(role in candidate_client.prefs.job_preferences)
+				if((role in candidate_client.prefs.job_preferences) && !SSjob.is_banned_from(candidate_player.ckey, role))
 					exclusive_candidate = TRUE
 					break
 
-			// If they didn't have any of the required job prefs enabled, they're not eligible for this antag type.
+			// If they didn't have any of the required job prefs enabled or were banned from all enabled prefs,
+			// they're not eligible for this antag type.
 			if(!exclusive_candidate)
 				candidates.Remove(candidate_player)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Malf AI being its own thing strikes again.

AI job banned players can be assigned as malf AIs, fail the job check and instead spawn in as... Well...

```
[2021-05-31 22:35:09.913] killermankey \ Kalium XL \ Station Engineer \ Malf AI \ ROUNDSTART
```

Sooooo... For dynamic roundstart rulesets we now check that the player not only has the job pref enabled but if they do, that they're also not banned from it. If they're job banned from all required prefs they have enabled, they're removed from the candidate list. This should prevent job banned AIs from rolling malf as humans.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Please God, why?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Dynamic will no longer create malf humans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
