### PR TITLE
Make Toggle-CDN use alert() instead of tgui_alert()

### DIFF
--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -84,7 +84,7 @@
 	set name = "Toggle CDN"
 	set category = "Server"
 	var/static/admin_disabled_cdn_transport = null
-	if (tgui_alert(usr, "Are you sure you want to toggle the CDN asset transport?", "Confirm", list("Yes", "No")) != "Yes")
+	if (alert(usr, "Are you sure you want to toggle the CDN asset transport?", "Confirm", "Yes", "No") != "Yes")
 		return
 	var/current_transport = CONFIG_GET(string/asset_transport)
 	if (!current_transport || current_transport == "simple")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces tgui_alert() with alert() when toggling the CDN. Currently on live Servers tgui is broken, disabling the CDN fixes this. However the verb for this relies on tgui_alert, which does not work if tgui is broken. Speedmerge or Testmerge would be appreciated.

I've tested this PR on localhost.

There are other instances of tgui_alert in critical verbs that should also be replaced with alert, notably rebooting the Server.

