### PR TITLE
Massively buffs debriding surgery

### DIFF
--- a/code/modules/surgery/burn_dressing.dm
+++ b/code/modules/surgery/burn_dressing.dm
@@ -35,7 +35,7 @@
 	/// How much sanitization is added per step
 	var/sanitization_added = 0.5
 	/// How much infestation is removed per step (positive number)
-	var/infestation_removed = 0.5
+	var/infestation_removed = 4
 
 /// To give the surgeon a heads up how much work they have ahead of them
 /datum/surgery_step/debride/proc/get_progress(mob/user, mob/living/carbon/target, datum/wound/burn/burn_wound)


### PR DESCRIPTION
Multiplies the debriding surgery rate by 8. 


:cl:
balance: Debriding surgery efficiency has been multiplied by 8
/:cl:

### Why this is good for the game
Yesterday, I got lasered in the arm twice. A good three minutes later I lose all controle off my arm and have an assistant debride my arm. On a surgical table with sterilizine, this took 2 minutes and 30 seconds. 

All wounds can be fixed quite easily, but the infection wound type has always been an absolute nightmare. This was the only time I recorded it, but this has happened so many times and it feels like the average lies around 4~ minutes for this surgery to complete. 

It still depends on how badly infected your burn wound is, but it shouldn't take longer than 30 seconds now. 