### PR TITLE
New contraband peanuts

### DIFF
--- a/code/game/objects/items/food/snacks.dm
+++ b/code/game/objects/items/food/snacks.dm
@@ -220,7 +220,7 @@
 
 /obj/item/food/peanuts/random/Initialize()
 	// Generate a sample p
-	var/peanut_type = pick(subtypesof(/obj/item/food/peanuts) - /obj/item/food/peanuts/random - /obj/item/food/peanuts/banappeal)
+	var/peanut_type = pick(subtypesof(/obj/item/food/peanuts) - /obj/item/food/peanuts/random - /obj/item/food/peanuts/ban_appeal)
 	var/obj/item/food/sample = new peanut_type(loc)
 
 	name = sample.name

--- a/code/game/objects/items/food/snacks.dm
+++ b/code/game/objects/items/food/snacks.dm
@@ -210,7 +210,7 @@
 /obj/item/food/peanuts/banappeal
 	name = "\improper Gallery's Ban Appel roast peanuts"
 	desc = "Yearly lobbying is denied not because the roasting apples are toxic, but because they keep evading the ban."
-	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/cyanide = 1) //uses roasted poison apples
+	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin/cyanide = 1) //uses roasted poison apples
 	tastes = list("peanuts" = 3, "apples" = 1, "regret" = 1)
 
 /obj/item/food/peanuts/random

--- a/code/game/objects/items/food/snacks.dm
+++ b/code/game/objects/items/food/snacks.dm
@@ -221,7 +221,7 @@
 	icon_state = "peanuts"
 	safe_for_consumption = FALSE
 
-GLOBAL_LIST(safe_peanut_types) = populate_safe_peanut_types()
+GLOBAL_LIST_INIT(safe_peanut_types, populate_safe_peanut_types())
 
 /proc/populate_safe_peanut_types()
 	. = list()

--- a/code/game/objects/items/food/snacks.dm
+++ b/code/game/objects/items/food/snacks.dm
@@ -182,6 +182,7 @@
 	junkiness = 10 //less junky than other options, since peanuts are a decently healthy snack option
 	w_class = WEIGHT_CLASS_SMALL
 	grind_results = list(/datum/reagent/consumable/peanut_butter = 5, /datum/reagent/consumable/cooking_oil = 2)
+	var/safe_for_consumption = TRUE
 
 /obj/item/food/peanuts/salted
 	name = "\improper Gallery's salt reserves peanuts"
@@ -212,15 +213,26 @@
 	desc = "An ill-fated attempt at trail mix, banned in 6 sectors. Yearly lobbying to overturn is denied not because the apples are toxic, but because they keep evading the ban."
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin/cyanide = 1) //uses dried poison apples
 	tastes = list("peanuts" = 3, "apples" = 1, "regret" = 1)
+	safe_for_consumption = FALSE
 
 /obj/item/food/peanuts/random
 	name = "\improper Gallery's every-flavour peanuts"
 	desc = "What flavour will you get?"
 	icon_state = "peanuts"
+	safe_for_consumption = FALSE
+
+GLOBAL_LIST(safe_peanut_types) = populate_safe_peanut_types()
+
+/proc/populate_safe_peanut_types()
+	. = list()
+	for(var/obj/item/food/peanuts/peanut_type as anything in subtypesof(/obj/item/food/peanuts))
+		if(!initial(peanut_type.safe_for_consumption))
+			continue
+		. += peanut_type
 
 /obj/item/food/peanuts/random/Initialize()
 	// Generate a sample p
-	var/peanut_type = pick(subtypesof(/obj/item/food/peanuts) - /obj/item/food/peanuts/random - /obj/item/food/peanuts/ban_appeal)
+	var/peanut_type = pick(GLOB.safe_peanut_types)
 	var/obj/item/food/sample = new peanut_type(loc)
 
 	name = sample.name

--- a/code/game/objects/items/food/snacks.dm
+++ b/code/game/objects/items/food/snacks.dm
@@ -178,6 +178,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2)
 	tastes = list("peanuts" = 4, "anger" = 1)
 	foodtypes = JUNKFOOD | NUTS
+	custom_price = PAYCHECK_ASSISTANT * 0.8 //nuts are expensive in real life, and this is the best food in the vendor.
 	junkiness = 10 //less junky than other options, since peanuts are a decently healthy snack option
 	w_class = WEIGHT_CLASS_SMALL
 	grind_results = list(/datum/reagent/consumable/peanut_butter = 5, /datum/reagent/consumable/cooking_oil = 2)
@@ -206,6 +207,12 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/bbqsauce = 1)
 	tastes = list("peanuts" = 3, "bbq sauce" = 1, "arguments" = 1)
 
+/obj/item/food/peanuts/banappeal
+	name = "\improper Gallery's Ban Appel roast peanuts"
+	desc = "Yearly lobbying is denied not because the roasting apples are toxic, but because they keep evading the ban."
+	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/cyanide = 1) //uses roasted poison apples
+	tastes = list("peanuts" = 3, "apples" = 1, "regret" = 1)
+
 /obj/item/food/peanuts/random
 	name = "\improper Gallery's every-flavour peanuts"
 	desc = "What flavour will you get?"
@@ -213,7 +220,7 @@
 
 /obj/item/food/peanuts/random/Initialize()
 	// Generate a sample p
-	var/peanut_type = pick(subtypesof(/obj/item/food/peanuts) - /obj/item/food/peanuts/random)
+	var/peanut_type = pick(subtypesof(/obj/item/food/peanuts) - /obj/item/food/peanuts/random - /obj/item/food/peanuts/banappeal)
 	var/obj/item/food/sample = new peanut_type(loc)
 
 	name = sample.name

--- a/code/game/objects/items/food/snacks.dm
+++ b/code/game/objects/items/food/snacks.dm
@@ -210,7 +210,7 @@
 /obj/item/food/peanuts/ban_appeal
 	name = "\improper Gallery's peanuts Ban Appel mix"
 	desc = "An ill-fated attempt at trail mix, banned in 6 sectors. Yearly lobbying to overturn is denied not because the apples are toxic, but because they keep evading the ban."
-	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin = 1) //tasty for slime people
+	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin/cyanide = 1) //uses dried poison apples
 	tastes = list("peanuts" = 3, "apples" = 1, "regret" = 1)
 
 /obj/item/food/peanuts/random

--- a/code/game/objects/items/food/snacks.dm
+++ b/code/game/objects/items/food/snacks.dm
@@ -207,10 +207,10 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/bbqsauce = 1)
 	tastes = list("peanuts" = 3, "bbq sauce" = 1, "arguments" = 1)
 
-/obj/item/food/peanuts/banappeal
-	name = "\improper Gallery's Ban Appel roast peanuts"
-	desc = "Yearly lobbying is denied not because the roasting apples are toxic, but because they keep evading the ban."
-	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin/cyanide = 1) //uses roasted poison apples
+/obj/item/food/peanuts/ban_appeal
+	name = "\improper Gallery's peanuts Ban Appel mix"
+	desc = "An ill-fated attempt at trail mix, banned in 6 sectors. Yearly lobbying to overturn is denied not because the apples are toxic, but because they keep evading the ban."
+	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/toxin = 1) //tasty for slime people
 	tastes = list("peanuts" = 3, "apples" = 1, "regret" = 1)
 
 /obj/item/food/peanuts/random

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -19,6 +19,7 @@
 					/obj/item/storage/box/gum = 3,
 					/obj/item/food/energybar = 6)
 	contraband = list(/obj/item/food/syndicake = 6,
+					/obj/item/food/peanuts/banappeal = 3,
 					/obj/item/food/candy/bronx = 1)
 	refill_canister = /obj/item/vending_refill/snack
 	canload_access_list = list(ACCESS_KITCHEN)

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -19,7 +19,7 @@
 					/obj/item/storage/box/gum = 3,
 					/obj/item/food/energybar = 6)
 	contraband = list(/obj/item/food/syndicake = 6,
-					/obj/item/food/peanuts/banappeal = 3,
+					/obj/item/food/peanuts/ban_appeal = 3,
 					/obj/item/food/candy/bronx = 1)
 	refill_canister = /obj/item/vending_refill/snack
 	canload_access_list = list(ACCESS_KITCHEN)


### PR DESCRIPTION


## About The Pull Request
Adds a new variety of peanuts to Getmore
Tweaks peanuts to have a higher price, since they're currently the best thing to buy in the vendor.

## Why It's Good For The Game

The joke isn't complete without this.

## Changelog
:cl:
expansion: Adds a contraband flavor of Gallery's Peanuts to Getmore vendor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
