### PR TITLE
Custom Outfits can now remember their trims

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -336,6 +336,7 @@
 	.["ears"] = ears
 	.["glasses"] = glasses
 	.["id"] = id
+	.["id_trim"] = id_trim
 	.["l_pocket"] = l_pocket
 	.["r_pocket"] = r_pocket
 	.["suit_store"] = suit_store
@@ -363,6 +364,7 @@
 	ears = target.ears
 	glasses = target.glasses
 	id = target.id
+	id_trim = target.id_trim
 	l_pocket = target.l_pocket
 	r_pocket = target.r_pocket
 	suit_store = target.suit_store
@@ -401,6 +403,7 @@
 	ears = text2path(outfit_data["ears"])
 	glasses = text2path(outfit_data["glasses"])
 	id = text2path(outfit_data["id"])
+	id_trim = text2path(outfit_data["id_trim"])
 	l_pocket = text2path(outfit_data["l_pocket"])
 	r_pocket = text2path(outfit_data["r_pocket"])
 	suit_store = text2path(outfit_data["suit_store"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So, someone did an oopsie and forgot to change outfit saving code, which meant that you couldn't save a custom outfit's ID trim. So, here I go, fixing that, so we can actually customize what job our outfit would start as.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less copy-pasting for admins, and feex good.
Also, I was worried that it might not be compatible with previous custom outfits, and it's 100% compatible with old .json files for outfits that didn't have an `id_trim` set.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Custom outfits will now save their ID trim.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
