### PR TITLE
Revert "Fixes Coniine making you suffocate forever"

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -842,8 +842,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/toxin/coniine/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	if(M.losebreath < 5)
-		M.losebreath = min(M.losebreath + 5 * REM * delta_time, 5)
+	M.losebreath += 5 * REM * delta_time
 	return ..()
 
 /datum/reagent/toxin/spewium


### PR DESCRIPTION
Reverts tgstation/tgstation#59455

This actually was the intended behavior, I checked the Goon chemistry wiki that I added Coniine from. Coniine adds +5 LOSEBREATH a tick. This is consistent with 2016 goonstation code as well.

https://github.com/goonstation/goonstation-2016/blob/9a588eff75c22720ec6bd00852441498724932a7/code/datums/chemistry/Reagents-PoisonEtc.dm#L214

