### PR TITLE
Right-clicking on reagent containers picks previous reagent transfer amount

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -1217,6 +1217,8 @@
 #define COMSIG_ITEM_ATTACK "item_attack"
 ///from base of obj/item/attack_self(): (/mob)
 #define COMSIG_ITEM_ATTACK_SELF "item_attack_self"
+//from base of obj/item/attack_self_secondary(): (/mob)
+#define COMSIG_ITEM_ATTACK_SELF_SECONDARY "item_attack_self_secondary"
 ///from base of obj/item/attack_obj(): (/obj, /mob)
 #define COMSIG_ITEM_ATTACK_OBJ "item_attack_obj"
 ///from base of obj/item/pre_attack(): (atom/target, mob/user, params)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -127,9 +127,14 @@
 	var/obj/item/W = get_active_held_item()
 
 	if(W == A)
-		W.attack_self(src, modifiers)
-		update_inv_hands()
-		return
+		if(LAZYACCESS(modifiers, RIGHT_CLICK))
+			W.attack_self_secondary(src, modifiers)
+			update_inv_hands()
+			return
+		else
+			W.attack_self(src, modifiers)
+			update_inv_hands()
+			return
 
 	//These are always reachable.
 	//User itself, current loc, and user inventory

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -71,7 +71,6 @@
 /obj/item/proc/attack_self_secondary(mob/user, modifiers)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF_SECONDARY, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE
-	interact(user)
 
 /**
  * Called on the item before it hits something

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -68,6 +68,7 @@
 		return TRUE
 	interact(user)
 
+/// Called when the item is in the active hand, and right-clicked. Useful for alternate or opposite functions. At the moment, there is no verb or hotkey.
 /obj/item/proc/attack_self_secondary(mob/user, modifiers)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF_SECONDARY, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -68,7 +68,7 @@
 		return TRUE
 	interact(user)
 
-/// Called when the item is in the active hand, and right-clicked. Useful for alternate or opposite functions. At the moment, there is no verb or hotkey.
+/// Called when the item is in the active hand, and right-clicked. Intended for alternate or opposite functions, such as lowering reagent transfer amount. At the moment, there is no verb or hotkey.
 /obj/item/proc/attack_self_secondary(mob/user, modifiers)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF_SECONDARY, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -68,6 +68,11 @@
 		return TRUE
 	interact(user)
 
+/obj/item/proc/attack_self_secondary(mob/user, modifiers)
+	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SELF_SECONDARY, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
+		return TRUE
+	interact(user)
+
 /**
  * Called on the item before it hits something
  *

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -114,7 +114,8 @@
 	righthand_file = 'icons/mob/inhands/equipment/mister_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	amount_per_transfer_from_this = 50
-	possible_transfer_amounts = list(25,50,100)
+	possible_transfer_amounts = list()
+	can_toggle_range = FALSE
 	volume = 500
 	item_flags = NOBLUDGEON | ABSTRACT  // don't put in storage
 	slot_flags = NONE
@@ -127,9 +128,6 @@
 	if(!istype(tank))
 		return INITIALIZE_HINT_QDEL
 	reagents = tank.reagents //This mister is really just a proxy for the tank's reagents
-
-/obj/item/reagent_containers/spray/mister/attack_self()
-	return
 
 /obj/item/reagent_containers/spray/mister/doMove(atom/destination)
 	if(destination && (destination != tank.loc || !ismob(destination)))
@@ -164,15 +162,13 @@
 	lefthand_file = 'icons/mob/inhands/equipment/mister_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mister_righthand.dmi'
 	amount_per_transfer_from_this = 5
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = list(5,10)
 	current_range = 5
-	spray_range = 5
 
 /obj/item/watertank/janitor/make_noz()
 	return new /obj/item/reagent_containers/spray/mister/janitor(src)
 
-/obj/item/reagent_containers/spray/mister/janitor/attack_self(mob/user)
-	amount_per_transfer_from_this = (amount_per_transfer_from_this == 10 ? 5 : 10)
+/obj/item/reagent_containers/spray/mister/janitor/mode_change_message(mob/user)
 	to_chat(user, "<span class='notice'>You [amount_per_transfer_from_this == 10 ? "remove" : "fix"] the nozzle. You'll now use [amount_per_transfer_from_this] units per spray.</span>")
 
 //ATMOS FIRE FIGHTING BACKPACK

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -114,7 +114,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/mister_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	amount_per_transfer_from_this = 50
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = list(50)
 	can_toggle_range = FALSE
 	volume = 500
 	item_flags = NOBLUDGEON | ABSTRACT  // don't put in storage

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -719,6 +719,13 @@
 /obj/item/reagent_containers/food/drinks/soda_cans/attack_self(mob/user)
 	if(!is_drainable())
 		open_soda(user)
+		return
+	return ..()
+
+/obj/item/reagent_containers/food/drinks/soda_cans/attack_self_secondary(mob/user)
+	if(!is_drainable())
+		open_soda(user)
+		return
 	return ..()
 
 /obj/item/reagent_containers/food/drinks/soda_cans/cola

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -184,7 +184,7 @@
 	throwforce = 1
 	amount_per_transfer_from_this = 5
 	custom_materials = list(/datum/material/iron=100)
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = list(5)
 	volume = 5
 	flags_1 = CONDUCT_1
 	spillable = TRUE
@@ -458,7 +458,7 @@
 	name = "paper cup"
 	desc = "A paper water cup."
 	icon_state = "water_cup_e"
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = list(10)
 	volume = 10
 	spillable = TRUE
 	isGlass = FALSE

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -525,7 +525,7 @@
 	list_reagents = list()
 	var/list/accelerants = list( /datum/reagent/consumable/ethanol, /datum/reagent/fuel, /datum/reagent/clf3, /datum/reagent/phlogiston,
 							/datum/reagent/napalm, /datum/reagent/hellwater, /datum/reagent/toxin/plasma, /datum/reagent/toxin/spore_burning)
-	var/active = 0
+	var/active = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/molotov/CheckParts(list/parts_list)
 	..()
@@ -579,7 +579,9 @@
 			return
 		to_chat(user, "<span class='info'>You snuff out the flame on [src].</span>")
 		cut_overlay(custom_fire_overlay ? custom_fire_overlay : GLOB.fire_overlay)
-		active = 0
+		active = FALSE
+		return
+	return ..()
 
 /obj/item/reagent_containers/food/drinks/bottle/pruno
 	name = "pruno mix"

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -67,7 +67,7 @@
 	base_icon_state = "shotglass"
 	gulp_size = 15
 	amount_per_transfer_from_this = 15
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = list(15)
 	volume = 15
 	custom_materials = list(/datum/material/glass=100)
 	custom_price = PAYCHECK_ASSISTANT * 0.4

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -262,7 +262,7 @@
 	icon_state = "condi_empty"
 	volume = 10
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = list(10)
 	/**
 	  * List of possible styles (list(<icon_state>, <name>, <desc>)) for condiment packs.
 	  * Since all of them differs only in color should probably be replaced with usual reagentfillings instead

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -69,7 +69,7 @@
 					amount_per_transfer_from_this = possible_transfer_amounts[possible_transfer_amounts.len]
 				else
 					amount_per_transfer_from_this = possible_transfer_amounts[i-1]
-				balloon_alert(user, "Transferring [amount_per_transfer_from_this]u")
+				balloon_alert(user, "transferring [amount_per_transfer_from_this]u")
 				return TRUE
 
 /obj/item/reagent_containers/pre_attack_secondary(atom/target, mob/living/user, params)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -6,6 +6,8 @@
 	w_class = WEIGHT_CLASS_TINY
 	var/amount_per_transfer_from_this = 5
 	var/list/possible_transfer_amounts = list(5,10,15,20,25,30)
+	/// Where we are in the possible transfer amount list.
+	var/amount_list_position = 1
 	var/volume = 30
 	var/reagent_flags
 	var/list/list_reagents = null
@@ -14,7 +16,6 @@
 	var/spillable = FALSE
 	var/list/fill_icon_thresholds = null
 	var/fill_icon_state = null // Optional custom name for reagent fill icon_state prefix
-	var/mode_change_message = ""
 
 /obj/item/reagent_containers/Initialize(mapload, vol)
 	. = ..()
@@ -31,7 +32,9 @@
 /obj/item/reagent_containers/examine()
 	. = ..()
 	if(possible_transfer_amounts.len > 1)
-		. += "<span class='notice'>Left-click to increase or right-click to decrease its transfer amount in-hand.</span>"
+		. += "<span class='notice'>Left-click or right-click in-hand to increase or decrease its transfer amount.</span>"
+	else if(possible_transfer_amounts.len)
+		. += "<span class='notice'>Left-click or right-click in-hand to view its transfer amount.</span>"
 
 /obj/item/reagent_containers/create_reagents(max_vol, flags)
 	. = ..()
@@ -67,12 +70,12 @@
 		return
 	switch(direction)
 		if(FORWARD)
-			list_position = (list_position % list_len) + 1
+			amount_list_position = (amount_list_position % list_len) + 1
 		if(BACKWARD)
-			list_position = (list_position - 1) || list_len
+			amount_list_position = (amount_list_position - 1) || list_len
 		else
 			CRASH("change_transfer_amount() called with invalid direction value")
-	amount_per_transfer_from_this = possible_transfer_amounts[list_position]
+	amount_per_transfer_from_this = possible_transfer_amounts[amount_list_position]
 	balloon_alert(user, "transferring [amount_per_transfer_from_this]u")
 	mode_change_message(user)
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -59,6 +59,19 @@
 				balloon_alert(user, "Transferring [amount_per_transfer_from_this]u")
 				return
 
+/obj/item/reagent_containers/attack_self_secondary(mob/user)
+	if(possible_transfer_amounts.len)
+		var/i=0
+		for(var/A in possible_transfer_amounts)
+			i++
+			if(A == amount_per_transfer_from_this)
+				if(i==1)
+					amount_per_transfer_from_this = possible_transfer_amounts[possible_transfer_amounts.len]
+				else
+					amount_per_transfer_from_this = possible_transfer_amounts[i-1]
+				balloon_alert(user, "Transferring [amount_per_transfer_from_this]u")
+				return TRUE
+
 /obj/item/reagent_containers/pre_attack_secondary(atom/target, mob/living/user, params)
 	if(HAS_TRAIT(target, DO_NOT_SPLASH))
 		return ..()

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -62,16 +62,16 @@
 /obj/item/reagent_containers/attack_self_secondary(mob/user)
 	if(!possible_transfer_amounts.len)
 	    return
-var/i=0
-for(var/A in possible_transfer_amounts)
-	i++
-	if(A == amount_per_transfer_from_this)
-		if(i==1)
-			amount_per_transfer_from_this = possible_transfer_amounts[possible_transfer_amounts.len]
-		else
-			amount_per_transfer_from_this = possible_transfer_amounts[i-1]
-		balloon_alert(user, "transferring [amount_per_transfer_from_this]u")
-		return TRUE
+  var/i=0
+  for(var/A in possible_transfer_amounts)
+	  i++
+	  if(A == amount_per_transfer_from_this)
+		  if(i==1)
+			  amount_per_transfer_from_this = possible_transfer_amounts[possible_transfer_amounts.len]
+		  else
+			  amount_per_transfer_from_this = possible_transfer_amounts[i-1]
+		  balloon_alert(user, "transferring [amount_per_transfer_from_this]u")
+		  return TRUE
 
 /obj/item/reagent_containers/pre_attack_secondary(atom/target, mob/living/user, params)
 	if(HAS_TRAIT(target, DO_NOT_SPLASH))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -60,17 +60,18 @@
 				return
 
 /obj/item/reagent_containers/attack_self_secondary(mob/user)
-	if(possible_transfer_amounts.len)
-		var/i=0
-		for(var/A in possible_transfer_amounts)
-			i++
-			if(A == amount_per_transfer_from_this)
-				if(i==1)
-					amount_per_transfer_from_this = possible_transfer_amounts[possible_transfer_amounts.len]
-				else
-					amount_per_transfer_from_this = possible_transfer_amounts[i-1]
-				balloon_alert(user, "transferring [amount_per_transfer_from_this]u")
-				return TRUE
+	if(!possible_transfer_amounts.len)
+	    return
+var/i=0
+for(var/A in possible_transfer_amounts)
+	i++
+	if(A == amount_per_transfer_from_this)
+		if(i==1)
+			amount_per_transfer_from_this = possible_transfer_amounts[possible_transfer_amounts.len]
+		else
+			amount_per_transfer_from_this = possible_transfer_amounts[i-1]
+		balloon_alert(user, "transferring [amount_per_transfer_from_this]u")
+		return TRUE
 
 /obj/item/reagent_containers/pre_attack_secondary(atom/target, mob/living/user, params)
 	if(HAS_TRAIT(target, DO_NOT_SPLASH))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -61,27 +61,20 @@
 /obj/item/reagent_containers/proc/mode_change_message(mob/user)
 	return
 
-/obj/item/reagent_containers/proc/change_transfer_amount(mob/user, direction)
-	if(!possible_transfer_amounts.len)
+/obj/item/reagent_containers/proc/change_transfer_amount(mob/user, direction = FORWARD)
+	var/list_len = length(possible_transfer_amounts)
+	if(!list_len)
 		return
-	var/list_position = 0
-	for(var/transfer_amount in possible_transfer_amounts)
-		list_position++
-		if(transfer_amount == amount_per_transfer_from_this)
-			switch(direction)
-				if(FORWARD)
-					if(list_position < possible_transfer_amounts.len) //not at end
-						amount_per_transfer_from_this = possible_transfer_amounts[list_position + 1] //move to next entry
-					else
-						amount_per_transfer_from_this = possible_transfer_amounts[1] //move to list start
-				if(BACKWARD)
-					if(list_position == 1) //at list start
-						amount_per_transfer_from_this = possible_transfer_amounts[possible_transfer_amounts.len] //move to list end
-					else
-						amount_per_transfer_from_this = possible_transfer_amounts[list_position - 1] //move to previous entry
-			balloon_alert(user, "transferring [amount_per_transfer_from_this]u")
-			mode_change_message(user)
-			return
+	switch(direction)
+		if(FORWARD)
+			list_position = (list_position % list_len) + 1
+		if(BACKWARD)
+			list_position = (list_position - 1) || list_len
+		else
+			CRASH("change_transfer_amount() called with invalid direction value")
+	amount_per_transfer_from_this = possible_transfer_amounts[list_position]
+	balloon_alert(user, "transferring [amount_per_transfer_from_this]u")
+	mode_change_message(user)
 
 /obj/item/reagent_containers/pre_attack_secondary(atom/target, mob/living/user, params)
 	if(HAS_TRAIT(target, DO_NOT_SPLASH))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -27,6 +27,11 @@
 
 	add_initial_reagents()
 
+/obj/item/reagent_containers/examine()
+	. = ..()
+	if(possible_transfer_amounts.len > 1)
+		. += "<span class='notice'>Left-click to increase or right-click to decrease its transfer amount in-hand.</span>"
+
 /obj/item/reagent_containers/create_reagents(max_vol, flags)
 	. = ..()
 	RegisterSignal(reagents, list(COMSIG_REAGENTS_NEW_REAGENT, COMSIG_REAGENTS_ADD_REAGENT, COMSIG_REAGENTS_DEL_REAGENT, COMSIG_REAGENTS_REM_REAGENT), .proc/on_reagent_change)
@@ -47,31 +52,32 @@
 		reagents.add_reagent_list(list_reagents)
 
 /obj/item/reagent_containers/attack_self(mob/user)
-	if(possible_transfer_amounts.len)
-		var/i=0
-		for(var/A in possible_transfer_amounts)
-			i++
-			if(A == amount_per_transfer_from_this)
-				if(i<possible_transfer_amounts.len)
-					amount_per_transfer_from_this = possible_transfer_amounts[i+1]
-				else
-					amount_per_transfer_from_this = possible_transfer_amounts[1]
-				balloon_alert(user, "Transferring [amount_per_transfer_from_this]u")
-				return
+	if(!possible_transfer_amounts.len)
+		return
+	var/iteration=0
+	for(var/transfer_amount in possible_transfer_amounts)
+		iteration++
+		if(transfer_amount == amount_per_transfer_from_this)
+			if(iteration<possible_transfer_amounts.len)
+				amount_per_transfer_from_this = possible_transfer_amounts[iteration+1]
+			else
+				amount_per_transfer_from_this = possible_transfer_amounts[1]
+			balloon_alert(user, "transferring [amount_per_transfer_from_this]u")
+			return
 
 /obj/item/reagent_containers/attack_self_secondary(mob/user)
 	if(!possible_transfer_amounts.len)
-	    return
-  var/i=0
-  for(var/A in possible_transfer_amounts)
-	  i++
-	  if(A == amount_per_transfer_from_this)
-		  if(i==1)
-			  amount_per_transfer_from_this = possible_transfer_amounts[possible_transfer_amounts.len]
-		  else
-			  amount_per_transfer_from_this = possible_transfer_amounts[i-1]
-		  balloon_alert(user, "transferring [amount_per_transfer_from_this]u")
-		  return TRUE
+		return
+	var/iteration=0
+	for(var/transfer_amount in possible_transfer_amounts)
+		iteration++
+		if(transfer_amount == amount_per_transfer_from_this)
+			if(iteration==1)
+				amount_per_transfer_from_this = possible_transfer_amounts[possible_transfer_amounts.len]
+			else
+				amount_per_transfer_from_this = possible_transfer_amounts[iteration-1]
+			balloon_alert(user, "transferring [amount_per_transfer_from_this]u")
+			return TRUE
 
 /obj/item/reagent_containers/pre_attack_secondary(atom/target, mob/living/user, params)
 	if(HAS_TRAIT(target, DO_NOT_SPLASH))

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -19,7 +19,7 @@ Borg Hypospray
 	icon_state = "borghypo"
 	amount_per_transfer_from_this = 5
 	volume = 30
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = list(5)
 	var/mode = 1
 	var/charge_cost = 50
 	var/charge_timer = 0

--- a/code/modules/reagents/reagent_containers/chem_pack.dm
+++ b/code/modules/reagents/reagent_containers/chem_pack.dm
@@ -10,6 +10,7 @@
 	resistance_flags = ACID_PROOF
 	var/sealed = FALSE
 	fill_icon_thresholds = list(10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
+	possible_transfer_amounts = list()
 
 /obj/item/reagent_containers/chem_pack/AltClick(mob/living/user)
 	if(user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY) && !sealed)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -10,7 +10,7 @@
 	worn_icon_state = "hypo"
 	amount_per_transfer_from_this = 5
 	volume = 30
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = list(5)
 	resistance_flags = ACID_PROOF
 	reagent_flags = OPENCONTAINER
 	slot_flags = ITEM_SLOT_BELT

--- a/code/modules/reagents/reagent_containers/maunamug.dm
+++ b/code/modules/reagents/reagent_containers/maunamug.dm
@@ -24,6 +24,8 @@
 	. += "<span class='notice'>The status display reads: Current temperature: <b>[reagents.chem_temp]K</b> Current Charge:[cell ? "[cell.charge / cell.maxcharge * 100]%" : "No cell found"].</span>"
 	if(open)
 		. += "<span class='notice'>The battery case is open.</span>"
+	if(cell && cell.charge > 0)
+		. += "<span class='notice'><b>Ctrl+Click</b> to toggle the power.</span>"
 
 /obj/item/reagent_containers/glass/maunamug/process(delta_time)
 	..()
@@ -48,8 +50,7 @@
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 
-
-/obj/item/reagent_containers/glass/maunamug/attack_self(mob/user)
+/obj/item/reagent_containers/glass/maunamug/CtrlClick(mob/living/user)
 	if(on)
 		change_power_status(FALSE)
 	else

--- a/code/modules/reagents/reagent_containers/medigel.dm
+++ b/code/modules/reagents/reagent_containers/medigel.dm
@@ -16,13 +16,13 @@
 	throw_speed = 3
 	throw_range = 7
 	amount_per_transfer_from_this = 10
+	possible_transfer_amounts = list(5,10)
 	volume = 60
 	var/can_fill_from_container = TRUE
 	var/apply_type = PATCH
 	var/apply_method = "spray" //the thick gel is sprayed and then dries into patch like film.
 	var/self_delay = 30
 	var/squirt_mode = 0
-	var/squirt_amount = 5
 	custom_price = PAYCHECK_MEDIUM * 2
 	unique_reskin = list(
 		"Blue" = "medigel_blue",
@@ -35,10 +35,13 @@
 
 /obj/item/reagent_containers/medigel/attack_self(mob/user)
 	squirt_mode = !squirt_mode
-	if(squirt_mode)
-		amount_per_transfer_from_this = squirt_amount
-	else
-		amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
+	return ..()
+
+/obj/item/reagent_containers/medigel/attack_self_secondary(mob/user)
+	squirt_mode = !squirt_mode
+	return ..()
+
+/obj/item/reagent_containers/medigel/mode_change_message(mob/user)
 	to_chat(user, "<span class='notice'>You will now apply the medigel's contents in [squirt_mode ? "short bursts":"extended sprays"]. You'll now use [amount_per_transfer_from_this] units per use.</span>")
 
 /obj/item/reagent_containers/medigel/attack(mob/M, mob/user, def_zone)

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -23,11 +23,6 @@
 	if(reagents.total_volume && rename_with_volume)
 		name += " ([reagents.total_volume]u)"
 
-
-/obj/item/reagent_containers/pill/attack_self(mob/user)
-	return
-
-
 /obj/item/reagent_containers/pill/attack(mob/M, mob/user, def_zone)
 	if(!canconsume(M, user))
 		return FALSE

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -273,7 +273,7 @@
 	icon_state = "sunflower"
 	inhand_icon_state = "sunflower"
 	amount_per_transfer_from_this = 1
-	possible_transfer_amounts = list()
+	possible_transfer_amounts = list(1)
 	can_toggle_range = FALSE
 	current_range = 1
 	volume = 10

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -14,12 +14,13 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 3
 	throw_range = 7
-	var/can_switch_mode = TRUE
 	var/stream_mode = FALSE //whether we use the more focused mode
 	var/current_range = 3 //the range of tiles the sprayer will reach.
 	var/spray_range = 3 //the range of tiles the sprayer will reach when in spray mode.
 	var/stream_range = 1 //the range of tiles the sprayer will reach when in stream mode.
 	var/can_fill_from_container = TRUE
+	/// Are we able to toggle between stream and spray modes, which change the distance and amount sprayed?
+	var/can_toggle_range = TRUE
 	amount_per_transfer_from_this = 5
 	volume = 250
 	possible_transfer_amounts = list(5,10)
@@ -133,18 +134,14 @@
 
 /obj/item/reagent_containers/spray/attack_self(mob/user)
 	..()
-	if(!can_switch_mode)
-		return
-	stream_mode = !stream_mode
-	if(stream_mode)
-		current_range = stream_range
-	else
-		current_range = spray_range
-	to_chat(user, "<span class='notice'>You switch the nozzle setting to [stream_mode ? "\"stream\"":"\"spray\""].</span>")
+	toggle_stream_mode(user)
 
 /obj/item/reagent_containers/spray/attack_self_secondary(mob/user)
 	..()
-	if(!can_switch_mode)
+	toggle_stream_mode(user)
+
+/obj/item/reagent_containers/spray/proc/toggle_stream_mode(mob/user)
+	if(stream_range == spray_range || !stream_range || !spray_range || possible_transfer_amounts.len > 2 || !can_toggle_range)
 		return
 	stream_mode = !stream_mode
 	if(stream_mode)
@@ -276,10 +273,11 @@
 	icon_state = "sunflower"
 	inhand_icon_state = "sunflower"
 	amount_per_transfer_from_this = 1
-	possible_transfer_amounts = list(1)
+	possible_transfer_amounts = list()
+	can_toggle_range = FALSE
+	current_range = 1
 	volume = 10
 	list_reagents = list(/datum/reagent/water = 10)
-	can_switch_mode = FALSE
 
 ///Subtype used for the lavaland clown ruin.
 /obj/item/reagent_containers/spray/waterflower/superlube

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -133,11 +133,11 @@
 	qdel(reagent_puff)
 
 /obj/item/reagent_containers/spray/attack_self(mob/user)
-	..()
+	. = ..()
 	toggle_stream_mode(user)
 
 /obj/item/reagent_containers/spray/attack_self_secondary(mob/user)
-	..()
+	. = ..()
 	toggle_stream_mode(user)
 
 /obj/item/reagent_containers/spray/proc/toggle_stream_mode(mob/user)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -14,15 +14,15 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 3
 	throw_range = 7
-	var/stream_mode = 0 //whether we use the more focused mode
+	var/can_switch_mode = TRUE
+	var/stream_mode = FALSE //whether we use the more focused mode
 	var/current_range = 3 //the range of tiles the sprayer will reach.
 	var/spray_range = 3 //the range of tiles the sprayer will reach when in spray mode.
 	var/stream_range = 1 //the range of tiles the sprayer will reach when in stream mode.
-	var/stream_amount = 10 //the amount of reagents transfered when in stream mode.
 	var/can_fill_from_container = TRUE
 	amount_per_transfer_from_this = 5
 	volume = 250
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100)
+	possible_transfer_amounts = list(5,10)
 
 /obj/item/reagent_containers/spray/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
@@ -132,14 +132,26 @@
 	qdel(reagent_puff)
 
 /obj/item/reagent_containers/spray/attack_self(mob/user)
+	..()
+	if(!can_switch_mode)
+		return
 	stream_mode = !stream_mode
 	if(stream_mode)
-		amount_per_transfer_from_this = stream_amount
 		current_range = stream_range
 	else
-		amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
 		current_range = spray_range
-	to_chat(user, "<span class='notice'>You switch the nozzle setting to [stream_mode ? "\"stream\"":"\"spray\""]. You'll now use [amount_per_transfer_from_this] units per use.</span>")
+	to_chat(user, "<span class='notice'>You switch the nozzle setting to [stream_mode ? "\"stream\"":"\"spray\""].</span>")
+
+/obj/item/reagent_containers/spray/attack_self_secondary(mob/user)
+	..()
+	if(!can_switch_mode)
+		return
+	stream_mode = !stream_mode
+	if(stream_mode)
+		current_range = stream_range
+	else
+		current_range = spray_range
+	to_chat(user, "<span class='notice'>You switch the nozzle setting to [stream_mode ? "\"stream\"":"\"spray\""].</span>")
 
 /obj/item/reagent_containers/spray/attackby(obj/item/I, mob/user, params)
 	var/hotness = I.get_temperature()
@@ -205,7 +217,7 @@
 	volume = 100
 	list_reagents = list(/datum/reagent/space_cleaner = 100)
 	amount_per_transfer_from_this = 2
-	stream_amount = 5
+	possible_transfer_amounts = list(2,5)
 
 /obj/item/reagent_containers/spray/cleaner/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is putting the nozzle of \the [src] in [user.p_their()] mouth. It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -264,11 +276,10 @@
 	icon_state = "sunflower"
 	inhand_icon_state = "sunflower"
 	amount_per_transfer_from_this = 1
+	possible_transfer_amounts = list(1)
 	volume = 10
 	list_reagents = list(/datum/reagent/water = 10)
-
-/obj/item/reagent_containers/spray/waterflower/attack_self(mob/user) //Don't allow changing how much the flower sprays
-	return
+	can_switch_mode = FALSE
 
 ///Subtype used for the lavaland clown ruin.
 /obj/item/reagent_containers/spray/waterflower/superlube


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reopening #59351

- Right-clicking a reagent container in your active hand will pick the previous transfer amount instead of the next one
- Adds an attack_self_secondary proc which allows for different interactions when right-clicking things in your active hand

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Should solve the tedium of picking reagent transfer amounts. You don't have to click as many times to pick the amount you want and if you overshoot you don't have to go through the entire list again.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
qol: Right-clicking a reagent container in your active hand will pick the previous transfer amount instead of the next
code: Mauna mug uses ctrl+click instead of attack_self() to toggle power
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
