### PR TITLE
Adds tail rejection on wag for non tail using species

### DIFF
--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -35,6 +35,7 @@
 #define MEDAL_HOT_DAMN "Hot Damn!"
 #define MEDAL_CAYENNE_DISK "Very Important Piscis"
 #define MEDAL_TRAM_SURFER "Tram Surfer"
+#define MEDAL_WAG_TAILPOP "Wag Tailpop"
 
 //Skill medal hub IDs
 #define MEDAL_LEGENDARY_MINER "Legendary Miner"

--- a/code/datums/achievements/misc_achievements.dm
+++ b/code/datums/achievements/misc_achievements.dm
@@ -171,3 +171,9 @@
 	desc = "Lights out, guerilla radio!"
 	database_id = MEDAL_TRAM_SURFER
 	icon = "tram_surfer"
+
+/datum/award/achievement/misc/wag_tailpop
+	name = "Wagpocalypse"
+	desc = "Holy hell it just came right off!"
+	database_id = MEDAL_WAG_TAILPOP
+	icon = "wag_tailpop"

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -121,6 +121,17 @@
 		return
 	var/mob/living/carbon/human/H = user
 	if(!istype(H) || !H.dna || !H.dna.species || !H.dna.species.can_wag_tail(H))
+		if(prob(0.1) && locate(/obj/item/organ/tail) in H.internal_organs)
+			for(var/obj/item/organ/tail/tail in H.internal_organs)
+				H.visible_message(
+					span_notice("[user]'s tail rips off in a bloody squelch!"),
+					span_warning("Your tail rips off with a bloody squelch!"),
+					span_notice("You hear a wet squelching sound")
+				)
+				H.spawn_gibs()
+				user.client?.give_award(/datum/award/achievement/misc/wag_tailpop, user)
+				tail.Remove(H)
+				tail.forceMove(H.drop_location())
 		return
 	if(!H.dna.species.is_wagging_tail())
 		H.dna.species.start_wagging_tail(H)
@@ -131,7 +142,7 @@
 	if(!..())
 		return FALSE
 	var/mob/living/carbon/human/H = user
-	return H.dna && H.dna.species && H.dna.species.can_wag_tail(user)
+	return locate(/obj/item/organ/tail) in H.internal_organs
 
 /datum/emote/living/carbon/human/wag/select_message_type(mob/user, intentional)
 	. = ..()


### PR DESCRIPTION
If you are not a species adapted to having a tail, there is a small
chance that when you go to *wag, your tail falls off

## Why It's Good For The Game
You need specialised muscles and sockets for a tail.


:cl: oranges
add: wagging your tail as a non tail wearing species might have a bad outcome
/:cl: