### PR TITLE
Ghost QoL: Check plant genes and reagents easily

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -623,7 +623,7 @@
 			materials_list += "[M.name]"
 		. += "<u>It is made out of [english_list(materials_list)]</u>."
 	if(reagents)
-		if(reagents.flags & TRANSPARENT)
+		if((reagents.flags & TRANSPARENT) || user.stat == DEAD) //Ghosts always see all the reagents
 			. += "It contains:"
 			if(length(reagents.reagent_list))
 				if(user.can_see_reagents()) //Show each individual reagent

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -56,6 +56,9 @@
 	. = ..()
 	. += "This is a [generation]\th generation [name]!"
 
+	if(user.stat == DEAD)
+		. += myseed.get_text_traits()
+
 /**
  * Creates a new glowshroom structure.
  *

--- a/code/modules/hydroponics/grafts.dm
+++ b/code/modules/hydroponics/grafts.dm
@@ -46,3 +46,21 @@
 /obj/item/graft/Destroy()
 	QDEL_NULL(stored_trait)
 	return ..()
+
+/obj/item/graft/examine(mob/user)
+	. = ..()
+	if(user.stat == DEAD)
+		var/text = "[span_info("*---------*")]\n<span class='info'>- Plant Graft -\n"
+		if(parent_name)
+			text += "- Parent Plant: [span_notice("[parent_name]")] -\n"
+		if(stored_trait)
+			text += "- Graftable Traits: [span_notice("[stored_trait.get_name()]")] -\n"
+		text += "*---------*\n"
+		text += "- Yield: [span_notice("[yield]")]\n"
+		text += "- Production speed: [span_notice("[production]")]\n"
+		text += "- Endurance: [span_notice("[endurance]")]\n"
+		text += "- Lifespan: [span_notice("[lifespan]")]\n"
+		text += "- Weed Growth Rate: [span_notice("[weed_rate]")]\n"
+		text += "- Weed Vulnerability: [span_notice("[weed_chance]")]\n"
+		text += "*---------*</span>"
+		. += text

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -93,6 +93,28 @@
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Tray efficiency at <b>[rating*100]%</b>.")
 
+/obj/machinery/hydroponics/examine(mob/user)
+	. = ..()
+	if(user.stat == DEAD)
+		var/returned_message = "<span class='info'>*---------*\n"
+		if(myseed)
+			returned_message += "*** <B>[myseed.plantname]</B> ***\n"
+			returned_message += "- Plant Age: [span_notice("[age]")]</span>\n"
+			returned_message += myseed.get_text_traits()
+		else
+			returned_message += "[span_info("<B>No plant found.</B>")]\n"
+
+		returned_message += "<span class='info'>"
+		returned_message += "- Weed level: [span_notice("[weedlevel] / [MAX_TRAY_WEEDS]")]\n"
+		returned_message += "- Pest level: [span_notice("[pestlevel] / [MAX_TRAY_PESTS]")]\n"
+		returned_message += "- Toxicity level: [span_notice("[toxic] / [MAX_TRAY_TOXINS]")]\n"
+			returned_message += "- Water level: [span_notice("[waterlevel] / [maxwater]")]\n"
+		returned_message += "- Nutrition level: [span_notice("[reagents.total_volume] / [maxnutri]")]\n"
+		if(yieldmod != 1)
+			returned_message += "- Yield modifier on harvest: [span_notice("[yieldmod]x")]\n"
+
+		returned_message += "*---------*</span>"
+		. += returned_message
 
 /obj/machinery/hydroponics/Destroy()
 	if(myseed)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -104,10 +104,62 @@
 /obj/item/seeds/examine(mob/user)
 	. = ..()
 	. += span_notice("Use a pen on it to rename it or change its description.")
-	if(reagents_add && user.can_see_reagents())
+	if(user.stat == DEAD)
+		var/returned_message = get_text_traits()
+		returned_message += "</span>\n"
+		. += returned_message
+	else if(reagents_add && user.can_see_reagents())
 		. += span_notice("- Plant Reagents -")
 		for(var/datum/plant_gene/reagent/G in genes)
 			. += span_notice("- [G.get_name()] -")
+
+/obj/item/seeds/proc/get_text_traits(obj/item/seeds/scanned)
+	var/text = ""
+	if(get_gene(/datum/plant_gene/trait/plant_type/weed_hardy))
+		text += "- Plant type: [span_notice("Weed. Can grow in nutrient-poor soil.")]\n"
+	else if(get_gene(/datum/plant_gene/trait/plant_type/fungal_metabolism))
+		text += "- Plant type: [span_notice("Mushroom. Can grow in dry soil.")]\n"
+	else if(get_gene(/datum/plant_gene/trait/plant_type/alien_properties))
+		text += "- Plant type: [span_warning("UNKNOWN")] \n"
+	else
+		text += "- Plant type: [span_notice("Normal plant")]\n"
+
+	if(potency != -1)
+		text += "- Potency: [span_notice("[potency]")]\n"
+	if(yield != -1)
+		text += "- Yield: [span_notice("[yield]")]\n"
+	text += "- Maturation speed: [span_notice("[maturation]")]\n"
+	if(yield != -1)
+		text += "- Production speed: [span_notice("[production]")]\n"
+	text += "- Endurance: [span_notice("[scanned.endurance]")]\n"
+	text += "- Lifespan: [span_notice("[lifespan]")]\n"
+	text += "- Instability: [span_notice("[instability]")]\n"
+	text += "- Weed Growth Rate: [span_notice("[weed_rate]")]\n"
+	text += "- Weed Vulnerability: [span_notice("[weed_chance]")]\n"
+	if(rarity)
+		text += "- Species Discovery Value: [span_notice("[rarity]")]</span>\n"
+	var/all_removable_traits = ""
+	var/all_immutable_traits = ""
+	for(var/datum/plant_gene/trait/traits in genes)
+		if(istype(traits, /datum/plant_gene/trait/plant_type))
+			continue
+		if(traits.mutability_flags & PLANT_GENE_REMOVABLE)
+			all_removable_traits += "[(all_removable_traits == "") ? "" : ", "][traits.get_name()]"
+		else
+			all_immutable_traits += "[(all_immutable_traits == "") ? "" : ", "][traits.get_name()]"
+
+	text += "- Plant Traits: [span_notice("[all_removable_traits? all_removable_traits : "None."]")]</span>\n"
+	text += "- Core Plant Traits: [span_notice("[all_immutable_traits? all_immutable_traits : "None."]")]</span>\n"
+	var/datum/plant_gene/scanned_graft_result = graft_gene? new scanned.graft_gene : new /datum/plant_gene/trait/repeated_harvest
+	text += "- Grafting this plant would give: [span_notice("[scanned_graft_result.get_name()]")]\n"
+	QDEL_NULL(scanned_graft_result) //graft genes are stored as typepaths so if we want to get their formatted name we need a datum ref - musn't forget to clean up afterwards
+	text += "*---------*"
+	var/unique_text = get_unique_analyzer_text()
+	if(unique_text)
+		text += "\n"
+		text += unique_text
+		text += "\n*---------*"
+	return text
 
 /obj/item/seeds/proc/Copy()
 	var/obj/item/seeds/copy_seed = new type(null, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Now you can check pill/patch/anything's reagents with chem scan enabled. Examining seeds/trays/grafts will now show all of their traits to you as a ghost.

## Why It's Good For The Game

It makes easier to find about peoples' gimmicks as a ghost

## Changelog
:cl:
qol: You can now check plant genes as a ghost
qol: Chem scan now allows to check pill/patch/whatever reagents as a ghost
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
