### PR TITLE
Make statpanel relay used mouse button when clicking turf contents

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1956,6 +1956,8 @@
 		return
 	var/client/usr_client = usr.client
 	var/list/paramslist = list()
+	if(href_list["statpanel_item_middleclick"])
+		paramslist[MIDDLE_CLICK] = "1"
 	if(href_list["statpanel_item_shiftclick"])
 		paramslist[SHIFT_CLICK] = "1"
 	if(href_list["statpanel_item_ctrlclick"])

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1956,16 +1956,25 @@
 		return
 	var/client/usr_client = usr.client
 	var/list/paramslist = list()
-	if(href_list["statpanel_item_middleclick"])
-		paramslist[MIDDLE_CLICK] = "1"
-	if(href_list["statpanel_item_shiftclick"])
-		paramslist[SHIFT_CLICK] = "1"
-	if(href_list["statpanel_item_ctrlclick"])
-		paramslist[CTRL_CLICK] = "1"
-	if(href_list["statpanel_item_altclick"])
-		paramslist[ALT_CLICK] = "1"
+
 	if(href_list["statpanel_item_click"])
-		// first of all make sure we valid
+		switch(href_list["statpanel_item_click"])
+			if("left")
+				paramslist[LEFT_CLICK] = "1"
+			if("right")
+				paramslist[RIGHT_CLICK] = "1"
+			if("middle")
+				paramslist[MIDDLE_CLICK] = "1"
+			else
+				return
+
+		if(href_list["statpanel_item_shiftclick"])
+			paramslist[SHIFT_CLICK] = "1"
+		if(href_list["statpanel_item_ctrlclick"])
+			paramslist[CTRL_CLICK] = "1"
+		if(href_list["statpanel_item_altclick"])
+			paramslist[ALT_CLICK] = "1"
+
 		var/mouseparams = list2params(paramslist)
 		usr_client.Click(src, loc, null, mouseparams)
 		return TRUE

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -970,6 +970,9 @@ function draw_listedturf() {
 			return function(e) {
 				e.preventDefault();
 				clickcatcher = "?src=" + part[1] + ";statpanel_item_click=1";
+				if(e.button == 1){
+					clickcatcher += ";statpanel_item_middleclick=1"
+				}
 				if(e.shiftKey){
 					clickcatcher += ";statpanel_item_shiftclick=1";
 				}

--- a/html/statbrowser.html
+++ b/html/statbrowser.html
@@ -969,9 +969,16 @@ function draw_listedturf() {
 			// rather than every onmousedown getting the "part" of the last entry.
 			return function(e) {
 				e.preventDefault();
-				clickcatcher = "?src=" + part[1] + ";statpanel_item_click=1";
-				if(e.button == 1){
-					clickcatcher += ";statpanel_item_middleclick=1"
+				clickcatcher = "?src=" + part[1];
+				switch(e.button){
+					case 1:
+						clickcatcher += ";statpanel_item_click=middle"
+						break;
+					case 2:
+						clickcatcher += ";statpanel_item_click=right"
+						break;
+					default:
+						clickcatcher += ";statpanel_item_click=left"
 				}
 				if(e.shiftKey){
 					clickcatcher += ";statpanel_item_shiftclick=1";
@@ -1009,7 +1016,7 @@ function draw_sdql2(){
 		var td2 = document.createElement("td");
 		if(part[2]) {
 			var a = document.createElement("a");
-			a.href = "?src=" + part[2] + ";statpanel_item_click=1";
+			a.href = "?src=" + part[2] + ";statpanel_item_click=left";
 			a[textContentKey] = part[1];
 			td2.appendChild(a);
 		} else {
@@ -1035,12 +1042,12 @@ function draw_tickets() {
 		var td2 = document.createElement("td");
 		if(part[2]) {
 			var a = document.createElement("a");
-			a.href = "?_src_=holder;admin_token=" + href_token + ";ahelp=" + part[2] + ";ahelp_action=ticket;statpanel_item_click=1;action=ticket" ;
+			a.href = "?_src_=holder;admin_token=" + href_token + ";ahelp=" + part[2] + ";ahelp_action=ticket;statpanel_item_click=left;action=ticket" ;
 			a[textContentKey] = part[1];
 			td2.appendChild(a);
 		} else if(part[3]){
 			var a = document.createElement("a");
-			a.href = "?src=" + part[3] + ";statpanel_item_click=1";
+			a.href = "?src=" + part[3] + ";statpanel_item_click=left";
 			a[textContentKey] = part[1];
 			td2.appendChild(a);
 		} else {
@@ -1062,7 +1069,7 @@ function draw_interviews() {
 	manDiv.className = "interview_panel_controls"
 	var manLink = document.createElement("a");
 	manLink[textContentKey] = "Open Interview Manager Panel";
-	manLink.href = "?_src_=holder;admin_token=" + href_token + ";interview_man=1;statpanel_item_click=1";
+	manLink.href = "?_src_=holder;admin_token=" + href_token + ";interview_man=1;statpanel_item_click=left";
 	manDiv.appendChild(manLink);
 	body.appendChild(manDiv);
 
@@ -1094,7 +1101,7 @@ function draw_interviews() {
 		var td = document.createElement("td");
 		var a = document.createElement("a");
 		a[textContentKey] = part["status"];
-		a.href = "?_src_=holder;admin_token=" + href_token + ";interview=" + part["ref"] + ";statpanel_item_click=1";
+		a.href = "?_src_=holder;admin_token=" + href_token + ";interview=" + part["ref"] + ";statpanel_item_click=left";
 		td.appendChild(a);
 		tr.appendChild(td);
 		table.appendChild(tr);
@@ -1114,7 +1121,7 @@ function draw_spells(cat) {
 		var td2 = document.createElement("td");
 		if(part[3]) {
 			var a = document.createElement("a");
-			a.href = "?src=" + part[3] + ";statpanel_item_click=1";
+			a.href = "?src=" + part[3] + ";statpanel_item_click=left";
 			a[textContentKey] = part[2];
 			td2.appendChild(a);
 		} else {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Just makes it so statpanel clicks are relayed with the relevant mouse button instead of always left click. As of current it only relays shift/alt/ctrl modifiers.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Don't know if this is actually relevant to any specific feature in /tg/ proper, so all I can say is consistency. This prevents users from interacting in a way they wouldn't actually have wanted to, and allows them to use the middle/right click for anything that might need it now or later. Other modifiers are already relayed properly.

The change itself is motivated by CM13 as we use the middle click for abilities triggering and often get confused users about it, figured I would shoot it here aswell as it just makes sense.

## Changelog
:cl:
fix: Made statpanel relay used mouse button when clicking on turf contents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
