### PR TITLE
Makes master support ss.postpone()ing the next fire of running subsystems

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -525,7 +525,9 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 
 			queue_node.last_fire = world.time
 			queue_node.times_fired++
-
+			
+			var/postpone = queue_node.next_fire - queue_node.queued_time 
+			
 			if (queue_node_flags & SS_TICKER)
 				queue_node.next_fire = world.time + (world.tick_lag * queue_node.wait)
 			else if (queue_node_flags & SS_POST_FIRE_TIMING)
@@ -534,6 +536,9 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 				queue_node.next_fire += queue_node.wait
 			else
 				queue_node.next_fire = queue_node.queued_time + queue_node.wait + (world.tick_lag * (queue_node.tick_overrun/100))
+
+			if (postpone >= world.tick_lag)
+				queue_node.next_fire += postpone
 
 			queue_node.queued_time = 0
 


### PR DESCRIPTION
Sadly it can't apply this to the next fire resume of paused subsystems, but at least its not resetting that postpone.
