### PR TITLE
Fixes bug in Ripley mech construction where it would say "securing the screwdriver"

### DIFF
--- a/code/modules/vehicles/mecha/mecha_construction_paths.dm
+++ b/code/modules/vehicles/mecha/mecha_construction_paths.dm
@@ -350,7 +350,7 @@
 				user.visible_message(span_notice("[user] unfastens the scanner module."), span_notice("You unfasten the scanner module."))
 		if(12)
 			if(diff==FORWARD)
-				user.visible_message(span_notice("[user] secures [I]."), span_notice("You secure [I]."))
+				user.visible_message(span_notice("[user] secures the capacitor."), span_notice("You secure the capacitor."))
 			else
 				user.visible_message(span_notice("[user] removes the capacitor from [parent]."), span_notice("You remove the capacitor from [parent]."))
 		if(13)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
[I] in this case refers to the inhand item so in this case it would be the screwdriver / hand drill, this changes it to properly reflect that the capacitor is being screwed in.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes undocumented bug.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: Fixes bug in Ripley mech construction where it would say "securing the screwdriver"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
