### PR TITLE
Fix forensic component inheritance inserting null entries into lists and causing to_chat errors.

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -571,3 +571,18 @@
 			return FALSE
 
 	return TRUE
+
+/// Performs (lhs | rhs) on two lazylists without inserting accidental nulls. Returns a new list.
+/proc/or_two_lazy_lists(list/lhs, list/rhs)
+	// Is neither list empty?
+	if(LAZYLEN(rhs) && LAZYLEN(lhs))
+		return (lhs | rhs)
+
+	// Is at least one of the lists empty?
+	if(LAZYLEN(lhs))
+		return lhs.Copy()
+	if(LAZYLEN(rhs))
+		return rhs.Copy()
+
+	// Both lists empty.
+	return null

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -572,17 +572,12 @@
 
 	return TRUE
 
-/// Performs (lhs | rhs) on two lazylists without inserting accidental nulls. Returns a new list.
-/proc/or_two_lazy_lists(list/lhs, list/rhs)
-	// Is neither list empty?
-	if(LAZYLEN(rhs) && LAZYLEN(lhs))
-		return (lhs | rhs)
-
-	// Is at least one of the lists empty?
-	if(LAZYLEN(lhs))
-		return lhs.Copy()
-	if(LAZYLEN(rhs))
-		return rhs.Copy()
-
-	// Both lists empty.
-	return null
+#define LAZY_LISTS_OR(left_list, right_list)\
+	( length(left_list)\
+		? length(right_list)\
+			? (left_list | right_list)\
+			: left_list.Copy()\
+		: length(right_list)\
+			? right_list.Copy()\
+			: null\
+	)

--- a/code/datums/components/forensics.dm
+++ b/code/datums/components/forensics.dm
@@ -7,10 +7,10 @@
 	var/list/fibers //assoc print = print
 
 /datum/component/forensics/InheritComponent(datum/component/forensics/F, original) //Use of | and |= being different here is INTENTIONAL.
-	fingerprints = LAZYLEN(F.fingerprints) ? fingerprints | F.fingerprints : fingerprints
-	hiddenprints = LAZYLEN(F.hiddenprints) ? hiddenprints | F.hiddenprints : hiddenprints
-	blood_DNA = LAZYLEN(F.blood_DNA) ? blood_DNA | F.blood_DNA : blood_DNA
-	fibers = LAZYLEN(F.fibers) ? fibers | F.fibers : fibers
+	fingerprints = or_two_lazy_lists(fingerprints, F.fingerprints)
+	hiddenprints = or_two_lazy_lists(hiddenprints, F.hiddenprints)
+	blood_DNA = or_two_lazy_lists(blood_DNA, F.blood_DNA)
+	fibers = or_two_lazy_lists(fibers, F.fibers)
 	check_blood()
 	return ..()
 

--- a/code/datums/components/forensics.dm
+++ b/code/datums/components/forensics.dm
@@ -7,10 +7,10 @@
 	var/list/fibers //assoc print = print
 
 /datum/component/forensics/InheritComponent(datum/component/forensics/F, original) //Use of | and |= being different here is INTENTIONAL.
-	fingerprints = fingerprints | F.fingerprints
-	hiddenprints = hiddenprints | F.hiddenprints
-	blood_DNA = blood_DNA | F.blood_DNA
-	fibers = fibers | F.fibers
+	fingerprints = LAZYLEN(F.fingerprints) ? fingerprints | F.fingerprints : fingerprints
+	hiddenprints = LAZYLEN(F.hiddenprints) ? hiddenprints | F.hiddenprints : hiddenprints
+	blood_DNA = LAZYLEN(F.blood_DNA) ? blood_DNA | F.blood_DNA : blood_DNA
+	fibers = LAZYLEN(F.fibers) ? fibers | F.fibers : fibers
 	check_blood()
 	return ..()
 

--- a/code/datums/components/forensics.dm
+++ b/code/datums/components/forensics.dm
@@ -7,10 +7,10 @@
 	var/list/fibers //assoc print = print
 
 /datum/component/forensics/InheritComponent(datum/component/forensics/F, original) //Use of | and |= being different here is INTENTIONAL.
-	fingerprints = or_two_lazy_lists(fingerprints, F.fingerprints)
-	hiddenprints = or_two_lazy_lists(hiddenprints, F.hiddenprints)
-	blood_DNA = or_two_lazy_lists(blood_DNA, F.blood_DNA)
-	fibers = or_two_lazy_lists(fibers, F.fibers)
+	fingerprints = LAZY_LISTS_OR(fingerprints, F.fingerprints)
+	hiddenprints = LAZY_LISTS_OR(hiddenprints, F.hiddenprints)
+	blood_DNA = LAZY_LISTS_OR(blood_DNA, F.blood_DNA)
+	fibers = LAZY_LISTS_OR(fibers, F.fibers)
 	check_blood()
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixing the following runtime:
```
[17:13:04] Runtime in to_chat.dm,88: Empty or null string in to_chat proc call.
  proc name: to chat (/proc/to_chat)
  usr: Cowboy_penis_monster/(Zackary Mason)
  usr.loc: (Telecomms Control Room (105,89,2))
  src: null
  call stack:
  to chat(Zackary Mason (/mob/living/carbon/human), "", null, "", 0, 1, 1, 0)
  the forensic scanner (/obj/item/detective_scanner): add log("", 1)
  the forensic scanner (/obj/item/detective_scanner): scan(Control Room (/obj/machinery/door/airlock/command/glass), Zackary Mason (/mob/living/carbon/human))
```

Forensic scanner attempting to add `""` to the logs, which eventually gets output to_chat.

Tracked error down to forensic component lazylists and the fun of trying to OR two lazylists together.

If the rhs lazylist is null, null gets added as an entry into the lhs list.

I have created a proc to OR two lazylists together without inserting errant nulls, returning a new list and not modifying the existing lists.

As a result, forensics components should no longer have null entries inserted into their various lists. This fixes the underlying behaviour which was causing the `""` messages to be sent to_chat.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The detective's scanner should now always properly output the correct data for scans and should no longer print out blank entries erroneously.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
