### PR TITLE
Fix phantom mobs getting quirks from silicon job selections.

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -484,7 +484,7 @@ SUBSYSTEM_DEF(job)
 
 	to_chat(M, "<span class='infoplain'><b>You are the [rank].</b></span>")
 	if(job)
-		var/new_mob = job.equip(living_mob, null, null, joined_late , null, M.client, is_captain)//silicons override this proc to return a mob
+		var/new_mob = job.equip(living_mob, null, null, joined_late, null, M.client, is_captain)//silicons override this proc to return a mob
 		if(ismob(new_mob))
 			living_mob = new_mob
 			if(!joined_late)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -379,16 +379,16 @@ SUBSYSTEM_DEF(ticker)
 		picked_spare_id_candidate = pick(spare_id_candidates)
 
 	for(var/mob/dead/new_player/new_player_mob as anything in GLOB.new_player_list)
-		var/mob/living/carbon/human/new_player_human = new_player_mob.new_character
-		if(istype(new_player_human) && new_player_human.mind?.assigned_role)
-			var/player_assigned_role = new_player_human.mind.assigned_role
+		var/mob/living/new_player_living = new_player_mob.new_character
+		if(istype(new_player_living) && new_player_living.mind?.assigned_role)
+			var/player_assigned_role = new_player_living.mind.assigned_role
 			var/player_is_captain = (picked_spare_id_candidate == new_player_mob) || (SSjob.always_promote_captain_job && (player_assigned_role == "Captain"))
 			if(player_is_captain)
 				captainless = FALSE
-			if(player_assigned_role != new_player_human.mind.special_role)
-				SSjob.EquipRank(new_player_mob, player_assigned_role, FALSE, player_is_captain)
-				if(CONFIG_GET(flag/roundstart_traits) && ishuman(new_player_human))
-					SSquirks.AssignQuirks(new_player_human, new_player_mob.client)
+			if(player_assigned_role != new_player_living.mind.special_role)
+				new_player_living = SSjob.EquipRank(new_player_mob, player_assigned_role, FALSE, player_is_captain)
+				if(CONFIG_GET(flag/roundstart_traits) && ishuman(new_player_living))
+					SSquirks.AssignQuirks(new_player_living, new_player_mob.client)
 		CHECK_TICK
 
 	if(captainless)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #58626

As part of spawning in and equipping new players, they're given a shiny new `/mob/living/carbon/human` - However AIs and silicons get transformed in their job datum `equip` procs. Due to some dodgy logic, the old human mob was referenced for the check for assigning quirks.

![image](https://user-images.githubusercontent.com/24975989/122138388-8c2d3800-ce3e-11eb-824e-9185c3896c24.png)
![image](https://user-images.githubusercontent.com/24975989/122138535-d6aeb480-ce3e-11eb-8d5b-3f54848d1a53.png)
![image](https://user-images.githubusercontent.com/24975989/122138661-11b0e800-ce3f-11eb-88a5-a9d92ed6593b.png)

This meant a phantom mob that was sat in nullspace would potentially be given a bunch of items (and fail the species check) or be given a bunch of processing quirks (and fail just about everything ever because that mob shouldn't even exist) and generate 6mb runtime logs.

Tested locally spawning in as an AI and silicon. Incorrect quirk assignment no longer occurs, no runtimes happen, everyone is happy.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex is good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fix some runtimes with quirks and equipping silicons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
