### PR TITLE
Revert "Prevent SSinput from constantly requesting moving in-place"

### DIFF
--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -7,13 +7,8 @@
 		movement_dir = movement_dir | user.movement_keys[_key]
 	if(user.next_move_dir_add)
 		movement_dir |= user.next_move_dir_add
-		user.next_move_dir_add = 0
 	if(user.next_move_dir_sub)
 		movement_dir &= ~user.next_move_dir_sub
-		user.next_move_dir_sub = 0
-	if(!movement_dir)
-		return
-
 	// Sanity checks in case you hold left and right and up to make sure you only go up
 	if((movement_dir & NORTH) && (movement_dir & SOUTH))
 		movement_dir &= ~(NORTH|SOUTH)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -69,6 +69,9 @@
 /client/Move(new_loc, direct)
 	if(world.time < move_delay) //do not move anything ahead of this check please
 		return FALSE
+	else
+		next_move_dir_add = 0
+		next_move_dir_sub = 0
 	var/old_move_delay = move_delay
 	move_delay = world.time + world.tick_lag //this is here because Move() can now be called mutiple times per tick
 	if(!mob || !mob.loc)


### PR DESCRIPTION
Reverts tgstation/tgstation#59558

Fucky movement fix oranges is literally threatening me.

I feel like I've messed up somewhere here...

Either way this is causing movements to be a bit fucky where one input counts as two in a direction.