### PR TITLE
Fixes custom emotes not working with slimes

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -2,7 +2,7 @@
 /* EMOTE DATUMS */
 /datum/emote/living
 	mob_type_allowed_typecache = /mob/living
-	mob_type_blacklist_typecache = list(/mob/living/simple_animal/slime, /mob/living/brain)
+	mob_type_blacklist_typecache = list(/mob/living/brain)
 
 /datum/emote/living/blush
 	key = "blush"


### PR DESCRIPTION
## About The Pull Request
Allows slimes to use hotkey emotes and custom emotes by removing `/mob/living/simple_animal/slime` from `mob_type_blacklist_typecache` in `code/modules/mob/living/emote.dm`, added by #22405
 
## Why It's Good For The Game
Fixes #59655

## Changelog
🆑
fix: Slimes can now use custom emotes.
/🆑