### PR TITLE
Removes potential github liability

### DIFF
--- a/strings/ion_laws.json
+++ b/strings/ion_laws.json
@@ -993,7 +993,6 @@
         "SKELETONS",
         "CAPITALISTS",
         "SINGULARITIES",
-        "ANGRY BLACK MEN",
         "GODS",
         "THIEVES",
         "ASSHOLES",


### PR DESCRIPTION
See closed pr #59793

The other two were fine but having this one under `ionthreats` isn't worth the risk.

(i briefly considered not opening this pr so that when github bans the repo and i unveil my self hosted gog/phabricator clone that already has prs and issues mirrored with github oauth so authors can own their own comments i would take over. but then i remembered that i never got around to making that so here we are)