### PR TITLE
Correctly pluralize multiple projectiles

### DIFF
--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -39,6 +39,13 @@
 /datum/proc/p_es(temp_gender)
 	. = "es"
 
+/datum/proc/plural_s(pluralize)
+	switch(copytext_char(pluralize, -1))
+		if ("s")
+			. = "es"
+		else
+			. = "s"
+
 //like clients, which do have gender.
 /client/p_they(capitalized, temp_gender)
 	if(!temp_gender)

--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -45,8 +45,6 @@
 			. = "es"
 		if ("x")
 			. = "es"
-		if ("y")
-			. = "ies"
 		else
 			. = "s"
 

--- a/code/__HELPERS/pronouns.dm
+++ b/code/__HELPERS/pronouns.dm
@@ -43,6 +43,10 @@
 	switch(copytext_char(pluralize, -1))
 		if ("s")
 			. = "es"
+		if ("x")
+			. = "es"
+		if ("y")
+			. = "ies"
 		else
 			. = "s"
 

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -308,7 +308,7 @@
 				hit_part.painless_wound_roll(wound_type, damage_dealt, w_bonus, bw_bonus, initial(P.sharpness))
 
 		if(num_hits > 1)
-			target.visible_message(span_danger("[target] is hit by [num_hits] [proj_name]s[hit_part ? " in the [hit_part.name]" : ""][did_damage ? ", which don't leave a mark" : ""]!"), null, null, COMBAT_MESSAGE_RANGE, target)
+			target.visible_message(span_danger("[target] is hit by [num_hits] [proj_name][plural_s(proj_name)][hit_part ? " in the [hit_part.name]" : ""][did_damage ? ", which don't leave a mark" : ""]!"), null, null, COMBAT_MESSAGE_RANGE, target)
 			to_chat(target, span_userdanger("You're hit by [num_hits] [proj_name]s[hit_part ? " in the [hit_part.name]" : ""]!"))
 		else
 			target.visible_message(span_danger("[target] is hit by a [proj_name][hit_part ? " in the [hit_part.name]" : ""][did_damage ? ", which doesn't leave a mark" : ""]!"), null, null, COMBAT_MESSAGE_RANGE, target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Before
![image](https://user-images.githubusercontent.com/66640614/122333989-d6212700-ceed-11eb-934e-297feb5a4e42.png)
After
![image](https://user-images.githubusercontent.com/66640614/122334182-27c9b180-ceee-11eb-97a0-369610dfff6e.png)

When something gets hit by multiple projectiles whose names end in "s", an extra "s" gets added to pluralize them. Sadly \s doesn't add the es, so I've made a proc with the other conjugation methods and used it for projectiles.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Grammatically correct kissiles. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: multiple projectiles are now pluralized correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
