### PR TITLE
Lets Shaft miners enter Cargo on Tramstation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -39803,7 +39803,7 @@
 "lft" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
-	req_access_txt = "31"
+	req_one_access_txt = "31;48"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/brown/filled/line{


### PR DESCRIPTION
## About The Pull Request

![baa](https://user-images.githubusercontent.com/53777086/120249392-bc72b500-c248-11eb-8a77-36a24fc00298.png)

I usually do the code locally, then just copy paste it on web due to laziness, but I cant edit maps from the site because its thousands of lines of code.

## Why It's Good For The Game

Shaft miners can reach their job on Tramstation.

## Changelog
:cl:
fix: Shaft Miners can now access Cargo on Tramstation
/:cl: