### PR TITLE
Forcefield Projector Nerf

### DIFF
--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -47,7 +47,8 @@
 		to_chat(user, span_warning("[src] cannot sustain any more forcefields!"))
 		return
 	if(force_proj_busy)
-		to_chat(user, span_notice("[src] is busy creating a forcefield."))	
+		to_chat(user, span_notice("[src] is busy creating a forcefield."))
+		return
 	playsound(loc, 'sound/machines/click.ogg', 20, TRUE)
 	if(creation_time)
 		force_proj_busy = TRUE

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -16,6 +16,8 @@
 	var/max_fields = 3
 	var/list/current_fields
 	var/field_distance_limit = 7
+	var/creation_time = 10
+	var/forceproj_busy = FALSE
 
 /obj/item/forcefield_projector/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
@@ -42,7 +44,16 @@
 	if(LAZYLEN(current_fields) >= max_fields)
 		to_chat(user, span_warning("[src] cannot sustain any more forcefields!"))
 		return
-
+	if(forceproj_busy)
+		to_chat(user, span_notice("[src] is busy creating a forcefield."))	
+	playsound(loc, 'sound/machines/click.ogg', 20, TRUE)
+	if(creation_time)
+		forceproj_busy = TRUE
+		if(!do_after(user, creation_time, target = target))
+			forceproj_busy = FALSE
+			return
+		forceproj_busy = FALSE
+	
 	playsound(src,'sound/weapons/resonator_fire.ogg',50,TRUE)
 	user.visible_message(span_warning("[user] projects a forcefield!"),span_notice("You project a forcefield."))
 	var/obj/structure/projected_forcefield/F = new(T, src)

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -16,8 +16,10 @@
 	var/max_fields = 3
 	var/list/current_fields
 	var/field_distance_limit = 7
-	var/creation_time = 10
-	var/forceproj_busy = FALSE
+	/// Time it takes to materialize a forcefield.
+	var/creation_time = 1 SECONDS
+	/// Checks to make sure the projector isn't busy with making another forcefield.
+	var/force_proj_busy = FALSE
 
 /obj/item/forcefield_projector/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
@@ -44,15 +46,15 @@
 	if(LAZYLEN(current_fields) >= max_fields)
 		to_chat(user, span_warning("[src] cannot sustain any more forcefields!"))
 		return
-	if(forceproj_busy)
+	if(force_proj_busy)
 		to_chat(user, span_notice("[src] is busy creating a forcefield."))	
 	playsound(loc, 'sound/machines/click.ogg', 20, TRUE)
 	if(creation_time)
-		forceproj_busy = TRUE
+		force_proj_busy = TRUE
 		if(!do_after(user, creation_time, target = target))
-			forceproj_busy = FALSE
+			force_proj_busy = FALSE
 			return
-		forceproj_busy = FALSE
+		force_proj_busy = FALSE
 	
 	playsound(src,'sound/weapons/resonator_fire.ogg',50,TRUE)
 	user.visible_message(span_warning("[user] projects a forcefield!"),span_notice("You project a forcefield."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

All this does is implement some code from holosign_creator.dm into forcefield_projector.dm so it takes a second to put down a forcefield.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The item can no longer be used to instantly lock someone into a corner. It's a minor balance change, but the projector is way too bullshit to play against as-is.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The Forcefield Projector takes a second to put a forcefield down.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
