### PR TITLE
Fix the 2person mech destroying it's own items on skyfall and runtiming.

### DIFF
--- a/code/modules/vehicles/mecha/combat/savannah_ivanov.dm
+++ b/code/modules/vehicles/mecha/combat/savannah_ivanov.dm
@@ -185,7 +185,7 @@
 			crushed_wall.ScrapeAway()
 		if(isobj(thing))
 			var/obj/crushed_object = thing
-			if(crushed_object == src)
+			if(crushed_object == src || crushed_object.loc == src)
 				continue
 			crushed_object.take_damage(150) //same as a hulk punch, makes sense to me
 		if(isliving(thing))


### PR DESCRIPTION
Thought there were some funny things afoot with the air code with mechs, turns out there are none.

## About The Pull Request
Added a loc check to the skyfall damage thing, title is self explanatory.

## Why It's Good For The Game
Less null.return_pressure or return_air runtimes. Probably kills off some other runtimes too.

## Changelog
:cl:
fix: fixed the 2person mech crushing it's own parts
/:cl: