### PR TITLE
When a midround ghost event doesn't get any applicants, a sleeper agent/syndicate infiltrator will roll in its place

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -166,7 +166,7 @@
 	var/datum/dynamic_ruleset/midround/autotraitor/sleeper_agent = new
 
 	// Otherwise, it has a chance to fail. We don't want that, since this is already pretty unlikely.
-	sleeper_agent.randomly_acceptable = FALSE
+	sleeper_agent.has_failure_chance = FALSE
 
 	mode.configure_ruleset(sleeper_agent)
 
@@ -195,7 +195,7 @@
 
 	/// Whether or not this instance of sleeper agent should be randomly acceptable.
 	/// If TRUE, then this has a threat level% chance to succeed.
-	var/randomly_acceptable = TRUE
+	var/has_failure_chance = TRUE
 
 /datum/dynamic_ruleset/midround/autotraitor/acceptable(population = 0, threat = 0)
 	var/player_count = GLOB.alive_player_list.len
@@ -208,7 +208,7 @@
 		log_game("DYNAMIC: Too many living antags compared to living players ([antag_count] living antags, [player_count] living players, [max_traitors] max traitors)")
 		return FALSE
 
-	if (randomly_acceptable && !prob(mode.threat_level))
+	if (has_failure_chance && !prob(mode.threat_level))
 		log_game("DYNAMIC: Random chance to roll autotraitor failed, it was a [mode.threat_level]% chance.")
 		return FALSE
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -107,9 +107,9 @@
 	candidates = pollGhostCandidates("The mode is looking for volunteers to become [antag_flag] for [name]", antag_flag, antag_flag_override ? antag_flag_override : antag_flag, poll_time = 300)
 
 	if(!candidates || candidates.len <= 0)
-		message_admins("The ruleset [name] received no applications.")
-		log_game("DYNAMIC: The ruleset [name] received no applications.")
+		mode.dynamic_log("The ruleset [name] received no applications.")
 		mode.executed_rules -= src
+		attempt_replacement()
 		return
 
 	message_admins("[candidates.len] players volunteered for the ruleset [name].")
@@ -161,6 +161,20 @@
 /datum/dynamic_ruleset/midround/from_ghosts/proc/setup_role(datum/antagonist/new_role)
 	return
 
+/// Fired when there are no valid candidates. Will spawn a sleeper agent or latejoin traitor.
+/datum/dynamic_ruleset/midround/from_ghosts/proc/attempt_replacement()
+	var/datum/dynamic_ruleset/midround/autotraitor/sleeper_agent = new
+
+	// Otherwise, it has a chance to fail. We don't want that, since this is already pretty unlikely.
+	sleeper_agent.randomly_acceptable = FALSE
+
+	mode.configure_ruleset(sleeper_agent)
+
+	if (!mode.picking_specific_rule(sleeper_agent))
+		return
+
+	mode.picking_specific_rule(/datum/dynamic_ruleset/latejoin/infiltrator)
+
 //////////////////////////////////////////////
 //                                          //
 //           SYNDICATE TRAITORS             //
@@ -179,6 +193,10 @@
 	requirements = list(50,40,30,20,10,10,10,10,10,10)
 	repeatable = TRUE
 
+	/// Whether or not this instance of sleeper agent should be randomly acceptable.
+	/// If TRUE, then this has a threat level% chance to succeed.
+	var/randomly_acceptable = TRUE
+
 /datum/dynamic_ruleset/midround/autotraitor/acceptable(population = 0, threat = 0)
 	var/player_count = GLOB.alive_player_list.len
 	var/antag_count = GLOB.current_living_antags.len
@@ -190,7 +208,7 @@
 		log_game("DYNAMIC: Too many living antags compared to living players ([antag_count] living antags, [player_count] living players, [max_traitors] max traitors)")
 		return FALSE
 
-	if (!prob(mode.threat_level))
+	if (randomly_acceptable && !prob(mode.threat_level))
 		log_game("DYNAMIC: Random chance to roll autotraitor failed, it was a [mode.threat_level]% chance.")
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When a midround ghost event doesn't get any applicants, a sleeper agent/syndicate infiltrator will roll in its place.

A sleeper agent will attempt to roll first, followed by a syndicate infiltrator. Neither of these rolls are forced, so if there is not enough threat, or the threat level doesn't match the requirements, then it will not roll, however the threat_level% chance of sleeper agent does not come into effect.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes rounds without active observers a lot more dull than they should be. This should hopefully spice things up.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: When a midround ghost event doesn't get any applicants, a sleeper agent/syndicate infiltrator will roll in its place.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
