### PR TITLE
Fixes banana juice appearing twice in mystery soup initialization

### DIFF
--- a/code/game/objects/items/food/soup.dm
+++ b/code/game/objects/items/food/soup.dm
@@ -96,7 +96,17 @@
 /obj/item/food/soup/mystery/Initialize()
 	. = ..()
 	var/extra_reagent = null
-	extra_reagent = pick(/datum/reagent/consumable/capsaicin, /datum/reagent/consumable/frostoil, /datum/reagent/medicine/omnizine, /datum/reagent/consumable/banana, /datum/reagent/blood, /datum/reagent/toxin/slimejelly, /datum/reagent/toxin, /datum/reagent/carbon, /datum/reagent/medicine/oculine)
+	extra_reagent = pick(
+		/datum/reagent/blood,
+		/datum/reagent/carbon,
+		/datum/reagent/consumable/banana,
+		/datum/reagent/consumable/capsaicin,
+		/datum/reagent/consumable/frostoil,
+		/datum/reagent/medicine/oculine,
+		/datum/reagent/medicine/omnizine,
+		/datum/reagent/toxin,
+		/datum/reagent/toxin/slimejelly,
+		)
 	reagents.add_reagent(extra_reagent, 5)
 	reagents.add_reagent(/datum/reagent/consumable/nutriment, 6)
 

--- a/code/game/objects/items/food/soup.dm
+++ b/code/game/objects/items/food/soup.dm
@@ -96,7 +96,7 @@
 /obj/item/food/soup/mystery/Initialize()
 	. = ..()
 	var/extra_reagent = null
-	extra_reagent = pick(/datum/reagent/consumable/capsaicin, /datum/reagent/consumable/frostoil, /datum/reagent/medicine/omnizine, /datum/reagent/consumable/banana, /datum/reagent/blood, /datum/reagent/toxin/slimejelly, /datum/reagent/toxin, /datum/reagent/consumable/banana, /datum/reagent/carbon, /datum/reagent/medicine/oculine)
+	extra_reagent = pick(/datum/reagent/consumable/capsaicin, /datum/reagent/consumable/frostoil, /datum/reagent/medicine/omnizine, /datum/reagent/consumable/banana, /datum/reagent/blood, /datum/reagent/toxin/slimejelly, /datum/reagent/toxin, /datum/reagent/carbon, /datum/reagent/medicine/oculine)
 	reagents.add_reagent(extra_reagent, 5)
 	reagents.add_reagent(/datum/reagent/consumable/nutriment, 6)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #59129 

## Changelog
:cl:
fix: Fixed banana juice having x2 chance of appearing in mystery soup
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
