### PR TITLE
fixes not being able to upload mutations from disk to dna console

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -823,8 +823,7 @@
 				say("ERROR: This mutation is anomalous, and cannot be saved.")
 				return
 
-			var/datum/mutation/human/A = new HM.type()
-			A.copy_mutation(HM)
+			var/datum/mutation/human/A = new HM.type(MUT_EXTRA, null, HM)
 			stored_mutations += A
 			to_chat(usr,span_notice("Mutation successfully stored."))
 			return
@@ -873,8 +872,7 @@
 			if(!HM)
 				return
 
-			var/datum/mutation/human/A = new HM.type()
-			A.copy_mutation(HM)
+			var/datum/mutation/human/A = new HM.type(MUT_EXTRA, null, HM)
 			diskette.mutations += A
 			to_chat(usr,span_notice("Mutation successfully stored to disk."))
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
does what the title says, by default mutations get MUT_OTHER which cant be saved or uploaded and stuff, so instead they get MUT_EXTRA
seemed to work when i tried it but i dont know much dna code at all so im not sure if this is the best
requested by armhulen

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
lets go

## Changelog
:cl:
fix: fixes not being able to upload mutations from disk to dna console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
