### PR TITLE
Airlock overlay refactor and code cleanup.

### DIFF
--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -1068,7 +1068,7 @@
 /area/awaymission/research/interior/secure)
 "cR" = (
 /obj/machinery/door/airlock/highsecurity{
-	aiDisabledIdScanner = 1;
+	ai_disabled_id_scanner = 1;
 	name = "Gateway Access";
 	req_access_txt = "205"
 	},
@@ -1704,7 +1704,7 @@
 "dW" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/highsecurity{
-	aiDisabledIdScanner = 1;
+	ai_disabled_id_scanner = 1;
 	name = "Secure Storage C";
 	req_access_txt = "205"
 	},
@@ -1713,7 +1713,7 @@
 "dX" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/highsecurity{
-	aiDisabledIdScanner = 1;
+	ai_disabled_id_scanner = 1;
 	name = "Secure Storage D";
 	req_access_txt = "205"
 	},
@@ -2677,7 +2677,7 @@
 /area/awaymission/research/interior/secure)
 "gg" = (
 /obj/machinery/door/airlock/highsecurity{
-	aiDisabledIdScanner = 1;
+	ai_disabled_id_scanner = 1;
 	name = "Power Storage";
 	req_access_txt = "205"
 	},
@@ -3421,7 +3421,7 @@
 "hI" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/highsecurity{
-	aiDisabledIdScanner = 1;
+	ai_disabled_id_scanner = 1;
 	name = "Secure Storage A";
 	req_access_txt = "205"
 	},
@@ -3430,7 +3430,7 @@
 "hJ" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/highsecurity{
-	aiDisabledIdScanner = 1;
+	ai_disabled_id_scanner = 1;
 	name = "Secure Storage B";
 	req_access_txt = "205"
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -60518,7 +60518,7 @@
 "kEH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
+	ai_control_disabled = 1;
 	name = "Education Chamber";
 	req_access_txt = "3"
 	},

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2769,7 +2769,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
 	req_access_txt = "2";
-	shuttledocked = 1
+	shuttle_docked = 1
 	},
 /turf/open/floor/plating,
 /area/security/processing)
@@ -3498,7 +3498,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
-	shuttledocked = 1
+	shuttle_docked = 1
 	},
 /turf/open/floor/plating,
 /area/security/processing)
@@ -8733,7 +8733,7 @@
 "aWD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
+	ai_control_disabled = 1;
 	name = "Prisoner Transfer Centre";
 	req_access_txt = "2"
 	},
@@ -44461,7 +44461,7 @@
 	},
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Four";
-	shuttledocked = 1
+	shuttle_docked = 1
 	},
 /turf/open/floor/plating,
 /area/engineering/main)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -24161,7 +24161,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
 	req_access_txt = "2";
-	shuttledocked = 1
+	shuttle_docked = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28028,7 +28028,7 @@
 "bUP" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
-	shuttledocked = 1
+	shuttle_docked = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37548,7 +37548,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
 	req_access_txt = "2";
-	shuttledocked = 1
+	shuttle_docked = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -37603,7 +37603,7 @@
 "cxz" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
-	shuttledocked = 1
+	shuttle_docked = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -54358,7 +54358,7 @@
 "iPQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
+	ai_control_disabled = 1;
 	id_tag = "justicedoor_2";
 	name = "Justice Chamber";
 	req_access_txt = "3"
@@ -57955,7 +57955,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
+	ai_control_disabled = 1;
 	id_tag = "justicedoor";
 	name = "Justice Chamber";
 	req_access_txt = "3"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -60478,7 +60478,7 @@
 "rMZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
+	ai_control_disabled = 1;
 	id_tag = "prisonereducation";
 	name = "Prisoner Education Chamber";
 	req_access_txt = "3"
@@ -77916,8 +77916,8 @@
 /area/ai_monitored/command/storage/eva)
 "xBG" = (
 /obj/machinery/door/airlock/wood{
-	doorClose = 'sound/effects/doorcreaky.ogg';
-	doorOpen = 'sound/effects/doorcreaky.ogg';
+	door_close_sound = 'sound/effects/doorcreaky.ogg';
+	door_open_sound = 'sound/effects/doorcreaky.ogg';
 	name = "The Gobetting Barmaid"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -21596,7 +21596,7 @@
 "egb" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
-	shuttledocked = 1
+	shuttle_docked = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -39249,7 +39249,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
 	req_access_txt = "2";
-	shuttledocked = 1
+	shuttle_docked = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,

--- a/_maps/shuttles/assault_pod_default.dmm
+++ b/_maps/shuttles/assault_pod_default.dmm
@@ -14,7 +14,7 @@
 /area/shuttle/assault_pod)
 "e" = (
 /obj/machinery/door/airlock/centcom{
-	aiControlDisabled = 1;
+	ai_control_disabled = 1;
 	name = "Assault Pod";
 	req_access_txt = "150"
 	},
@@ -34,7 +34,7 @@
 /area/shuttle/assault_pod)
 "t" = (
 /obj/machinery/door/airlock/centcom{
-	aiControlDisabled = 1;
+	ai_control_disabled = 1;
 	name = "Assault Pod";
 	req_access_txt = "150"
 	},

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -78,7 +78,7 @@
 	var/list/status = list()
 	status += "The door bolts [A.locked ? "have fallen!" : "look up."]"
 	status += "The test light is [A.hasPower() ? "on" : "off"]."
-	status += "The AI connection light is [A.aiControlDisabled || (A.obj_flags & EMAGGED) ? "off" : "on"]."
+	status += "The AI connection light is [A.ai_control_disabled || (A.obj_flags & EMAGGED) ? "off" : "on"]."
 	status += "The check wiring light is [A.safe ? "off" : "on"]."
 	status += "The timer is powered [A.autoclose ? "on" : "off"]."
 	status += "The speed light is [A.normalspeed ? "on" : "off"]."
@@ -115,10 +115,10 @@
 					A.emergency = FALSE
 					A.update_appearance()
 		if(WIRE_AI) // Pulse to disable WIRE_AI control for 10 ticks (follows same rules as cutting).
-			if(A.aiControlDisabled == AI_WIRE_NORMAL)
-				A.aiControlDisabled = AI_WIRE_DISABLED
-			else if(A.aiControlDisabled == AI_WIRE_DISABLED_HACKED)
-				A.aiControlDisabled = AI_WIRE_HACKED
+			if(A.ai_control_disabled == AI_WIRE_NORMAL)
+				A.ai_control_disabled = AI_WIRE_DISABLED
+			else if(A.ai_control_disabled == AI_WIRE_DISABLED_HACKED)
+				A.ai_control_disabled = AI_WIRE_HACKED
 			addtimer(CALLBACK(A, /obj/machinery/door/airlock.proc/reset_ai_wire), 1 SECONDS)
 		if(WIRE_SHOCK) // Pulse to shock the door for 10 ticks.
 			if(!A.secondsElectrified)
@@ -135,10 +135,10 @@
 			A.update_appearance()
 
 /obj/machinery/door/airlock/proc/reset_ai_wire()
-	if(aiControlDisabled == AI_WIRE_DISABLED)
-		aiControlDisabled = AI_WIRE_NORMAL
-	else if(aiControlDisabled == AI_WIRE_HACKED)
-		aiControlDisabled = AI_WIRE_DISABLED_HACKED
+	if(ai_control_disabled == AI_WIRE_DISABLED)
+		ai_control_disabled = AI_WIRE_NORMAL
+	else if(ai_control_disabled == AI_WIRE_HACKED)
+		ai_control_disabled = AI_WIRE_DISABLED_HACKED
 
 /datum/wires/airlock/on_cut(wire, mend)
 	var/obj/machinery/door/airlock/A = holder
@@ -162,15 +162,15 @@
 				A.bolt()
 		if(WIRE_AI) // Cut to disable WIRE_AI control, mend to re-enable.
 			if(mend)
-				if(A.aiControlDisabled == AI_WIRE_DISABLED) // 0 = normal, 1 = locked out, 2 = overridden by WIRE_AI, -1 = previously overridden by WIRE_AI
-					A.aiControlDisabled = AI_WIRE_NORMAL
-				else if(A.aiControlDisabled == AI_WIRE_HACKED)
-					A.aiControlDisabled = AI_WIRE_DISABLED_HACKED
+				if(A.ai_control_disabled == AI_WIRE_DISABLED) // 0 = normal, 1 = locked out, 2 = overridden by WIRE_AI, -1 = previously overridden by WIRE_AI
+					A.ai_control_disabled = AI_WIRE_NORMAL
+				else if(A.ai_control_disabled == AI_WIRE_HACKED)
+					A.ai_control_disabled = AI_WIRE_DISABLED_HACKED
 			else
-				if(A.aiControlDisabled == AI_WIRE_NORMAL)
-					A.aiControlDisabled = AI_WIRE_DISABLED
-				else if(A.aiControlDisabled == AI_WIRE_DISABLED_HACKED)
-					A.aiControlDisabled = AI_WIRE_HACKED
+				if(A.ai_control_disabled == AI_WIRE_NORMAL)
+					A.ai_control_disabled = AI_WIRE_DISABLED
+				else if(A.ai_control_disabled == AI_WIRE_DISABLED_HACKED)
+					A.ai_control_disabled = AI_WIRE_HACKED
 		if(WIRE_SHOCK) // Cut to shock the door, mend to unshock.
 			if(mend)
 				if(A.secondsElectrified)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -473,129 +473,55 @@
 	var/mutable_appearance/note_overlay
 	var/mutable_appearance/seal_overlay
 	var/notetype = note_type()
+
+	var/door_state_suffix = ""
+	var/light_state_suffix = ""
+	var/mobile_state = FALSE
 	switch(airlock_state)
-		if(AIRLOCK_CLOSED)
-			frame_overlay = get_airlock_overlay("closed", icon)
-			if(airlock_material)
-				filling_overlay = get_airlock_overlay("[airlock_material]_closed", overlays_file)
-			else
-				filling_overlay = get_airlock_overlay("fill_closed", icon)
-			if(panel_open)
-				if(security_level)
-					panel_overlay = get_airlock_overlay("panel_closed_protected", overlays_file)
-				else
-					panel_overlay = get_airlock_overlay("panel_closed", overlays_file)
-			if(welded)
-				weld_overlay = get_airlock_overlay("welded", overlays_file)
-			if(seal)
-				seal_overlay = get_airlock_overlay("sealed", overlays_file)
-			if(obj_integrity < integrity_failure * max_integrity)
-				damag_overlay = get_airlock_overlay("sparks_broken", overlays_file)
-			else if(obj_integrity < (0.75 * max_integrity))
-				damag_overlay = get_airlock_overlay("sparks_damaged", overlays_file)
-			if(lights && hasPower())
-				if(locked)
-					lights_overlay = get_airlock_overlay("lights_bolts", overlays_file)
-				else if(emergency)
-					lights_overlay = get_airlock_overlay("lights_emergency", overlays_file)
-			if(note)
-				note_overlay = get_airlock_overlay(notetype, note_overlay_file)
-
+		if(AIRLOCK_CLOSED || AIRLOCK_EMAG)
+			door_state_suffix = "closed"
 		if(AIRLOCK_DENY)
-			if(!hasPower())
-				return
-			frame_overlay = get_airlock_overlay("closed", icon)
-			if(airlock_material)
-				filling_overlay = get_airlock_overlay("[airlock_material]_closed", overlays_file)
-			else
-				filling_overlay = get_airlock_overlay("fill_closed", icon)
-			if(panel_open)
-				if(security_level)
-					panel_overlay = get_airlock_overlay("panel_closed_protected", overlays_file)
-				else
-					panel_overlay = get_airlock_overlay("panel_closed", overlays_file)
-			if(obj_integrity < integrity_failure * max_integrity)
-				damag_overlay = get_airlock_overlay("sparks_broken", overlays_file)
-			else if(obj_integrity < (0.75 * max_integrity))
-				damag_overlay = get_airlock_overlay("sparks_damaged", overlays_file)
-			if(welded)
-				weld_overlay = get_airlock_overlay("welded", overlays_file)
-			if(seal)
-				seal_overlay = get_airlock_overlay("sealed", overlays_file)
-			lights_overlay = get_airlock_overlay("lights_denied", overlays_file)
-			if(note)
-				note_overlay = get_airlock_overlay(notetype, note_overlay_file)
-
-		if(AIRLOCK_EMAG)
-			frame_overlay = get_airlock_overlay("closed", icon)
-			sparks_overlay = get_airlock_overlay("sparks", overlays_file)
-			if(airlock_material)
-				filling_overlay = get_airlock_overlay("[airlock_material]_closed", overlays_file)
-			else
-				filling_overlay = get_airlock_overlay("fill_closed", icon)
-			if(panel_open)
-				if(security_level)
-					panel_overlay = get_airlock_overlay("panel_closed_protected", overlays_file)
-				else
-					panel_overlay = get_airlock_overlay("panel_closed", overlays_file)
-			if(obj_integrity < integrity_failure * max_integrity)
-				damag_overlay = get_airlock_overlay("sparks_broken", overlays_file)
-			else if(obj_integrity < (0.75 * max_integrity))
-				damag_overlay = get_airlock_overlay("sparks_damaged", overlays_file)
-			if(welded)
-				weld_overlay = get_airlock_overlay("welded", overlays_file)
-			if(seal)
-				seal_overlay = get_airlock_overlay("sealed", overlays_file)
-			if(note)
-				note_overlay = get_airlock_overlay(notetype, note_overlay_file)
-
+			door_state_suffix = "closed"
+			light_state_suffix = "denied"
 		if(AIRLOCK_CLOSING)
-			frame_overlay = get_airlock_overlay("closing", icon)
-			if(airlock_material)
-				filling_overlay = get_airlock_overlay("[airlock_material]_closing", overlays_file)
-			else
-				filling_overlay = get_airlock_overlay("fill_closing", icon)
-			if(lights && hasPower())
-				lights_overlay = get_airlock_overlay("lights_closing", overlays_file)
-			if(panel_open)
-				if(security_level)
-					panel_overlay = get_airlock_overlay("panel_closing_protected", overlays_file)
-				else
-					panel_overlay = get_airlock_overlay("panel_closing", overlays_file)
-			if(note)
-				note_overlay = get_airlock_overlay("[notetype]_closing", note_overlay_file)
-
-		if(AIRLOCK_OPEN)
-			frame_overlay = get_airlock_overlay("open", icon)
-			if(airlock_material)
-				filling_overlay = get_airlock_overlay("[airlock_material]_open", overlays_file)
-			else
-				filling_overlay = get_airlock_overlay("fill_open", icon)
-			if(panel_open)
-				if(security_level)
-					panel_overlay = get_airlock_overlay("panel_open_protected", overlays_file)
-				else
-					panel_overlay = get_airlock_overlay("panel_open", overlays_file)
-			if(obj_integrity < (0.75 * max_integrity))
-				damag_overlay = get_airlock_overlay("sparks_open", overlays_file)
-			if(note)
-				note_overlay = get_airlock_overlay("[notetype]_open", note_overlay_file)
-
+			door_state_suffix = "closing"
+			light_state_suffix = "closing"
+			mobile_state = TRUE
 		if(AIRLOCK_OPENING)
-			frame_overlay = get_airlock_overlay("opening", icon)
-			if(airlock_material)
-				filling_overlay = get_airlock_overlay("[airlock_material]_opening", overlays_file)
-			else
-				filling_overlay = get_airlock_overlay("fill_opening", icon)
-			if(lights && hasPower())
-				lights_overlay = get_airlock_overlay("lights_opening", overlays_file)
-			if(panel_open)
-				if(security_level)
-					panel_overlay = get_airlock_overlay("panel_opening_protected", overlays_file)
-				else
-					panel_overlay = get_airlock_overlay("panel_opening", overlays_file)
-			if(note)
-				note_overlay = get_airlock_overlay("[notetype]_opening", note_overlay_file)
+			door_state_suffix = "opening"
+			light_state_suffix = "opening"
+			mobile_state = TRUE
+		if(AIRLOCK_OPEN)
+			door_state_suffix = "open"
+
+
+	frame_overlay = get_airlock_overlay("[door_state_suffix]", icon)
+	if(airlock_material)
+		filling_overlay = get_airlock_overlay("[airlock_material]_[door_state_suffix]", overlays_file)
+	else
+		filling_overlay = get_airlock_overlay("fill_[door_state_suffix]", icon)
+	if(panel_open)
+		if(security_level)
+			panel_overlay = get_airlock_overlay("panel_[door_state_suffix]_protected", overlays_file)
+		else
+			panel_overlay = get_airlock_overlay("panel_[door_state_suffix]", overlays_file)
+	if(welded)
+		weld_overlay = get_airlock_overlay("welded", overlays_file)
+	if(seal)
+		seal_overlay = get_airlock_overlay("sealed", overlays_file)
+	if((obj_integrity < integrity_failure * max_integrity) && (!mobile_state))
+		damag_overlay = get_airlock_overlay("sparks_broken", overlays_file)
+	else if((obj_integrity < (0.75 * max_integrity)) && (!mobile_state))
+		damag_overlay = get_airlock_overlay("sparks_damaged", overlays_file)
+	if(lights && hasPower())
+		if(locked)
+			lights_overlay = get_airlock_overlay("lights_bolts", overlays_file)
+		else if(emergency)
+			lights_overlay = get_airlock_overlay("lights_emergency", overlays_file)
+		if(mobile_state)
+			lights_overlay = get_airlock_overlay("lights_[light_state_suffix]")
+	if(note)
+		note_overlay = get_airlock_overlay(notetype, note_overlay_file)
 
 	. += frame_overlay
 	. += filling_overlay

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -522,7 +522,6 @@
 		if(AIRLOCK_OPEN)
 			door_state_suffix = "open"
 
-
 	frame_overlay = get_airlock_overlay("[door_state_suffix]", icon)
 	if(airlock_material)
 		filling_overlay = get_airlock_overlay("[airlock_material]_[door_state_suffix]", overlays_file)
@@ -539,28 +538,40 @@
 		seal_overlay = get_airlock_overlay("sealed", overlays_file)
 	if((obj_integrity < integrity_failure * max_integrity) && (!mobile_state))
 		damag_overlay = get_airlock_overlay("sparks_broken", overlays_file)
-	else if((obj_integrity < (0.75 * max_integrity)) && (!mobile_state))
+	else if((obj_integrity < (0.75 * max_integrity)) && (!mobile_state) && ((airlock_state != AIRLOCK_OPEN)))
 		damag_overlay = get_airlock_overlay("sparks_damaged", overlays_file)
+	else if((obj_integrity < (0.75 * max_integrity)) && (!mobile_state))
+		damag_overlay = get_airlock_overlay("sparks_open", overlays_file)
 	if(lights && hasPower())
-		if(mobile_state)
-			lights_overlay = get_airlock_overlay("lights_[light_state_suffix]")
+		if(mobile_state || (airlock_state == AIRLOCK_DENY))
+			lights_overlay = get_airlock_overlay("lights_[light_state_suffix]", overlays_file)
 		if(locked)
 			lights_overlay = get_airlock_overlay("lights_bolts", overlays_file)
 		else if(emergency)
 			lights_overlay = get_airlock_overlay("lights_emergency", overlays_file)
-
+	if(obj_flags & EMAGGED)
+		sparks_overlay = get_airlock_overlay("sparks", overlays_file)
 	if(note)
 		note_overlay = get_airlock_overlay("[notetype]_[door_state_suffix]", note_overlay_file)
 
-	. += frame_overlay
-	. += filling_overlay
-	. += lights_overlay
-	. += panel_overlay
-	. += weld_overlay
-	. += sparks_overlay
-	. += damag_overlay
-	. += note_overlay
-	. += seal_overlay
+	if(frame_overlay)
+		. += frame_overlay
+	if(filling_overlay)
+		. += filling_overlay
+	if(lights_overlay)
+		. += lights_overlay
+	if(panel_overlay)
+		. += panel_overlay
+	if(weld_overlay)
+		. += weld_overlay
+	if(sparks_overlay)
+		. += sparks_overlay
+	if(damag_overlay)
+		. += damag_overlay
+	if(note_overlay)
+		. += note_overlay
+	if(seal_overlay)
+		. += seal_overlay
 
 	if(hasPower() && unres_sides)
 		if(unres_sides & NORTH)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -506,7 +506,9 @@
 	var/light_state_suffix = ""
 	var/mobile_state = FALSE
 	switch(airlock_state)
-		if(AIRLOCK_CLOSED || AIRLOCK_EMAG)
+		if(AIRLOCK_CLOSED)
+			door_state_suffix = "closed"
+		if(AIRLOCK_EMAG)
 			door_state_suffix = "closed"
 		if(AIRLOCK_DENY)
 			door_state_suffix = "closed"
@@ -549,7 +551,7 @@
 			lights_overlay = get_airlock_overlay("lights_bolts", overlays_file)
 		else if(emergency)
 			lights_overlay = get_airlock_overlay("lights_emergency", overlays_file)
-	if(obj_flags & EMAGGED)
+	if((airlock_state == AIRLOCK_EMAG))
 		sparks_overlay = get_airlock_overlay("sparks", overlays_file)
 	if(note)
 		note_overlay = get_airlock_overlay("[notetype]_[door_state_suffix]", note_overlay_file)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -256,7 +256,7 @@
 	desc = "Honkhonkhonk"
 	icon = 'icons/obj/doors/airlocks/station/bananium.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_bananium
-	doorOpen = 'sound/items/bikehorn.ogg'
+	door_open_sound = 'sound/items/bikehorn.ogg'
 
 /obj/machinery/door/airlock/bananium/glass
 	opacity = FALSE
@@ -436,8 +436,8 @@
 	note_overlay_file = 'icons/obj/doors/airlocks/external/overlays.dmi'
 	damage_deflection = 30
 	explosion_block = 3
-	hackProof = TRUE
-	aiControlDisabled = AI_WIRE_DISABLED
+	hack_proof = TRUE
+	ai_control_disabled = AI_WIRE_DISABLED
 	normal_integrity = 700
 	security_level = 1
 
@@ -451,8 +451,8 @@
 	icon = 'icons/obj/doors/airlocks/cult/runed/cult.dmi'
 	overlays_file = 'icons/obj/doors/airlocks/cult/runed/overlays.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_cult
-	hackProof = TRUE
-	aiControlDisabled = AI_WIRE_DISABLED
+	hack_proof = TRUE
+	ai_control_disabled = AI_WIRE_DISABLED
 	req_access = list(ACCESS_BLOODCULT)
 	damage_deflection = 10
 	var/openingoverlaytype = /obj/effect/temp_visual/cult/door

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -79,7 +79,7 @@
 				if(!D.density)
 					doors_need_closing = TRUE
 			if(specialfunctions & IDSCAN)
-				D.aiDisabledIdScanner = !D.aiDisabledIdScanner
+				D.ai_disabled_id_scanner = !D.ai_disabled_id_scanner
 			if(specialfunctions & BOLTS)
 				if(!D.wires.is_cut(WIRE_BOLTS) && D.hasPower())
 					D.locked = !D.locked

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -121,10 +121,10 @@
 	icon_state = "airlock_cyclelink_helper"
 
 /obj/effect/mapping_helpers/airlock/cyclelink_helper/payload(obj/machinery/door/airlock/airlock)
-	if(airlock.cyclelinkeddir)
-		log_mapping("[src] at [AREACOORD(src)] tried to set [airlock] cyclelinkeddir, but it's already set!")
+	if(airlock.cycle_linked_dir)
+		log_mapping("[src] at [AREACOORD(src)] tried to set [airlock] cycle_linked_dir, but it's already set!")
 	else
-		airlock.cyclelinkeddir = dir
+		airlock.cycle_linked_dir = dir
 
 
 /obj/effect/mapping_helpers/airlock/locked
@@ -160,10 +160,10 @@
 	icon_state = "airlock_cutaiwire"
 
 /obj/effect/mapping_helpers/airlock/cutaiwire/payload(obj/machinery/door/airlock/airlock)
-	if(airlock.cutAiWire)
+	if(airlock.cut_ai_wire)
 		log_mapping("[src] at [AREACOORD(src)] tried to cut the ai wire on [airlock] but it's already cut!")
 	else
-		airlock.cutAiWire = TRUE
+		airlock.cut_ai_wire = TRUE
 
 //needs to do its thing before spawn_rivers() is called
 INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -183,7 +183,7 @@ All ShuttleMove procs go here
 /obj/machinery/door/airlock/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)
 	. = ..()
 	for(var/obj/machinery/door/airlock/A in range(1, src))  // includes src
-		A.shuttledocked = FALSE
+		A.shuttle_docked = FALSE
 		A.air_tight = TRUE
 		INVOKE_ASYNC(A, /obj/machinery/door/.proc/close)
 
@@ -193,8 +193,8 @@ All ShuttleMove procs go here
 	for(var/obj/machinery/door/airlock/A in orange(1, src))  // does not include src
 		if(get_area(A) != current_area)  // does not include double-wide airlocks unless actually docked
 			// Cycle linking is only disabled if we are actually adjacent to another airlock
-			shuttledocked = TRUE
-			A.shuttledocked = TRUE
+			shuttle_docked = TRUE
+			A.shuttle_docked = TRUE
 
 /obj/machinery/camera/beforeShuttleMove(turf/newT, rotation, move_mode, obj/docking_port/mobile/moving_dock)
 	. = ..()

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -105,8 +105,8 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 
 /obj/machinery/door/airlock/shuttleRotate(rotation, params)
 	. = ..()
-	if(cyclelinkeddir && (params & ROTATE_DIR))
-		cyclelinkeddir = angle2dir(rotation+dir2angle(cyclelinkeddir))
+	if(cycle_linked_dir && (params & ROTATE_DIR))
+		cycle_linked_dir = angle2dir(rotation+dir2angle(cycle_linked_dir))
 		// If we update the linked airlock here, the partner airlock might
 		// not be present yet, so don't do that. Just assume we're still
 		// partnered with the same airlock as before.


### PR DESCRIPTION
## About The Pull Request

This PR was written in an attempt to improve the update_overlay proc on airlocks so that they weren't adding so many empty mutable_appearances which is breaking another project I have in another branch for the wall project. In the meantime, this removes much of the state machine from that proc as it's not necessary to rewrite as much of that proc as we are currently doing for EVERY single door_state. 

- [x] Someone please tell me why the opening and closing lights overlay is broken for this before I un-draft this.

In addition, I've fully autodoc'd the variables used in the whole file, and changed the variable names to fit the correct variable naming scheme (`variable_name` not `variableName`).
It also gave me a chance to remove the unused detonated variable, which as far as I can tell was removed at some point probably alongside some element of C4 or perhaps airlock charges, it's hard to tell.

## Why It's Good For The Game

Updates decaying old code, documents some of the most common yet most complex objects used on nearly every map and ruin, and hopefully optimizes airlocks as well by the time we're done.

## Changelog
:cl:
refactor: Refactors how airlocks handle their overlays and lights in-game.
code: Documents airlock code.
/:cl:
