### PR TITLE
Port: fixes of SStimer subsystem from RU SS220 Paradise

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -98,6 +98,8 @@
 
 /datum/config_entry/flag/log_shuttle // log shuttle related actions, ie shuttle computers, shuttle manipulator, emergency console
 
+/datum/config_entry/flag/log_timers_on_bucket_reset // logs all timers in buckets on automatic bucket reset (Useful for timer debugging)
+
 /datum/config_entry/flag/allow_admin_ooccolor // Allows admins with relevant permissions to have their own ooc colour
 
 /datum/config_entry/flag/allow_admin_asaycolor //Allows admins with relevant permissions to have a personalized asay color

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -12,9 +12,9 @@
  *
  * Handles creation, callbacks, and destruction of timed events.
  *
- * It is important to understand the buckets used in the timer subsystem are just a series of circular doubly-linked
- * lists. The object at a given index in bucket_list is a /datum/timedevent, the head of a circular list, which has prev
- * and next references for the respective elements in that bucket's circular list.
+ * It is important to understand the buckets used in the timer subsystem are just a series of doubly-linked
+ * lists. The object at a given index in bucket_list is a /datum/timedevent, the head of a list, which has prev
+ * and next references for the respective elements in that bucket's list.
  */
 SUBSYSTEM_DEF(timer)
 	name = "Timer"

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -299,7 +299,7 @@ SUBSYSTEM_DEF(timer)
 				qdel(timer)
 			continue
 
-		// Insert the timer into the bucket, and perform necessary circular doubly-linked list operations
+		// Insert the timer into the bucket, and perform necessary doubly-linked list operations
 		new_bucket_count++
 		var/bucket_pos = BUCKET_POS(timer)
 		timer.bucket_pos = bucket_pos

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -304,12 +304,11 @@ SUBSYSTEM_DEF(timer)
 			timer.next = null
 			timer.prev = null
 			continue
-		if (!bucket_head.prev)
-			bucket_head.prev = bucket_head
+
+		bucket_head.prev = timer
 		timer.next = bucket_head
-		timer.prev = bucket_head.prev
-		timer.next.prev = timer
-		timer.prev.next = timer
+		timer.prev = null
+		bucket_list[bucket_pos] = timer
 
 	// Cut the timers that are tracked by the buckets from the secondary queue
 	if (i)
@@ -460,12 +459,10 @@ SUBSYSTEM_DEF(timer)
 
 	// Remove the timed event from the bucket, ensuring to maintain
 	// the integrity of the bucket's list if relevant
-	if(prev != next)
+	if (prev && prev.next == src)
 		prev.next = next
+	if (next && next.prev == src)
 		next.prev = prev
-	else
-		prev?.next = null
-		next?.prev = null
 	prev = next = null
 
 /**
@@ -512,15 +509,12 @@ SUBSYSTEM_DEF(timer)
 		return
 
 	// Otherwise, we merely add this timed event into the bucket, which is a
-	// circularly doubly-linked list
-	if (!bucket_head.prev)
-		bucket_head.prev = bucket_head
-
+	// doubly-linked list
 	bucket_joined = TRUE
+	bucket_head.prev = src
 	next = bucket_head
-	prev = bucket_head.prev
-	next.prev = src
-	prev.next = src
+	prev = null
+	bucket_list[bucket_pos] = src
 
 /**
  * Returns a string of the type of the callback for this timer

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -185,7 +185,8 @@ SUBSYSTEM_DEF(timer)
 
 		if (!bucket_list[practical_offset])
 			// Empty the bucket, check if anything in the secondary queue should be shifted to this bucket
-			bucket_list[practical_offset++] = null
+			bucket_list[practical_offset] = null // Just in case
+			practical_offset++
 			var/i = 0
 			for (i in 1 to length(second_queue))
 				timer = second_queue[i]

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -470,6 +470,7 @@ SUBSYSTEM_DEF(timer)
 		next.prev = prev
 	prev = next = null
 	bucket_pos = -1
+	bucket_joined = FALSE
 
 /**
  * Attempts to add this timed event to a bucket, will enter the secondary queue

--- a/config/config.txt
+++ b/config/config.txt
@@ -154,6 +154,9 @@ LOG_CLONING
 ## log shuttle actions
 LOG_SHUTTLE
 
+## Log all timers on timer auto reset
+# LOG_TIMERS_ON_BUCKET_RESET
+
 ##Log camera pictures - Must have picture logging enabled
 PICTURE_LOGGING_CAMERA
 


### PR DESCRIPTION
### Unobvious problem spot
`#define BUCKET_POS(timer) (((round((timer.timeToRun - SStimer.head_offset) / world.tick_lag)+1) % BUCKET_LEN)||BUCKET_LEN)`

With `tick_lag` equal to `0.1`, `0.25`, `0.5`, rounding of division is normal. But at other values it may be shifted either more or less due to the specifics of floating-point storage and processing. Numbers `0.1`, `0.25`, `0.5` have **blank mantissa**, unlike others which lead to numbers such as 245.0000004 when divided.
PS: `tick_lag` is rounded to the first two decimal places.

![image](https://user-images.githubusercontent.com/8555356/122315476-d12a9a80-cf22-11eb-9078-fe6906c610a8.png)
![image](https://user-images.githubusercontent.com/8555356/122315484-d7b91200-cf22-11eb-8861-ad4b17f1bf31.png)

### What it looked like before the fix when the subsystem crashed

![image](https://user-images.githubusercontent.com/8555356/122491296-647bd280-cfec-11eb-9e75-dda2a9dcb4be.png)

![image](https://user-images.githubusercontent.com/8555356/122491311-69408680-cfec-11eb-802c-69154b133a6a.png)


### Fixes
- Rewrote the circular doubly linked list to a regular doubly linked list, because it could cause timers to loop infinitely.
- Fixed re-creation of a bucket if the timer does not have a callback.
- Added debug stat indicator `RST` to MC SStimer.
- Added optional ability to log dump all timers on crash.
- Fixed subsystem logic when a bucket position is misplaced due to division and rounding inaccuracy. The system now captures such rounding errors and restores the correct timer position.

Tested on 3 paracode prod servers running on single OVH Rise 2 machine (avarage concurrent peak):
1. 180 online
2. 80 online
2. 80 online

### References
**[RU] SS220 Paradise port process from TGstation and fixes:**
- https://github.com/ss220-space/Paradise/pull/5
- https://github.com/ss220-space/Paradise/pull/10
- https://github.com/ss220-space/Paradise/pull/26
- https://github.com/ss220-space/Paradise/pull/32
- https://github.com/ss220-space/Paradise/pull/37

### Contributors
- @semoro: fixes
- @Bizzonium: port

## Changelog
:cl: Semoro and azizonkg
fix: Ported fixes of SStimer subsystem from RU SS220 Paradise
config: Added a new config var: flag/log_timers_on_bucket_reset 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
