### PR TITLE
Makes the Surrender Emote grammatically consistent (and improves replace_pronoun())

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -99,6 +99,8 @@
 		message = replacetext(message, "their", user.p_their())
 	if(findtext(message, "them"))
 		message = replacetext(message, "them", user.p_them())
+	if(findtext(message, "they"))
+		message = replacetext(message, "they", user.p_they())
 	if(findtext(message, "%s"))
 		message = replacetext(message, "%s", user.p_s())
 	return message

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -361,7 +361,7 @@
 /datum/emote/living/surrender
 	key = "surrender"
 	key_third_person = "surrenders"
-	message = "puts their hands on their head and falls to the ground, they surrender!"
+	message = "puts their hands on their head and falls to the ground, they surrender%s!"
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/living/surrender/run_emote(mob/user, params, type_override, intentional)


### PR DESCRIPTION
## About The Pull Request

This PR makes the surrender emote grammatically consistent by adding a text replacement case for "they" to the `replace_pronoun()` proc and adding a "%s" at the end of "surrender" so that the word has the correct form for the subject's gender.

## Why It's Good For The Game

Fixing up grammar is generally a good thing.

## Changelog
:cl:
spellcheck: The text for the surrender emote is now grammatically consistent.
/:cl:

