### PR TITLE
Adds time range for hard deletion curfew (from #59750)

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -516,3 +516,11 @@
 /datum/config_entry/flag/disable_gc_failure_hard_deletes
 
 /datum/config_entry/flag/disable_all_hard_deletes
+
+/datum/config_entry/number/hard_delete_curfew_start
+	config_entry_value = 0
+	integer = FALSE
+
+/datum/config_entry/number/hard_delete_curfew_end
+	config_entry_value = 24
+	integer = FALSE

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -512,3 +512,13 @@
 
 /// URL for admins to be redirected to for 2FA
 /datum/config_entry/string/admin_2fa_url
+
+/datum/config_entry/flag/disable_gc_failure_hard_deletes
+
+/datum/config_entry/flag/disable_all_hard_deletes
+
+
+
+
+
+

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -516,9 +516,3 @@
 /datum/config_entry/flag/disable_gc_failure_hard_deletes
 
 /datum/config_entry/flag/disable_all_hard_deletes
-
-
-
-
-
-

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -201,7 +201,8 @@ SUBSYSTEM_DEF(garbage)
 				#endif
 				I.failures++
 			if (GC_QUEUE_HARDDELETE)
-				HardDelete(D)
+				if (!CONFIG_GET(flag/disable_gc_failure_hard_deletes))
+					HardDelete(D)
 				if (MC_TICK_CHECK)
 					return
 				continue
@@ -242,8 +243,8 @@ SUBSYSTEM_DEF(garbage)
 	++totaldels
 	var/type = D.type
 	var/refID = "\ref[D]"
-
-	del(D)
+	if (!CONFIG_GET(flag/disable_all_hard_deletes))
+		del(D)
 
 	tick = (TICK_USAGE-tick+((world.time-ticktime)/world.tick_lag*100))
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -541,12 +541,11 @@ DEFAULT_VIEW_SQUARE 15x15
 ## Add the ID of the role you want assigning here
 #DISCORD_ROLEID 000000000000000000
 
-## Uncomment to disable hard deleting garbage collection failures. (Hard deleting GC failures causes lag in order to bring memory usage down and keep bugged objects from hanging around and causing bugs in other things.) You can safely enable this for preformance on production if the lag spikes are too disruptive)
+## Uncomment to disable hard deleting garbage collection failures. (Hard deleting GC failures causes lag in order to bring memory usage down and keep bugged objects from hanging around and causing bugs in other things.) You can safely enable this for performance on production if the lag spikes are too disruptive)
 #DISABLE_GC_FAILURE_HARD_DELETES
 
-## Uncommand to disable hard deletes entirely, even things that explicitly request. This is not recommended unless you have a need for it during events or other high pop times where preformance is key.
+## Uncomment to disable hard deletes entirely, even things that explicitly request. This is not recommended unless you have a need for it during events or other high pop times where performance is key.
 #DISABLE_ALL_HARD_DELETES
-
 
 
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -546,10 +546,3 @@ DEFAULT_VIEW_SQUARE 15x15
 
 ## Uncomment to disable hard deletes entirely, even things that explicitly request. This is not recommended unless you have a need for it during events or other high pop times where performance is key.
 #DISABLE_ALL_HARD_DELETES
-
-
-
-
-
-
-

--- a/config/config.txt
+++ b/config/config.txt
@@ -541,8 +541,15 @@ DEFAULT_VIEW_SQUARE 15x15
 ## Add the ID of the role you want assigning here
 #DISCORD_ROLEID 000000000000000000
 
+#### HARD DELETION ####
 ## Uncomment to disable hard deleting garbage collection failures. (Hard deleting GC failures causes lag in order to bring memory usage down and keep bugged objects from hanging around and causing bugs in other things.) You can safely enable this for performance on production if the lag spikes are too disruptive)
 #DISABLE_GC_FAILURE_HARD_DELETES
 
 ## Uncomment to disable hard deletes entirely, even things that explicitly request. This is not recommended unless you have a need for it during events or other high pop times where performance is key.
 #DISABLE_ALL_HARD_DELETES
+
+## Which hour of the day the above hard delete settings are in force. Supports decimal values
+#HARD_DELETE_CURFEW_START 0
+
+## Which hour of the day the above hard delete settings cease being in force. Supports decimal values
+#HARD_DELETE_CURFEW_END 24

--- a/config/config.txt
+++ b/config/config.txt
@@ -540,3 +540,17 @@ DEFAULT_VIEW_SQUARE 15x15
 
 ## Add the ID of the role you want assigning here
 #DISCORD_ROLEID 000000000000000000
+
+## Uncomment to disable hard deleting garbage collection failures. (Hard deleting GC failures causes lag in order to bring memory usage down and keep bugged objects from hanging around and causing bugs in other things.) You can safely enable this for preformance on production if the lag spikes are too disruptive)
+#DISABLE_GC_FAILURE_HARD_DELETES
+
+## Uncommand to disable hard deletes entirely, even things that explicitly request. This is not recommended unless you have a need for it during events or other high pop times where preformance is key.
+#DISABLE_ALL_HARD_DELETES
+
+
+
+
+
+
+
+


### PR DESCRIPTION
## About The Pull Request
My solution to the controversial #59750

A time range in hours that the config is enabled, so it could be enabled only during peak time, for example.

If you have read the previous PR you can review just my changes with https://github.com/tgstation/tgstation/pull/59788/commits/2b42ae15f6215f57bde7585a2618b8d8cf939d6e

## Changelog
:cl: MrStonedOne
server: Added configs to disable hard deletes on Garbage Collection failures for cases where performance concerns outweighs the need to clear these from memory.
/:cl:
