### PR TITLE
Fixes the game triggering a do_after when you mouse over an inventory slot with a non-instantly equippable item.

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -178,7 +178,7 @@
 	var/image/item_overlay = image(holding)
 	item_overlay.alpha = 92
 
-	if(!user.can_equip(holding, slot_id, TRUE))
+	if(!user.can_equip(holding, slot_id, disable_warning = TRUE, bypass_equip_delay_self = TRUE))
 		item_overlay.color = "#FF0000"
 	else
 		item_overlay.color = "#00ff00"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Mousing over an inventory slot with an item in-hand can trigger a call to equip_delay_self_check.
![image](https://user-images.githubusercontent.com/24975989/121060388-783c6300-c7ba-11eb-8b7a-48c5839357c8.png)

If the item has an equip_delay_self and bypass_equip_delay_self is FALSE, then it acts like it's going to equip the item and starts a do_after.
![image](https://user-images.githubusercontent.com/24975989/121060408-7ecada80-c7ba-11eb-8efd-094035e1fc05.png)

I think the only two items that do this are `/obj/item/clothing/gloves/cargo_gauntlet` and `/obj/item/clothing/suit/straight_jacket`

I make sure the call to can_equip back in the /atom/movable/screen/inventory/add_overlays section of the call stack calls with bypass_equip_delay_self = TRUE to prevent this.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fix unintended do_after/behaviour.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Straight jackets and cargo gauntlets no longer pretend they're trying to equip themselves when you hold them in your hand and mouse over an inventory slot they can be equipped to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
