### PR TITLE
Fixes oneway effects

### DIFF
--- a/code/modules/awaymissions/away_props.dm
+++ b/code/modules/awaymissions/away_props.dm
@@ -8,7 +8,7 @@
 
 /obj/effect/oneway/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	return . && border_dir == dir
+	return . && (REVERSE_DIR(border_dir) == dir || get_turf(mover) == get_turf(src))
 
 
 /obj/effect/wind


### PR DESCRIPTION
I broke this one. Assumed wrongly that it worked similarly to on border objects, but it had the inverse logic.