### PR TITLE
Fixes a non-initialized trim variable runtime

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -110,7 +110,7 @@
 		return "hudno_id"
 
 	var/card_assignment
-	if(!istype(id_card, /obj/item/card/id/advanced))
+	if(istype(id_card, /obj/item/card/id/advanced))
 		var/obj/item/card/id/advanced/advanced_id_card = id_card
 		if(advanced_id_card.trim_assignment_override)
 			card_assignment = advanced_id_card.trim_assignment_override

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -110,9 +110,15 @@
 		return "hudno_id"
 
 	var/card_assignment
-	if(istype(id_card, /obj/item/card/id/advanced))
+	if(!istype(id_card, /obj/item/card/id/advanced))
 		var/obj/item/card/id/advanced/advanced_id_card = id_card
-		card_assignment = advanced_id_card.trim_assignment_override ? advanced_id_card.trim_assignment_override : advanced_id_card.trim?.assignment
+		if(advanced_id_card.trim_assignment_override)
+			card_assignment = advanced_id_card.trim_assignment_override
+		else if(ispath(advanced_id_card.trim))
+			var/datum/id_trim/trim = SSid_access.trim_singletons_by_path[advanced_id_card.trim]
+			card_assignment = trim.assignment
+		else
+			card_assignment = advanced_id_card.trim?.assignment
 	else
 		card_assignment = id_card.trim?.assignment
 


### PR DESCRIPTION
Minor runtime fix:
```
[17:39:01] Runtime in access.dm, line 115: Cannot read /datum/id_trim/job/prisoner (/datum/id_trim/job/prisoner).assignment
proc name: get sechud job icon state (/obj/item/proc/get_sechud_job_icon_state)
usr: CKEY/(CKEY)
usr.loc: (start area (8,174,1))
src: the prisoner ID card (/obj/item/card/id/advanced/prisoner)
src.loc: Name Surname (/mob/living/carbon/human/dummy)
call stack:
the prisoner ID card (/obj/item/card/id/advanced/prisoner): get sechud job icon state()
Name Surname (/mob/living/carbon/human/dummy): sec hud set ID()
Name Surname (/mob/living/carbon/human/dummy): equip to slot(the prisoner ID card (/obj/item/card/id/advanced/prisoner), 256, 1, 0)
Name Surname (/mob/living/carbon/human/dummy): equip to slot if possible(the prisoner ID card (/obj/item/card/id/advanced/prisoner), 256, 1, 1, 0, 1, 1)
Name Surname (/mob/living/carbon/human/dummy): equip to slot or del(the prisoner ID card (/obj/item/card/id/advanced/prisoner), 256, 1)
Prisoner (/datum/outfit/job/prisoner): equip(Name Surname (/mob/living/carbon/human/dummy), 1)
Name Surname (/mob/living/carbon/human/dummy): equipOutfit(/datum/outfit/job/prisoner (/datum/outfit/job/prisoner), 1)
/datum/job/prisoner (/datum/job/prisoner): equip(Name Surname (/mob/living/carbon/human/dummy), 1, 1, 0, null, CKEY (/client), 0)
/datum/preferences (/datum/preferences): update preview icon()
/datum/preferences (/datum/preferences): ShowChoices(CKEY (/mob/dead/new_player))
/datum/preferences (/datum/preferences): process link(CKEY (/mob/dead/new_player), /list (/list))
CKEY (/client): Topic("_src_=prefs;preference=job;tas...", /list (/list), null)
```