### PR TITLE
Updates vscode settings to remove the warning with workbench.editorAssociation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,12 +12,9 @@
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": true
 	},
-	"workbench.editorAssociations": [
-		{
-			"filenamePattern": "*.dmi",
-			"viewType": "imagePreview.previewEditor"
-		}
-	],
+	"workbench.editorAssociations": {
+		"*.dmi": "imagePreview.previewEditor"
+	},
 	"files.eol": "\n",
 	"gitlens.advanced.blame.customArguments": ["-w"],
 	"tgstationTestExplorer.project.resultsType": "json",


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Latest vscode version seems to just be automatically do this, so I've made a PR for it. Previous version doesn't let you view the DMI files on the latest vscode version. Latest version does as so:
![image](https://user-images.githubusercontent.com/37270891/121606725-9b7b4280-ca46-11eb-98a5-fad857df0ffa.png)


## Changelog
No changelog because it doesn't really affect the game in any way.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
