### PR TITLE
Chat messages that lack a valid target no longer hide their error states and runtime properly.

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -474,7 +474,7 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 #define CLIENT_FROM_VAR(I) (ismob(I) ? I:client : (istype(I, /client) ? I : (istype(I, /datum/mind) ? I:current?:client : null)))
 
 /// Helper macro for ascertaining if the target is of a type that *could* potentially receieve chat messages. Does not guarantee the target has a client.
-#define IS_VALID_CHAT_TARGET(target) (ismob(target) || istype(target, /client) || istype(target, /datum/mind))
+#define IS_VALID_CHAT_TARGET(target) (ismob(target) || istype(target, /client) || istype(target, /datum/mind) || (target == world))
 
 #define AREASELECT_CORNERA "corner A"
 #define AREASELECT_CORNERB "corner B"

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -473,7 +473,7 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 
 #define CLIENT_FROM_VAR(I) (ismob(I) ? I:client : (istype(I, /client) ? I : (istype(I, /datum/mind) ? I:current?:client : null)))
 
-/// Helper macro for ascertaining if the target is of a type that *could* potentially receieve chat messages. Does not guarantee the target has a client.
+/// Helper macro for ascertaining if the target is of a type that *could* potentially receieve chat messages. Does not guarantee the target has a client or that it can receive messages, just that it's a valid input type.
 #define IS_VALID_CHAT_TARGET(target) (ismob(target) || istype(target, /client) || istype(target, /datum/mind) || (target == world) || islist(target))
 
 #define AREASELECT_CORNERA "corner A"

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -474,7 +474,7 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 #define CLIENT_FROM_VAR(I) (ismob(I) ? I:client : (istype(I, /client) ? I : (istype(I, /datum/mind) ? I:current?:client : null)))
 
 /// Helper macro for ascertaining if the target is of a type that *could* potentially receieve chat messages. Does not guarantee the target has a client or that it can receive messages, just that it's a valid input type.
-#define IS_VALID_CHAT_TARGET(target) (ismob(target) || istype(target, /client) || istype(target, /datum/mind) || (target == world) || islist(target))
+#define IS_VALID_TO_CHAT_TARGET(target) (ismob(target) || istype(target, /client) || istype(target, /datum/mind) || (target == world) || islist(target))
 
 #define AREASELECT_CORNERA "corner A"
 #define AREASELECT_CORNERB "corner B"

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -474,7 +474,7 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 #define CLIENT_FROM_VAR(I) (ismob(I) ? I:client : (istype(I, /client) ? I : (istype(I, /datum/mind) ? I:current?:client : null)))
 
 /// Helper macro for ascertaining if the target is of a type that *could* potentially receieve chat messages. Does not guarantee the target has a client.
-#define IS_VALID_CHAT_TARGET(target) (ismob(target) || istype(target, /client) || istype(target, /datum/mind) || (target == world))
+#define IS_VALID_CHAT_TARGET(target) (ismob(target) || istype(target, /client) || istype(target, /datum/mind) || (target == world) || islist(target))
 
 #define AREASELECT_CORNERA "corner A"
 #define AREASELECT_CORNERB "corner B"

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -473,6 +473,9 @@ GLOBAL_LIST_INIT(pda_styles, sortList(list(MONO, VT, ORBITRON, SHARE)))
 
 #define CLIENT_FROM_VAR(I) (ismob(I) ? I:client : (istype(I, /client) ? I : (istype(I, /datum/mind) ? I:current?:client : null)))
 
+/// Helper macro for ascertaining if the target is of a type that *could* potentially receieve chat messages. Does not guarantee the target has a client.
+#define IS_VALID_CHAT_TARGET(target) (ismob(target) || istype(target, /client) || istype(target, /datum/mind))
+
 #define AREASELECT_CORNERA "corner A"
 #define AREASELECT_CORNERB "corner B"
 

--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -32,12 +32,14 @@ SUBSYSTEM_DEF(chat)
 			var/client/client = CLIENT_FROM_VAR(_target)
 			if(client)
 				LAZYADD(payload_by_client[client], list(message))
-			else
+			else if(!IS_VALID_CHAT_TARGET(_target))
 				stack_trace("Chat message queued with invalid target: \[[_target]\].")
 		return
+
 	var/client/client = CLIENT_FROM_VAR(target)
 	if(client)
 		LAZYADD(payload_by_client[client], list(message))
 		return
 
-	CRASH("Chat message queued with invalid target: \[[target]\].")
+	if(!IS_VALID_CHAT_TARGET(target))
+		CRASH("Chat message queued with invalid target: \[[target]\].")

--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -32,14 +32,7 @@ SUBSYSTEM_DEF(chat)
 			var/client/client = CLIENT_FROM_VAR(_target)
 			if(client)
 				LAZYADD(payload_by_client[client], list(message))
-			else if(!IS_VALID_CHAT_TARGET(_target))
-				stack_trace("Chat message queued with invalid target: \[[_target]\].")
 		return
-
 	var/client/client = CLIENT_FROM_VAR(target)
 	if(client)
 		LAZYADD(payload_by_client[client], list(message))
-		return
-
-	if(!IS_VALID_CHAT_TARGET(target))
-		CRASH("Chat message queued with invalid target: \[[target]\].")

--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -32,7 +32,12 @@ SUBSYSTEM_DEF(chat)
 			var/client/client = CLIENT_FROM_VAR(_target)
 			if(client)
 				LAZYADD(payload_by_client[client], list(message))
+			else
+				stack_trace("Chat message queued with invalid target: \[[_target]\].")
 		return
 	var/client/client = CLIENT_FROM_VAR(target)
 	if(client)
 		LAZYADD(payload_by_client[client], list(message))
+		return
+
+	CRASH("Chat message queued with invalid target: \[[target]\].")

--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -34,7 +34,9 @@
 
 //Called when given to a mob
 /datum/brain_trauma/proc/on_gain()
-	to_chat(owner, gain_text)
+	if(gain_text)
+		to_chat(owner, gain_text)
+
 	RegisterSignal(owner, COMSIG_MOB_SAY, .proc/handle_speech)
 	RegisterSignal(owner, COMSIG_MOVABLE_HEAR, .proc/handle_hearing)
 

--- a/code/modules/modular_computers/computers/item/computer_components.dm
+++ b/code/modules/modular_computers/computers/item/computer_components.dm
@@ -3,19 +3,23 @@
 		return FALSE
 
 	if(H.w_class > max_hardware_size)
-		to_chat(user, span_warning("This component is too large for \the [src]!"))
+		if(user)
+			to_chat(user, span_warning("This component is too large for \the [src]!"))
 		return FALSE
 
 	if(H.expansion_hw)
 		if(LAZYLEN(expansion_bays) >= max_bays)
-			to_chat(user, span_warning("All of the computer's expansion bays are filled."))
+			if(user)
+				to_chat(user, span_warning("All of the computer's expansion bays are filled."))
 			return FALSE
 		if(LAZYACCESS(expansion_bays, H.device_type))
-			to_chat(user, span_warning("The computer immediately ejects /the [H] and flashes an error: \"Hardware Address Conflict\"."))
+			if(user)
+				to_chat(user, span_warning("The computer immediately ejects /the [H] and flashes an error: \"Hardware Address Conflict\"."))
 			return FALSE
 
 	if(all_components[H.device_type])
-		to_chat(user, span_warning("This computer's hardware slot is already occupied by \the [all_components[H.device_type]]."))
+		if(user)
+			to_chat(user, span_warning("This computer's hardware slot is already occupied by \the [all_components[H.device_type]]."))
 		return FALSE
 	return TRUE
 
@@ -32,7 +36,8 @@
 		LAZYSET(expansion_bays, H.device_type, H)
 	all_components[H.device_type] = H
 
-	to_chat(user, span_notice("You install \the [H] into \the [src]."))
+	if(user)
+		to_chat(user, span_notice("You install \the [H] into \the [src]."))
 	H.holder = src
 	H.forceMove(src)
 	H.on_install(src, user)
@@ -47,7 +52,8 @@
 		LAZYREMOVE(expansion_bays, H.device_type)
 	all_components.Remove(H.device_type)
 
-	to_chat(user, span_notice("You remove \the [H] from \the [src]."))
+	if(user)
+		to_chat(user, span_notice("You remove \the [H] from \the [src]."))
 
 	H.forceMove(get_turf(src))
 	H.holder = null

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -29,31 +29,36 @@
 		return FALSE
 
 	if(stored_card)
-		to_chat(user, span_warning("You try to insert \the [I] into \the [src], but the slot is occupied."))
+		if(user)
+			to_chat(user, span_warning("You try to insert \the [I] into \the [src], but the slot is occupied."))
 		return FALSE
 	if(user && !user.transferItemToLoc(I, src))
 		return FALSE
 
 	stored_card = I
-	to_chat(user, span_notice("You insert \the [I] into \the [src]."))
+
+	if(user)
+		to_chat(user, span_notice("You insert \the [I] into \the [src]."))
 
 	return TRUE
 
 
 /obj/item/computer_hardware/ai_slot/try_eject(mob/living/user = null, forced = FALSE)
 	if(!stored_card)
-		to_chat(user, span_warning("There is no card in \the [src]."))
+		if(user)
+			to_chat(user, span_warning("There is no card in \the [src]."))
 		return FALSE
 
 	if(locked && !forced)
-		to_chat(user, span_warning("Safeties prevent you from removing the card until reconstruction is complete..."))
+		if(user)
+			to_chat(user, span_warning("Safeties prevent you from removing the card until reconstruction is complete..."))
 		return FALSE
 
 	if(stored_card)
-		to_chat(user, span_notice("You remove [stored_card] from [src]."))
 		locked = FALSE
 		if(user)
 			user.put_in_hands(stored_card)
+			to_chat(user, span_notice("You remove [stored_card] from [src]."))
 		else
 			stored_card.forceMove(drop_location())
 

--- a/code/modules/modular_computers/hardware/battery_module.dm
+++ b/code/modules/modular_computers/hardware/battery_module.dm
@@ -52,7 +52,8 @@
 
 /obj/item/computer_hardware/battery/try_eject(mob/living/user, forced = FALSE)
 	if(!battery)
-		to_chat(user, span_warning("There is no power cell connected to \the [src]."))
+		if(user)
+			to_chat(user, span_warning("There is no power cell connected to \the [src]."))
 		return FALSE
 	else
 		if(user)

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -69,11 +69,12 @@
 	if(user)
 		if(!user.transferItemToLoc(I, src))
 			return FALSE
+		to_chat(user, span_notice("You insert \the [I] into \the [expansion_hw ? "secondary":"primary"] [src]."))
 	else
 		I.forceMove(src)
 
 	stored_card = I
-	to_chat(user, span_notice("You insert \the [I] into \the [expansion_hw ? "secondary":"primary"] [src]."))
+
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
 
 	var/holder_loc = holder.loc
@@ -88,15 +89,18 @@
 
 /obj/item/computer_hardware/card_slot/try_eject(mob/living/user = null, forced = FALSE)
 	if(!stored_card)
-		to_chat(user, span_warning("There are no cards in \the [src]."))
+		if(user)
+			to_chat(user, span_warning("There are no cards in \the [src]."))
 		return FALSE
 
-	if(user && !issilicon(user) && in_range(src, user))
-		user.put_in_hands(stored_card)
+	if(user)
+		if(!issilicon(user) && in_range(src, user))
+			user.put_in_hands(stored_card)
+		to_chat(user, span_notice("You remove the card from \the [src]."))
 	else
 		stored_card.forceMove(drop_location())
 
-	to_chat(user, span_notice("You remove the card from \the [src]."))
+
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
 
 	return TRUE
@@ -106,7 +110,8 @@
 		return
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		if(stored_card)
-			to_chat(user, span_notice("You press down on the manual eject button with \the [I]."))
+			if(user)
+				to_chat(user, span_notice("You press down on the manual eject button with \the [I]."))
 			try_eject(user)
 			return
 		swap_slot()

--- a/code/modules/tgchat/to_chat.dm
+++ b/code/modules/tgchat/to_chat.dm
@@ -64,7 +64,7 @@
 	if(Master.current_runlevel == RUNLEVEL_INIT || !SSchat?.initialized)
 		to_chat_immediate(target, html, type, text)
 		return
-	if(!IS_VALID_CHAT_TARGET(target))
+	if(!IS_VALID_TO_CHAT_TARGET(target))
 		CRASH("Chat message sent to invalid target: \[[target]\].")
 	if(!html && !text)
 		CRASH("Chat message sent to \[[target]\] with no text or HTML provided.")

--- a/code/modules/tgchat/to_chat.dm
+++ b/code/modules/tgchat/to_chat.dm
@@ -66,7 +66,7 @@
 		return
 	if(!IS_VALID_CHAT_TARGET(target))
 		CRASH("Chat message sent to invalid target: \[[target]\].")
-	if(!html && !text))
+	if(!html && !text)
 		CRASH("Chat message sent to \[[target]\] with no text or HTML provided.")
 	if(target == world)
 		target = GLOB.clients

--- a/code/modules/tgchat/to_chat.dm
+++ b/code/modules/tgchat/to_chat.dm
@@ -64,8 +64,10 @@
 	if(Master.current_runlevel == RUNLEVEL_INIT || !SSchat?.initialized)
 		to_chat_immediate(target, html, type, text)
 		return
-	if(!target || (!html && !text))
-		return
+	if(!IS_VALID_CHAT_TARGET(target))
+		CRASH("Chat message sent to invalid target: \[[target]\].")
+	if(!html && !text))
+		CRASH("Chat message sent to \[[target]\] with no text or HTML provided.")
 	if(target == world)
 		target = GLOB.clients
 	// Build a message


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See the issue fixed in: https://github.com/tgstation/tgstation/pull/59839

Turns out that neither `to_chat(null, "Text")` or `to_chat("Text")` runtime.

This takes a couple of old faliure states where to_chat was lacking a valid target or text/html and would silently return, instead making them runtime loudly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Silent runtimes get in the way of identifying and fixing code issues. This may help identify areas in the future where to_chat is given invalid targets to send messages to.

No player-facing changes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
