### PR TITLE
Punch your local clown in the balls!

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -323,6 +323,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Trait used by fugu glands to avoid double buffing
 #define TRAIT_FUGU_GLANDED "fugu_glanded"
 
+/// If human with this trait is punched into groin they will get stam damage, scream and LOOOOOUDLY honk
+#define TRAIT_BALLS_VULNERABLE "clown_balls"
+
 // METABOLISMS
 // Various jobs on the station have historically had better reactions
 // to various drinks and foodstuffs. Security liking donuts is a classic

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -74,9 +74,11 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	switch(icon_state)
 		if("honk1")
 			user.dna.add_mutation(CLOWNMUT)
+			ADD_TRAIT(user, TRAIT_BALLS_VULNERABLE, MAGIC_TRAIT)
 			user.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(user), ITEM_SLOT_MASK)
 		if("honk2")
 			user.dna.add_mutation(CLOWNMUT)
+			ADD_TRAIT(user, TRAIT_BALLS_VULNERABLE, MAGIC_TRAIT)
 			user.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(user), ITEM_SLOT_MASK)
 		if("insuls")
 			var/obj/item/clothing/gloves/color/fyellow/insuls = new

--- a/code/modules/antagonists/clown_ops/bananium_bomb.dm
+++ b/code/modules/antagonists/clown_ops/bananium_bomb.dm
@@ -54,4 +54,5 @@
 			H.equip_to_slot_or_del(C, ITEM_SLOT_MASK)
 
 		H.dna.add_mutation(CLOWNMUT)
+		ADD_TRAIT(H, TRAIT_BALLS_VULNERABLE, MAGIC_TRAIT)
 		H.gain_trauma(/datum/brain_trauma/mild/phobia/clowns, TRAUMA_RESILIENCE_LOBOTOMY) //MWA HA HA

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -73,6 +73,7 @@
 
 	H.fully_replace_character_name(H.real_name, pick(GLOB.clown_names)) //rename the mob AFTER they're equipped so their ID gets updated properly.
 	ADD_TRAIT(H, TRAIT_NAIVE, JOB_TRAIT)
+	ADD_TRAIT(H, TRAIT_BALLS_VULNERABLE, JOB_TRAIT)
 	H.dna.add_mutation(CLOWNMUT)
 	for(var/datum/mutation/human/clumsy/M in H.dna.mutations)
 		M.mutadone_proof = TRUE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1439,6 +1439,15 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(user.limb_destroyer)
 			target.dismembering_strike(user, affecting.body_zone)
 
+		if(HAS_TRAIT(target, TRAIT_BALLS_VULNERABLE) && user.zone_selected == BODY_ZONE_PRECISE_GROIN) //Clowns can be punched in groin for memes
+			target.apply_damage(damage, user.dna.species.attack_type, affecting, armor_block)
+			target.apply_damage(damage * 5, STAMINA, affecting, armor_block)
+			target.emote("scream")
+			playsound(target, 'sound/items/bikehorn.ogg', 200, TRUE) //Loudly honks
+			new /obj/effect/decal/cleanable/confetti(get_turf(target)) //And shits themselves
+			log_combat(user, target, "punched in the balls")
+			return
+
 		if(atk_effect == ATTACK_EFFECT_KICK)//kicks deal 1.5x raw damage
 			target.apply_damage(damage*1.5, user.dna.species.attack_type, affecting, armor_block)
 			log_combat(user, target, "kicked")

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -588,6 +588,7 @@
 		TRAIT_GENELESS,
 		TRAIT_PIERCEIMMUNE,
 		TRAIT_NODISMEMBER,
+		TRAIT_BALLS_VULNERABLE
 	)
 	punchdamagelow = 0
 	punchdamagehigh = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows people to punch clowns(and chaplains with clown bible because it also makes them clumsy and clowny) in the balls, dealing damage*5 stamina damage, making them scream, loudly honk and shit confetti. Yes, even female clowns. Any species. The main point here is that it's not their balls but their clown instincts that make them do the funny thing for the audience.

## Why It's Good For The Game

Clowns need to funny and this allows more fun shenanigans to happen

## Changelog
:cl:
add: Clowns can be punched in the balls to make them scream, honk and shit confetti.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
