### PR TITLE
Fix tgui async modals

### DIFF
--- a/code/modules/tgui/tgui_alert.dm
+++ b/code/modules/tgui/tgui_alert.dm
@@ -124,9 +124,12 @@
 		if("choose")
 			if (!(params["choice"] in buttons))
 				return
-			choice = params["choice"]
+			set_choice(params["choice"])
 			SStgui.close_uis(src)
 			return TRUE
+
+/datum/tgui_modal/proc/set_choice(choice)
+	src.choice = choice
 
 /**
  * # async tgui_modal
@@ -145,16 +148,10 @@
 	QDEL_NULL(callback)
 	. = ..()
 
-/datum/tgui_modal/async/ui_close(mob/user)
+/datum/tgui_modal/async/set_choice(choice)
 	. = ..()
-	qdel(src)
-
-/datum/tgui_modal/async/ui_act(action, list/params)
-	. = ..()
-	if (!. || choice == null)
-		return
-	callback.InvokeAsync(choice)
-	qdel(src)
+	if(!isnull(src.choice))
+		callback?.InvokeAsync(src.choice)
 
 /datum/tgui_modal/async/wait()
 	return

--- a/code/modules/tgui/tgui_alert.dm
+++ b/code/modules/tgui/tgui_alert.dm
@@ -138,7 +138,7 @@
 	var/datum/callback/callback
 
 /datum/tgui_modal/async/New(mob/user, message, title, list/buttons, callback, timeout)
-	..(user, title, message, buttons, timeout)
+	..(user, message, title, buttons, timeout)
 	src.callback = callback
 
 /datum/tgui_modal/async/Destroy(force, ...)

--- a/code/modules/tgui/tgui_input_list.dm
+++ b/code/modules/tgui/tgui_input_list.dm
@@ -148,13 +148,16 @@
 		if("choose")
 			if (!(params["choice"] in buttons))
 				return
-			choice = buttons_map[params["choice"]]
+			set_choice(buttons_map[params["choice"]])
 			SStgui.close_uis(src)
 			return TRUE
 		if("cancel")
 			SStgui.close_uis(src)
 			closed = TRUE
 			return TRUE
+
+/datum/tgui_list_input/proc/set_choice(choice)
+	src.choice = choice
 
 /**
  * # async tgui_list_input
@@ -173,16 +176,10 @@
 	QDEL_NULL(callback)
 	. = ..()
 
-/datum/tgui_list_input/async/ui_close(mob/user)
+/datum/tgui_list_input/async/set_choice(choice)
 	. = ..()
-	qdel(src)
-
-/datum/tgui_list_input/async/ui_act(action, list/params)
-	. = ..()
-	if (!. || choice == null)
-		return
-	callback.InvokeAsync(choice)
-	qdel(src)
+	if(!isnull(src.choice))
+		callback?.InvokeAsync(src.choice)
 
 /datum/tgui_list_input/async/wait()
 	return

--- a/code/modules/tgui/tgui_input_list.dm
+++ b/code/modules/tgui/tgui_input_list.dm
@@ -166,7 +166,7 @@
 	var/datum/callback/callback
 
 /datum/tgui_list_input/async/New(mob/user, message, title, list/buttons, callback, timeout)
-	..(user, title, message, buttons, timeout)
+	..(user, message, title, buttons, timeout)
 	src.callback = callback
 
 /datum/tgui_list_input/async/Destroy(force, ...)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The super call in the /async types of the tgui modals (created with `tgui_alert_async()` and `tgui_input_list_async()`) have the arguments to the parent in the wrong order: it's message before title, not the other way around.

Also, the callbacks for the async ones are deleted before they can be called because the parent ui_act calls SStgui.close_uis which calls ui_closed which calls qdel which qdel_nulls callback! So we just add a setter for choice and fire the callback from there.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
All async modals are currently broken (they display the title as the body and the body as the title). They also don't fire the callback.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: async modal message/title swapped
fix: async modal not firing callbacks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
