### PR TITLE
[DNM] Log deltas for create_message

### DIFF
--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -44,6 +44,8 @@ GLOBAL_VAR(world_paper_log)
 GLOBAL_PROTECT(world_paper_log)
 GLOBAL_VAR(tgui_log)
 GLOBAL_PROTECT(tgui_log)
+GLOBAL_VAR(tgui_delta_log)
+GLOBAL_PROTECT(tgui_log)
 GLOBAL_VAR(world_shuttle_log)
 GLOBAL_PROTECT(world_shuttle_log)
 

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -26,6 +26,9 @@ SUBSYSTEM_DEF(tgui)
 	/// The HTML base used for all UIs.
 	var/basehtml
 
+	/// Queued logs for the time it takes to calculate tgui messages
+	var/list/queued_calculate_deltas = list()
+
 /datum/controller/subsystem/tgui/PreInit()
 	basehtml = file2text('tgui/public/tgui.html')
 
@@ -51,6 +54,12 @@ SUBSYSTEM_DEF(tgui)
 			open_uis.Remove(ui)
 		if(MC_TICK_CHECK)
 			return
+
+	var/list/calculate_delta_logs = queued_calculate_deltas
+	queued_calculate_deltas = null
+
+	for (var/log in calculate_delta_logs)
+		WRITE_LOG(GLOB.tgui_delta_log, "MESSAGE: [log[1]]\nDELTA: [log[2]]\n")
 
 /**
  * public

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -143,6 +143,7 @@ GLOBAL_VAR(restart_counter)
 	GLOB.world_job_debug_log = "[GLOB.log_directory]/job_debug.log"
 	GLOB.world_paper_log = "[GLOB.log_directory]/paper.log"
 	GLOB.tgui_log = "[GLOB.log_directory]/tgui.log"
+	GLOB.tgui_delta_log = "[GLOB.log_directory]/tgui_delta.log"
 	GLOB.world_shuttle_log = "[GLOB.log_directory]/shuttle.log"
 
 	GLOB.demo_log = "[GLOB.log_directory]/demo.log"

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -214,7 +214,7 @@
 	var/message = TGUI_CREATE_MESSAGE(type, payload)
 	var/delta = TICK_USAGE - tick_usage
 
-	SStgui.queued_calculate_deltas += list(list(message, TICK_USAGE_TO_MS(delta)))
+	SStgui.queued_calculate_deltas += list(list(message, TICK_DELTA_TO_MS(delta)))
 
 	// Place into queue if window is still loading
 	if(!force && status != TGUI_WINDOW_READY)

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -209,7 +209,13 @@
 /datum/tgui_window/proc/send_message(type, payload, force)
 	if(!client)
 		return
+
+	var/tick_usage = TICK_USAGE
 	var/message = TGUI_CREATE_MESSAGE(type, payload)
+	var/delta = TICK_USAGE - tick_usage
+
+	SStgui.queued_calculate_deltas += list(list(message, TICK_USAGE_TO_MS(delta)))
+
 	// Place into queue if window is still loading
 	if(!force && status != TGUI_WINDOW_READY)
 		if(!message_queue)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Logs deltas for `/datum/tgui_window/proc/send_message` into tgui_delta.log.

This is on DNM as I don't want to add any extra processing to send_message, at least until we bring it down from consistently one of the largest overtime procs.

Queues logs until SStgui fire, and only after all tgui inputs are sent out. This necessarily comes with MC_TICK_CHECK as to make sure it's only done when we have time.