### PR TITLE
Felinids don't like getting sprayed with water.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -651,8 +651,6 @@
 #define COMSIG_LIVING_STATUS_PARALYZE "living_paralyze"
 ///from base of mob/living/Immobilize() (amount, ignore_canstun)
 #define COMSIG_LIVING_STATUS_IMMOBILIZE "living_immobilize"
-///from base of mob/living/Incapacitate() (amount, ignore_canstun)
-#define COMSIG_LIVING_STATUS_INCAPACITATE "living_incapacitate"
 ///from base of mob/living/Unconscious() (amount, ignore_canstun)
 #define COMSIG_LIVING_STATUS_UNCONSCIOUS "living_unconscious"
 ///from base of mob/living/Sleeping() (amount, ignore_canstun)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -651,6 +651,8 @@
 #define COMSIG_LIVING_STATUS_PARALYZE "living_paralyze"
 ///from base of mob/living/Immobilize() (amount, ignore_canstun)
 #define COMSIG_LIVING_STATUS_IMMOBILIZE "living_immobilize"
+///from base of mob/living/Startle() (amount, ignore_canstun)
+#define COMSIG_LIVING_STATUS_STARTLE "living_startle"
 ///from base of mob/living/Unconscious() (amount, ignore_canstun)
 #define COMSIG_LIVING_STATUS_UNCONSCIOUS "living_unconscious"
 ///from base of mob/living/Sleeping() (amount, ignore_canstun)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -651,8 +651,8 @@
 #define COMSIG_LIVING_STATUS_PARALYZE "living_paralyze"
 ///from base of mob/living/Immobilize() (amount, ignore_canstun)
 #define COMSIG_LIVING_STATUS_IMMOBILIZE "living_immobilize"
-///from base of mob/living/Startle() (amount, ignore_canstun)
-#define COMSIG_LIVING_STATUS_STARTLE "living_startle"
+///from base of mob/living/Incapacitate() (amount, ignore_canstun)
+#define COMSIG_LIVING_STATUS_INCAPACITATE "living_incapacitate"
 ///from base of mob/living/Unconscious() (amount, ignore_canstun)
 #define COMSIG_LIVING_STATUS_UNCONSCIOUS "living_unconscious"
 ///from base of mob/living/Sleeping() (amount, ignore_canstun)

--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -57,7 +57,7 @@
 
 #define STATUS_EFFECT_PARALYZED /datum/status_effect/incapacitating/paralyzed //the affected is unable to move, use items, or stand up.
 
-#define STATUS_EFFECT_STARTLED /datum/status_effect/incapacitating/startled //the startled gets their do_afters canceled.
+#define STATUS_EFFECT_INCAPACITATED /datum/status_effect/incapacitating/incapacitated //the incapacitated is unable to perform some basic actions and gets their do_afters canceled
 
 #define STATUS_EFFECT_UNCONSCIOUS /datum/status_effect/incapacitating/unconscious //the affected is unconscious
 

--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -57,6 +57,8 @@
 
 #define STATUS_EFFECT_PARALYZED /datum/status_effect/incapacitating/paralyzed //the affected is unable to move, use items, or stand up.
 
+#define STATUS_EFFECT_STARTLED /datum/status_effect/incapacitating/startled //the startled gets their do_afters canceled.
+
 #define STATUS_EFFECT_UNCONSCIOUS /datum/status_effect/incapacitating/unconscious //the affected is unconscious
 
 #define STATUS_EFFECT_SLEEPING /datum/status_effect/incapacitating/sleeping //the affected is asleep

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -353,6 +353,6 @@
 	timeout = 1 MINUTES
 
 /datum/mood_event/watersprayed
-	description = "<span class='boldwarning'>Grrrr, I hate being sprayed with water!</span>\n"
+	description = "<span class='boldwarning'>I hate being sprayed with water!</span>\n"
 	mood_change = -5
 	timeout = 30 SECONDS

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -351,3 +351,8 @@
 	description = span_warning("Cool! That's fine, I wanted to wear that soda, not drink it...\n")
 	mood_change = -2
 	timeout = 1 MINUTES
+
+/datum/mood_event/watersprayed
+	description = "<span class='boldwarning'>Grrrr, I hate being sprayed with water!</span>\n"
+	mood_change = -5
+	timeout = 1 MINUTES

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -355,4 +355,4 @@
 /datum/mood_event/watersprayed
 	description = "<span class='boldwarning'>Grrrr, I hate being sprayed with water!</span>\n"
 	mood_change = -5
-	timeout = 1 MINUTES
+	timeout = 30 SECONDS

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -91,18 +91,18 @@
 	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
-//STARTLED
+//INCAPACITATED
+/// This status effect represents anything that leaves a character unable to perform basic tasks, but doesn't incapacitate them further than that (no stuns etc..)
+/datum/status_effect/incapacitating/incapacitated
+	id = "incapacitated"
 
-/datum/status_effect/incapacitating/startled
-	id = "startled"
-
-/datum/status_effect/incapacitating/startled/on_apply()
+/datum/status_effect/incapacitating/incapacitated/on_apply()
 	. = ..()
 	if(!.)
 		return
 	ADD_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
 
-/datum/status_effect/incapacitating/startled/on_remove()
+/datum/status_effect/incapacitating/incapacitated/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
 	return ..()
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -96,14 +96,14 @@
 /datum/status_effect/incapacitating/incapacitated
 	id = "incapacitated"
 
-/// What happens when you get the incapacitated status. You get TRAIT_INCAPACITATED added to you for the duration of the status effect.
+// What happens when you get the incapacitated status. You get TRAIT_INCAPACITATED added to you for the duration of the status effect.
 /datum/status_effect/incapacitating/incapacitated/on_apply()
 	. = ..()
 	if(!.)
 		return
 	ADD_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
 
-/// When the status effect runs out, your TRAIT_INCAPACITATED is removed.
+// When the status effect runs out, your TRAIT_INCAPACITATED is removed.
 /datum/status_effect/incapacitating/incapacitated/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
 	return ..()

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -96,11 +96,15 @@
 /datum/status_effect/incapacitating/incapacitated
 	id = "incapacitated"
 
+/// What happens when you get the incapacitated status. You get TRAIT_INCAPACITATED added to you for the duration of the status effect.
+
 /datum/status_effect/incapacitating/incapacitated/on_apply()
 	. = ..()
 	if(!.)
 		return
 	ADD_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
+
+/// When the status effect runs out, your TRAIT_INCAPACITATED is removed.
 
 /datum/status_effect/incapacitating/incapacitated/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -92,12 +92,11 @@
 	return ..()
 
 //INCAPACITATED
-/// This status effect represents anything that leaves a character unable to perform basic tasks, but doesn't incapacitate them further than that (no stuns etc..)
+/// This status effect represents anything that leaves a character unable to perform basic tasks (interrupting do-afters, for example), but doesn't incapacitate them further than that (no stuns etc..)
 /datum/status_effect/incapacitating/incapacitated
 	id = "incapacitated"
 
 /// What happens when you get the incapacitated status. You get TRAIT_INCAPACITATED added to you for the duration of the status effect.
-
 /datum/status_effect/incapacitating/incapacitated/on_apply()
 	. = ..()
 	if(!.)
@@ -105,7 +104,6 @@
 	ADD_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
 
 /// When the status effect runs out, your TRAIT_INCAPACITATED is removed.
-
 /datum/status_effect/incapacitating/incapacitated/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
 	return ..()

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -91,6 +91,21 @@
 	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
+//STARTLED
+
+/datum/status_effect/incapacitating/startled
+	id = "startled"
+
+/datum/status_effect/incapacitating/startled/on_apply()
+	. = ..()
+	if(!.)
+		return
+	ADD_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
+
+/datum/status_effect/incapacitating/startled/on_remove()
+	REMOVE_TRAIT(owner, TRAIT_INCAPACITATED, TRAIT_STATUS_EFFECT(id))
+	return ..()
+
 
 //UNCONSCIOUS
 /datum/status_effect/incapacitating/unconscious

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -3,8 +3,8 @@
 // eye damage, eye_blind, eye_blurry, druggy, TRAIT_BLIND trait, and TRAIT_NEARSIGHT trait.
 
 #define IS_STUN_IMMUNE(source, ignore_canstun) ((source.status_flags & GODMODE) || (!ignore_canstun && (!(source.status_flags & CANKNOCKDOWN) || HAS_TRAIT(source, TRAIT_STUNIMMUNE))))
-////////////////////////////// STUN ////////////////////////////////////
 
+/* STUN */
 /mob/living/proc/IsStun() //If we're stunned
 	return has_status_effect(STATUS_EFFECT_STUN)
 
@@ -60,8 +60,7 @@
 		S = apply_status_effect(STATUS_EFFECT_STUN, amount)
 	return S
 
-///////////////////////////////// KNOCKDOWN /////////////////////////////////////
-
+/* KNOCKDOWN */
 /mob/living/proc/IsKnockdown() //If we're knocked down
 	return has_status_effect(STATUS_EFFECT_KNOCKDOWN)
 
@@ -117,7 +116,7 @@
 		K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount)
 	return K
 
-///////////////////////////////// IMMOBILIZED ////////////////////////////////////
+/* IMMOBILIZED */
 /mob/living/proc/IsImmobilized() //If we're immobilized
 	return has_status_effect(STATUS_EFFECT_IMMOBILIZED)
 
@@ -173,7 +172,7 @@
 		I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount)
 	return I
 
-///////////////////////////////// PARALYZED //////////////////////////////////
+/* PARALYZED */
 /mob/living/proc/IsParalyzed() //If we're paralyzed
 	return has_status_effect(STATUS_EFFECT_PARALYZED)
 
@@ -229,7 +228,7 @@
 		P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount)
 	return P
 
-///////////////////////////////// INCAPACITATED //////////////////////////////////
+/* INCAPACITATED */
 
 /// Proc that checks if a mob/living currently has the incapacitated status effect.
 /mob/living/proc/is_incapacitated()
@@ -319,7 +318,7 @@
 	AdjustImmobilized(amount)
 
 
-//////////////////UNCONSCIOUS
+/* UNCONSCIOUS */
 /mob/living/proc/IsUnconscious() //If we're unconscious
 	return has_status_effect(STATUS_EFFECT_UNCONSCIOUS)
 
@@ -368,8 +367,7 @@
 		U = apply_status_effect(STATUS_EFFECT_UNCONSCIOUS, amount)
 	return U
 
-/////////////////////////////////// SLEEPING ////////////////////////////////////
-
+/* SLEEPING */
 /mob/living/proc/IsSleeping() //If we're asleep
 	if(!HAS_TRAIT(src, TRAIT_SLEEPIMMUNE))
 		return has_status_effect(STATUS_EFFECT_SLEEPING)
@@ -444,11 +442,12 @@
 
 ///////////////////////////////// FROZEN /////////////////////////////////////
 
+/* FROZEN */
 /mob/living/proc/IsFrozen()
 	return has_status_effect(/datum/status_effect/freon)
 
-///////////////////////////////////// STUN ABSORPTION /////////////////////////////////////
 
+/* STUN ABSORPTION*/
 /mob/living/proc/add_stun_absorption(key, duration, priority, message, self_message, examine_message)
 //adds a stun absorption with a key, a duration in deciseconds, its priority, and the messages it makes when you're stun/examined, if any
 	if(!islist(stun_absorption))
@@ -510,8 +509,7 @@
 			return TRUE
 	return FALSE
 
-/////////////////////////////////// TRAIT PROCS ////////////////////////////////////
-
+/* TRAIT PROCS */
 /mob/living/proc/cure_blind(source)
 	if(source)
 		REMOVE_TRAIT(src, TRAIT_BLIND, source)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -233,7 +233,7 @@
 
 /// Proc that returns the remaining duration of the status efect in deciseconds.
 /mob/living/proc/amount_incapacitated()
-	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
+	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = has_status_effect(STATUS_EFFECT_INCAPACITATED)
 	return incapacitated_status_effect?.duration - world.time || 0
 
 /** Proc that actually applies the status effect.

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -241,12 +241,12 @@
  * * amount - Amount of time the status effect should be applied for, in deciseconds.
  * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
  */
-/mob/living/proc/Incapacitate(amount, ignore_canstun = FALSE)
+/mob/living/proc/incapacitate(amount, ignore_canstun = FALSE)
 	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
 	if(absorb_stun(amount, ignore_canstun))
 		return
-	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
+	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = has_status_effect(STATUS_EFFECT_INCAPACITATED)
 	if(incapacitated_status_effect)
 		incapacitated_status_effect.duration = max(world.time + amount, incapacitated_status_effect.duration)
 	else if(amount > 0)
@@ -262,7 +262,7 @@
 /mob/living/proc/set_incapacitated(amount, ignore_canstun = FALSE)
 	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
+	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = has_status_effect(STATUS_EFFECT_INCAPACITATED)
 	if(amount <= 0)
 		if(incapacitated_status_effect)
 			qdel(incapacitated_status_effect)
@@ -286,7 +286,7 @@
 		return
 	if(absorb_stun(amount, ignore_canstun))
 		return
-	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
+	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = has_status_effect(STATUS_EFFECT_INCAPACITATED)
 	if(incapacitated_status_effect)
 		incapacitated_status_effect.duration += amount
 	else if(amount > 0)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -241,16 +241,16 @@
 			P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount)
 		return P
 
-///////////////////////////////// STARTLED //////////////////////////////////
+///////////////////////////////// INCAPACITATED //////////////////////////////////
 
-/mob/living/proc/IsStartled() //If we're Startled
-	return has_status_effect(STATUS_EFFECT_STARTLED)
+/mob/living/proc/is_incapacitated() //If we're incapacitated
+	return has_status_effect(STATUS_EFFECT_INCAPACITATED)
 
-/mob/living/proc/AmountStartled() //How many deciseconds remain in our Startled status effect
-	var/datum/status_effect/incapacitating/startled/I = IsStartled()
+/mob/living/proc/amount_incapacitated() //How many deciseconds remain in our Incapacitated status effect
+	var/datum/status_effect/incapacitating/incapacitated/I = is_incapacitated()
 	return I?.duration - world.time || 0
 
-/mob/living/proc/Startle(amount, ignore_canstun = FALSE) //Can't go below remaining duration
+/mob/living/proc/Incapacitate(amount, ignore_canstun = FALSE) //Can't go below remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(status_flags & GODMODE)
@@ -258,20 +258,20 @@
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
 		if(absorb_stun(amount, ignore_canstun))
 			return
-		var/datum/status_effect/incapacitating/startled/I = IsStartled()
+		var/datum/status_effect/incapacitating/incapacitated/I = is_incapacitated()
 		if(I)
 			I.duration = max(world.time + amount, I.duration)
 		else if(amount > 0)
-			I = apply_status_effect(STATUS_EFFECT_STARTLED, amount)
+			I = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
 		return I
 
-/mob/living/proc/SetStartled(amount, ignore_canstun = FALSE) //Sets remaining duration
+/mob/living/proc/set_incapacitated(amount, ignore_canstun = FALSE) //Sets remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(status_flags & GODMODE)
 		return
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		var/datum/status_effect/incapacitating/startled/I = IsStartled()
+		var/datum/status_effect/incapacitating/incapacitated/I = is_incapacitated()
 		if(amount <= 0)
 			if(I)
 				qdel(I)
@@ -281,10 +281,10 @@
 			if(I)
 				I.duration = world.time + amount
 			else
-				I = apply_status_effect(STATUS_EFFECT_STARTLED, amount)
+				I = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
 		return I
 
-/mob/living/proc/AdjustStartled(amount, ignore_canstun = FALSE) //Adds to remaining duration
+/mob/living/proc/adjust_incapacitated(amount, ignore_canstun = FALSE) //Adds to remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(status_flags & GODMODE)
@@ -292,11 +292,11 @@
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
 		if(absorb_stun(amount, ignore_canstun))
 			return
-		var/datum/status_effect/incapacitating/startled/I = IsStartled()
+		var/datum/status_effect/incapacitating/incapacitated/I = is_incapacitated()
 		if(I)
 			I.duration += amount
 		else if(amount > 0)
-			I = apply_status_effect(STATUS_EFFECT_STARTLED, amount)
+			I = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
 		return I
 
 //Blanket

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -2,7 +2,7 @@
 //The effects include: stun, knockdown, unconscious, sleeping, resting, jitteriness, dizziness,
 // eye damage, eye_blind, eye_blurry, druggy, TRAIT_BLIND trait, and TRAIT_NEARSIGHT trait.
 
-
+#define IS_STUN_IMMUNE(source, ignore_canstun) ((source.status_flags & GODMODE) || (!ignore_canstun && (!(source.status_flags & CANKNOCKDOWN) || HAS_TRAIT(source, TRAIT_STUNIMMUNE))))
 ////////////////////////////// STUN ////////////////////////////////////
 
 /mob/living/proc/IsStun() //If we're stunned
@@ -17,51 +17,48 @@
 /mob/living/proc/Stun(amount, ignore_canstun = FALSE) //Can't go below remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STUN, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANSTUN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
-			return
-		var/datum/status_effect/incapacitating/stun/S = IsStun()
-		if(S)
-			S.duration = max(world.time + amount, S.duration)
-		else if(amount > 0)
-			S = apply_status_effect(STATUS_EFFECT_STUN, amount)
-		return S
+	if(absorb_stun(amount, ignore_canstun))
+		return
+	var/datum/status_effect/incapacitating/stun/S = IsStun()
+	if(S)
+		S.duration = max(world.time + amount, S.duration)
+	else if(amount > 0)
+		S = apply_status_effect(STATUS_EFFECT_STUN, amount)
+	return S
 
 /mob/living/proc/SetStun(amount, ignore_canstun = FALSE) //Sets remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STUN, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANSTUN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		var/datum/status_effect/incapacitating/stun/S = IsStun()
-		if(amount <= 0)
-			if(S)
-				qdel(S)
+	var/datum/status_effect/incapacitating/stun/S = IsStun()
+	if(amount <= 0)
+		if(S)
+			qdel(S)
+	else
+		if(absorb_stun(amount, ignore_canstun))
+			return
+		if(S)
+			S.duration = world.time + amount
 		else
-			if(absorb_stun(amount, ignore_canstun))
-				return
-			if(S)
-				S.duration = world.time + amount
-			else
-				S = apply_status_effect(STATUS_EFFECT_STUN, amount)
-		return S
+			S = apply_status_effect(STATUS_EFFECT_STUN, amount)
+	return S
 
 /mob/living/proc/AdjustStun(amount, ignore_canstun = FALSE) //Adds to remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STUN, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANSTUN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
-			return
-		var/datum/status_effect/incapacitating/stun/S = IsStun()
-		if(S)
-			S.duration += amount
-		else if(amount > 0)
-			S = apply_status_effect(STATUS_EFFECT_STUN, amount)
-		return S
+	if(absorb_stun(amount, ignore_canstun))
+		return
+	var/datum/status_effect/incapacitating/stun/S = IsStun()
+	if(S)
+		S.duration += amount
+	else if(amount > 0)
+		S = apply_status_effect(STATUS_EFFECT_STUN, amount)
+	return S
 
 ///////////////////////////////// KNOCKDOWN /////////////////////////////////////
 
@@ -77,51 +74,48 @@
 /mob/living/proc/Knockdown(amount, ignore_canstun = FALSE) //Can't go below remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_KNOCKDOWN, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
-			return
-		var/datum/status_effect/incapacitating/knockdown/K = IsKnockdown()
-		if(K)
-			K.duration = max(world.time + amount, K.duration)
-		else if(amount > 0)
-			K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount)
-		return K
+	if(absorb_stun(amount, ignore_canstun))
+		return
+	var/datum/status_effect/incapacitating/knockdown/K = IsKnockdown()
+	if(K)
+		K.duration = max(world.time + amount, K.duration)
+	else if(amount > 0)
+		K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount)
+	return K
 
 /mob/living/proc/SetKnockdown(amount, ignore_canstun = FALSE) //Sets remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_KNOCKDOWN, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		var/datum/status_effect/incapacitating/knockdown/K = IsKnockdown()
-		if(amount <= 0)
-			if(K)
-				qdel(K)
+	var/datum/status_effect/incapacitating/knockdown/K = IsKnockdown()
+	if(amount <= 0)
+		if(K)
+			qdel(K)
+	else
+		if(absorb_stun(amount, ignore_canstun))
+			return
+		if(K)
+			K.duration = world.time + amount
 		else
-			if(absorb_stun(amount, ignore_canstun))
-				return
-			if(K)
-				K.duration = world.time + amount
-			else
-				K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount)
-		return K
+			K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount)
+	return K
 
 /mob/living/proc/AdjustKnockdown(amount, ignore_canstun = FALSE) //Adds to remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_KNOCKDOWN, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
-			return
-		var/datum/status_effect/incapacitating/knockdown/K = IsKnockdown()
-		if(K)
-			K.duration += amount
-		else if(amount > 0)
-			K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount)
-		return K
+	if(absorb_stun(amount, ignore_canstun))
+		return
+	var/datum/status_effect/incapacitating/knockdown/K = IsKnockdown()
+	if(K)
+		K.duration += amount
+	else if(amount > 0)
+		K = apply_status_effect(STATUS_EFFECT_KNOCKDOWN, amount)
+	return K
 
 ///////////////////////////////// IMMOBILIZED ////////////////////////////////////
 /mob/living/proc/IsImmobilized() //If we're immobilized
@@ -136,51 +130,48 @@
 /mob/living/proc/Immobilize(amount, ignore_canstun = FALSE) //Can't go below remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_IMMOBILIZE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
-			return
-		var/datum/status_effect/incapacitating/immobilized/I = IsImmobilized()
-		if(I)
-			I.duration = max(world.time + amount, I.duration)
-		else if(amount > 0)
-			I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount)
-		return I
+	if(absorb_stun(amount, ignore_canstun))
+		return
+	var/datum/status_effect/incapacitating/immobilized/I = IsImmobilized()
+	if(I)
+		I.duration = max(world.time + amount, I.duration)
+	else if(amount > 0)
+		I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount)
+	return I
 
 /mob/living/proc/SetImmobilized(amount, ignore_canstun = FALSE) //Sets remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_IMMOBILIZE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		var/datum/status_effect/incapacitating/immobilized/I = IsImmobilized()
-		if(amount <= 0)
-			if(I)
-				qdel(I)
+	var/datum/status_effect/incapacitating/immobilized/I = IsImmobilized()
+	if(amount <= 0)
+		if(I)
+			qdel(I)
+	else
+		if(absorb_stun(amount, ignore_canstun))
+			return
+		if(I)
+			I.duration = world.time + amount
 		else
-			if(absorb_stun(amount, ignore_canstun))
-				return
-			if(I)
-				I.duration = world.time + amount
-			else
-				I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount)
-		return I
+			I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount)
+	return I
 
 /mob/living/proc/AdjustImmobilized(amount, ignore_canstun = FALSE) //Adds to remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_IMMOBILIZE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
-			return
-		var/datum/status_effect/incapacitating/immobilized/I = IsImmobilized()
-		if(I)
-			I.duration += amount
-		else if(amount > 0)
-			I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount)
-		return I
+	if(absorb_stun(amount, ignore_canstun))
+		return
+	var/datum/status_effect/incapacitating/immobilized/I = IsImmobilized()
+	if(I)
+		I.duration += amount
+	else if(amount > 0)
+		I = apply_status_effect(STATUS_EFFECT_IMMOBILIZED, amount)
+	return I
 
 ///////////////////////////////// PARALYZED //////////////////////////////////
 /mob/living/proc/IsParalyzed() //If we're paralyzed
@@ -195,51 +186,48 @@
 /mob/living/proc/Paralyze(amount, ignore_canstun = FALSE) //Can't go below remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_PARALYZE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
-			return
-		var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
-		if(P)
-			P.duration = max(world.time + amount, P.duration)
-		else if(amount > 0)
-			P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount)
-		return P
+	if(absorb_stun(amount, ignore_canstun))
+		return
+	var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
+	if(P)
+		P.duration = max(world.time + amount, P.duration)
+	else if(amount > 0)
+		P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount)
+	return P
 
 /mob/living/proc/SetParalyzed(amount, ignore_canstun = FALSE) //Sets remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_PARALYZE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
-		if(amount <= 0)
-			if(P)
-				qdel(P)
+	var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
+	if(amount <= 0)
+		if(P)
+			qdel(P)
+	else
+		if(absorb_stun(amount, ignore_canstun))
+			return
+		if(P)
+			P.duration = world.time + amount
 		else
-			if(absorb_stun(amount, ignore_canstun))
-				return
-			if(P)
-				P.duration = world.time + amount
-			else
-				P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount)
-		return P
+			P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount)
+	return P
 
 /mob/living/proc/AdjustParalyzed(amount, ignore_canstun = FALSE) //Adds to remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_PARALYZE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
-			return
-		var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
-		if(P)
-			P.duration += amount
-		else if(amount > 0)
-			P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount)
-		return P
+	if(absorb_stun(amount, ignore_canstun))
+		return
+	var/datum/status_effect/incapacitating/paralyzed/P = IsParalyzed(FALSE)
+	if(P)
+		P.duration += amount
+	else if(amount > 0)
+		P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount)
+	return P
 
 ///////////////////////////////// INCAPACITATED //////////////////////////////////
 
@@ -258,19 +246,16 @@
  * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
  */
 /mob/living/proc/Incapacitate(amount, ignore_canstun = FALSE)
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_INCAPACITATE, amount, ignore_canstun) & COMPONENT_NO_STUN)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(status_flags & GODMODE)
+	if(absorb_stun(amount, ignore_canstun))
 		return
-	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
-			return
-		var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
-		if(incapacitated_status_effect)
-			incapacitated_status_effect.duration = max(world.time + amount, incapacitated_status_effect.duration)
-		else if(amount > 0)
-			incapacitated_status_effect = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
-		return incapacitated_status_effect
+	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
+	if(incapacitated_status_effect)
+		incapacitated_status_effect.duration = max(world.time + amount, incapacitated_status_effect.duration)
+	else if(amount > 0)
+		incapacitated_status_effect = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
+	return incapacitated_status_effect
 
 /** Proc that set the incapacitated status effect's remaining duration to a certain time.
  * Checks if the mob has the status effect. If yes, it sets the duration to the amount passed in arguments. If not, applies the status effect
@@ -279,23 +264,20 @@
  * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
  */
 /mob/living/proc/set_incapacitated(amount, ignore_canstun = FALSE)
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_INCAPACITATE, amount, ignore_canstun) & COMPONENT_NO_STUN)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(status_flags & GODMODE)
-		return
-	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
-		if(amount <= 0)
-			if(incapacitated_status_effect)
-				qdel(incapacitated_status_effect)
+	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
+	if(amount <= 0)
+		if(incapacitated_status_effect)
+			qdel(incapacitated_status_effect)
+	else
+		if(absorb_stun(amount, ignore_canstun))
+			return
+		if(incapacitated_status_effect)
+			incapacitated_status_effect.duration = world.time + amount
 		else
-			if(absorb_stun(amount, ignore_canstun))
-				return
-			if(incapacitated_status_effect)
-				incapacitated_status_effect.duration = world.time + amount
-			else
-				incapacitated_status_effect = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
-		return incapacitated_status_effect
+			incapacitated_status_effect = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
+	return incapacitated_status_effect
 
 /** Proc that adds duration to an incapacitated status effect.
  * Checks if the mob has the status effect. If yes, it adds the amount passed in arguments to the remaining duration. If not, applies the status effect
@@ -304,19 +286,16 @@
  * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
  */
 /mob/living/proc/adjust_incapacitated(amount, ignore_canstun = FALSE) //Adds to remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_INCAPACITATE, amount, ignore_canstun) & COMPONENT_NO_STUN)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(status_flags & GODMODE)
+	if(absorb_stun(amount, ignore_canstun))
 		return
-	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		if(absorb_stun(amount, ignore_canstun))
-			return
-		var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
-		if(incapacitated_status_effect)
-			incapacitated_status_effect.duration += amount
-		else if(amount > 0)
-			incapacitated_status_effect = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
-		return incapacitated_status_effect
+	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
+	if(incapacitated_status_effect)
+		incapacitated_status_effect.duration += amount
+	else if(amount > 0)
+		incapacitated_status_effect = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
+	return incapacitated_status_effect
 
 //Blanket
 /mob/living/proc/AllImmobility(amount)
@@ -353,44 +332,41 @@
 /mob/living/proc/Unconscious(amount, ignore_canstun = FALSE) //Can't go below remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_UNCONSCIOUS, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANUNCONSCIOUS) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE))  || ignore_canstun)
-		var/datum/status_effect/incapacitating/unconscious/U = IsUnconscious()
-		if(U)
-			U.duration = max(world.time + amount, U.duration)
-		else if(amount > 0)
-			U = apply_status_effect(STATUS_EFFECT_UNCONSCIOUS, amount)
-		return U
+	var/datum/status_effect/incapacitating/unconscious/U = IsUnconscious()
+	if(U)
+		U.duration = max(world.time + amount, U.duration)
+	else if(amount > 0)
+		U = apply_status_effect(STATUS_EFFECT_UNCONSCIOUS, amount)
+	return U
 
 /mob/living/proc/SetUnconscious(amount, ignore_canstun = FALSE) //Sets remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_UNCONSCIOUS, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANUNCONSCIOUS) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		var/datum/status_effect/incapacitating/unconscious/U = IsUnconscious()
-		if(amount <= 0)
-			if(U)
-				qdel(U)
-		else if(U)
-			U.duration = world.time + amount
-		else
-			U = apply_status_effect(STATUS_EFFECT_UNCONSCIOUS, amount)
-		return U
+	var/datum/status_effect/incapacitating/unconscious/U = IsUnconscious()
+	if(amount <= 0)
+		if(U)
+			qdel(U)
+	else if(U)
+		U.duration = world.time + amount
+	else
+		U = apply_status_effect(STATUS_EFFECT_UNCONSCIOUS, amount)
+	return U
 
 /mob/living/proc/AdjustUnconscious(amount, ignore_canstun = FALSE) //Adds to remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_UNCONSCIOUS, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
-	if(status_flags & GODMODE)
+	if(IS_STUN_IMMUNE(src, ignore_canstun))
 		return
-	if(((status_flags & CANUNCONSCIOUS) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		var/datum/status_effect/incapacitating/unconscious/U = IsUnconscious()
-		if(U)
-			U.duration += amount
-		else if(amount > 0)
-			U = apply_status_effect(STATUS_EFFECT_UNCONSCIOUS, amount)
-		return U
+	var/datum/status_effect/incapacitating/unconscious/U = IsUnconscious()
+	if(U)
+		U.duration += amount
+	else if(amount > 0)
+		U = apply_status_effect(STATUS_EFFECT_UNCONSCIOUS, amount)
+	return U
 
 /////////////////////////////////// SLEEPING ////////////////////////////////////
 

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -258,7 +258,7 @@
  * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
  */
 /mob/living/proc/Incapacitate(amount, ignore_canstun = FALSE)
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_INCAPACITATE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(status_flags & GODMODE)
 		return
@@ -279,7 +279,7 @@
  * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
  */
 /mob/living/proc/set_incapacitated(amount, ignore_canstun = FALSE)
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_INCAPACITATE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(status_flags & GODMODE)
 		return
@@ -304,7 +304,7 @@
  * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
  */
 /mob/living/proc/adjust_incapacitated(amount, ignore_canstun = FALSE) //Adds to remaining duration
-	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_INCAPACITATE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(status_flags & GODMODE)
 		return

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -248,9 +248,7 @@
 
 /mob/living/proc/AmountStartled() //How many deciseconds remain in our Startled status effect
 	var/datum/status_effect/incapacitating/startled/I = IsStartled()
-	if(I)
-		return I.duration - world.time
-	return 0
+	return I?.duration - world.time || 0
 
 /mob/living/proc/Startle(amount, ignore_canstun = FALSE) //Can't go below remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -234,7 +234,7 @@
 /// Proc that returns the remaining duration of the status efect in deciseconds.
 /mob/living/proc/amount_incapacitated()
 	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = has_status_effect(STATUS_EFFECT_INCAPACITATED)
-	if incapacitated_status_effect
+	if (incapacitated_status_effect)
 		return incapacitated_status_effect.duration - world.time
 	else
 		return 0

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -244,12 +244,10 @@
 ///////////////////////////////// INCAPACITATED //////////////////////////////////
 
 /// Proc that checks if a mob/living currently has the incapacitated status effect.
-
 /mob/living/proc/is_incapacitated()
 	return has_status_effect(STATUS_EFFECT_INCAPACITATED)
 
 /// Proc that returns the remaining duration of the status efect in deciseconds.
-
 /mob/living/proc/amount_incapacitated()
 	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
 	return incapacitated_status_effect?.duration - world.time || 0
@@ -259,7 +257,6 @@
  * * amount - Amount of time the status effect should be applied for, in deciseconds.
  * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
  */
-
 /mob/living/proc/Incapacitate(amount, ignore_canstun = FALSE)
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
@@ -281,7 +278,6 @@
  * * amount - Amount of time the status effect should be set to, in deciseconds.
  * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
  */
-
 /mob/living/proc/set_incapacitated(amount, ignore_canstun = FALSE)
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
@@ -307,8 +303,6 @@
  * * amount - Amount of time the status effect should be set to, in deciseconds.
  * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
  */
-
-
 /mob/living/proc/adjust_incapacitated(amount, ignore_canstun = FALSE) //Adds to remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -234,7 +234,10 @@
 /// Proc that returns the remaining duration of the status efect in deciseconds.
 /mob/living/proc/amount_incapacitated()
 	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = has_status_effect(STATUS_EFFECT_INCAPACITATED)
-	return incapacitated_status_effect?.duration - world.time || 0
+	if incapacitated_status_effect
+		return incapacitated_status_effect.duration - world.time
+	else
+		return 0
 
 /** Proc that actually applies the status effect.
  * Applies the Incapacitated status effect to a mob/living.

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -243,14 +243,24 @@
 
 ///////////////////////////////// INCAPACITATED //////////////////////////////////
 
-/mob/living/proc/is_incapacitated() //If we're incapacitated
+/// Proc that checks if a mob/living currently has the incapacitated status effect.
+
+/mob/living/proc/is_incapacitated()
 	return has_status_effect(STATUS_EFFECT_INCAPACITATED)
 
-/mob/living/proc/amount_incapacitated() //How many deciseconds remain in our Incapacitated status effect
-	var/datum/status_effect/incapacitating/incapacitated/I = is_incapacitated()
-	return I?.duration - world.time || 0
+/// Proc that returns the remaining duration of the status efect in deciseconds.
 
-/mob/living/proc/Incapacitate(amount, ignore_canstun = FALSE) //Can't go below remaining duration
+/mob/living/proc/amount_incapacitated()
+	var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
+	return incapacitated_status_effect?.duration - world.time || 0
+
+/** Proc that actually applies the status effect.
+ * Applies the Incapacitated status effect to a mob/living.
+ * * amount - Amount of time the status effect should be applied for, in deciseconds.
+ * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
+ */
+
+/mob/living/proc/Incapacitate(amount, ignore_canstun = FALSE)
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(status_flags & GODMODE)
@@ -258,31 +268,46 @@
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
 		if(absorb_stun(amount, ignore_canstun))
 			return
-		var/datum/status_effect/incapacitating/incapacitated/I = is_incapacitated()
-		if(I)
-			I.duration = max(world.time + amount, I.duration)
+		var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
+		if(incapacitated_status_effect)
+			incapacitated_status_effect.duration = max(world.time + amount, incapacitated_status_effect.duration)
 		else if(amount > 0)
-			I = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
-		return I
+			incapacitated_status_effect = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
+		return incapacitated_status_effect
 
-/mob/living/proc/set_incapacitated(amount, ignore_canstun = FALSE) //Sets remaining duration
+/** Proc that set the incapacitated status effect's remaining duration to a certain time.
+ * Checks if the mob has the status effect. If yes, it sets the duration to the amount passed in arguments. If not, applies the status effect
+ * and sets the duration to the amount passed in arguments.
+ * * amount - Amount of time the status effect should be set to, in deciseconds.
+ * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
+ */
+
+/mob/living/proc/set_incapacitated(amount, ignore_canstun = FALSE)
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
 		return
 	if(status_flags & GODMODE)
 		return
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
-		var/datum/status_effect/incapacitating/incapacitated/I = is_incapacitated()
+		var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
 		if(amount <= 0)
-			if(I)
-				qdel(I)
+			if(incapacitated_status_effect)
+				qdel(incapacitated_status_effect)
 		else
 			if(absorb_stun(amount, ignore_canstun))
 				return
-			if(I)
-				I.duration = world.time + amount
+			if(incapacitated_status_effect)
+				incapacitated_status_effect.duration = world.time + amount
 			else
-				I = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
-		return I
+				incapacitated_status_effect = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
+		return incapacitated_status_effect
+
+/** Proc that adds duration to an incapacitated status effect.
+ * Checks if the mob has the status effect. If yes, it adds the amount passed in arguments to the remaining duration. If not, applies the status effect
+ * and sets the duration to the amount passed in arguments.
+ * * amount - Amount of time the status effect should be set to, in deciseconds.
+ * * ignore_canstun - If TRUE, the mob's resistance to stuns is ignored.
+ */
+
 
 /mob/living/proc/adjust_incapacitated(amount, ignore_canstun = FALSE) //Adds to remaining duration
 	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
@@ -292,12 +317,12 @@
 	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
 		if(absorb_stun(amount, ignore_canstun))
 			return
-		var/datum/status_effect/incapacitating/incapacitated/I = is_incapacitated()
-		if(I)
-			I.duration += amount
+		var/datum/status_effect/incapacitating/incapacitated/incapacitated_status_effect = is_incapacitated()
+		if(incapacitated_status_effect)
+			incapacitated_status_effect.duration += amount
 		else if(amount > 0)
-			I = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
-		return I
+			incapacitated_status_effect = apply_status_effect(STATUS_EFFECT_INCAPACITATED, amount)
+		return incapacitated_status_effect
 
 //Blanket
 /mob/living/proc/AllImmobility(amount)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -230,9 +230,6 @@
 
 /* INCAPACITATED */
 
-/// Proc that checks if a mob/living currently has the incapacitated status effect.
-/mob/living/proc/is_incapacitated()
-	return has_status_effect(STATUS_EFFECT_INCAPACITATED)
 
 /// Proc that returns the remaining duration of the status efect in deciseconds.
 /mob/living/proc/amount_incapacitated()

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -241,6 +241,66 @@
 			P = apply_status_effect(STATUS_EFFECT_PARALYZED, amount)
 		return P
 
+///////////////////////////////// STARTLED //////////////////////////////////
+
+/mob/living/proc/IsStartled() //If we're Startled
+	return has_status_effect(STATUS_EFFECT_STARTLED)
+
+/mob/living/proc/AmountStartled() //How many deciseconds remain in our Startled status effect
+	var/datum/status_effect/incapacitating/startled/I = IsStartled()
+	if(I)
+		return I.duration - world.time
+	return 0
+
+/mob/living/proc/Startle(amount, ignore_canstun = FALSE) //Can't go below remaining duration
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
+		return
+	if(status_flags & GODMODE)
+		return
+	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
+		if(absorb_stun(amount, ignore_canstun))
+			return
+		var/datum/status_effect/incapacitating/startled/I = IsStartled()
+		if(I)
+			I.duration = max(world.time + amount, I.duration)
+		else if(amount > 0)
+			I = apply_status_effect(STATUS_EFFECT_STARTLED, amount)
+		return I
+
+/mob/living/proc/SetStartled(amount, ignore_canstun = FALSE) //Sets remaining duration
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
+		return
+	if(status_flags & GODMODE)
+		return
+	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
+		var/datum/status_effect/incapacitating/startled/I = IsStartled()
+		if(amount <= 0)
+			if(I)
+				qdel(I)
+		else
+			if(absorb_stun(amount, ignore_canstun))
+				return
+			if(I)
+				I.duration = world.time + amount
+			else
+				I = apply_status_effect(STATUS_EFFECT_STARTLED, amount)
+		return I
+
+/mob/living/proc/AdjustStartled(amount, ignore_canstun = FALSE) //Adds to remaining duration
+	if(SEND_SIGNAL(src, COMSIG_LIVING_STATUS_STARTLE, amount, ignore_canstun) & COMPONENT_NO_STUN)
+		return
+	if(status_flags & GODMODE)
+		return
+	if(((status_flags & CANKNOCKDOWN) && !HAS_TRAIT(src, TRAIT_STUNIMMUNE)) || ignore_canstun)
+		if(absorb_stun(amount, ignore_canstun))
+			return
+		var/datum/status_effect/incapacitating/startled/I = IsStartled()
+		if(I)
+			I.duration += amount
+		else if(amount > 0)
+			I = apply_status_effect(STATUS_EFFECT_STARTLED, amount)
+		return I
+
 //Blanket
 /mob/living/proc/AllImmobility(amount)
 	Paralyze(amount)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -215,7 +215,7 @@
 	if(methods & VAPOR)
 		if(!isfelinid(exposed_mob))
 			return
-		exposed_mob.Incapacitate(1) //cancels any do_after
+		exposed_mob.Incapacitate(1) // startles the felinid, canceling any do_after
 		SEND_SIGNAL(exposed_mob, COMSIG_ADD_MOOD_EVENT, "watersprayed", /datum/mood_event/watersprayed)
 
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -215,6 +215,7 @@
 	if(methods & VAPOR)
 		if(!isfelinid(exposed_mob))
 			return
+		expose_mob.stun(1) //cancels any do_after
 		SEND_SIGNAL(exposed_mob, COMSIG_ADD_MOOD_EVENT, "watersprayed", /datum/mood_event/watersprayed)
 
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -215,7 +215,7 @@
 	if(methods & VAPOR)
 		if(!isfelinid(exposed_mob))
 			return
-		exposed_mob.Incapacitate(1) // startles the felinid, canceling any do_after
+		exposed_mob.incapacitate(1) // startles the felinid, canceling any do_after
 		SEND_SIGNAL(exposed_mob, COMSIG_ADD_MOOD_EVENT, "watersprayed", /datum/mood_event/watersprayed)
 
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -215,7 +215,7 @@
 	if(methods & VAPOR)
 		if(!isfelinid(exposed_mob))
 			return
-		expose_mob.stun(1) //cancels any do_after
+		exposed_mob.stun(1) //cancels any do_after
 		SEND_SIGNAL(exposed_mob, COMSIG_ADD_MOOD_EVENT, "watersprayed", /datum/mood_event/watersprayed)
 
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -212,6 +212,11 @@
 	. = ..()
 	if(methods & TOUCH)
 		exposed_mob.extinguish_mob() // extinguish removes all fire stacks
+	if(methods & VAPOR)
+		if(!isfelinid(exposed_mob))
+			return
+		SEND_SIGNAL(exposed_mob, COMSIG_ADD_MOOD_EVENT, "watersprayed", /datum/mood_event/watersprayed)
+
 
 /datum/reagent/water/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -215,7 +215,7 @@
 	if(methods & VAPOR)
 		if(!isfelinid(exposed_mob))
 			return
-		exposed_mob.Startle(1) //cancels any do_after
+		exposed_mob.Incapacitate(1) //cancels any do_after
 		SEND_SIGNAL(exposed_mob, COMSIG_ADD_MOOD_EVENT, "watersprayed", /datum/mood_event/watersprayed)
 
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -215,7 +215,7 @@
 	if(methods & VAPOR)
 		if(!isfelinid(exposed_mob))
 			return
-		exposed_mob.Stun(1) //cancels any do_after
+		exposed_mob.Startle(1) //cancels any do_after
 		SEND_SIGNAL(exposed_mob, COMSIG_ADD_MOOD_EVENT, "watersprayed", /datum/mood_event/watersprayed)
 
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -215,7 +215,7 @@
 	if(methods & VAPOR)
 		if(!isfelinid(exposed_mob))
 			return
-		exposed_mob.stun(1) //cancels any do_after
+		exposed_mob.Stun(1) //cancels any do_after
 		SEND_SIGNAL(exposed_mob, COMSIG_ADD_MOOD_EVENT, "watersprayed", /datum/mood_event/watersprayed)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# This PR is an ode to @Ryll-Ryll, who inspired me to try and find fun, silly things to PR to try and make people smile.

## About The Pull Request

Felinids now get a SMALL and SHORT mood debuff when getting sprayed with water. The intent of this PR is not to provide content to grief felinid (flashback to the "Felinids hate water" pr), but rather to provide a funny interaction.

Bonus point (Suggested by Ninja) : Getting sprayed with water interrupts do_after. Felinid climbing on your table ? Pssshttt. Straight in the face.

PR with permission from @ninjanomnom 

## Why It's Good For The Game

Light-hearted fun and a bit of flavour to felinids.

## Changelog
:cl:
add: Felinids don't like getting sprayed with water.
code: Adds a new status effect, incapacitated, which causes your do_afters to stop.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
