### PR TITLE
Allows ghosts to see the status of the power network by examining cables.

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -153,6 +153,12 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 	return ..()
 
 
+/obj/structure/cable/examine(mob/user)
+	. = ..()
+	if(isobserver(user))
+		. += get_power_info(user)
+
+
 /obj/structure/cable/proc/handlecable(obj/item/W, mob/user, params)
 	var/turf/T = get_turf(src)
 	if(T.intact)
@@ -166,13 +172,18 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 		return
 
 	else if(W.tool_behaviour == TOOL_MULTITOOL)
-		if(powernet && (powernet.avail > 0)) // is it powered?
-			to_chat(user, "<span class='danger'>Total power: [DisplayPower(powernet.avail)]\nLoad: [DisplayPower(powernet.load)]\nExcess power: [DisplayPower(surplus())]</span>")
-		else
-			to_chat(user, "<span class='danger'>The cable is not powered.</span>")
+		to_chat(user, get_power_info(user))
 		shock(user, 5, 0.2)
 
 	add_fingerprint(user)
+
+
+/obj/structure/cable/proc/get_power_info(mob/user)
+	if(powernet && (powernet.avail > 0)) // is it powered?
+		return "<span class='danger'>Total power: [DisplayPower(powernet.avail)]\nLoad: [DisplayPower(powernet.load)]\nExcess power: [DisplayPower(surplus())]</span>"
+	else
+		return "<span class='danger'>The cable is not powered.</span>"
+
 
 // Items usable on a cable :
 //   - Wirecutters : cut it duh !

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -156,7 +156,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 /obj/structure/cable/examine(mob/user)
 	. = ..()
 	if(isobserver(user))
-		. += get_power_info(user)
+		. += get_power_info()
 
 
 /obj/structure/cable/proc/handlecable(obj/item/W, mob/user, params)
@@ -172,13 +172,13 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 		return
 
 	else if(W.tool_behaviour == TOOL_MULTITOOL)
-		to_chat(user, get_power_info(user))
+		to_chat(user, get_power_info())
 		shock(user, 5, 0.2)
 
 	add_fingerprint(user)
 
 
-/obj/structure/cable/proc/get_power_info(mob/user)
+/obj/structure/cable/proc/get_power_info()
 	if(powernet && (powernet.avail > 0)) // is it powered?
 		return "<span class='danger'>Total power: [DisplayPower(powernet.avail)]\nLoad: [DisplayPower(powernet.load)]\nExcess power: [DisplayPower(surplus())]</span>"
 	else

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -179,7 +179,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 
 
 /obj/structure/cable/proc/get_power_info()
-	if(powernet && (powernet.avail > 0)) // is it powered?
+	if(powernet?.avail > 0)
 		return "<span class='danger'>Total power: [DisplayPower(powernet.avail)]\nLoad: [DisplayPower(powernet.load)]\nExcess power: [DisplayPower(surplus())]</span>"
 	else
 		return "<span class='danger'>The cable is not powered.</span>"

--- a/strings/round_start_sounds.txt
+++ b/strings/round_start_sounds.txt
@@ -1,4 +1,5 @@
 sound/ambience/title1.ogg
 sound/ambience/title2.ogg
 sound/ambience/title3.ogg
+sound/ambience/title3.ogg
 sound/ambience/clown.ogg

--- a/strings/round_start_sounds.txt
+++ b/strings/round_start_sounds.txt
@@ -1,5 +1,4 @@
 sound/ambience/title1.ogg
 sound/ambience/title2.ogg
 sound/ambience/title3.ogg
-sound/ambience/title3.ogg
 sound/ambience/clown.ogg


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ghosts can now inspect cables to get the same readout that the multitool gives when you use it on a cable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I wanted to see how much power the engies were dumping into the grid while I was dead.
Now that's possible.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Ghosts can now find out how much power is in the network by examining cables
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
