### PR TITLE
Add more intercoms to new Metastation medbay

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9882,6 +9882,7 @@
 "bQn" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "bQF" = (
@@ -12669,6 +12670,7 @@
 	dir = 4
 	},
 /obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "crq" = (
@@ -14048,6 +14050,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/break_room)
 "cFS" = (
@@ -24923,6 +24926,23 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
+"fPr" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "fPu" = (
 /turf/open/floor/iron/chapel{
 	dir = 4
@@ -50620,6 +50640,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"oDH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "oDK" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -50857,6 +50883,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/range)
+"oHt" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "oHU" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -65156,6 +65186,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "tqs" = (
@@ -71210,10 +71241,10 @@
 	pixel_x = 14
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
 "vmM" = (
@@ -99627,7 +99658,7 @@ dux
 vrc
 urg
 cia
-cXe
+fPr
 cXe
 fFS
 sPt
@@ -102711,7 +102742,7 @@ khQ
 buV
 ifK
 gHm
-xRu
+oDH
 ljU
 rWs
 tid
@@ -103246,7 +103277,7 @@ cCa
 tQy
 lfR
 lNj
-cca
+oHt
 cca
 cca
 uOo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds more intercoms (and an extra fire extinguisher) to metastation medbay
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There's currently way too little intercoms in medbay, you have to go to the pharmacy / south surgery to find one, and that's if you knew that these places had the closest intercoms to begin with. Also adds an extra fire entinguisher for similar reasons.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Adds more intercoms and a new fire extinguisher to Metastation's new medbay.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
