### PR TITLE
Add $reset directive to config processor for setting a config entry to default value

### DIFF
--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -8,9 +8,9 @@
 /datum/config_entry
 	/// Read-only, this is determined by the last portion of the derived entry type
 	var/name
-	/// The configured value for this entry
+	/// The configured value for this entry. This shouldn't be initialized in code, instead set default
 	var/config_entry_value
-	/// Read-only default value for this config entry, used for resetting value to defaults when necessary
+	/// Read-only default value for this config entry, used for resetting value to defaults when necessary. This is what config_entry_value is initially set to
 	var/default
 	/// The file which this was loaded from, if any
 	var/resident_file
@@ -34,6 +34,7 @@
 		CRASH("Abstract config entry [type] instatiated!")
 	name = lowertext(type2top(type))
 	default_protection = protection
+	set_default()
 
 /datum/config_entry/Destroy()
 	config.RemoveEntry(src)
@@ -92,7 +93,7 @@
 	return
 
 /datum/config_entry/string
-	config_entry_value = ""
+	default = ""
 	abstract_type = /datum/config_entry/string
 	var/auto_trim = TRUE
 
@@ -106,7 +107,7 @@
 	return TRUE
 
 /datum/config_entry/number
-	config_entry_value = 0
+	default = 0
 	abstract_type = /datum/config_entry/number
 	var/integer = TRUE
 	var/max_val = INFINITY
@@ -128,7 +129,7 @@
 	return !(var_name in banned_edits) && ..()
 
 /datum/config_entry/flag
-	config_entry_value = FALSE
+	default = FALSE
 	abstract_type = /datum/config_entry/flag
 
 /datum/config_entry/flag/ValidateAndSet(str_val)
@@ -140,7 +141,7 @@
 /// List config entry, used for configuring a list of strings
 /datum/config_entry/str_list
 	abstract_type = /datum/config_entry/str_list
-	config_entry_value = list()
+	default = list()
 	dupes_allowed = TRUE
 
 /datum/config_entry/str_list/ValidateAndSet(str_val)
@@ -153,7 +154,7 @@
 
 /datum/config_entry/number_list
 	abstract_type = /datum/config_entry/number_list
-	config_entry_value = list()
+	default = list()
 
 /datum/config_entry/number_list/ValidateAndSet(str_val)
 	if(!VASProcCallGuard(str_val))
@@ -173,7 +174,7 @@
 
 /datum/config_entry/keyed_list
 	abstract_type = /datum/config_entry/keyed_list
-	config_entry_value = list()
+	default = list()
 	dupes_allowed = TRUE
 	vv_VAS = FALSE //VAS will not allow things like deleting from lists, it'll just bug horribly.
 	var/key_mode

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -147,6 +147,16 @@
 				++.
 			continue
 
+		// Reset directive, used for setting a config value back to defaults. Useful for string list config types
+		if (entry == "$reset")
+			var/datum/config_entry/resetee = _entries[lowertext(value)]
+			if (!value || !resetee)
+				log_config("Warning: invalid $reset directive: [value]")
+				continue
+			resetee.set_default()
+			log_config("Reset configured value for [value] to original defaults")
+			continue
+
 		var/datum/config_entry/E = _entries[entry]
 		if(!E)
 			log_config("Unknown setting in configuration: '[entry]'")

--- a/code/controllers/configuration/entries/dbconfig.dm
+++ b/code/controllers/configuration/entries/dbconfig.dm
@@ -2,21 +2,21 @@
 	protection = CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/string/address
-	config_entry_value = "localhost"
+	default = "localhost"
 	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
 
 /datum/config_entry/number/port
-	config_entry_value = 3306
+	default = 3306
 	min_val = 0
 	max_val = 65535
 	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
 
 /datum/config_entry/string/feedback_database
-	config_entry_value = "test"
+	default = "test"
 	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
 
 /datum/config_entry/string/feedback_login
-	config_entry_value = "root"
+	default = "root"
 	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
 
 /datum/config_entry/string/feedback_password
@@ -26,7 +26,7 @@
 	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
 
 /datum/config_entry/number/query_debug_log_timeout
-	config_entry_value = 70
+	default = 70
 	min_val = 1
 	protection = CONFIG_ENTRY_LOCKED
 	deprecated_by = /datum/config_entry/number/blocking_query_timeout
@@ -35,19 +35,19 @@
 	return value
 
 /datum/config_entry/number/async_query_timeout
-	config_entry_value = 10
+	default = 10
 	min_val = 0
 	protection = CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/number/blocking_query_timeout
-	config_entry_value = 5
+	default = 5
 	min_val = 0
 	protection = CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/number/bsql_thread_limit
-	config_entry_value = 50
+	default = 50
 	min_val = 1
 
 /datum/config_entry/number/max_concurrent_queries
-	config_entry_value = 25
+	default = 25
 	min_val = 1

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -22,7 +22,7 @@
 	return key_name in config.modes
 
 /datum/config_entry/number/damage_multiplier
-	config_entry_value = 1
+	default = 1
 	integer = FALSE
 
 /datum/config_entry/number/minimal_access_threshold //If the number of players is larger than this threshold, minimal access will be turned on.
@@ -55,36 +55,36 @@
 /datum/config_entry/flag/disable_warops
 
 /datum/config_entry/number/traitor_scaling_coeff //how much does the amount of players get divided by to determine traitors
-	config_entry_value = 6
+	default = 6
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/brother_scaling_coeff //how many players per brother team
-	config_entry_value = 25
+	default = 25
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/changeling_scaling_coeff //how much does the amount of players get divided by to determine changelings
-	config_entry_value = 6
+	default = 6
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/ecult_scaling_coeff //how much does the amount of players get divided by to determine e_cult
-	config_entry_value = 6
+	default = 6
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/security_scaling_coeff //how much does the amount of players get divided by to determine open security officer positions
-	config_entry_value = 8
+	default = 8
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/traitor_objectives_amount
-	config_entry_value = 2
+	default = 2
 	min_val = 0
 
 /datum/config_entry/number/brother_objectives_amount
-	config_entry_value = 2
+	default = 2
 	min_val = 0
 
 /datum/config_entry/flag/reactionary_explosions //If we use reactionary explosions, explosions that react to walls and doors
@@ -98,7 +98,7 @@
 /datum/config_entry/flag/allow_latejoin_antagonists // If late-joining players can be traitor/changeling
 
 /datum/config_entry/number/shuttle_refuel_delay
-	config_entry_value = 12000
+	default = 12000
 	integer = FALSE
 	min_val = 0
 
@@ -121,7 +121,7 @@
 /datum/config_entry/flag/no_intercept_report //Whether or not to send a communications intercept report roundstart. This may be overridden by gamemodes.
 
 /datum/config_entry/number/arrivals_shuttle_dock_window //Time from when a player late joins on the arrivals shuttle to when the shuttle docks on the station
-	config_entry_value = 55
+	default = 55
 	integer = FALSE
 	min_val = 30
 
@@ -130,27 +130,27 @@
 /datum/config_entry/flag/arrivals_shuttle_require_safe_latejoin //Require the arrivals shuttle to be operational in order for latejoiners to join
 
 /datum/config_entry/string/alert_green
-	config_entry_value = "All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced."
+	default = "All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced."
 
 /datum/config_entry/string/alert_blue_upto
-	config_entry_value = "The station has received reliable information about possible hostile activity on the station. Security staff may have weapons visible, random searches are permitted."
+	default = "The station has received reliable information about possible hostile activity on the station. Security staff may have weapons visible, random searches are permitted."
 
 /datum/config_entry/string/alert_blue_downto
-	config_entry_value = "The immediate threat has passed. Security may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still allowed."
+	default = "The immediate threat has passed. Security may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still allowed."
 
 /datum/config_entry/string/alert_red_upto
-	config_entry_value = "There is an immediate serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised."
+	default = "There is an immediate serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised."
 
 /datum/config_entry/string/alert_red_downto
-	config_entry_value = "The station's destruction has been averted. There is still however an immediate serious threat to the station. Security may have weapons unholstered at all times, random searches are allowed and advised."
+	default = "The station's destruction has been averted. There is still however an immediate serious threat to the station. Security may have weapons unholstered at all times, random searches are allowed and advised."
 
 /datum/config_entry/string/alert_delta
-	config_entry_value = "Destruction of the station is imminent. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill."
+	default = "Destruction of the station is imminent. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill."
 
 /datum/config_entry/flag/revival_pod_plants
 
 /datum/config_entry/number/revival_brain_life
-	config_entry_value = -1
+	default = -1
 	integer = FALSE
 	min_val = -1
 
@@ -169,7 +169,7 @@
 /datum/config_entry/keyed_list/multiplicative_movespeed
 	key_mode = KEY_MODE_TYPE
 	value_mode = VALUE_MODE_NUM
-	config_entry_value = list( //DEFAULTS
+	default = list( //DEFAULTS
 	/mob/living/simple_animal = 1,
 	/mob/living/silicon/pai = 1,
 	/mob/living/carbon/alien/humanoid/hunter = -1,
@@ -243,7 +243,7 @@
 /datum/config_entry/flag/roundstart_away //Will random away mission be loaded.
 
 /datum/config_entry/number/gateway_delay //How long the gateway takes before it activates. Default is half an hour. Only matters if roundstart_away is enabled.
-	config_entry_value = 18000
+	default = 18000
 	integer = FALSE
 	min_val = 0
 
@@ -257,12 +257,12 @@
 /datum/config_entry/flag/sandbox_autoclose // close the sandbox panel after spawning an item, potentially reducing griff
 
 /datum/config_entry/number/default_laws //Controls what laws the AI spawns with.
-	config_entry_value = 0
+	default = 0
 	min_val = 0
 	max_val = 3
 
 /datum/config_entry/number/silicon_max_law_amount
-	config_entry_value = 12
+	default = 12
 	min_val = 0
 
 /datum/config_entry/keyed_list/random_laws
@@ -275,51 +275,51 @@
 	splitter = ","
 
 /datum/config_entry/number/max_law_len
-	config_entry_value = 1024
+	default = 1024
 
 /datum/config_entry/number/overflow_cap
-	config_entry_value = -1
+	default = -1
 	min_val = -1
 
 /datum/config_entry/string/overflow_job
-	config_entry_value = "Assistant"
+	default = "Assistant"
 
 /datum/config_entry/flag/starlight
 /datum/config_entry/flag/grey_assistants
 
 /datum/config_entry/number/lavaland_budget
-	config_entry_value = 60
+	default = 60
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/icemoon_budget
-	config_entry_value = 90
+	default = 90
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/space_budget
-	config_entry_value = 16
+	default = 16
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/flag/allow_random_events // Enables random events mid-round when set
 
 /datum/config_entry/number/events_min_time_mul // Multipliers for random events minimal starting time and minimal players amounts
-	config_entry_value = 1
+	default = 1
 	min_val = 0
 	integer = FALSE
 
 /datum/config_entry/number/events_min_players_mul
-	config_entry_value = 1
+	default = 1
 	min_val = 0
 	integer = FALSE
 
 /datum/config_entry/number/mice_roundstart
-	config_entry_value = 10
+	default = 10
 	min_val = 0
 
 /datum/config_entry/number/bombcap
-	config_entry_value = 14
+	default = 14
 	min_val = 4
 
 /datum/config_entry/number/bombcap/ValidateAndSet(str_val)
@@ -345,24 +345,24 @@
 /datum/config_entry/flag/shift_time_realtime
 
 /datum/config_entry/number/monkeycap
-	config_entry_value = 64
+	default = 64
 	min_val = 0
 
 /datum/config_entry/number/ratcap
-	config_entry_value = 64
+	default = 64
 	min_val = 0
 
 /datum/config_entry/number/maxfine
-	config_entry_value = 1000
+	default = 1000
 	min_val = 0
 
 /datum/config_entry/flag/dynamic_config_enabled
 
 /datum/config_entry/string/drone_required_role
-	config_entry_value = "Silicon"
+	default = "Silicon"
 
 /datum/config_entry/number/drone_role_playtime
-	config_entry_value = 14
+	default = 14
 	min_val = 0
 	integer = FALSE // It is in hours, but just in case one wants to specify minutes.
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -2,14 +2,14 @@
 	protection = CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/string/autoadmin_rank // the rank for autoadmins
-	config_entry_value = "Game Master"
+	default = "Game Master"
 	protection = CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/flag/auto_deadmin_players
 	protection = CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/number/auto_deadmin_timegate
-	config_entry_value = null
+	default = null
 	protection = CONFIG_ENTRY_LOCKED
 
 /datum/config_entry/flag/auto_deadmin_antagonists
@@ -32,19 +32,19 @@
 /datum/config_entry/string/stationname // station name (the name of the station in-game)
 
 /datum/config_entry/number/lobby_countdown // In between round countdown.
-	config_entry_value = 120
+	default = 120
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/round_end_countdown // Post round murder death kill countdown
-	config_entry_value = 25
+	default = 25
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/flag/hub // if the game appears on the hub or not
 
 /datum/config_entry/number/max_hub_pop //At what pop to take hub off the server
-	config_entry_value = 0 //0 means disabled
+	default = 0 //0 means disabled
 	integer = TRUE
 	min_val = 0
 
@@ -109,12 +109,12 @@
 /datum/config_entry/flag/allow_vote_map // allow votes to change map
 
 /datum/config_entry/number/vote_delay // minimum time between voting sessions (deciseconds, 10 minute default)
-	config_entry_value = 6000
+	default = 6000
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/vote_period  // length of voting period (deciseconds, default 1 minute)
-	config_entry_value = 600
+	default = 600
 	integer = FALSE
 	min_val = 0
 
@@ -125,7 +125,7 @@
 /datum/config_entry/flag/popup_admin_pm // adminPMs to non-admins show in a pop-up 'reply' window when set
 
 /datum/config_entry/number/fps
-	config_entry_value = 20
+	default = 20
 	integer = FALSE
 	min_val = 1
 	max_val = 100   //byond will start crapping out at 50, so this is just ridic
@@ -146,7 +146,7 @@
 
 /datum/config_entry/number/ticklag/New() //ticklag weirdly just mirrors fps
 	var/datum/config_entry/CE = /datum/config_entry/number/fps
-	config_entry_value = 10 / initial(CE.config_entry_value)
+	default = 10 / initial(CE.default)
 	..()
 
 /datum/config_entry/number/ticklag/ValidateAndSet(str_val)
@@ -161,7 +161,7 @@
 /datum/config_entry/flag/allow_holidays
 
 /datum/config_entry/number/tick_limit_mc_init //SSinitialization throttling
-	config_entry_value = TICK_LIMIT_MC_INIT_DEFAULT
+	default = TICK_LIMIT_MC_INIT_DEFAULT
 	min_val = 0 //oranges warned us
 	integer = FALSE
 
@@ -195,7 +195,7 @@
 /datum/config_entry/flag/use_exp_restrictions_heads
 
 /datum/config_entry/number/use_exp_restrictions_heads_hours
-	config_entry_value = 0
+	default = 0
 	integer = FALSE
 	min_val = 0
 
@@ -208,7 +208,7 @@
 /datum/config_entry/flag/use_low_living_hour_intern
 
 /datum/config_entry/number/use_low_living_hour_intern_hours
-	config_entry_value = 0
+	default = 0
 	integer = FALSE
 	min_val = 0
 
@@ -217,19 +217,19 @@
 /datum/config_entry/string/banappeals
 
 /datum/config_entry/string/wikiurl
-	config_entry_value = "http://www.tgstation13.org/wiki"
+	default = "http://www.tgstation13.org/wiki"
 
 /datum/config_entry/string/forumurl
-	config_entry_value = "http://tgstation13.org/phpBB/index.php"
+	default = "http://tgstation13.org/phpBB/index.php"
 
 /datum/config_entry/string/rulesurl
-	config_entry_value = "http://www.tgstation13.org/wiki/Rules"
+	default = "http://www.tgstation13.org/wiki/Rules"
 
 /datum/config_entry/string/githuburl
-	config_entry_value = "https://www.github.com/tgstation/tgstation"
+	default = "https://www.github.com/tgstation/tgstation"
 
 /datum/config_entry/string/discordbotcommandprefix
-	config_entry_value = "?"
+	default = "?"
 
 /datum/config_entry/string/roundstatsurl
 
@@ -238,12 +238,12 @@
 /datum/config_entry/flag/guest_ban
 
 /datum/config_entry/number/id_console_jobslot_delay
-	config_entry_value = 30
+	default = 30
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/inactivity_period //time in ds until a player is considered inactive
-	config_entry_value = 3000
+	default = 3000
 	integer = FALSE
 	min_val = 0
 
@@ -253,7 +253,7 @@
 		config_entry_value *= 10 //documented as seconds in config.txt
 
 /datum/config_entry/number/afk_period //time in ds until a player is considered inactive
-	config_entry_value = 3000
+	default = 3000
 	integer = FALSE
 	min_val = 0
 
@@ -288,37 +288,37 @@
 /datum/config_entry/flag/see_own_notes //Can players see their own admin notes
 
 /datum/config_entry/number/note_fresh_days
-	config_entry_value = null
+	default = null
 	min_val = 0
 	integer = FALSE
 
 /datum/config_entry/number/note_stale_days
-	config_entry_value = null
+	default = null
 	min_val = 0
 	integer = FALSE
 
 /datum/config_entry/flag/maprotation
 
 /datum/config_entry/number/soft_popcap
-	config_entry_value = null
+	default = null
 	min_val = 0
 
 /datum/config_entry/number/hard_popcap
-	config_entry_value = null
+	default = null
 	min_val = 0
 
 /datum/config_entry/number/extreme_popcap
-	config_entry_value = null
+	default = null
 	min_val = 0
 
 /datum/config_entry/string/soft_popcap_message
-	config_entry_value = "Be warned that the server is currently serving a high number of users, consider using alternative game servers."
+	default = "Be warned that the server is currently serving a high number of users, consider using alternative game servers."
 
 /datum/config_entry/string/hard_popcap_message
-	config_entry_value = "The server is currently serving a high number of users, You cannot currently join. You may wait for the number of living crew to decline, observe, or find alternative servers."
+	default = "The server is currently serving a high number of users, You cannot currently join. You may wait for the number of living crew to decline, observe, or find alternative servers."
 
 /datum/config_entry/string/extreme_popcap_message
-	config_entry_value = "The server is currently serving a high number of users, find alternative servers."
+	default = "The server is currently serving a high number of users, find alternative servers."
 
 /datum/config_entry/flag/byond_member_bypass_popcap
 
@@ -330,7 +330,7 @@
 /datum/config_entry/flag/panic_bunker_interview
 
 /datum/config_entry/string/panic_bunker_message
-	config_entry_value = "Sorry but the server is currently not accepting connections from never before seen players."
+	default = "Sorry but the server is currently not accepting connections from never before seen players."
 
 /datum/config_entry/number/notify_new_player_age // how long do we notify admins of a new player
 	min_val = -1
@@ -348,23 +348,23 @@
 	return str_val != "ch@nge.me" && ..()
 
 /datum/config_entry/number/ipintel_rating_bad
-	config_entry_value = 1
+	default = 1
 	integer = FALSE
 	min_val = 0
 	max_val = 1
 
 /datum/config_entry/number/ipintel_save_good
-	config_entry_value = 12
+	default = 12
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/ipintel_save_bad
-	config_entry_value = 1
+	default = 1
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/string/ipintel_domain
-	config_entry_value = "check.getipintel.net"
+	default = "check.getipintel.net"
 
 /datum/config_entry/flag/aggressive_changelog
 
@@ -388,55 +388,55 @@
 /datum/config_entry/flag/preference_map_voting
 
 /datum/config_entry/number/client_warn_version
-	config_entry_value = null
+	default = null
 	min_val = 500
 
 /datum/config_entry/string/client_warn_message
-	config_entry_value = "Your version of byond may have issues or be blocked from accessing this server in the future."
+	default = "Your version of byond may have issues or be blocked from accessing this server in the future."
 
 /datum/config_entry/flag/client_warn_popup
 
 /datum/config_entry/number/client_error_version
-	config_entry_value = null
+	default = null
 	min_val = 500
 
 /datum/config_entry/string/client_error_message
-	config_entry_value = "Your version of byond is too old, may have issues, and is blocked from accessing this server."
+	default = "Your version of byond is too old, may have issues, and is blocked from accessing this server."
 
 /datum/config_entry/number/client_error_build
-	config_entry_value = null
+	default = null
 	min_val = 0
 
 /datum/config_entry/number/minute_topic_limit
-	config_entry_value = null
+	default = null
 	min_val = 0
 
 /datum/config_entry/number/second_topic_limit
-	config_entry_value = null
+	default = null
 	min_val = 0
 
 /datum/config_entry/number/minute_click_limit
-	config_entry_value = 400
+	default = 400
 	min_val = 0
 
 /datum/config_entry/number/second_click_limit
-	config_entry_value = 15
+	default = 15
 	min_val = 0
 
 /datum/config_entry/number/error_cooldown // The "cooldown" time for each occurrence of a unique error
-	config_entry_value = 600
+	default = 600
 	integer = FALSE
 	min_val = 0
 
 /datum/config_entry/number/error_limit // How many occurrences before the next will silence them
-	config_entry_value = 50
+	default = 50
 
 /datum/config_entry/number/error_silence_time // How long a unique error will be silenced for
-	config_entry_value = 6000
+	default = 6000
 	integer = FALSE
 
 /datum/config_entry/number/error_msg_delay // How long to wait between messaging admins about occurrences of a unique error
-	config_entry_value = 50
+	default = 50
 	integer = FALSE
 
 /datum/config_entry/flag/irc_announce_new_game
@@ -446,26 +446,26 @@
 	return "" //default broadcast
 
 /datum/config_entry/string/chat_announce_new_game
-	config_entry_value = null
+	default = null
 
 /datum/config_entry/string/chat_new_game_notifications
-	config_entry_value = null
+	default = null
 
 /datum/config_entry/flag/debug_admin_hrefs
 
 /datum/config_entry/number/mc_tick_rate/base_mc_tick_rate
 	integer = FALSE
-	config_entry_value = 1
+	default = 1
 
 /datum/config_entry/number/mc_tick_rate/high_pop_mc_tick_rate
 	integer = FALSE
-	config_entry_value = 1.1
+	default = 1.1
 
 /datum/config_entry/number/mc_tick_rate/high_pop_mc_mode_amount
-	config_entry_value = 65
+	default = 65
 
 /datum/config_entry/number/mc_tick_rate/disable_high_pop_mc_mode_amount
-	config_entry_value = 60
+	default = 60
 
 /datum/config_entry/number/mc_tick_rate
 	abstract_type = /datum/config_entry/number/mc_tick_rate
@@ -483,14 +483,14 @@
 		world.sleep_offline = !config_entry_value
 
 /datum/config_entry/number/rounds_until_hard_restart
-	config_entry_value = -1
+	default = -1
 	min_val = 0
 
 /datum/config_entry/string/default_view
-	config_entry_value = "15x15"
+	default = "15x15"
 
 /datum/config_entry/string/default_view_square
-	config_entry_value = "15x15"
+	default = "15x15"
 
 /datum/config_entry/flag/log_pictures
 
@@ -518,8 +518,8 @@
 /datum/config_entry/number/hard_deletes_overrun_threshold
 	integer = FALSE
 	min_val = 0
-	config_entry_value = 0.5
+	default = 0.5
 
 /datum/config_entry/number/hard_deletes_overrun_limit
-	config_entry_value = 0
+	default = 0
 	min_val = 0

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -65,11 +65,11 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 		configured_error_silence_time = CONFIG_GET(number/error_silence_time)
 	else
 		var/datum/config_entry/CE = /datum/config_entry/number/error_cooldown
-		configured_error_cooldown = initial(CE.config_entry_value)
+		configured_error_cooldown = initial(CE.default)
 		CE = /datum/config_entry/number/error_limit
-		configured_error_limit = initial(CE.config_entry_value)
+		configured_error_limit = initial(CE.default)
 		CE = /datum/config_entry/number/error_silence_time
-		configured_error_silence_time = initial(CE.config_entry_value)
+		configured_error_silence_time = initial(CE.default)
 
 
 	//Each occurence of a unique error adds to its cooldown time...

--- a/code/modules/error_handler/error_viewer.dm
+++ b/code/modules/error_handler/error_viewer.dm
@@ -122,7 +122,7 @@ GLOBAL_DATUM(error_cache, /datum/error_viewer/error_cache)
 			err_msg_delay = CONFIG_GET(number/error_msg_delay)
 		else
 			var/datum/config_entry/CE = /datum/config_entry/number/error_msg_delay
-			err_msg_delay = initial(CE.config_entry_value)
+			err_msg_delay = initial(CE.default)
 		error_source.next_message_at = world.time + err_msg_delay
 
 /datum/error_viewer/error_source


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

i added this so that the value of ``INTERVIEW_QUESTIONS`` (and subsequently any other string list) can be overridden without much issue by additional config files.

i also changed the functionality of ``default`` on ``config_entry`` as it seemed to be counterintuitive to have it be set to the initial value of the ``config_entry``. in my opinion this should be a compile-time default, and so i've refactored the code such that ``default`` now contains the actual default, and the ``config_entry_value`` is set at intialization.

![Code_2021-06-28_17-58-31](https://user-images.githubusercontent.com/10467687/123703433-be756700-d83a-11eb-93da-02318d81f5bc.png)
![dreamseeker_2021-06-28_17-58-24](https://user-images.githubusercontent.com/10467687/123703439-bf0dfd80-d83a-11eb-99b4-d20e12cd0a42.png)

noting the var edit protection works
![notepad_2021-06-28_18-00-00](https://user-images.githubusercontent.com/10467687/123703443-c0d7c100-d83a-11eb-935f-45daf786787e.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

lets you override config values that are additive

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
server: Added the $reset directive to reset a configuration entry's values to its default
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
