### PR TITLE
Fixes regal rat abilities

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -148,6 +148,11 @@
 
 /datum/action/cooldown/domain/Trigger()
 	. = ..()
+	if(!.)
+		return
+	if(owner.stat == DEAD)
+		return
+
 	var/turf/T = get_turf(owner)
 	T.atmos_spawn_air("miasma=4;TEMP=[T20C]")
 	switch (rand(1,10))
@@ -178,6 +183,9 @@
 	. = ..()
 	if(!.)
 		return
+	if(owner.stat == DEAD)
+		return
+
 	var/cap = CONFIG_GET(number/ratcap)
 	var/something_from_nothing = FALSE
 	for(var/mob/living/simple_animal/mouse/M in oview(owner, 5))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes regal rats being able to use their abilities while they're on cooldown/dead

Closes #58737 

## Changelog
:cl:
fix: Fixes regal rats being able to use their abilities while they're on cooldown/dead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
