### PR TITLE
Prevent SSinput from constantly requesting moving in-place

### DIFF
--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -7,8 +7,13 @@
 		movement_dir = movement_dir | user.movement_keys[_key]
 	if(user.next_move_dir_add)
 		movement_dir |= user.next_move_dir_add
+		user.next_move_dir_add = 0
 	if(user.next_move_dir_sub)
 		movement_dir &= ~user.next_move_dir_sub
+		user.next_move_dir_sub = 0
+	if(!movement_dir)
+		return
+
 	// Sanity checks in case you hold left and right and up to make sure you only go up
 	if((movement_dir & NORTH) && (movement_dir & SOUTH))
 		movement_dir &= ~(NORTH|SOUTH)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -69,9 +69,6 @@
 /client/Move(new_loc, direct)
 	if(world.time < move_delay) //do not move anything ahead of this check please
 		return FALSE
-	else
-		next_move_dir_add = 0
-		next_move_dir_sub = 0
 	var/old_move_delay = move_delay
 	move_delay = world.time + world.tick_lag //this is here because Move() can now be called mutiple times per tick
 	if(!mob || !mob.loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Just prevents SSinput from constantly calling Move() every tick for every user even when no actual movement is requested. 

Only done rudimentary testing - straightforward and we've been using this for months on CM13 but without diagonal movement. 

I asked the original SSinput author back then which said that it was likely an oversight. I believe moving the diagonal movement direction buffer reset to keyLoop instead of Move() also makes sense as it is actually relevant to SSinput and not client actions as a whole (eg. if you call built-in movement verbs)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Basically performance... This is called every tick for every user, but just imparts an extra proc call and extra checking in client's Move(). It's one of two changes we did on CM13 to lessen the raw performance hit of introducing SSinput, alongside #59339 (which in itself seemed to lessen the calls overhead by about 40%)

## Changelog
:cl:
fix: Input system won't request in-place movements constantly anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
