### PR TITLE
Radial info box layer fix

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -231,7 +231,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 			if (choice_datum.info)
 				var/obj/effect/abstract/info/info_button = new(E, choice_datum.info)
 				info_button.plane = ABOVE_HUD_PLANE
-				info_button.layer = RADIAL_BACKGROUND_LAYER
+				info_button.layer = RADIAL_CONTENT_LAYER
 				E.vis_contents += info_button
 
 /datum/radial_menu/New()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR fixes radial info boxes, like blob strains or spider clusters have. Since some layer changes sometime ago, these little boxes layer behind the rest of radial button - so they are quite hard to spot and click. Now they will once again properly layer over the radial button, like they used to and how are they supposed to.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugfix.

## Changelog
:cl: Arkatos
fix: Radial info boxes will now layer properly over the radial button, so it is actually visible and clickable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
