### PR TITLE
Fixed RAM component retaining its type after the input port is cleared

### DIFF
--- a/code/modules/wiremod/component.dm
+++ b/code/modules/wiremod/component.dm
@@ -135,6 +135,9 @@
 		if(connected_port.datatype != output_port.datatype)
 			output_port.set_datatype(connected_port.datatype)
 			return TRUE
+	else
+		output_port.set_datatype(output_port.default_datatype)
+		return TRUE
 	return FALSE
 
 

--- a/code/modules/wiremod/port.dm
+++ b/code/modules/wiremod/port.dm
@@ -15,6 +15,9 @@
 	/// The port type. Ports can only connect to each other if the type matches
 	var/datatype
 
+	/// The default port type. Stores the original datatype of the port set on Initialize.
+	var/default_datatype
+
 	/// The port color. If unset, appears as blue.
 	var/color
 
@@ -28,6 +31,7 @@
 	src.connected_component = to_connect
 	src.name = name
 	src.datatype = datatype
+	src.default_datatype = datatype
 	src.color = datatype_to_color()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixed RAM component retaining its type after the input port is cleared

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Allows people to input types, such as strings, entities or numbers with the Stored Value type retaining its last input type, which can result in bugs.

## Changelog
:cl:
fix: Fixed the RAM component retaining its output type after the input port is cleared.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
