### PR TITLE
Adds a few new types of admin lipsticks/kisses

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -646,9 +646,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 //traits granted by lipstick that change your *kiss projectile
 /// Blowing kisses actually does damage to the victim
 #define TRAIT_KISS_OF_DEATH "kiss_of_death"
-/// Blowing kisses actually does damage to the victim
+/// Blowing kisses instantly breaks the heart of the victim
 #define TRAIT_KISS_OF_OBLITERATION "kiss_of_obliteration"
-/// Blowing kisses actually does damage to the victim
+/// Blowing kisses provides minor healing to whoever is hit
 #define TRAIT_KISS_OF_LIFE "kiss_of_life"
-/// Blowing kisses actually does damage to the victim
+/// Blowing kisses aheals whoever is hit
 #define TRAIT_KISS_OF_REBIRTH "kiss_of_rebirth"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -287,8 +287,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_ANTICONVULSANT "anticonvulsant"
 /// The holder of this trait has antennae or whatever that hurt a ton when noogied
 #define TRAIT_ANTENNAE "antennae"
-/// Blowing kisses actually does damage to the victim
-#define TRAIT_KISS_OF_DEATH "kiss_of_death"
 /// Used on limbs in the process of turning a human into a plasmaman while in plasma lava
 #define TRAIT_PLASMABURNT "plasma_burnt"
 /// Addictions don't tick down, basically they're permanently addicted
@@ -644,3 +642,13 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_FILLED_MAINT "station_trait_filled_maint"
 #define STATION_TRAIT_EMPTY_MAINT "station_trait_empty_maint"
 #define STATION_TRAIT_PDA_GLITCHED "station_trait_pda_glitched"
+
+//traits granted by lipstick that change your *kiss projectile
+/// Blowing kisses actually does damage to the victim
+#define TRAIT_KISS_OF_DEATH "kiss_of_death"
+/// Blowing kisses actually does damage to the victim
+#define TRAIT_KISS_OF_OBLITERATION "kiss_of_obliteration"
+/// Blowing kisses actually does damage to the victim
+#define TRAIT_KISS_OF_LIFE "kiss_of_life"
+/// Blowing kisses actually does damage to the victim
+#define TRAIT_KISS_OF_REBIRTH "kiss_of_rebirth"

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -578,6 +578,7 @@
 	if(!was_in_proximity)
 		ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, STATUS_EFFECT_TRAIT)
 		was_in_proximity = TRUE
+	new /obj/effect/temp_visual/heal(get_turf(owner), "#375637")
 	owner.adjustBruteLoss(-2)
 	owner.adjustFireLoss(-2)
 	owner.adjustToxLoss(-1)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -524,7 +524,7 @@
 
 /atom/movable/screen/alert/status_effect/kiss_of_life
 	name = "Kiss of Life"
-	desc = "You're not sure if this healing is divine'"
+	desc = "You're not sure if this healing is divine, but it definitely feels nice!"
 	icon_state = "regenerative_core"
 
 /datum/status_effect/kiss_of_life
@@ -534,19 +534,18 @@
 	alert_type = /atom/movable/screen/alert/status_effect/kiss_of_life
 	/// You have to stay near the source to heal
 	var/atom/heal_source
-
+	/// The first time the recepient wanders off, remind them they need to stay near the kisser
 	var/warned_proximity = FALSE
-
+	/// Whether they were in proximity to the kisser last tick, for purposes of giving/taking the ignore damage slowdown trait
 	var/was_in_proximity = FALSE
 
 /datum/status_effect/kiss_of_life/on_creation(mob/living/new_owner, atom/source)
 	if(!source)
 		qdel(src)
 		return
-
-	. = ..()
-
 	heal_source = source
+
+	return ..()
 
 /datum/status_effect/kiss_of_life/on_apply()
 	owner.adjustBruteLoss(-5)
@@ -558,7 +557,7 @@
 	return TRUE
 
 /datum/status_effect/kiss_of_life/on_remove()
-	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, STATUS_EFFECT_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "[STATUS_EFFECT_TRAIT]_[id]")
 	heal_source = null
 
 /datum/status_effect/kiss_of_life/tick()
@@ -568,7 +567,7 @@
 
 	if(!can_see(owner, heal_source, 7))
 		if(was_in_proximity)
-			REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, STATUS_EFFECT_TRAIT)
+			REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "[STATUS_EFFECT_TRAIT]_[id]")
 			was_in_proximity = FALSE
 		if(!warned_proximity)
 			to_chat(owner, "<span class='warning'>Your body stops mending itself as you lose track of [heal_source]!</span>")
@@ -576,7 +575,7 @@
 		return
 
 	if(!was_in_proximity)
-		ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, STATUS_EFFECT_TRAIT)
+		ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "[STATUS_EFFECT_TRAIT]_[id]")
 		was_in_proximity = TRUE
 	new /obj/effect/temp_visual/heal(get_turf(owner), "#375637")
 	owner.adjustBruteLoss(-2)

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -28,6 +28,25 @@
 	desc = "An incredibly potent tube of lipstick made from the venom of the dreaded Yellow Spotted Space Lizard, as deadly as it is chic. Try not to smear it!"
 	lipstick_trait = TRAIT_KISS_OF_DEATH
 
+/obj/item/lipstick/black/obliteration
+	name = "\improper Kiss of Obliteration"
+	desc = "An incredibly potent tube of lipstick made from the venom of the dreaded Yellow Spotted Space Lizard, as deadly as it is chic. Try not to smear it!"
+	lipstick_trait = TRAIT_KISS_OF_OBLITERATION
+
+/obj/item/lipstick/blue
+	name = "blue lipstick"
+	colour = "blue"
+
+/obj/item/lipstick/blue/life
+	name = "\improper Kiss of Life"
+	desc = "An incredibly potent tube of lipstick made from the venom of the dreaded Yellow Spotted Space Lizard, as deadly as it is chic. Try not to smear it!"
+	lipstick_trait = TRAIT_KISS_OF_LIFE
+
+/obj/item/lipstick/blue/rebirth
+	name = "\improper Kiss of Rebirth"
+	desc = "An incredibly potent tube of lipstick made from the venom of the dreaded Yellow Spotted Space Lizard, as deadly as it is chic. Try not to smear it!"
+	lipstick_trait = TRAIT_KISS_OF_REBIRTH
+
 /obj/item/lipstick/random
 	name = "lipstick"
 	icon_state = "random_lipstick"

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -30,7 +30,7 @@
 
 /obj/item/lipstick/black/obliteration
 	name = "\improper Kiss of Obliteration"
-	desc = "An incredibly potent tube of lipstick made from the venom of the dreaded Yellow Spotted Space Lizard, as deadly as it is chic. Try not to smear it!"
+	desc = "A lipstick that could only have been dreamed up by the most angsty and heartbroken of country music artists, literally capable of destroying the hearts of anyone hit by one."
 	lipstick_trait = TRAIT_KISS_OF_OBLITERATION
 
 /obj/item/lipstick/blue
@@ -39,12 +39,12 @@
 
 /obj/item/lipstick/blue/life
 	name = "\improper Kiss of Life"
-	desc = "An incredibly potent tube of lipstick made from the venom of the dreaded Yellow Spotted Space Lizard, as deadly as it is chic. Try not to smear it!"
+	desc = "A powerful tube of lipstick that grants the wearer the ability to blow kisses that provide healing to the recepients, as long as they don't wander off too far."
 	lipstick_trait = TRAIT_KISS_OF_LIFE
 
 /obj/item/lipstick/blue/rebirth
 	name = "\improper Kiss of Rebirth"
-	desc = "An incredibly potent tube of lipstick made from the venom of the dreaded Yellow Spotted Space Lizard, as deadly as it is chic. Try not to smear it!"
+	desc = "A unique line of lipstick produced by the Space Wizard's Federation providing an alternative to bulky wands and staves for their revival abilities. Not actually very fashionable, though."
 	lipstick_trait = TRAIT_KISS_OF_REBIRTH
 
 /obj/item/lipstick/random

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -407,8 +407,7 @@
 
 /obj/projectile/kiss/life/harmless_on_hit(mob/living/living_target)
 	. = ..()
-	new /obj/effect/temp_visual/heal(get_turf(target), "#375637")
-	testing("landed life")
+	new /obj/effect/temp_visual/heal(get_turf(living_target), "#375637")
 
 	if(!firer)
 		living_target.adjustBruteLoss(-7.5)
@@ -416,7 +415,6 @@
 		living_target.adjustToxLoss(-5)
 		return
 
-	testing("apply life")
 	living_target.apply_status_effect(/datum/status_effect/kiss_of_life, firer)
 
 /obj/projectile/kiss/rebirth
@@ -425,8 +423,4 @@
 
 /obj/projectile/kiss/rebirth/harmless_on_hit(mob/living/living_target)
 	. = ..()
-	testing("land rebi")
 	living_target.revive(full_heal = TRUE)
-	testing("apply reb")
-
-

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -428,4 +428,4 @@
 	if(!isliving(target))
 		return
 	var/mob/living/benefactor = target
-	benefactor.fully_heal()
+	benefactor.revive(full_heal = TRUE)

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -405,27 +405,28 @@
 	name = "kiss of life"
 	color = COLOR_BLUE
 
-/obj/projectile/kiss/life/on_hit(atom/target, blocked, pierce_hit)
+/obj/projectile/kiss/life/harmless_on_hit(mob/living/living_target)
 	. = ..()
-	if(!isliving(target))
-		return
+	new /obj/effect/temp_visual/heal(get_turf(target), "#375637")
+	testing("landed life")
 
-	var/mob/living/benefactor = target
 	if(!firer)
-		benefactor.adjustBruteLoss(-7.5)
-		benefactor.adjustFireLoss(-7.5)
-		benefactor.adjustToxLoss(-5)
+		living_target.adjustBruteLoss(-7.5)
+		living_target.adjustFireLoss(-7.5)
+		living_target.adjustToxLoss(-5)
 		return
 
-	benefactor.apply_status_effect(/datum/status_effect/kiss_of_life, firer)
+	testing("apply life")
+	living_target.apply_status_effect(/datum/status_effect/kiss_of_life, firer)
 
 /obj/projectile/kiss/rebirth
 	name = "kiss of rebirth"
 	color = COLOR_VIVID_YELLOW
 
-/obj/projectile/kiss/rebirth/on_hit(atom/target, blocked, pierce_hit)
+/obj/projectile/kiss/rebirth/harmless_on_hit(mob/living/living_target)
 	. = ..()
-	if(!isliving(target))
-		return
-	var/mob/living/benefactor = target
-	benefactor.revive(full_heal = TRUE)
+	testing("land rebi")
+	living_target.revive(full_heal = TRUE)
+	testing("apply reb")
+
+

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -285,8 +285,26 @@
 /obj/item/kisser/death
 	name = "kiss of death"
 	desc = "If looks could kill, they'd be this."
-	color = COLOR_BLACK
+	color = COLOR_DARK
 	kiss_type = /obj/projectile/kiss/death
+
+/obj/item/kisser/obliteration
+	name = "kiss of obliteration"
+	desc = "If looks could kill, they'd be this."
+	color = COLOR_BLACK
+	kiss_type = /obj/projectile/kiss/obliteration
+
+/obj/item/kisser/life
+	name = "kiss of life"
+	desc = "If looks could kill, they'd be this."
+	color = COLOR_BLUE
+	kiss_type = /obj/projectile/kiss/life
+
+/obj/item/kisser/rebirth
+	name = "kiss of rebirth"
+	desc = "If looks could kill, they'd be this."
+	color = COLOR_VIVID_YELLOW
+	kiss_type = /obj/projectile/kiss/rebirth
 
 /obj/projectile/kiss
 	name = "kiss"
@@ -363,14 +381,51 @@
 	name = "kiss of death"
 	nodamage = FALSE // okay i kinda lied about love not being able to hurt you
 	damage = 35
+	wound_bonus = 30
+	sharpness = SHARP_POINTY
+	color = COLOR_DARK
+
+/obj/projectile/kiss/obliteration
+	name = "kiss of obliteration"
+	nodamage = FALSE // okay i kinda lied about love not being able to hurt you
+	damage = 35
 	wound_bonus = 0
 	sharpness = SHARP_POINTY
 	color = COLOR_BLACK
 
-/obj/projectile/kiss/death/on_hit(atom/target, blocked, pierce_hit)
+/obj/projectile/kiss/obliteration/on_hit(atom/target, blocked, pierce_hit)
 	. = ..()
 	if(!iscarbon(target))
 		return
 	var/mob/living/carbon/heartbreakee = target
 	var/obj/item/organ/heart/dont_go_breakin_my_heart = heartbreakee.getorganslot(ORGAN_SLOT_HEART)
 	dont_go_breakin_my_heart.applyOrganDamage(999)
+
+/obj/projectile/kiss/life
+	name = "kiss of life"
+	color = COLOR_BLUE
+
+/obj/projectile/kiss/life/on_hit(atom/target, blocked, pierce_hit)
+	. = ..()
+	if(!isliving(target))
+		return
+
+	var/mob/living/benefactor = target
+	if(!firer)
+		benefactor.adjustBruteLoss(-7.5)
+		benefactor.adjustFireLoss(-7.5)
+		benefactor.adjustToxLoss(-5)
+		return
+
+	benefactor.apply_status_effect(/datum/status_effect/kiss_of_life, firer)
+
+/obj/projectile/kiss/rebirth
+	name = "kiss of rebirth"
+	color = COLOR_VIVID_YELLOW
+
+/obj/projectile/kiss/rebirth/on_hit(atom/target, blocked, pierce_hit)
+	. = ..()
+	if(!isliving(target))
+		return
+	var/mob/living/benefactor = target
+	benefactor.fully_heal()

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -290,19 +290,19 @@
 
 /obj/item/kisser/obliteration
 	name = "kiss of obliteration"
-	desc = "If looks could kill, they'd be this."
+	desc = "Guaranteed to shred someone's heart from the inside out."
 	color = COLOR_BLACK
 	kiss_type = /obj/projectile/kiss/obliteration
 
 /obj/item/kisser/life
 	name = "kiss of life"
-	desc = "If looks could kill, they'd be this."
+	desc = "Operates on the same magic that makes mom kisses heal your scraped elbow."
 	color = COLOR_BLUE
 	kiss_type = /obj/projectile/kiss/life
 
 /obj/item/kisser/rebirth
 	name = "kiss of rebirth"
-	desc = "If looks could kill, they'd be this."
+	desc = "Like a bolt of healing, but more loving."
 	color = COLOR_VIVID_YELLOW
 	kiss_type = /obj/projectile/kiss/rebirth
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -205,6 +205,12 @@
 
 	if(HAS_TRAIT(user, TRAIT_KISS_OF_DEATH))
 		kiss_type = /obj/item/kisser/death
+	else if(HAS_TRAIT(user, TRAIT_KISS_OF_OBLITERATION))
+		kiss_type = /obj/item/kisser/obliteration
+	else if(HAS_TRAIT(user, TRAIT_KISS_OF_LIFE))
+		kiss_type = /obj/item/kisser/life
+	else if(HAS_TRAIT(user, TRAIT_KISS_OF_REBIRTH))
+		kiss_type = /obj/item/kisser/rebirth
 
 	var/obj/item/kiss_blower = new kiss_type(user)
 	if(user.put_in_hands(kiss_blower))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR expands on the types of lipsticks available to admins, adding a few new kinds of kiss projectiles based on ideas of my own and from other admins. They are:

- Kiss of Obliteration: The former Kiss of Death has been changed to this, still causes instant heart failure by applying 999 damage to the target's heart.
- Kiss of Death: Now just causes 35 brute and a really bad piercing wound instead of actual instant death, so you can hurt someone without basically removing them from the round.
- Kiss of Life: Provides the target a 15 second buff that slowly heals them and gives them damage slowdown immunity as long as they stay within sight of the person who blew the kiss at them.
- Kiss of Rebirth: Basically a rethemed bolt of healing, full revive.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds new content for a fun feature
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
add: Centcom's hybrid fashion/armaments division has released a few new prototype lipstick formulas to select Centcom staff, embued with the powers to harm or heal. Just make sure you don't mix them up!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
