### PR TITLE
Fix error on secondary attacking certain secure closets.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -467,14 +467,13 @@
 	open()
 
 /obj/structure/closet/attack_hand_secondary(mob/user, modifiers)
+	. = SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 	if(!user.canUseTopic(src, BE_CLOSE) || !isturf(loc))
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		return
 
 	if(!opened && secure)
 		togglelock(user)
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-	return SECONDARY_ATTACK_CALL_NORMAL
 
 /obj/structure/closet/proc/togglelock(mob/living/user, silent)
 	if(secure && !broken)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -468,11 +468,13 @@
 
 /obj/structure/closet/attack_hand_secondary(mob/user, modifiers)
 	if(!user.canUseTopic(src, BE_CLOSE) || !isturf(loc))
-		return
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	if(!opened && secure)
 		togglelock(user)
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	return SECONDARY_ATTACK_CALL_NORMAL
 
 /obj/structure/closet/proc/togglelock(mob/living/user, silent)
 	if(secure && !broken)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/123673667-a3a1f300-d838-11eb-84c0-476d83413f81.png)

The `/obj/structure/closet/attack_hand_secondary` proc didn't return one of the appropriate defines and thus triggered an entry into the runtime logs.

Default behaviour in that scenario was to revert to primary attack chain. This behaviour has simply been codified if none of the pre-reqs are met.

I've also set it to cancel the attack chain if the loc and canUseTopic pre-reqs aren't met. Seemed to make sense.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes an error.

No player-facing changes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
