### PR TITLE
Fixes a typo in tend wounds (burn) surgery

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -208,7 +208,7 @@
 	var/progress_text
 
 	if(locate(/obj/item/healthanalyzer) in user.held_items)
-		progress_text = ". Remaining brute: <font color='#ff9933'>[target.getFireLoss()]</font>"
+		progress_text = ". Remaining burn: <font color='#ff9933'>[target.getFireLoss()]</font>"
 	else
 		switch(estimated_remaining_steps)
 			if(-INFINITY to 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the remaining damage messave when tending burns to say burn and not brute.

Fixes #59555

## Why It's Good For The Game
One less typo

## Changelog
:cl:
spellcheck: The remaining damage message when tending burns no longer calls it brute damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
