### PR TITLE
Fixes space having gas sometimes

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -30,7 +30,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	/// Used for analyzer feedback - not initialized until its used
 	var/list/analyzer_results
 	/// Whether to call garbage_collect() on the sharer during shares, used for immutable mixtures
-	var/gc_share = FALSE 
+	var/gc_share = FALSE
 
 /datum/gas_mixture/New(volume)
 	gases = new
@@ -250,7 +250,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 			var/total_moles = gases[gas_id][MOLES] + other.gases[gas_id][MOLES]
 			gases[gas_id][MOLES] = total_moles * (volume/total_volume)
 			other.gases[gas_id][MOLES] = total_moles * (other.volume/total_volume)
-
+	garbage_collect()
+	other.garbage_collect()
 
 ///Creates new, identical gas mixture
 ///Returns: duplicate gas mixture


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ok so uhhhhhhhhh
Passive vents were using return_air and equalize to operate on potentially space turfs
This was causing the contents of the passive vent to "teleport" to other tiles, especially if it was placed on a
space turf with no connected normal turfs

I'm just gonna call garbage collect in equalize, because it's A:Only used by passive vents, and B:Genuinely is needed, since you might end up with below the threshold of "whatever gas"

It would also occasionally form a grid, due to turfs activating from super-conduction

HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH

Oh also, I know why this was happening, but I'm not totally sure why it's only coming up now. My gut says it's some optimization I made or something, but as of ~6000 commits ago the gas didn't infect the space gasmix properly. It was still like, showing gas overlays on the tile itself which it shouldn't tho, so still borked.

This would be needed anyway, and maybe that was just an anomaly of where the air ss was sleeping in my testing, but thought it was worth mentioning 
## Why It's Good For The Game
I have successfully staved off the hounds biting at my feet named technical debt and auxmos. I pray they do not return before I've healed up

## Changelog
:cl:
fix: Fixes passive vents on space tiles flooding space with whatever was being vented
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
