### PR TITLE
Removes monastery purchasability 

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -235,6 +235,7 @@
 	admin_notes = "WARNING: This shuttle WILL destroy a fourth of the station, likely picking up a lot of objects with it."
 	credit_cost = CARGO_CRATE_VALUE * 250
 	movement_force = list("KNOCKDOWN" = 3, "THROW" = 5)
+	who_can_purchase = null
 
 /datum/map_template/shuttle/emergency/luxury
 	suffix = "luxury"


### PR DESCRIPTION
## About The Pull Request

Removes the monastery shuttle from the purchasable list.

## Why It's Good For The Game

No extra mapping or edits went into the process of making the monastery a shuttle. No maps have an available entrance to be able to get on naturally from escape. A lot of the insides of the shuttle bug out extremely, it's hard to know what is and isn't a wall. 

It exists only as a grief tool, and we all know it.

## Changelog
:cl:
config: changed some config setting
/:cl: