### PR TITLE
Make tgui alerts no longer automatically focus

### DIFF
--- a/tgui/packages/tgui/interfaces/AlertModal.js
+++ b/tgui/packages/tgui/interfaces/AlertModal.js
@@ -23,7 +23,7 @@ export class AlertModal extends Component {
 
     this.buttonRefs = [createRef()];
     this.state = { current: 0 };
-    this.autofocus = true; // stops the autofocusing from functioning
+    this.autofocus = true; // stops the autofocusing from functioning if set to false
   }
 
   componentDidMount() {

--- a/tgui/packages/tgui/interfaces/AlertModal.js
+++ b/tgui/packages/tgui/interfaces/AlertModal.js
@@ -23,7 +23,7 @@ export class AlertModal extends Component {
 
     this.buttonRefs = [createRef()];
     this.state = { current: 0 };
-    this.autofocus = false; // stops the autofocusing from functioning
+    this.autofocus = true; // stops the autofocusing from functioning
   }
 
   componentDidMount() {

--- a/tgui/packages/tgui/interfaces/AlertModal.js
+++ b/tgui/packages/tgui/interfaces/AlertModal.js
@@ -18,11 +18,12 @@ import {
 } from 'common/keycodes';
 
 export class AlertModal extends Component {
-  constructor() {
+  constructor(autofocus = false) {
     super();
 
     this.buttonRefs = [createRef()];
     this.state = { current: 0 };
+    this.autofocus = autofocus;
   }
 
   componentDidMount() {
@@ -35,8 +36,6 @@ export class AlertModal extends Component {
     for (let i = 1; i < buttons.length; i++) {
       this.buttonRefs.push(createRef());
     }
-
-    setTimeout(() => button.focus(), 1);
   }
 
   setCurrent(current, isArrowKey) {
@@ -64,6 +63,16 @@ export class AlertModal extends Component {
     const { title, message, buttons, timeout } = data;
     const { current } = this.state;
     const focusCurrentButton = () => this.setCurrent(current, false);
+    const updateCurrentFocus = () => {
+      if (this.autofocus) {
+        focusCurrentButton;
+      } else {
+        const button = this.buttonRefs[current].current;
+        if (button) {
+          setTimeout(() => button.blur(), 1);
+        }
+      }
+    };
 
     return (
       <Window
@@ -73,7 +82,7 @@ export class AlertModal extends Component {
         canClose={timeout > 0}>
         {timeout && <Loader value={timeout} />}
         <Window.Content
-          onFocus={focusCurrentButton}
+          onFocus={updateCurrentFocus}
           onClick={focusCurrentButton}>
           <Section fill>
             <Flex direction="column" height="100%">

--- a/tgui/packages/tgui/interfaces/AlertModal.js
+++ b/tgui/packages/tgui/interfaces/AlertModal.js
@@ -18,12 +18,12 @@ import {
 } from 'common/keycodes';
 
 export class AlertModal extends Component {
-  constructor(autofocus = false) {
+  constructor() {
     super();
 
     this.buttonRefs = [createRef()];
     this.state = { current: 0 };
-    this.autofocus = autofocus;
+    this.autofocus = false; // stops the autofocusing from functioning
   }
 
   componentDidMount() {

--- a/tgui/packages/tgui/interfaces/AlertModal.js
+++ b/tgui/packages/tgui/interfaces/AlertModal.js
@@ -23,7 +23,7 @@ export class AlertModal extends Component {
 
     this.buttonRefs = [createRef()];
     this.state = { current: 0 };
-    this.autofocus = true; // stops the autofocusing from functioning if set to false
+    this.autofocus = true; // determines if the alert autofocuses
   }
 
   componentDidMount() {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
TGUI alerts no longer automatically focus. 
An autofocus parameter was also added to the AlertModal class which can be set to restore the old behavior of automatically focusing.
TGUI alerts still focus (and highlight the option) when clicked on.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #59517
Allows for more flexibility with TGUI alerts while preventing people accidentally clicking them (most notably with ghost role spawners) by pressing space (such as when typing).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: TGUI pop-up alerts no longer automatically focus by default until you click on them. This prevents people from accidentally clicking an option they did not intend to pick by pressing space.
code: TGUI pop-ups now have a new parameter to focus automatically by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
