### PR TITLE
Fixes syndie-sleepers / self-use sleepers

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -134,7 +134,7 @@
 		open_machine()
 
 /obj/machinery/sleeper/ui_state(mob/user)
-	if(controls_inside)
+	if(!controls_inside)
 		return GLOB.notcontained_state
 	return GLOB.default_state
 


### PR DESCRIPTION
## About The Pull Request

Fixes syndie-sleepers / sleepers that allow self-use so you can actually self-use them again. 

Fixes #59528

## Why It's Good For The Game

Bugfix.

## Changelog
:cl: Melbert
fix: Fixes self-use sleepers like syndie-sleepers so you can actually use them by yourself when you're inside them.
/:cl:
