### PR TITLE
Adds verification for reference layers to check if target config has the desired icon_state

### DIFF
--- a/code/controllers/subsystem/greyscale.dm
+++ b/code/controllers/subsystem/greyscale.dm
@@ -20,6 +20,12 @@ SUBSYSTEM_DEF(greyscale)
 		var/datum/greyscale_config/config = configurations[greyscale_type]
 		config.Refresh()
 
+	// This final verification step is for things that need other greyscale configurations to be finished loading
+	for(var/greyscale_type as anything in configurations)
+		CHECK_TICK
+		var/datum/greyscale_config/config = configurations[greyscale_type]
+		config.CrossVerify()
+
 	return ..()
 
 /datum/controller/subsystem/greyscale/proc/RefreshConfigsFromFile()

--- a/code/datums/greyscale/_greyscale_config.dm
+++ b/code/datums/greyscale/_greyscale_config.dm
@@ -51,6 +51,7 @@
 	if(!name)
 		stack_trace("Greyscale config object [DebugName()] is missing a name, make sure `name` has been assigned a value.")
 
+/// Call this proc to handle all the data extraction from the json configuration. Can be forced to load values from disk instead of memory.
 /datum/greyscale_config/proc/Refresh(loadFromDisk=FALSE)
 	if(loadFromDisk)
 		json_config = file(string_json_config)
@@ -66,12 +67,25 @@
 
 	ReadMetadata()
 
+/// Called after every config has refreshed, this proc handles data verification that depends on multiple entwined configurations.
+/datum/greyscale_config/proc/CrossVerify()
+	for(var/icon_state in icon_states)
+		var/list/verification_targets = icon_states[icon_state]
+		verification_targets = verification_targets.Copy()
+		while(length(verification_targets))
+			var/datum/greyscale_layer/layer = verification_targets[length(verification_targets)]
+			verification_targets.len--
+			if(islist(layer))
+				verification_targets += layer
+				continue
+			layer.CrossVerify()
+
 /// Gets the name used for debug purposes
 /datum/greyscale_config/proc/DebugName()
 	var/display_name = name || "MISSING_NAME"
 	return "[display_name] ([icon_file]|[json_config])"
 
-/// Takes the json icon state configuration and puts it into a more processed format
+/// Takes the json icon state configuration and puts it into a more processed format.
 /datum/greyscale_config/proc/ReadIconStateConfiguration(list/data)
 	icon_states = list()
 	for(var/state in data)

--- a/code/datums/greyscale/json_configs/items/cleric_mace_worn_gold.json
+++ b/code/datums/greyscale/json_configs/items/cleric_mace_worn_gold.json
@@ -3,6 +3,7 @@
 		{
 			"type": "reference",
 			"reference_type": "/datum/greyscale_config/cleric_mace_worn",
+			"icon_state": "default",
 			"blend_mode": "overlay",
 			"color_ids": [ 1 ]
 		},

--- a/code/datums/greyscale/layer.dm
+++ b/code/datums/greyscale/layer.dm
@@ -56,6 +56,10 @@
 	optional_values[NAMEOF(src, color_ids)] = /datum/json_reader/number_color_list
 	required_values[NAMEOF(src, blend_mode)] = /datum/json_reader/blend_mode
 
+/// Use this proc for extra verification needed by a particular layer, gets run after all greyscale configs have finished reading their json files.
+/datum/greyscale_layer/proc/CrossVerify()
+	return
+
 /// Used to actualy create the layer using the given colors
 /// Do not override, use InternalGenerate instead
 /datum/greyscale_layer/proc/Generate(list/colors, list/render_steps)
@@ -112,6 +116,11 @@
 	. = ..()
 	optional_values[NAMEOF(src, icon_state)] = /datum/json_reader/text
 	required_values[NAMEOF(src, reference_type)] = /datum/json_reader/greyscale_config
+
+/datum/greyscale_layer/reference/CrossVerify()
+	. = ..()
+	if(!reference_type.icon_states[icon_state])
+		CRASH("[src] expects icon_state '[icon_state]' but referenced configuration '[reference_type]' does not have it.")
 
 /datum/greyscale_layer/reference/InternalGenerate(list/colors, list/render_steps)
 	if(render_steps)

--- a/code/datums/greyscale/layer.dm
+++ b/code/datums/greyscale/layer.dm
@@ -109,7 +109,7 @@
 /// A layer created by using another greyscale icon's configuration
 /datum/greyscale_layer/reference
 	layer_type = "reference"
-	var/icon_state
+	var/icon_state = ""
 	var/datum/greyscale_config/reference_type
 
 /datum/greyscale_layer/reference/GetExpectedValues(list/required_values, list/optional_values)


### PR DESCRIPTION
This should deal with an assortment of gags sprites using reference layers with no icon_state specified. This is fine normally but it was defaulting to null instead of blank string.

First commit fails intentionally to show the added test working.

fixes #59298

## Changelog
:cl:
fix: Some greyscale icons like the sombrero have had their errors fixed.
/:cl:
