### PR TITLE
Agent ID cards now jump to the front of wallets and can disguise other more powerful ID cards.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -657,3 +657,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_FILLED_MAINT "station_trait_filled_maint"
 #define STATION_TRAIT_EMPTY_MAINT "station_trait_empty_maint"
 #define STATION_TRAIT_PDA_GLITCHED "station_trait_pda_glitched"
+
+/// ID cards with this trait will attempt to forcibly occupy the front-facing ID card slot in wallets.
+#define TRAIT_MAGNETIC_ID_CARD "magnetic_id_card"
+/// Traits granted to items due to their chameleon properties.
+#define CHAMELEON_ITEM_TRAIT "chameleon_item_trait"

--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -184,7 +184,10 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		"TRAIT_MOVE_VENTCRAWLING" = TRAIT_MOVE_VENTCRAWLING,
 		"TRAIT_MOVE_FLOATING" = TRAIT_MOVE_FLOATING,
 		"TRAIT_MOVE_PHASING" = TRAIT_MOVE_PHASING
-		)
+		),
+	/obj/item/card/id = list(
+		"TRAIT_MAGNETIC_ID_CARD" = TRAIT_MAGNETIC_ID_CARD,
+	)
 	))
 
 /// value -> trait name, generated on use from trait_by_type global

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1040,7 +1040,7 @@
 
 /obj/item/card/id/advanced/chameleon
 	name = "agent card"
-	desc = "A highly advanced chameleon ID card. Touch this card on another ID card to choose which accesses to copy."
+	desc = "A highly advanced chameleon ID card. Touch this card on another ID card to choose which accesses to copy. Has special magnetic properties which force it to the front of wallets."
 	trim = /datum/id_trim/chameleon
 	wildcard_slots = WILDCARD_LIMIT_CHAMELEON
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1053,6 +1053,7 @@
 
 /obj/item/card/id/advanced/chameleon/Initialize()
 	. = ..()
+
 	var/datum/action/item_action/chameleon/change/id/chameleon_card_action = new(src)
 	chameleon_card_action.chameleon_type = /obj/item/card/id/advanced
 	chameleon_card_action.chameleon_name = "ID Card"
@@ -1205,6 +1206,9 @@
 				if(new_age)
 					registered_age = max(round(text2num(new_age)), 0)
 
+				if(tgui_alert(user, "Activate wallet ID spoofing, allowing this card to force itself to occupy the visible ID slot in wallets?", "Wallet ID Spoofing", list("Yes", "No")) == "Yes")
+					ADD_TRAIT(src, TRAIT_MAGNETIC_ID_CARD, CHAMELEON_ITEM_TRAIT)
+
 				update_label()
 				update_icon()
 				forged = TRUE
@@ -1225,6 +1229,7 @@
 				registered_name = initial(registered_name)
 				assignment = initial(assignment)
 				SSid_access.remove_trim_from_chameleon_card(src)
+				REMOVE_TRAIT(src, TRAIT_MAGNETIC_ID_CARD, CHAMELEON_ITEM_TRAIT)
 				log_game("[key_name(user)] has reset \the [initial(name)] named \"[src]\" to default.")
 				update_label()
 				update_icon()

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -64,6 +64,12 @@
 		var/obj/item/card/id/id_card = card
 		if(!istype(id_card))
 			continue
+
+		// Chameleon IDs explicitly jump to the front so they can disguise other cards in wallets.
+		if(istype(id_card, /obj/item/card/id/advanced/chameleon))
+			front_id = id_card
+			break
+
 		var/card_tally = SSid_access.tally_access(id_card, ACCESS_FLAG_COMMAND)
 		if(card_tally > winning_tally)
 			winning_tally = card_tally

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -65,8 +65,8 @@
 		if(!istype(id_card))
 			continue
 
-		// Chameleon IDs explicitly jump to the front so they can disguise other cards in wallets.
-		if(istype(id_card, /obj/item/card/id/advanced/chameleon))
+		// Certain IDs can forcibly jump to the front so they can disguise other cards in wallets. Chameleon/Agent ID cards are an example of this.
+		if(HAS_TRAIT(id_card, TRAIT_MAGNETIC_ID_CARD))
 			front_id = id_card
 			break
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Many moons after I reworked ID cards, I feel the Agent ID card needs a little bit of extra love.

This change adds an option during forging which allows the user to specify whether the agent ID card will force itself to the front-facing/visible ID slot in wallets.

This provides traitors with a way to effectively disguse any special ID cards and accesses they may have without making the agent ID card a must-buy TC tax. If your traitor strategy involves gathering many ID cards, this is a definite buff to an item that took a heavy hit to power in the rework.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I feel the agent ID card is a bit underpowered and could use a boost in utility. This should give it that boost without defeating the whole point of the ID card and access overhaul.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The traitor's Agent ID card has a new option available during forging called Wallet ID Spoofing. Selecting this option will automatically snap the Agent ID card to the front of any wallet, allowing the traitor to hide more valuable ID cards behind it. This is disabled when the card is unforged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
