### PR TITLE
Stops the drive-by landing from sending some players to space

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -703,7 +703,7 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/DropLandAtRandomHallwayPoint(mob/living/living_mob)
 	var/turf/spawn_turf = get_safe_random_station_turf(typesof(/area/hallway))
 
-	if(spawn_turf == null)
+	if(!spawn_turf)
 		SendToLateJoin(living_mob)
 	else
 		var/obj/structure/closet/supplypod/centcompod/toLaunch = new()

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -703,9 +703,12 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/DropLandAtRandomHallwayPoint(mob/living/living_mob)
 	var/turf/spawn_turf = get_safe_random_station_turf(typesof(/area/hallway))
 
-	var/obj/structure/closet/supplypod/centcompod/toLaunch = new()
-	living_mob.forceMove(toLaunch)
-	new /obj/effect/pod_landingzone(spawn_turf, toLaunch)
+	if(spawn_turf == null)
+		SendToLateJoin(living_mob)
+	else
+		var/obj/structure/closet/supplypod/centcompod/toLaunch = new()
+		living_mob.forceMove(toLaunch)
+		new /obj/effect/pod_landingzone(spawn_turf, toLaunch)
 
 ///////////////////////////////////
 //Keeps track of all living heads//


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a safety check to DropLandAtRandomHallwayPoint() to send mobs to the arrivals shuttle if get_safe_random_station_turf() returns null. This prevents people from being dumped in the supply pod shipping lane.

Fixes #58559 
Fixes #58024

## Why It's Good For The Game

Players getting spaced roundstart and being round removed barring admin intervention is a poor gameplay experience.

## Changelog
:cl:
fix: The drive-by landing station trait can no longer send players to space.
/:cl:



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
