### PR TITLE
Fixes integrated circuits not being able to have more components added to them

### DIFF
--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -201,7 +201,7 @@
 	UnregisterSignal(attached_circuit, list(
 		COMSIG_MOVABLE_MOVED,
 		COMSIG_PARENT_QDELETING,
-		COMSIG_CIRCUIT_ADD_COMPONENT,
+		COMSIG_CIRCUIT_ADD_COMPONENT_MANUALLY,
 	))
 	if(attached_circuit.loc == parent)
 		var/atom/parent_atom = parent


### PR DESCRIPTION
Fixed being unable to add extra circuit components when an integrated circuit was removed because of a failure to unregister a signal properly when removed from a shell.

Fixes #59715

## Changelog
:cl:
fix: Fixed being unable to add extra circuit components when an integrated circuit was removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
