### PR TITLE
Specifies which way -/+ moves things with Modify Transform

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1272,8 +1272,8 @@
 				if(!isnull(x) && !isnull(y))
 					transform = M.Scale(x,y)
 			if("Translate")
-				var/x = input(usr, "Choose x mod","Transform Mod") as null|num
-				var/y = input(usr, "Choose y mod","Transform Mod") as null|num
+				var/x = input(usr, "Choose x mod (negative = left, positive = right)","Transform Mod") as null|num
+				var/y = input(usr, "Choose y mod (negative = down, positive = up)","Transform Mod") as null|num
 				if(!isnull(x) && !isnull(y))
 					transform = M.Translate(x,y)
 			if("Rotate")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I have forgotten which way using positive/negative numbers on the Modify Transform -> Translate VV option moves sprites on the y-axis a million times, and I'm sure I'm not the only person who's accidentally moved something up when they meant down, and vice versa. This changes the prompt to tell you which way positive/negative numbers move the sprite (including for the x-axis since it'd be weird to only tell you for one).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No longer will you have to face the classic programmer's dilemma of wondering if increasing the y-axis moves you towards the top of the grid/screen or the bottom
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
admin: The Modify Transform -> Translate option in the VV dropdown will now remind you which way positive or negative numbers will move the sprite in question. For those of you wondering, on the Y-axis, positive moves you up and negative moves you down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
