### PR TITLE
Added audio cooldown for emotes TAKE 2

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -104,7 +104,7 @@
 	return TRUE
 
 /datum/emote/proc/get_sound(mob/living/user)
-	return sound
+	return sound //by default just return this var
 
 /datum/emote/proc/replace_pronoun(mob/user, message)
 	if(findtext(message, "their"))

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -63,7 +63,14 @@
 	var/dchatmsg = "<b>[user]</b> [msg]"
 
 	var/tmp_sound = get_sound(user)
-	var/tmp_condition = check_audio(user, intentional)
+	var/tmp_condition = TRUE
+	// Only check if we can play a sound if there's actually a sound to play.
+	if(tmp_sound != null)
+		if(user.audio_emotes_used && user.audio_emotes_used[src] + audio_cooldown > world.time)
+			tmp_condition = FALSE
+		if(!user.audio_emotes_used)
+			user.audio_emotes_used = list()
+		user.audio_emotes_used[src] = world.time
 	if(tmp_sound && tmp_condition && (!only_forced_audio || !intentional))
 		playsound(user, tmp_sound, 50, vary)
 
@@ -91,16 +98,6 @@
 	if(!user.emotes_used)
 		user.emotes_used = list()
 	user.emotes_used[src] = world.time
-	return TRUE
-	
-/datum/emote/proc/check_audio(mob/living/user, intentional)
-	if(!intentional)
-		return TRUE
-	if(user.audio_emotes_used && user.audio_emotes_used[src] + audio_cooldown > world.time)
-		return FALSE
-	if(!user.audio_emotes_used)
-		user.audio_emotes_used = list()
-	user.audio_emotes_used[src] = world.time
 	return TRUE
 
 /datum/emote/proc/get_sound(mob/living/user)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -25,6 +25,7 @@
 	var/vary = FALSE //used for the honk borg emote
 	var/only_forced_audio = FALSE //can only code call this event instead of the player.
 	var/cooldown = 0.8 SECONDS
+	var/audio_cooldown = 2 SECONDS
 
 /datum/emote/New()
 	if (ispath(mob_type_allowed_typecache))
@@ -92,7 +93,14 @@
 	return TRUE
 
 /datum/emote/proc/get_sound(mob/living/user)
-	return sound //by default just return this var.
+	if(!intentional)
+		return sound
+	if(user.emotes_used && user.emotes_used[src] + audio_cooldown > world.time)
+		return
+	if(!user.emotes_used)
+		user.emotes_used = list()
+	user.emotes_used[src] = world.time
+	return sound
 
 /datum/emote/proc/replace_pronoun(mob/user, message)
 	if(findtext(message, "their"))

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -63,15 +63,8 @@
 	var/dchatmsg = "<b>[user]</b> [msg]"
 
 	var/tmp_sound = get_sound(user)
-	var/play_emote_audio = TRUE
-	// Only check if we can play a sound if there's actually a sound to play.
-	if(tmp_sound != null)
-		if(!user.audio_emotes_used)
-			user.audio_emotes_used = list()
-		else if(user.audio_emotes_used[src] + audio_cooldown > world.time)
-			play_emote_audio = FALSE
-		user.audio_emotes_used[src] = world.time
-	if(tmp_sound && play_emote_audio && (!only_forced_audio || !intentional))
+	if(tmp_sound && (!only_forced_audio || !intentional) && !TIMER_COOLDOWN_CHECK(user, type))
+		TIMER_COOLDOWN_START(user, type, audio_cooldown)
 		playsound(user, tmp_sound, 50, vary)
 
 	for(var/mob/M in GLOB.dead_mob_list)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -104,7 +104,7 @@
 	return TRUE
 
 /datum/emote/proc/get_sound(mob/living/user)
-	return sound //by default just return this var
+	return sound //by default just return this var.
 
 /datum/emote/proc/replace_pronoun(mob/user, message)
 	if(findtext(message, "their"))

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -62,7 +62,7 @@
 	user.log_message(msg, LOG_EMOTE)
 	var/dchatmsg = "<b>[user]</b> [msg]"
 
-	var/tmp_sound = get_sound(user)
+	var/tmp_sound = get_sound(user, intentional)
 	if(tmp_sound && (!only_forced_audio || !intentional))
 		playsound(user, tmp_sound, 50, vary)
 
@@ -92,7 +92,7 @@
 	user.emotes_used[src] = world.time
 	return TRUE
 
-/datum/emote/proc/get_sound(mob/living/user)
+/datum/emote/proc/get_sound(mob/living/user, intentional)
 	if(!intentional)
 		return sound
 	if(user.emotes_used && user.emotes_used[src] + audio_cooldown > world.time)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -62,8 +62,9 @@
 	user.log_message(msg, LOG_EMOTE)
 	var/dchatmsg = "<b>[user]</b> [msg]"
 
-	var/tmp_sound = get_sound(user, intentional)
-	if(tmp_sound && (!only_forced_audio || !intentional))
+	var/tmp_sound = get_sound(user)
+	var/tmp_condition = check_audio(user, intentional)
+	if(tmp_sound && tmp_condition && (!only_forced_audio || !intentional))
 		playsound(user, tmp_sound, 50, vary)
 
 	for(var/mob/M in GLOB.dead_mob_list)
@@ -91,15 +92,18 @@
 		user.emotes_used = list()
 	user.emotes_used[src] = world.time
 	return TRUE
-
-/datum/emote/proc/get_sound(mob/living/user, intentional)
+	
+/datum/emote/proc/check_audio(mob/living/user, intentional)
 	if(!intentional)
-		return sound
+		return TRUE
 	if(user.emotes_used && user.emotes_used[src] + audio_cooldown > world.time)
-		return
+		return FALSE
 	if(!user.emotes_used)
 		user.emotes_used = list()
 	user.emotes_used[src] = world.time
+	return TRUE
+
+/datum/emote/proc/get_sound(mob/living/user)
 	return sound
 
 /datum/emote/proc/replace_pronoun(mob/user, message)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -96,11 +96,11 @@
 /datum/emote/proc/check_audio(mob/living/user, intentional)
 	if(!intentional)
 		return TRUE
-	if(user.emotes_used && user.emotes_used[src] + audio_cooldown > world.time)
+	if(user.audio_emotes_used && user.audio_emotes_used[src] + audio_cooldown > world.time)
 		return FALSE
-	if(!user.emotes_used)
-		user.emotes_used = list()
-	user.emotes_used[src] = world.time
+	if(!user.audio_emotes_used)
+		user.audio_emotes_used = list()
+	user.audio_emotes_used[src] = world.time
 	return TRUE
 
 /datum/emote/proc/get_sound(mob/living/user)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -63,15 +63,15 @@
 	var/dchatmsg = "<b>[user]</b> [msg]"
 
 	var/tmp_sound = get_sound(user)
-	var/tmp_condition = TRUE
+	var/play_emote_audio = TRUE
 	// Only check if we can play a sound if there's actually a sound to play.
 	if(tmp_sound != null)
 		if(user.audio_emotes_used && user.audio_emotes_used[src] + audio_cooldown > world.time)
-			tmp_condition = FALSE
+			play_emote_audio = FALSE
 		if(!user.audio_emotes_used)
 			user.audio_emotes_used = list()
 		user.audio_emotes_used[src] = world.time
-	if(tmp_sound && tmp_condition && (!only_forced_audio || !intentional))
+	if(tmp_sound && play_emote_audio && (!only_forced_audio || !intentional))
 		playsound(user, tmp_sound, 50, vary)
 
 	for(var/mob/M in GLOB.dead_mob_list)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -66,10 +66,10 @@
 	var/play_emote_audio = TRUE
 	// Only check if we can play a sound if there's actually a sound to play.
 	if(tmp_sound != null)
-		if(user.audio_emotes_used && user.audio_emotes_used[src] + audio_cooldown > world.time)
-			play_emote_audio = FALSE
 		if(!user.audio_emotes_used)
 			user.audio_emotes_used = list()
+		else if(user.audio_emotes_used[src] + audio_cooldown > world.time)
+			play_emote_audio = FALSE
 		user.audio_emotes_used[src] = world.time
 	if(tmp_sound && play_emote_audio && (!only_forced_audio || !intentional))
 		playsound(user, tmp_sound, 50, vary)

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -22,6 +22,7 @@
 	muzzle_ignore = TRUE
 	hands_use_check = TRUE
 	emote_type = EMOTE_AUDIBLE
+	audio_cooldown = 5 SECONDS
 	vary = TRUE
 
 /datum/emote/living/carbon/clap/get_sound(mob/living/user)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -219,6 +219,7 @@
 	message = "laughs."
 	message_mime = "laughs silently!"
 	emote_type = EMOTE_AUDIBLE
+	audio_cooldown = 5 SECONDS
 	vary = TRUE
 
 /datum/emote/living/laugh/can_run_emote(mob/living/user, status_check = TRUE , intentional)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -219,6 +219,9 @@
 
 	/// Used for tracking last uses of emotes for cooldown purposes
 	var/list/emotes_used
+	
+	// Used for tracking the last uses of emotes that produce audio for audio cooldowns
+	var/list/audio_emotes_used
 
 	///Whether the mob is updating glide size when movespeed updates or not
 	var/updating_glide_size = TRUE

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -219,9 +219,6 @@
 
 	/// Used for tracking last uses of emotes for cooldown purposes
 	var/list/emotes_used
-	
-	/// Used for tracking the last uses of emotes that produce audio for audio cooldowns
-	var/list/audio_emotes_used
 
 	///Whether the mob is updating glide size when movespeed updates or not
 	var/updating_glide_size = TRUE

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -220,7 +220,7 @@
 	/// Used for tracking last uses of emotes for cooldown purposes
 	var/list/emotes_used
 	
-	// Used for tracking the last uses of emotes that produce audio for audio cooldowns
+	/// Used for tracking the last uses of emotes that produce audio for audio cooldowns
 	var/list/audio_emotes_used
 
 	///Whether the mob is updating glide size when movespeed updates or not


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a 5-second cooldown for the audio of clapping and laughing when they are done voluntarily. Also adds the new audio_cooldown var for emotes to set new audio cooldowns.

Yes Mothblocks, despite all the webedits you see down there I did test this most recent code and found it to work as intended.

## Why It's Good For The Game

Better version of my first PR with actual internal functions, aiming at stopping emote sounds from overlapping too much. Admins and coders seem to want something to help stop emote spam, and this takes a step toward that in a way that doesn't outright prevent emote use but rather only the noise (which is the bigger complaint).

## Changelog
:cl:
add: audio_cooldown, a var for coders to use in new emotes to add a cooldown for sounds when the emote is used voluntarily.
add: Clapping and laughing now have 5-second audio cooldowns.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
