### PR TITLE
Durathread Strangling Bug Fix and Better Feedback

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -249,6 +249,7 @@
 //OTHER DEBUFFS
 /datum/status_effect/strandling //get it, strand as in durathread strand + strangling = strandling hahahahahahahahahahhahahaha i want to die
 	id = "strandling"
+	examine_text = "SUBJECTPRONOUN seems to be being choked by some durathread strands. You may be able to <b>cut</b> them off."
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = /atom/movable/screen/alert/status_effect/strandling
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -249,7 +249,7 @@
 //OTHER DEBUFFS
 /datum/status_effect/strandling //get it, strand as in durathread strand + strangling = strandling hahahahahahahahahahhahahaha i want to die
 	id = "strandling"
-	examine_text = "SUBJECTPRONOUN seems to be being choked by some durathread strands. You may be able to <b>cut</b> them off."
+	examine_text = "SUBJECTPRONOUN seem[p_s()] to be being choked by some durathread strands. You may be able to <b>cut</b> them off."
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = /atom/movable/screen/alert/status_effect/strandling
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -249,7 +249,7 @@
 //OTHER DEBUFFS
 /datum/status_effect/strandling //get it, strand as in durathread strand + strangling = strandling hahahahahahahahahahhahahaha i want to die
 	id = "strandling"
-	examine_text = "SUBJECTPRONOUN seem[p_s()] to be being choked by some durathread strands. You may be able to <b>cut</b> them off."
+	examine_text = "SUBJECTPRONOUN seems to be being choked by some durathread strands. You may be able to <b>cut</b> them off."
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = /atom/movable/screen/alert/status_effect/strandling
 

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -133,7 +133,7 @@
 		qdel(C.handcuffed)
 		return
 	else if(istype(C) && C.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND) && tool_behaviour == TOOL_WIRECUTTER)
-		user.visisble_message("<span class='notice'>[user] attempts to cut the durathread strand from around [C]'s neck.</span>")
+		user.visible_message("<span class='notice'>[user] attempts to cut the durathread strand from around [C]'s neck.</span>")
 		if(do_after(user, 1.5 SECONDS, C))
 			user.visible_message("<span class='notice'>[user] succesfully cuts the durathread strand from around [C]'s neck.</span>")
 			C.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -132,7 +132,7 @@
 		user.visible_message("<span class='notice'>[user] cuts [C]'s restraints with [src]!</span>")
 		qdel(C.handcuffed)
 		return
-	else if(istype(C) && C.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND))
+	else if(istype(C) && C.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND) && tool_behaviour == TOOL_WIRECUTTER)
 		user.visisble_message("<span class='notice'>[user] attempts to cut the durathread strand from around [C]'s neck.</span>")
 		if(do_after(user, 1.5 SECONDS, C))
 			user.visible_message("<span class='notice'>[user] succesfully cuts the durathread strand from around [C]'s neck.</span>")

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -132,6 +132,13 @@
 		user.visible_message("<span class='notice'>[user] cuts [C]'s restraints with [src]!</span>")
 		qdel(C.handcuffed)
 		return
+	else if(istype(C) && C.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND))
+		user.visisble_message("<span class='notice'>[user] attempts to cut the durathread strand from around [C]'s neck.</span>")
+		if(do_after(user, 1.5 SECONDS, C))
+			user.visible_message("<span class='notice'>[user] succesfully cuts the durathread strand from around [C]'s neck.</span>")
+			C.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
+			playsound(loc, usesound, 50, TRUE, -1)
+		return
 	else
 		..()
 

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -50,10 +50,12 @@
 		qdel(C.handcuffed)
 		return
 	else if(istype(C) && C.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND))
-		to_chat(C, "<span class='notice'>You attempt to remove the durathread strand from around your neck.</span>")
+		user.visisble_message("<span class='notice'>[user] attempts to remove the durathread strand from around [C]'s neck.</span>")
 		if(do_after(user, 1.5 SECONDS, C))
-			to_chat(C, "<span class='notice'>You succesfuly remove the durathread strand.</span>")
+			user.visible_message("<span class='notice'>[user] succesfully removes the durathread strand from [C].</span>")
 			C.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
+			playsound(loc, usesound, 50, TRUE, -1)
+		return
 	else
 		..()
 

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -50,9 +50,9 @@
 		qdel(C.handcuffed)
 		return
 	else if(istype(C) && C.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND))
-		user.visisble_message("<span class='notice'>[user] attempts to remove the durathread strand from around [C]'s neck.</span>")
+		user.visisble_message("<span class='notice'>[user] attempts to cut the durathread strand from around [C]'s neck.</span>")
 		if(do_after(user, 1.5 SECONDS, C))
-			user.visible_message("<span class='notice'>[user] succesfully removes the durathread strand from [C].</span>")
+			user.visible_message("<span class='notice'>[user] succesfully cuts the durathread strand from around [C]'s neck.</span>")
 			C.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
 			playsound(loc, usesound, 50, TRUE, -1)
 		return

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -50,7 +50,7 @@
 		qdel(C.handcuffed)
 		return
 	else if(istype(C) && C.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND))
-		user.visisble_message("<span class='notice'>[user] attempts to cut the durathread strand from around [C]'s neck.</span>")
+		user.visible_message("<span class='notice'>[user] attempts to cut the durathread strand from around [C]'s neck.</span>")
 		if(do_after(user, 1.5 SECONDS, C))
 			user.visible_message("<span class='notice'>[user] succesfully cuts the durathread strand from around [C]'s neck.</span>")
 			C.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds examine feedback for people being strangled by durathread.
Jaws of life can now cut durathread strangling.
Better cut messages (and a playsound()) when cutting the durathread off, previously it only sent messages to the person being freed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #59569 and also related bugs / qol issues / lack of feedback
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: You can now examine people to see if they are being strangled with durathread.
qol: Cutting durathread off of someone else now produces a public message for everyone to know.
fix: Durathread strangling caused by golems can now be cut off with jaws of life as well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
