### PR TITLE
Increases the minimum age to 18, ups the drinking age to 21.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -303,9 +303,9 @@
 #define OFFSET_NECK "neck"
 
 //MINOR TWEAKS/MISC
-#define AGE_MIN 17 //youngest a character can be
+#define AGE_MIN 18 //youngest a character can be
 #define AGE_MAX 85 //oldest a character can be
-#define AGE_MINOR 20  //legal age of space drinking and smoking
+#define AGE_MINOR 21  //legal age of space drinking and smoking
 #define WIZARD_AGE_MIN 30 //youngest a wizard can be
 #define APPRENTICE_AGE_MIN 29 //youngest an apprentice can be
 #define SHOES_SLOWDOWN 0 //How much shoes slow you down by default. Negative values speed you up


### PR DESCRIPTION


## About The Pull Request

See title.

## Why It's Good For The Game

Resolves some issues with character ages, and makes the drinking age the more consistent 21.

## Changelog
:cl:
balance: Nanotrasen no longer allows high schoolers to join their crews after pressure from the Spinward Stellar Coalition.
balance: The Spinward Stellar Coalition has increased the minimum age for drinking and smoking to 21.
/:cl: