### PR TITLE
Disables the keybinding conflict message to players DO NOT UNTESTMERGE

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -126,6 +126,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		addtimer(CALLBACK(src, .proc/announce_conflict, notadded), 5 SECONDS)
 
 /datum/preferences/proc/announce_conflict(list/notadded)
+	CRASH("KEYBINDING CONFLICT IS STILL A THING")
 	to_chat(parent, "<span class='warningplain'><b><u>Keybinding Conflict</u></b></span>\n\
 					<span class='warningplain'><b>There are new <a href='?_src_=prefs;preference=tab;tab=3'>keybindings</a> that default to keys you've already bound. The new ones will be unbound.</b></span>")
 	for(var/item in notadded)


### PR DESCRIPTION
This is triggering on a default keybind, and as such is fucking useless.

Somebody who understands what the fuck this is please fix it.

fixes #59491