### PR TITLE
Fixes oversights and disables AI interaction with door shell

### DIFF
--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -1,3 +1,13 @@
+/datum/wires/airlock/shell
+	holder_type = /obj/machinery/door/airlock/shell
+	proper_name = "Circuit Airlock"
+
+/datum/wires/airlock/shell/on_cut(wire, mend)
+	// Don't allow them to re-enable autoclose.
+	if(wire == WIRE_TIMING)
+		return
+	return ..()
+
 /obj/machinery/door/airlock/shell
 	name = "circuit airlock"
 	autoclose = FALSE
@@ -13,6 +23,15 @@
 
 /obj/machinery/door/airlock/shell/check_access(obj/item/I)
 	return FALSE
+
+/obj/machinery/door/airlock/shell/canAIControl(mob/user)
+	return FALSE
+
+/obj/machinery/door/airlock/shell/canAIHack(mob/user)
+	return FALSE
+
+/obj/machinery/door/airlock/shell/set_wires()
+	return new /datum/wires/airlock/shell(src)
 
 /obj/item/circuit_component/airlock
 	display_name = "Airlock"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
The AI can no longer interact with the door shell.
This was more of an oversight as it defeats the purpose if the AI can just ignore your contraption with ease. The shell is supposed to be completely disconnected from the network.
Also fixes a bug with re-enabling the timer on the door shell, which shouldn't be possible.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes design flaw in shell door. 
Also fixes a bug.

## Changelog
:cl:
balance: Disabled AI from interacting with the door shell.
fix: Fixed being able to re-enable the timer on the door shell.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
