### PR TITLE
Sets RD consoles to have two ID card slots

### DIFF
--- a/code/modules/modular_computers/computers/machinery/console_presets.dm
+++ b/code/modules/modular_computers/computers/machinery/console_presets.dm
@@ -43,6 +43,7 @@
 	console_department = "Research"
 	name = "research director's console"
 	desc = "A stationary computer. This one comes preloaded with research programs."
+	_has_second_id_slot = TRUE
 	_has_ai = TRUE
 
 /obj/machinery/modular_computer/console/preset/research/install_programs()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
RD consoles have software to edit IDs, but not two ID card slots. This is somewhat inconsistent.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes inconsistency.
Fixes #59722
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: RD consoles now have hardware supporting ID changes by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
