### PR TITLE
Makes injectors not double-calculate every gas property.

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -68,12 +68,7 @@
 	var/datum/gas_mixture/air_contents = airs[1]
 
 	if(air_contents.temperature > 0)
-		var/transfer_moles = (air_contents.return_pressure() * volume_rate) / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
-
-		if(!transfer_moles)
-			return
-
-		var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
+		var/datum/gas_mixture/removed = air_contents.remove_ratio(volume / volume_rate)
 
 		location.assume_air(removed)
 
@@ -90,12 +85,7 @@
 	flick("inje_inject", src)
 
 	if(air_contents.temperature > 0)
-		var/transfer_moles = (air_contents.return_pressure() * volume_rate) / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
-
-		if(!transfer_moles)
-			return
-
-		var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
+		var/datum/gas_mixture/removed = air_contents.remove_ratio(volume / volume_rate)
 		loc.assume_air(removed)
 		update_parents()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right now, injectors calculate how much they should inject via the equation 
```
var/transfer_moles = (air_contents.return_pressure() * volume_rate) / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
```
This is technically correct. However, expand return_pressure() and you get:
```
var/transfer_moles = (air_contents.total_moles() * R_IDEAL_GAS_EQUATION * temperature/volume) * volume_rate) / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
```

If you can do basic algebra, you'll find that this cancels out to `air_contents.total_moles() * volume_rate / volume`. Which is what we call a "ratio". Which there's already a proc for.

## Why It's Good For The Game

It's faster and more correct than the previous.

## Changelog
:cl:
refactor: injectors no longer throw numbers together in the most complicated way possible to do what they do
/:cl: