### PR TITLE
Add new Wallets! station trait

### DIFF
--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -27,6 +27,12 @@ PROCESSING_SUBSYSTEM_DEF(station)
 /datum/controller/subsystem/processing/station/proc/SetupTraits()
 	for(var/i in subtypesof(/datum/station_trait))
 		var/datum/station_trait/trait_typepath = i
+
+		// If forced, (probably debugging), just set it up now, keep it out of the pool.
+		if(initial(trait_typepath.force))
+			setup_trait(trait_typepath)
+			continue
+
 		if(initial(trait_typepath.trait_flags) & STATION_TRAIT_ABSTRACT)
 			continue //Dont add abstract ones to it
 		selectable_traits_by_types[initial(trait_typepath.trait_type)][trait_typepath] = initial(trait_typepath.weight)
@@ -40,15 +46,19 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	pick_traits(STATION_TRAIT_NEGATIVE, negative_trait_count)
 
 ///Picks traits of a specific category (e.g. bad or good) and a specified amount, then initializes them and adds them to the list of traits.
-/datum/controller/subsystem/processing/station/proc/pick_traits(trait_type, amount)
+/datum/controller/subsystem/processing/station/proc/pick_traits(trait_sign, amount)
 	if(!amount)
 		return
 	for(var/iterator in 1 to amount)
-		var/datum/station_trait/picked_trait = pickweight(selectable_traits_by_types[trait_type]) //Rolls from the table for the specific trait type
-		picked_trait = new picked_trait()
-		station_traits += picked_trait
-		if(!picked_trait.blacklist)
-			continue
-		for(var/i in picked_trait.blacklist)
-			var/datum/station_trait/trait_to_remove = i
-			selectable_traits_by_types[initial(trait_to_remove.trait_type)] -= trait_to_remove
+		var/datum/station_trait/trait_type = pickweight(selectable_traits_by_types[trait_sign]) //Rolls from the table for the specific trait type
+		setup_trait(trait_type)
+
+///Creates a given trait of a specific type, while also removing any blacklisted ones from the future pool.
+/datum/controller/subsystem/processing/station/proc/setup_trait(datum/station_trait/trait_type)
+	var/datum/station_trait/trait_instance = new trait_type()
+	station_traits += trait_instance
+	if(!trait_instance.blacklist)
+		return
+	for(var/i in trait_instance.blacklist)
+		var/datum/station_trait/trait_to_remove = i
+		selectable_traits_by_types[initial(trait_to_remove.trait_type)] -= trait_to_remove

--- a/code/datums/station_traits/_station_trait.dm
+++ b/code/datums/station_traits/_station_trait.dm
@@ -8,6 +8,8 @@
 	var/trait_processes = FALSE
 	///Chance relative to other traits of its type to be picked
 	var/weight = 10
+	///Whether this trait is always enabled; generally used for debugging
+	var/force = FALSE
 	///Does this trait show in the centcom report?
 	var/show_in_report = FALSE
 	///What message to show in the centcom report?

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -217,3 +217,43 @@
 	var/obj/item/implant/deathrattle/implant_to_give = new()
 	deathrattle_group.register(implant_to_give)
 	implant_to_give.implant(living_mob, living_mob, TRUE, TRUE)
+
+
+/datum/station_trait/wallets
+	name = "Wallets!"
+	trait_type = STATION_TRAIT_POSITIVE
+	show_in_report = TRUE
+	weight = 10
+	report_message = "It has become temporarily fashionable to use a wallet, so everyone on the station has been issued one."
+
+/datum/station_trait/wallets/New()
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, .proc/on_job_after_spawn)
+
+/datum/station_trait/wallets/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/living_mob, mob/M, joined_late)
+	SIGNAL_HANDLER
+
+	var/obj/item/card/id/advanced/id_card = living_mob.get_item_by_slot(ITEM_SLOT_ID)
+	if(!istype(id_card))
+		return
+
+	living_mob.temporarilyRemoveItemFromInventory(id_card, force=TRUE)
+
+	// "Doc, what's wrong with me?"
+	var/obj/item/storage/wallet/wallet = new(src)
+	// "You've got a wallet embedded in your chest."
+	wallet.add_fingerprint(living_mob, ignoregloves = TRUE)
+
+	living_mob.equip_to_slot_if_possible(wallet, ITEM_SLOT_ID, initial=TRUE)
+
+	id_card.forceMove(wallet)
+
+	var/holochip_amount = id_card.registered_account.account_balance
+	new /obj/item/holochip(wallet, holochip_amount)
+	id_card.registered_account.adjust_money(-holochip_amount)
+
+	new /obj/effect/spawner/lootdrop/wallet_loot(wallet)
+
+	// Put our filthy fingerprints all over the contents
+	for(var/obj/item/item as anything in wallet.contents)
+		item.add_fingerprint(living_mob, ignoregloves = TRUE)

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -255,5 +255,5 @@
 	new /obj/effect/spawner/lootdrop/wallet_loot(wallet)
 
 	// Put our filthy fingerprints all over the contents
-	for(var/obj/item/item as anything in wallet.contents)
+	for(var/obj/item/item in wallet)
 		item.add_fingerprint(living_mob, ignoregloves = TRUE)

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -743,3 +743,105 @@
 	/obj/item/phone = 5,
 	/obj/item/flashlight/lamp/bananalamp = 3
 	)
+
+/obj/effect/spawner/lootdrop/wallet_loot
+	lootcount = 1
+	loot = list(
+		list(
+			// Same weights as contraband loot cigarettes (with no packs)
+			/obj/item/clothing/mask/cigarette/space_cigarette = 4,
+			/obj/item/clothing/mask/cigarette/robust = 2,
+			/obj/item/clothing/mask/cigarette/carp = 3,
+			/obj/item/clothing/mask/cigarette/uplift = 2,
+			/obj/item/clothing/mask/cigarette/dromedary = 3,
+			/obj/item/clothing/mask/cigarette/robustgold = 1,
+			/obj/item/clothing/mask/cigarette/rollie/cannabis = 4,
+		) = 1,
+		list(
+			/obj/item/flashlight/pen = 90,
+			/obj/item/flashlight/pen/paramedic = 10,
+		) = 1,
+		list( // The same seeds in the Supply "Seeds Crate"
+			/obj/item/seeds/chili = 1,
+			/obj/item/seeds/cotton = 1,
+			/obj/item/seeds/berry = 1,
+			/obj/item/seeds/corn = 1,
+			/obj/item/seeds/eggplant = 1,
+			/obj/item/seeds/tomato = 1,
+			/obj/item/seeds/soya = 1,
+			/obj/item/seeds/wheat = 1,
+			/obj/item/seeds/wheat/rice = 1,
+			/obj/item/seeds/carrot = 1,
+			/obj/item/seeds/sunflower = 1,
+			/obj/item/seeds/rose = 1,
+			/obj/item/seeds/chanter = 1,
+			/obj/item/seeds/potato = 1,
+			/obj/item/seeds/sugarcane = 1,
+		) = 1,
+		list(
+			/obj/item/stack/medical/suture = 1,
+			/obj/item/stack/medical/mesh = 1,
+			/obj/item/stack/medical/gauze = 1,
+		) = 1,
+		list(
+			/obj/item/toy/crayon/red = 1,
+			/obj/item/toy/crayon/orange = 1,
+			/obj/item/toy/crayon/yellow = 1,
+			/obj/item/toy/crayon/green = 1,
+			/obj/item/toy/crayon/blue = 1,
+			/obj/item/toy/crayon/purple = 1,
+			/obj/item/toy/crayon/black = 1,
+			/obj/item/toy/crayon/rainbow = 1,
+		) = 1,
+		list(
+			/obj/item/coin/iron = 1,
+			/obj/item/coin/silver = 1,
+			/obj/item/coin/diamond = 1,
+			/obj/item/coin/plasma = 1,
+			/obj/item/coin/uranium = 1,
+			/obj/item/coin/titanium = 1,
+			/obj/item/coin/bananium = 1,
+			/obj/item/coin/adamantine = 1,
+			/obj/item/coin/mythril = 1,
+			/obj/item/coin/plastic = 1,
+			/obj/item/coin/runite = 1,
+			/obj/item/coin/twoheaded = 1,
+			/obj/item/coin/antagtoken = 1,
+		) = 1,
+		list(
+			/obj/item/dice/d4 = 1,
+			/obj/item/dice/d6 = 1,
+			/obj/item/dice/d8 = 1,
+			/obj/item/dice/d10 = 1,
+			/obj/item/dice/d12 = 1,
+			/obj/item/dice/d20 = 1,
+		) = 1,
+		list(
+			/obj/item/disk/data = 99,
+			/obj/item/disk/nuclear/fake/obvious = 1,
+		) = 1,
+		/obj/item/implanter = 1,
+		list(
+			/obj/item/lighter = 25,
+			/obj/item/lighter/greyscale = 75,
+		) = 1,
+		/obj/item/lipstick/random = 1,
+		/obj/item/match = 1,
+		/obj/item/paper/pamphlet/gateway = 1,
+		list(
+			/obj/item/pen = 1,
+			/obj/item/pen/blue = 1,
+			/obj/item/pen/red = 1,
+			/obj/item/pen/fourcolor = 1,
+			/obj/item/pen/fountain = 1,
+		) = 1,
+		// random photos would go here. IF I HAD ONE. :'(
+		/obj/item/reagent_containers/dropper = 1,
+		/obj/item/reagent_containers/syringe = 1,
+		/obj/item/reagent_containers/pill/maintenance = 1,
+		/obj/item/screwdriver = 1,
+		list(
+			/obj/item/stamp = 50,
+			/obj/item/stamp/denied = 50,
+		) = 1,
+	)

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -36,6 +36,7 @@
 		/obj/item/photo,
 		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/pill,
 		/obj/item/screwdriver,
 		/obj/item/stamp),
 		list(/obj/item/screwdriver/power))
@@ -100,6 +101,7 @@
 	cached_flat_icon = null
 	if(!front_id)
 		return
+	COMPILE_OVERLAYS(front_id)
 	. += mutable_appearance(front_id.icon, front_id.icon_state)
 	. += front_id.overlays
 	. += mutable_appearance(icon, "wallet_overlay")
@@ -155,8 +157,12 @@
 		return ..()
 
 /obj/item/storage/wallet/random
-	icon_state = "random_wallet"
+	icon_state = "random_wallet" // for mapping purposes
+
+/obj/item/storage/wallet/random/Initialize()
+	. = ..()
+	icon_state = "wallet"
 
 /obj/item/storage/wallet/random/PopulateContents()
-	new /obj/item/holochip(src, rand(5,30))
-	icon_state = "wallet"
+	new /obj/item/holochip(src, rand(5, 30))
+	new /obj/effect/spawner/lootdrop/wallet_loot(src)


### PR DESCRIPTION
> Add a new simple station trait, that replaces everyone's ID with a
> wallet containing said ID, as well as their starting money, and if
> they're lucky, a little bonus surprise.
> 
> - In addition, adds a `force` variable to station traits, which will
>   always enable them, rather than having to edit weight and probability
>   of rolling a trait of that sign (postive, negative).

---

## Why It's Good For The Game

1. It's a small station trait to surprise people occasionally, but doesn't drastically change the round.
2. It provides camoflague for antagonists who want to use wallets to store multiple IDs.

## Changelog
:cl: coiax, Timberpoes
expansion: Adds the new Wallets! station trait. Makes everyone start with wallets with
their ID card inside, along with their starting budget. Might also include a little
surprise.
expansion: Wallets that spawn inside dorm wardrobes also have little surprises in them.
expansion: Wallets can now hold pills.
/:cl:

---

- [x] Work out why people are spawning with no ID card at all