### PR TITLE
Fix incorrect return for closet attack_hand_secondary causing lockers to have their locks toggled twice.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -469,9 +469,10 @@
 /obj/structure/closet/attack_hand_secondary(mob/user, modifiers)
 	if(!user.canUseTopic(src, BE_CLOSE) || !isturf(loc))
 		return
+
 	if(!opened && secure)
 		togglelock(user)
-	return TRUE
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/structure/closet/proc/togglelock(mob/living/user, silent)
 	if(secure && !broken)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #59812

`/obj/structure/closet/attack_hand_secondary(mob/user, modifiers)` doesn't return one of the expected attack chain cancelling/continuing defines and instead returns TRUE.

This means that right clicking them acts as a secondary attack followed by a primary attack.

When the secondary attack against a secure closet actually attempts to toggle the lock, it now cancels the entire attack chain.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People can lock and/or unlock lockers on right click again.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes an issue where right clicking on an ID-secured locker would unintentionally trigger twice, locking then unlocking the locker. Right clicking now correctly attempts to lock and unlock a locker only once.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
