### PR TITLE
Adds a kneecapping element and adds that very element to baseball bats.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -1249,6 +1249,8 @@
 	#define COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN (1<<0)
 	#define COMPONENT_SECONDARY_CONTINUE_ATTACK_CHAIN (1<<1)
 	#define COMPONENT_SECONDARY_CALL_NORMAL_ATTACK_CHAIN (1<<2)
+/// From base of [/obj/item/proc/attack_secondary()]: (atom/target, mob/user, params)
+#define COMSIG_ITEM_ATTACK_SECONDARY "item_pre_attack_secondary"
 ///from base of obj/item/afterattack(): (atom/target, mob/user, params)
 #define COMSIG_ITEM_AFTERATTACK "item_afterattack"
 ///from base of obj/item/attack_qdeleted(): (atom/target, mob/user, params)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -205,6 +205,14 @@
 
 /// The equivalent of [/obj/item/proc/attack] but for alternate attacks, AKA right clicking
 /obj/item/proc/attack_secondary(mob/living/victim, mob/living/user, params)
+	var/signal_result = SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_SECONDARY, victim, user, params)
+
+	if(signal_result & COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	if(signal_result & COMPONENT_SECONDARY_CONTINUE_ATTACK_CHAIN)
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
+
 	return SECONDARY_ATTACK_CALL_NORMAL
 
 /// The equivalent of the standard version of [/obj/item/proc/attack] but for object targets.

--- a/code/datums/components/kneecapping.dm
+++ b/code/datums/components/kneecapping.dm
@@ -1,44 +1,51 @@
 /**
- * Kneecapping component replaces the item's secondary attack with an aimed attack at the kneecaps under certain circumstances.
+ * Kneecapping element replaces the item's secondary attack with an aimed attack at the kneecaps under certain circumstances.
  *
- * Component incompatible with non-items. Requires the parent item to have a force equal to or greater than WOUND_MINIMUM_DAMAGE.
+ * Element is incompatible with non-items. Requires the parent item to have a force equal to or greater than WOUND_MINIMUM_DAMAGE.
  * Also requires that the parent can actually get past pre_secondary_attack without the attack chain cancelling.
  *
  * Kneecapping attacks have a wounding bonus between severe and critical+10 wound thresholds. Without some serious wound protecting
  * armour this all but guarantees a wound of some sort. The attack is directed specifically at a limb and the limb takes the damage.
  *
- * Requires the attacker to be aiming for either leg zone, which will be targetted specifically. They will than have a 2-second
+ * Requires the attacker to be aiming for either leg zone, which will be targetted specifically. They will than have a 3-second long
  * do_mob before executing the attack.
  *
- * Kneecapping requires the target to either be on the floor, immobilised or buckled to something.
+ * Kneecapping requires the target to either be on the floor, immobilised or buckled to something. And also to have an appropriate leg.
  *
  * Passing all the checks will cancel the entire attack chain.
  */
-/datum/component/kneecapping
+/datum/element/kneecapping
+	element_flags = ELEMENT_DETACH
 
-/datum/component/kneecapping/Initialize()
-	if(!isitem(parent))
-		stack_trace("Kneecapping component added to non-item object: \[[parent]\]")
-		return COMPONENT_INCOMPATIBLE
+/datum/element/kneecapping/Attach(datum/target)
+	if(!isitem(target))
+		stack_trace("Kneecapping element added to non-item object: \[[target]\]")
+		return ELEMENT_INCOMPATIBLE
 
-	var/obj/item/parent_item = parent
+	var/obj/item/target_item = target
 
-	if(parent_item.force < WOUND_MINIMUM_DAMAGE)
-		stack_trace("Kneecapping component added to item with too little force to wound: \[[parent]\]")
-		return COMPONENT_INCOMPATIBLE
+	if(target_item.force < WOUND_MINIMUM_DAMAGE)
+		stack_trace("Kneecapping element added to item with too little force to wound: \[[target]\]")
+		return ELEMENT_INCOMPATIBLE
 
-/datum/component/kneecapping/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SECONDARY , .proc/try_kneecap_target)
+	. = ..()
 
-/datum/component/kneecapping/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_SECONDARY)
+	if(. == ELEMENT_INCOMPATIBLE)
+		return
+
+	RegisterSignal(target, COMSIG_ITEM_ATTACK_SECONDARY , .proc/try_kneecap_target)
+
+/datum/element/kneecapping/Detach(datum/target)
+	UnregisterSignal(target, COMSIG_ITEM_ATTACK_SECONDARY)
+
+	return ..()
 
 /**
  * Signal handler for COMSIG_ITEM_ATTACK_SECONDARY. Does checks for pacifism, zones and target state before either returning nothing
  * if the special attack could not be attempted, performing the ordinary attack procs instead - Or cancelling the attack chain if
  * the attack can be started.
  */
-/datum/component/kneecapping/proc/try_kneecap_target(obj/item/source, mob/living/carbon/target, mob/attacker, params)
+/datum/element/kneecapping/proc/try_kneecap_target(obj/item/source, mob/living/carbon/target, mob/attacker, params)
 	SIGNAL_HANDLER
 
 	if((attacker.zone_selected != BODY_ZONE_L_LEG) && (attacker.zone_selected != BODY_ZONE_R_LEG))
@@ -65,14 +72,14 @@
 /**
  * After a short do_mob, attacker applies damage to the given leg with a significant wounding bonus, applying the weapon's force as damage.
  */
-/datum/component/kneecapping/proc/do_kneecap_target(obj/item/weapon, obj/item/bodypart/leg, mob/living/carbon/target, mob/attacker)
-	if(LAZYACCESS(attacker.do_afters, src))
+/datum/element/kneecapping/proc/do_kneecap_target(obj/item/weapon, obj/item/bodypart/leg, mob/living/carbon/target, mob/attacker)
+	if(LAZYACCESS(attacker.do_afters, weapon))
 		return
 
 	attacker.visible_message(span_warning("[attacker] carefully aims [attacker.p_their()] [weapon] for a swing at [target]'s kneecaps!"), span_danger("You carefully aim \the [weapon] for a swing at [target]'s kneecaps!"))
 	log_combat(attacker, target, "started aiming a swing to break the kneecaps of", weapon)
 
-	if(do_mob(attacker, target, 3 SECONDS, interaction_key = src))
+	if(do_mob(attacker, target, 3 SECONDS, interaction_key = weapon))
 		attacker.visible_message(span_warning("[attacker] swings [attacker.p_their()] [weapon] at [target]'s kneecaps!"), span_danger("You swing \the [weapon] at [target]'s kneecaps!"))
 		var/datum/wound/blunt/severe/severe_wound_type = /datum/wound/blunt/severe
 		var/datum/wound/blunt/critical/critical_wound_type = /datum/wound/blunt/critical

--- a/code/datums/components/kneecapping.dm
+++ b/code/datums/components/kneecapping.dm
@@ -1,0 +1,59 @@
+/datum/component/kneecapping
+
+/datum/component/kneecapping/Initialize()
+	if(!isitem(parent))
+		stack_trace("Kneecapping component added to non-item object: \[[parent]\]")
+		return COMPONENT_INCOMPATIBLE
+
+	var/obj/item/parent_item = parent
+
+	if(parent_item.force < WOUND_MINIMUM_DAMAGE)
+		stack_trace("Kneecapping component added to item with too little force to wound: \[[parent]\]")
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/kneecapping/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SECONDARY , .proc/try_kneecap_target)
+
+/datum/component/kneecapping/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_ITEM_PRE_ATTACK_SECONDARY)
+
+/datum/component/kneecapping/proc/try_kneecap_target(obj/item/source, mob/living/carbon/target, mob/attacker, params)
+	SIGNAL_HANDLER
+
+	if((attacker.zone_selected != BODY_ZONE_L_LEG) && (attacker.zone_selected != BODY_ZONE_R_LEG))
+		return
+
+	if(HAS_TRAIT(attacker, TRAIT_PACIFISM))
+		return
+
+	if(!iscarbon(target))
+		return
+
+	if(!target.buckled && !HAS_TRAIT(target, TRAIT_FLOORED) && !HAS_TRAIT(target, TRAIT_IMMOBILIZED))
+		return
+
+	var/obj/item/bodypart/leg = target.get_bodypart(attacker.zone_selected)
+
+	if(!leg)
+		return
+
+	. = COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN
+
+	INVOKE_ASYNC(src, .proc/do_kneecap_target, source, leg, target, attacker)
+
+/datum/component/kneecapping/proc/do_kneecap_target(obj/item/weapon, obj/item/bodypart/leg, mob/living/carbon/target, mob/attacker)
+	if(LAZYACCESS(attacker.do_afters, src))
+		return
+
+	attacker.visible_message(span_warning("[attacker] carefully aims [attacker.p_their()] [weapon] for a swing at [target]'s kneecaps!"), span_danger("You carefully aim \the [weapon] for a swing at [target]'s kneecaps!"))
+	log_combat(attacker, target, "started aiming a swing to break the kneecaps of", weapon)
+
+	if(do_mob(attacker, target, 2 SECONDS, interaction_key = src))
+		attacker.visible_message(span_warning("[attacker] swings [attacker.p_their()] [weapon] at [target]'s kneecaps!"), span_danger("You swing \the [weapon] at [target]'s kneecaps!"))
+		var/datum/wound/blunt/severe/severe_wound_type = /datum/wound/blunt/severe
+		var/datum/wound/blunt/critical/critical_wound_type = /datum/wound/blunt/critical
+		leg.receive_damage(brute = weapon.force, wound_bonus = rand(initial(severe_wound_type.threshold_minimum), initial(critical_wound_type.threshold_minimum) + 10))
+		log_combat(attacker, target, "broke ther kneecaps of", weapon)
+		target.update_damage_overlays()
+		attacker.do_attack_animation(target, used_item = weapon)
+		playsound(source = get_turf(weapon), soundin = weapon.hitsound, vol = weapon.get_clamped_volume(), vary = TRUE)

--- a/code/datums/components/kneecapping.dm
+++ b/code/datums/components/kneecapping.dm
@@ -84,7 +84,7 @@
 		var/datum/wound/blunt/severe/severe_wound_type = /datum/wound/blunt/severe
 		var/datum/wound/blunt/critical/critical_wound_type = /datum/wound/blunt/critical
 		leg.receive_damage(brute = weapon.force, wound_bonus = rand(initial(severe_wound_type.threshold_minimum), initial(critical_wound_type.threshold_minimum) + 10))
-		log_combat(attacker, target, "broke ther kneecaps of", weapon)
+		log_combat(attacker, target, "broke the kneecaps of", weapon)
 		target.update_damage_overlays()
 		attacker.do_attack_animation(target, used_item = weapon)
 		playsound(source = get_turf(weapon), soundin = weapon.hitsound, vol = weapon.get_clamped_volume(), vary = TRUE)

--- a/code/datums/components/kneecapping.dm
+++ b/code/datums/components/kneecapping.dm
@@ -1,3 +1,19 @@
+/**
+ * Kneecapping component replaces the item's secondary attack with an aimed attack at the kneecaps under certain circumstances.
+ *
+ * Component incompatible with non-items. Requires the parent item to have a force equal to or greater than WOUND_MINIMUM_DAMAGE.
+ * Also requires that the parent can actually get past pre_secondary_attack without the attack chain cancelling.
+ *
+ * Kneecapping attacks have a wounding bonus between severe and critical+10 wound thresholds. Without some serious wound protecting
+ * armour this all but guarantees a wound of some sort. The attack is directed specifically at a limb and the limb takes the damage.
+ *
+ * Requires the attacker to be aiming for either leg zone, which will be targetted specifically. They will than have a 2-second
+ * do_mob before executing the attack.
+ *
+ * Kneecapping requires the target to either be on the floor, immobilised or buckled to something.
+ *
+ * Passing all the checks will cancel the entire attack chain.
+ */
 /datum/component/kneecapping
 
 /datum/component/kneecapping/Initialize()
@@ -15,8 +31,13 @@
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SECONDARY , .proc/try_kneecap_target)
 
 /datum/component/kneecapping/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_ITEM_PRE_ATTACK_SECONDARY)
+	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_SECONDARY)
 
+/**
+ * Signal handler for COMSIG_ITEM_ATTACK_SECONDARY. Does checks for pacifism, zones and target state before either returning nothing
+ * if the special attack could not be attempted, performing the ordinary attack procs instead - Or cancelling the attack chain if
+ * the attack can be started.
+ */
 /datum/component/kneecapping/proc/try_kneecap_target(obj/item/source, mob/living/carbon/target, mob/attacker, params)
 	SIGNAL_HANDLER
 
@@ -41,6 +62,9 @@
 
 	INVOKE_ASYNC(src, .proc/do_kneecap_target, source, leg, target, attacker)
 
+/**
+ * After a short do_mob, attacker applies damage to the given leg with a significant wounding bonus, applying the weapon's force as damage.
+ */
 /datum/component/kneecapping/proc/do_kneecap_target(obj/item/weapon, obj/item/bodypart/leg, mob/living/carbon/target, mob/attacker)
 	if(LAZYACCESS(attacker.do_afters, src))
 		return

--- a/code/datums/components/kneecapping.dm
+++ b/code/datums/components/kneecapping.dm
@@ -72,7 +72,7 @@
 	attacker.visible_message(span_warning("[attacker] carefully aims [attacker.p_their()] [weapon] for a swing at [target]'s kneecaps!"), span_danger("You carefully aim \the [weapon] for a swing at [target]'s kneecaps!"))
 	log_combat(attacker, target, "started aiming a swing to break the kneecaps of", weapon)
 
-	if(do_mob(attacker, target, 2 SECONDS, interaction_key = src))
+	if(do_mob(attacker, target, 3 SECONDS, interaction_key = src))
 		attacker.visible_message(span_warning("[attacker] swings [attacker.p_their()] [weapon] at [target]'s kneecaps!"), span_danger("You swing \the [weapon] at [target]'s kneecaps!"))
 		var/datum/wound/blunt/severe/severe_wound_type = /datum/wound/blunt/severe
 		var/datum/wound/blunt/critical/critical_wound_type = /datum/wound/blunt/critical

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -661,6 +661,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		icon_state = "baseball_bat_brit"
 		inhand_icon_state = "baseball_bat_brit"
 
+	AddComponent(/datum/component/kneecapping)
+
 /obj/item/melee/baseball_bat/homerun
 	name = "home run bat"
 	desc = "This thing looks dangerous... Dangerously good at baseball, that is."

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -661,7 +661,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		icon_state = "baseball_bat_brit"
 		inhand_icon_state = "baseball_bat_brit"
 
-	AddComponent(/datum/component/kneecapping)
+	AddElement(/datum/element/kneecapping)
 
 /obj/item/melee/baseball_bat/homerun
 	name = "home run bat"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -521,6 +521,7 @@
 #include "code\datums\components\infective.dm"
 #include "code\datums\components\itempicky.dm"
 #include "code\datums\components\jousting.dm"
+#include "code\datums\components\kneecapping.dm"
 #include "code\datums\components\knockback.dm"
 #include "code\datums\components\knockoff.dm"
 #include "code\datums\components\label.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/123346072-5af3ec80-d54f-11eb-8a9d-9fb66b69c2ad.png)
![image](https://user-images.githubusercontent.com/24975989/123350117-3ea57f00-d552-11eb-8b41-8c6c83cb4e19.png)

Implements appropriate signal handlers for `/obj/item/proc/attack_secondary()` - Secondary item attacks now send signals and signal handlers can now cancel the attack chain, continue it or move to the primary attack chain.

Adds a kneecapping element.

Kneecapping element replaces the item's secondary attack with an aimed attack at the kneecaps under certain circumstances. If these circumstances are not met, the secondary attack chain will continue as normal with the item's normal secondary attack.

Element is incompatible with non-items. Requires the parent item to have a force equal to or greater than WOUND_MINIMUM_DAMAGE. Also requires that the parent can actually get past pre_secondary_attack without the attack chain cancelling. Funnily enough, the Element doesn't require a blunt weapon. If admins add it to sharp or pointy weapons, they get the same aimed attack but with sharp and pointy wounds instead - Because all the Element does is add a hefty wounding modifier.

Kneecapping attacks have a wounding bonus between severe and critical+10 wound thresholds. Without some serious wound protecting armour this all but guarantees a wound of some sort. The attack is directed specifically at a limb and the limb takes the damage.

Requires the attacker to be aiming for either leg zone, which will be targetted specifically. They will than have a 3-second do_mob before executing the attack.

Kneecapping requires the target to either be on the floor, immobilised or buckled to something.

Passing all the checks will cancel the entire attack chain for the Element to handle attacking logic.

This Element has been added to the baseball bat. Any other items that wish to implement its functionality in the future are free to.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Now you can genuinely break people's kneecaps, causing near guaranteed wounds to the legs.

Another secondary attack added, leveraging the awesome power of right clicking things.

A lot of RP potential. Become a loan shark and break the kneecaps of defaulters. Apply inhanced interrogation to your suspects. Show that asshole monkey who's boss.

Gives medbay more work.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Baseball bats can now be used to break kneecaps with their right click attack. This requires the target to be one of either prone, immobilised or buckled to something. If you aim for the legs and right click, you'll wind up a swing for the kneecaps. Research indicates that this isn't good for the target's legs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
