### PR TITLE
Replaces broken valueless space cash item in old AI sat ruin with a 200 credit one

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -252,7 +252,7 @@
 /obj/item/food/meat/slab/synthmeat{
 	name = "Cuban Pete-Meat"
 	},
-/obj/item/stack/spacecash,
+/obj/item/stack/spacecash/c200,
 /turf/open/floor/engine,
 /area/tcommsat/oldaisat)
 "aY" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces broken valueless space cash item (ie, just the stack/spacecash item) in the old AI sat ruin with a 200 credit one
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes undocumented bug. Also less glitched items in the game (and this apparently can cause potential money duplication according to comments in the space cash code)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Replaces broken valueless space cash item in old AI sat ruin with a 200 credit one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
