### PR TITLE
Admins hiding music title will hide it from the music player too

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -111,11 +111,11 @@
 					music_extra_data["start"] = data["start_time"]
 					music_extra_data["end"] = data["end_time"]
 					music_extra_data["link"] = data["webpage_url"]
-					music_extra_data["title"] = data["title"]
 
 					var/res = tgui_alert(usr, "Show the title of and link to this song to the players?\n[title]",, list("No", "Yes", "Cancel"))
 					switch(res)
 						if("Yes")
+							music_extra_data["title"] = data["title"]
 							to_chat(world, span_boldannounce("An admin played: [webpage_url]"), confidential = TRUE)
 						if("Cancel")
 							return


### PR DESCRIPTION
## About The Pull Request
Hiding the title still showed it in the music player, this fixes that.

Alternatives are:
 - Never show the message in chat and make the title have a link to the song as well
 - Remove the "hide the title from players?" prompt

## Why It's Good For The Game
Hiding the title properly hides it for good in all player-facing elements, instead of just the chat announcement.

🆑 JJRcop
qol: Hidden admin music no longer shows a title on the music player.
/:cl: