### PR TITLE
Fixes split personality sometimes switching to other person upon death

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -58,7 +58,7 @@
 	QDEL_NULL(owner_backseat)
 	..()
 
-/datum/brain_trauma/severe/split_personality/proc/switch_personalities(var/reset_to_owner)
+/datum/brain_trauma/severe/split_personality/proc/switch_personalities(var/reset_to_owner = FALSE)
 	if(QDELETED(owner) || QDELETED(stranger_backseat) || QDELETED(owner_backseat))
 		return
 

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -45,7 +45,7 @@
 /datum/brain_trauma/severe/split_personality/on_life(delta_time, times_fired)
 	if(owner.stat == DEAD)
 		if(current_controller != OWNER)
-			switch_personalities()
+			switch_personalities(TRUE)
 		qdel(src)
 	else if(DT_PROB(1.5, delta_time))
 		switch_personalities()
@@ -53,23 +53,23 @@
 
 /datum/brain_trauma/severe/split_personality/on_lose()
 	if(current_controller != OWNER) //it would be funny to cure a guy only to be left with the other personality, but it seems too cruel
-		switch_personalities()
+		switch_personalities(TRUE)
 	QDEL_NULL(stranger_backseat)
 	QDEL_NULL(owner_backseat)
 	..()
 
-/datum/brain_trauma/severe/split_personality/proc/switch_personalities()
+/datum/brain_trauma/severe/split_personality/proc/switch_personalities(var/reset_to_owner)
 	if(QDELETED(owner) || QDELETED(stranger_backseat) || QDELETED(owner_backseat))
 		return
 
 	var/mob/living/split_personality/current_backseat
-	var/mob/living/split_personality/free_backseat
-	if(current_controller == OWNER)
-		current_backseat = stranger_backseat
-		free_backseat = owner_backseat
-	else
+	var/mob/living/split_personality/new_backseat
+	if(current_controller == STRANGER || reset_to_owner)
 		current_backseat = owner_backseat
-		free_backseat = stranger_backseat
+		new_backseat = stranger_backseat	
+	else
+		current_backseat = stranger_backseat
+		new_backseat = owner_backseat
 
 	if(!current_backseat.client) //Make sure we never switch to a logged off mob.
 		return
@@ -85,18 +85,21 @@
 	owner.computer_id = null
 	owner.lastKnownIP = null
 
-	free_backseat.ckey = owner.ckey
+	new_backseat.ckey = owner.ckey
 
-	free_backseat.name = owner.name
+	new_backseat.name = owner.name
 
 	if(owner.mind)
-		free_backseat.mind = owner.mind
+		new_backseat.mind = owner.mind
 
-	if(!free_backseat.computer_id)
-		free_backseat.computer_id = h2b_id
+	if(!new_backseat.computer_id)
+		new_backseat.computer_id = h2b_id
 
-	if(!free_backseat.lastKnownIP)
-		free_backseat.lastKnownIP = h2b_ip
+	if(!new_backseat.lastKnownIP)
+		new_backseat.lastKnownIP = h2b_ip
+	
+	if(reset_to_owner && new_backseat.mind)
+		new_backseat.ghostize(FALSE)
 
 	//Backseat to body
 

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -58,7 +58,7 @@
 	QDEL_NULL(owner_backseat)
 	..()
 
-/datum/brain_trauma/severe/split_personality/proc/switch_personalities(var/reset_to_owner = FALSE)
+/datum/brain_trauma/severe/split_personality/proc/switch_personalities(reset_to_owner = FALSE)
 	if(QDELETED(owner) || QDELETED(stranger_backseat) || QDELETED(owner_backseat))
 		return
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes split personality sometimes switching to other person upon death or loss.
This was due to both minds being bounded to the body, this fixes it.
Also changes free_backseat into new_backseat because the former is an incredibly unintuitive variable name.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #56394
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes split personality sometimes switching to other person upon death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
