### PR TITLE
Gives bartenders a Weapons permit for their gun

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -105,7 +105,7 @@
 	assignment = "Bartender"
 	trim_state = "trim_bartender"
 	full_access = list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_MORGUE, ACCESS_WEAPONS, ACCESS_MINERAL_STOREROOM, ACCESS_THEATRE)
-	minimal_access = list(ACCESS_BAR, ACCESS_MINERAL_STOREROOM, ACCESS_THEATRE)
+	minimal_access = list(ACCESS_BAR, ACCESS_WEAPONS, ACCESS_MINERAL_STOREROOM, ACCESS_THEATRE)
 	config_job = "bartender"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 


### PR DESCRIPTION
## About The Pull Request

Bartenders used to only have it on skeleton crew, now they have it by default.

## Why It's Good For The Game

I don't know why Bartenders only get a weapon's permit on lowpop, they literally spawn with a shotgun, I dont see why they wouldn't have a permit for it.

## Changelog
:cl:
balance: Bartenders now properly have a weapon's permit for their gun.
/:cl: