### PR TITLE
lmao we played ambient sounds every 30 seconds for areas

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -86,9 +86,9 @@
 	var/sound_environment = SOUND_ENVIRONMENT_NONE
 
 	///Used to decide what the minimum time between ambience is
-	var/min_ambience_cooldown = 30 SECONDS
+	var/min_ambience_cooldown = 2 MINUTES
 	///Used to decide what the maximum time between ambience is
-	var/max_ambience_cooldown = 90 SECONDS
+	var/max_ambience_cooldown = 5 MINUTES
 
 /**
  * A list of teleport locations


### PR DESCRIPTION
Fixes #59509

## About The Pull Request

Ups the ambient sound cooldown from *30 seconds* up to like between 2 to 5 minutes.

## Why It's Good For The Game

AI players were feeling malf after the fifth time they heard EVERYBODY GET UP IT'S TIME TO SLAM NOW in the last 3 minutes.

## Changelog
:cl:
fix: Fixes Space Jam spam for the AI.
/:cl:
