### PR TITLE
Fixes proximity sensors

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -183,6 +183,7 @@
 		assemblies[color] = S
 		S.forceMove(holder)
 		S.connected = src
+		S.on_attach()
 		return S
 
 /datum/wires/proc/detach_assembly(color)
@@ -191,6 +192,7 @@
 		assemblies -= color
 		S.connected = null
 		S.forceMove(holder.drop_location())
+		S.on_detach()
 		return S
 
 /// Called from [/atom/proc/emp_act]

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -48,7 +48,6 @@
 	else if(istype(S,/obj/item/assembly/prox_sensor))
 		var/obj/item/grenade/chem_grenade/G = holder
 		G.landminemode = S
-		S.proximity_monitor.wire = TRUE
 	fingerprint = S.fingerprintslast
 	return ..()
 
@@ -67,14 +66,9 @@
 
 
 /datum/wires/explosive/chem_grenade/detach_assembly(color)
-	var/obj/item/assembly/S = get_attached(color)
-	if(S && istype(S))
-		assemblies -= color
-		S.connected = null
-		S.forceMove(holder.drop_location())
-		var/obj/item/grenade/chem_grenade/G = holder
-		G.landminemode = null
-		return S
+	var/obj/item/grenade/chem_grenade/G = holder
+	G.landminemode = null
+	return ..()
 
 /datum/wires/explosive/c4 // Also includes X4
 	holder_type = /obj/item/grenade/c4

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -204,7 +204,7 @@
 			cut_overlays()
 			set_anchored(FALSE)
 			power_change()
-			proximity_monitor.SetRange(0)
+			proximity_monitor.SetRange(-1)
 
 	else
 		return ..()

--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -57,7 +57,7 @@
 		QDEL_LAZYLIST(checkers)
 		return
 
-	var/list/turfs = RANGE_TURFS(range, host.loc)
+	var/list/turfs = RANGE_TURFS(range, loc_to_use)
 	var/turfs_len = turfs.len
 	var/old_checkers_used = min(turfs_len, old_checkers_len)
 

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -39,7 +39,7 @@
 
 /obj/item/electropack/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/clothing/head/helmet))
-		var/obj/item/assembly/shock_kit/A = new /obj/item/assembly/shock_kit(user)
+		var/obj/item/shock_kit/A = new /obj/item/shock_kit(user)
 		A.icon = 'icons/obj/assemblies.dmi'
 
 		if(!user.transferItemToLoc(W, A))
@@ -75,11 +75,7 @@
 
 		L.Paralyze(100)
 
-	if(master)
-		if(isassembly(master))
-			var/obj/item/assembly/master_as_assembly = master
-			master_as_assembly.pulsed()
-		master.receive_signal()
+	master?.receive_signal()
 
 /obj/item/electropack/proc/set_frequency(new_frequency)
 	SSradio.remove_object(src, frequency)

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -262,7 +262,7 @@
 				. = TRUE
 		if("remove_device")
 			if(attached_device)
-				attached_device.on_detach()
+				attached_device.detach()
 				attached_device = null
 				. = TRUE
 

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -336,7 +336,7 @@
 //drops and kills the hugger if any is remaining
 /obj/structure/alien/egg/proc/Burst(kill = TRUE)
 	if(status == GROWN || status == GROWING)
-		proximity_monitor.SetRange(0)
+		proximity_monitor.SetRange(-1)
 		status = BURST
 		update_appearance()
 		flick("egg_opening", src)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -77,13 +77,13 @@
 /obj/structure/chair/attackby(obj/item/W, mob/user, params)
 	if(flags_1 & NODECONSTRUCT_1)
 		return . = ..()
-	if(istype(W, /obj/item/assembly/shock_kit) && !HAS_TRAIT(src, TRAIT_ELECTRIFIED_BUCKLE))
+	if(istype(W, /obj/item/shock_kit) && !HAS_TRAIT(src, TRAIT_ELECTRIFIED_BUCKLE))
 		electrify_self(W, user)
 		return
 	. = ..()
 
 ///allows each chair to request the electrified_buckle component with overlays that dont look ridiculous
-/obj/structure/chair/proc/electrify_self(obj/item/assembly/shock_kit/input_shock_kit, mob/user, list/overlays_from_child_procs)
+/obj/structure/chair/proc/electrify_self(obj/item/shock_kit/input_shock_kit, mob/user, list/overlays_from_child_procs)
 	SHOULD_CALL_PARENT(TRUE)
 	if(!user.temporarilyRemoveItemFromInventory(input_shock_kit))
 		return
@@ -225,7 +225,7 @@
 /obj/structure/chair/comfy/shuttle/GetArmrest()
 	return mutable_appearance('icons/obj/chairs.dmi', "shuttle_chair_armrest")
 
-/obj/structure/chair/comfy/shuttle/electrify_self(obj/item/assembly/shock_kit/input_shock_kit, mob/user, list/overlays_from_child_procs)
+/obj/structure/chair/comfy/shuttle/electrify_self(obj/item/shock_kit/input_shock_kit, mob/user, list/overlays_from_child_procs)
 	if(!overlays_from_child_procs)
 		overlays_from_child_procs = list(image('icons/obj/chairs.dmi', loc, "echair_over", pixel_x = -1))
 	. = ..()
@@ -242,7 +242,7 @@
 	if(has_gravity())
 		playsound(src, 'sound/effects/roll.ogg', 100, TRUE)
 
-/obj/structure/chair/office/electrify_self(obj/item/assembly/shock_kit/input_shock_kit, mob/user, list/overlays_from_child_procs)
+/obj/structure/chair/office/electrify_self(obj/item/shock_kit/input_shock_kit, mob/user, list/overlays_from_child_procs)
 	if(!overlays_from_child_procs)
 		overlays_from_child_procs = list(image('icons/obj/chairs.dmi', loc, "echair_over", pixel_x = -1))
 	. = ..()

--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -10,7 +10,7 @@
 	armrest = mutable_appearance(icon, "[icon_state]_armrest", ABOVE_MOB_LAYER)
 	return ..()
 
-/obj/structure/chair/sofa/electrify_self(obj/item/assembly/shock_kit/input_shock_kit, mob/user, list/overlays_from_child_procs)
+/obj/structure/chair/sofa/electrify_self(obj/item/shock_kit/input_shock_kit, mob/user, list/overlays_from_child_procs)
 	if(!overlays_from_child_procs)
 		overlays_from_child_procs = list(image('icons/obj/chairs.dmi', loc, "echair_over", pixel_x = -1))
 	. = ..()

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -8,7 +8,7 @@
 
 /obj/structure/chair/e_chair/Initialize()
 	. = ..()
-	var/obj/item/assembly/shock_kit/stored_kit = new(contents)
+	var/obj/item/shock_kit/stored_kit = new(contents)
 	var/image/export_to_component = image('icons/obj/chairs.dmi', loc, "echair_over")
 	AddComponent(/datum/component/electrified_buckle, (SHOCK_REQUIREMENT_ITEM | SHOCK_REQUIREMENT_LIVE_CABLE | SHOCK_REQUIREMENT_SIGNAL_RECEIVED_TOGGLE), stored_kit, list(export_to_component))
 

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -39,15 +39,16 @@
 /obj/item/assembly/get_part_rating()
 	return 1
 
+/obj/item/assembly/proc/detach()
+	if(holder)
+		forceMove(holder.drop_location())
+		holder = null
+	on_detach()
+
 /obj/item/assembly/proc/on_attach()
 
 //Call this when detaching it from a device. handles any special functions that need to be updated ex post facto
 /obj/item/assembly/proc/on_detach()
-	if(!holder)
-		return FALSE
-	forceMove(holder.drop_location())
-	holder = null
-	return TRUE
 
 //Called when the holder is moved
 /obj/item/assembly/proc/holder_movement()

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -2,7 +2,6 @@
 	name = "blast door controller"
 	desc = "A small electronic device able to control a blast door remotely."
 	icon_state = "control"
-	attachable = TRUE
 	var/id = null
 	var/can_change_id = 0
 	var/cooldown = FALSE //Door cooldowns
@@ -34,11 +33,6 @@
 /obj/item/assembly/control/curtain
 	name = "curtain controller"
 	desc = "A small electronic device able to control a mechanical curtain remotely."
-
-/obj/item/assembly/control/curtain/examine(mob/user)
-	. = ..()
-	if(id)
-		. += span_notice("Its channel ID is '[id]'.")
 
 /obj/item/assembly/control/curtain/activate()
 	var/openclose

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -3,7 +3,6 @@
 	desc = "Used for scanning and monitoring health."
 	icon_state = "health"
 	custom_materials = list(/datum/material/iron=800, /datum/material/glass=200)
-	attachable = TRUE
 
 	var/scanning = FALSE
 	var/health_scan

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -105,10 +105,10 @@
 		return TRUE
 	to_chat(user, span_notice("You disassemble [src]!"))
 	if(a_left)
-		a_left.on_detach()
+		a_left.detach()
 		a_left = null
 	if(a_right)
-		a_right.on_detach()
+		a_right.detach()
 		a_right = null
 	qdel(src)
 	return TRUE

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -122,8 +122,6 @@
 
 /obj/item/assembly/infra/on_detach()
 	. = ..()
-	if(!.)
-		return
 	refreshBeam()
 
 /obj/item/assembly/infra/attack_hand(mob/user, list/modifiers)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -47,11 +47,11 @@
 
 /obj/item/assembly/mousetrap/on_attach()
 	. = ..()
-	AddElement(/datum/element/connect_loc, holder, holder_connections)
+	AddElement(/datum/element/connect_loc, loc, holder_connections)
 
 /obj/item/assembly/mousetrap/on_detach()
 	. = ..()
-	RemoveElement(/datum/element/connect_loc, holder, holder_connections)
+	RemoveElement(/datum/element/connect_loc, loc, holder_connections)
 
 /obj/item/assembly/mousetrap/proc/triggered(mob/target, type = "feet")
 	if(!armed)

--- a/code/modules/assembly/shock_kit.dm
+++ b/code/modules/assembly/shock_kit.dm
@@ -1,4 +1,4 @@
-/obj/item/assembly/shock_kit
+/obj/item/shock_kit
 	name = "electrohelmet assembly"
 	desc = "This appears to be made from both an electropack and a helmet."
 	icon = 'icons/obj/assemblies.dmi'
@@ -8,12 +8,12 @@
 	w_class = WEIGHT_CLASS_HUGE
 	flags_1 = CONDUCT_1
 
-/obj/item/assembly/shock_kit/Destroy()
+/obj/item/shock_kit/Destroy()
 	QDEL_NULL(helmet_part)
 	QDEL_NULL(electropack_part)
 	return ..()
 
-/obj/item/assembly/shock_kit/Initialize()
+/obj/item/shock_kit/Initialize()
 	. = ..()
 	if(!helmet_part)
 		helmet_part = new(src)
@@ -22,7 +22,11 @@
 		electropack_part = new(src)
 		electropack_part.master = src
 
-/obj/item/assembly/shock_kit/wrench_act(mob/living/user, obj/item/I)
+/obj/item/shock_kit/receive_signal(datum/signal/signal)
+	SEND_SIGNAL(src, COMSIG_ASSEMBLY_PULSED)
+	return
+
+/obj/item/shock_kit/wrench_act(mob/living/user, obj/item/I)
 	..()
 	to_chat(user, span_notice("You disassemble [src]."))
 	if(helmet_part)
@@ -36,7 +40,7 @@
 	qdel(src)
 	return TRUE
 
-/obj/item/assembly/shock_kit/attack_self(mob/user)
+/obj/item/shock_kit/attack_self(mob/user)
 	helmet_part.attack_self(user)
 	electropack_part.attack_self(user)
 	add_fingerprint(user)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the nest of snakes called proximity_monitor after some champ decided it was a perfect type to inherit, breaking it horribly in the process. Proximity monitors can now be used reliably in assemblies, grenades and as wire attachments. They will handle movement properly and won't detect themselves or proximity_checkers. This means live grenades with proximity sensors wont immediately explode in your face.
Other changes include mostly code cleanups, such as making shock_kit a subtype of item, not item/assembly


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Proximity sensors are a broken, buggy mess which makes them very hard to use reliably
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed proximity sensors. They can now be used reliably in assemblies, grenades and as wire attachments. Thrown proximity grenades should not explode in your face now.
code: Cleaned up proximity_monitor and assembly code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
