### PR TITLE
Removes the traitor assistant toolbox

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_lavaland.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_lavaland.dmm
@@ -53,12 +53,6 @@
 "T" = (
 /turf/open/floor/cult,
 /area/icemoon/underground)
-"V" = (
-/obj/item/storage/toolbox/mechanical/old/clean,
-/turf/open/floor/plating/asteroid{
-	initial_gas_mix = "LAVALAND_ATMOS"
-	},
-/area/icemoon/underground)
 "Z" = (
 /turf/open/floor/plating/asteroid{
 	initial_gas_mix = "LAVALAND_ATMOS"
@@ -754,7 +748,7 @@ q
 q
 q
 q
-V
+Z
 Z
 Z
 Z

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -97,39 +97,6 @@
 /obj/item/storage/toolbox/mechanical/old/heirloom/PopulateContents()
 	return
 
-/obj/item/storage/toolbox/mechanical/old/clean // the assistant traitor toolbox, damage scales with TC inside
-	name = "toolbox"
-	desc = "An old, blue toolbox, it looks robust."
-	icon_state = "oldtoolboxclean"
-	inhand_icon_state = "toolbox_blue"
-	has_latches = FALSE
-	force = 19
-	throwforce = 22
-
-/obj/item/storage/toolbox/mechanical/old/clean/proc/calc_damage()
-	var/power = 0
-	for (var/obj/item/stack/telecrystal/TC in GetAllContents())
-		power += TC.amount
-	force = 19 + power
-	throwforce = 22 + power
-
-/obj/item/storage/toolbox/mechanical/old/clean/attack(mob/target, mob/living/user)
-	calc_damage()
-	..()
-
-/obj/item/storage/toolbox/mechanical/old/clean/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	calc_damage()
-	..()
-
-/obj/item/storage/toolbox/mechanical/old/clean/PopulateContents()
-	new /obj/item/screwdriver(src)
-	new /obj/item/wrench(src)
-	new /obj/item/weldingtool(src)
-	new /obj/item/crowbar(src)
-	new /obj/item/wirecutters(src)
-	new /obj/item/multitool(src)
-	new /obj/item/clothing/gloves/color/yellow(src)
-
 /obj/item/storage/toolbox/electrical
 	name = "electrical toolbox"
 	icon_state = "yellow"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1717,14 +1717,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	restricted_roles = list("Assistant")
 	surplus = 0
 
-/datum/uplink_item/role_restricted/oldtoolboxclean
-	name = "Ancient Toolbox"
-	desc = "An iconic toolbox design notorious with Assistants everywhere, this design was especially made to become more robust the more telecrystals it has inside it! Tools and insulated gloves included."
-	item = /obj/item/storage/toolbox/mechanical/old/clean
-	cost = 2
-	restricted_roles = list("Assistant")
-	surplus = 0
-
 /datum/uplink_item/role_restricted/pie_cannon
 	name = "Banana Cream Pie Cannon"
 	desc = "A special pie cannon for a special clown, this gadget can hold up to 20 pies and automatically fabricates one every two seconds!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR removes the funny traitor assistant toolbox that scales damage based on how many TC are inside of it. For those of you who don't know, this toolbox:

- Costs 2 telecrystals
- Is entirely inconspicuous other than the insane damage
- Deals 19 brute by itself without any crystals (50% chance to dislocate a limb on hit) (for a 2TC item!!)
- Deals 37 brute with the other 18 telecrystals (50% chance to cause an outright hairline fracture on the first hit, and a **20% chance to cause an outright compound fracture on the first hit**)
- Leaves the bodies of victims crippled with broken bones requiring long surgeries to repair even after they're revived
- Also gives you a full set of tools and insulated gloves

Every time I've seen this dumb toolbox in use, the round sucked. I've seen three traitors go together and have a toolbox that did 77 brute, and that round sucked too. Sometimes broken and wildly unbalanced things can be funny, but this is not one of them.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This item sucks and probably only still exists because anything relating to assistants and toolboxes (especially old toolboxes) is considered SOUL, but I was also the one who added sacrificing souls to toolboxes, so maybe I'm the right person for the job
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
del: Removed the assistant traitor toolbox
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
