### PR TITLE
[READY] Adds another jetpack and a pair of magboots to Tramstation EVA

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -196,10 +196,17 @@
 /area/maintenance/port/central)
 "aaD" = (
 /obj/structure/rack,
-/obj/item/clothing/shoes/magboots,
 /obj/effect/turf_decal/trimline/blue,
 /obj/machinery/airalarm/directional/north,
-/obj/item/tank/jetpack/carbondioxide,
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots{
+	pixel_x = -4;
+	pixel_y = 3
+	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aaE" = (
@@ -219,9 +226,16 @@
 /area/security/prison)
 "aaI" = (
 /obj/structure/rack,
-/obj/item/clothing/shoes/magboots,
 /obj/effect/turf_decal/trimline/blue,
+/obj/item/tank/jetpack/carbondioxide{
+	pixel_x = 4;
+	pixel_y = -1
+	},
 /obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide{
+	pixel_x = -4;
+	pixel_y = 1
+	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "aaJ" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title

## Why It's Good For The Game

Every station has 3 pairs of magboots and 3 jetpacks while Tram has only 2.

## Changelog
:cl:
balance: Tram now has 3 jetpacks and 3 pairs of magboots like every other station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
