### PR TITLE
Calomel now actually does as described

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,12 +12,9 @@
 	"editor.codeActionsOnSave": {
 		"source.fixAll.eslint": true
 	},
-	"workbench.editorAssociations": [
-		{
-			"filenamePattern": "*.dmi",
-			"viewType": "imagePreview.previewEditor"
-		}
-	],
+	"workbench.editorAssociations": {
+		"*.dmi": "imagePreview.previewEditor"
+	},
 	"files.eol": "\n",
 	"gitlens.advanced.blame.customArguments": ["-w"],
 	"tgstationTestExplorer.project.resultsType": "json",

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -431,7 +431,7 @@
 
 /datum/reagent/medicine/calomel/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	for(var/datum/reagent/R in M.reagents.reagent_list)
-		if(istype(R.type, /datum/reagent/medicine/calomel))
+		if(!istype(R.type, /datum/reagent/medicine/calomel))
 			M.reagents.remove_reagent(R.type, 3 * REM * delta_time)
 	if(M.health > 20)
 		M.adjustToxLoss(1 * REM * delta_time, 0)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -430,8 +430,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/medicine/calomel/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	for(var/datum/reagent/toxin/R in M.reagents.reagent_list)
-		M.reagents.remove_reagent(R.type, 3 * REM * delta_time)
+	for(var/datum/reagent/R in M.reagents.reagent_list)
+		if(istype(R.type, /datum/reagent/medicine/calomel))
+			M.reagents.remove_reagent(R.type, 3 * REM * delta_time)
 	if(M.health > 20)
 		M.adjustToxLoss(1 * REM * delta_time, 0)
 		. = TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -431,7 +431,7 @@
 
 /datum/reagent/medicine/calomel/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	for(var/datum/reagent/R in M.reagents.reagent_list)
-		if(!istype(R.type, /datum/reagent/medicine/calomel))
+		if(!istype(R, /datum/reagent/medicine/calomel))
 			M.reagents.remove_reagent(R.type, 3 * REM * delta_time)
 	if(M.health > 20)
 		M.adjustToxLoss(1 * REM * delta_time, 0)


### PR DESCRIPTION
:cl:
fix: calomel now actually purges all chems, instead of only toxins
/:cl:

Not sure what to label this as, since I'm not sure if the description is wrong or the functionality is wrong. 

The wiki and the chems description all describe calomel removing ALL reagents, which could be very useful when dealing with any harmful amount of chems, but it only removed toxin reagents