### PR TITLE
MetaMaint Chems Nerf or Nothing

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -11842,9 +11842,10 @@
 "ckz" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
-/obj/item/clothing/mask/cigarette/carp{
-	pixel_x = 6;
-	pixel_y = 13
+/obj/item/clothing/mask/cigarette/rollie/nicotine{
+	name = "Hal's Custom";
+	pixel_x = 7;
+	pixel_y = 14
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
@@ -12023,7 +12024,7 @@
 /area/maintenance/starboard/secondary)
 "cmb" = (
 /obj/structure/frame/machine,
-/obj/item/circuitboard/machine/chem_dispenser,
+/obj/item/circuitboard/machine/chem_master,
 /turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/secondary)
 "cmd" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2433,7 +2433,12 @@
 /obj/machinery/reagentgrinder{
 	pixel_y = 4
 	},
-/turf/open/floor/plating,
+/obj/item/reagent_containers/pill/morphine{
+	name = "Exponential Entrophy";
+	pixel_x = -9;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/secondary)
 "ari" = (
 /obj/machinery/camera{
@@ -11832,11 +11837,15 @@
 	pixel_y = 28
 	},
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
-/turf/open/floor/plating,
+/turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/secondary)
 "ckz" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
+/obj/item/clothing/mask/cigarette/carp{
+	pixel_x = 6;
+	pixel_y = 13
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "ckE" = (
@@ -12010,13 +12019,12 @@
 /obj/structure/rack,
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/suit/apron/chef,
-/turf/open/floor/plating,
+/turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/secondary)
 "cmb" = (
-/obj/machinery/chem_master{
-	pixel_x = -4
-	},
-/turf/open/floor/plating,
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/chem_dispenser,
+/turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/secondary)
 "cmd" = (
 /obj/effect/mapping_helpers/airlock/locked,
@@ -12102,7 +12110,7 @@
 /obj/item/clothing/head/soft/mime,
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/mask/surgical,
-/turf/open/floor/plating,
+/turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/secondary)
 "cnb" = (
 /turf/open/floor/plating{
@@ -12483,7 +12491,8 @@
 /obj/item/stack/medical/suture,
 /obj/item/stack/medical/mesh,
 /obj/item/clothing/glasses/hud/health,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/secondary)
 "cpN" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -12591,9 +12600,19 @@
 /area/maintenance/starboard/secondary)
 "crb" = (
 /obj/structure/bed,
-/obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/secondary)
 "crc" = (
 /obj/structure/lattice,
@@ -12723,7 +12742,7 @@
 /obj/structure/rack,
 /obj/item/hatchet,
 /obj/item/reagent_containers/blood/random,
-/turf/open/floor/plating,
+/turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/secondary)
 "csc" = (
 /obj/machinery/iv_drip,
@@ -12734,7 +12753,17 @@
 /obj/structure/rack,
 /obj/item/tank/internals/anesthetic,
 /obj/item/clothing/mask/gas,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/secondary)
 "csf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -13113,6 +13142,12 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/command/gateway)
+"cwG" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard/secondary)
 "cwM" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1;
@@ -16916,6 +16951,12 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"dny" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard/secondary)
 "dnz" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -30325,6 +30366,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
+"hPn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard/secondary)
 "hPw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -34789,7 +34843,8 @@
 /area/service/library)
 "jtQ" = (
 /obj/structure/chair/stool/directional/west,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/iron/showroomfloor,
 /area/maintenance/starboard/secondary)
 "jtY" = (
 /obj/structure/cable,
@@ -42972,6 +43027,9 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/fore)
+"mhf" = (
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard/secondary)
 "mhh" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/machinery/door/window{
@@ -53709,12 +53767,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
-"pBL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/secondary)
 "pBO" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -54410,6 +54462,14 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/science/xenobiology)
+"pPA" = (
+/obj/machinery/iv_drip,
+/obj/item/roller,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/maintenance/starboard/secondary)
 "pPQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -60516,7 +60576,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "rPx" = (
-/obj/machinery/chem_heater/withbuffer,
+/obj/machinery/space_heater/improvised_chem_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "rPP" = (
@@ -116881,8 +116941,8 @@ cku
 shM
 cmY
 ovj
-pBL
-pBL
+ovj
+ovj
 ovj
 dwL
 ctL
@@ -117653,7 +117713,7 @@ cma
 cna
 cos
 dxh
-shM
+hPn
 crZ
 ctL
 bmT
@@ -118422,7 +118482,7 @@ ozE
 ckz
 nbv
 dwY
-nbv
+mhf
 nbv
 rYC
 csc
@@ -118678,11 +118738,11 @@ xaY
 ozE
 aqe
 jtQ
-cnb
+dny
 cou
 cpK
-nbv
-csc
+cwG
+pPA
 dwL
 ctL
 ctL


### PR DESCRIPTION
I've been asked by @EOBGames to downgrade the chemistry setup in Metastation's Abandoned Medbay.

## Changelog
:cl:
qol: There's some eye candy in the Abandoned Medbay that now suggests that it was at some point a medbay. 
balance: Downgrades the Chem Dispenser and Heater to their Ghetto Counterparts
/:cl: