### PR TITLE
Moves opening storage items from alt-click to right-click

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -8,7 +8,7 @@
 	. = ..()
 	if(. && silent && !prevent_warning)
 		if(quickdraw)
-			to_chat(user, "<span class='notice'>You discreetly slip [I] into [parent]. Alt-click [parent] to remove it.</span>")
+			to_chat(user, "<span class='notice'>You discreetly slip [I] into [parent]. Right-click [parent] to remove it.</span>")
 		else
 			to_chat(user, "<span class='notice'>You discreetly slip [I] into [parent].</span>")
 

--- a/code/datums/components/storage/concrete/wallet.dm
+++ b/code/datums/components/storage/concrete/wallet.dm
@@ -1,4 +1,4 @@
-/datum/component/storage/concrete/wallet/on_alt_click(datum/source, mob/user)
+/datum/component/storage/concrete/wallet/on_right_click(datum/source, mob/user)
 	if(!isliving(user) || !user.CanReach(parent) || user.incapacitated())
 		return
 	if(locked)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -99,6 +99,7 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/on_move)
 
 	RegisterSignal(parent, COMSIG_CLICK_ALT, .proc/on_alt_click)
+	RegisterSignal(parent, COMSIG_CLICK_RIGHT, .proc/on_right_click)
 	RegisterSignal(parent, COMSIG_MOUSEDROP_ONTO, .proc/mousedrop_onto)
 	RegisterSignal(parent, COMSIG_MOUSEDROPPED_ONTO, .proc/mousedrop_receive)
 
@@ -831,13 +832,17 @@
 	return hide_from(target)
 
 /datum/component/storage/proc/on_alt_click(datum/source, mob/user)
+	to_chat(user,"<span class='warning'>This action has been moved to right click.</span>")
+
+/datum/component/storage/proc/on_right_click(datum/source, mob/user)
 	SIGNAL_HANDLER
 
+	. = COMPONENT_CANCEL_CLICK_RIGHT
 	if(!isliving(user) || !user.CanReach(parent) || user.incapacitated())
 		return
 	if(locked)
 		to_chat(user, "<span class='warning'>[parent] seems to be locked!</span>")
-		return
+		return FALSE
 
 	var/atom/A = parent
 	if(!quickdraw)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -834,8 +834,8 @@
 /datum/component/storage/proc/on_alt_click(datum/source, mob/user)
 	SIGNAL_HANDLER
 
-	to_chat(user,"<span class='warning'>This action is being moved from alt-click to right-click.</span>")
-	on_right_click(source, user)
+	if(on_right_click(source, user))
+		to_chat(user,"<span class='warning'>This action is being moved from alt-click to right-click.</span>")
 
 /datum/component/storage/proc/on_right_click(datum/source, mob/user)
 	SIGNAL_HANDLER

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -840,13 +840,13 @@
 /datum/component/storage/proc/on_right_click(datum/source, mob/user)
 	SIGNAL_HANDLER
 
-	. = COMPONENT_CANCEL_CLICK_RIGHT
 	if(!isliving(user) || !user.CanReach(parent) || user.incapacitated())
 		return
 	if(locked)
 		to_chat(user, "<span class='warning'>[parent] seems to be locked!</span>")
-		return FALSE
+		return
 
+	. = COMPONENT_CANCEL_CLICK_RIGHT
 	var/atom/A = parent
 	if(!quickdraw)
 		A.add_fingerprint(user)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -834,7 +834,8 @@
 /datum/component/storage/proc/on_alt_click(datum/source, mob/user)
 	SIGNAL_HANDLER
 
-	to_chat(user,"<span class='warning'>This action has been moved to right click.</span>")
+	to_chat(user,"<span class='warning'>This action is being moved from alt-click to right-click.</span>")
+	on_right_click(source, user)
 
 /datum/component/storage/proc/on_right_click(datum/source, mob/user)
 	SIGNAL_HANDLER

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -832,6 +832,8 @@
 	return hide_from(target)
 
 /datum/component/storage/proc/on_alt_click(datum/source, mob/user)
+	SIGNAL_HANDLER
+
 	to_chat(user,"<span class='warning'>This action has been moved to right click.</span>")
 
 /datum/component/storage/proc/on_right_click(datum/source, mob/user)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -309,7 +309,7 @@
 		else
 			how_cool_are_your_threads += "[src] can store [pockets.max_items] item\s that are [weightclass2text(pockets.max_w_class)] or smaller.\n"
 		if(pockets.quickdraw)
-			how_cool_are_your_threads += "You can quickly remove an item from [src] using Alt-Click.\n"
+			how_cool_are_your_threads += "You can quickly remove an item from [src] using Right-Click.\n"
 		if(pockets.silent)
 			how_cool_are_your_threads += "Adding or removing items from [src] makes no noise.\n"
 		how_cool_are_your_threads += "</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Same as #58469 , which went stale.

Storage items can no longer be opened with alt-click, it's been moved to right-click. Attempting to use alt-click on a storage item will give a message that explains the change, as requested by MSO.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Right-click is more accessible than alt-click, and this action is used a lot.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Storage items open on right-click, instead of alt-click
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
