### PR TITLE
Cult stun nerf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ Temporary Items
 /tools/LinuxOneShot/TGS_Config
 /tools/LinuxOneShot/TGS_Instances
 /tools/LinuxOneShot/TGS_Logs
+tgstation.dme

--- a/.gitignore
+++ b/.gitignore
@@ -193,4 +193,3 @@ Temporary Items
 /tools/LinuxOneShot/TGS_Config
 /tools/LinuxOneShot/TGS_Instances
 /tools/LinuxOneShot/TGS_Logs
-tgstation.dme

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,12 +12,9 @@
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": true
 	},
-	"workbench.editorAssociations": [
-		{
-			"filenamePattern": "*.dmi",
-			"viewType": "imagePreview.previewEditor"
-		}
-	],
+	"workbench.editorAssociations": {
+		"*.dmi": "imagePreview.previewEditor"
+	},
 	"files.eol": "\n",
 	"gitlens.advanced.blame.customArguments": ["-w"],
 	"tgstationTestExplorer.project.resultsType": "json",

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -442,18 +442,28 @@
 									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 
 		else
-			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-			L.Paralyze(16 SECONDS)
-			L.flash_act(1,TRUE)
-			if(issilicon(target))
-				var/mob/living/silicon/S = L
-				S.emp_act(EMP_HEAVY)
-			else if(iscarbon(target))
+			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 				var/mob/living/carbon/C = L
-				C.silent += 6
-				C.stuttering += 15
-				C.cultslurring += 15
-				C.Jitter(1.5 SECONDS)
+				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
+				C.stuttering += 8
+				C.dizziness += 30
+				C.Jitter(8)
+				C.drop_all_held_items()
+				C.bleed(40)
+				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
+			else
+				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+				L.Paralyze(160)
+				L.flash_act(1,1)
+				if(issilicon(target))
+					var/mob/living/silicon/S = L
+					S.emp_act(EMP_HEAVY)
+				else if(iscarbon(target))
+					var/mob/living/carbon/C = L
+					C.silent += 6
+					C.stuttering += 15
+					C.cultslurring += 15
+					C.Jitter(15)
 		uses--
 	..()
 


### PR DESCRIPTION
## About The Pull Request

Causes mind shields to only cause a disarm and stamina damage when bopped by a cult hand, it is no longer the silent/stun free win slap that it used to be. Code was made by archanial back in the day and was reverted for REASONS.

## Why It's Good For The Game

One hit stuns for sec/rest of the crew have been removed for a long ass time, this brings it into line with everything else in the game.  

## Changelog
:cl:
balance: Mindshields weaken cult stun, crew rejoices. 
/:cl:
