### PR TITLE
Dynamic can no longer creates malf AI humans 2: Electric Boogaloo

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -218,11 +218,11 @@
 				continue
 
 		// If this ruleset has exclusive_roles set, we want to only consider players who have those
-		// job prefs enabled and aren't role banned from that job. Otherwise, continue as before.
+		// job prefs enabled and are eligible to play that job. Otherwise, continue as before.
 		if(length(exclusive_roles))
 			var/exclusive_candidate = FALSE
 			for(var/role in exclusive_roles)
-				if((role in candidate_client.prefs.job_preferences) && !is_banned_from(candidate_player.ckey, role))
+				if((role in candidate_client.prefs.job_preferences) && !is_banned_from(candidate_player.ckey, role) &&!job_is_xp_locked(candidate_player.ckey, role))
 					exclusive_candidate = TRUE
 					break
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -222,7 +222,7 @@
 		if(length(exclusive_roles))
 			var/exclusive_candidate = FALSE
 			for(var/role in exclusive_roles)
-				if((role in candidate_client.prefs.job_preferences) && !is_banned_from(candidate_player.ckey, role) &&!job_is_xp_locked(candidate_player.ckey, role))
+				if((role in candidate_client.prefs.job_preferences) && !is_banned_from(candidate_player.ckey, role) && !job_is_xp_locked(candidate_player.ckey, role))
 					exclusive_candidate = TRUE
 					break
 


### PR DESCRIPTION


## About The Pull Request

An oversight #59418 missed allowed malf AI to roll on players that did not have sufficient playtime to enable AI, thus causing the exact same bug as before.

## Why It's Good For The Game

Bugfix

## Changelog
:cl: YakumoChen
fix: Dynamic will no longer create malf humans for players for never play silicon in the first place.
/:cl:
