### PR TITLE
Fixes wigs

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -241,24 +241,29 @@
 	item_flags &= ~EXAMINE_SKIP
 
 /obj/item/clothing/head/wig/update_icon_state()
-	var/datum/sprite_accessory/S = GLOB.hairstyles_list[hairstyle]
-	if(S)
-		icon_state = S.icon_state
+	var/datum/sprite_accessory/hair_style = GLOB.hairstyles_list[hairstyle]
+	if(hair_style)
+		icon_state = hair_style.icon_state
 	return ..()
 
 
 /obj/item/clothing/head/wig/worn_overlays(mutable_appearance/standing, isinhands = FALSE, file2use)
 	. = ..()
-	if(!isinhands)
+	if(isinhands)
 		return
 
-	var/datum/sprite_accessory/S = GLOB.hairstyles_list[hairstyle]
-	if(!S)
+	var/datum/sprite_accessory/hair = GLOB.hairstyles_list[hairstyle]
+	if(!hair)
 		return
-	var/mutable_appearance/M = mutable_appearance(S.icon, S.icon_state,layer = -HAIR_LAYER)
-	M.appearance_flags |= RESET_COLOR
-	M.color = color
-	. += M
+
+	var/mutable_appearance/hair_overlay = mutable_appearance(hair.icon, hair.icon_state, layer = -HAIR_LAYER, appearance_flags = RESET_COLOR)
+	hair_overlay.color = color
+	. += hair_overlay
+
+	// So that the wig actually blocks emissives.
+	var/mutable_appearance/hair_blocker = mutable_appearance(hair.icon, hair.icon_state, plane = EMISSIVE_PLANE, appearance_flags = KEEP_APART)
+	hair_blocker.color = GLOB.em_block_color
+	hair_overlay.overlays += hair_blocker
 
 /obj/item/clothing/head/wig/attack_self(mob/user)
 	var/new_style = input(user, "Select a hairstyle", "Wig Styling")  as null|anything in (GLOB.hairstyles_list - "Bald")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I added an early return in the neon carpet PR and forgot to invert the check. This fixes that so worn wigs actually show up.
Fixes #59653 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- ![fix-wigs-please](https://user-images.githubusercontent.com/53582584/121920652-1b2a3b00-cced-11eb-912c-8b0b2c417120.PNG)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Wigs work when on your head again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
