### PR TITLE
(Hopefully) Stops cryopodded contract targets from breaking contractor uplinks

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -172,8 +172,17 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 			for(var/datum/mind/mind in objective.team.members)
 				to_chat(mind.current, "<BR>[span_userdanger("Your target is no longer within reach. Objective removed!")]")
 				mind.announce_objectives()
-		else if(objective.target && istype(objective.target, /datum/mind))
-			if(objective.target == mob_occupant.mind)
+		else if(istype(objective.target) && objective.target == mob_occupant.mind)
+			if(istype(objective, /datum/objective/contract))
+				var/datum/antagonist/traitor/affected_traitor = objective.owner.has_antag_datum(/datum/antagonist/traitor)
+				var/datum/contractor_hub/affected_contractor_hub = affected_traitor.contractor_hub
+				for(var/datum/syndicate_contract/affected_contract as anything in affected_contractor_hub.assigned_contracts)
+					if(affected_contract.contract == objective)
+						affected_contract.generate(affected_contractor_hub.assigned_targets)
+						affected_contractor_hub.assigned_targets.Add(affected_contract.contract.target)
+						to_chat(objective.owner.current, "<BR>[span_userdanger("Contract target out of reach. Contract rerolled.")]")
+						break
+			else
 				var/old_target = objective.target
 				objective.target = null
 				if(!objective)

--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -77,10 +77,7 @@
 
 			return TRUE
 		if("PRG_contract_abort")
-			var/contract_id = hard_drive.traitor_data.contractor_hub.current_contract?.id
-			if(!contract_id)
-				stack_trace("Contract hub attempted to abort a null or missing contract!")
-				return
+			var/contract_id = hard_drive.traitor_data.contractor_hub.current_contract.id
 
 			hard_drive.traitor_data.contractor_hub.current_contract = null
 			hard_drive.traitor_data.contractor_hub.assigned_contracts[contract_id].status = CONTRACT_STATUS_ABORTED
@@ -170,7 +167,7 @@
 		for (var/datum/syndicate_contract/contract in traitor_data.contractor_hub.assigned_contracts)
 			if(!contract.contract)
 				stack_trace("Syndiate contract with null contract objective found in [traitor_data.owner]'s contractor hub!")
-				traitor_data.contractor_hub.assigned_contracts.Remove(contract)
+				contract.status = CONTRACT_STATUS_ABORTED
 				continue
 
 			data["contracts"] += list(list(

--- a/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/contract_uplink.dm
@@ -77,7 +77,10 @@
 
 			return TRUE
 		if("PRG_contract_abort")
-			var/contract_id = hard_drive.traitor_data.contractor_hub.current_contract.id
+			var/contract_id = hard_drive.traitor_data.contractor_hub.current_contract?.id
+			if(!contract_id)
+				stack_trace("Contract hub attempted to abort a null or missing contract!")
+				return
 
 			hard_drive.traitor_data.contractor_hub.current_contract = null
 			hard_drive.traitor_data.contractor_hub.assigned_contracts[contract_id].status = CONTRACT_STATUS_ABORTED
@@ -165,6 +168,11 @@
 			))
 
 		for (var/datum/syndicate_contract/contract in traitor_data.contractor_hub.assigned_contracts)
+			if(!contract.contract)
+				stack_trace("Syndiate contract with null contract objective found in [traitor_data.owner]'s contractor hub!")
+				traitor_data.contractor_hub.assigned_contracts.Remove(contract)
+				continue
+
 			data["contracts"] += list(list(
 				"target" = contract.contract.target,
 				"target_rank" = contract.target_rank,


### PR DESCRIPTION
## About The Pull Request

Fixes #59630 .

This PR aims to stop contractor uplinks from breaking due to having a target cryopod. When a contract target enters cryosleep, it now manually rerolls the contract.

This PR is admittedly somewhat bandaid-y, as contractors are slotted for removal soon, apparently.

## Why It's Good For The Game

Stops contractors from breaking?

## Changelog
:cl: Melbert
fix: Fixes contractor tablets breaking due to contract targets cryoing.
/:cl:


