### PR TITLE
Sorts the traitor panel

### DIFF
--- a/code/modules/antagonists/abductor/abductee/abductee.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee.dm
@@ -1,0 +1,37 @@
+/**
+ * ## Abductees
+ *
+ * Abductees are created by being operated on by abductors. They get some instructions about not
+ * remembering the abduction, plus some random weird objectives for them to act crazy with.
+ */
+/datum/antagonist/abductee
+	name = "Abductee"
+	roundend_category = "abductees"
+	antagpanel_category = "Other"
+	antag_hud_type = ANTAG_HUD_ABDUCTOR
+	antag_hud_name = "abductee"
+
+/datum/antagonist/abductee/on_gain()
+	give_objective()
+	. = ..()
+
+/datum/antagonist/abductee/greet()
+	to_chat(owner, "<span class='warning'><b>Your mind snaps!</b></span>")
+	to_chat(owner, "<big><span class='warning'><b>You can't remember how you got here...</b></span></big>")
+	owner.announce_objectives()
+
+/datum/antagonist/abductee/proc/give_objective()
+	var/mob/living/carbon/human/H = owner.current
+	if(istype(H))
+		H.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_LOBOTOMY)
+	var/objtype = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))
+	var/datum/objective/abductee/O = new objtype()
+	objectives += O
+
+/datum/antagonist/abductee/apply_innate_effects(mob/living/mob_override)
+	var/mob/living/M = mob_override || owner.current
+	add_antag_hud(antag_hud_type, antag_hud_name, M)
+
+/datum/antagonist/abductee/remove_innate_effects(mob/living/mob_override)
+	var/mob/living/M = mob_override || owner.current
+	remove_antag_hud(antag_hud_type, M)

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -166,39 +166,6 @@ GLOBAL_LIST_INIT(possible_abductor_names, list("Alpha","Beta","Gamma","Delta","E
 
 	return "<div class='panel redborder'>[result.Join("<br>")]</div>"
 
-/datum/antagonist/abductee
-	name = "Abductee"
-	roundend_category = "abductees"
-	antagpanel_category = "Abductee"
-	antag_hud_type = ANTAG_HUD_ABDUCTOR
-	antag_hud_name = "abductee"
-
-/datum/antagonist/abductee/on_gain()
-	give_objective()
-	. = ..()
-
-/datum/antagonist/abductee/greet()
-	to_chat(owner, "<span class='warning'><b>Your mind snaps!</b></span>")
-	to_chat(owner, "<big><span class='warning'><b>You can't remember how you got here...</b></span></big>")
-	owner.announce_objectives()
-
-/datum/antagonist/abductee/proc/give_objective()
-	var/mob/living/carbon/human/H = owner.current
-	if(istype(H))
-		H.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_LOBOTOMY)
-	var/objtype = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))
-	var/datum/objective/abductee/O = new objtype()
-	objectives += O
-
-/datum/antagonist/abductee/apply_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
-
-/datum/antagonist/abductee/remove_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)
-
-
 // LANDMARKS
 /obj/effect/landmark/abductor
 	var/team_number = 1

--- a/code/modules/antagonists/blob/blob.dm
+++ b/code/modules/antagonists/blob/blob.dm
@@ -1,7 +1,7 @@
 /datum/antagonist/blob
 	name = "Blob"
 	roundend_category = "blobs"
-	antagpanel_category = "Blob"
+	antagpanel_category = "Biohazards"
 	show_to_ghosts = TRUE
 	job_rank = ROLE_BLOB
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -663,12 +663,6 @@
 	newprofile.profile_snapshot = profile_snapshot
 	newprofile.id_icon = id_icon
 
-/datum/antagonist/changeling/xenobio
-	name = "Xenobio Changeling"
-	give_objectives = FALSE
-	show_in_roundend = FALSE //These are here for admin tracking purposes only
-	you_are_greet = FALSE
-
 /datum/antagonist/changeling/roundend_report()
 	var/list/parts = list()
 
@@ -698,5 +692,3 @@
 
 	return parts.Join("<br>")
 
-/datum/antagonist/changeling/xenobio/antag_listing_name()
-	return ..() + "(Xenobio)"

--- a/code/modules/antagonists/disease/disease_datum.dm
+++ b/code/modules/antagonists/disease/disease_datum.dm
@@ -1,7 +1,7 @@
 /datum/antagonist/disease
 	name = "Sentient Disease"
 	roundend_category = "diseases"
-	antagpanel_category = "Disease"
+	antagpanel_category = "Biohazards"
 	show_to_ghosts = TRUE
 	var/disease_name = ""
 

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -242,6 +242,7 @@
 			nuke_team.memorized_code = null
 
 /datum/antagonist/nukeop/reinforcement
+	show_in_antagpanel = FALSE
 	send_to_spawnpoint = FALSE
 	nukeop_outfit = /datum/outfit/syndicate/no_crystals
 

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -2,7 +2,6 @@
 	name = "Space Pirate"
 	job_rank = ROLE_TRAITOR
 	roundend_category = "space pirates"
-	antagpanel_category = "Pirate"
 	show_to_ghosts = TRUE
 	var/datum/team/pirate/crew
 

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -2,6 +2,7 @@
 	name = "Space Pirate"
 	job_rank = ROLE_TRAITOR
 	roundend_category = "space pirates"
+	show_in_antagpanel = FALSE
 	show_to_ghosts = TRUE
 	var/datum/team/pirate/crew
 

--- a/code/modules/antagonists/slaughter/imp_antag.dm
+++ b/code/modules/antagonists/slaughter/imp_antag.dm
@@ -1,0 +1,20 @@
+/**
+ * ## Imps
+ *
+ * Imps used to be summoned by a devil ascending to their final form, but now they're just
+ * kinda sitting in limbo... Well, whatever! They're kinda cool anyways!
+ */
+/datum/antagonist/imp
+	name = "Imp"
+	show_in_antagpanel = FALSE
+	show_in_roundend = FALSE
+
+/datum/antagonist/imp/on_gain()
+	. = ..()
+	give_objectives()
+
+/datum/antagonist/imp/proc/give_objectives()
+	var/datum/objective/newobjective = new
+	newobjective.explanation_text = "Try to get a promotion to a higher devilish rank."
+	newobjective.owner = owner
+	objectives += newobjective

--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -44,21 +44,6 @@
 							Though you are not obligated to help, perhaps by aiding a higher ranking devil, you might just get a promotion. However, you are incapable \
 							of intentionally harming a fellow devil.</B>"
 
-/datum/antagonist/imp
-	name = "Imp"
-	antagpanel_category = "Other"
-	show_in_roundend = FALSE
-
-/datum/antagonist/imp/on_gain()
-	. = ..()
-	give_objectives()
-
-/datum/antagonist/imp/proc/give_objectives()
-	var/datum/objective/newobjective = new
-	newobjective.explanation_text = "Try to get a promotion to a higher devilish rank."
-	newobjective.owner = owner
-	objectives += newobjective
-
 //////////////////The Man Behind The Slaughter
 
 /mob/living/simple_animal/hostile/imp/slaughter

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -7,7 +7,6 @@
 /datum/antagonist/traitor/internal_affairs
 	name = "Internal Affairs Agent"
 	employer = "Nanotrasen"
-	antagpanel_category = "IAA"
 
 	var/special_role = "internal affairs agent"
 	var/syndicate = FALSE

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -214,6 +214,7 @@
 //Random event wizard
 /datum/antagonist/wizard/apprentice/imposter
 	name = "Wizard Imposter"
+	show_in_antagpanel = FALSE
 	allow_rename = FALSE
 	move_to_lair = FALSE
 
@@ -246,6 +247,7 @@
 
 /datum/antagonist/wizard/academy
 	name = "Academy Teacher"
+	show_in_antagpanel = FALSE
 	outfit_type = /datum/outfit/wizard/academy
 	move_to_lair = FALSE
 

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -78,7 +78,7 @@
 		origin.transfer_to(M)
 		var/datum/antagonist/changeling/C = origin.has_antag_datum(/datum/antagonist/changeling)
 		if(!C)
-			C = origin.add_antag_datum(/datum/antagonist/changeling/xenobio)
+			C = origin.add_antag_datum(/datum/antagonist/changeling)
 		if(C.can_absorb_dna(owner))
 			C.add_new_profile(owner)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1619,6 +1619,7 @@
 #include "code\modules\antagonists\_common\antag_team.dm"
 #include "code\modules\antagonists\abductor\abductor.dm"
 #include "code\modules\antagonists\abductor\ice_abductor.dm"
+#include "code\modules\antagonists\abductor\abductee\abductee.dm"
 #include "code\modules\antagonists\abductor\abductee\abductee_objectives.dm"
 #include "code\modules\antagonists\abductor\equipment\abduction_gear.dm"
 #include "code\modules\antagonists\abductor\equipment\abduction_outfits.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1769,6 +1769,7 @@
 #include "code\modules\antagonists\revolution\revolution.dm"
 #include "code\modules\antagonists\santa\santa.dm"
 #include "code\modules\antagonists\separatist\separatist.dm"
+#include "code\modules\antagonists\slaughter\imp_antag.dm"
 #include "code\modules\antagonists\slaughter\slaughter.dm"
 #include "code\modules\antagonists\slaughter\slaughter_antag.dm"
 #include "code\modules\antagonists\slaughter\slaughterevent.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I've moved around some antags into categories and removed some others:

* Abductees now get their own file, and a quick blurb about them in the code docs
* Abductees are now part of the "Other" section instead of their own section just for them.
* Blob and Sentient disease are now together under "Biohazards"
* Nuke op now doesn't include the reinforcement subtype.
* Removed Xenobio Changeling, it's been a very long time since the *ahem* good old days *ahem* of xenobio changelings. Even if I didn't remove the datum, i'd be removing it from this list as it's a redundant variation in the traitor panel
* Pirates are no longer in the traitor panel. They need to be spawned with the spawners!
* IAA is now part of traitor (But expect me gutting IAA soon anyways, since the gamemode removals left IAA broken as fuck and my other prs, if merged, kind of completely dab on IAA

## Why It's Good For The Game

### Look how cluttered and hard to read this list is:

![image](https://user-images.githubusercontent.com/40974010/120717934-4acf7c80-c47d-11eb-83b0-9107078590f8.png)

### Still a bit cluttered, but a lot better is my version:

![image](https://user-images.githubusercontent.com/40974010/120721218-3a6dd080-c482-11eb-8e0f-52322772903c.png)

## Changelog
:cl:
admin: Sorted the traitor panel a bit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
