### PR TITLE
Remove multiple overrides of /atom/New

### DIFF
--- a/code/_onclick/hud/families.dm
+++ b/code/_onclick/hud/families.dm
@@ -10,9 +10,6 @@
 	/// Boolean, have the cops arrived? If so, the icon stops changing and remains the same.
 	var/cops_arrived = 0
 
-/atom/movable/screen/wanted/New()
-	return ..()
-
 /atom/movable/screen/wanted/Initialize()
 	. = ..()
 	update_appearance()

--- a/code/_onclick/hud/plane_master_controller.dm
+++ b/code/_onclick/hud/plane_master_controller.dm
@@ -6,7 +6,7 @@
 	var/datum/hud/owner_hud
 
 ///Ensures that all the planes are correctly in the controlled_planes list.
-/atom/movable/plane_master_controller/New(hud)
+/atom/movable/plane_master_controller/Initialize(mapload, hud)
 	. = ..()
 	owner_hud = hud
 	var/assoc_controlled_planes = list()

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -266,7 +266,7 @@
 	icon_state = "combat_off"
 	screen_loc = ui_combat_toggle
 
-/atom/movable/screen/combattoggle/New(loc, ...)
+/atom/movable/screen/combattoggle/Initialize()
 	. = ..()
 	update_appearance()
 

--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -378,10 +378,10 @@
 	image_state = "secbot-c"
 	var/victim
 
-/obj/effect/hallucination/simple/securitron/New()
+/obj/effect/hallucination/simple/securitron/Initialize()
 	name = pick ( "officer Beepsky", "officer Johnson", "officer Pingsky")
 	START_PROCESSING(SSfastprocess,src)
-	..()
+	. = ..()
 
 /obj/effect/hallucination/simple/securitron/process()
 	if(prob(60))

--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -64,12 +64,9 @@
 	else
 		to_chat(user, "<span class='notice'>A no server error appears on the screen.</span>")
 
-/obj/machinery/computer/message_monitor/New()
-	..()
-	GLOB.telecomms_list += src
-
 /obj/machinery/computer/message_monitor/Initialize()
 	..()
+	GLOB.telecomms_list += src
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/computer/message_monitor/LateInitialize()

--- a/code/game/objects/effects/spawners/vaultspawner.dm
+++ b/code/game/objects/effects/spawners/vaultspawner.dm
@@ -4,7 +4,8 @@
 	var/minX = 2
 	var/minY = 2
 
-/obj/effect/vaultspawner/New(turf/location,lX = minX,uX = maxX,lY = minY,uY = maxY,type = null)
+/obj/effect/vaultspawner/Initialize(mapload, turf/location,lX = minX,uX = maxX,lY = minY,uY = maxY,type = null)
+	..()
 	if(!type)
 		type = pick("sandstone","rock","alien")
 
@@ -24,4 +25,4 @@
 			else
 				T.PlaceOnTop(text2path("/turf/open/floor/vault/[type]"))
 
-	qdel(src)
+	return INITIALIZE_HINT_QDEL

--- a/code/game/objects/effects/temporary_visuals/projectiles/projectile_effects.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/projectile_effects.dm
@@ -31,7 +31,7 @@
 	M.Turn(angle)
 	transform = M
 
-/obj/effect/projectile/New(angle_override, p_x, p_y, color_override, scaling = 1)
+/obj/effect/projectile/Initialize(mapload, angle_override, p_x, p_y, color_override, scaling = 1)
 	if(angle_override && p_x && p_y && color_override && scaling)
 		apply_vars(angle_override, p_x, p_y, color_override, scaling)
 	return ..()

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -31,8 +31,8 @@
 	var/last_found = null
 	var/last_seen = null
 
-/obj/item/camera_bug/New()
-	..()
+/obj/item/camera_bug/Initialize()
+	. = ..()
 	START_PROCESSING(SSobj, src)
 
 /obj/item/camera_bug/Destroy()
@@ -44,6 +44,7 @@
 	bugged_cameras = list()
 	if(tracking)
 		tracking = null
+	STOP_PROCESSING(SSobj, src)
 	return ..()
 
 /obj/item/camera_bug/interact(mob/user)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -398,8 +398,8 @@
 	/// How many seconds between each recharge
 	var/charge_delay = 20
 
-/obj/item/flashlight/emp/New()
-	..()
+/obj/item/flashlight/emp/Initialize()
+	. = ..()
 	START_PROCESSING(SSobj, src)
 
 /obj/item/flashlight/emp/Destroy()

--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -37,8 +37,8 @@
 	var/forgedseal = 0
 	var/copy_type = null
 
-/obj/item/documents/photocopy/New(loc, obj/item/documents/copy=null)
-	..()
+/obj/item/documents/photocopy/Initialize(loc, obj/item/documents/copy=null)
+	. = ..()
 	if(copy)
 		copy_type = copy.type
 		if(istype(copy, /obj/item/documents/photocopy)) // Copy Of A Copy Of A Copy

--- a/code/game/objects/items/implants/implant_track.dm
+++ b/code/game/objects/items/implants/implant_track.dm
@@ -15,13 +15,13 @@
 	. = ..()
 	QDEL_IN(src, lifespan)
 
-/obj/item/implant/tracking/New()
-	..()
+/obj/item/implant/tracking/Initialize()
+	. = ..()
 	GLOB.tracked_implants += src
 
 /obj/item/implant/tracking/Destroy()
-	. = ..()
 	GLOB.tracked_implants -= src
+	. = ..()
 
 /obj/item/implanter/tracking
 	imp_type = /obj/item/implant/tracking

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -102,8 +102,8 @@
 	var/refill_rate = 0.5
 	var/refill_reagent = /datum/reagent/water //Determins what reagent to use for refilling, just in case someone wanted to make a HOLY MOP OF PURGING
 
-/obj/item/mop/advanced/New()
-	..()
+/obj/item/mop/advanced/Initialize()
+	. = ..()
 	START_PROCESSING(SSobj, src)
 
 /obj/item/mop/advanced/attack_self(mob/user)

--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -16,7 +16,7 @@
 	var/fuel_added = 0
 	var/flame_expiry_timer
 
-/obj/structure/fireplace/New()
+/obj/structure/fireplace/Initialize()
 	..()
 	START_PROCESSING(SSobj, src)
 

--- a/code/game/objects/structures/industrial_lift.dm
+++ b/code/game/objects/structures/industrial_lift.dm
@@ -155,12 +155,10 @@ GLOBAL_LIST_EMPTY(lifts)
 	var/list/atom/movable/lift_load //things to move
 	var/datum/lift_master/lift_master_datum    //control from
 
-/obj/structure/industrial_lift/New()
-	GLOB.lifts.Add(src)
-	..()
-
 /obj/structure/industrial_lift/Initialize(mapload)
 	. = ..()
+	GLOB.lifts.Add(src)
+
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_EXITED =.proc/UncrossedRemoveItemFromLift,
 		COMSIG_ATOM_ENTERED = .proc/AddItemOnLift,

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -139,25 +139,25 @@
 	icon_state = "magic_mirror"
 	var/list/choosable_races = list()
 
-/obj/structure/mirror/magic/New()
+/obj/structure/mirror/magic/Initialize()
+	. = ..()
 	if(!choosable_races.len)
 		for(var/speciestype in subtypesof(/datum/species))
 			var/datum/species/S = speciestype
 			if(initial(S.changesource_flags) & MIRROR_MAGIC)
 				choosable_races += initial(S.id)
 		choosable_races = sortList(choosable_races)
-	..()
 
-/obj/structure/mirror/magic/lesser/New()
+/obj/structure/mirror/magic/lesser/Initialize()
 	choosable_races = GLOB.roundstart_races.Copy()
-	..()
+	. = ..()
 
-/obj/structure/mirror/magic/badmin/New()
+/obj/structure/mirror/magic/badmin/Initialize()
 	for(var/speciestype in subtypesof(/datum/species))
 		var/datum/species/S = speciestype
 		if(initial(S.changesource_flags) & MIRROR_BADMIN)
 			choosable_races += initial(S.id)
-	..()
+	. = ..()
 
 /obj/structure/mirror/magic/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -225,9 +225,9 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	GLOB.crematoriums.Remove(src)
 	return ..()
 
-/obj/structure/bodycontainer/crematorium/New()
+/obj/structure/bodycontainer/crematorium/Initialize()
+	. = ..()
 	GLOB.crematoriums.Add(src)
-	..()
 
 /obj/structure/bodycontainer/crematorium/Initialize()
 	. = ..()

--- a/code/game/objects/structures/petrified_statue.dm
+++ b/code/game/objects/structures/petrified_statue.dm
@@ -8,7 +8,7 @@
 	var/timer = 480 //eventually the person will be freed
 	var/mob/living/petrified_mob
 
-/obj/structure/statue/petrified/New(loc, mob/living/L, statue_timer)
+/obj/structure/statue/petrified/Initialize(mapload, loc, mob/living/L, statue_timer)
 	if(statue_timer)
 		timer = statue_timer
 	if(L)
@@ -23,7 +23,7 @@
 		obj_integrity = L.health + 100 //stoning damaged mobs will result in easier to shatter statues
 		max_integrity = obj_integrity
 		START_PROCESSING(SSobj, src)
-	..()
+	. = ..()
 
 /obj/structure/statue/petrified/process(delta_time)
 	if(!petrified_mob)

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -21,8 +21,8 @@
 	var/base_icon = "station0"
 	var/boarding_dir //from which direction you can board the tube
 
-/obj/structure/transit_tube/station/New()
-	..()
+/obj/structure/transit_tube/station/Initialize()
+	. = ..()
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/transit_tube/station/Destroy()

--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -13,8 +13,8 @@
 	var/exit_delay = 1
 	var/enter_delay = 0
 
-/obj/structure/transit_tube/New(loc, newdirection)
-	..(loc)
+/obj/structure/transit_tube/Initialize(mapload, loc, newdirection)
+	. = ..(mapload, loc)
 	if(newdirection)
 		setDir(newdirection)
 	init_tube_dirs()

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -60,11 +60,11 @@
 	plane = SPLASHSCREEN_PLANE
 	bullet_bounce_sound = null
 
-/turf/closed/indestructible/splashscreen/New()
+/turf/closed/indestructible/splashscreen/Initialize()
 	SStitle.splash_turf = src
 	if(SStitle.icon)
 		icon = SStitle.icon
-	..()
+	. = ..()
 
 /turf/closed/indestructible/splashscreen/vv_edit_var(var_name, var_value)
 	. = ..()

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -138,7 +138,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 /obj/effect/statclick/ticket_list
 	var/current_state
 
-/obj/effect/statclick/ticket_list/New(loc, name, state)
+/obj/effect/statclick/ticket_list/Initialize(mapload, loc, name, state)
 	current_state = state
 	..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -358,11 +358,11 @@
 	var/health_cost = 0 //The amount of health taken from the user when invoking the spell
 	var/datum/action/innate/cult/blood_spell/source
 
-/obj/item/melee/blood_magic/New(loc, spell)
+/obj/item/melee/blood_magic/Initialize(maplod, loc, spell)
 	source = spell
 	uses = source.charges
 	health_cost = source.health_cost
-	..()
+	. = ..()
 
 /obj/item/melee/blood_magic/Destroy()
 	if(!QDELETED(source))

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -184,9 +184,9 @@
 	var/corrupt_delay = 50
 	var/last_corrupt = 0
 
-/obj/structure/destructible/cult/pylon/New()
+/obj/structure/destructible/cult/pylon/Initialize()
+	. = ..()
 	START_PROCESSING(SSfastprocess, src)
-	..()
 
 /obj/structure/destructible/cult/pylon/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -44,13 +44,19 @@
 	var/spawn_amt_left = 20
 	var/spawn_fast = FALSE
 
-/obj/effect/rend/New(loc, spawn_type, spawn_amt, desc, spawn_fast)
+/obj/effect/rend/Initialize(mapload, loc, spawn_type, spawn_amt, desc, spawn_fast)
+	. = ..()
+
 	src.spawn_path = spawn_type
 	src.spawn_amt_left = spawn_amt
 	src.desc = desc
 	src.spawn_fast = spawn_fast
+
 	START_PROCESSING(SSobj, src)
-	return
+
+/obj/effect/rend/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	. = ..()
 
 /obj/effect/rend/process()
 	if(!spawn_fast)

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -262,7 +262,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	appearance_flags = TILE_BOUND
 	vis_flags = NONE
 
-/obj/effect/overlay/gas/New(state, alph)
+/obj/effect/overlay/gas/Initialize(mapload, state, alph)
 	. = ..()
 	icon_state = state
 	alpha = alph

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -212,8 +212,8 @@
 	var/list/air_vent_info = list()
 	var/list/air_scrub_info = list()
 
-/obj/machinery/airalarm/New(loc, ndir, nbuild)
-	..()
+/obj/machinery/airalarm/Initialize(mapload, loc, ndir, nbuild)
+	. = ..()
 	wires = new /datum/wires/airalarm(src)
 	if(ndir)
 		setDir(ndir)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -77,7 +77,7 @@
 		if(HAS_TRAIT(L, TRAIT_VENTCRAWLER_NUDE) || HAS_TRAIT(L, TRAIT_VENTCRAWLER_ALWAYS))
 			. += "<span class='notice'>Alt-click to crawl through it.</span>"
 
-/obj/machinery/atmospherics/New(loc, process = TRUE, setdir, init_dir = ALL_CARDINALS)
+/obj/machinery/atmospherics/Initialize(mapload, loc, process = TRUE, setdir, init_dir = ALL_CARDINALS)
 	if(!isnull(setdir))
 		setDir(setdir)
 	if(pipe_flags & PIPING_CARDINAL_AUTONORMALIZE)
@@ -85,7 +85,7 @@
 	nodes = new(device_type)
 	if (!armor)
 		armor = list(MELEE = 25, BULLET = 10, LASER = 10, ENERGY = 100, BOMB = 0, BIO = 100, RAD = 100, FIRE = 100, ACID = 70)
-	..()
+	. = ..()
 	if(process)
 		SSair.start_processing_machine(src)
 	SetInitDirections(init_dir)

--- a/code/modules/atmospherics/machinery/bluespace_vendor.dm
+++ b/code/modules/atmospherics/machinery/bluespace_vendor.dm
@@ -67,7 +67,7 @@
 	dir = EAST
 	pixel_x = -30
 
-/obj/machinery/bluespace_vendor/New(loc, ndir, nbuild)
+/obj/machinery/bluespace_vendor/Initialize(mapload, loc, ndir, nbuild)
 	. = ..()
 	if(ndir)
 		setDir(ndir)
@@ -79,8 +79,6 @@
 
 	update_appearance()
 
-/obj/machinery/bluespace_vendor/Initialize()
-	. = ..()
 	AddComponent(/datum/component/payment, tank_cost, SSeconomy.get_dep_account(ACCOUNT_ENG), PAYMENT_ANGRY)
 
 /obj/machinery/bluespace_vendor/LateInitialize()

--- a/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/dp_vent_pump.dm
@@ -190,8 +190,8 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume
 	name = "large dual-port air vent"
 
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/New()
-	..()
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/Initialize()
+	. = ..()
 	var/datum/gas_mixture/air1 = airs[1]
 	var/datum/gas_mixture/air2 = airs[2]
 	air1.volume = 1000

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -14,19 +14,16 @@
 	///Stores the component gas mixture
 	var/list/datum/gas_mixture/airs
 
-/obj/machinery/atmospherics/components/New()
+/obj/machinery/atmospherics/components/Initialize()
 	parents = new(device_type)
 	airs = new(device_type)
 
-	..()
+	. = ..()
 
 	for(var/i in 1 to device_type)
 		var/datum/gas_mixture/A = new
 		A.volume = 200
 		airs[i] = A
-
-/obj/machinery/atmospherics/components/Initialize()
-	. = ..()
 
 	if(hide)
 		RegisterSignal(src, COMSIG_OBJ_HIDE, .proc/hide_pipe)

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -43,8 +43,8 @@
 	var/on_state = on && nodes[1] && nodes[2] && nodes[3] && is_operational
 	icon_state = "mixer_[on_state ? "on" : "off"]-[set_overlay_offset(piping_layer)][flipped ? "_f" : ""]"
 
-/obj/machinery/atmospherics/components/trinary/mixer/New()
-	..()
+/obj/machinery/atmospherics/components/trinary/mixer/Initialize()
+	. = ..()
 	var/datum/gas_mixture/air3 = airs[3]
 	air3.volume = 300
 	airs[3] = air3

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -16,8 +16,8 @@
 
 	var/obj/machinery/portable_atmospherics/connected_device
 
-/obj/machinery/atmospherics/components/unary/portables_connector/New()
-	..()
+/obj/machinery/atmospherics/components/unary/portables_connector/Initialize()
+	. = ..()
 	var/datum/gas_mixture/air_contents = airs[1]
 	air_contents.volume = 0
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/tank.dm
@@ -15,8 +15,8 @@
 	/// The typepath of the gas this tank should be filled with.
 	var/gas_type = null
 
-/obj/machinery/atmospherics/components/unary/tank/New()
-	..()
+/obj/machinery/atmospherics/components/unary/tank/Initialize()
+	. = ..()
 	var/datum/gas_mixture/air_contents = airs[1]
 	air_contents.volume = volume
 	air_contents.temperature = T20C
@@ -31,8 +31,8 @@
 	icon_state = "grey"
 	name = "pressure tank (Air)"
 
-/obj/machinery/atmospherics/components/unary/tank/air/New()
-	..()
+/obj/machinery/atmospherics/components/unary/tank/air/Initialize()
+	. = ..()
 	var/datum/gas_mixture/air_contents = airs[1]
 	air_contents.assert_gases(/datum/gas/oxygen, /datum/gas/nitrogen)
 	air_contents.gases[/datum/gas/oxygen][MOLES] = AIR_CONTENTS * 0.2

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -35,7 +35,7 @@
 	pipe_state = "uvent"
 	vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE | VENTCRAWL_ENTRANCE_ALLOWED
 
-/obj/machinery/atmospherics/components/unary/vent_pump/New()
+/obj/machinery/atmospherics/components/unary/vent_pump/Initialize()
 	if(!id_tag)
 		id_tag = SSnetworks.assign_random_name()
 	. = ..()
@@ -303,8 +303,8 @@
 	name = "large air vent"
 	power_channel = AREA_USAGE_EQUIP
 
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/New()
-	..()
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/Initialize()
+	. = ..()
 	var/datum/gas_mixture/air_contents = airs[1]
 	air_contents.volume = 1000
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -30,7 +30,7 @@
 	pipe_state = "scrubber"
 	vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE | VENTCRAWL_ENTRANCE_ALLOWED
 
-/obj/machinery/atmospherics/components/unary/vent_scrubber/New()
+/obj/machinery/atmospherics/components/unary/vent_scrubber/Initialize()
 	if(!id_tag)
 		id_tag = SSnetworks.assign_random_name()
 	. = ..()

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -18,7 +18,7 @@
 	///List of cached overlays of the middle part indexed by piping layer
 	var/static/list/mutable_appearance/center_cache = list()
 
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/New()
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold/Initialize()
 	icon_state = ""
 	return ..()
 

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
@@ -17,7 +17,7 @@
 	///List of cached overlays of the middle part indexed by piping layer
 	var/static/list/mutable_appearance/center_cache = list()
 
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/New()
+/obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/Initialize()
 	icon_state = ""
 	return ..()
 

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -14,13 +14,10 @@
 	buckle_requires_restraints = TRUE
 	buckle_lying = NO_BUCKLE_LYING
 
-/obj/machinery/atmospherics/pipe/New()
+/obj/machinery/atmospherics/pipe/Initialize(mapload)
 	add_atom_colour(pipe_color, FIXED_COLOUR_PRIORITY)
 	volume = 35 * device_type
-	..()
 
-///I have no idea why there's a new and at this point I'm too afraid to ask
-/obj/machinery/atmospherics/pipe/Initialize(mapload)
 	. = ..()
 
 	if(hide)

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -94,7 +94,8 @@
 	var/faction = ROLE_WIZARD
 	var/braindead_check = 0
 
-/obj/structure/academy_wizard_spawner/New()
+/obj/structure/academy_wizard_spawner/Initialize()
+	. = ..()
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/academy_wizard_spawner/Destroy()

--- a/code/modules/buildmode/buttons.dm
+++ b/code/modules/buildmode/buttons.dm
@@ -4,7 +4,7 @@
 	// If we don't do this, we get occluded by item action buttons
 	plane = ABOVE_HUD_PLANE
 
-/atom/movable/screen/buildmode/New(bld)
+/atom/movable/screen/buildmode/Initialize(mapload, bld)
 	bd = bld
 	return ..()
 
@@ -58,7 +58,7 @@
 /atom/movable/screen/buildmode/modeswitch
 	var/datum/buildmode_mode/modetype
 
-/atom/movable/screen/buildmode/modeswitch/New(bld, mt)
+/atom/movable/screen/buildmode/modeswitch/Initialize(mapload, bld, mt)
 	modetype = mt
 	icon_state = "buildmode_[initial(modetype.key)]"
 	name = initial(modetype.key)
@@ -72,7 +72,7 @@
 /atom/movable/screen/buildmode/dirswitch
 	icon_state = "build"
 
-/atom/movable/screen/buildmode/dirswitch/New(bld, dir)
+/atom/movable/screen/buildmode/dirswitch/Initialize(mapload, bld, dir)
 	src.dir = dir
 	name = dir2text(dir)
 	return ..(bld)

--- a/code/modules/buildmode/effects/line.dm
+++ b/code/modules/buildmode/effects/line.dm
@@ -2,7 +2,9 @@
 	var/image/I
 	var/client/cl
 
-/obj/effect/buildmode_line/New(client/C, atom/atom_a, atom/atom_b, linename)
+/obj/effect/buildmode_line/Initialize(mapload, client/C, atom/atom_a, atom/atom_b, linename)
+	. = ..()
+
 	name = linename
 	abstract_move(get_turf(atom_a))
 	I = image('icons/misc/mark.dmi', src, "line", 19.0)

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -3,8 +3,8 @@
 	var/order_id = 0
 	var/errors = 0
 
-/obj/item/paper/fluff/jobs/cargo/manifest/New(atom/A, id, cost)
-	..()
+/obj/item/paper/fluff/jobs/cargo/manifest/Initialize(mapload, atom/A, id, cost)
+	. = ..()
 	order_id = id
 	order_cost = cost
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -73,7 +73,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	/// Whether the rod can loop across other z-levels. The rod will still loop when the z-level is self-looping even if this is FALSE.
 	var/loopy_rod = FALSE
 
-/obj/effect/immovablerod/New(atom/start, atom/end, aimed_at, force_looping)
+/obj/effect/immovablerod/Initialize(mapload, atom/start, atom/end, aimed_at, force_looping)
 	. = ..()
 	SSaugury.register_doom(src, 2000)
 
@@ -130,7 +130,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/Moved()
 	if(!loc)
 		return ..()
-		
+
 	for(var/atom/movable/to_bump in loc)
 		if((to_bump != src) && !QDELETED(to_bump) && (to_bump.density || isliving(to_bump)))
 			Bump(to_bump)

--- a/code/modules/mob/living/simple_animal/guardian/types/support.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/support.dm
@@ -98,7 +98,7 @@
 	anchored = TRUE
 	layer = ABOVE_OPEN_TURF_LAYER
 
-/obj/structure/receiving_pad/New(loc, mob/living/simple_animal/hostile/guardian/healer/G)
+/obj/structure/receiving_pad/Initialize(mapload, loc, mob/living/simple_animal/hostile/guardian/healer/G)
 	. = ..()
 	if(G.guardiancolor)
 		add_atom_colour(G.guardiancolor, FIXED_COLOUR_PRIORITY)

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -19,8 +19,8 @@
 	machinery_computer = null
 	. = ..()
 
-/obj/item/modular_computer/processor/New(comp)
-	..()
+/obj/item/modular_computer/processor/Initialize(mapload, comp)
+	. = ..()
 	STOP_PROCESSING(SSobj, src) // Processed by its machine
 
 	if(!comp || !istype(comp, /obj/machinery/modular_computer))

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -34,8 +34,8 @@
 	// What define is used to qualify this piece of hardware? Important for upgraded versions of the same hardware.
 	var/device_type
 
-/obj/item/computer_hardware/New(obj/L)
-	..()
+/obj/item/computer_hardware/Initialize()
+	. = ..()
 	pixel_x = base_pixel_x + rand(-8, 8)
 	pixel_y = base_pixel_y + rand(-8, 8)
 

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -17,11 +17,10 @@
 /obj/item/paper/contract/employment
 	icon_state = "paper_words"
 
-/obj/item/paper/contract/employment/New(atom/loc, mob/living/nOwner)
+/obj/item/paper/contract/employment/Initialize(mapload, atom/loc, mob/living/nOwner)
 	. = ..()
 	if(!nOwner || !nOwner.mind)
-		qdel(src)
-		return -1
+		return INITIALIZE_HINT_QDEL
 	target = nOwner.mind
 	update_text()
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -207,12 +207,12 @@
 	if(terminal)
 		terminal.connect_to_network()
 
-/obj/machinery/power/apc/New(turf/loc, ndir, building=0)
+/obj/machinery/power/apc/Initialize(mapload, turf/loc, ndir, building=0)
 	if (!req_access)
 		req_access = list(ACCESS_ENGINE_EQUIP)
 	if (!armor)
 		armor = list(MELEE = 20, BULLET = 20, LASER = 10, ENERGY = 100, BOMB = 30, BIO = 100, RAD = 100, FIRE = 90, ACID = 50)
-	..()
+	. = ..()
 	GLOB.apcs_list += src
 
 	wires = new /datum/wires/apc(src)

--- a/code/modules/procedural_mapping/mapGeneratorObj.dm
+++ b/code/modules/procedural_mapping/mapGeneratorObj.dm
@@ -8,8 +8,8 @@
 	var/mapGeneratorType = /datum/map_generator/nature
 	var/datum/map_generator/mapGenerator
 
-/obj/effect/landmark/map_generator/New()
-	..()
+/obj/effect/landmark/map_generator/Initialize()
+	. = ..()
 	if(startTurfZ < 0)
 		startTurfZ = z
 	if(endTurfZ < 0)

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -15,8 +15,8 @@
 	var/pin_removeable = FALSE // Can be replaced by any pin.
 	var/obj/item/gun/gun
 
-/obj/item/firing_pin/New(newloc)
-	..()
+/obj/item/firing_pin/Initialize(mapload, newloc)
+	. = ..()
 	if(istype(newloc, /obj/item/gun))
 		gun = newloc
 

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -111,12 +111,13 @@
 	desc = "Pride cometh before the..."
 	icon_state = "magic_mirror"
 
-/obj/structure/mirror/magic/pride/New()
+/obj/structure/mirror/magic/pride/Initialize()
 	for(var/speciestype in subtypesof(/datum/species))
 		var/datum/species/S = speciestype
 		if(initial(S.changesource_flags) & MIRROR_PRIDE)
 			choosable_races += initial(S.id)
-	..()
+	// Populate choosable_races before calling super, to supress default behaviour
+	. = ..()
 
 /obj/structure/mirror/magic/pride/curse(mob/user)
 	user.visible_message("<span class='danger'><B>The ground splits beneath [user] as [user.p_their()] hand leaves the mirror!</B></span>", \

--- a/code/modules/spells/spell_types/personality_commune.dm
+++ b/code/modules/spells/spell_types/personality_commune.dm
@@ -10,7 +10,7 @@
 	var/datum/brain_trauma/severe/split_personality/trauma
 	var/flufftext = "You hear an echoing voice in the back of your head..."
 
-/obj/effect/proc_holder/spell/targeted/personality_commune/New(datum/brain_trauma/severe/split_personality/T)
+/obj/effect/proc_holder/spell/targeted/personality_commune/Initialize(mapload, datum/brain_trauma/severe/split_personality/T)
 	. = ..()
 	trauma = T
 

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -8,7 +8,7 @@
 	var/implant_overlay
 	var/syndicate_implant = FALSE //Makes the implant invisible to health analyzers and medical HUDs.
 
-/obj/item/organ/cyberimp/New(mob/implanted_mob = null)
+/obj/item/organ/cyberimp/Initialize(mapload, mob/implanted_mob = null)
 	if(iscarbon(implanted_mob))
 		src.Insert(implanted_mob)
 	if(implant_overlay)


### PR DESCRIPTION
With the use of a temporary `SHOULD_NOT_OVERRIDE` in /atom/New(), a
number of unrequired overrides of New() were identified, and replaced
with Initialize() calls.

The order of before and after the parent call has been improved where it
was obvious that the order did not matter, with more esoteric ordering
remaining static to avoid breaking anything.

A number of STOP_PROCESSING macros were added where appropriate.

This commit does not replace all New() overrides, technically
INITIALIZE_IMMEDIATE overrides New(), and a number have distinct
comments warning against casual Initialize() replacements.