### PR TITLE
Shuttle Insurance can now trigger before the Shuttle Catastrophe it is supposed to protect against

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -211,6 +211,8 @@
 			if (bank_account.account_balance < shuttle.credit_cost)
 				return
 			SSshuttle.shuttle_purchased = SHUTTLEPURCHASE_PURCHASED
+			for(var/datum/round_event_control/shuttle_insurance/insurance_event in SSevents.control)
+				insurance_event.weight *= 20
 			SSshuttle.unload_preview()
 			SSshuttle.existing_shuttle = SSshuttle.emergency
 			SSshuttle.action_load(shuttle, replace = TRUE)

--- a/code/modules/events/shuttle_insurance.dm
+++ b/code/modules/events/shuttle_insurance.dm
@@ -9,7 +9,7 @@
 /datum/round_event_control/shuttle_insurance/canSpawnEvent(players)
 	if(!SSeconomy.get_dep_account(ACCOUNT_CAR))
 		return FALSE //They can't pay?
-	if(SSshuttle.shuttle_purchased != SHUTTLEPURCHASE_FORCED)
+	if(SSshuttle.shuttle_purchased == SHUTTLEPURCHASE_FORCED)
 		return FALSE //don't do it if there's nothing to insure
 	if(EMERGENCY_AT_LEAST_DOCKED)
 		return FALSE //catastrophes won't trigger so no point

--- a/code/modules/events/shuttle_insurance.dm
+++ b/code/modules/events/shuttle_insurance.dm
@@ -3,7 +3,6 @@
 /datum/round_event_control/shuttle_insurance
 	name = "Shuttle Insurance"
 	typepath = /datum/round_event/shuttle_insurance
-	weight = 200 //you're basically bound to get it
 	max_occurrences = 1
 
 /datum/round_event_control/shuttle_insurance/canSpawnEvent(players)


### PR DESCRIPTION
## About The Pull Request

Fixes #59430.

## Why It's Good For The Game

Currently, Shuttle Insurance can only trigger after a Shuttle Catastrophe has occurred. Because insurance prevents the shuttle from being forcibly changed by a catastrophe, it is pointless because the catastrophe it was meant to protect against already happened. Now insurance can trigger when it's supposed to.

## Changelog
:cl:
fix: Local insurance providers have realized that they should advertise their services BEFORE the occurrence of the very accidents they are supposed to insure against.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
