### PR TITLE
Slightly buffs knife wounds, slightly nerfs scalpel wounds

### DIFF
--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -98,8 +98,8 @@
 	sharpness = SHARP_EDGED
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 	var/bayonet = FALSE //Can this be attached to a gun?
-	wound_bonus = -5
-	bare_wound_bonus = 10
+	wound_bonus = 5
+	bare_wound_bonus = 15
 	tool_behaviour = TOOL_KNIFE
 
 /obj/item/kitchen/knife/Initialize()
@@ -185,12 +185,15 @@
 	attack_verb_simple = list("cleave", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_price = PAYCHECK_EASY * 5
+	wound_bonus = 15
+	bare_wound_bonus = 10
 
 /obj/item/kitchen/knife/hunting
 	name = "hunting knife"
 	desc = "Despite its name, it's mainly used for cutting meat from dead prey rather than actual hunting."
 	inhand_icon_state = "huntingknife"
 	icon_state = "huntingknife"
+	wound_bonus = 10
 
 /obj/item/kitchen/knife/hunting/set_butchering()
 	AddComponent(/datum/component/butchering, 80 - force, 100, force + 10)

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -186,7 +186,6 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	custom_price = PAYCHECK_EASY * 5
 	wound_bonus = 15
-	bare_wound_bonus = 10
 
 /obj/item/kitchen/knife/hunting
 	name = "hunting knife"

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -152,7 +152,7 @@
 	sharpness = SHARP_EDGED
 	tool_behaviour = TOOL_SCALPEL
 	toolspeed = 1
-	wound_bonus = 15
+	wound_bonus = 10
 	bare_wound_bonus = 15
 
 /obj/item/scalpel/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Recently it came to my attention that knives are actually really bad at causing slashing wounds, while the scalpel is probably a little too good at causing them, even through armor. So, here's what this PR does:

- Knives in general are more effective at causing slash wounds, especially if the target has no armor/clothing on that limb. The butcher's cleaver in particular is now equally as effective as a circular saw.
- Scalpels are a bit less effective at causing slash wounds against armor/clothing, though they're still extremely good at cutting, especially against exposed flesh.

With these stats, knives will be more effective against unarmored targets, and can actually be counted on to draw blood when needed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
What's the fun in having a bunch of sharp, deadly cutlery if you can't do anything with them?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
balance: Knives (such as the kitchen knife, hunting knife, combat knife, etc...) are generally more effective at causing slashing wounds now. The butcher's cleaver in particular is now equal to a circular saw in terms of wounding.
balance: Scalpels are an eensy bit less effective at wounding enemies wearing armor, though they are still very effective at causing bleeding.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
