### PR TITLE
Make SSinput set usr for movement

### DIFF
--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -18,6 +18,7 @@
 	if(movement_dir) //If we're not moving, don't compensate, as byond will auto-fill dir otherwise
 		movement_dir = turn(movement_dir, -dir2angle(user.dir)) //By doing this we ensure that our input direction is offset by the client (camera) direction
 
+	usr = user.mob
 	if(user.movement_locked)
 		keybind_face_direction(movement_dir)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Simply sets `usr` when in a SSinput-triggered movement, same as it would be when using regular movement. Because it's handled by keyLoop that is called periodically by the subsystem, this information is lost when done this way.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Consistency with regular and verb based movement - hopefully nothing noteworthy down call graph uses `usr` in that context anyway

## Changelog
:cl:
fix: Keybind triggered movement will now set client usr, in line with other movement.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
