### PR TITLE
Jaunting no longer allows you to end up inside a wall

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -615,7 +615,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define DRONE_SHY_TRAIT "drone_shy"
 /// Pacifism trait given by stabilized light pink extracts.
 #define STABILIZED_LIGHT_PINK_TRAIT "stabilized_light_pink"
-/// Climbable trait, given and taken by the climbable element
+/// Climbable trait, given and taken by the climbable element when added or removed. Exists to be easily checked via HAS_TRAIT().
 #define TRAIT_CLIMBABLE "trait_climbable"
 
 /**

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -375,6 +375,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
  */
 #define TRAIT_AREA_SENSITIVE "area-sensitive"
 
+/// Climbable trait, given and taken by the climbable element when added or removed. Exists to be easily checked via HAS_TRAIT().
+#define TRAIT_CLIMBABLE "trait_climbable"
+
 ///Used for managing KEEP_TOGETHER in [/atom/var/appearance_flags]
 #define TRAIT_KEEP_TOGETHER "keep-together"
 
@@ -615,8 +618,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define DRONE_SHY_TRAIT "drone_shy"
 /// Pacifism trait given by stabilized light pink extracts.
 #define STABILIZED_LIGHT_PINK_TRAIT "stabilized_light_pink"
-/// Climbable trait, given and taken by the climbable element when added or removed. Exists to be easily checked via HAS_TRAIT().
-#define TRAIT_CLIMBABLE "trait_climbable"
 
 /**
 * Trait granted by [/mob/living/carbon/Initialize] and

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -615,6 +615,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define DRONE_SHY_TRAIT "drone_shy"
 /// Pacifism trait given by stabilized light pink extracts.
 #define STABILIZED_LIGHT_PINK_TRAIT "stabilized_light_pink"
+/// Climbable trait, given and taken by the climbable element
+#define TRAIT_CLIMBABLE "trait_climbable"
 
 /**
 * Trait granted by [/mob/living/carbon/Initialize] and

--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -22,9 +22,11 @@
 	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/on_examine)
 	RegisterSignal(target, COMSIG_MOUSEDROPPED_ONTO, .proc/mousedrop_receive)
 	RegisterSignal(target, COMSIG_ATOM_BUMPED, .proc/try_speedrun)
+	ADD_TRAIT(target, TRAIT_CLIMBABLE, src)
 
 /datum/element/climbable/Detach(datum/target)
 	UnregisterSignal(target, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_PARENT_EXAMINE, COMSIG_MOUSEDROPPED_ONTO, COMSIG_ATOM_BUMPED))
+	REMOVE_TRAIT(target, TRAIT_CLIMBABLE, src)
 	return ..()
 
 /datum/element/climbable/proc/on_examine(atom/source, mob/user, list/examine_texts)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -185,7 +185,30 @@ GLOBAL_LIST_EMPTY(station_turfs)
  * * source_atom - If this is not null, will check whether any contents on the turf can block this atom specifically. Also ignores itself on the turf.
  * * ignore_atoms - Check will ignore any atoms in this list. Useful to prevent an atom from blocking itself on the turf.
  */
-/turf/proc/is_blocked_turf(exclude_mobs = FALSE, ignore_climbable = FALSE, source_atom = null, list/ignore_atoms)
+/turf/proc/is_blocked_turf(exclude_mobs = FALSE, source_atom = null, list/ignore_atoms)
+	if(density)
+		return TRUE
+
+	for(var/content in contents)
+		// We don't want to block ourselves or consider any ignored atoms.
+		if((content == source_atom) || (content in ignore_atoms))
+			continue
+		var/atom/atom_content = content
+		// If the thing is dense AND we're including mobs or the thing isn't a mob AND if there's a source atom and
+		// it cannot pass through the thing on the turf,  we consider the turf blocked.
+		if(atom_content.density && (!exclude_mobs || !ismob(atom_content)))
+			if(source_atom && atom_content.CanPass(source_atom, src))
+				continue
+			return TRUE
+	return FALSE
+
+/**
+ * Checks whether the specified turf is blocked by something dense inside it, but ignores anything with the climbable trait
+ *
+ * Works the same way is_blocked_turf() works, except with an extra check for TRAIT_CLIMBABLE in atoms. So lockers
+ * and walls will return blocked, but not tables.
+ */
+/turf/proc/is_blocked_turf_ignore_climbable(exclude_mobs = FALSE, source_atom = null, list/ignore_atoms)
 	if(density)
 		return TRUE
 
@@ -198,11 +221,12 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		// if we're not excluding climbables while the thing is climbable AND
 		// if there's a source atom AND
 		// it cannot pass through the thing on the turf,  we consider the turf blocked.
-		if(atom_content.density && (!exclude_mobs || !ismob(atom_content)) && !(ignore_climbable && HAS_TRAIT(atom_content, TRAIT_CLIMBABLE)))
+		if(atom_content.density && (!exclude_mobs || !ismob(atom_content)) && !HAS_TRAIT(atom_content, TRAIT_CLIMBABLE))
 			if(source_atom && atom_content.CanPass(source_atom, src))
 				continue
 			return TRUE
 	return FALSE
+
 
 //zPassIn doesn't necessarily pass an atom!
 //direction is direction of travel of air

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -205,28 +205,17 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /**
  * Checks whether the specified turf is blocked by something dense inside it, but ignores anything with the climbable trait
  *
- * Works the same way is_blocked_turf() works, except with an extra check for TRAIT_CLIMBABLE in atoms. So lockers
- * and walls will return blocked, but not tables.
+ * Works similar to is_blocked_turf(), but ignores climbables and has less options. Primarily added for jaunting checks
  */
-/turf/proc/is_blocked_turf_ignore_climbable(exclude_mobs = FALSE, source_atom = null, list/ignore_atoms)
+/turf/proc/is_blocked_turf_ignore_climbable()
 	if(density)
 		return TRUE
 
-	for(var/content in contents)
-		// We don't want to block ourselves or consider any ignored atoms.
-		if((content == source_atom) || (content in ignore_atoms))
-			continue
-		var/atom/atom_content = content
-		// If the thing is dense AND we're including mobs or the thing isn't a mob AND
-		// if we're not excluding climbables while the thing is climbable AND
-		// if there's a source atom AND
-		// it cannot pass through the thing on the turf,  we consider the turf blocked.
-		if(atom_content.density && (!exclude_mobs || !ismob(atom_content)) && !HAS_TRAIT(atom_content, TRAIT_CLIMBABLE))
-			if(source_atom && atom_content.CanPass(source_atom, src))
-				continue
+	for(var/atom/movable/atom_content as anything in contents)
+		to_chat(world, "DEBUG -- Evaluating atom [atom_content].")
+		if(atom_content.density && !HAS_TRAIT(atom_content, TRAIT_CLIMBABLE))
 			return TRUE
 	return FALSE
-
 
 //zPassIn doesn't necessarily pass an atom!
 //direction is direction of travel of air

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -212,7 +212,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		return TRUE
 
 	for(var/atom/movable/atom_content as anything in contents)
-		if(atom_content.density && !HAS_TRAIT(atom_content, TRAIT_CLIMBABLE))
+		if(atom_content.density && !(atom_content.flags_1 & ON_BORDER_1) && !HAS_TRAIT(atom_content, TRAIT_CLIMBABLE))
 			return TRUE
 	return FALSE
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -212,7 +212,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		return TRUE
 
 	for(var/atom/movable/atom_content as anything in contents)
-		to_chat(world, "DEBUG -- Evaluating atom [atom_content].")
 		if(atom_content.density && !HAS_TRAIT(atom_content, TRAIT_CLIMBABLE))
 			return TRUE
 	return FALSE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -185,7 +185,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
  * * source_atom - If this is not null, will check whether any contents on the turf can block this atom specifically. Also ignores itself on the turf.
  * * ignore_atoms - Check will ignore any atoms in this list. Useful to prevent an atom from blocking itself on the turf.
  */
-/turf/proc/is_blocked_turf(exclude_mobs = FALSE, source_atom = null, list/ignore_atoms)
+/turf/proc/is_blocked_turf(exclude_mobs = FALSE, ignore_climbable = FALSE, source_atom = null, list/ignore_atoms)
 	if(density)
 		return TRUE
 
@@ -194,9 +194,11 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		if((content == source_atom) || (content in ignore_atoms))
 			continue
 		var/atom/atom_content = content
-		// If the thing is dense AND we're including mobs or the thing isn't a mob AND if there's a source atom and
+		// If the thing is dense AND we're including mobs or the thing isn't a mob AND
+		// if we're not excluding climbables while the thing is climbable AND
+		// if there's a source atom AND
 		// it cannot pass through the thing on the turf,  we consider the turf blocked.
-		if(atom_content.density && (!exclude_mobs || !ismob(atom_content)))
+		if(atom_content.density && (!exclude_mobs || !ismob(atom_content)) && !(ignore_climbable && HAS_TRAIT(atom_content, TRAIT_CLIMBABLE)))
 			if(source_atom && atom_content.CanPass(source_atom, src))
 				continue
 			return TRUE

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -22,8 +22,6 @@
 	var/jaunt_in_type = /obj/effect/temp_visual/wizard
 	/// Visual for exiting the jaunt
 	var/jaunt_out_type = /obj/effect/temp_visual/wizard/out
-	///Jaunt start location
-	var/turf/jaunt_start_location
 	/// List of valid exit points
 	var/list/exit_point_list
 
@@ -55,7 +53,7 @@
 		ADD_TRAIT(target, TRAIT_IMMOBILIZED, type)
 		sleep(jaunt_out_time)
 		REMOVE_TRAIT(target, TRAIT_IMMOBILIZED, type)
-	jaunt_start_location = get_turf(target)
+	var/turf/exit_point = get_turf(holder) //Hopefully this gets updated, otherwise this is our fallback
 	exit_point_list = new /list(5) //Clear list, if it was still full from the last jaunt
 	RegisterSignal(holder, COMSIG_MOVABLE_MOVED, .proc/update_exit_point, target)
 	sleep(jaunt_duration)
@@ -66,7 +64,6 @@
 		return
 
 	var/found_exit = FALSE
-	var/turf/exit_point = jaunt_start_location
 	for(var/turf/possible_exit in exit_point_list)
 		if(possible_exit.is_blocked_turf(ignore_climbable = TRUE))
 			continue

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -102,6 +102,7 @@
  * by (doors closing, engineers building walls, etc)
  */
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/proc/update_exit_point(mob/living/target)
+	SIGNAL_HANDLER
 	var/turf/location = get_turf(target)
 	if(location.is_blocked_turf(ignore_climbable = TRUE))
 		return

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -54,7 +54,7 @@
 		sleep(jaunt_out_time)
 		REMOVE_TRAIT(target, TRAIT_IMMOBILIZED, type)
 	var/turf/exit_point = get_turf(holder) //Hopefully this gets updated, otherwise this is our fallback
-	exit_point_list = list() //Clear list, if it was still full from the last jaunt
+	LAZYINITLIST(exit_point_list)
 	RegisterSignal(holder, COMSIG_MOVABLE_MOVED, .proc/update_exit_point, target)
 	sleep(jaunt_duration)
 
@@ -72,6 +72,7 @@
 		break
 	if(!found_exit)
 		to_chat(target, "<span='danger'>Unable to find an unobstructed space, you find yourself ripped back to where you started.</span>")
+	exit_point_list.Cut()
 	holder.forceMove(exit_point)
 
 	mobloc = get_turf(target.loc)

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -54,7 +54,7 @@
 		sleep(jaunt_out_time)
 		REMOVE_TRAIT(target, TRAIT_IMMOBILIZED, type)
 	var/turf/exit_point = get_turf(holder) //Hopefully this gets updated, otherwise this is our fallback
-	exit_point_list = new /list(5) //Clear list, if it was still full from the last jaunt
+	exit_point_list = list() //Clear list, if it was still full from the last jaunt
 	RegisterSignal(holder, COMSIG_MOVABLE_MOVED, .proc/update_exit_point, target)
 	sleep(jaunt_duration)
 
@@ -64,8 +64,8 @@
 		return
 
 	var/found_exit = FALSE
-	for(var/turf/possible_exit in exit_point_list)
-		if(possible_exit.is_blocked_turf(ignore_climbable = TRUE))
+	for(var/turf/possible_exit as anything in exit_point_list)
+		if(possible_exit.is_blocked_turf_ignore_climbable())
 			continue
 		exit_point = possible_exit
 		found_exit = TRUE
@@ -104,10 +104,11 @@
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/proc/update_exit_point(mob/living/target)
 	SIGNAL_HANDLER
 	var/turf/location = get_turf(target)
-	if(location.is_blocked_turf(ignore_climbable = TRUE))
+	if(location.is_blocked_turf_ignore_climbable())
 		return
-	exit_point_list[5] = null
 	exit_point_list.Insert(1, location)
+	if(length(exit_point_list) >= 5)
+		exit_point_list.Cut(5)
 
 /obj/effect/proc_holder/spell/targeted/ethereal_jaunt/proc/jaunt_steam(mobloc)
 	var/datum/effect_system/steam_spread/steam = new /datum/effect_system/steam_spread()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Jaunting now keeps track of the last five non-blocked tiles you moved across while in the jaunt. Upon exit, it will attempt to deposit you into the last unblocked tile. Should it run out of tiles to try, you will be returned to your starting location. As such, jaunting mobs can no longer end up inside walls or dense objects. Tables, and anything else with the climbable element, are still allowed.

- Added support to `/turf/proc/is_blocked_turf()` to allow ignoring climbable atoms. 

- Added the TRAIT_CLIMBABLE trait, applied by the climbable element, to accomplish the above.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Jaunting into a solid wall is dumb. So instead, we'll put the mob somewhere nearby(ish) on an open tile. This attempts to keep you somewhat safe by allowing users to control their exit point directly; If you don't want to end up spaced, don't scroll over a space tile before running out of steam mid-wall.

Jaunting onto glass tables is, of course, still allowed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Jaunting spells of all types (except for Nightmare) no longer allow for the user to end up inside a wall or most other dense objects. Instead, you will be moved to a valid spot on the path you took, or returned to your start location.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
