### PR TITLE
Fixes nuke ops lobby meta exploit

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -42,7 +42,6 @@
 	forge_objectives()
 	. = ..()
 	equip_op()
-	memorize_code()
 	if(send_to_spawnpoint)
 		move_to_spawnpoint()
 		// grant extra TC for the people who start in the nukie base ie. not the lone op
@@ -50,8 +49,7 @@
 		var/datum/component/uplink/U = owner.find_syndicate_uplink()
 		if (U)
 			U.telecrystals += extra_tc
-
-
+	memorize_code()
 
 /datum/antagonist/nukeop/get_team()
 	return nuke_team


### PR DESCRIPTION
## About The Pull Request

This pr fixes #56332. 

- Nuke ops leaders are given their paper _during_ the `memorize_code` proc. 
- Nuke ops are moved to spawn _after_ `memorize_code` is called.
- So: nuke ops leaders got their paper **before** they were moved to the nuke ops spawn - allowing anyone to hear it that's nearby the spawn box.

This PR just moves the `memorize_code` call to after nuke ops are moved to their spawn, so it prevents the lobby from hearing the sound of the paper.

## Why It's Good For The Game

Figuring out round type before joining game bad?

## Changelog
:cl: Melbert
fix: Fixed nuke ops lobby meta exploit
/:cl:
