### PR TITLE
Reverting Blob Buffs Made on a Refactor PR

### DIFF
--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -56,7 +56,8 @@
 #define BLOB_RESOURCE_GATHER_ADDED_DELAY            0.25 SECONDS// Every additional resource blob adds this amount to the gather delay
 #define BLOB_RESOURCE_GATHER_AMOUNT                 1           // The amount of points added to the overmind
 
-#define BLOB_REGULAR_MAX_HP                         30
+#define BLOB_REGULAR_MAX_HP                         25
+#define BLOB_REGULAR_HP_INIT			    		21			// The starting HP of the blob node
 #define BLOB_REGULAR_HP_REGEN                       1           // Health regenerated when pulsed by a node/core
 
 #define BLOB_STRONG_MAX_HP                          150
@@ -76,6 +77,7 @@
 
 #define BLOB_REFUND_STRONG_COST                     4           // Points refunded when destroying the structure
 #define BLOB_REFUND_REFLECTOR_COST                  8
+#define BLOB_REFUND_RESOURCE_COST					15
 #define BLOB_REFUND_FACTORY_COST                    25
 #define BLOB_REFUND_NODE_COST                       25
 

--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -57,7 +57,7 @@
 #define BLOB_RESOURCE_GATHER_AMOUNT                 1           // The amount of points added to the overmind
 
 #define BLOB_REGULAR_MAX_HP                         25
-#define BLOB_REGULAR_HP_INIT			    		21			// The starting HP of the blob node
+#define BLOB_REGULAR_HP_INIT			    		21			// The starting HP of a normal blob tile
 #define BLOB_REGULAR_HP_REGEN                       1           // Health regenerated when pulsed by a node/core
 
 #define BLOB_STRONG_MAX_HP                          150

--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -1,109 +1,109 @@
 // Overmind defines
 
-#define OVERMIND_MAX_POINTS_DEFAULT                 100         // Max point storage
-#define OVERMIND_STARTING_POINTS                    60          // Points granted upon start
-#define OVERMIND_STARTING_REROLLS                   1           // Free strain rerolls at the start
-#define OVERMIND_STARTING_MIN_PLACE_TIME            1 MINUTES   // Minimum time before the core can be placed
-#define OVERMIND_STARTING_AUTO_PLACE_TIME           6 MINUTES   // After this time, randomly place the core somewhere viable
-#define OVERMIND_WIN_CONDITION_AMOUNT               400         // Blob structures required to win
-#define OVERMIND_ANNOUNCEMENT_MIN_SIZE              75          // Once the blob has this many structures, announce their presence
-#define OVERMIND_ANNOUNCEMENT_MAX_TIME              10 MINUTES  // If the blob hasn't reached the minimum size before this time, announce their presence
-#define OVERMIND_MAX_CAMERA_STRAY                   "3x3"       // How far the overmind camera is allowed to stray from blob tiles. 3x3 is 1 tile away, 5x5 2 tiles etc
+#define OVERMIND_MAX_POINTS_DEFAULT 100 // Max point storage
+#define OVERMIND_STARTING_POINTS 60 // Points granted upon start
+#define OVERMIND_STARTING_REROLLS 1 // Free strain rerolls at the start
+#define OVERMIND_STARTING_MIN_PLACE_TIME 1 MINUTES // Minimum time before the core can be placed
+#define OVERMIND_STARTING_AUTO_PLACE_TIME 6 MINUTES // After this time, randomly place the core somewhere viable
+#define OVERMIND_WIN_CONDITION_AMOUNT 400 // Blob structures required to win
+#define OVERMIND_ANNOUNCEMENT_MIN_SIZE 75 // Once the blob has this many structures, announce their presence
+#define OVERMIND_ANNOUNCEMENT_MAX_TIME 10 MINUTES // If the blob hasn't reached the minimum size before this time, announce their presence
+#define OVERMIND_MAX_CAMERA_STRAY "3x3" // How far the overmind camera is allowed to stray from blob tiles. 3x3 is 1 tile away, 5x5 2 tiles etc
 
 
 // Generic blob defines
 
-#define BLOB_BASE_POINT_RATE                        2           // Base amount of points per process()
-#define BLOB_EXPAND_COST                            4           // Price to expand onto a new tile
-#define BLOB_ATTACK_REFUND                          2           // Points 'refunded' when the expand attempt actually attacks something instead
-#define BLOB_BRUTE_RESIST                           0.5         // Brute damage taken gets multiplied by this value
-#define BLOB_FIRE_RESIST                            1           // Burn damage taken gets multiplied by this value
-#define BLOB_EXPAND_CHANCE_MULTIPLIER               1           // Increase this value to make blobs naturally expand faster
-#define BLOB_REINFORCE_CHANCE                       2.5         // The delta_time chance for cores/nodes to reinforce their surroundings
-#define BLOB_REAGENTATK_VOL                         25          // Amount of strain-reagents that get injected when the blob attacks: main source of blob damage
+#define BLOB_BASE_POINT_RATE 2 // Base amount of points per process()
+#define BLOB_EXPAND_COST 4 // Price to expand onto a new tile
+#define BLOB_ATTACK_REFUND 2 // Points 'refunded' when the expand attempt actually attacks something instead
+#define BLOB_BRUTE_RESIST 0.5 // Brute damage taken gets multiplied by this value
+#define BLOB_FIRE_RESIST 1 // Burn damage taken gets multiplied by this value
+#define BLOB_EXPAND_CHANCE_MULTIPLIER 1 // Increase this value to make blobs naturally expand faster
+#define BLOB_REINFORCE_CHANCE 2.5 // The delta_time chance for cores/nodes to reinforce their surroundings
+#define BLOB_REAGENTATK_VOL 25 // Amount of strain-reagents that get injected when the blob attacks: main source of blob damage
 
 
 // Structure properties
 
-#define BLOB_CORE_MAX_HP                            400
-#define BLOB_CORE_HP_REGEN                          2           // Bases health regeneration rate every process(), can be added on by strains
-#define BLOB_CORE_CLAIM_RANGE                       12          // Range in which blob tiles are 'claimed' (converted from dead to alive, rarely useful)
-#define BLOB_CORE_PULSE_RANGE                       4           // The radius up to which the core activates structures, and up to which structures can be built
-#define BLOB_CORE_EXPAND_RANGE                      3           // Radius of automatic expansion
-#define BLOB_CORE_STRONG_REINFORCE_RANGE            1           // The radius of tiles surrounding the core that get upgraded
-#define BLOB_CORE_REFLECTOR_REINFORCE_RANGE         0
-#define BLOB_CORE_MAX_SPORES                        0           // Spores that the core can produce for free
+#define BLOB_CORE_MAX_HP 400
+#define BLOB_CORE_HP_REGEN 2 // Bases health regeneration rate every process(), can be added on by strains
+#define BLOB_CORE_CLAIM_RANGE 12 // Range in which blob tiles are 'claimed' (converted from dead to alive, rarely useful)
+#define BLOB_CORE_PULSE_RANGE 4 // The radius up to which the core activates structures, and up to which structures can be built
+#define BLOB_CORE_EXPAND_RANGE 3 // Radius of automatic expansion
+#define BLOB_CORE_STRONG_REINFORCE_RANGE 1 // The radius of tiles surrounding the core that get upgraded
+#define BLOB_CORE_REFLECTOR_REINFORCE_RANGE 0
+#define BLOB_CORE_MAX_SPORES 0 // Spores that the core can produce for free
 
-#define BLOB_NODE_MAX_HP                            200
-#define BLOB_NODE_HP_REGEN                          3
-#define BLOB_NODE_MIN_DISTANCE                      5           // Minimum distance between nodes
-#define BLOB_NODE_CLAIM_RANGE                       10
-#define BLOB_NODE_PULSE_RANGE                       3           // The radius up to which the core activates structures, and up to which structures can be built
-#define BLOB_NODE_EXPAND_RANGE                      2           // Radius of automatic expansion
-#define BLOB_NODE_STRONG_REINFORCE_RANGE            0           // The radius of tiles surrounding the node that get upgraded
-#define BLOB_NODE_REFLECTOR_REINFORCE_RANGE         0
-#define BLOB_NODE_MAX_SPORES                        0           // Spores that nodes can maintain
+#define BLOB_NODE_MAX_HP 200
+#define BLOB_NODE_HP_REGEN 3
+#define BLOB_NODE_MIN_DISTANCE 5 // Minimum distance between nodes
+#define BLOB_NODE_CLAIM_RANGE 10
+#define BLOB_NODE_PULSE_RANGE 3 // The radius up to which the core activates structures, and up to which structures can be built
+#define BLOB_NODE_EXPAND_RANGE 2 // Radius of automatic expansion
+#define BLOB_NODE_STRONG_REINFORCE_RANGE 0 // The radius of tiles surrounding the node that get upgraded
+#define BLOB_NODE_REFLECTOR_REINFORCE_RANGE 0
+#define BLOB_NODE_MAX_SPORES 0 // Spores that nodes can maintain
 
-#define BLOB_FACTORY_MAX_HP                         200
-#define BLOB_FACTORY_HP_REGEN                       1
-#define BLOB_FACTORY_MIN_DISTANCE                   7           // Minimum distance between factories
-#define BLOB_FACTORY_MAX_SPORES                     3
+#define BLOB_FACTORY_MAX_HP 200
+#define BLOB_FACTORY_HP_REGEN 1
+#define BLOB_FACTORY_MIN_DISTANCE 7 // Minimum distance between factories
+#define BLOB_FACTORY_MAX_SPORES 3
 
-#define BLOB_RESOURCE_MAX_HP                        60
-#define BLOB_RESOURCE_HP_REGEN                      15
-#define BLOB_RESOURCE_MIN_DISTANCE                  4           // Minimum distance between resource blobs
-#define BLOB_RESOURCE_GATHER_DELAY                  4 SECONDS   // Gather points when pulsed outside this interval
-#define BLOB_RESOURCE_GATHER_ADDED_DELAY            0.25 SECONDS// Every additional resource blob adds this amount to the gather delay
-#define BLOB_RESOURCE_GATHER_AMOUNT                 1           // The amount of points added to the overmind
+#define BLOB_RESOURCE_MAX_HP 60
+#define BLOB_RESOURCE_HP_REGEN 15
+#define BLOB_RESOURCE_MIN_DISTANCE 4 // Minimum distance between resource blobs
+#define BLOB_RESOURCE_GATHER_DELAY 4 SECONDS // Gather points when pulsed outside this interval
+#define BLOB_RESOURCE_GATHER_ADDED_DELAY 0.25 SECONDS // Every additional resource blob adds this amount to the gather delay
+#define BLOB_RESOURCE_GATHER_AMOUNT 1 // The amount of points added to the overmind
 
-#define BLOB_REGULAR_MAX_HP                         25
-#define BLOB_REGULAR_HP_INIT			    		21			// The starting HP of a normal blob tile
-#define BLOB_REGULAR_HP_REGEN                       1           // Health regenerated when pulsed by a node/core
+#define BLOB_REGULAR_MAX_HP 25
+#define BLOB_REGULAR_HP_INIT 21 // The starting HP of a normal blob tile
+#define BLOB_REGULAR_HP_REGEN 1 // Health regenerated when pulsed by a node/core
 
-#define BLOB_STRONG_MAX_HP                          150
-#define BLOB_STRONG_HP_REGEN                        2
+#define BLOB_STRONG_MAX_HP 150
+#define BLOB_STRONG_HP_REGEN 2
 
-#define BLOB_REFLECTOR_MAX_HP                       150
-#define BLOB_REFLECTOR_HP_REGEN                     2
+#define BLOB_REFLECTOR_MAX_HP 150
+#define BLOB_REFLECTOR_HP_REGEN 2
 
 
 // Structure purchasing
 
-#define BLOB_UPGRADE_STRONG_COST                    15          // Upgrade and build costs here
-#define BLOB_UPGRADE_REFLECTOR_COST                 15
-#define BLOB_STRUCTURE_RESOURCE_COST                40
-#define BLOB_STRUCTURE_FACTORY_COST                 60
-#define BLOB_STRUCTURE_NODE_COST                    50
+#define BLOB_UPGRADE_STRONG_COST 15 // Upgrade and build costs here
+#define BLOB_UPGRADE_REFLECTOR_COST 15
+#define BLOB_STRUCTURE_RESOURCE_COST 40
+#define BLOB_STRUCTURE_FACTORY_COST 60
+#define BLOB_STRUCTURE_NODE_COST 50
 
-#define BLOB_REFUND_STRONG_COST                     4           // Points refunded when destroying the structure
-#define BLOB_REFUND_REFLECTOR_COST                  8
-#define BLOB_REFUND_RESOURCE_COST					15
-#define BLOB_REFUND_FACTORY_COST                    25
-#define BLOB_REFUND_NODE_COST                       25
+#define BLOB_REFUND_STRONG_COST 4 // Points refunded when destroying the structure
+#define BLOB_REFUND_REFLECTOR_COST 8
+#define BLOB_REFUND_RESOURCE_COST 15
+#define BLOB_REFUND_FACTORY_COST 25
+#define BLOB_REFUND_NODE_COST 25
 
 // Blob power properties
 
-#define BLOB_POWER_RELOCATE_COST                    80          // Resource cost to move your core to a different node
-#define BLOB_POWER_REROLL_COST                      40          // Strain reroll
-#define BLOB_POWER_REROLL_FREE_TIME                 4 MINUTES   // Gain a free strain reroll every x minutes
-#define BLOB_POWER_REROLL_CHOICES                   6           // Possibilities to choose from; keep in mind increasing this might fuck with the radial menu
+#define BLOB_POWER_RELOCATE_COST 80 // Resource cost to move your core to a different node
+#define BLOB_POWER_REROLL_COST 40 // Strain reroll
+#define BLOB_POWER_REROLL_FREE_TIME 4 MINUTES // Gain a free strain reroll every x minutes
+#define BLOB_POWER_REROLL_CHOICES 6 // Possibilities to choose from; keep in mind increasing this might fuck with the radial menu
 
 
 // Mob defines
 
-#define BLOBMOB_HEALING_MULTIPLIER                  0.0125      // Multiplies by -maxHealth and heals the blob by this amount every blob_act
-#define BLOBMOB_SPORE_HEALTH                        30          // Base spore health
-#define BLOBMOB_SPORE_SPAWN_COOLDOWN                8 SECONDS
-#define BLOBMOB_SPORE_DMG_LOWER                     2
-#define BLOBMOB_SPORE_DMG_UPPER                     4
-#define BLOBMOB_BLOBBERNAUT_RESOURCE_COST           40          // Purchase price for making a blobbernaut
-#define BLOBMOB_BLOBBERNAUT_HEALTH                  200         // Base blobbernaut health
-#define BLOBMOB_BLOBBERNAUT_DMG_SOLO_LOWER          20          // Damage without active overmind (core dead or xenobio mob)
-#define BLOBMOB_BLOBBERNAUT_DMG_SOLO_UPPER          20
-#define BLOBMOB_BLOBBERNAUT_DMG_LOWER               4           // Damage dealt with active overmind (most damage comes from strain chems)
-#define BLOBMOB_BLOBBERNAUT_DMG_UPPER               4
-#define BLOBMOB_BLOBBERNAUT_REAGENTATK_VOL          20          // Amounts of strain reagents applied on attack -- basically the main damage stat
-#define BLOBMOB_BLOBBERNAUT_DMG_OBJ                 60          // Damage dealth to objects/machines
-#define BLOBMOB_BLOBBERNAUT_HEALING_CORE            0.05        // Percentage multiplier HP restored on Life() when within 2 tiles of the blob core
-#define BLOBMOB_BLOBBERNAUT_HEALING_NODE            0.025       // Same, but for a nearby node
-#define BLOBMOB_BLOBBERNAUT_HEALTH_DECAY            0.0125      // Percentage multiplier HP lost when not near blob tiles or without factory
+#define BLOBMOB_HEALING_MULTIPLIER 0.0125 // Multiplies by -maxHealth and heals the blob by this amount every blob_act
+#define BLOBMOB_SPORE_HEALTH 30 // Base spore health
+#define BLOBMOB_SPORE_SPAWN_COOLDOWN 8 SECONDS
+#define BLOBMOB_SPORE_DMG_LOWER 2
+#define BLOBMOB_SPORE_DMG_UPPER 4
+#define BLOBMOB_BLOBBERNAUT_RESOURCE_COST 40 // Purchase price for making a blobbernaut
+#define BLOBMOB_BLOBBERNAUT_HEALTH 200 // Base blobbernaut health
+#define BLOBMOB_BLOBBERNAUT_DMG_SOLO_LOWER 20 // Damage without active overmind (core dead or xenobio mob)
+#define BLOBMOB_BLOBBERNAUT_DMG_SOLO_UPPER 20
+#define BLOBMOB_BLOBBERNAUT_DMG_LOWER 4 // Damage dealt with active overmind (most damage comes from strain chems)
+#define BLOBMOB_BLOBBERNAUT_DMG_UPPER 4
+#define BLOBMOB_BLOBBERNAUT_REAGENTATK_VOL 20 // Amounts of strain reagents applied on attack -- basically the main damage stat
+#define BLOBMOB_BLOBBERNAUT_DMG_OBJ 60 // Damage dealth to objects/machines
+#define BLOBMOB_BLOBBERNAUT_HEALING_CORE 0.05 // Percentage multiplier HP restored on Life() when within 2 tiles of the blob core
+#define BLOBMOB_BLOBBERNAUT_HEALING_NODE 0.025 // Same, but for a nearby node
+#define BLOBMOB_BLOBBERNAUT_HEALTH_DECAY 0.0125 // Percentage multiplier HP lost when not near blob tiles or without factory

--- a/code/modules/antagonists/blob/blobstrains/networked_fibers.dm
+++ b/code/modules/antagonists/blob/blobstrains/networked_fibers.dm
@@ -9,7 +9,7 @@
 	color = "#4F4441"
 	complementary_color = "#414C4F"
 	reagent = /datum/reagent/blob/networked_fibers
-	core_regen_bonus = 5
+	core_regen_bonus = 3
 
 /datum/blobstrain/reagent/networked_fibers/expand_reaction(obj/structure/blob/spawning_blob, obj/structure/blob/new_blob, turf/chosen_turf, mob/camera/blob/overmind)
 	if(!overmind && new_blob.overmind)

--- a/code/modules/antagonists/blob/blobstrains/regenerative_materia.dm
+++ b/code/modules/antagonists/blob/blobstrains/regenerative_materia.dm
@@ -7,7 +7,7 @@
 	complementary_color = "#AF7B8D"
 	message_living = ", and you feel <i>alive</i>"
 	reagent = /datum/reagent/blob/regenerative_materia
-	core_regen_bonus = 20
+	core_regen_bonus = 18
 	point_rate_bonus = 1
 
 /datum/reagent/blob/regenerative_materia

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -12,7 +12,7 @@
 	CanAtmosPass = ATMOS_PASS_PROC
 	/// How many points the blob gets back when it removes a blob of that type. If less than 0, blob cannot be removed.
 	var/point_return = 0
-	max_integrity = 30
+	max_integrity = BLOB_REGULAR_MAX_HP
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 80, ACID = 70)
 	/// how much health this blob regens when pulsed
 	var/health_regen = BLOB_REGULAR_HP_REGEN
@@ -314,8 +314,13 @@
 	icon_state = "blob"
 	light_range = 0
 	max_integrity = BLOB_REGULAR_MAX_HP
+	var/initial_integrity = BLOB_REGULAR_HP_INIT
 	health_regen = BLOB_REGULAR_HP_REGEN
 	brute_resist = BLOB_BRUTE_RESIST * 0.5
+
+/obj/structure/blob/normal/Initialize(mapload, owner_overmind)
+	. = ..()
+	update_integrity(initial_integrity)
 
 /obj/structure/blob/normal/scannerreport()
 	if(obj_integrity <= 15)

--- a/code/modules/antagonists/blob/structures/resource.dm
+++ b/code/modules/antagonists/blob/structures/resource.dm
@@ -3,8 +3,8 @@
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_resource"
 	desc = "A thin spire of slightly swaying tendrils."
-	max_integrity = 60
-	point_return = 15
+	max_integrity = BLOB_RESOURCE_MAX_HP
+	point_return = BLOB_REFUND_RESOURCE_COST
 	resistance_flags = LAVA_PROOF
 	var/resource_delay = 0
 

--- a/code/modules/antagonists/blob/structures/shield.dm
+++ b/code/modules/antagonists/blob/structures/shield.dm
@@ -4,7 +4,7 @@
 	icon_state = "blob_shield"
 	desc = "A solid wall of slightly twitching tendrils."
 	var/damaged_desc = "A wall of twitching tendrils."
-	max_integrity = 150
+	max_integrity = BLOB_STRONG_MAX_HP
 	health_regen = BLOB_STRONG_HP_REGEN
 	brute_resist = BLOB_BRUTE_RESIST * 0.5
 	explosion_block = 3


### PR DESCRIPTION
## About The Pull Request

This PR fixes some of the balance changes made as part of #56306, as it is a refactor PR and the comments say to revert all the balance changes made as a part of the PR

## Why It's Good For The Game

Unapproved balance changes begone

## Changelog
:cl:
fix: Reverted the normal blob's max HP and initial HP values, which were accidentally modified (Old: 30 and 30, New: 25 and 21)
fix: Fixed an issue where certain strains with bonus core regeneration were regenerating faster than intended
code: Used a few unimplemented defines from the PR, like for the Strong and Resource blobs
code: Added an initial HP define that is set as a normal blob's integrity upon Initialize
/:cl:
