### PR TITLE
Makes it so the matchbox's matches visibly empty from the sprite when you take matches out

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -708,7 +708,7 @@
 	drop_sound = 'sound/items/handling/matchbox_drop.ogg'
 	pickup_sound =  'sound/items/handling/matchbox_pickup.ogg'
 	custom_price = PAYCHECK_ASSISTANT * 0.4
-	base_icon_state = icon_state
+	base_icon_state = "matchbox"
 
 /obj/item/storage/box/matches/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -722,6 +722,17 @@
 	if(istype(W, /obj/item/match))
 		W.matchignite()
 
+/obj/item/storage/box/matches/update_icon_state()
+	switch(length(contents))
+		if(10)
+			icon_state = initial(icon_state)
+		if(5 to 9)
+			icon_state = "[initial(icon_state)]_almostfull"
+		if(1 to 4)
+			icon_state = "[initial(icon_state)]_almostempty"
+		if(0)
+			icon_state = "[initial(icon_state)]_e"
+
 /obj/item/storage/box/lights
 	name = "box of replacement bulbs"
 	icon = 'icons/obj/storage.dmi'

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -708,6 +708,7 @@
 	drop_sound = 'sound/items/handling/matchbox_drop.ogg'
 	pickup_sound =  'sound/items/handling/matchbox_pickup.ogg'
 	custom_price = PAYCHECK_ASSISTANT * 0.4
+	base_icon_state = icon_state
 
 /obj/item/storage/box/matches/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -726,13 +726,13 @@
 	. = ..()
 	switch(length(contents))
 		if(10)
-			icon_state = initial(icon_state)
+			icon_state = base_icon_state
 		if(5 to 9)
-			icon_state = "[initial(icon_state)]_almostfull"
+			icon_state = "[base_icon_state]_almostfull"
 		if(1 to 4)
-			icon_state = "[initial(icon_state)]_almostempty"
+			icon_state = "[base_icon_state]_almostempty"
 		if(0)
-			icon_state = "[initial(icon_state)]_e"
+			icon_state = "[base_icon_state]_e"
 
 /obj/item/storage/box/lights
 	name = "box of replacement bulbs"

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -723,6 +723,7 @@
 		W.matchignite()
 
 /obj/item/storage/box/matches/update_icon_state()
+	. = ..()
 	switch(length(contents))
 		if(10)
 			icon_state = initial(icon_state)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I was doing downstream stuff when I noticed there were 4 matchbox sprite states when only one of them was being used.
![image](https://user-images.githubusercontent.com/66052067/121278094-ed359880-c89f-11eb-901b-51490d0ef116.png)
This instantly gave me extreme OCD and I cannot sleep soundly knowing that this is at all the case.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Alleviates my OCD.
Also good to know how full a matchbox is without needing to open it I guess.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Wallem
fix: Matchbox sprite properly empties.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
