### PR TITLE
Allows bluespace beakers in grenades again.

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -8,7 +8,7 @@
 	var/stage = GRENADE_EMPTY
 	var/list/obj/item/reagent_containers/glass/beakers = list()
 	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle)
-	var/list/banned_containers = list(/obj/item/reagent_containers/glass/beaker/bluespace) //Containers to exclude from specific grenade subtypes
+	var/list/banned_containers = list() //Containers to exclude from specific grenade subtypes
 	var/affected_area = 3
 	var/ignition_temp = 10 // The amount of heat added to the reagents when this grenade goes off.
 	var/threatscale = 1 // Used by advanced grenades to make them slightly more worthy.


### PR DESCRIPTION
This was done back during old explosions being laggy as shit, we have new explosions now that don't lag.

If there's any other beakers that should be in the allowed list hit me up with the typepath and I'll add it here.

## Changelog
:cl:
expansion: Grenades can now hold more reagent containers, such as bluespace beakers.
/:cl:
