### PR TITLE
Fixes some minor tramstation mapping issues

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -28258,6 +28258,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"gPs" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/science/research)
 "gPt" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -42895,6 +42906,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"mtk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/research)
 "mtB" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -66508,11 +66524,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"vIq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/science/research)
 "vIB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -72957,7 +72968,6 @@
 	name = "Research Requests Console";
 	receive_ore_updates = 1
 	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science/lab)
 "xXC" = (
@@ -114917,7 +114927,7 @@ hmN
 hmN
 vXT
 ecX
-ecX
+gPs
 ecX
 tSp
 der
@@ -117227,9 +117237,9 @@ der
 der
 der
 der
-vIq
+mtk
 nFJ
-vIq
+mtk
 der
 der
 der

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -17725,6 +17725,17 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
+"cKv" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/science/research)
 "cKC" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -18752,9 +18763,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"deT" = (
-/turf/closed/wall,
-/area/service/kitchen/coldroom)
 "dfo" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -21124,6 +21132,9 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"dYT" = (
+/turf/closed/wall,
+/area/service/kitchen/coldroom)
 "dYV" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
@@ -41442,6 +41453,13 @@
 	},
 /turf/open/floor/iron,
 /area/medical/virology)
+"lNh" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "lNm" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -46236,11 +46254,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"nQc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/science/research)
 "nQj" = (
 /turf/closed/wall,
 /area/tcommsat/server)
@@ -46404,17 +46417,6 @@
 "nTn" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
-"nTp" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/science/research)
 "nTD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	name = "Server Vent"
@@ -65522,6 +65524,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"vmf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/research)
 "vml" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -114939,7 +114946,7 @@ hmN
 hmN
 vXT
 ecX
-nTp
+cKv
 ecX
 tSp
 der
@@ -117249,9 +117256,9 @@ der
 der
 der
 der
-nQc
+vmf
 nFJ
-nQc
+vmf
 der
 der
 der
@@ -160131,10 +160138,10 @@ sUz
 nqs
 qxK
 amK
-deT
+dYT
 adp
-deT
-deT
+dYT
+dYT
 ayP
 vRt
 ltP
@@ -160391,7 +160398,7 @@ amK
 acK
 gQi
 aXK
-deT
+dYT
 aBQ
 msi
 aTJ
@@ -160648,7 +160655,7 @@ acw
 aUO
 mQa
 apq
-deT
+dYT
 ltD
 hmf
 aEU
@@ -161162,7 +161169,7 @@ amK
 acW
 hFl
 auC
-deT
+dYT
 wzb
 fAF
 anI
@@ -161419,7 +161426,7 @@ amK
 abv
 atV
 aKQ
-deT
+dYT
 aiT
 jGO
 wDL
@@ -161673,10 +161680,10 @@ ssw
 vFb
 azY
 amK
-deT
-deT
-deT
-deT
+dYT
+dYT
+dYT
+dYT
 afA
 qVG
 tzb
@@ -185083,7 +185090,7 @@ vNK
 ooX
 aEQ
 kkf
-xNV
+lNh
 xNV
 the
 abm

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -12870,6 +12870,8 @@
 "aWx" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "aWC" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -17662,7 +17662,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "cJH" = (
@@ -17725,17 +17724,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
-"cKv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/science/research)
 "cKC" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -21132,9 +21120,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"dYT" = (
-/turf/closed/wall,
-/area/service/kitchen/coldroom)
 "dYV" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
@@ -26205,6 +26190,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/office)
+"fYk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/research)
 "fYq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -36566,6 +36556,9 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
+"jZY" = (
+/turf/closed/wall,
+/area/service/kitchen/coldroom)
 "jZZ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -37207,6 +37200,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"kkp" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/science/research)
 "kkw" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/virology{
@@ -41453,13 +41457,6 @@
 	},
 /turf/open/floor/iron,
 /area/medical/virology)
-"lNh" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "lNm" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -65524,11 +65521,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"vmf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/science/research)
 "vml" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -66087,6 +66079,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
+"vBv" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "vBA" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -114946,7 +114945,7 @@ hmN
 hmN
 vXT
 ecX
-cKv
+kkp
 ecX
 tSp
 der
@@ -117256,9 +117255,9 @@ der
 der
 der
 der
-vmf
+fYk
 nFJ
-vmf
+fYk
 der
 der
 der
@@ -160138,10 +160137,10 @@ sUz
 nqs
 qxK
 amK
-dYT
+jZY
 adp
-dYT
-dYT
+jZY
+jZY
 ayP
 vRt
 ltP
@@ -160398,7 +160397,7 @@ amK
 acK
 gQi
 aXK
-dYT
+jZY
 aBQ
 msi
 aTJ
@@ -160655,7 +160654,7 @@ acw
 aUO
 mQa
 apq
-dYT
+jZY
 ltD
 hmf
 aEU
@@ -161169,7 +161168,7 @@ amK
 acW
 hFl
 auC
-dYT
+jZY
 wzb
 fAF
 anI
@@ -161426,7 +161425,7 @@ amK
 abv
 atV
 aKQ
-dYT
+jZY
 aiT
 jGO
 wDL
@@ -161680,10 +161679,10 @@ ssw
 vFb
 azY
 amK
-dYT
-dYT
-dYT
-dYT
+jZY
+jZY
+jZY
+jZY
 afA
 qVG
 tzb
@@ -185090,7 +185089,7 @@ vNK
 ooX
 aEQ
 kkf
-lNh
+vBv
 xNV
 the
 abm

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7148,6 +7148,7 @@
 	dir = 5
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "awX" = (
@@ -18385,6 +18386,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "cXQ" = (
@@ -25019,6 +25021,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"fDe" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/science/research)
 "fDf" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -28258,17 +28271,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"gPs" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/science/research)
 "gPt" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -42906,11 +42908,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"mtk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/science/research)
 "mtB" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -57749,6 +57746,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"spB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/research)
 "spP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -114927,7 +114929,7 @@ hmN
 hmN
 vXT
 ecX
-gPs
+fDe
 ecX
 tSp
 der
@@ -117237,9 +117239,9 @@ der
 der
 der
 der
-mtk
+spB
 nFJ
-mtk
+spB
 der
 der
 der

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -5644,6 +5644,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "ass" = (
@@ -20806,17 +20807,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
-"dSa" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/science/research)
 "dSb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -23864,6 +23854,9 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"ffc" = (
+/turf/closed/wall,
+/area/service/kitchen/coldroom)
 "ffe" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -24587,6 +24580,17 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
+"ftR" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/science/research)
 "fub" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -26572,6 +26576,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"ggv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/research)
 "ggA" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -46855,9 +46864,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
-"oei" = (
-/turf/closed/wall,
-/area/service/kitchen/coldroom)
 "oep" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -51347,11 +51353,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
-"pLF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/science/research)
 "pLR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -114932,7 +114933,7 @@ hmN
 hmN
 vXT
 ecX
-dSa
+ftR
 ecX
 tSp
 der
@@ -117242,9 +117243,9 @@ der
 der
 der
 der
-pLF
+ggv
 nFJ
-pLF
+ggv
 der
 der
 der
@@ -160124,10 +160125,10 @@ sUz
 nqs
 qxK
 amK
-oei
+ffc
 adp
-oei
-oei
+ffc
+ffc
 ayP
 vRt
 ltP
@@ -160384,7 +160385,7 @@ amK
 acK
 gQi
 aXK
-oei
+ffc
 aBQ
 msi
 aTJ
@@ -160641,7 +160642,7 @@ acw
 aUO
 mQa
 apq
-oei
+ffc
 ltD
 hmf
 aEU
@@ -161155,7 +161156,7 @@ amK
 acW
 hFl
 auC
-oei
+ffc
 wzb
 fAF
 anI
@@ -161412,7 +161413,7 @@ amK
 abv
 atV
 aKQ
-oei
+ffc
 aiT
 jGO
 wDL
@@ -161666,10 +161667,10 @@ ssw
 vFb
 azY
 amK
-oei
-oei
-oei
-oei
+ffc
+ffc
+ffc
+ffc
 afA
 qVG
 tzb

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -45792,7 +45792,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/white,
 /area/science/research)
 "nGc" = (
@@ -50808,7 +50808,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/science/mixing)
 "pCt" = (
@@ -58111,8 +58111,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/science/mixing)
 "svV" = (
@@ -59073,7 +59073,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/science/mixing)
 "sSU" = (
@@ -66508,6 +66508,11 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"vIq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/research)
 "vIB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -117222,9 +117227,9 @@ der
 der
 der
 der
-lar
+vIq
 nFJ
-lar
+vIq
 der
 der
 der

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -432,7 +432,7 @@
 "abv" = (
 /obj/machinery/icecream_vat,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "abx" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -778,7 +778,7 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/structure/kitchenspike,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "acL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -842,7 +842,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "acY" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -974,7 +974,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "adr" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -4498,7 +4498,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "aps" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
@@ -6218,7 +6218,7 @@
 "atV" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "atZ" = (
 /obj/structure/chair/pew/left{
 	dir = 4
@@ -6405,7 +6405,7 @@
 /area/hallway/secondary/entry)
 "auC" = (
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "auD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -11046,7 +11046,7 @@
 "aKQ" = (
 /obj/machinery/gibber,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "aKU" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -12646,7 +12646,7 @@
 "aUO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "aUV" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -12960,7 +12960,7 @@
 "aXK" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "aXN" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/button/door/directional/east{
@@ -19165,7 +19165,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "doC" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /turf/open/floor/iron/dark,
@@ -20806,6 +20806,17 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
+"dSa" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/science/research)
 "dSb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -23585,7 +23596,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "eZa" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
@@ -25021,17 +25032,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"fDe" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/science/research)
 "fDf" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -28297,7 +28297,7 @@
 "gQi" = (
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "gQo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
@@ -30446,7 +30446,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "hGh" = (
 /turf/closed/wall,
 /area/science/robotics/mechbay)
@@ -35955,7 +35955,7 @@
 	name = "Pete"
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "jOk" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Escape Wing"
@@ -43952,7 +43952,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "mQb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -46855,6 +46855,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
+"oei" = (
+/turf/closed/wall,
+/area/service/kitchen/coldroom)
 "oep" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -51344,6 +51347,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
+"pLF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/research)
 "pLR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -57746,11 +57754,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"spB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/science/research)
 "spP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -62391,7 +62394,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "tZl" = (
 /obj/effect/turf_decal/arrows/red{
 	pixel_y = 15
@@ -114929,7 +114932,7 @@ hmN
 hmN
 vXT
 ecX
-fDe
+dSa
 ecX
 tSp
 der
@@ -117239,9 +117242,9 @@ der
 der
 der
 der
-spB
+pLF
 nFJ
-spB
+pLF
 der
 der
 der
@@ -160121,10 +160124,10 @@ sUz
 nqs
 qxK
 amK
-aGY
+oei
 adp
-aGY
-aGY
+oei
+oei
 ayP
 vRt
 ltP
@@ -160381,7 +160384,7 @@ amK
 acK
 gQi
 aXK
-aGY
+oei
 aBQ
 msi
 aTJ
@@ -160638,7 +160641,7 @@ acw
 aUO
 mQa
 apq
-aGY
+oei
 ltD
 hmf
 aEU
@@ -161152,7 +161155,7 @@ amK
 acW
 hFl
 auC
-aGY
+oei
 wzb
 fAF
 anI
@@ -161409,7 +161412,7 @@ amK
 abv
 atV
 aKQ
-aGY
+oei
 aiT
 jGO
 wDL
@@ -161663,10 +161666,10 @@ ssw
 vFb
 azY
 amK
-aGY
-aGY
-aGY
-aGY
+oei
+oei
+oei
+oei
 afA
 qVG
 tzb

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -15486,6 +15486,7 @@
 /obj/item/mmi,
 /obj/item/mmi,
 /obj/item/mmi,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "bPs" = (
@@ -18751,6 +18752,9 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
+"deT" = (
+/turf/closed/wall,
+/area/service/kitchen/coldroom)
 "dfo" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -21245,6 +21249,7 @@
 "ebe" = (
 /obj/structure/table,
 /obj/item/ai_module/reset,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "ebt" = (
@@ -34470,6 +34475,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "jjN" = (
@@ -46230,6 +46236,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"nQc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/research)
 "nQj" = (
 /turf/closed/wall,
 /area/tcommsat/server)
@@ -46393,6 +46404,17 @@
 "nTn" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
+"nTp" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/science/research)
 "nTD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	name = "Server Vent"
@@ -48736,6 +48758,7 @@
 	id = "cytologylockdown";
 	name = "Cytology Lockdown"
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "oNe" = (
@@ -49794,17 +49817,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
-"pgZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/science/research)
 "phh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -55678,11 +55690,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"rzx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/science/research)
 "rzK" = (
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
@@ -73464,9 +73471,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
-"yiX" = (
-/turf/closed/wall,
-/area/service/kitchen/coldroom)
 "yja" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
@@ -114935,7 +114939,7 @@ hmN
 hmN
 vXT
 ecX
-pgZ
+nTp
 ecX
 tSp
 der
@@ -117245,9 +117249,9 @@ der
 der
 der
 der
-rzx
+nQc
 nFJ
-rzx
+nQc
 der
 der
 der
@@ -160127,10 +160131,10 @@ sUz
 nqs
 qxK
 amK
-yiX
+deT
 adp
-yiX
-yiX
+deT
+deT
 ayP
 vRt
 ltP
@@ -160387,7 +160391,7 @@ amK
 acK
 gQi
 aXK
-yiX
+deT
 aBQ
 msi
 aTJ
@@ -160644,7 +160648,7 @@ acw
 aUO
 mQa
 apq
-yiX
+deT
 ltD
 hmf
 aEU
@@ -161158,7 +161162,7 @@ amK
 acW
 hFl
 auC
-yiX
+deT
 wzb
 fAF
 anI
@@ -161415,7 +161419,7 @@ amK
 abv
 atV
 aKQ
-yiX
+deT
 aiT
 jGO
 wDL
@@ -161669,10 +161673,10 @@ ssw
 vFb
 azY
 amK
-yiX
-yiX
-yiX
-yiX
+deT
+deT
+deT
+deT
 afA
 qVG
 tzb

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -23854,9 +23854,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"ffc" = (
-/turf/closed/wall,
-/area/service/kitchen/coldroom)
 "ffe" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -24580,17 +24577,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
-"ftR" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/science/research)
 "fub" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -26576,11 +26562,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"ggv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plating,
-/area/science/research)
 "ggA" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -35910,6 +35891,7 @@
 	name = "Security Requests Console"
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "jNk" = (
@@ -49812,6 +49794,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
+"pgZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/science/research)
 "phh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -55109,6 +55102,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "roW" = (
@@ -55684,6 +55678,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"rzx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plating,
+/area/science/research)
 "rzK" = (
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
@@ -73465,6 +73464,9 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
+"yiX" = (
+/turf/closed/wall,
+/area/service/kitchen/coldroom)
 "yja" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
@@ -114933,7 +114935,7 @@ hmN
 hmN
 vXT
 ecX
-ftR
+pgZ
 ecX
 tSp
 der
@@ -117243,9 +117245,9 @@ der
 der
 der
 der
-ggv
+rzx
 nFJ
-ggv
+rzx
 der
 der
 der
@@ -160125,10 +160127,10 @@ sUz
 nqs
 qxK
 amK
-ffc
+yiX
 adp
-ffc
-ffc
+yiX
+yiX
 ayP
 vRt
 ltP
@@ -160385,7 +160387,7 @@ amK
 acK
 gQi
 aXK
-ffc
+yiX
 aBQ
 msi
 aTJ
@@ -160642,7 +160644,7 @@ acw
 aUO
 mQa
 apq
-ffc
+yiX
 ltD
 hmf
 aEU
@@ -161156,7 +161158,7 @@ amK
 acW
 hFl
 auC
-ffc
+yiX
 wzb
 fAF
 anI
@@ -161413,7 +161415,7 @@ amK
 abv
 atV
 aKQ
-ffc
+yiX
 aiT
 jGO
 wDL
@@ -161667,10 +161669,10 @@ ssw
 vFb
 azY
 amK
-ffc
-ffc
-ffc
-ffc
+yiX
+yiX
+yiX
+yiX
 afA
 qVG
 tzb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes several minor mapping errors i noticed on Tram Station during play

1. toxins not only used normal firelocks, but the windows into sci hall had no firelocks whatsoever, despite toxin fires often breaking those windows. added heavy firelocks to the windows and replaced the normal firelocks in toxins with heavy ones, to be in line with toxin standard

2. Sci hall only had a single air alarm in sci lobby, added a second one next to experimentation room on the lower floor of sci halls (close to toxins for easy fixing any leaks from there). Added a second Air Alarm in upper xenobio.

3. The Kitchen Freezer used the same area as the kitchen proper, despite their air temps needing to remain different between them. made the Kitchen Freezer use the Kitchen Cold Room area like it should.

4. Added missing Air Alarms in arrivals secpost, wardens office, and HoS office. as well as added the missing Air Alarms in Robotics Assembly Line and the interior of the AI Upload. Added missing Air Alarm in escape hallway. Engineering hallway and Engineering Foyer had no air alarms, added them in.

5. Science RnD had two air alarms in the small room. removed one. Interrogation Room had 3 air alarms, one in the room itself, two in the viewing section, removed one in viewing.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Proper mapping allows for better gameplay. having a chunk of air alarms missing for example makes it hard for atmos techs to actually fix air issues mid game.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: added missing air alarms on Tramstation in several areas that previously had none
fix: removed air alarms that was right next to each other in the same room on Tramstation
fix: Tramstation toxins now has proper firelock safety, no more toxin fires breaking the windows into sci halls
fix: Tramstation Kitchen Freezer now uses the proper area so the kitchen and freezer air alarms dont control the same vents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
