### PR TITLE
Fixes collapsed or burnt paper bins from voiding new papers added

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -61,11 +61,13 @@
 		if(!movable_atom.pixel_x)
 			movable_atom.pixel_x = rand(-3,3)
 	LAZYNULL(papers)
+	LAZYINITLIST(papers)
 	update_appearance()
 
 /obj/item/paper_bin/fire_act(exposed_temperature, exposed_volume)
 	if(LAZYLEN(papers))
 		LAZYNULL(papers)
+		LAZYINITLIST(papers)
 		update_appearance()
 	..()
 
@@ -125,7 +127,7 @@
 		return ..()
 
 /obj/item/paper_bin/proc/at_overlay_limit()
-	return overlays.len >= MAX_ATOM_OVERLAYS
+	return overlays.len >= MAX_ATOM_OVERLAYS - 1
 
 /obj/item/paper_bin/examine(mob/user)
 	. = ..()

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -61,13 +61,11 @@
 		if(!movable_atom.pixel_x)
 			movable_atom.pixel_x = rand(-3,3)
 	LAZYNULL(papers)
-	LAZYINITLIST(papers)
 	update_appearance()
 
 /obj/item/paper_bin/fire_act(exposed_temperature, exposed_volume)
 	if(LAZYLEN(papers))
 		LAZYNULL(papers)
-		LAZYINITLIST(papers)
 		update_appearance()
 	..()
 
@@ -94,7 +92,7 @@
 		update_appearance()
 	else if(LAZYLEN(papers))
 		var/obj/item/paper/top_paper = papers[papers.len]
-		papers.Remove(top_paper)
+		LAZYREMOVE(papers, top_paper)
 		top_paper.add_fingerprint(user)
 		top_paper.forceMove(user.loc)
 		user.put_in_hands(top_paper)
@@ -114,7 +112,7 @@
 		if(!user.transferItemToLoc(paper, src))
 			return
 		to_chat(user, span_notice("You put [paper] in [src]."))
-		papers.Add(paper)
+		LAZYADD(papers, paper)
 		update_appearance()
 	else if(istype(I, /obj/item/pen) && !bin_pen)
 		var/obj/item/pen/pen = I


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #59687
Also fixes paper bins that were on fire from also voiding new papers added in.
Modified the collapse check so papers added in after the paper bin's stack collapse will allow the papers overlay when inserting into the same bin.

### Perceived Problems
After either case of collapse or burning the paper bin will `LAZYNULL(papers)` without re initializing the list for papers to be re added.
As far as i know, an objects overlays will stop being processed if the overlay limit is reached.

### Fix
Adding `LAZYINITLIST(papers)` right after `LAZYNULL(papers)` allows paper to be readded.
I have modified the collapse check of `/obj/item/paper_bin/proc/at_overlay_limit()` to contain `return overlays.len >= MAX_ATOM_OVERLAYS - 1` so it will collapse but not trigger the overlay limit and prevent this lock of new overlays from being processed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents voiding important or hard to prepare paper forms if you happen to put it in a bugged paper bin.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Paper bins after being stacked too high to fall over or getting burnt will no longer void your "important" paper forms when trying to add more paper afterwards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
