### PR TITLE
Cleans up some pointlessly defined initialization procs

### DIFF
--- a/code/game/machinery/telecomms/machines/server.dm
+++ b/code/game/machinery/telecomms/machines/server.dm
@@ -16,9 +16,6 @@
 	var/list/log_entries = list()
 	var/totaltraffic = 0 // gigabytes (if > 1024, divide by 1024 -> terrabytes)
 
-/obj/machinery/telecomms/server/Initialize()
-	. = ..()
-
 /obj/machinery/telecomms/server/receive_information(datum/signal/subspace/vocal/signal, obj/machinery/telecomms/machine_from)
 	// can't log non-vocal signals
 	if(!istype(signal) || !signal.data["message"] || !is_freq_listening(signal))

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -428,9 +428,6 @@
 	foodtypes = VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/food/stewedsoymeat/Initialize()
-	. = ..()
-
 /obj/item/food/boiledspiderleg
 	name = "boiled spider leg"
 	desc = "A giant spider's leg that's still twitching after being cooked. Gross!"

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -8,9 +8,6 @@
 	/// Lazylist to keep track of bullet-hole overlays.
 	var/list/bullethole_overlays
 
-/obj/item/target/Initialize()
-	. = ..()
-
 /obj/item/target/welder_act(mob/living/user, obj/item/I)
 	..()
 	if(I.use_tool(src, user, 0, volume=40))

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -466,9 +466,6 @@
 	overlay_ignore_lighting = TRUE
 	var/obj/item/flashlight/eyelight/adapted/adapt_light
 
-/obj/item/organ/eyes/night_vision/maintenance_adapted/Initialize()
-	. = ..()
-
 /obj/item/organ/eyes/night_vision/maintenance_adapted/Insert(mob/living/carbon/adapted, special = FALSE)
 	. = ..()
 	//add lighting


### PR DESCRIPTION
## About The Pull Request

cleans up four cases where `initialize()` was defined and did nothing but call parent

## Why It's Good For The Game

it does nothing, I assume they're copy+paste errors?

## Changelog
:cl: Melbert
code: removes some pointless initialize definitions
/:cl:
