### PR TITLE
Ghoul Moodlet + Max HP fix

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -981,3 +981,4 @@
 	name = "Flesh Servant"
 	desc = "You are a Ghoul! A eldritch monster reanimated to serve its master."
 	icon_state = "mind_control"
+	

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -968,3 +968,16 @@
 /datum/status_effect/cloudstruck/Destroy()
 	. = ..()
 	QDEL_NULL(mob_overlay)
+
+
+/datum/status_effect/ghoul
+	id = "ghoul"
+	status_type = STATUS_EFFECT_UNIQUE
+	duration = -1
+	examine_text = "<span class='warning'>SUBJECTPRONOUN has a blank, catatonic like stare.</span>"
+	alert_type = /atom/movable/screen/alert/status_effect/ghoul
+
+/atom/movable/screen/alert/status_effect/ghoul
+	name = "Flesh Servant"
+	desc = "You are a Ghoul! A eldritch monster reanimated to serve its master."
+	icon_state = "mind_control"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -974,7 +974,7 @@
 	id = "ghoul"
 	status_type = STATUS_EFFECT_UNIQUE
 	duration = -1
-	examine_text = "<span class='warning'>SUBJECTPRONOUN has a blank, catatonic like stare.</span>"
+	examine_text = "<span class='warning'>SUBJECTPRONOUN has a blank, lifeless stare.</span>"
 	alert_type = /atom/movable/screen/alert/status_effect/ghoul
 
 /atom/movable/screen/alert/status_effect/ghoul

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -974,7 +974,6 @@
 	id = "ghoul"
 	status_type = STATUS_EFFECT_UNIQUE
 	duration = -1
-	examine_text = "<span class='warning'>SUBJECTPRONOUN has a blank, lifeless stare.</span>"
 	alert_type = /atom/movable/screen/alert/status_effect/ghoul
 
 /atom/movable/screen/alert/status_effect/ghoul

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -254,6 +254,7 @@
 	grasp_ghoul.ghoul_amt *= 3
 	var/datum/eldritch_knowledge/flesh_ghoul/better_ghoul = heretic_datum.get_knowledge(/datum/eldritch_knowledge/flesh_ghoul)
 	better_ghoul.max_amt *= 3
+	
 #undef GHOUL_MAX_HEALTH
 #undef MUTE_MAX_HEALTH
 #undef ORIGINAL_MAX_HEALTH

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -58,8 +58,6 @@
 	ADD_TRAIT(humie, TRAIT_MUTE, MAGIC_TRAIT)
 	log_game("[key_name_admin(humie)] has become a voiceless dead, their master is [user.real_name]")
 	humie.revive(full_heal = TRUE, admin_revive = TRUE)
-	humie.setMaxHealth(50)
-	humie.health = 50 // Voiceless dead are much tougher than ghouls
 	humie.setMaxHealth(MUTE_MAX_HEALTH)
 	humie.health = MUTE_MAX_HEALTH // Voiceless dead are much tougher than ghouls
 	humie.become_husk()
@@ -115,8 +113,6 @@
 	. = TRUE
 	RegisterSignal(human_target,COMSIG_LIVING_DEATH,.proc/remove_ghoul)
 	human_target.revive(full_heal = TRUE, admin_revive = TRUE)
-	human_target.setMaxHealth(25)
-	human_target.health = 25
 	human_target.setMaxHealth(GHOUL_MAX_HEALTH)
 	human_target.health = GHOUL_MAX_HEALTH
 	human_target.become_husk()

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -1,6 +1,5 @@
 #define GHOUL_MAX_HEALTH 25
 #define MUTE_MAX_HEALTH 50
-#define ORIGINAL_MAX_HEALTH 100
 
 /datum/eldritch_knowledge/base_flesh
 	name = "Principle of Hunger"
@@ -75,7 +74,7 @@
 	SIGNAL_HANDLER
 	var/mob/living/carbon/human/humie = source
 	ghouls -= humie
-	humie.setMaxHealth(ORIGINAL_MAX_HEALTH)
+	humie.setMaxHealth(initial(humie.maxHealth))
 	humie.remove_status_effect(/datum/status_effect/ghoul)
 	humie.mind.remove_antag_datum(/datum/antagonist/heretic_monster)
 	UnregisterSignal(source,COMSIG_LIVING_DEATH)
@@ -139,7 +138,7 @@
 /datum/eldritch_knowledge/flesh_grasp/proc/remove_ghoul(datum/source)
 	var/mob/living/carbon/human/humie = source
 	spooky_scaries -= humie
-	humie.setMaxHealth(ORIGINAL_MAX_HEALTH)
+	humie.setMaxHealth(initial(humie.maxHealth))
 	humie.remove_status_effect(/datum/status_effect/ghoul)
 	humie.mind.remove_antag_datum(/datum/antagonist/heretic_monster)
 	UnregisterSignal(source, COMSIG_LIVING_DEATH)
@@ -257,4 +256,3 @@
 	
 #undef GHOUL_MAX_HEALTH
 #undef MUTE_MAX_HEALTH
-#undef ORIGINAL_MAX_HEALTH

--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -1,3 +1,7 @@
+#define GHOUL_MAX_HEALTH 25
+#define MUTE_MAX_HEALTH 50
+#define ORIGINAL_MAX_HEALTH 100
+
 /datum/eldritch_knowledge/base_flesh
 	name = "Principle of Hunger"
 	desc = "Opens up the Path of Flesh to you. Allows you to transmute a pool of blood with a kitchen knife, or its derivatives, into a Flesh Blade."
@@ -56,8 +60,11 @@
 	humie.revive(full_heal = TRUE, admin_revive = TRUE)
 	humie.setMaxHealth(50)
 	humie.health = 50 // Voiceless dead are much tougher than ghouls
+	humie.setMaxHealth(MUTE_MAX_HEALTH)
+	humie.health = MUTE_MAX_HEALTH // Voiceless dead are much tougher than ghouls
 	humie.become_husk()
 	humie.faction |= "heretics"
+	humie.apply_status_effect(/datum/status_effect/ghoul)
 
 	var/datum/antagonist/heretic_monster/heretic_monster = humie.mind.add_antag_datum(/datum/antagonist/heretic_monster)
 	var/datum/antagonist/heretic/master = user.mind.has_antag_datum(/datum/antagonist/heretic)
@@ -70,6 +77,8 @@
 	SIGNAL_HANDLER
 	var/mob/living/carbon/human/humie = source
 	ghouls -= humie
+	humie.setMaxHealth(ORIGINAL_MAX_HEALTH)
+	humie.remove_status_effect(/datum/status_effect/ghoul)
 	humie.mind.remove_antag_datum(/datum/antagonist/heretic_monster)
 	UnregisterSignal(source,COMSIG_LIVING_DEATH)
 
@@ -108,7 +117,10 @@
 	human_target.revive(full_heal = TRUE, admin_revive = TRUE)
 	human_target.setMaxHealth(25)
 	human_target.health = 25
+	human_target.setMaxHealth(GHOUL_MAX_HEALTH)
+	human_target.health = GHOUL_MAX_HEALTH
 	human_target.become_husk()
+	human_target.apply_status_effect(/datum/status_effect/ghoul)
 	human_target.faction |= "heretics"
 	var/datum/antagonist/heretic_monster/heretic_monster = human_target.mind.add_antag_datum(/datum/antagonist/heretic_monster)
 	var/datum/antagonist/heretic/master = user.mind.has_antag_datum(/datum/antagonist/heretic)
@@ -131,6 +143,8 @@
 /datum/eldritch_knowledge/flesh_grasp/proc/remove_ghoul(datum/source)
 	var/mob/living/carbon/human/humie = source
 	spooky_scaries -= humie
+	humie.setMaxHealth(ORIGINAL_MAX_HEALTH)
+	humie.remove_status_effect(/datum/status_effect/ghoul)
 	humie.mind.remove_antag_datum(/datum/antagonist/heretic_monster)
 	UnregisterSignal(source, COMSIG_LIVING_DEATH)
 
@@ -244,3 +258,6 @@
 	grasp_ghoul.ghoul_amt *= 3
 	var/datum/eldritch_knowledge/flesh_ghoul/better_ghoul = heretic_datum.get_knowledge(/datum/eldritch_knowledge/flesh_ghoul)
 	better_ghoul.max_amt *= 3
+#undef GHOUL_MAX_HEALTH
+#undef MUTE_MAX_HEALTH
+#undef ORIGINAL_MAX_HEALTH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds ghoul moodlet.
Fixes a undocumented issue with ghouls dying and being revived with 25/50 max health.

## Why It's Good For The Game

Clears a little confusion. Hypnosis type spells/effects should have a tooltip of some sort.

## Changelog
:cl:
fix: Fixed heretic ghouls having reduced max health after being revived after deghouled
qol: heretic ghouls now have a little moodlet tooltip
/:cl:
