### PR TITLE
Fixes relic war hammer typepath

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -561,7 +561,7 @@
 	tool_behaviour = TOOL_SAW
 	toolspeed = 0.5 //faster than normal saw
 
-/obj/item/nullrod/hammmer
+/obj/item/nullrod/hammer
 	name = "relic war hammer"
 	desc = "This war hammer cost the chaplain forty thousand space dollars."
 	icon_state = "hammeron"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR fixes a typepath mismatch - `/obj/item/nullrod/hammmer` and `/obj/item/nullrod/hammer`, which are supposed to be one item. This mismatch caused relic war hammer not to be able to do kneejerk action, and it also meant that one duplicate nullrod item was showing in the radial menu for the null rod reskin variant selection.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugfixes.

## Changelog
:cl: Arkatos
fix: Fixed a case where a relic war hammer was not able to do kneejerk action.
fix: Fixed a case where a radial menu for the null rod reskin variant selection was showing one duplicate option.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
