### PR TITLE
Fixes a runtime: Entered() passing the wrong args

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -677,6 +677,7 @@
 		var/same_loc = oldloc == destination
 		var/area/old_area = get_area(oldloc)
 		var/area/destarea = get_area(destination)
+		var/movement_dir = get_dir(src, destination)
 
 		moving_diagonally = 0
 
@@ -684,18 +685,18 @@
 
 		if(!same_loc)
 			if(oldloc)
-				oldloc.Exited(src, destination)
+				oldloc.Exited(src, movement_dir)
 				if(old_area && old_area != destarea)
-					old_area.Exited(src, destination)
+					old_area.Exited(src, movement_dir)
 			var/turf/oldturf = get_turf(oldloc)
 			var/turf/destturf = get_turf(destination)
 			var/old_z = (oldturf ? oldturf.z : null)
 			var/dest_z = (destturf ? destturf.z : null)
 			if (old_z != dest_z)
 				onTransitZ(old_z, dest_z)
-			destination.Entered(src, oldloc)
+			destination.Entered(src, movement_dir)
 			if(destarea && old_area != destarea)
-				destarea.Entered(src, oldloc)
+				destarea.Entered(src, movement_dir)
 
 		. = TRUE
 
@@ -705,9 +706,9 @@
 		loc = null
 		if (oldloc)
 			var/area/old_area = get_area(oldloc)
-			oldloc.Exited(src, null)
+			oldloc.Exited(src, NONE)
 			if(old_area)
-				old_area.Exited(src, null)
+				old_area.Exited(src, NONE)
 
 	Moved(oldloc, NONE, TRUE)
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -105,8 +105,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 	visibilityChanged()
 
-	for(var/atom/movable/AM in src)
-		Entered(AM)
+	for(var/atom/movable/content as anything in src)
+		Entered(content, NONE)
 
 	var/area/A = loc
 	if(!IS_DYNAMIC_LIGHTING(src) && IS_DYNAMIC_LIGHTING(A))

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -478,7 +478,7 @@
 
 	for(var/datum/spacevine_mutation/SM in SV.mutations)
 		SM.on_birth(SV)
-	location.Entered(SV)
+	location.Entered(SV, NONE)
 	return SV
 
 /datum/spacevine_controller/proc/VineDestroyed(obj/structure/spacevine/S)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -187,7 +187,7 @@
 	update_body()
 	if(isturf(loc))
 		var/turf/T = loc
-		T.Entered(src)
+		T.Entered(src, NONE)
 
 //Ayy lmao
 


### PR DESCRIPTION
Runtime:
```
[2021-06-27 16:27:06.114] runtime error: type mismatch: the floor (188,168,2) (/turf/open/floor/iron/sepia) & 85
 - proc name: on entered (/obj/effect/portal/proc/on_entered)
 -   source file: portals.dm,59
 -   usr: Kathleen Thorley (/mob/living/carbon/human)
 -   src: the permanent portal (/obj/effect/portal/permanent)
 -   usr.loc: the floor (78,180,2) (/turf/open/floor/wood)
 -   src.loc: the floor (78,180,2) (/turf/open/floor/wood)
 -   call stack:
 - the permanent portal (/obj/effect/portal/permanent): on entered(the floor (78,180,2) (/turf/open/floor/wood), Kathleen Thorley (/mob/living/carbon/human), the floor (188,168,2) (/turf/open/floor/iron/sepia))
 - the floor (78,180,2) (/turf/open/floor/wood):  SendSignal("atom_entered", /list (/list))
 - the floor (78,180,2) (/turf/open/floor/wood): Entered(Kathleen Thorley (/mob/living/carbon/human), the floor (188,168,2) (/turf/open/floor/iron/sepia))
 - the floor (78,180,2) (/turf/open/floor/wood): Entered(Kathleen Thorley (/mob/living/carbon/human), the floor (188,168,2) (/turf/open/floor/iron/sepia))
 - Kathleen Thorley (/mob/living/carbon/human): doMove(the floor (78,180,2) (/turf/open/floor/wood))
 - Kathleen Thorley (/mob/living/carbon/human): forceMove(the floor (78,180,2) (/turf/open/floor/wood))
 - Kathleen Thorley (/mob/living/carbon/human): forceMove(the floor (78,180,2) (/turf/open/floor/wood))
 - do teleport(Kathleen Thorley (/mob/living/carbon/human), the floor (78,180,2) (/turf/open/floor/wood), 0, 1, /datum/effect_system/spark_spr... (/datum/effect_system/spark_spread), /datum/effect_system/spark_spr... (/datum/effect_system/spark_spread), null, null, 0, "bluespace", 1)
 - the permanent portal (/obj/effect/portal/permanent): teleport(Kathleen Thorley (/mob/living/carbon/human), 0)
 - the permanent portal (/obj/effect/portal/permanent): teleport(Kathleen Thorley (/mob/living/carbon/human), 0)
 - ...
 - Kathleen Thorley (/mob/living/carbon/human): Move(the floor (188,168,2) (/turf/open/floor/iron/sepia), 8, 0)
 - Kathleen Thorley (/mob/living/carbon/human): Move(the floor (188,168,2) (/turf/open/floor/iron/sepia), 8, 0)
 - Kathleen Thorley (/mob/living/carbon/human): Move(the floor (188,168,2) (/turf/open/floor/iron/sepia), 8, null)
 - Kathleen Thorley (/mob/living/carbon/human): Move(the floor (188,168,2) (/turf/open/floor/iron/sepia), 8)
 - Kathleen Thorley (/mob/living/carbon/human): Move(the floor (188,168,2) (/turf/open/floor/iron/sepia), 8)
 - WaylandSmithy (/client): Move(the floor (188,168,2) (/turf/open/floor/iron/sepia), 8)
 - Input (/datum/controller/subsystem/input): fire(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): StartProcessing(0)
 ```
Thanks to @Wayland-Smithy for reporting it.