### PR TITLE
Makes icon scale following the Nearest Neighbor scaling method in the GAGS Color Customization menu

### DIFF
--- a/tgui/packages/tgui/interfaces/GreyscaleModifyMenu.tsx
+++ b/tgui/packages/tgui/interfaces/GreyscaleModifyMenu.tsx
@@ -206,13 +206,13 @@ const PreviewDisplay = (props, context) => {
             data.sprites?.finished
               ? (
                 <Table.Cell>
-                  <Box as="img" src={data.sprites.finished} m={0} width="75%" mx="10%" />
+                  <Box as="img" src={data.sprites.finished} m={0} width="75%" mx="10%" style={{"-ms-interpolation-mode": "nearest-neighbor"}}/>
                 </Table.Cell>
               )
               : (
                 <Table.Cell>
                   <Box grow>
-                    <Icon name="image" ml="25%" size={5} />
+                    <Icon name="image" ml="25%" size={5} style={{"-ms-interpolation-mode": "nearest-neighbor"}}/>
                   </Box>
                 </Table.Cell>
               )
@@ -268,6 +268,7 @@ const SingleSprite = (props) => {
       as="img"
       src={source}
       width="100%"
+      style={{"-ms-interpolation-mode": "nearest-neighbor"}}
     />
   );
 };

--- a/tgui/packages/tgui/interfaces/GreyscaleModifyMenu.tsx
+++ b/tgui/packages/tgui/interfaces/GreyscaleModifyMenu.tsx
@@ -206,13 +206,13 @@ const PreviewDisplay = (props, context) => {
             data.sprites?.finished
               ? (
                 <Table.Cell>
-                  <Box as="img" src={data.sprites.finished} m={0} width="75%" mx="10%" style={{ "-ms-interpolation-mode": "nearest-neighbor" }}/>
+                  <Box as="img" src={data.sprites.finished} m={0} width="75%" mx="10%" style={{ "-ms-interpolation-mode": "nearest-neighbor" }} />
                 </Table.Cell>
               )
               : (
                 <Table.Cell>
                   <Box grow>
-                    <Icon name="image" ml="25%" size={5} style={{ "-ms-interpolation-mode": "nearest-neighbor" }}/>
+                    <Icon name="image" ml="25%" size={5} style={{ "-ms-interpolation-mode": "nearest-neighbor" }} />
                   </Box>
                 </Table.Cell>
               )

--- a/tgui/packages/tgui/interfaces/GreyscaleModifyMenu.tsx
+++ b/tgui/packages/tgui/interfaces/GreyscaleModifyMenu.tsx
@@ -206,13 +206,13 @@ const PreviewDisplay = (props, context) => {
             data.sprites?.finished
               ? (
                 <Table.Cell>
-                  <Box as="img" src={data.sprites.finished} m={0} width="75%" mx="10%" style={{"-ms-interpolation-mode": "nearest-neighbor"}}/>
+                  <Box as="img" src={data.sprites.finished} m={0} width="75%" mx="10%" style={{ "-ms-interpolation-mode": "nearest-neighbor" }}/>
                 </Table.Cell>
               )
               : (
                 <Table.Cell>
                   <Box grow>
-                    <Icon name="image" ml="25%" size={5} style={{"-ms-interpolation-mode": "nearest-neighbor"}}/>
+                    <Icon name="image" ml="25%" size={5} style={{ "-ms-interpolation-mode": "nearest-neighbor" }}/>
                   </Box>
                 </Table.Cell>
               )
@@ -268,7 +268,7 @@ const SingleSprite = (props) => {
       as="img"
       src={source}
       width="100%"
-      style={{"-ms-interpolation-mode": "nearest-neighbor"}}
+      style={{ "-ms-interpolation-mode": "nearest-neighbor" }}
     />
   );
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title.

Less of this:
![image](https://user-images.githubusercontent.com/58045821/120941789-b2423200-c6f2-11eb-9768-b05599462d00.png)

More of this:
![image](https://user-images.githubusercontent.com/58045821/120941738-5b3c5d00-c6f2-11eb-9651-55888f2d3abb.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You will stop squinting at the screen when looking at the icons and trying to figure whether it's right or wrong.
I mean. Look at the difference.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex, but actually Mothblocks
fix: Looking at the images in the Color Customization of the GAGS menu will no longer make you feel like you dropped your glasses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
