### PR TITLE
Fixes explosions having a higher chance of delimbing you if they're weaker

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -74,7 +74,7 @@
 /// Base amonut for the maximum amount of delimbs a human can suffer from an explosion
 #define HUMAN_EXP_MAX_DELIMB 1.33
 
-/// Base chance for a human to get delimbed by an explosion
+/// Base chance for a limb to get delimbed by an explosion
 #define HUMAN_EXP_DELIMB_CHANCE 16.6
 
 #define STAMINA_REGEN_BLOCK_TIME (10 SECONDS)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -71,12 +71,6 @@
 #define HUMAN_MAX_OXYLOSS 3
 #define HUMAN_CRIT_MAX_OXYLOSS (SSMOBS_DT/3)
 
-/// Base amonut for the maximum amount of delimbs a human can suffer from an explosion
-#define HUMAN_EXP_MAX_DELIMB 1.33
-
-/// Base chance for a limb to get delimbed by an explosion
-#define HUMAN_EXP_DELIMB_CHANCE 16.6
-
 #define STAMINA_REGEN_BLOCK_TIME (10 SECONDS)
 
 #define HEAT_DAMAGE_LEVEL_1 1 //Amount of damage applied when your body temperature just passes the 360.15k safety point

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -71,6 +71,9 @@
 #define HUMAN_MAX_OXYLOSS 3
 #define HUMAN_CRIT_MAX_OXYLOSS (SSMOBS_DT/3)
 
+/// Base chance for a human to get delimbed by an explosion
+#define HUMAN_EXP_DELIMB_CHANCE 16.6
+
 #define STAMINA_REGEN_BLOCK_TIME (10 SECONDS)
 
 #define HEAT_DAMAGE_LEVEL_1 1 //Amount of damage applied when your body temperature just passes the 360.15k safety point

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -71,6 +71,9 @@
 #define HUMAN_MAX_OXYLOSS 3
 #define HUMAN_CRIT_MAX_OXYLOSS (SSMOBS_DT/3)
 
+/// Base amonut for the maximum amount of delimbs a human can suffer from an explosion
+#define HUMAN_EXP_MAX_DELIMB 1.33
+
 /// Base chance for a human to get delimbed by an explosion
 #define HUMAN_EXP_DELIMB_CHANCE 16.6
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -438,16 +438,10 @@
 		var/max_limb_loss = 0
 		var/probability = 0
 		switch(severity)
-			if(EXPLODE_NONE to EXPLODE_LIGHT)
-				max_limb_loss = 1
-				probability = 20
-			if(EXPLODE_LIGHT to EXPLODE_HEAVY)
-				max_limb_loss = 2
-				probability = 30
-			if(EXPLODE_HEAVY to EXPLODE_DEVASTATE)
+			if(EXPLODE_HEAVY)
 				max_limb_loss = 3
 				probability = 40
-			if(EXPLODE_DEVASTATE to INFINITY)
+			if(EXPLODE_DEVASTATE)
 				max_limb_loss = 4
 				probability = 50
 		for(var/X in bodyparts)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -438,7 +438,7 @@
 		var/max_limb_loss = round(4/severity) //so you don't lose four limbs at severity 3.
 		for(var/X in bodyparts)
 			var/obj/item/bodypart/BP = X
-			if(prob(50/severity) && !prob(getarmor(BP, BOMB)) && BP.body_zone != BODY_ZONE_HEAD && BP.body_zone != BODY_ZONE_CHEST)
+			if(prob(HUMAN_EXP_DELIMB_CHANCE*severity) && !prob(getarmor(BP, BOMB)) && BP.body_zone != BODY_ZONE_HEAD && BP.body_zone != BODY_ZONE_CHEST)
 				BP.brute_dam = BP.max_damage
 				BP.dismember()
 				max_limb_loss--

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -435,7 +435,7 @@
 
 	//attempt to dismember bodyparts
 	if(severity >= EXPLODE_HEAVY || !bomb_armor)
-		var/max_limb_loss = round(4/severity) //so you don't lose four limbs at severity 3.
+		var/max_limb_loss = round(HUMAN_EXP_MAX_DELIMB*severity, 1) //so you don't lose four limbs at severity 3.
 		for(var/X in bodyparts)
 			var/obj/item/bodypart/BP = X
 			if(prob(HUMAN_EXP_DELIMB_CHANCE*severity) && !prob(getarmor(BP, BOMB)) && BP.body_zone != BODY_ZONE_HEAD && BP.body_zone != BODY_ZONE_CHEST)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -435,10 +435,24 @@
 
 	//attempt to dismember bodyparts
 	if(severity >= EXPLODE_HEAVY || !bomb_armor)
-		var/max_limb_loss = round(HUMAN_EXP_MAX_DELIMB*severity, 1) //so you don't lose four limbs at severity 3.
+		var/max_limb_loss = 0
+		var/probability = 0
+		switch(severity)
+			if(EXPLODE_NONE to EXPLODE_LIGHT)
+				max_limb_loss = 1
+				probability = 20
+			if(EXPLODE_LIGHT to EXPLODE_HEAVY)
+				max_limb_loss = 2
+				probability = 30
+			if(EXPLODE_HEAVY to EXPLODE_DEVASTATE)
+				max_limb_loss = 3
+				probability = 40
+			if(EXPLODE_DEVASTATE to INFINITY)
+				max_limb_loss = 4
+				probability = 50
 		for(var/X in bodyparts)
 			var/obj/item/bodypart/BP = X
-			if(prob(HUMAN_EXP_DELIMB_CHANCE*severity) && !prob(getarmor(BP, BOMB)) && BP.body_zone != BODY_ZONE_HEAD && BP.body_zone != BODY_ZONE_CHEST)
+			if(prob(probability) && !prob(getarmor(BP, BOMB)) && BP.body_zone != BODY_ZONE_HEAD && BP.body_zone != BODY_ZONE_CHEST)
 				BP.brute_dam = BP.max_damage
 				BP.dismember()
 				max_limb_loss--


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Don't know if it's an oversight or not, but currently, explosions delimb you if they're weaker. This PR fixes that by removing the division in the probability calculations and replacing it with a multiplication, whilst also changing the base probability value.

The value 16.6 was chosen because at devastation 3, aka max devastation, that will equal out to approximately 50%

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Explosions should have a greater chance of delimbing you if their severity is greater.

## Changelog
:cl:
fix: Fixed explosions delimbing you if they're weaker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
