### PR TITLE
Admins will no longer accidentally undelay round end or reboot the server when multiple admins attempt to delay it at the same time.

### DIFF
--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -138,7 +138,10 @@
 		else
 			dat += "ETA: <a href='?_src_=holder;[HrefToken()];edit_shuttle_time=1'>[(timeleft / 60) % 60]:[add_leading(num2text(timeleft % 60), 2, "0")]</a><BR>"
 	dat += "<a href='?_src_=holder;[HrefToken()];end_round=[REF(usr)]'>End Round Now</a><br>"
-	dat += "<a href='?_src_=holder;[HrefToken()];delay_round_end=1'>[SSticker.delay_end ? "End Round Normally" : "Delay Round End"]</a><br>"
+	if(SSticker.delay_end)
+		dat += "<a href='?_src_=holder;[HrefToken()];undelay_round_end=1'>End Round Normally</a><br>"
+	else
+		dat += "<a href='?_src_=holder;[HrefToken()];delay_round_end=1'>Delay Round End</a><br>"
 	dat += "<a href='?_src_=holder;[HrefToken()];ctf_toggle=1'>Enable/Disable CTF</a><br>"
 	dat += "<a href='?_src_=holder;[HrefToken()];rebootworld=1'>Reboot World</a><br>"
 	dat += "<a href='?_src_=holder;[HrefToken()];check_teams=1'>Check Teams</a>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -189,7 +189,10 @@
 		SSticker.delay_end = FALSE
 
 		log_admin("[key_name(usr)] undelayed the round end.")
-		message_admins("[key_name_admin(usr)] undelayed the round end. You must now manually Reboot World to start the next shift.")
+		if(SSticker.ready_for_reboot)
+			message_admins("[key_name_admin(usr)] undelayed the round end. You must now manually Reboot World to start the next shift.")
+		else
+			message_admins("[key_name_admin(usr)] undelayed the round end.")
 	else if(href_list["end_round"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -159,22 +159,39 @@
 	else if(href_list["delay_round_end"])
 		if(!check_rights(R_SERVER))
 			return
-		if(!SSticker.delay_end)
-			SSticker.admin_delay_notice = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
-			if(isnull(SSticker.admin_delay_notice))
-				return
-		else
-			if(tgui_alert(usr, "Really cancel current round end delay? The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Undelay round end", list("Yes", "No")) != "Yes")
-				return
-			SSticker.admin_delay_notice = null
-		SSticker.delay_end = !SSticker.delay_end
-		var/reason = SSticker.delay_end ? "for reason: [SSticker.admin_delay_notice]" : "."//laziness
-		var/msg = "[SSticker.delay_end ? "delayed" : "undelayed"] the round end [reason]"
-		log_admin("[key_name(usr)] [msg]")
-		message_admins("[key_name_admin(usr)] [msg]")
-		if(SSticker.ready_for_reboot && !SSticker.delay_end) //we undelayed after standard reboot would occur
-			SSticker.standard_reboot()
 
+		if(SSticker.delay_end)
+			tgui_alert(usr, "The round end is already delayed. The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Alert", list("Ok"))
+			return
+
+		var/delay_reason = input(usr, "Enter a reason for delaying the round end", "Round Delay Reason") as null|text
+
+		if(isnull(delay_reason))
+			return
+
+		if(SSticker.delay_end)
+			tgui_alert(usr, "The round end is already delayed. The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Alert", list("Ok"))
+			return
+
+		SSticker.delay_end = TRUE
+		SSticker.admin_delay_notice = delay_reason
+
+		log_admin("[key_name(usr)] delayed the round end for reason: [SSticker.admin_delay_notice]")
+		message_admins("[key_name_admin(usr)] delayed the round end for reason: [SSticker.admin_delay_notice]")
+	else if(href_list["undelay_round_end"])
+		if(!check_rights(R_SERVER))
+			return
+
+		if(tgui_alert(usr, "Really cancel current round end delay? The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Undelay round end", list("Yes", "No")) == "No")
+			return
+
+		SSticker.admin_delay_notice = null
+		SSticker.delay_end = FALSE
+
+		log_admin("[key_name(usr)] undelayed the round end.")
+		message_admins("[key_name_admin(usr)] undelayed the round end.")
+		if(SSticker.ready_for_reboot) //we undelayed after standard reboot would occur
+			SSticker.standard_reboot()
 	else if(href_list["end_round"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -189,7 +189,7 @@
 		SSticker.delay_end = FALSE
 
 		log_admin("[key_name(usr)] undelayed the round end.")
-		message_admins("[key_name_admin(usr)] undelayed the round end.")
+		message_admins("[key_name_admin(usr)] undelayed the round end. You must now manually Reboot World to start the next shift.")
 	else if(href_list["end_round"])
 		if(!check_rights(R_ADMIN))
 			return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -190,8 +190,6 @@
 
 		log_admin("[key_name(usr)] undelayed the round end.")
 		message_admins("[key_name_admin(usr)] undelayed the round end.")
-		if(SSticker.ready_for_reboot) //we undelayed after standard reboot would occur
-			SSticker.standard_reboot()
 	else if(href_list["end_round"])
 		if(!check_rights(R_ADMIN))
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Delaying/undelaying round end is no longer a toggle under the same href.

Delaying and undelaying the round end are now explicit operations. If two admins attempt to delay round end at the same time, the first admin to input a reason wins and the second admin instead gets an alert that the round end is already delayed along with the reason instead of accidentally untoggling it.

FINALLY, undelaying round end will no longer trigger an immediate auto server reboot when SSticker.ready_for_reboot is TRUE. The admins are messaged that they must Reboot World manually. This is the final guard against admins accidentally undelaying when they're not actually ready to do so.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Admins stepping on eachothers' toes delaying the round no longer cancel eachother out.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Admins will no longer accidentally toggle delaying the end of the shift off when multiple admins attempt to delay at the same time.
admin: When a round end delay goes past the ordinary server restart time, admins are now required to manually end the shift through Reboot World in the Server verb tab or Reboot-World in the command bar. The shift will no longer automatically restart past this point just because an admin undelayed end.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
