### PR TITLE
Stimformation requirements list fix + some small heads-up on the requirements list.

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -39,8 +39,12 @@
 	return priority_reactions
 
 /datum/gas_reaction
-	//regarding the requirements list: the minimum or maximum requirements must be non-zero.
-	//when in doubt, use MINIMUM_MOLE_COUNT.
+	/** 
+	 * Regarding the requirements list: the minimum or maximum requirements must be non-zero.
+	 * When in doubt, use MINIMUM_MOLE_COUNT.
+	 * Another thing to note is that reactions will not fire if we have any requirements outside of gas id path or MIN_TEMP or MAX_TEMP. 
+	 * More complex implementations will require modifications to gas_mixture.react()
+	 */
 	var/list/requirements
 	var/major_gas //the highest rarity gas used in the reaction.
 	var/exclude = FALSE //do it this way to allow for addition/removal of reactions midmatch in the future
@@ -551,6 +555,7 @@
 		/datum/gas/tritium = 30,
 		/datum/gas/bz = 20,
 		/datum/gas/nitryl = 30,
+		/datum/gas/plasma = MINIMUM_MOLE_COUNT,
 		"MIN_TEMP" = 1500)
 
 /datum/gas_reaction/stimformation/react(datum/gas_mixture/air)


### PR DESCRIPTION
## About The Pull Request
Atomized out of my stimball PR #55558, stimformation has a `min()` proc hooked to the gas formed that accounts for the amount of plasma present inside it, while not explicitly stating that in the `requirements` list. This PR would make `stimformation/react()` not get called by `gas_mixture/react()` when no gas will be formed.
Also added a short doc-comment to the requirements list in case someone else wanted to add new requirement interactions.

## Why It's Good For The Game
Ditto

## Changelog 
:cl:
fix: stimformation should not be called if no gas is actually being formed.
/:cl: