### PR TITLE
removes unnecessary species breath code

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -79,8 +79,8 @@
 		..()
 
 /mob/living/carbon/human/breathe()
-	if(!dna.species.breathe(src))
-		..()
+	if(!HAS_TRAIT(src, TRAIT_NOBREATH))
+		return ..()
 
 /mob/living/carbon/human/check_breath(datum/gas_mixture/breath)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1588,14 +1588,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	// called before a projectile hit
 	return 0
 
-/////////////
-//BREATHING//
-/////////////
-
-/datum/species/proc/breathe(mob/living/carbon/human/H)
-	if(HAS_TRAIT(H, TRAIT_NOBREATH))
-		return TRUE
-
 //////////////////////////
 // ENVIRONMENT HANDLERS //
 //////////////////////////

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -506,8 +506,8 @@
 	desc = "A spongy rib-shaped mass for filtering plasma from the air."
 	icon_state = "lungs-plasma"
 
-	safe_oxygen_min = 0 //We don't breath this
-	safe_toxins_min = 16 //We breath THIS!
+	safe_oxygen_min = 0 //We don't breathe this
+	safe_toxins_min = 16 //We breathe THIS!
 	safe_toxins_max = 0
 
 /obj/item/organ/lungs/slime


### PR DESCRIPTION
Human code override breathe(), called the species datum which checked if the human had NO_BREATH. I just made it check for NOBREATH directly, since it is apparently a human only trait. 

If someone wants to implement special breathing checks/behaviour, make custom lungs

No player facing changes, it's just a small code improvement
