### PR TITLE
Adds 2 basic healing chems

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -154,7 +154,7 @@
 
 /datum/reagent/medicine/c2/purabital
 	name = "Purabital"
-	description = "A purified reagent that heals brute with no side effects. It heals more based on purity."
+	description = "A purified reagent that heals brute damage without side effects, scales with purity."
 	color = "#d2eb62"
 	ph = 9
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -257,7 +257,7 @@
 
 /datum/reagent/medicine/c2/purauri
 	name = "Purauri"
-	description = "A purified reagent that heals burns without side effects. It heals more based on purity."
+	description = "A purified reagent that heals burn damages without side effects, scales with purity."
 	color = "#6bf0c3"
 	ph = 9.7
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -154,7 +154,7 @@
 
 /datum/reagent/medicine/c2/purabital
 	name = "Purabital"
-	description = "A purified reagent that heals brute damage without side effects, scales with purity."
+	description = "A purified reagent that heals brute damage without side effects. The amount healed can scale with purity."
 	color = "#d2eb62"
 	ph = 9
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -257,7 +257,7 @@
 
 /datum/reagent/medicine/c2/purauri
 	name = "Purauri"
-	description = "A purified reagent that heals burn damages without side effects, scales with purity."
+	description = "A purified reagent that heals burn damages without side effects. The amount healed can scale with purity."
 	color = "#6bf0c3"
 	ph = 9.7
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -152,6 +152,29 @@
 
 	..()
 
+/datum/reagent/medicine/c2/purabital
+	name = "Purabital"
+	description = "A purified reagent that heals brute with no side effects. It heals more based on purity."
+	color = "#d2eb62"
+	ph = 9
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	overdose_threshold = 15
+
+/datum/reagent/medicine/c2/purabital/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	M.adjustBruteLoss(LERP(-1.25 * REM, normalise_creation_purity()*-1.05, 0.85) * delta_time, FALSE)	//Heals ~0.2 - 2.2 brute
+	..()
+	return TRUE
+
+/datum/reagent/medicine/c2/purabital/overdose_process(mob/living/M, delta_time, times_fired)
+	M.adjustBruteLoss(2 * REM * delta_time, FALSE)
+	M.adjustOxyLoss(7 * delta_time)
+	if(prob(10))
+		M.emote("gasp")
+	else if (prob(10))
+		M.emote("cough")
+	..()
+	return TRUE
+
 /******BURN******/
 /*Suffix: -uri*/
 /datum/reagent/medicine/c2/lenturi
@@ -232,6 +255,28 @@
 		humi.adjust_coretemperature(-10 * TEMPERATURE_DAMAGE_COEFFICIENT * REM * delta_time, 50)
 	..()
 
+/datum/reagent/medicine/c2/purauri
+	name = "Purauri"
+	description = "A purified reagent that heals burns without side effects. It heals more based on purity."
+	color = "#6bf0c3"
+	ph = 9.7
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	overdose_threshold = 15
+
+/datum/reagent/medicine/c2/purauri/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	M.adjustFireLoss(LERP(-1.25 * REM, normalise_creation_purity()*-1.05, 0.85) * delta_time, FALSE)	//Heals ~0.2 - 2.2 burn
+	..()
+	return TRUE
+
+/datum/reagent/medicine/c2/purauri/overdose_process(mob/living/M, delta_time, times_fired)
+	M.adjustFireLoss(2 * REM * delta_time, FALSE)
+	M.adjustOxyLoss(7 * delta_time)
+	if(prob(10))
+		M.emote("gasp")
+	else if (prob(10))
+		M.emote("cough")
+	..()
+	return TRUE
 
 /******OXY******/
 /*Suffix: -mol*/

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -161,7 +161,7 @@
 	overdose_threshold = 15
 
 /datum/reagent/medicine/c2/purabital/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.adjustBruteLoss(LERP(-1.25 * REM, normalise_creation_purity()*-1.05, 0.85) * delta_time, FALSE)	//Heals ~0.2 - 2.2 brute
+	M.adjustBruteLoss(LERP(-1.25 * REM, normalise_creation_purity()*-1.05, 0.85) * delta_time, FALSE)	//Heals ~1 - 2.2 brute
 	..()
 	return TRUE
 
@@ -264,7 +264,7 @@
 	overdose_threshold = 15
 
 /datum/reagent/medicine/c2/purauri/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.adjustFireLoss(LERP(-1.25 * REM, normalise_creation_purity()*-1.05, 0.85) * delta_time, FALSE)	//Heals ~0.2 - 2.2 burn
+	M.adjustFireLoss(LERP(-1.25 * REM, normalise_creation_purity()*-1.05, 0.85) * delta_time, FALSE)	//Heals ~1 - 2.2 burn
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
+++ b/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
@@ -84,6 +84,27 @@
 	reaction_flags = REACTION_CLEAR_INVERSE | REACTION_PH_VOL_CONSTANT
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE
 
+/datum/chemical_reaction/medicine/purabital
+	results = list(/datum/reagent/medicine/c2/purabital = 1)
+	required_reagents = list(/datum/reagent/medicine/c2/probital = 1, /datum/reagent/stabilizing_agent = 3)
+	required_temp = 615
+	optimal_temp = 750
+	overheat_temp = 1000
+	optimal_ph_min = 0
+	optimal_ph_max = 13
+	temp_exponent_factor = 1.25
+	thermic_constant = 75
+	H_ion_release = 0.05
+	rate_up_lim = 50
+	//reaction_flags = REACTION_INSTANT	//This -would- be instant, but apparently being instant only calls one proc!
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BRUTE
+
+/datum/chemical_reaction/medicine/purabital/reaction_step(datum/reagents/holder, datum/equilibrium/reaction, delta_t, delta_ph, step_reaction_vol)
+	var/datum/reagent/medicine/c2/purabital/P = holder.get_reagent(/datum/reagent/medicine/c2/purabital)
+	var/datum/reagent/medicine/c2/probital/R = holder.get_reagent(/datum/reagent/medicine/c2/probital)
+	if(R && P)
+		P.purity = R.purity*0.85	//End result is slightly more pure (~0.06) than the probital
+
 /*****BURN*****/
 //These are all endothermic!
 
@@ -159,6 +180,27 @@
 	var/radius = max((equilibrium.step_target_vol/50), 1)
 	freeze_radius(holder, equilibrium, 200, radius, 60 SECONDS) //drying agent exists
 	explode_shockwave(holder, equilibrium, sound_and_text = FALSE)
+
+/datum/chemical_reaction/medicine/purauri
+	results = list(/datum/reagent/medicine/c2/purauri = 2)
+	required_reagents = list(/datum/reagent/medicine/c2/aiuri = 1, /datum/reagent/stabilizing_agent = 1, /datum/reagent/stable_plasma = 1)
+	required_temp = 215
+	optimal_temp = 220
+	overheat_temp = 250
+	optimal_ph_min = 0
+	optimal_ph_max = 13
+	temp_exponent_factor = 0.25
+	thermic_constant = -5
+	H_ion_release = 0
+	rate_up_lim = 100
+	//reaction_flags = REACTION_INSTANT	//This -would- be instant, but apparently being instant only calls one proc!
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_BURN
+
+/datum/chemical_reaction/medicine/purauri/reaction_step(datum/reagents/holder, datum/equilibrium/reaction, delta_t, delta_ph, step_reaction_vol)
+	var/datum/reagent/medicine/c2/purauri/P = holder.get_reagent(/datum/reagent/medicine/c2/purauri)
+	var/datum/reagent/medicine/c2/aiuri/R = holder.get_reagent(/datum/reagent/medicine/c2/aiuri)
+	if(R && P)
+		P.purity = R.purity*0.85	//End result is slightly less pure (~0.06) than the aiuri
 
 /*****OXY*****/
 //These react faster with optional oxygen, and have blastback effects! (the oxygen makes their fail states deadlier)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Purauri and Purabital, burn- and brute- healing chems with no side-effects (besides overdose). I know these are dumb names but eh
They both heal around 2 units of damage per tick when at max purity, which is half as powerful as other basic-healing chems. Purity for both of these is also scaled by the required reagents' purity

Overdose process instead deals 2 brute/burn damage, 7 oxygen damage, and has a chance to make the player gasp/cough

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The current basic burn medicine was either a bit inconvenient to make (lenturi) or had annoying side-effects (eye damage and temps), so I added the purauri. The brute chemical is to just have the same number of brute and burn healing chems, and isn't really needed.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: brute- and burn-healing basic chems
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
