### PR TITLE
Juke Build Hotfix 2 - PreCompile script compatibility

### DIFF
--- a/BUILD.bat
+++ b/BUILD.bat
@@ -1,2 +1,3 @@
-@call "%~dp0\tools\build\build" %*
-@pause
+@echo off
+call "%~dp0\tools\build\build.bat" %*
+pause

--- a/BUILD.bat
+++ b/BUILD.bat
@@ -1,2 +1,2 @@
-@call "%~dp0\tools\build\build"
+@call "%~dp0\tools\build\build" %*
 @pause

--- a/tools/LinuxOneShot/SetupProgram/PreCompile.sh
+++ b/tools/LinuxOneShot/SetupProgram/PreCompile.sh
@@ -66,7 +66,7 @@ cd ..
 echo "Compiling tgui..."
 cd "$1"
 chmod +x tools/bootstrap/node  # Workaround for https://github.com/tgstation/tgstation-server/issues/1167
-env TG_BOOTSTRAP_CACHE="$original_dir" TG_BOOTSTRAP_NODE_LINUX=1 tools/bootstrap/node tools/build/build.js tgs
+env TG_BOOTSTRAP_CACHE="$original_dir" TG_BOOTSTRAP_NODE_LINUX=1 CBT_BUILD_MODE="TGS" tools/bootstrap/node tools/build/build.js
 cd "$original_dir"
 
 if [ ! -d "../GameStaticFiles/config" ]; then
@@ -89,4 +89,4 @@ echo "Compiling tgui..."
 cd "$1"
 chmod +x tools/bootstrap/node  # Workaround for https://github.com/tgstation/tgstation-server/issues/1167
 chmod +x tgui/bin/tgui
-env TG_BOOTSTRAP_CACHE="$original_dir" TG_BOOTSTRAP_NODE_LINUX=1 tools/bootstrap/node tools/build/build.js tgs
+env TG_BOOTSTRAP_CACHE="$original_dir" TG_BOOTSTRAP_NODE_LINUX=1 CBT_BUILD_MODE="TGS" tools/bootstrap/node tools/build/build.js

--- a/tools/bootstrap/python.bat
+++ b/tools/bootstrap/python.bat
@@ -1,1 +1,2 @@
-@call powershell.exe -NoLogo -ExecutionPolicy Bypass -File "%~dp0\python_.ps1" %*
+@echo off
+call powershell.exe -NoLogo -ExecutionPolicy Bypass -File "%~dp0\python_.ps1" %*

--- a/tools/build/build.bat
+++ b/tools/build/build.bat
@@ -1,1 +1,1 @@
-@"%~dp0\..\bootstrap\node" "%~dp0\build.js"
+@"%~dp0\..\bootstrap\node" "%~dp0\build.js" %*

--- a/tools/build/build.bat
+++ b/tools/build/build.bat
@@ -1,1 +1,2 @@
-@"%~dp0\..\bootstrap\node" "%~dp0\build.js" %*
+@echo off
+"%~dp0\..\bootstrap\node.bat" "%~dp0\build.js" %*

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -137,8 +137,14 @@ const TgsTarget = Juke.createTarget({
   },
 });
 
-Juke.setup({
-  default: DefaultTarget,
-}).then((code) => {
-  process.exit(code);
-});
+Juke
+  .setup({
+    default: (
+      process.env.CBT_BUILD_MODE === 'TGS'
+        ? TgsTarget
+        : DefaultTarget
+    ),
+  })
+  .then((code) => {
+    process.exit(code);
+  });

--- a/tools/tgs4_scripts/PreCompile.bat
+++ b/tools/tgs4_scripts/PreCompile.bat
@@ -11,4 +11,5 @@ IF NOT %1 == "" (
 	rem TGS3: Otherwise build in Game/B
 	cd ..\Game\B
 )
-tools\build\build tgs
+set CBT_BUILD_MODE=TGS
+tools\build\build

--- a/tools/tgs4_scripts/PreCompile.sh
+++ b/tools/tgs4_scripts/PreCompile.sh
@@ -111,4 +111,4 @@ fi
 echo "Compiling tgui..."
 cd "$1"
 chmod +x tools/bootstrap/node  # Workaround for https://github.com/tgstation/tgstation-server/issues/1167
-env TG_BOOTSTRAP_CACHE="$original_dir" TG_BOOTSTRAP_NODE_LINUX=1 tools/bootstrap/node tools/build/build.js tgs
+env TG_BOOTSTRAP_CACHE="$original_dir" TG_BOOTSTRAP_NODE_LINUX=1 CBT_BUILD_MODE="TGS" tools/bootstrap/node tools/build/build.js


### PR DESCRIPTION
## About The Pull Request

> MSO: the precompile script will not be getting updated, revert what ever changed.
> MSO: updating the precompile script is a pain and you should be focusing on making changes to build.bat not require updates to precompile.bat.

Addressing that.
