### PR TITLE
Makes it so changeling legs copy digitigrade/normal, try number 2

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -57,6 +57,7 @@
 	new_dna.blood_type = blood_type
 	new_dna.features = features.Copy()
 	new_dna.species = new species.type
+	new_dna.species.species_traits = species.species_traits
 	new_dna.real_name = real_name
 	new_dna.mutations = mutations.Copy()
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -516,6 +516,7 @@
 	user.socks = chosen_prof.socks
 
 	chosen_dna.transfer_identity(user, 1)
+	user.Digitigrade_Leg_Swap((DIGITIGRADE in chosen_dna.species.species_traits))
 	user.updateappearance(mutcolor_update=1)
 	user.update_body()
 	user.domutcheck()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -516,7 +516,7 @@
 	user.socks = chosen_prof.socks
 
 	chosen_dna.transfer_identity(user, 1)
-	user.Digitigrade_Leg_Swap((DIGITIGRADE in chosen_dna.species.species_traits))
+	user.Digitigrade_Leg_Swap(!(DIGITIGRADE in chosen_dna.species.species_traits))
 	user.updateappearance(mutcolor_update=1)
 	user.update_body()
 	user.domutcheck()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -516,7 +516,10 @@
 	user.socks = chosen_prof.socks
 
 	chosen_dna.transfer_identity(user, 1)
-	user.Digitigrade_Leg_Swap(!(DIGITIGRADE in chosen_dna.species.species_traits))
+	if (DIGITIGRADE in chosen_dna.species.species_traits)
+		user.Digitigrade_Leg_Swap(FALSE)
+	else
+		user.Digitigrade_Leg_Swap(TRUE)
 	user.updateappearance(mutcolor_update=1)
 	user.update_body()
 	user.domutcheck()

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -516,10 +516,7 @@
 	user.socks = chosen_prof.socks
 
 	chosen_dna.transfer_identity(user, 1)
-	if (DIGITIGRADE in chosen_dna.species.species_traits)
-		user.Digitigrade_Leg_Swap(FALSE)
-	else
-		user.Digitigrade_Leg_Swap(TRUE)
+	user.Digitigrade_Leg_Swap(!(DIGITIGRADE in chosen_dna.species.species_traits))
 	user.updateappearance(mutcolor_update=1)
 	user.update_body()
 	user.domutcheck()


### PR DESCRIPTION
## About The Pull Request

Last attempt was #58852, failed because I had IRL things and stuff.

Makes it so changeling legs copy digitigrade/normal.

## Why It's Good For The Game

bug fixes

## Changelog
:cl:
fix: changeling legs now copy digitigrade/normal legs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
