### PR TITLE
Logs opening/closing job slots

### DIFF
--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -74,6 +74,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 				GLOB.time_last_changed_position = world.time / 10
 			j.total_positions++
 			opened_positions[edit_job_target]++
+			log_game("[key_name(usr)] opened a [j.title] job position.")
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_close_job")
@@ -85,6 +86,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			if(opened_positions[edit_job_target] <= 0)
 				GLOB.time_last_changed_position = world.time / 10
 			j.total_positions--
+			log_game("[key_name(usr)] closed a [j.title] job position.")
 			opened_positions[edit_job_target]--
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -74,7 +74,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 				GLOB.time_last_changed_position = world.time / 10
 			j.total_positions++
 			opened_positions[edit_job_target]++
-			log_game("[key_name(usr)] opened a [j.title] job position.")
+			log_game("[key_name(usr)] opened a [j.title] job position, for a total of [j.total_positions] open job slots.")
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_close_job")
@@ -86,8 +86,8 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			if(opened_positions[edit_job_target] <= 0)
 				GLOB.time_last_changed_position = world.time / 10
 			j.total_positions--
-			log_game("[key_name(usr)] closed a [j.title] job position.")
 			opened_positions[edit_job_target]--
+			log_game("[key_name(usr)] closed a [j.title] job position, leaving [j.total_positions] open job slots.")
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_priority")


### PR DESCRIPTION
## About The Pull Request

Exactly what the title says. Opening/Closing job slots will log who changed what job slot.
![image](https://user-images.githubusercontent.com/53777086/121602179-eb411600-ca14-11eb-8891-8bd7f0029fee.png)


## Why It's Good For The Game

Admins have a hard time telling if all job slots were closed by a bureaucracy error, or if the HoP also helped with that. Also other examples could be an antag closing all Security job positions, which would be hard for admins to tell if done by said antag, or a shitter HoP.

## Changelog
:cl:
admin: Opening and closing job slots is now logged.
/:cl: