### PR TITLE
Refactors move procs to support multitle objects

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -130,14 +130,14 @@
 #define COMSIG_ATOM_UPDATED_ICON "atom_updated_icon"
 ///from base of [/atom/proc/smooth_icon]: ()
 #define COMSIG_ATOM_SMOOTHED_ICON "atom_smoothed_icon"
-///from base of atom/Entered(): (atom/movable/entering, /atom/oldLoc)
+///from base of atom/Entered(): (atom/movable/arrived, direction)
 #define COMSIG_ATOM_ENTERED "atom_entered"
-/// Sent from the atom that just Entered src. From base of atom/Entered(): (/atom/entered_atom, /atom/oldLoc)
+/// Sent from the atom that just Entered src. From base of atom/Entered(): (/atom/destination, direction)
 #define COMSIG_ATOM_ENTERING "atom_entering"
-///from base of atom/Exit(): (/atom/movable/exiting, /atom/newloc)
+///from base of atom/Exit(): (/atom/movable/leaving, direction)
 #define COMSIG_ATOM_EXIT "atom_exit"
 	#define COMPONENT_ATOM_BLOCK_EXIT (1<<0)
-///from base of atom/Exited(): (atom/movable/exiting, atom/newloc)
+///from base of atom/Exited(): (atom/movable/gone, direction)
 #define COMSIG_ATOM_EXITED "atom_exited"
 ///from base of atom/Bumped(): (/atom/movable)
 #define COMSIG_ATOM_BUMPED "atom_bumped"
@@ -368,9 +368,9 @@
 
 ///from base of area/proc/power_change(): ()
 #define COMSIG_AREA_POWER_CHANGE "area_power_change"
-///from base of area/Entered(): (atom/movable/M)
+///from base of area/Entered(): (atom/movable/arrived, direction)
 #define COMSIG_AREA_ENTERED "area_entered"
-///from base of area/Exited(): (atom/movable/M)
+///from base of area/Exited(): (atom/movable/gone, direction)
 #define COMSIG_AREA_EXITED "area_exited"
 
 // /turf signals

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -310,11 +310,11 @@ have ways of interacting with a specific mob and control it.
 			var/mob/living/carbon/human/H = thrown_by
 			retaliate(H)
 
-/datum/ai_controller/monkey/proc/on_entered(datum/source, atom/movable/AM)
+/datum/ai_controller/monkey/proc/on_entered(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
 	var/mob/living/living_pawn = pawn
-	if(!IS_DEAD_OR_INCAP(living_pawn) && ismob(AM))
-		var/mob/living/in_the_way_mob = AM
+	if(!IS_DEAD_OR_INCAP(living_pawn) && isliving(arrived))
+		var/mob/living/in_the_way_mob = arrived
 		in_the_way_mob.knockOver(living_pawn)
 		return
 

--- a/code/datums/components/acid.dm
+++ b/code/datums/components/acid.dm
@@ -201,11 +201,12 @@
 
 
 /// Handles searing the feet of whoever walks over this without protection. Only active if the parent is a turf.
-/datum/component/acid/proc/on_entered(atom/parent_atom, mob/living/crosser)
+/datum/component/acid/proc/on_entered(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
 
-	if(!isliving(crosser))
+	if(!isliving(arrived))
 		return
+	var/mob/living/crosser = arrived
 	if(crosser.movement_type & FLYING)
 		return
 	if(crosser.m_intent & MOVE_INTENT_WALK)

--- a/code/datums/components/aquarium.dm
+++ b/code/datums/components/aquarium.dm
@@ -247,9 +247,9 @@
 	base_layer = current_aquarium.request_layer(properties.layer_mode)
 	vc_obj.layer = base_layer
 
-/datum/component/aquarium_content/proc/on_removed(datum/source, atom/movable/mover)
+/datum/component/aquarium_content/proc/on_removed(datum/source, atom/movable/gone, direction)
 	SIGNAL_HANDLER
-	if(mover != parent)
+	if(parent != gone)
 		return
 	remove_from_aquarium()
 

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -148,13 +148,14 @@
 	)
 	AddElement(/datum/element/connect_loc, parent, loc_connections)
 
-/datum/component/butchering/recycler/proc/on_entered(datum/source, mob/living/L)
+/datum/component/butchering/recycler/proc/on_entered(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
 
-	if(!istype(L))
+	if(!isliving(arrived))
 		return
+	var/mob/living/victim = arrived
 	var/obj/machinery/recycler/eater = parent
 	if(eater.safety_mode || (eater.machine_stat & (BROKEN|NOPOWER))) //I'm so sorry.
 		return
-	if(L.stat == DEAD && (L.butcher_results || L.guaranteed_butcher_results))
-		Butcher(parent, L)
+	if(victim.stat == DEAD && (victim.butcher_results || victim.guaranteed_butcher_results))
+		Butcher(parent, victim)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -31,11 +31,11 @@
 	target_turf = target
 	START_PROCESSING(SSobj, src) // process on create, in case stuff is still there
 
-/datum/component/chasm/proc/Entered(datum/source, atom/movable/AM)
+/datum/component/chasm/proc/Entered(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
 
 	START_PROCESSING(SSobj, src)
-	drop_stuff(AM)
+	drop_stuff(arrived)
 
 /datum/component/chasm/process()
 	if (!drop_stuff())

--- a/code/datums/components/electrified_buckle.dm
+++ b/code/datums/components/electrified_buckle.dm
@@ -104,7 +104,7 @@
 
 	if(parent)
 		REMOVE_TRAIT(parent_as_movable, TRAIT_ELECTRIFIED_BUCKLE, INNATE_TRAIT)
-		UnregisterSignal(parent, list(COMSIG_MOVABLE_BUCKLE, COMSIG_MOVABLE_UNBUCKLE, COMSIG_ATOM_EXIT, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER)))
+		UnregisterSignal(parent, list(COMSIG_MOVABLE_BUCKLE, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER)))
 		if(requested_signal_parent_emits)
 			UnregisterSignal(parent, requested_signal_parent_emits)
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -435,9 +435,9 @@ Behavior that's still missing from this component that original food items had t
 
 
 ///Ability to feed food to puppers
-/datum/component/edible/proc/on_entered(datum/source, mob/user)
+/datum/component/edible/proc/on_entered(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
-	SEND_SIGNAL(parent, COMSIG_FOOD_CROSSED, user, bitecount)
+	SEND_SIGNAL(parent, COMSIG_FOOD_CROSSED, arrived, bitecount)
 
 ///Response to being used to customize something
 /datum/component/edible/proc/used_to_customize(datum/source, atom/customized)

--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -109,11 +109,11 @@
 		var/obj/item/I = parent
 		I.permeability_coefficient = old_permeability
 
-/datum/component/infective/proc/try_infect_crossed(datum/source, atom/movable/M)
+/datum/component/infective/proc/try_infect_crossed(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
 
-	if(isliving(M))
-		try_infect(M, BODY_ZONE_PRECISE_L_FOOT)
+	if(isliving(arrived))
+		try_infect(arrived, BODY_ZONE_PRECISE_L_FOOT)
 
 /datum/component/infective/proc/try_infect_streak(datum/source, list/directions, list/output_diseases)
 	SIGNAL_HANDLER

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -354,10 +354,10 @@
 		bodies += L
 
 /// Someone who was originally "under" the grenade has moved off the tile and is now eligible for being a martyr and "covering" it
-/datum/component/pellet_cloud/proc/grenade_uncrossed(datum/source, atom/movable/AM)
+/datum/component/pellet_cloud/proc/grenade_uncrossed(datum/source, atom/movable/gone, direction)
 	SIGNAL_HANDLER
 
-	bodies -= AM
+	bodies -= gone
 
 /// Our grenade or landmine or caseless shell or whatever tried deleting itself, so we intervene and nullspace it until we're done here
 /datum/component/pellet_cloud/proc/nullspace_parent()

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -18,7 +18,7 @@
 	var/blockers = NONE
 
 	var/static/list/loc_connections = list(
-		COMSIG_ATOM_ENTERED = .proc/rot_react,
+		COMSIG_ATOM_ENTERED = .proc/on_entered,
 	)
 
 /datum/component/rot/Initialize(delay, scaling, severity)
@@ -112,6 +112,11 @@
 /datum/component/rot/proc/rot_react_touch(datum/source, mob/living/react_to)
 	SIGNAL_HANDLER
 	rot_react(source, react_to, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
+
+/// Triggered when something enters the component's parent.
+/datum/component/rot/proc/on_entered(datum/source, atom/movable/arrived, direction)
+	SIGNAL_HANDLER
+	rot_react(source, arrived)
 
 ///The main bit of logic for the rot component, does a temperature check and has a chance to infect react_to
 /datum/component/rot/proc/rot_react(source, mob/living/react_to, target_zone = null)

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -83,7 +83,7 @@
 	RegisterSignal(parent, COMSIG_MOVABLE_PRE_MOVE, .proc/moved)
 	RegisterSignal(parent, COMSIG_ATOM_BUMPED, .proc/consume)
 	var/static/list/loc_connections = list(
-		COMSIG_ATOM_ENTERED = .proc/consume,
+		COMSIG_ATOM_ENTERED = .proc/on_entered,
 	)
 	AddElement(/datum/element/connect_loc, parent, loc_connections)
 
@@ -129,7 +129,13 @@
 
 	return COMPONENT_CANCEL_BLOB_ACT
 
+/// Triggered when something enters the component's parent.
+/datum/component/singularity/proc/on_entered(datum/source, atom/movable/arrived, direction)
+	SIGNAL_HANDLER
+	consume(source, arrived)
+
 /datum/component/singularity/proc/consume(datum/source, atom/thing)
+	SIGNAL_HANDLER
 	if (thing == parent)
 		stack_trace("Singularity tried to consume itself.")
 		return

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -47,11 +47,12 @@
  * source - the source of the signal
  * AM - the atom/movable that is being slipped.
  */
-/datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
+/datum/component/slippery/proc/Slip(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
-
-	var/mob/victim = AM
-	if(istype(victim) && !(victim.movement_type & FLYING) && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
+	if(!isliving(arrived))
+		return
+	var/mob/living/victim = arrived
+	if(!(victim.movement_type & FLYING) && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
 		callback.Invoke(victim)
 
 /*
@@ -105,11 +106,11 @@
  * source - the source of the signal
  * AM - the atom/movable that slipped on us.
  */
-/datum/component/slippery/proc/Slip_on_wearer(datum/source, atom/movable/AM)
+/datum/component/slippery/proc/Slip_on_wearer(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
 
 	if(holder.body_position == LYING_DOWN && !holder.buckled)
-		Slip(source, AM)
+		Slip(source, arrived)
 
 /datum/component/slippery/UnregisterFromParent()
 	. = ..()

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -87,14 +87,14 @@
 	else
 		steps++
 
-/datum/component/squeak/proc/play_squeak_crossed(datum/source, atom/movable/AM)
+/datum/component/squeak/proc/play_squeak_crossed(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
 
-	if(isitem(AM))
-		var/obj/item/I = AM
+	if(isitem(arrived))
+		var/obj/item/I = arrived
 		if(I.item_flags & ABSTRACT)
 			return
-	if(AM.movement_type & (FLYING|FLOATING) || !AM.has_gravity())
+	if(arrived.movement_type & (FLYING|FLOATING) || !arrived.has_gravity())
 		return
 	var/atom/current_parent = parent
 	if(isturf(current_parent?.loc))

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -467,10 +467,10 @@
 		return FALSE
 	return master._removal_reset(thing)
 
-/datum/component/storage/proc/_remove_and_refresh(datum/source, atom/movable/thing)
+/datum/component/storage/proc/_remove_and_refresh(datum/source, atom/movable/gone, direction)
 	SIGNAL_HANDLER
 
-	_removal_reset(thing)
+	_removal_reset(gone)
 	refresh_mob_views()
 
 //Call this proc to handle the removal of an item from the storage item. The item will be moved to the new_location target, if that is null it's being deleted

--- a/code/datums/components/swarming.dm
+++ b/code/datums/components/swarming.dm
@@ -26,10 +26,10 @@
 	swarm_members = null
 	return ..()
 
-/datum/component/swarming/proc/join_swarm(datum/source, atom/movable/AM)
+/datum/component/swarming/proc/join_swarm(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
 
-	var/datum/component/swarming/other_swarm = AM.GetComponent(/datum/component/swarming)
+	var/datum/component/swarming/other_swarm = arrived.GetComponent(/datum/component/swarming)
 	if(!other_swarm)
 		return
 	swarm()
@@ -37,10 +37,10 @@
 	other_swarm.swarm()
 	other_swarm.swarm_members |= src
 
-/datum/component/swarming/proc/leave_swarm(datum/source, atom/movable/AM)
+/datum/component/swarming/proc/leave_swarm(datum/source, atom/movable/gone, direction)
 	SIGNAL_HANDLER
 
-	var/datum/component/swarming/other_swarm = AM.GetComponent(/datum/component/swarming)
+	var/datum/component/swarming/other_swarm = gone.GetComponent(/datum/component/swarming)
 	if(!other_swarm || !(other_swarm in swarm_members))
 		return
 	swarm_members -= other_swarm

--- a/code/datums/elements/caltrop.dm
+++ b/code/datums/elements/caltrop.dm
@@ -39,16 +39,16 @@
 	else
 		RegisterSignal(get_turf(target), COMSIG_ATOM_ENTERED, .proc/on_entered)
 
-/datum/element/caltrop/proc/on_entered(atom/caltrop, atom/movable/AM)
+/datum/element/caltrop/proc/on_entered(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
 
 	if(!prob(probability))
 		return
 
-	if(!ishuman(AM))
+	if(!ishuman(arrived))
 		return
 
-	var/mob/living/carbon/human/H = AM
+	var/mob/living/carbon/human/H = arrived
 	if(HAS_TRAIT(H, TRAIT_PIERCEIMMUNE))
 		return
 
@@ -84,8 +84,10 @@
 
 	if(!(flags & CALTROP_SILENT) && !H.has_status_effect(/datum/status_effect/caltropped))
 		H.apply_status_effect(/datum/status_effect/caltropped)
-		H.visible_message(span_danger("[H] steps on [caltrop]."), \
-					span_userdanger("You step on [caltrop]!"))
+		H.visible_message(
+			span_danger("[H] steps on [source]."),
+			span_userdanger("You step on [source]!")
+		)
 
 	H.apply_damage(damage, BRUTE, picked_def_zone, wound_bonus = CANT_WOUND)
 	H.Paralyze(60)

--- a/code/datums/elements/light_blocking.dm
+++ b/code/datums/elements/light_blocking.dm
@@ -11,26 +11,32 @@
 		return ELEMENT_INCOMPATIBLE
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/on_target_move)
 	var/atom/movable/movable_target = target
-	if(isturf(movable_target.loc))
-		var/turf/turf_loc = movable_target.loc
+	if(!isturf(movable_target.loc))
+		return
+	for(var/turf/turf_loc as anything in movable_target.locs)
 		turf_loc.add_opacity_source(target)
 
 
-/datum/element/light_blocking/Detach(atom/movable/target)
+/datum/element/light_blocking/Detach(datum/target)
 	. = ..()
 	UnregisterSignal(target, list(COMSIG_MOVABLE_MOVED))
 	var/atom/movable/movable_target = target
-	if(isturf(movable_target.loc))
-		var/turf/turf_loc = movable_target.loc
+	if(!isturf(movable_target.loc))
+		return
+	for(var/turf/turf_loc as anything in movable_target.locs)
 		turf_loc.remove_opacity_source(target)
 
 
 ///Updates old and new turf loc opacities.
-/datum/element/light_blocking/proc/on_target_move(atom/movable/source, atom/OldLoc, Dir, Forced = FALSE)
+/datum/element/light_blocking/proc/on_target_move(atom/movable/source, atom/old_loc, dir, forced, list/old_locs)
 	SIGNAL_HANDLER
-	if(isturf(OldLoc))
-		var/turf/old_turf = OldLoc
-		old_turf.remove_opacity_source(source)
+	if(isturf(old_loc))
+		if(old_locs)
+			for(var/turf/old_turf as anything in old_locs)
+				old_turf.remove_opacity_source(source)
+		else
+			var/turf/old_turf = old_loc
+			old_turf.remove_opacity_source(source)
 	if(isturf(source.loc))
-		var/turf/new_turf = source.loc
-		new_turf.add_opacity_source(source)
+		for(var/turf/new_turf as anything in source.locs)
+			new_turf.add_opacity_source(source)

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -169,9 +169,10 @@ If you make a derivative work from this code, you must include this notification
 			A.setDir(turn(A.dir, 90))
 			var/turf/T = get_step(A, A.dir)
 			var/turf/S = D.loc
-			if ((S && isturf(S) && S.Exit(D)) && (T && isturf(T) && T.Enter(A)))
+			var/direction = get_dir(D, A)
+			if ((S && isturf(S) && S.Exit(D, direction)) && (T && isturf(T) && T.Enter(A)))
 				D.forceMove(T)
-				D.setDir(get_dir(D, A))
+				D.setDir(direction)
 		else
 			return
 

--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -186,8 +186,9 @@
 	var/turf/current_spin_turf = yeeted_person.loc
 	var/turf/intermediate_spin_turf = get_step(yeeted_person, the_hulk.dir) // the diagonal
 	var/turf/next_spin_turf = get_step(the_hulk, the_hulk.dir)
+	var/direction = get_dir(current_spin_turf, intermediate_spin_turf)
 
-	if((isturf(current_spin_turf) && current_spin_turf.Exit(yeeted_person)) && (isturf(next_spin_turf) && next_spin_turf.Enter(yeeted_person)))
+	if((isturf(current_spin_turf) && current_spin_turf.Exit(yeeted_person, direction)) && (isturf(next_spin_turf) && next_spin_turf.Enter(yeeted_person)))
 		yeeted_person.forceMove(next_spin_turf)
 		yeeted_person.face_atom(the_hulk)
 

--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -14,20 +14,20 @@
 
 //Only need to use one camera
 
-/area/ai_monitored/Entered(atom/movable/O)
-	..()
-	if (ismob(O) && motioncameras.len)
+/area/ai_monitored/Entered(atom/movable/arrived, direction)
+	. = ..()
+	if (ismob(arrived) && motioncameras.len)
 		for(var/X in motioncameras)
 			var/obj/machinery/camera/cam = X
-			cam.newTarget(O)
+			cam.newTarget(arrived)
 			return
 
-/area/ai_monitored/Exited(atom/movable/O)
+/area/ai_monitored/Exited(atom/movable/gone, direction)
 	..()
-	if (ismob(O) && motioncameras.len)
+	if (ismob(gone) && motioncameras.len)
 		for(var/X in motioncameras)
 			var/obj/machinery/camera/cam = X
-			cam.lostTargetRef(WEAKREF(O))
+			cam.lostTargetRef(WEAKREF(gone))
 			return
 
 /area/ai_monitored/turret_protected/ai/Initialize()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -596,15 +596,15 @@ GLOBAL_LIST_EMPTY(teleportlocs)
  *
  * If the area has ambience, then it plays some ambience music to the ambience channel
  */
-/area/Entered(atom/movable/M)
+/area/Entered(atom/movable/arrived, direction)
 	set waitfor = FALSE
-	SEND_SIGNAL(src, COMSIG_AREA_ENTERED, M)
-	for(var/atom/movable/recipient as anything in M.area_sensitive_contents)
+	SEND_SIGNAL(src, COMSIG_AREA_ENTERED, arrived, direction)
+	for(var/atom/movable/recipient as anything in arrived.area_sensitive_contents)
 		SEND_SIGNAL(recipient, COMSIG_ENTER_AREA, src)
-	if(!isliving(M))
+	if(!isliving(arrived))
 		return
 
-	var/mob/living/L = M
+	var/mob/living/L = arrived
 	if(!L.ckey)
 		return
 
@@ -628,9 +628,9 @@ GLOBAL_LIST_EMPTY(teleportlocs)
  *
  * Sends signals COMSIG_AREA_EXITED and COMSIG_EXIT_AREA (to a list of atoms)
  */
-/area/Exited(atom/movable/M)
-	SEND_SIGNAL(src, COMSIG_AREA_EXITED, M)
-	for(var/atom/movable/recipient as anything in M.area_sensitive_contents)
+/area/Exited(atom/movable/gone, direction)
+	SEND_SIGNAL(src, COMSIG_AREA_EXITED, gone, direction)
+	for(var/atom/movable/recipient as anything in gone.area_sensitive_contents)
 		SEND_SIGNAL(recipient, COMSIG_EXIT_AREA, src)
 
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1312,20 +1312,20 @@
  *
  * Default behaviour is to send the [COMSIG_ATOM_ENTERED]
  */
-/atom/Entered(atom/movable/AM, atom/oldLoc)
-	SEND_SIGNAL(src, COMSIG_ATOM_ENTERED, AM, oldLoc)
-	SEND_SIGNAL(AM, COMSIG_ATOM_ENTERING, src, oldLoc)
+/atom/Entered(atom/movable/arrived, direction)
+	SEND_SIGNAL(src, COMSIG_ATOM_ENTERED, arrived, direction)
+	SEND_SIGNAL(arrived, COMSIG_ATOM_ENTERING, src, direction)
 
 /**
  * An atom is attempting to exit this atom's contents
  *
  * Default behaviour is to send the [COMSIG_ATOM_EXIT]
  */
-/atom/Exit(atom/movable/AM, atom/newLoc)
+/atom/Exit(atom/movable/leaving, direction)
 	// Don't call `..()` here, otherwise `Uncross()` gets called.
 	// See the doc comment on `Uncross()` to learn why this is bad.
 
-	if(SEND_SIGNAL(src, COMSIG_ATOM_EXIT, AM, newLoc) & COMPONENT_ATOM_BLOCK_EXIT)
+	if(SEND_SIGNAL(src, COMSIG_ATOM_EXIT, leaving, direction) & COMPONENT_ATOM_BLOCK_EXIT)
 		return FALSE
 
 	return TRUE
@@ -1335,8 +1335,8 @@
  *
  * Default behaviour is to send the [COMSIG_ATOM_EXITED]
  */
-/atom/Exited(atom/movable/AM, atom/newLoc)
-	SEND_SIGNAL(src, COMSIG_ATOM_EXITED, AM, newLoc)
+/atom/Exited(atom/movable/gone, direction)
+	SEND_SIGNAL(src, COMSIG_ATOM_EXITED, gone, direction)
 
 ///Return atom temperature
 /atom/proc/return_temperature()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -386,8 +386,6 @@
 	var/list/old_locs
 	if(is_multi_tile_object && isturf(loc))
 		old_locs = locs.Copy()
-
-	if(old_locs) // Is a large object moving away from a turf.
 		for(var/atom/exiting_loc as anything in old_locs)
 			if(!exiting_loc.Exit(src, direction))
 				return
@@ -405,8 +403,6 @@
 				newloc.z
 				)
 		)
-
-	if(new_locs) // Is a large object 
 		for(var/atom/entering_loc as anything in new_locs)
 			if(!entering_loc.Enter(src))
 				return

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -402,13 +402,13 @@
 				min(world.maxy, newloc.y + CEILING(bound_height / 32, 1)),
 				newloc.z
 				)
-		)
+		) // If this is a multi-tile object then we need to predict the new locs and check if they allow our entrance.
 		for(var/atom/entering_loc as anything in new_locs)
 			if(!entering_loc.Enter(src))
 				return
 			if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, entering_loc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
 				return
-	else
+	else // Else just try to enter the single destination.
 		if(!newloc.Enter(src))
 			return
 		if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
@@ -424,15 +424,15 @@
 
 	. = TRUE
 
-	if(old_locs)
+	if(old_locs) // This condition will only be true if it is a multi-tile object.
 		for(var/atom/exited_loc as anything in (old_locs - new_locs))
 			exited_loc.Exited(src, direction)
-	else
+	else // Else there's just one loc to be exited.
 		oldloc.Exited(src, direction)
 	if(oldarea != newarea)
 		oldarea.Exited(src, direction)
 
-	if(new_locs)
+	if(new_locs) // Same here, only if multi-tile.
 		for(var/atom/entered_loc as anything in (new_locs - old_locs))
 			entered_loc.Entered(src, direction)
 	else

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -370,25 +370,53 @@
 // Here's where we rewrite how byond handles movement except slightly different
 // To be removed on step_ conversion
 // All this work to prevent a second bump
-/atom/movable/Move(atom/newloc, direct=0, glide_size_override = 0)
+/atom/movable/Move(atom/newloc, direction, glide_size_override = 0)
 	. = FALSE
 	if(!newloc || newloc == loc)
 		return
 
-	if(!direct)
-		direct = get_dir(src, newloc)
+	if(!direction)
+		direction = get_dir(src, newloc)
 
 	if(set_dir_on_move)
-		setDir(direct)
+		setDir(direction)
 
-	if(!loc.Exit(src, newloc))
-		return
+	var/is_multi_tile_object = bound_width > 32 || bound_height > 32
 
-	if(!newloc.Enter(src, src.loc))
-		return
+	var/list/old_locs
+	if(is_multi_tile_object && isturf(loc))
+		old_locs = locs.Copy()
 
-	if (SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
-		return
+	if(old_locs) // Is a large object moving away from a turf.
+		for(var/atom/exiting_loc as anything in old_locs)
+			if(!exiting_loc.Exit(src, direction))
+				return
+	else
+		if(!loc.Exit(src, direction))
+			return
+
+	var/list/new_locs
+	if(is_multi_tile_object && isturf(newloc))
+		new_locs = block(
+			newloc,
+			locate(
+				min(world.maxx, newloc.x + CEILING(bound_width / 32, 1)),
+				min(world.maxy, newloc.y + CEILING(bound_height / 32, 1)),
+				newloc.z
+				)
+		)
+
+	if(new_locs) // Is a large object 
+		for(var/atom/entering_loc as anything in new_locs)
+			if(!entering_loc.Enter(src))
+				return
+			if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, entering_loc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
+				return
+	else
+		if(!newloc.Enter(src))
+			return
+		if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
+			return
 
 	// Past this is the point of no return
 	var/atom/oldloc = loc
@@ -399,15 +427,24 @@
 	loc = newloc
 
 	. = TRUE
-	oldloc.Exited(src, newloc)
-	if(oldarea != newarea)
-		oldarea.Exited(src, newloc)
 
-	newloc.Entered(src, oldloc)
+	if(old_locs)
+		for(var/atom/exited_loc as anything in (old_locs - new_locs))
+			exited_loc.Exited(src, direction)
+	else
+		oldloc.Exited(src, direction)
 	if(oldarea != newarea)
-		newarea.Entered(src, oldloc)
+		oldarea.Exited(src, direction)
 
-	Moved(oldloc, direct)
+	if(new_locs)
+		for(var/atom/entered_loc as anything in (new_locs - old_locs))
+			entered_loc.Entered(src, direction)
+	else
+		newloc.Entered(src, direction)
+	if(oldarea != newarea)
+		newarea.Entered(src, direction)
+
+	Moved(oldloc, direction)
 
 ////////////////////////////////////////
 
@@ -587,18 +624,18 @@
 			return
 	A.Bumped(src)
 
-/atom/movable/Exited(atom/movable/AM, atom/newLoc)
+/atom/movable/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(AM.area_sensitive_contents)
+	if(gone.area_sensitive_contents)
 		for(var/atom/movable/location as anything in get_nested_locs(src) + src)
-			LAZYREMOVE(location.area_sensitive_contents, AM.area_sensitive_contents)
+			LAZYREMOVE(location.area_sensitive_contents, gone.area_sensitive_contents)
 
-/atom/movable/Entered(atom/movable/AM, atom/oldLoc)
+/atom/movable/Entered(atom/movable/arrived, direction)
 	. = ..()
-	if(AM.area_sensitive_contents)
+	if(arrived.area_sensitive_contents)
 		for(var/atom/movable/location as anything in get_nested_locs(src) + src)
 			//We can't make the assumption that objects won't become area sensitive in the process of entering us
-			LAZYOR(location.area_sensitive_contents, AM.area_sensitive_contents)
+			LAZYOR(location.area_sensitive_contents, arrived.area_sensitive_contents)
 
 /// See traits.dm. Use this in place of ADD_TRAIT.
 /atom/movable/proc/become_area_sensitive(trait_source = TRAIT_GENERIC)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -64,9 +64,9 @@
 		span_notice("You climb out of [src]!"))
 	open_machine()
 
-/obj/machinery/sleeper/Exited(atom/movable/user)
-	if (!state_open && user == occupant)
-		container_resist_act(user)
+/obj/machinery/sleeper/Exited(atom/movable/gone, direction)
+	if (!state_open && gone == occupant)
+		container_resist_act(gone)
 
 /obj/machinery/sleeper/relaymove(mob/living/user, direction)
 	if (!state_open)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -770,12 +770,12 @@
 		power -= power * 0.0005
 	return ..()
 
-/obj/machinery/Exited(atom/movable/AM, atom/newloc)
+/obj/machinery/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(AM == occupant)
+	if(gone == occupant)
 		set_occupant(null)
-	if(AM == circuit)
-		LAZYREMOVE(component_parts, AM)
+	if(gone == circuit)
+		LAZYREMOVE(component_parts, gone)
 		circuit = null
 
 /obj/machinery/proc/adjust_item_drop_location(atom/movable/AM) // Adjust item drop location to a 3x3 grid inside the tile, returns slot id from 0 to 8

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -277,10 +277,10 @@
 	if(!(get_dir(loc, target) == dir)) //Make sure looking at appropriate border
 		return TRUE
 
-/obj/machinery/door/firedoor/border_only/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+/obj/machinery/door/firedoor/border_only/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER
 
-	if(get_dir(leaving.loc, new_location) == dir && density)
+	if(direction == dir && density)
 		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -138,13 +138,13 @@
 /obj/machinery/door/window/CanAStarPass(obj/item/card/id/ID, to_dir)
 	return !density || (dir != to_dir) || (check_access(ID) && hasPower())
 
-/obj/machinery/door/window/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+/obj/machinery/door/window/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER
 
 	if((pass_flags_self & leaving.pass_flags) || ((pass_flags_self & LETPASSTHROW) && leaving.throwing))
 		return
 
-	if(get_dir(loc, new_location) == dir && density)
+	if(direction == dir && density)
 		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 

--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -180,9 +180,9 @@
 	else
 		to_chat(user,span_warning("[src] is active and can't be opened!")) //rip
 
-/obj/machinery/harvester/Exited(atom/movable/user)
-	if (!state_open && user == occupant)
-		container_resist_act(user)
+/obj/machinery/harvester/Exited(atom/movable/gone, direction)
+	if (!state_open && gone == occupant)
+		container_resist_act(gone)
 
 /obj/machinery/harvester/relaymove(mob/living/user, direction)
 	if (!state_open)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -48,12 +48,12 @@
 		play_power_sound()
 		update_appearance()
 
-/obj/machinery/stasis/Exited(atom/movable/AM, atom/newloc)
-	if(AM == occupant)
-		var/mob/living/L = AM
+/obj/machinery/stasis/Exited(atom/movable/gone, direction)
+	if(gone == occupant)
+		var/mob/living/L = gone
 		if(IS_IN_STASIS(L))
 			thaw_them(L)
-	. = ..()
+	return ..()
 
 /obj/machinery/stasis/proc/stasis_running()
 	return stasis_enabled && is_operational

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -140,11 +140,11 @@
 		M.emote("cough")
 		return TRUE
 
-/obj/effect/particle_effect/smoke/bad/proc/on_entered(datum/source, atom/movable/AM, oldloc)
+/obj/effect/particle_effect/smoke/bad/proc/on_entered(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
-	if(istype(AM, /obj/projectile/beam))
-		var/obj/projectile/beam/B = AM
-		B.damage = (B.damage/2)
+	if(istype(arrived, /obj/projectile/beam))
+		var/obj/projectile/beam/beam = arrived
+		beam.damage *= 0.5
 
 /datum/effect_system/smoke_spread/bad
 	effect_type = /obj/effect/particle_effect/smoke/bad

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -52,13 +52,13 @@
 /obj/effect/portal/attack_tk(mob/user)
 	return
 
-/obj/effect/portal/proc/on_entered(atom/newloc, atom/movable/entering_movable, atom/oldloc)
+/obj/effect/portal/proc/on_entered(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
-	if(isobserver(entering_movable))
+	if(isobserver(arrived))
 		return
-	if(linked && (get_turf(oldloc) == get_turf(linked)))
+	if(linked && (get_step(source, REVERSE_DIR(direction)) == get_turf(linked)))
 		return
-	teleport(entering_movable)
+	teleport(arrived)
 
 /obj/effect/portal/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/code/game/objects/effects/proximity.dm
+++ b/code/game/objects/effects/proximity.dm
@@ -113,7 +113,7 @@
 	)
 	AddElement(/datum/element/connect_loc, src, loc_connections)
 
-/obj/effect/abstract/proximity_checker/proc/on_uncrossed(datum/source, atom/movable/AM)
+/obj/effect/abstract/proximity_checker/proc/on_uncrossed(datum/source, atom/movable/gone, direction)
 	SIGNAL_HANDLER
 	return
 

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -31,10 +31,10 @@
 			remove_occupant(V)
 	return ..()
 
-/obj/item/pet_carrier/Exited(atom/movable/occupant)
-	if(occupant in occupants && isliving(occupant))
-		var/mob/living/L = occupant
-		occupants -= occupant
+/obj/item/pet_carrier/Exited(atom/movable/gone, direction)
+	if(isliving(gone) && (gone in occupants))
+		var/mob/living/L = gone
+		occupants -= gone
 		occupant_weight -= L.mob_size
 
 /obj/item/pet_carrier/handle_atom_del(atom/A)

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -805,12 +805,12 @@
 		stored.forceMove(get_turf(src))
 		stored = null
 
-/obj/item/borg/apparatus/Exited(atom/A)
-	if(A == stored) //sanity check
+/obj/item/borg/apparatus/Exited(atom/movable/gone, direction)
+	if(gone == stored) //sanity check
 		UnregisterSignal(stored, COMSIG_ATOM_UPDATED_ICON)
 		stored = null
 	update_appearance()
-	. = ..()
+	return ..()
 
 ///A right-click verb, for those not using hotkey mode.
 /obj/item/borg/apparatus/verb/verb_dropHeld()

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -372,11 +372,11 @@
 		I_copy.layer = FLOAT_LAYER
 		. += I_copy
 
-/obj/item/storage/bag/tray/Entered()
+/obj/item/storage/bag/tray/Entered(atom/movable/arrived, direction)
 	. = ..()
 	update_appearance()
 
-/obj/item/storage/bag/tray/Exited()
+/obj/item/storage/bag/tray/Exited(atom/movable/gone, direction)
 	. = ..()
 	update_appearance()
 

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -57,12 +57,12 @@
 	user.put_in_active_hand(fold_result)
 	qdel(src)
 
-/obj/item/storage/fancy/Exited()
+/obj/item/storage/fancy/Exited(atom/movable/gone, direction)
 	. = ..()
 	is_open = TRUE
 	update_appearance()
 
-/obj/item/storage/fancy/Entered()
+/obj/item/storage/fancy/Entered(atom/movable/arrived, direction)
 	. = ..()
 	is_open = TRUE
 	update_appearance()

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -57,12 +57,12 @@
 			visible_message(span_warning("\The [src] is broken by [user] with an electromagnetic card!"))
 			return
 
-/obj/item/storage/lockbox/Entered()
+/obj/item/storage/lockbox/Entered(atom/movable/arrived, direction)
 	. = ..()
 	open = TRUE
 	update_appearance()
 
-/obj/item/storage/lockbox/Exited()
+/obj/item/storage/lockbox/Exited(atom/movable/gone, direction)
 	. = ..()
 	open = TRUE
 	update_appearance()

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -40,7 +40,7 @@
 		/obj/item/stamp),
 		list(/obj/item/screwdriver/power))
 
-/obj/item/storage/wallet/Exited(atom/movable/AM)
+/obj/item/storage/wallet/Exited(atom/movable/gone, direction)
 	. = ..()
 	refreshID(removed = TRUE)
 
@@ -85,7 +85,7 @@
 	update_appearance(UPDATE_ICON)
 	update_slot_icon()
 
-/obj/item/storage/wallet/Entered(atom/movable/AM)
+/obj/item/storage/wallet/Entered(atom/movable/arrived, direction)
 	. = ..()
 	refreshID(removed = FALSE)
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -415,9 +415,9 @@
 // Objects that try to exit a locker by stepping were doing so successfully,
 // and due to an oversight in turf/Enter() were going through walls.  That
 // should be independently resolved, but this is also an interesting twist.
-/obj/structure/closet/Exit(atom/movable/AM)
+/obj/structure/closet/Exit(atom/movable/leaving, direction)
 	open()
-	if(AM.loc == src)
+	if(leaving.loc == src)
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/structures/industrial_lift.dm
+++ b/code/game/objects/structures/industrial_lift.dm
@@ -173,9 +173,9 @@ GLOBAL_LIST_EMPTY(lifts)
 		lift_master_datum = new(src)
 
 
-/obj/structure/industrial_lift/proc/UncrossedRemoveItemFromLift(datum/source, atom/movable/potential_rider)
+/obj/structure/industrial_lift/proc/UncrossedRemoveItemFromLift(datum/source, atom/movable/gone, direction)
 	SIGNAL_HANDLER
-	RemoveItemFromLift(potential_rider)
+	RemoveItemFromLift(gone)
 
 /obj/structure/industrial_lift/proc/RemoveItemFromLift(atom/movable/potential_rider)
 	SIGNAL_HANDLER

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -84,10 +84,10 @@
 
 	AddElement(/datum/element/connect_loc, src, loc_connections)
 
-/obj/structure/railing/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+/obj/structure/railing/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER
 
-	if(!(get_dir(leaving.loc, new_location) & dir))
+	if(!(direction & dir))
 		return
 
 	if (!density)

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -60,10 +60,10 @@
 		if(S)
 			S.update_appearance()
 
-/obj/structure/stairs/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+/obj/structure/stairs/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER
 
-	if(!isobserver(leaving) && isTerminator() && (get_dir(src, new_location) == dir))
+	if(!isobserver(leaving) && isTerminator() && direction == dir)
 		INVOKE_ASYNC(src, .proc/stair_ascend, leaving)
 		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -74,13 +74,13 @@
 	else
 		return 1
 
-/obj/structure/windoor_assembly/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+/obj/structure/windoor_assembly/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER
 
 	if (leaving.pass_flags & pass_flags_self)
 		return
 
-	if (get_dir(loc, new_location) == dir && density)
+	if (direction == dir && density)
 		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -124,7 +124,7 @@
 
 	return TRUE
 
-/obj/structure/window/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+/obj/structure/window/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER
 
 	if (istype(leaving) && (leaving.pass_flags & pass_flags_self))
@@ -133,7 +133,7 @@
 	if (fulltile)
 		return
 
-	if(get_dir(leaving.loc, new_location) == dir && density)
+	if(direction == dir && density)
 		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 

--- a/code/game/turfs/closed/wall/misc_walls.dm
+++ b/code/game/turfs/closed/wall/misc_walls.dm
@@ -17,13 +17,13 @@
 /turf/closed/wall/mineral/cult/devastate_wall()
 	new sheet_type(get_turf(src), sheet_amount)
 
-/turf/closed/wall/mineral/cult/Exited(atom/movable/AM, atom/newloc)
+/turf/closed/wall/mineral/cult/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(istype(AM, /mob/living/simple_animal/hostile/construct/harvester)) //harvesters can go through cult walls, dragging something with
-		var/mob/living/simple_animal/hostile/construct/harvester/H = AM
+	if(istype(gone, /mob/living/simple_animal/hostile/construct/harvester)) //harvesters can go through cult walls, dragging something with
+		var/mob/living/simple_animal/hostile/construct/harvester/H = gone
 		var/atom/movable/stored_pulling = H.pulling
 		if(stored_pulling)
-			stored_pulling.setDir(get_dir(stored_pulling.loc, newloc))
+			stored_pulling.setDir(direction)
 			stored_pulling.forceMove(src)
 			H.start_pulling(stored_pulling, supress_message = TRUE)
 

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -79,10 +79,10 @@
 	. = ..()
 	AddComponent(/datum/component/wet_floor, TURF_WET_SUPERLUBE, INFINITY, 0, INFINITY, TRUE)
 
-/turf/open/indestructible/honk/Entered(atom/movable/AM)
-	..()
-	if(ismob(AM))
-		playsound(src,sound,50,TRUE)
+/turf/open/indestructible/honk/Entered(atom/movable/arrived, direction)
+	. = ..()
+	if(ismob(arrived))
+		playsound(src, sound, 50, TRUE)
 
 /turf/open/indestructible/necropolis
 	name = "necropolis floor"

--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -202,11 +202,12 @@
 	custom_materials = list(/datum/material/bananium = 500)
 	var/sound_cooldown = 0
 
-/turf/open/floor/mineral/bananium/Entered(atom/movable/AM)
-	.=..()
-	if(!.)
-		if(isliving(AM))
-			squeak()
+/turf/open/floor/mineral/bananium/Entered(atom/movable/arrived, direction)
+	. = ..()
+	if(.)
+		return
+	if(isliving(arrived))
+		squeak()
 
 /turf/open/floor/mineral/bananium/attackby(obj/item/W, mob/user, params)
 	.=..()
@@ -257,11 +258,12 @@
 	var/last_event = 0
 	var/active = null
 
-/turf/open/floor/mineral/uranium/Entered(atom/movable/AM)
-	.=..()
-	if(!.)
-		if(ismob(AM))
-			radiate()
+/turf/open/floor/mineral/uranium/Entered(atom/movable/arrived, direction)
+	. = ..()
+	if(.)
+		return
+	if(isliving(arrived))
+		radiate()
 
 /turf/open/floor/mineral/uranium/attackby(obj/item/W, mob/user, params)
 	.=..()

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -36,15 +36,15 @@
 /turf/open/lava/airless
 	initial_gas_mix = AIRLESS_ATMOS
 
-/turf/open/lava/Entered(atom/movable/AM)
-	if(burn_stuff(AM))
+/turf/open/lava/Entered(atom/movable/arrived, direction)
+	if(burn_stuff(arrived))
 		START_PROCESSING(SSobj, src)
 
-/turf/open/lava/Exited(atom/movable/Obj, atom/newloc)
+/turf/open/lava/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(isliving(Obj))
-		var/mob/living/L = Obj
-		if(!islava(newloc))
+	if(isliving(gone))
+		var/mob/living/L = gone
+		if(!islava(get_step(src, direction)))
 			REMOVE_TRAIT(L, TRAIT_PERMANENTLY_ONFIRE, TURF_TRAIT)
 		if(!L.on_fire)
 			L.update_fire()

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -158,19 +158,19 @@
 		else
 			to_chat(user, span_warning("The plating is going to need some support! Place metal rods first."))
 
-/turf/open/space/Entered(atom/movable/A)
+/turf/open/space/Entered(atom/movable/arrived, direction)
 	. = ..()
-	if ((!(A) || src != A.loc))
+	if(!arrived || src != arrived.loc)
 		return
 
-	if(destination_z && destination_x && destination_y && !(A.pulledby || !A.can_be_z_moved))
+	if(destination_z && destination_x && destination_y && !(arrived.pulledby || !arrived.can_be_z_moved))
 		var/tx = destination_x
 		var/ty = destination_y
 		var/turf/DT = locate(tx, ty, destination_z)
 		var/itercount = 0
 		while(DT.density || istype(DT.loc,/area/shuttle)) // Extend towards the center of the map, trying to look for a better place to arrive
 			if (itercount++ >= 100)
-				log_game("SPACE Z-TRANSIT ERROR: Could not find a safe place to land [A] within 100 iterations.")
+				log_game("SPACE Z-TRANSIT ERROR: Could not find a safe place to land [arrived] within 100 iterations.")
 				break
 			if (tx < 128)
 				tx++
@@ -182,9 +182,9 @@
 				ty--
 			DT = locate(tx, ty, destination_z)
 
-		var/atom/movable/pulling = A.pulling
-		var/atom/movable/puller = A
-		A.forceMove(DT)
+		var/atom/movable/pulling = arrived.pulling
+		var/atom/movable/puller = arrived
+		arrived.forceMove(DT)
 
 		while (pulling != null)
 			var/next_pulling = pulling.pulling
@@ -200,8 +200,8 @@
 
 		//now we're on the new z_level, proceed the space drifting
 		stoplag()//Let a diagonal move finish, if necessary
-		A.newtonian_move(A.inertia_dir)
-		A.inertia_moving = TRUE
+		arrived.newtonian_move(arrived.inertia_dir)
+		arrived.inertia_moving = TRUE
 
 
 /turf/open/space/MakeSlippery(wet_setting, min_wet_time, wet_time_to_add, max_wet_time, permanent)

--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -26,10 +26,10 @@
 /turf/open/space/transit/east
 	dir = EAST
 
-/turf/open/space/transit/Entered(atom/movable/AM, atom/OldLoc)
-	..()
+/turf/open/space/transit/Entered(atom/movable/arrived, direction)
+	. = ..()
 	if(!locate(/obj/structure/lattice) in src)
-		throw_atom(AM)
+		throw_atom(arrived)
 
 /turf/open/space/transit/proc/throw_atom(atom/movable/AM)
 	set waitfor = FALSE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -289,7 +289,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	return FALSE
 
 //There's a lot of QDELETED() calls here if someone can figure out how to optimize this but not runtime when something gets deleted by a Bump/CanPass/Cross call, lemme know or go ahead and fix this mess - kevinz000
-/turf/Enter(atom/movable/mover, atom/oldloc)
+/turf/Enter(atom/movable/mover)
 	// Do not call ..()
 	// Byond's default turf/Enter() doesn't have the behaviour we want with Bump()
 	// By default byond will call Bump() on the first dense object in contents
@@ -321,26 +321,16 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		return (mover.movement_type & PHASING)
 	return TRUE
 
-/turf/Exit(atom/movable/mover, atom/newloc)
-	. = ..()
-	if(!. || QDELETED(mover))
-		return FALSE
-	for(var/i in contents)
-		if(i == mover)
-			continue
-		if(QDELETED(mover))
-			return FALSE //We were deleted.
 
-
-/turf/open/Entered(atom/movable/AM)
+/turf/open/Entered(atom/movable/arrived, direction)
 	..()
 	//melting
-	if(isobj(AM) && air && air.temperature > T0C)
-		var/obj/O = AM
+	if(isobj(arrived) && air && air.temperature > T0C)
+		var/obj/O = arrived
 		if(O.obj_flags & FROZEN)
 			O.make_unfrozen()
-	if(!AM.zfalling)
-		zFall(AM)
+	if(!arrived.zfalling)
+		zFall(arrived)
 
 // A proc in case it needs to be recreated or badmins want to change the baseturfs
 /turf/proc/assemble_baseturfs(turf/fake_baseturf_type)

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -159,7 +159,7 @@
 	if(make_blob) //well, can we?
 		var/obj/structure/blob/B = new /obj/structure/blob/normal(src.loc, (controller || overmind))
 		B.set_density(TRUE)
-		if(T.Enter(B,src)) //NOW we can attempt to move into the tile
+		if(T.Enter(B)) //NOW we can attempt to move into the tile
 			B.set_density(initial(B.density))
 			B.forceMove(T)
 			B.update_appearance()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -167,15 +167,15 @@
 	RegisterSignal(newloc, COMSIG_ATOM_EXITED, .proc/check_exit)
 	listeningTo = newloc
 
-/obj/item/assembly/infra/proc/check_exit(datum/source, atom/movable/offender)
+/obj/item/assembly/infra/proc/check_exit(datum/source, atom/movable/gone, direction)
 	SIGNAL_HANDLER
 
 	if(QDELETED(src))
 		return
-	if(offender == src || istype(offender,/obj/effect/beam/i_beam))
+	if(src == gone || istype(gone, /obj/effect/beam/i_beam))
 		return
-	if (offender && isitem(offender))
-		var/obj/item/I = offender
+	if(isitem(gone))
+		var/obj/item/I = gone
 		if (I.item_flags & ABSTRACT)
 			return
 	INVOKE_ASYNC(src, .proc/refreshBeam)

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -258,11 +258,11 @@
 		T.active_hotspot = null
 	return ..()
 
-/obj/effect/hotspot/proc/on_entered(datum/source, atom/movable/AM, oldLoc)
+/obj/effect/hotspot/proc/on_entered(datum/source, atom/movable/arrived, direction)
 	SIGNAL_HANDLER
-	if(isliving(AM))
-		var/mob/living/L = AM
-		L.fire_act(temperature, volume)
+	if(isliving(arrived))
+		var/mob/living/immolated = arrived
+		immolated.fire_act(temperature, volume)
 
 /obj/effect/hotspot/singularity_pull()
 	return

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -471,9 +471,9 @@
 		A.addMember(src)
 	SSair.add_to_rebuild_queue(src)
 
-/obj/machinery/atmospherics/Entered(atom/movable/AM)
-	if(istype(AM, /mob/living))
-		var/mob/living/L = AM
+/obj/machinery/atmospherics/Entered(atom/movable/arrived, direction)
+	if(istype(arrived, /mob/living))
+		var/mob/living/L = arrived
 		L.ventcrawl_layer = piping_layer
 	return ..()
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -122,10 +122,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if((atom_crossed_over.density || isliving(atom_crossed_over)) && !QDELETED(atom_crossed_over))
 		Bump(atom_crossed_over)
 
-/obj/effect/immovablerod/proc/on_entering_atom(datum/source, atom/atom_entered)
+/obj/effect/immovablerod/proc/on_entering_atom(datum/source, atom/destination, direction)
 	SIGNAL_HANDLER
-	if(atom_entered.density && isturf(atom_entered))
-		Bump(atom_entered)
+	if(destination.density && isturf(destination))
+		Bump(destination)
 
 /obj/effect/immovablerod/Moved()
 	if(!loc)

--- a/code/modules/fields/turf_objects.dm
+++ b/code/modules/fields/turf_objects.dm
@@ -34,10 +34,10 @@
 		return parent.field_turf_crossed(AM, src)
 	return TRUE
 
-/obj/effect/abstract/proximity_checker/advanced/field_turf/on_uncrossed(datum/source, atom/movable/AM)
+/obj/effect/abstract/proximity_checker/advanced/field_turf/on_uncrossed(datum/source, atom/movable/gone, direction)
 	. = ..()
 	if(parent)
-		return parent.field_turf_uncrossed(AM, src)
+		return parent.field_turf_uncrossed(gone, src)
 	return TRUE
 
 /obj/effect/abstract/proximity_checker/advanced/field_edge
@@ -55,9 +55,9 @@
 		return parent.field_edge_crossed(AM, src)
 	return TRUE
 
-/obj/effect/abstract/proximity_checker/advanced/field_edge/on_uncrossed(datum/source, atom/movable/AM)
+/obj/effect/abstract/proximity_checker/advanced/field_edge/on_uncrossed(datum/source, atom/movable/gone, direction)
 	if(parent)
-		return parent.field_edge_uncrossed(AM, src)
+		return parent.field_edge_uncrossed(gone, src)
 	return TRUE
 
 /proc/is_turf_in_field(turf/T, datum/proximity_monitor/advanced/F) //Looking for ways to optimize this!

--- a/code/modules/food_and_drinks/kitchen_machinery/grill.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/grill.dm
@@ -94,11 +94,11 @@
 		grill_fuel -= GRILL_FUELUSAGE_ACTIVE * delta_time
 		grilled_item.AddComponent(/datum/component/sizzle)
 
-/obj/machinery/grill/Exited(atom/movable/AM)
-	if(AM == grilled_item)
+/obj/machinery/grill/Exited(atom/movable/gone, direction)
+	if(gone == grilled_item)
 		finish_grill()
 		grilled_item = null
-	..()
+	return ..()
 
 /obj/machinery/grill/Destroy()
 	grilled_item = null

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -451,10 +451,10 @@
 	for(var/obj/item/organ/organ in contents)
 		organ.applyOrganDamage(-repair_rate * organ.maxHealth * delta_time)
 
-/obj/machinery/smartfridge/organ/Exited(atom/movable/AM, atom/newLoc)
+/obj/machinery/smartfridge/organ/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(isorgan(AM))
-		var/obj/item/organ/O = AM
+	if(isorgan(gone))
+		var/obj/item/organ/O = gone
 		O.organ_flags &= ~ORGAN_FROZEN
 
 // -----------------------------

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -110,11 +110,11 @@
 	add_overlay("basket-grass")
 	add_overlay("basket-egg[min(contents.len, 5)]")
 
-/obj/item/storage/basket/easter/Exited()
+/obj/item/storage/basket/easter/Exited(atom/movable/gone, direction)
 	. = ..()
 	countEggs()
 
-/obj/item/storage/basket/easter/Entered()
+/obj/item/storage/basket/easter/Entered(atom/movable/arrived, direction)
 	. = ..()
 	countEggs()
 

--- a/code/modules/library/skill_learning/skill_station.dm
+++ b/code/modules/library/skill_learning/skill_station.dm
@@ -52,9 +52,9 @@
 	. = ..()
 	interrupt_operation()
 
-/obj/machinery/skill_station/Exited(atom/movable/AM, atom/newloc)
+/obj/machinery/skill_station/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(AM == inserted_skillchip)
+	if(gone == inserted_skillchip)
 		inserted_skillchip = null
 		interrupt_operation()
 

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -48,7 +48,7 @@
 	* target - the atom that just moved onto the `source` turf.
 	* oldLoc - the old location that `target` was at before moving onto `source`.
 */
-/obj/machinery/mineral/proc/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
+/obj/machinery/mineral/proc/pickup_item(datum/source, atom/movable/target, direction)
 	SIGNAL_HANDLER
 
 	return
@@ -200,7 +200,7 @@
 
 	return dat
 
-/obj/machinery/mineral/processing_unit/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
+/obj/machinery/mineral/processing_unit/pickup_item(datum/source, atom/movable/target, direction)
 	if(QDELETED(target))
 		return
 	if(istype(target, /obj/item/stack/ore))

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -132,7 +132,7 @@
 	))
 	signal.send_to_receivers()
 
-/obj/machinery/mineral/ore_redemption/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
+/obj/machinery/mineral/ore_redemption/pickup_item(datum/source, atom/movable/target, direction)
 	if(QDELETED(target))
 		return
 	if(!materials.mat_container || panel_open || !powered())

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -11,7 +11,7 @@
 	needs_item_input = TRUE
 	processing_flags = START_PROCESSING_MANUALLY
 
-/obj/machinery/mineral/unloading_machine/pickup_item(datum/source, atom/movable/target, atom/oldLoc)
+/obj/machinery/mineral/unloading_machine/pickup_item(datum/source, atom/movable/target, direction)
 	if(QDELETED(target))
 		return
 	if(istype(target, /obj/structure/ore_box))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -742,8 +742,8 @@
 	*Checking Exited() to detect if a hat gets up and walks off.
 	*Drones and pAIs might do this, after all.
 */
-/mob/living/silicon/robot/Exited(atom/A)
-	if(hat && hat == A)
+/mob/living/silicon/robot/Exited(atom/movable/gone, direction)
+	if(hat && hat == gone)
 		hat = null
 		if(!QDELETED(src)) //Don't update icons if we are deleted.
 			update_icons()

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -54,8 +54,8 @@
 		health = 100
 		maxHealth = 100
 
-/mob/living/simple_animal/bot/floorbot/Exited(atom/movable/A, atom/newloc)
-	if(A == tilestack)
+/mob/living/simple_animal/bot/floorbot/Exited(atom/movable/gone, direction)
+	if(tilestack == gone)
 		if(tilestack && tilestack.max_amount < tilestack.amount) //split the stack if it exceeds its normal max_amount
 			var/iterations = round(tilestack.amount/tilestack.max_amount) //round() without second arg floors the value
 			for(var/a in 1 to iterations)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -280,9 +280,9 @@
 		return
 	return ..()
 
-/mob/living/simple_animal/hostile/carp/cayenne/Exited(atom/movable/AM, atom/newLoc)
+/mob/living/simple_animal/hostile/carp/cayenne/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(AM == disky)
+	if(disky == gone)
 		disky = null
 		update_icon()
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -762,9 +762,9 @@ GLOBAL_DATUM(blackbox, /obj/machinery/smartfridge/black_box)
 		holder_animal = loc
 	START_PROCESSING(SSobj, src)
 
-/obj/structure/closet/stasis/Entered(atom/A)
-	if(isliving(A) && holder_animal)
-		var/mob/living/L = A
+/obj/structure/closet/stasis/Entered(atom/movable/arrived, direction)
+	if(isliving(arrived) && holder_animal)
+		var/mob/living/L = arrived
 		L.notransform = 1
 		ADD_TRAIT(L, TRAIT_MUTE, STASIS_MUTE)
 		L.status_flags |= GODMODE

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -382,9 +382,9 @@
 /mob/living/simple_animal/hostile/retaliate/clown/mutant/glutton/add_cell_sample()
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_GLUTTON, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 
-/mob/living/simple_animal/hostile/retaliate/clown/mutant/glutton/Exited(atom/movable/AM, atom/newLoc)
+/mob/living/simple_animal/hostile/retaliate/clown/mutant/glutton/Exited(atom/movable/gone, direction)
 	. = ..()
-	prank_pouch -= AM
+	prank_pouch -= gone
 
 ///This ability will let you fire one random item from your pouch,
 /obj/effect/proc_holder/regurgitate

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -11,8 +11,8 @@
 	var/locked = FALSE
 
 ///What happens when the intellicard is removed (or deleted) from the module, through try_eject() or not.
-/obj/item/computer_hardware/ai_slot/Exited(atom/A, atom/newloc)
-	if(A == stored_card)
+/obj/item/computer_hardware/ai_slot/Exited(atom/movable/gone, direction)
+	if(stored_card == gone)
 		stored_card = null
 	return ..()
 

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -20,8 +20,8 @@
 	return ..()
 
 ///What happens when the battery is removed (or deleted) from the module, through try_eject() or not.
-/obj/item/computer_hardware/battery/Exited(atom/A, atom/newloc)
-	if(A == battery)
+/obj/item/computer_hardware/battery/Exited(atom/movable/gone, direction)
+	if(battery == gone)
 		battery = null
 		if(holder?.enabled && !holder.use_power())
 			holder.shutdown_computer()

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -9,8 +9,8 @@
 	var/obj/item/card/id/stored_card
 
 ///What happens when the ID card is removed (or deleted) from the module, through try_eject() or not.
-/obj/item/computer_hardware/card_slot/Exited(atom/A, atom/newloc)
-	if(A == stored_card)
+/obj/item/computer_hardware/card_slot/Exited(atom/movable/gone, direction)
+	if(stored_card == gone)
 		stored_card = null
 		if(holder)
 			if(holder.active_program)

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -34,9 +34,9 @@
 		icon_state = "paperplane_carbon" // It's the purple carbon copy. Use the purple paper plane
 	update_appearance()
 
-/obj/item/paperplane/Exited(atom/movable/AM, atom/newLoc)
+/obj/item/paperplane/Exited(atom/movable/gone, direction)
 	. = ..()
-	if (AM == internalPaper)
+	if (internalPaper == gone)
 		internalPaper = null
 		if(!QDELETED(src))
 			qdel(src)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -427,7 +427,7 @@
 			visible_message(span_warning("[document_copy] is shoved out of the way by [ass]!"))
 			document_copy = null
 
-/obj/machinery/photocopier/Exited(atom/movable/AM, atom/newloc)
+/obj/machinery/photocopier/Exited(atom/movable/gone, direction)
 	check_ass() // There was potentially a person sitting on the copier, check if they're still there.
 	return ..()
 

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -47,11 +47,11 @@
 	else
 		to_chat(user, span_notice("There are no modifications currently installed."))
 
-/obj/item/gun/energy/kinetic_accelerator/Exited(atom/A)
-	if(modkits.len && (A in modkits))
-		var/obj/item/borg/upgrade/modkit/MK = A
+/obj/item/gun/energy/kinetic_accelerator/Exited(atom/movable/gone, direction)
+	if(gone in modkits)
+		var/obj/item/borg/upgrade/modkit/MK = gone
 		MK.uninstall(src)
-	. = ..()
+	return ..()
 
 /obj/item/gun/energy/kinetic_accelerator/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/borg/upgrade/modkit))

--- a/code/modules/ruins/icemoonruin_code/hotsprings.dm
+++ b/code/modules/ruins/icemoonruin_code/hotsprings.dm
@@ -17,11 +17,11 @@ GLOBAL_LIST_EMPTY(cursed_minds)
 	planetary_atmos = TRUE
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
 
-/turf/open/water/cursed_spring/Entered(atom/movable/thing, atom/oldLoc)
+/turf/open/water/cursed_spring/Entered(atom/movable/arrived, direction)
 	. = ..()
-	if(!isliving(thing))
+	if(!isliving(arrived))
 		return
-	var/mob/living/L = thing
+	var/mob/living/L = arrived
 	if(!L.client || L.incorporeal_move)
 		return
 	if(GLOB.cursed_minds[L.mind])

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -67,10 +67,10 @@
 	if(!(get_dir(loc, target) == dir))
 		return TRUE
 
-/obj/structure/necropolis_gate/proc/on_exit(datum/source, atom/movable/leaving, atom/new_location)
+/obj/structure/necropolis_gate/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER
 
-	if (get_dir(leaving.loc, new_location) == dir && density)
+	if (direction == dir && density)
 		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -261,10 +261,10 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	icon_state = base_icon_state
 	return ..()
 
-/turf/open/space/bluespace/Entered(atom/movable/A)
+/turf/open/space/bluespace/Entered(atom/movable/arrived, direction)
 	. = ..()
-	if(parentSphere && A.forceMove(get_turf(parentSphere)))
-		do_sparks(3, FALSE, get_turf(A))
+	if(parentSphere && arrived.forceMove(get_turf(parentSphere)))
+		do_sparks(3, FALSE, get_turf(arrived))
 
 /turf/closed/indestructible/hoteldoor
 	name = "Hotel Door"
@@ -358,11 +358,11 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	var/datum/turf_reservation/reservation
 	var/turf/storageTurf
 
-/area/hilbertshotel/Entered(atom/movable/AM)
+/area/hilbertshotel/Entered(atom/movable/arrived, direction)
 	. = ..()
-	if(istype(AM, /obj/item/hilbertshotel))
-		relocate(AM)
-	var/list/obj/item/hilbertshotel/hotels = AM.get_all_contents_type(/obj/item/hilbertshotel)
+	if(istype(arrived, /obj/item/hilbertshotel))
+		relocate(arrived)
+	var/list/obj/item/hilbertshotel/hotels = arrived.get_all_contents_type(/obj/item/hilbertshotel)
 	for(var/obj/item/hilbertshotel/H in hotels)
 		if(parentSphere == H)
 			relocate(H)
@@ -395,10 +395,10 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		to_chat(M, span_danger("[H] almost implodes in upon itself, but quickly rebounds, shooting off into a random point in space!"))
 	H.forceMove(targetturf)
 
-/area/hilbertshotel/Exited(atom/movable/AM)
+/area/hilbertshotel/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(ismob(AM))
-		var/mob/M = AM
+	if(ismob(gone))
+		var/mob/M = gone
 		if(M.mind)
 			var/stillPopulated = FALSE
 			var/list/currentLivingMobs = get_all_contents_type(/mob/living) //Got to catch anyone hiding in anything
@@ -446,16 +446,16 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	var/roomNumber
 	var/obj/item/hilbertshotel/parentSphere
 
-/obj/item/abstracthotelstorage/Entered(atom/movable/AM, atom/oldLoc)
+/obj/item/abstracthotelstorage/Entered(atom/movable/arrived, direction)
 	. = ..()
-	if(ismob(AM))
-		var/mob/M = AM
+	if(ismob(arrived))
+		var/mob/M = arrived
 		M.notransform = TRUE
 
-/obj/item/abstracthotelstorage/Exited(atom/movable/AM, atom/newLoc)
+/obj/item/abstracthotelstorage/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(ismob(AM))
-		var/mob/M = AM
+	if(ismob(gone))
+		var/mob/M = gone
 		M.notransform = FALSE
 
 //Space Ruin stuff

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -179,8 +179,8 @@
 	if(A == stored && !restoring)
 		restore()
 
-/obj/shapeshift_holder/Exited(atom/movable/AM)
-	if(AM == stored && !restoring)
+/obj/shapeshift_holder/Exited(atom/movable/gone, direction)
+	if(stored == gone && !restoring)
 		restore()
 
 /obj/shapeshift_holder/proc/caster_death()

--- a/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
@@ -46,8 +46,8 @@
 		AM.forceMove(get_turf(src))
 	return ..()
 
-/obj/item/mecha_parts/mecha_equipment/medical/sleeper/Exit(atom/movable/O)//prevents them from leaving without being forcemoved I guess
-	return FALSE
+/obj/item/mecha_parts/mecha_equipment/medical/sleeper/Exit(atom/movable/leaving, direction)
+	return FALSE //prevents them from leaving without being forcemoved I guess
 
 /obj/item/mecha_parts/mecha_equipment/medical/sleeper/action(mob/source, atom/atomtarget, params)
 	if(!action_checks(atomtarget))

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -163,8 +163,8 @@
 
 	take_damage(max_integrity * 0.5, sound_effect=FALSE) //Low starting health
 
-/obj/vehicle/sealed/mecha/working/ripley/Exit(atom/movable/O)
-	if(O in cargo)
+/obj/vehicle/sealed/mecha/working/ripley/Exit(atom/movable/leaving, direction)
+	if(leaving in cargo)
 		return FALSE
 	return ..()
 

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -21,10 +21,10 @@
 		mob_try_enter(M)
 	return ..()
 
-/obj/vehicle/sealed/Exited(atom/movable/AM, atom/newLoc)
+/obj/vehicle/sealed/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(ismob(AM))
-		remove_occupant(AM)
+	if(ismob(gone))
+		remove_occupant(gone)
 
 // so that we can check the access of the vehicle's occupants. Ridden vehicles do this in the riding component, but these don't have that
 /obj/vehicle/sealed/Bump(atom/A)


### PR DESCRIPTION
`Enter()`, `Entered()`, `Exit()` and `Exited()` all passed the old `loc` forward, but everything except a single a case cared about the direction of the movement more than about the specific source.
Since moving multi-tile objects will have multiple sources of movement but a single direction, this change makes it easier to track their movement.

Cleaned up a lot of code around and made proc inputs compatible.

I'll add opacity support for multi-tile objects in a different PR after this is merged, as this has grown large enough and I don't want to compromise the reviewability.

Tested this locally and as expected it didn't impair movement nor produced any runtimes.

No player-facing changes.