### PR TITLE
Removes some socially charged things from the ion law lists, adds mothmen to the species list

### DIFF
--- a/strings/ion_laws.json
+++ b/strings/ion_laws.json
@@ -145,8 +145,6 @@
         "INVISIBLE",
         "PAINFUL",
         "HARMFUL",
-        "HOMOSEXUAL",
-        "HETEROSEXUAL",
         "SEXUAL",
         "BLOODY",
         "COLORFUL",
@@ -837,7 +835,8 @@
         "SLIME PEOPLE",
         "GOLEMS",
         "SHADOW PEOPLE",
-        "CHANGELINGS"
+        "CHANGELINGS",
+        "MOTHMEN"
     ],
     "ionthings": [
         "ABSENCE OF CYBORG HUGS",
@@ -993,7 +992,6 @@
         "SKELETONS",
         "CAPITALISTS",
         "SINGULARITIES",
-        "ANGRY BLACK MEN",
         "GODS",
         "THIEVES",
         "ASSHOLES",


### PR DESCRIPTION
## About The Pull Request

Removes "angry black men", "heterosexual", and "homosexual". Adds "mothmen".

## Why It's Good For The Game

Some players downstream mentioned being uncomfortable with the idea of being singled out because of a real-life sexuality or race. I was told to PR it up here first.

## Changelog
:cl:
tweak: Changed around the ion law lists
/:cl: