### PR TITLE
Removes the space jam ambience from the AI sat core area

### DIFF
--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -120,7 +120,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/ai_monitored/turret_protected/ai
 	name = "AI Chamber"
 	icon_state = "ai_chamber"
-	ai_will_not_hear_this = list()
+	ai_will_not_hear_this = null
 
 /area/ai_monitored/turret_protected/aisat
 	name = "AI Satellite"

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -99,7 +99,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/ai_monitored/turret_protected
 	ambientsounds = list('sound/ambience/ambitech.ogg', 'sound/ambience/ambitech2.ogg', 'sound/ambience/ambiatmos.ogg', 'sound/ambience/ambiatmos2.ogg')
-	var/ai_will_not_hear_this = list('sound/ambience/ambimalf.ogg') //This sound is terrible when you hear it constantly, so isolate it from the core's sound pool.
+	///Some sounds (like the space jam) are terrible when on loop. We use this varaible to add it to other AI areas, but override it to keep it from the AI's core.
+	var/ai_will_not_hear_this = list('sound/ambience/ambimalf.ogg')
 	airlock_wires = /datum/wires/airlock/ai
 
 /area/ai_monitored/turret_protected/Initialize()

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -112,9 +112,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/ai_monitored/turret_protected/ai
-	ambientsounds = list('sound/ambience/ambitech.ogg', 'sound/ambience/ambitech2.ogg', 'sound/ambience/ambiatmos.ogg', 'sound/ambience/ambiatmos2.ogg')
 	name = "AI Chamber"
 	icon_state = "ai_chamber"
+
+/area/ai_monitored/turret_protected/ai/Initialize()
+	ambientsounds -= 'sound/ambience/ambimalf.ogg' //This sound is terrible when you hear it constantly, so remove it from the core's sound pool.
 
 /area/ai_monitored/turret_protected/aisat
 	name = "AI Satellite"

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -112,6 +112,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 
 /area/ai_monitored/turret_protected/ai
+	ambientsounds = list('sound/ambience/ambitech.ogg', 'sound/ambience/ambitech2.ogg', 'sound/ambience/ambiatmos.ogg', 'sound/ambience/ambiatmos2.ogg')
 	name = "AI Chamber"
 	icon_state = "ai_chamber"
 

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -98,8 +98,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //AI - Turret_protected
 
 /area/ai_monitored/turret_protected
-	ambientsounds = list('sound/ambience/ambimalf.ogg', 'sound/ambience/ambitech.ogg', 'sound/ambience/ambitech2.ogg', 'sound/ambience/ambiatmos.ogg', 'sound/ambience/ambiatmos2.ogg')
+	ambientsounds = list('sound/ambience/ambitech.ogg', 'sound/ambience/ambitech2.ogg', 'sound/ambience/ambiatmos.ogg', 'sound/ambience/ambiatmos2.ogg')
+	var/ai_will_not_hear_this = list('sound/ambience/ambimalf.ogg') //This sound is terrible when you hear it constantly, so isolate it from the core's sound pool.
 	airlock_wires = /datum/wires/airlock/ai
+
+/area/ai_monitored/turret_protected/Initialize()
+	ambientsounds += ai_will_not_hear_this
 
 /area/ai_monitored/turret_protected/ai_upload
 	name = "AI Upload Chamber"
@@ -114,10 +118,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/ai_monitored/turret_protected/ai
 	name = "AI Chamber"
 	icon_state = "ai_chamber"
-
-/area/ai_monitored/turret_protected/ai/Initialize()
-	. = ..()
-	ambientsounds -= 'sound/ambience/ambimalf.ogg' //This sound is terrible when you hear it constantly, so remove it from the core's sound pool.
+	ai_will_not_hear_this = list()
 
 /area/ai_monitored/turret_protected/aisat
 	name = "AI Satellite"

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -103,7 +103,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	airlock_wires = /datum/wires/airlock/ai
 
 /area/ai_monitored/turret_protected/Initialize()
-	ambientsounds += ai_will_not_hear_this
+	. = ..()
+	if(ai_will_not_hear_this)
+		ambientsounds += ai_will_not_hear_this
 
 /area/ai_monitored/turret_protected/ai_upload
 	name = "AI Upload Chamber"

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -116,6 +116,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "ai_chamber"
 
 /area/ai_monitored/turret_protected/ai/Initialize()
+	. = ..()
 	ambientsounds -= 'sound/ambience/ambimalf.ogg' //This sound is terrible when you hear it constantly, so remove it from the core's sound pool.
 
 /area/ai_monitored/turret_protected/aisat


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the 'sound/ambience/ambimalf.ogg' file from playing inside the AI's core. The rest of the AI areas (including the rest of the satellite) can still play the sound.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I'm so sick of this playing constantly like holy shit.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
sounddel: The space-jam ambient sound will no longer play inside the AI's core.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
