### PR TITLE
Revert "Makes all laggy garbage failures log to admins as well as postpone further garbage ticks"

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -260,9 +260,9 @@ SUBSYSTEM_DEF(garbage)
 		time = TICK_DELTA_TO_MS(tick)/100
 	if (time > highest_del_time)
 		highest_del_time = time
-	if (time > 0.1 SECONDS)
-		log_game("Error: [type]([refID]) took longer than 0.1 seconds to delete (took [time/10] seconds to delete)")
-		message_admins("Error: [type]([refID]) took longer than 0.1 seconds to delete (took [time/10] seconds to delete).")
+	if (time > 10)
+		log_game("Error: [type]([refID]) took longer than 1 second to delete (took [time/10] seconds to delete)")
+		message_admins("Error: [type]([refID]) took longer than 1 second to delete (took [time/10] seconds to delete).")
 		postpone(time)
 
 /datum/controller/subsystem/garbage/Recover()


### PR DESCRIPTION
Reverts tgstation/tgstation#59791

In its current state, this exists only to piss off admins.

![dreamseeker_2021-06-25T18-49-19](https://user-images.githubusercontent.com/35135081/123498680-5595b100-d5e6-11eb-9a49-f15786c4fb27.png)
![dreamseeker_2021-06-25T18-48-08](https://user-images.githubusercontent.com/35135081/123498681-562e4780-d5e6-11eb-9aca-98847b5015a0.png)

I am getting one of these *every five fucking seconds*. 

To most admins, this information is absolutely *useless*. To coders, this information is STILL useless as it provides *zero* information as to what the problem actually is. We already know things hard del--that's what the VIEW DEL LOG IS FOR.

Even if you limited it to once per "laggy type", it doesn't solve the problem that this information is utterly useless to even the people trying to solve these problems. 

![image](https://user-images.githubusercontent.com/35135081/123498738-a907ff00-d5e6-11eb-9ab8-e8cc75b75ee4.png)

Yes, you've proven your point. Now LET ME READ ADMIN LOGS WITHOUT GOING INSANE.