### PR TITLE
Revert "Fixes integrated circuits not being able to have more components added to them"

### DIFF
--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -201,7 +201,7 @@
 	UnregisterSignal(attached_circuit, list(
 		COMSIG_MOVABLE_MOVED,
 		COMSIG_PARENT_QDELETING,
-		COMSIG_CIRCUIT_ADD_COMPONENT_MANUALLY,
+		COMSIG_CIRCUIT_ADD_COMPONENT,
 	))
 	if(attached_circuit.loc == parent)
 		var/atom/parent_atom = parent


### PR DESCRIPTION
Reverts tgstation/tgstation#59724

Violation of the 24 hour rule.