### PR TITLE
Dynamic Abductor Teams won't spawn a solo Scientist

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -25,6 +25,8 @@
 	required_type = /mob/dead/observer
 	/// Whether the ruleset should call generate_ruleset_body or not.
 	var/makeBody = TRUE
+	/// The rule needs this many applicants to be properly executed.
+	var/required_applicants = 1
 
 /datum/dynamic_ruleset/midround/trim_candidates()
 	living_players = trim_list(GLOB.alive_player_list)
@@ -117,11 +119,11 @@
 /// Here is where you can check if your ghost applicants are valid for the ruleset.
 /// Called by send_applications().
 /datum/dynamic_ruleset/midround/from_ghosts/proc/review_applications()
+	if(candidates.len < required_applicants)
+		mode.executed_rules -= src
+		return
 	for (var/i = 1, i <= required_candidates, i++)
 		if(candidates.len <= 0)
-			if(i == 1)
-				// We have found no candidates so far and we are out of applicants.
-				mode.executed_rules -= src
 			break
 		var/mob/applicant = pick(candidates)
 		candidates -= applicant
@@ -582,6 +584,7 @@
 	enemy_roles = list("Security Officer", "Detective", "Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 2
+	required_applicants = 2
 	weight = 4
 	cost = 10
 	requirements = list(101,101,101,80,60,50,30,20,10,10)


### PR DESCRIPTION
## About The Pull Request

Fixes lone abductor scientists by adding a variable to ghost poll rulesets for how many applicants are needed for the ruleset to execute. This fixes #59441 and any future dynamic rulesets that necessarily require there to be more than one applicant to function correctly.

## Why It's Good For The Game

Fixes good.

## Changelog
:cl:
fix: dynamic will no longer spawn abductors if there aren't enough applicants for a proper 2-person abductor team
/:cl:

