### PR TITLE
Makes revolvers not drop bullets if you're just flipping it

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -449,6 +449,7 @@
 			flip_cooldown = (world.time + 30)
 			user.visible_message("<span class='notice'>[user] spins the [src] around their finger by the trigger. That’s pretty badass.</span>")
 			playsound(src, 'sound/items/handling/ammobox_pickup.ogg', 20, FALSE)
+			return
 	if(!internal_magazine && magazine)
 		if(!magazine.ammo_count())
 			eject_magazine(user)


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/53777086/121768035-f9348b00-cb29-11eb-93ac-b67e23912aa4.png)
![image](https://user-images.githubusercontent.com/53777086/121768039-fdf93f00-cb29-11eb-8be6-71f0cefd2e88.png)

## Why It's Good For The Game

Detectives cant flip their gun while on the run without unloading all their bullets

## Changelog
:cl:
fix: Flipping a gun will no longer unload all its bullets.
/:cl: