### PR TITLE
Protects against signal race condition

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -313,8 +313,14 @@
 		var/datum/listening_datum = target
 		return NONE | call(listening_datum, listening_datum.signal_procs[src][sigtype])(arglist(arguments))
 	. = NONE
+	// This exists so that even if one of the signal receivers unregisters the signal,
+	// all the objects that are receiving the signal get the signal this final time.
+	// AKA: No you can't cancel the signal reception of another object by doing an unregister in the same signal.
+	var/list/queued_calls = list()
 	for(var/datum/listening_datum as anything in target)
-		. |= call(listening_datum, listening_datum.signal_procs[src][sigtype])(arglist(arguments))
+		queued_calls[listening_datum] = listening_datum.signal_procs[src][sigtype]
+	for(var/datum/listening_datum as anything in queued_calls)
+		. |= call(listening_datum, queued_calls[listening_datum])(arglist(arguments))
 
 // The type arg is casted so initial works, you shouldn't be passing a real instance into this
 /**


### PR DESCRIPTION
Due to how for loops copy the list they are iterating over, with the correct series of signal registrations and unregistrations you could cause signal code to runtime by attempting to activate a receiver that had been unregistered.

This change makes it so even if an object is unregistered to the ongoing signal by another registrant it will at least get the final signal that was in progress. If we were to just not send the signal to objects which had been unregistered midway we'd be opening ourselves up to bugs that depended on the order of registration which is a nightmare I don't want to deal with.
