### PR TITLE
Digitigrade Paralysis BugFix

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1820,6 +1820,7 @@
 	if(usable_legs == new_value)
 		return
 	if(new_value < 0) // Sanity check
+		stack_trace("[src] had set_usable_legs() called on them with a negative value!")
 		new_value = 0
 
 	. = usable_legs

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1819,6 +1819,9 @@
 /mob/living/proc/set_usable_legs(new_value)
 	if(usable_legs == new_value)
 		return
+	if(new_value < 0) // Sanity check
+		new_value = 0
+
 	. = usable_legs
 	usable_legs = new_value
 

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -323,7 +323,7 @@
 		return FALSE
 	. = TRUE
 	moveToNullspace()
-	owner = new_limb_owner
+	set_owner(new_limb_owner)
 	new_limb_owner.add_bodypart(src)
 	if(held_index)
 		if(held_index > new_limb_owner.hand_bodyparts.len)


### PR DESCRIPTION
## About The Pull Request

- A limb's attach_limb proc now uses the set_owner() proc instead of setting the owner manually, fixing problems where limbs that were meant to be paralyzed were not
- Added a sanity check to set_usable_legs to ensure the value isn't set lower than 0

## Why It's Good For The Game

Fewer bugs, more sanity

## Changelog
:cl:
fix: People with digitigrade legs are now properly paralyzed by the Paraplegic perk
fix: Usable_limbs can no longer be set below 0, which let people walk when they shouldn't be able to
/:cl:
