### PR TITLE
Temperature pump exploit fix

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/temperature_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/temperature_pump.dm
@@ -52,8 +52,13 @@
 		remove_output.temperature = max(remove_output.temperature + (cooling_heat_amount / output_capacity), TCMB)
 		update_parents()
 
+	var/power_usage = (remove_input.temperature * 1.5 + idle_power_usage) ** (0.75 - (3e7 / max(3e7, remove_input.temperature)))
+
 	air_input.merge(remove_input)
 	air_output.merge(remove_output)
+
+	if(power_usage)
+		use_power(power_usage)
 
 /obj/machinery/atmospherics/components/binary/temperature_pump/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/atmospherics/machinery/components/binary_devices/temperature_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/temperature_pump.dm
@@ -43,7 +43,7 @@
 
 	var/coolant_temperature_delta = remove_input.temperature - remove_output.temperature
 
-	if(coolant_temperature_delta > 0)
+	if(coolant_temperature_delta > 0 && remove_input.temperature < 1e8)
 		var/input_capacity = remove_input.heat_capacity()
 		var/output_capacity = air_output.heat_capacity()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix a well known but never reported exploit of the temperature pump that allows to get temperature well over 1e8 without much work (other than the repetitive tasks involved)
This is fixed by adding a power consumption that will exponentially increase once the input temperature reaches 3e7
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Exploits are bad
Atmos temperature has been limited for a reason, incredibly high temperature are a pain to deal with and to clear up.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fix temperature pump exploit that allows the users to go over 1e8 limiter. This is done by a power usage equation that become exponential upon reaching 3e7 and will eat through the room APC charge (so no makeshift power drain).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
