### PR TITLE
Sink frames are now deconstructable

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -467,6 +467,8 @@
 	desc = "A sink frame, that needs a water recycler to finish construction."
 	anchored = FALSE
 	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
+	var/buildstacktype = null
+	var/buildstackamount = 1
 
 /obj/structure/sinkframe/ComponentInitialize()
 	. = ..()
@@ -486,7 +488,25 @@
 		new_sink.setDir(dir)
 		qdel(src)
 		return
+	if(I.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1))
+		I.play_tool_sound(src)
+		deconstruct()
+		return
+
 	return ..()
+
+/obj/structure/sinkframe/deconstruct()
+	if(!(flags_1 & NODECONSTRUCT_1))
+		drop_materials()
+	..()
+
+/obj/structure/sinkframe/proc/drop_materials()
+	if(buildstacktype)
+		new buildstacktype(loc,buildstackamount)
+	else
+		for(var/i in custom_materials)
+			var/datum/material/M = i
+			new M.sheet_type(loc, FLOOR(custom_materials[M] / MINERAL_MATERIAL_AMOUNT, 1))
 
 //Water source, use the type water_source for unlimited water sources like classic sinks.
 /obj/structure/water_source

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -500,8 +500,8 @@
 	return ..()
 
 /obj/structure/sinkframe/proc/drop_materials()
-	for(var/datum/material/mat as anything in custom_materials)
-		new mat.sheet_type(loc, FLOOR(custom_materials[mat] / MINERAL_MATERIAL_AMOUNT, 1))
+	for(var/datum/material/material as anything in custom_materials)
+		new material.sheet_type(loc, FLOOR(custom_materials[material] / MINERAL_MATERIAL_AMOUNT, 1))
 	return
 
 //Water source, use the type water_source for unlimited water sources like classic sinks.

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -467,8 +467,6 @@
 	desc = "A sink frame, that needs a water recycler to finish construction."
 	anchored = FALSE
 	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
-	var/buildstacktype = null
-	var/buildstackamount = 1
 
 /obj/structure/sinkframe/ComponentInitialize()
 	. = ..()
@@ -488,7 +486,7 @@
 		new_sink.setDir(dir)
 		qdel(src)
 		return
-	if(I.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1))
+	if(I.tool_behaviour == TOOL_WRENCH && !(flags_1 & NODECONSTRUCT_1))
 		I.play_tool_sound(src)
 		deconstruct()
 		return
@@ -501,12 +499,8 @@
 	..()
 
 /obj/structure/sinkframe/proc/drop_materials()
-	if(buildstacktype)
-		new buildstacktype(loc,buildstackamount)
-	else
-		for(var/i in custom_materials)
-			var/datum/material/M = i
-			new M.sheet_type(loc, FLOOR(custom_materials[M] / MINERAL_MATERIAL_AMOUNT, 1))
+	for(var/datum/material/mat in custom_materials)
+		new mat.sheet_type(loc, FLOOR(custom_materials[mat] / MINERAL_MATERIAL_AMOUNT, 1))
 
 //Water source, use the type water_source for unlimited water sources like classic sinks.
 /obj/structure/water_source

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -486,21 +486,23 @@
 		new_sink.setDir(dir)
 		qdel(src)
 		return
-	if(I.tool_behaviour == TOOL_WRENCH && !(flags_1 & NODECONSTRUCT_1))
-		I.play_tool_sound(src)
-		deconstruct()
-		return
-
 	return ..()
+
+/obj/structure/sinkframe/wrench_act_secondary(mob/living/user, obj/item/tool)
+	. = ..()
+	tool.play_tool_sound(src)
+	deconstruct()
+	return TRUE
 
 /obj/structure/sinkframe/deconstruct()
 	if(!(flags_1 & NODECONSTRUCT_1))
 		drop_materials()
-	..()
+	return ..()
 
 /obj/structure/sinkframe/proc/drop_materials()
-	for(var/datum/material/mat in custom_materials)
+	for(var/datum/material/mat as anything in custom_materials)
 		new mat.sheet_type(loc, FLOOR(custom_materials[mat] / MINERAL_MATERIAL_AMOUNT, 1))
+	return
 
 //Water source, use the type water_source for unlimited water sources like classic sinks.
 /obj/structure/water_source


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> Previously sink frames were not deconstructable and had to be bashed until broken if you wanted to remove them.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
1. Cover the station in bananium sink frames
2. Laugh as crew are forced to slip or break each individual sink

## Changelog
:cl: aaaa1023

fix: Sink frames are now deconstructable with a wrench.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
