### PR TITLE
Nerfs abductor brain trauma

### DIFF
--- a/code/modules/antagonists/abductor/abductee/abductee.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee.dm
@@ -23,7 +23,7 @@
 /datum/antagonist/abductee/proc/give_objective()
 	var/mob/living/carbon/human/H = owner.current
 	if(istype(H))
-		H.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_LOBOTOMY)
+		H.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_BASIC)
 	var/objtype = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))
 	var/datum/objective/abductee/O = new objtype()
 	objectives += O


### PR DESCRIPTION
## About The Pull Request

Abductors is one of my favourite midround antags, I've had notes about trying to make things personal and fun for players. But we have always had an ugly scar to the antag. The trauma removes the fun of the crew member interacting with others with their new organ and takes away from the fun of their random (Or custom if you do brainwashing surgery) new trait.

## Why It's Good For The Game

This will put more focus on the organ and brainwashing that takes place to the abductees instead of "Oh I got a very annoying disability, I hope medbay doesn't fuck up my lobotomy." While I would personally rather remove the trauma altogether, I'm having this as a compromise as it doesn't run the risk of PERMANENT brain trauma if failed. My goal is to make it more fun with this tweak, for both the abductee and the abductor. I know I've felt genuinely defeated giving someone  brainwashing to make them act socially different, just to see them get speech impediment and stuck that way for 15 minutes

## Changelog
:cl:
balance: Abduction traumas are now cured by Neurine/brain surgery instead of lobotomy
/:cl:
