### PR TITLE
Fix tachyon across z-levels

### DIFF
--- a/code/modules/experisci/experiment/handlers/experiment_handler.dm
+++ b/code/modules/experisci/experiment/handlers/experiment_handler.dm
@@ -298,7 +298,7 @@
 	var/list/local_servers = list()
 	for (var/obj/machinery/rnd/server/server in SSresearch.servers)
 		var/turf/position_of_this_server_machine = get_turf(server)
-		if (turf_to_check_for_servers && position_of_this_server_machine && position_of_this_server_machine.z == turf_to_check_for_servers.z)
+		if (turf_to_check_for_servers && position_of_this_server_machine && SSmapping.level_trait(position_of_this_server_machine.z,ZTRAIT_STATION) && SSmapping.level_trait(turf_to_check_for_servers.z,ZTRAIT_STATION))
 			local_servers += server
 	return local_servers
 

--- a/code/modules/experisci/experiment/handlers/experiment_handler.dm
+++ b/code/modules/experisci/experiment/handlers/experiment_handler.dm
@@ -296,7 +296,7 @@
 	if (!turf_to_check_for_servers)
 		turf_to_check_for_servers = get_turf(parent)
 	var/list/local_servers = list()
-	if (SSmapping.level_trait(turf_to_check_for_servers.z,ZTRAIT_STATION))
+	if (!SSmapping.level_trait(turf_to_check_for_servers.z,ZTRAIT_STATION))
 		return local_servers
 	for (var/obj/machinery/rnd/server/server in SSresearch.servers)
 		var/turf/position_of_this_server_machine = get_turf(server)

--- a/code/modules/experisci/experiment/handlers/experiment_handler.dm
+++ b/code/modules/experisci/experiment/handlers/experiment_handler.dm
@@ -287,18 +287,20 @@
 	selected_experiment = null
 
 /**
- * Attempts to get rnd servers on the same z-level as a provided turf
+ * Attempts to get rnd servers that are on the station z-level, also checks if provided turf is on the station z-level
  *
  * Arguments:
- * * turf_to_check_for_servers - The turf to get servers on the same z-level of
+ * * turf_to_check_for_servers - The turf to check if its on the station z-level
  */
 /datum/component/experiment_handler/proc/get_available_servers(turf/turf_to_check_for_servers = null)
 	if (!turf_to_check_for_servers)
 		turf_to_check_for_servers = get_turf(parent)
 	var/list/local_servers = list()
+	if (SSmapping.level_trait(turf_to_check_for_servers.z,ZTRAIT_STATION))
+		return local_servers
 	for (var/obj/machinery/rnd/server/server in SSresearch.servers)
 		var/turf/position_of_this_server_machine = get_turf(server)
-		if (turf_to_check_for_servers && position_of_this_server_machine && SSmapping.level_trait(position_of_this_server_machine.z,ZTRAIT_STATION) && SSmapping.level_trait(turf_to_check_for_servers.z,ZTRAIT_STATION))
+		if (position_of_this_server_machine && SSmapping.level_trait(position_of_this_server_machine.z,ZTRAIT_STATION))
 			local_servers += server
 	return local_servers
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tachyon-doppler arrays now work when on a different z-level than the RD server provided both of them are on a station z.
Same applies for all things using the experiment handler component in fact.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #58380
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Tachyon-doppler arrays now connect with servers on different z-levels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
