### PR TITLE
Make smoke_all for cigarettes work correctly

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -250,14 +250,13 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(iscarbon(loc))
 			var/mob/living/carbon/C = loc
 			if (src == C.wear_mask) // if it's in the human/monkey mouth, transfer reagents to the mob
-				var/fraction = min(REAGENTS_METABOLISM/reagents.total_volume, 1)
 				/*
 				 * Given the amount of time the cig will last, and how often we take a hit, find the number
 				 * of chems to give them each time so they'll have smoked it all by the end.
 				 */
 				if (smoke_all)
 					to_smoke = reagents.total_volume / (smoketime / dragtime)
-
+				var/fraction = min(to_smoke/reagents.total_volume, 1)
 				reagents.expose(C, INGEST, fraction)
 				var/obj/item/organ/lungs/L = C.getorganslot(ORGAN_SLOT_LUNGS)
 				if(L && !(L.organ_flags & ORGAN_SYNTHETIC))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
smoke_all wasn't actually being considered when computing the amount of reagents transferred to the body, but only the reagents removed from the cigarette prior to this.
This makes the amount of reagents that cigarettes transfer into your body when you smoke them actually dependent on the smoke_all factor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the changes made in #45711 actually work properly, as otherwise there really isn't much of a meaning to the smoke_all property.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Cigarettes with the smoke_all property actually let you smoke in everything the cigarette contains now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
