### PR TITLE
Fixes carbon roses mutating into carbon roses

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -349,7 +349,6 @@
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	icon_grow = "carbonrose-grow"
 	icon_dead = "carbonrose-dead"
-	mutatelist = list(/obj/item/seeds/carbon_rose)
 	reagents_add = list(/datum/reagent/plastic_polymers = 0.05)
 	rarity = 10
 	graft_gene = /datum/plant_gene/reagent/carbon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #59626 

## Why It's Good For The Game

fix

## Changelog
:cl:
fix: carbon roses can no longer mutate into carbon roses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
