### PR TITLE
Standardize beach ball descriptions and branding

### DIFF
--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1628,8 +1628,8 @@
 /area/awaymission/caves/bmp_asteroid)
 "gd" = (
 /obj/item/toy/beach_ball{
-	desc = "Its a beachball with a face crudely drawn onto it with some soot.";
-	name = "wilson"
+	name = "\proper wilson";
+	desc = "It's a beachball with a face crudely drawn onto it with some soot."
 	},
 /turf/open/floor/plating/asteroid/basalt{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48263,9 +48263,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "nLZ" = (
-/obj/item/toy/beach_ball{
-	name = "Nanotrasen-branded beach ball"
-	},
+/obj/item/toy/beach_ball/branded,
 /turf/open/space/basic,
 /area/space)
 "nMa" = (
@@ -59520,9 +59518,7 @@
 	},
 /area/maintenance/starboard/fore)
 "rxh" = (
-/obj/item/toy/beach_ball{
-	desc = "The simple beach ball is one of Nanotrasen's most popular products. 'Why do we make beach balls? Because we can! (TM)' - Nanotrasen";
-	name = "\improper Nanotrasen-brand beach ball";
+/obj/item/toy/beach_ball/branded{
 	pixel_y = 7
 	},
 /obj/structure/table/wood,

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1153,11 +1153,15 @@
  * Beach ball
  */
 /obj/item/toy/beach_ball
+	name = "beach ball"
 	icon = 'icons/misc/beach.dmi'
 	icon_state = "ball"
-	name = "beach ball"
 	inhand_icon_state = "beachball"
 	w_class = WEIGHT_CLASS_BULKY //Stops people from hiding it in their bags/pockets
+
+/obj/item/toy/beach_ball/branded
+	name = "\improper Nanotrasen-brand beach ball"
+	desc = "The simple beach ball is one of Nanotrasen's most popular products. 'Why do we make beach balls? Because we can! (TM)' - Nanotrasen"
 
 /*
  * Clockwork Watch

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -135,9 +135,14 @@
 
 /datum/supply_pack/goody/beach_ball
 	name = "Beach Ball"
-	desc = "The simple beach ball is one of Nanotrasen's most popular products. 'Why do we make beach balls? Because we can! (TM)' - Nanotrasen"
+	// uses desc from item
 	cost = PAYCHECK_MEDIUM
-	contains = list(/obj/item/toy/beach_ball)
+	contains = list(/obj/item/toy/beach_ball/branded)
+
+/datum/supply_pack/goody/beach_ball/New()
+	..()
+	var/obj/item/toy/beach_ball/branded/beachball_type = /obj/item/toy/beach_ball/branded
+	desc = initial(beachball_type.desc)
 
 /datum/supply_pack/goody/medipen_twopak
 	name = "Medipen Two-Pak"


### PR DESCRIPTION
- All beach balls are now Nanotrasen-brand beach balls, including the
  ones that are ordered from Cargo.

- `wilson`, a beach ball in a cave, now has a proper name, despite their
  lack of capitalisation.

## Why It's Good For The Game

I noticed that one of the beach balls in the Metastation showcase had the
same description as a beach ball you could order in a goody crate, so
I made the branded beach balls their own type.