### PR TITLE
Freedom of owospeech - Adds the "uwuspeech" mutation

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -55,6 +55,7 @@
 #define TONGUESPIKECHEM /datum/mutation/human/tongue_spike/chem
 #define TOURETTES /datum/mutation/human/tourettes
 #define UNINTELLIGIBLE /datum/mutation/human/unintelligible
+#define UWU /datum/mutation/human/uwu
 #define VOID /datum/mutation/human/void
 #define WACKY /datum/mutation/human/wacky
 #define XRAY /datum/mutation/human/xray

--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -242,7 +242,7 @@
 		speech_args[SPEECH_MESSAGE] = message
 
 /datum/mutation/human/uwu
-	name = "UwU"
+	name = "uwuspeech"
 	desc = "An howwible mutation owiginating fwom a distant past. Thought we ewadicated it aftew 'weeducating' the fiwst Felinids in owdew to integwate them to the Society."
 	quality = MINOR_NEGATIVE
 	locked = TRUE

--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -240,3 +240,31 @@
 		message = "[chosen_starting] [message]"
 
 		speech_args[SPEECH_MESSAGE] = message
+
+/datum/mutation/human/uwu
+	name = "UwU"
+	desc = "An howwible mutation owiginating fwom a distant past. Thought we ewadicated it aftew 'weeducating' the fiwst Felinids in owdew to integwate them to the Society."
+	quality = MINOR_NEGATIVE
+	locked = TRUE
+	text_gain_indication = "<span class='notice'>You feew like you commited wawcwimes ~</span>"
+	text_lose_indication = "<span class='notice'>You no longer feel like participating in a furcon.</span>"
+
+/datum/mutation/human/uwu/on_acquiring(mob/living/carbon/human/owner)
+	if(..())
+		return
+	RegisterSignal(owner, COMSIG_MOB_SAY, .proc/handle_speech)
+
+/datum/mutation/human/uwu/on_losing(mob/living/carbon/human/owner)
+	if(..())
+		return
+	UnregisterSignal(owner, COMSIG_MOB_SAY)
+
+/datum/mutation/human/uwu/proc/handle_speech(datum/source, list/speech_args)
+	SIGNAL_HANDLER
+
+	var/message = speech_args[SPEECH_MESSAGE]
+	if(message)
+		message = replacetext(message,"r","w")
+		message = replacetext(message,"l","w")
+		message += "~"
+		speech_args[SPEECH_MESSAGE] = trim(message)

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -445,11 +445,11 @@
 	remove_mutations = list(SPIDER_WEB)
 
 /obj/item/dnainjector/uwu
-	name = "\improper DNA injector (Webbing)"
+	name = "\improper DNA injector (uwuspeech)"
 	add_mutations = list(UWU)
 
 /obj/item/dnainjector/antiuwu
-	name = "\improper DNA injector (Webbing)"
+	name = "\improper DNA injector (uwuspeech)"
 	remove_mutations = list(UWU)
 
 /obj/item/dnainjector/timed

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -444,6 +444,14 @@
 	name = "\improper DNA injector (Anti-Webbing)"
 	remove_mutations = list(SPIDER_WEB)
 
+/obj/item/dnainjector/uwu
+	name = "\improper DNA injector (Webbing)"
+	add_mutations = list(UWU)
+
+/obj/item/dnainjector/antiuwu
+	name = "\improper DNA injector (Webbing)"
+	remove_mutations = list(UWU)
+
 /obj/item/dnainjector/timed
 	var/duration = 600
 

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -12,6 +12,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/felinid
 	disliked_food = GROSS | RAW | CLOTH
+	inert_mutation = UWU
 	var/original_felinid = TRUE //set to false for felinids created by mass-purrbation
 	payday_modifier = 0.75
 	ass_image = 'icons/ass/asscat.png'

--- a/html/changelogs/AutoChangeLog-pr-59635.yml
+++ b/html/changelogs/AutoChangeLog-pr-59635.yml
@@ -1,7 +1,0 @@
-author: "Watermelon914"
-delete-after: True
-changes: 
-  - expansion: "Adds the multiplexer circuit component."
-  - expansion: "Changed the drone circuit to have a lower movement delay."
-  - qol: "Circuit components can now be directly inserted into shells."
-  - qol: "Added the description and special details to each circuit component that can be accessed when it is inside an integrated circuit. These will have specific details, such as power usage, distance effectiveness and more."

--- a/html/changelogs/AutoChangeLog-pr-59705.yml
+++ b/html/changelogs/AutoChangeLog-pr-59705.yml
@@ -1,4 +1,0 @@
-author: "Melbert"
-delete-after: True
-changes: 
-  - refactor: "Cow tipping and medibot tipping is now a component."

--- a/html/changelogs/AutoChangeLog-pr-59732.yml
+++ b/html/changelogs/AutoChangeLog-pr-59732.yml
@@ -1,4 +1,0 @@
-author: "Ed640"
-delete-after: True
-changes: 
-  - bugfix: "Paper bins after being stacked too high to fall over or getting burnt will no longer void your \"important\" paper forms when trying to add more paper afterwards."

--- a/html/changelogs/AutoChangeLog-pr-59762.yml
+++ b/html/changelogs/AutoChangeLog-pr-59762.yml
@@ -1,4 +1,0 @@
-author: "Ryll/Shaps"
-delete-after: True
-changes: 
-  - qol: "Admin ghosts can now use the :j speech prefix to relay messages from deadchat to their current linked body, if one exists. Perfect for keeping in touch with your deployed ERT via headset without needing to stay in your body back at Centcom!"

--- a/html/changelogs/AutoChangeLog-pr-59765.yml
+++ b/html/changelogs/AutoChangeLog-pr-59765.yml
@@ -1,4 +1,0 @@
-author: "YakumoChen"
-delete-after: True
-changes: 
-  - bugfix: "Dynamic will no longer create malf humans for players for never play silicon in the first place."

--- a/html/changelogs/archive/2021-06.yml
+++ b/html/changelogs/archive/2021-06.yml
@@ -521,3 +521,24 @@
   - bugfix: Specific chem dispenser recipes no longer create fonts of infinite power.
   Watermelon914:
   - bugfix: Fixed explosions delimbing you if they're weaker
+2021-06-24:
+  Ed640:
+  - bugfix: Paper bins after being stacked too high to fall over or getting burnt
+      will no longer void your "important" paper forms when trying to add more paper
+      afterwards.
+  Melbert:
+  - refactor: Cow tipping and medibot tipping is now a component.
+  Ryll/Shaps:
+  - qol: Admin ghosts can now use the :j speech prefix to relay messages from deadchat
+      to their current linked body, if one exists. Perfect for keeping in touch with
+      your deployed ERT via headset without needing to stay in your body back at Centcom!
+  Watermelon914:
+  - expansion: Adds the multiplexer circuit component.
+  - expansion: Changed the drone circuit to have a lower movement delay.
+  - qol: Circuit components can now be directly inserted into shells.
+  - qol: Added the description and special details to each circuit component that
+      can be accessed when it is inside an integrated circuit. These will have specific
+      details, such as power usage, distance effectiveness and more.
+  YakumoChen:
+  - bugfix: Dynamic will no longer create malf humans for players for never play silicon
+      in the first place.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new mutation called "uwu". This mutation replaces your R and L with "w". This is a dormant mutation in felinids DNA, you cannot find it in any other species.

## Why It's Good For The Game

Wouldn't it be hilarious if a traitor geneticist decided to blast the whole crew with "uwu" mutators ? It adds a little bit of soft grief to the game (you can still revert it with mutadone if you don't like that mutation). Admins can also use this if they feel like doing a little trolling.

## Changelog
:cl:
add: The geneticist discovered a long forgotten mutation called "uwuspeech" on felinids specimens. Be caweful you may stawt to- oh no...
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
