### PR TITLE
Fix race condition in SSmapping z-level creation

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -45,6 +45,8 @@ SUBSYSTEM_DEF(mapping)
 	var/datum/space_level/transit
 	var/datum/space_level/empty_space
 	var/num_of_res_levels = 1
+	/// True when in the process of adding a new Z-level, global locking
+	var/adding_new_zlevel = FALSE
 
 /datum/controller/subsystem/mapping/New()
 	..()

--- a/code/modules/mapping/space_management/zlevel_manager.dm
+++ b/code/modules/mapping/space_management/zlevel_manager.dm
@@ -17,6 +17,8 @@
 		z_list += S
 
 /datum/controller/subsystem/mapping/proc/add_new_zlevel(name, traits = list(), z_type = /datum/space_level)
+	UNTIL(!adding_new_zlevel)
+	adding_new_zlevel = TRUE
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NEW_Z, args)
 	var/new_z = z_list.len + 1
 	if (world.maxz < new_z)
@@ -25,6 +27,7 @@
 	// TODO: sleep here if the Z level needs to be cleared
 	var/datum/space_level/S = new z_type(new_z, name, traits)
 	z_list += S
+	adding_new_zlevel = FALSE
 	return S
 
 /datum/controller/subsystem/mapping/proc/get_level(z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

As described in issue #56733, there is a possibility of a race condition in `SSmapping.add_new_zlevel` - either during Z level incrementing, or the proc itself, as it only expands the amount of registered z-levels after being finished. 

While the first hopefully shouldn't happen, it can still manifest because of the `CHECK_TICK` within. A practical result is that two concurrent calls to this proc will both create a new Z-level, but actually report having made the same first one.

This is problematic for `map_template`s that will then load blindly to the reported Z-level when using `load_new_z`, overwriting each other. We sometimes encounter that end result on CM13 codebase because of a map load that can be triggered by an user topic - if two people click at the same time, it's not unlikely for the first call to sleep in `CHECK_TICK` and let the second run, causing double-loading. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Consistency - while such an occurence in /tg/ current setup probably seldom occurs if ever due to more sparse usage which limits odds, it still is a possibility for a complete showstopper when it does happen.

## Changelog
:cl:
fix: Fixed race condition in creation of z-levels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
