### PR TITLE
Rename component

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -120,8 +120,6 @@
 	#define COMSIG_ATOM_NO_UPDATE_ICON_STATE UPDATE_ICON_STATE
 	/// If returned from [COMSIG_ATOM_UPDATE_ICON] it prevents the atom from updating its overlays.
 	#define COMSIG_ATOM_NO_UPDATE_OVERLAYS UPDATE_OVERLAYS
-///from /obj/item/pen/afterattack(obj/O, mob/living/user, proximity)
-#define COMSIG_ATOM_RESET_PLAYER_RENAME "atom_reset_player_rename"
 ///from base of [atom/update_icon_state]: ()
 #define COMSIG_ATOM_UPDATE_ICON_STATE "atom_update_icon_state"
 ///from base of [/atom/update_overlays]: (list/new_overlays)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -120,6 +120,8 @@
 	#define COMSIG_ATOM_NO_UPDATE_ICON_STATE UPDATE_ICON_STATE
 	/// If returned from [COMSIG_ATOM_UPDATE_ICON] it prevents the atom from updating its overlays.
 	#define COMSIG_ATOM_NO_UPDATE_OVERLAYS UPDATE_OVERLAYS
+///from /obj/item/pen/afterattack(obj/O, mob/living/user, proximity)
+#define COMSIG_ATOM_RESET_PLAYER_RENAME "atom_reset_player_rename"
 ///from base of [atom/update_icon_state]: ()
 #define COMSIG_ATOM_UPDATE_ICON_STATE "atom_update_icon_state"
 ///from base of [/atom/update_overlays]: (list/new_overlays)

--- a/code/datums/components/rename.dm
+++ b/code/datums/components/rename.dm
@@ -1,0 +1,71 @@
+/**
+	The rename component.
+
+	This component is used to manage names and descriptions changed with the pen.
+
+	Atoms can only have one instance of this component at a time.
+
+	When a player renames or changes the description of an atom with a pen, this component gets applied to it.
+	If a player resets the name and description, it will be reverted to its state before renaming and the component will be removed.
+ */
+/datum/component/rename
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	///The name the player is applying to the parent.
+	var/custom_name
+	///The desc the player is applying to the parent.
+	var/custom_desc
+	///The name before the player changed it.
+	var/original_name
+	///The desc before the player changed it.
+	var/original_desc
+
+/datum/component/rename/Initialize(_custom_name, _custom_desc)
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	custom_name = _custom_name
+	custom_desc = _custom_desc
+	apply_rename()
+
+/datum/component/rename/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_ATOM_RESET_PLAYER_RENAME, .proc/remove_component)
+
+/datum/component/rename/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_ATOM_RESET_PLAYER_RENAME)
+
+/**
+	This proc will fire after the parent's name or desc is changed with a pen, which is trying to apply another rename component.
+	Since the parent already has a rename component, it will remove the old one and apply the new one.
+	The name and description changes will be merged or overwritten.
+*/
+/datum/component/rename/InheritComponent(datum/component/rename/new_comp , i_am_original, _custom_name, _custom_desc)
+	revert_rename()
+	if(new_comp)
+		custom_name = new_comp.custom_name
+		custom_desc = new_comp.custom_desc
+	else
+		custom_name = _custom_name
+		custom_desc = _custom_desc
+	apply_rename()
+
+///Saves the current name and description before changing them to the player's inputs.
+/datum/component/rename/proc/apply_rename()
+	var/atom/owner = parent
+	original_name = owner.name
+	original_desc = owner.desc
+	owner.name = custom_name
+	owner.desc = custom_desc
+
+///Reverts the name and description to the state before they were changed.
+/datum/component/rename/proc/revert_rename()
+	var/atom/owner = parent
+	owner.name = original_name
+	owner.desc = original_desc
+
+/datum/component/rename/proc/remove_component()
+	revert_rename()
+	qdel(src)
+
+/datum/component/rename/Destroy()
+	revert_rename()
+	return ..()

--- a/code/datums/components/rename.dm
+++ b/code/datums/components/rename.dm
@@ -19,33 +19,27 @@
 	///The desc before the player changed it.
 	var/original_desc
 
-/datum/component/rename/Initialize(_custom_name, _custom_desc)
+/datum/component/rename/Initialize(custom_name, custom_desc)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
-	custom_name = _custom_name
-	custom_desc = _custom_desc
+	src.custom_name = custom_name
+	src.custom_desc = custom_desc
 	apply_rename()
-
-/datum/component/rename/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_ATOM_RESET_PLAYER_RENAME, .proc/remove_component)
-
-/datum/component/rename/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_ATOM_RESET_PLAYER_RENAME)
 
 /**
 	This proc will fire after the parent's name or desc is changed with a pen, which is trying to apply another rename component.
 	Since the parent already has a rename component, it will remove the old one and apply the new one.
 	The name and description changes will be merged or overwritten.
 */
-/datum/component/rename/InheritComponent(datum/component/rename/new_comp , i_am_original, _custom_name, _custom_desc)
+/datum/component/rename/InheritComponent(datum/component/rename/new_comp , i_am_original, custom_name, custom_desc)
 	revert_rename()
 	if(new_comp)
-		custom_name = new_comp.custom_name
-		custom_desc = new_comp.custom_desc
+		src.custom_name = new_comp.custom_name
+		src.custom_desc = new_comp.custom_desc
 	else
-		custom_name = _custom_name
-		custom_desc = _custom_desc
+		src.custom_name = custom_name
+		src.custom_desc = custom_desc
 	apply_rename()
 
 ///Saves the current name and description before changing them to the player's inputs.

--- a/code/datums/components/rename.dm
+++ b/code/datums/components/rename.dm
@@ -6,7 +6,7 @@
 	Atoms can only have one instance of this component at a time.
 
 	When a player renames or changes the description of an atom with a pen, this component gets applied to it.
-	If a player resets the name and description, it will be reverted to its state before renaming and the component will be removed.
+	If a player resets the name and description, they will be reverted to their state before being changed and the component will be removed.
  */
 /datum/component/rename
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -150,10 +150,10 @@
 			var/oldname = O.name
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
-			if(oldname == input || input == "")
+			if(input == oldname || !input)
 				to_chat(user, "<span class='notice'>You changed [O] to... well... [O].</span>")
 			else
-				O.name = input
+				O.AddComponent(/datum/component/rename, input, O.desc)
 				var/datum/component/label/label = O.GetComponent(/datum/component/label)
 				if(label)
 					label.remove_label()
@@ -166,18 +166,18 @@
 			var/olddesc = O.desc
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
-			if(olddesc == input || input == "")
+			if(input == olddesc || !input)
 				to_chat(user, "<span class='notice'>You decide against changing [O]'s description.</span>")
 			else
-				O.desc = input
+				O.AddComponent(/datum/component/rename, O.name, input)
 				to_chat(user, "<span class='notice'>You have successfully changed [O]'s description.</span>")
 				O.renamedByPlayer = TRUE
 
 		if(penchoice == "Reset")
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
-			O.desc = initial(O.desc)
-			O.name = initial(O.name)
+
+			SEND_SIGNAL(O, COMSIG_ATOM_RESET_PLAYER_RENAME)
 			var/datum/component/label/label = O.GetComponent(/datum/component/label)
 			if(label)
 				label.remove_label()

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -177,11 +177,14 @@
 			if(QDELETED(O) || !user.canUseTopic(O, BE_CLOSE))
 				return
 
-			SEND_SIGNAL(O, COMSIG_ATOM_RESET_PLAYER_RENAME)
+			qdel(O.GetComponent(/datum/component/rename))
+
+			//reapply any label to name
 			var/datum/component/label/label = O.GetComponent(/datum/component/label)
 			if(label)
 				label.remove_label()
 				label.apply_label()
+
 			to_chat(user, "<span class='notice'>You have successfully reset [O]'s name and description.</span>")
 			O.renamedByPlayer = FALSE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -542,6 +542,7 @@
 #include "code\datums\components\radioactive.dm"
 #include "code\datums\components\religious_tool.dm"
 #include "code\datums\components\remote_materials.dm"
+#include "code\datums\components\rename.dm"
 #include "code\datums\components\rot.dm"
 #include "code\datums\components\rotation.dm"
 #include "code\datums\components\shell.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a component to manage player changes to object names and descriptions.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Object names and descriptions revert to what they were before being changed, instead of using initial(). Sometimes the initial name or description is not one that should be seen by players (such as in the case of player-carved statues).

Admins can delete the component from an object to quickly revert its name and description if needed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
code: Resetting an object's name and description with a pen will return them to what they were before being changed, instead of their initial values
fix: Resetting a sculpture's description will no longer result in a description telling you to yell at Firecage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
