### PR TITLE
You can now dump paper bins into the printer

### DIFF
--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -39,6 +39,22 @@
 	return TRUE
 
 /obj/item/computer_hardware/printer/try_insert(obj/item/I, mob/living/user = null)
+	if(istype(I, /obj/item/paper_bin))
+		var/obj/item/paper_bin/bin = I
+		var/bin_paper = bin.papers.len
+		var/to_insert = min(max_paper, stored_paper + bin_paper)
+		var/left_over = bin_paper - max_paper
+		if(left_over > 0)
+			visible_message(
+				span_notice("Paper spills out of the bin as the feed mechanism overloads"),
+				span_warning("UWU, the paper jams up your slot and spills out over the ground"), //nobody will ever see this :devilish:
+				span_notice("You hear crazy whirring and paper fluttering sounds")
+			)
+			bin.dump_papers(user.drop_location(), left_over)
+
+		bin.clear_paper()
+		stored_paper += to_insert
+
 	if(istype(I, /obj/item/paper))
 		if(stored_paper >= max_paper)
 			to_chat(user, span_warning("You try to add \the [I] into [src], but its paper bin is full!"))

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -46,8 +46,30 @@
 	return paper
 
 /obj/item/paper_bin/Destroy()
-	QDEL_LIST(papers)
+	clear_paper()
 	. = ..()
+
+/**
+ * Delete all paper contained within and clear the papers list
+ */
+/obj/item/paper_bin/proc/clear_paper()
+	QDEL_LIST(papers)
+
+/**
+ * Dump paper up to specified count into the given location
+ *
+ * This will remove items from the bin stack and drop them into the passed in location
+ *
+ * Arguments:
+ * * atom/droppoint the location to move the paper to
+ * * count, the count of the papers to dump (if more than in the bin only up to the bin amount will be dumped)
+ */
+/obj/item/paper_bin/proc/dump_papers(atom/droppoint, count)
+	while(count > 0 || papers.len <= 0)
+		var/obj/item/paper/top_paper = papers[papers.len]
+		papers.Remove(top_paper)
+		top_paper.forceMove(droppoint)
+		count -= 1
 
 /obj/item/paper_bin/dump_contents(atom/droppoint, collapse = FALSE)
 	if(!droppoint)
@@ -65,8 +87,7 @@
 
 /obj/item/paper_bin/fire_act(exposed_temperature, exposed_volume)
 	if(LAZYLEN(papers))
-		LAZYNULL(papers)
-		update_appearance()
+		dump_contents(null)
 	..()
 
 /obj/item/paper_bin/attack_paw(mob/user, list/modifiers)


### PR DESCRIPTION
This refills the printer from the paper bin up to the max amount the
printer can hold and then spills the rest over the ground

## Why It's Good For The Game
It's apparently annoying to refill the printer paper by paper, so this adds a fast way to do it

:cl: oranges
add: You can dump a paper bin into a printer now to refill it's paper fast
/:cl:
