### PR TITLE
Motion cameras flash a red light using manual_emote instead of visible_message

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -268,7 +268,7 @@
 *
 * Returns TRUE if it was able to run the emote, FALSE otherwise.
 */
-/mob/proc/manual_emote(text) //Just override the song and dance
+/atom/proc/manual_emote(text) //Just override the song and dance
 	. = TRUE
 	if(findtext(text, "their"))
 		text = replacetext(text, "their", p_their())
@@ -276,9 +276,6 @@
 		text = replacetext(text, "them", p_them())
 	if(findtext(text, "%s"))
 		text = replacetext(text, "%s", p_s())
-
-	if(stat != CONSCIOUS)
-		return
 
 	if(!text)
 		CRASH("Someone passed nothing to manual_emote(), fix it")
@@ -295,3 +292,7 @@
 			ghost.show_message("[FOLLOW_LINK(ghost, src)] [ghost_text]")
 
 	visible_message(text, visible_message_flags = EMOTE_MESSAGE)
+
+/mob/manual_emote(text)
+	if(stat == CONSCIOUS)
+		return ..()

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -294,5 +294,6 @@
 	visible_message(text, visible_message_flags = EMOTE_MESSAGE)
 
 /mob/manual_emote(text)
-	if(stat == CONSCIOUS)
-		return ..()
+	if(stat != CONSCIOUS)
+		return
+	return ..()

--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -66,7 +66,7 @@
 	for (var/mob/living/silicon/aiPlayer in GLOB.player_list)
 		if (status)
 			aiPlayer.triggerAlarm("Motion", get_area(src), list(src), src)
-			visible_message(span_warning("A red light flashes on the [src]!"))
+			manual_emote("flashes a red light")
 	detectTime = -1
 	return TRUE
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Triggered motion cameras will use emotes now, so that it shows up in runechat too. Also pulled up manual_emote proc to atom, so that machines can use it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better user feedback as per the [design doc](https://hackmd.io/@tgstation/SJIle5wYd#saymanual_emote)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: all objects can use emotes now, not only mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
