### PR TITLE
Adds a verb for disabling hard deletion

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -191,7 +191,8 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/check_timer_sources,
 	/client/proc/toggle_cdn,
 	/client/proc/cmd_give_sdql_spell,
-	/client/proc/adventure_manager
+	/client/proc/adventure_manager,
+	/client/proc/hard_deletion_toggle
 	)
 GLOBAL_LIST_INIT(admin_verbs_possess, list(/proc/possess, /proc/release))
 GLOBAL_PROTECT(admin_verbs_possess)

--- a/code/modules/admin/verbs/toggle_hard_dels.dm
+++ b/code/modules/admin/verbs/toggle_hard_dels.dm
@@ -1,0 +1,18 @@
+/client/proc/hard_deletion_toggle()
+	set category = "Debug"
+	set name = "Enable/Disable Hard Deletes"
+
+	var/static/list/warned_users
+
+	LAZYINITLIST(warned_users)
+
+	var/current_val = SSgarbage.enable_hard_deletes
+	if (current_val && !warned_users[usr.ckey])
+		to_chat(usr, "WARNING: Disabling garbage hard deletion will likely result in permanent memory leaks until the next round. Run this verb again to disable it.")
+		warned_users[usr.ckey] = TRUE
+		return
+
+	SSgarbage.enable_hard_deletes = !current_val
+
+	log_admin("[key_name(usr)] toggled garbage hard deletion [SSgarbage.enable_hard_deletes ? "ON" : "OFF"].")
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "hard_deletion_toggle") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -480,10 +480,9 @@
 	return text
 
 /datum/parsed_map/Destroy()
-	..()
 	turf_blacklist.Cut()
 	parsed_bounds.Cut()
 	bounds.Cut()
 	grid_models.Cut()
 	gridSets.Cut()
-	return QDEL_HINT_HARDDEL_NOW
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1609,6 +1609,7 @@
 #include "code\modules\admin\verbs\selectequipment.dm"
 #include "code\modules\admin\verbs\shuttlepanel.dm"
 #include "code\modules\admin\verbs\spawnobjasmob.dm"
+#include "code\modules\admin\verbs\toggle_hard_dels.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2_parser.dm"
 #include "code\modules\admin\verbs\SDQL2\SDQL_2_wrappers.dm"


### PR DESCRIPTION
- Added variable to enable hard deletion to SSgarbage.
- Added "Enable/Disable Hard Deletes" Debug verb.
- Non-datums that are qdel()'d now have their del() times logged.
- `/datum/parsed_map` no longer returns `QDEL_HINT_HARDDEL_NOW`.

Alternative to #59750 

:cl:
admin: Added a verb to toggle garbage hard deletes for the round. Objects destroyed while disabled may cause memory leaks.
/:cl: