### PR TITLE
Makes mafia roleblocks actually end

### DIFF
--- a/code/modules/mafia/roles.dm
+++ b/code/modules/mafia/roles.dm
@@ -469,7 +469,7 @@
 
 	. = ..()
 	if(current_target)
-		current_target.role_flags &= ROLE_ROLEBLOCKED
+		current_target.role_flags &= ~ROLE_ROLEBLOCKED
 		current_target = null
 
 /datum/mafia_role/hop


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug where if you were roleblocked one night by a lawyer in mafia you would be roleblocked FOREVER by adding a single missed character `~`
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I'm 99.999999% sure this isn't intended
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Makes roleblocks in mafia actually end properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
