### PR TITLE
Null rod radial menu update

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -848,7 +848,7 @@
 	attack_verb_continuous = list("pulses", "mends", "cuts")
 	attack_verb_simple = list("pulse", "mend", "cut")
 	hitsound = 'sound/effects/sparks4.ogg'
-	menu_description = "A tool dealing a brain damage which partially penetrates armor. Fits in pockets. Can be worn on the belt."
+	menu_description = "A tool dealing brain damage which partially penetrates armor. Fits in pockets. Can be worn on the belt."
 
 /obj/item/nullrod/spear
 	name = "ancient spear"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -526,7 +526,7 @@
 	attack_verb_continuous = list("chops", "slices", "cuts")
 	attack_verb_simple= list("chop", "slice", "cut")
 	hitsound = 'sound/weapons/rapierhit.ogg'
-	menu_description = "A sharp blade which partially penetrates armor. Able to awaken a friendly spirit providing guidance. Very effective at butchering bodies. Can be worn on the back."
+	menu_description = "A sharp blade which partially penetrates armor. Able to awaken a friendly spirit to provide guidance. Very effective at butchering bodies. Can be worn on the back."
 	/// If there is a ghost possessing the item
 	var/possessed = FALSE
 

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -698,7 +698,7 @@
 	sharpness = SHARP_EDGED
 	attack_verb_continuous = list("enlightens", "redpills")
 	attack_verb_simple = list("enlighten", "redpill")
-	menu_description = "A sharp fedora dealing a very high amount of throw damage, but none of melee. Can be worn on the head, obviously."
+	menu_description = "A sharp fedora dealing a very high amount of throw damage, but none of melee. Fits in pockets. Can be worn on the head, obviously."
 
 /obj/item/nullrod/armblade
 	name = "dark blessing"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -232,7 +232,7 @@
 	/// If this item can be used in a reskin variant selection
 	var/chaplain_spawnable = TRUE
 	/// Short description of what this item is capable of, for radial menu uses
-	var/menu_description = "A classic chaplain weapon dealing a decent amount of damage. Fits in pockets. Can be worn on the belt."
+	var/menu_description = "A standard chaplain's weapon. Fits in pockets. Can be worn on the belt."
 
 /obj/item/nullrod/Initialize()
 	. = ..()
@@ -311,19 +311,19 @@
 	damtype = BURN
 	attack_verb_continuous = list("punches", "cross counters", "pummels")
 	attack_verb_simple = list("punch", "cross counter", "pummel")
-	menu_description = "An undroppable hand dealing a decent amount of burn damage. Disappears if the arm holding it is cut off."
+	menu_description = "An undroppable god hand dealing a burn damage. Disappears if the arm holding it is cut off."
 
 /obj/item/nullrod/godhand/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
 
 /obj/item/nullrod/staff
+	name = "red holy staff"
+	desc = "It has a mysterious, protective aura."
 	icon_state = "godstaff-red"
 	inhand_icon_state = "godstaff-red"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
-	name = "red holy staff"
-	desc = "It has a mysterious, protective aura."
 	w_class = WEIGHT_CLASS_HUGE
 	force = 5
 	slot_flags = ITEM_SLOT_BACK
@@ -359,7 +359,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
-	menu_description = "A sharp claymore which provides a low chance of blocking incoming melee attacks and deals a decent amount of damage. Can be worn on the back or belt."
+	menu_description = "A sharp claymore which provides a low chance of blocking incoming melee attacks. Can be worn on the back or belt."
 
 /obj/item/nullrod/claymore/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(attack_type == PROJECTILE_ATTACK)
@@ -377,7 +377,7 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	hitsound = 'sound/hallucinations/growl1.ogg'
-	menu_description = "A sharp blade which provides a low chance of blocking incoming melee attacks and deals a decent amount of damage. Can be worn on the back or belt."
+	menu_description = "A sharp blade which provides a low chance of blocking incoming melee attacks. Can be worn on the back or belt."
 
 /obj/item/nullrod/claymore/chainsaw_sword
 	name = "sacred chainsaw sword"
@@ -391,7 +391,7 @@
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 	tool_behaviour = TOOL_SAW
 	toolspeed = 1.5 //slower than a real saw
-	menu_description = "A sharp chainsaw sword which provides a low chance of blocking incoming melee attacks and deals a decent amount of damage. Can be used as a slower saw tool. Can be worn on the belt."
+	menu_description = "A sharp chainsaw sword which provides a low chance of blocking incoming melee attacks. Can be used as a slower saw tool. Can be worn on the belt."
 
 /obj/item/nullrod/claymore/glowing
 	name = "force weapon"
@@ -399,7 +399,7 @@
 	icon_state = "swordon"
 	inhand_icon_state = "swordon"
 	worn_icon_state = "swordon"
-	menu_description = "A sharp weapon which provides a low chance of blocking incoming melee attacks and deals a decent amount of damage. Can be worn on the back or belt."
+	menu_description = "A sharp weapon which provides a low chance of blocking incoming melee attacks. Can be worn on the back or belt."
 
 /obj/item/nullrod/claymore/katana
 	name = "\improper Hanzo steel"
@@ -407,7 +407,7 @@
 	icon_state = "katana"
 	inhand_icon_state = "katana"
 	worn_icon_state = "katana"
-	menu_description = "A sharp katana which provides a low chance of blocking incoming melee attacks and deals a decent amount of damage. Can be worn on the back or belt."
+	menu_description = "A sharp katana which provides a low chance of blocking incoming melee attacks. Can be worn on the back or belt."
 
 /obj/item/nullrod/claymore/multiverse
 	name = "extradimensional blade"
@@ -434,7 +434,7 @@
 	worn_icon_state = "swordblue"
 	slot_flags = ITEM_SLOT_BELT
 	hitsound = 'sound/weapons/blade1.ogg'
-	menu_description = "A sharp energy sword which provides a low chance of blocking incoming melee attacks and deals a decent amount of damage. Can be worn on the belt."
+	menu_description = "A sharp energy sword which provides a low chance of blocking incoming melee attacks. Can be worn on the belt."
 
 /obj/item/nullrod/claymore/saber/red
 	name = "dark energy sword"
@@ -484,7 +484,7 @@
 	sharpness = SHARP_EDGED
 	attack_verb_continuous = list("chops", "slices", "cuts", "reaps")
 	attack_verb_simple = list("chop", "slice", "cut", "reap")
-	menu_description = "A sharp scythe dealing a decent amount of damage which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
+	menu_description = "A sharp scythe which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
 
 /obj/item/nullrod/scythe/Initialize()
 	. = ..()
@@ -501,7 +501,7 @@
 	attack_verb_continuous = list("chops", "slices", "cuts", "zandatsu's")
 	attack_verb_simple = list("chop", "slice", "cut", "zandatsu")
 	hitsound = 'sound/weapons/rapierhit.ogg'
-	menu_description = "A sharp blade dealing a decent amount of damage which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
+	menu_description = "A sharp blade dealing which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
 
 /obj/item/nullrod/scythe/spellblade
 	name = "dormant spellblade"
@@ -513,7 +513,7 @@
 	worn_icon_state = "spellblade"
 	icon = 'icons/obj/guns/magic.dmi'
 	hitsound = 'sound/weapons/rapierhit.ogg'
-	menu_description = "A sharp blade dealing a decent amount of damage which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
+	menu_description = "A sharp blade dealing which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
 
 /obj/item/nullrod/scythe/talking
 	name = "possessed blade"
@@ -526,7 +526,7 @@
 	attack_verb_continuous = list("chops", "slices", "cuts")
 	attack_verb_simple= list("chop", "slice", "cut")
 	hitsound = 'sound/weapons/rapierhit.ogg'
-	menu_description = "A sharp blade dealing a decent amount of damage which partially penetrates armor. Able to awaken a friendly spirit providing guidance. Very effective at butchering bodies. Can be worn on the back."
+	menu_description = "A sharp blade which partially penetrates armor. Able to awaken a friendly spirit providing guidance. Very effective at butchering bodies. Can be worn on the back."
 	/// If there is a ghost possessing the item
 	var/possessed = FALSE
 
@@ -597,7 +597,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb_continuous = list("smashes", "bashes", "hammers", "crunches")
 	attack_verb_simple = list("smash", "bash", "hammer", "crunch")
-	menu_description = "A hammer dealing a decent amount of damage. Capable of tapping knees to measure brain health. Can be worn on the belt."
+	menu_description = "A war hammer. Capable of tapping knees to measure brain health. Can be worn on the belt."
 
 /obj/item/nullrod/hammer/Initialize()
 	. = ..()
@@ -619,7 +619,7 @@
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 	tool_behaviour = TOOL_SAW
 	toolspeed = 2 //slower than a real saw
-	menu_description = "An undroppable sharp hand dealing a decent amount of damage. Can be used as a very slow saw tool. Capable of butchering bodies. Disappears if the arm holding it is cut off."
+	menu_description = "An undroppable sharp chainsaw hand. Can be used as a very slow saw tool. Capable of slowly butchering bodies. Disappears if the arm holding it is cut off."
 
 /obj/item/nullrod/chainsaw/Initialize()
 	. = ..()
@@ -637,7 +637,7 @@
 	sharpness = SHARP_EDGED
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
-	menu_description = "A sharp dagger dealing a decent amount of damage. Fits in pockets. Can be worn on the belt. Honk."
+	menu_description = "A sharp dagger. Fits in pockets. Can be worn on the belt. Honk."
 
 /obj/item/nullrod/pride_hammer
 	name = "Pride-struck Hammer"
@@ -654,7 +654,7 @@
 	attack_verb_continuous = list("attacks", "smashes", "crushes", "splatters", "cracks")
 	attack_verb_simple = list("attack", "smash", "crush", "splatter", "crack")
 	hitsound = 'sound/weapons/blade1.ogg'
-	menu_description = "A hammer dealing a decent amount of damage held back a little by a it's pride. Has a low chance of transferring some of the user's reagents to the target. Capable of tapping knees to measure brain health. Can be worn on the back."
+	menu_description = "A hammer dealing a little less damage due to it's user's pride. Has a low chance of transferring some of the user's reagents to the target. Capable of tapping knees to measure brain health. Can be worn on the back."
 
 /obj/item/nullrod/pride_hammer/Initialize()
 	. = ..()
@@ -682,7 +682,7 @@
 	attack_verb_continuous = list("whips", "lashes")
 	attack_verb_simple = list("whip", "lash")
 	hitsound = 'sound/weapons/chainhit.ogg'
-	menu_description = "A whip dealing a decent amount of damage. Deals extra damage to vampires. Fits in pockets. Can be worn on the belt."
+	menu_description = "A whip. Deals extra damage to vampires. Fits in pockets. Can be worn on the belt."
 
 /obj/item/nullrod/fedora
 	name = "atheist's fedora"
@@ -698,7 +698,7 @@
 	sharpness = SHARP_EDGED
 	attack_verb_continuous = list("enlightens", "redpills")
 	attack_verb_simple = list("enlighten", "redpill")
-	menu_description = "A sharp fedora dealing a very high amount of throw damage. Can also be worn on the head, obviously."
+	menu_description = "A sharp fedora dealing a very high amount of throw damage, but none of melee. Can be worn on the head, obviously."
 
 /obj/item/nullrod/armblade
 	name = "dark blessing"
@@ -714,7 +714,7 @@
 	sharpness = SHARP_EDGED
 	wound_bonus = -20
 	bare_wound_bonus = 25
-	menu_description = "An undroppable sharp armblade dealing a decent amount of damage and inflicting deep wounds. Capable of an ineffective butchering of bodies. Disappears if the arm holding it is cut off."
+	menu_description = "An undroppable sharp armblade capable of inflicting deep wounds. Capable of an ineffective butchering of bodies. Disappears if the arm holding it is cut off."
 
 /obj/item/nullrod/armblade/Initialize()
 	. = ..()
@@ -725,7 +725,7 @@
 	name = "unholy blessing"
 	icon_state = "tentacle"
 	inhand_icon_state = "tentacle"
-	menu_description = "An undroppable sharp tentacle dealing a decent amount of damage and inflicting deep wounds. Capable of an ineffective butchering of bodies. Disappears if the arm holding it is cut off."
+	menu_description = "An undroppable sharp tentacle capable of inflicting deep wounds. Capable of an ineffective butchering of bodies. Disappears if the arm holding it is cut off."
 
 /obj/item/nullrod/carp
 	name = "carp-sie plushie"
@@ -740,7 +740,7 @@
 	attack_verb_continuous = list("bites", "eats", "fin slaps")
 	attack_verb_simple = list("bite", "eat", "fin slap")
 	hitsound = 'sound/weapons/bite.ogg'
-	menu_description = "A plushie dealing a decent amount of damage held back a little by it's cute form. Capable of blessing one person with the Carp-Sie favor, which grants friendship of wild space carps. Fits in pockets. Can be worn on the belt."
+	menu_description = "A plushie dealing a little less damage due to it's cute form. Capable of blessing one person with the Carp-Sie favor, which grants friendship of all wild space carps. Fits in pockets. Can be worn on the belt."
 	/// If the item has already been used to bless someone
 	var/used_blessing = FALSE
 
@@ -768,7 +768,7 @@
 	worn_icon_state = "bostaff0"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
-	menu_description = "A staff which provides a medium chance of blocking incoming melee attacks and deals a decent amount of damage held back a little by it's wood material. Can be worn on the back."
+	menu_description = "A staff which provides a medium chance of blocking incoming melee attacks and deals a little less damage due to it's wood material. Can be worn on the back."
 
 /obj/item/nullrod/tribal_knife
 	icon_state = "crysknife"
@@ -784,7 +784,7 @@
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	item_flags = SLOWS_WHILE_IN_HAND
-	menu_description = "A sharp knife dealing a decent amount of damage. Randomly speeds or slows it's user at a regular intervals. Capable of butchering bodies. Cannot be worn anywhere."
+	menu_description = "A sharp knife. Randomly speeds or slows it's user at a regular intervals. Capable of butchering bodies. Cannot be worn anywhere."
 
 /obj/item/nullrod/tribal_knife/Initialize(mapload)
 	. = ..()
@@ -816,7 +816,7 @@
 	attack_verb_simple = list("poke", "impale", "pierce", "jab")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
-	menu_description = "A sharp pitchfork dealing a decent amount of damage. Can be worn on the back."
+	menu_description = "A sharp pitchfork. Can be worn on the back."
 
 /obj/item/nullrod/egyptian
 	name = "egyptian staff"
@@ -831,7 +831,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb_continuous = list("bashes", "smacks", "whacks")
 	attack_verb_simple = list("bash", "smack", "whack")
-	menu_description = "A staff dealing a decent amount of damage. Can be used as a tool to craft exclusive egyptian items. Easily stored. Can be worn on the back."
+	menu_description = "A staff. Can be used as a tool to craft exclusive egyptian items. Easily stored. Can be worn on the back."
 
 /obj/item/nullrod/hypertool
 	name = "hypertool"
@@ -848,7 +848,7 @@
 	attack_verb_continuous = list("pulses", "mends", "cuts")
 	attack_verb_simple = list("pulse", "mend", "cut")
 	hitsound = 'sound/effects/sparks4.ogg'
-	menu_description = "A tool dealing a decent amount of brain damage which partially penetrates armor. Fits in pockets. Can be worn on the belt."
+	menu_description = "A tool dealing a brain damage which partially penetrates armor. Fits in pockets. Can be worn on the belt."
 
 /obj/item/nullrod/spear
 	name = "ancient spear"
@@ -865,4 +865,4 @@
 	attack_verb_continuous = list("stabs", "pokes", "slashes", "clocks")
 	attack_verb_simple = list("stab", "poke", "slash", "clock")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	menu_description = "A pointy spear dealing a decent amount of damage which penetrates armor a little. Can be worn only on the belt."
+	menu_description = "A pointy spear which penetrates armor a little. Can be worn only on the belt."

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -768,7 +768,7 @@
 	worn_icon_state = "bostaff0"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
-	menu_description = "A staff which provides a medium chance of blocking incoming melee attacks and deals a little less damage due to it's wood material. Can be worn on the back."
+	menu_description = "A staff which provides a medium chance of blocking incoming melee attacks and deals a little less damage due to being made of wood. Can be worn on the back."
 
 /obj/item/nullrod/tribal_knife
 	icon_state = "crysknife"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -227,8 +227,12 @@
 	w_class = WEIGHT_CLASS_TINY
 	obj_flags = UNIQUE_RENAME
 	wound_bonus = -10
+	/// If this item has already been reskinned
 	var/reskinned = FALSE
+	/// If this item can be used in a reskin variant selection
 	var/chaplain_spawnable = TRUE
+	/// Short description of what this item is capable of, for radial menu uses
+	var/menu_description = "A classic chaplain weapon dealing a decent amount of damage. Fits in pockets. Can be worn on the belt."
 
 /obj/item/nullrod/Initialize()
 	. = ..()
@@ -243,29 +247,32 @@
 		reskin_holy_weapon(user)
 
 /**
- * reskin_holy_weapon: Shows a user a list of all available nullrod reskins and based on his choice replaces the nullrod with the reskinned version
+ * Shows a user a radial menu of all available null rod reskins and replaces the current null rod with the user's chosen reskinned variant
  *
  * Arguments:
- * * M The mob choosing a nullrod reskin
+ * * user The mob choosing a null rod reskin variant
  */
-/obj/item/nullrod/proc/reskin_holy_weapon(mob/M)
+/obj/item/nullrod/proc/reskin_holy_weapon(mob/user)
 	if(GLOB.holy_weapon_type)
 		return
 	var/list/display_names = list()
 	var/list/nullrod_icons = list()
-	for(var/rod in typesof(/obj/item/nullrod))
+	for(var/rod in subtypesof(/obj/item/nullrod))
 		var/obj/item/nullrod/rodtype = rod
 		if(initial(rodtype.chaplain_spawnable))
+			var/datum/radial_menu_choice/option = new
+			option.image = image(icon = initial(rodtype.icon), icon_state = initial(rodtype.icon_state))
+			option.info = span_boldnotice("[initial(rodtype.menu_description)]")
 			display_names[initial(rodtype.name)] = rodtype
-			nullrod_icons += list(initial(rodtype.name) = image(icon = initial(rodtype.icon), icon_state = initial(rodtype.icon_state)))
+			nullrod_icons += list(initial(rodtype.name) = option)
 
 	nullrod_icons = sortList(nullrod_icons)
-	var/choice = show_radial_menu(M, src , nullrod_icons, custom_check = CALLBACK(src, .proc/check_menu, M), radius = 42, require_near = TRUE)
-	if(!choice || !check_menu(M))
+	var/choice = show_radial_menu(user, src , nullrod_icons, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 42, require_near = TRUE)
+	if(!choice || !check_menu(user))
 		return
 
 	var/picked_rod_type = display_names[choice] // This needs to be on a separate var as list member access is not allowed for new
-	var/obj/item/nullrod/holy_weapon = new picked_rod_type(M.drop_location())
+	var/obj/item/nullrod/holy_weapon = new picked_rod_type(user.drop_location())
 	GLOB.holy_weapon_type = holy_weapon.type
 
 	SSblackbox.record_feedback("tally", "chaplain_weapon", 1, "[choice]")
@@ -273,13 +280,13 @@
 	if(holy_weapon)
 		holy_weapon.reskinned = TRUE
 		qdel(src)
-		M.put_in_hands(holy_weapon)
+		user.put_in_hands(holy_weapon)
 
 /**
- * check_menu: Checks if we are allowed to interact with a radial menu
+ * Checks if we are allowed to interact with a radial menu
  *
  * Arguments:
- * * user The mob interacting with a menu
+ * * user The mob interacting with the menu
  */
 /obj/item/nullrod/proc/check_menu(mob/user)
 	if(!istype(user))
@@ -291,12 +298,12 @@
 	return TRUE
 
 /obj/item/nullrod/godhand
+	name = "god hand"
+	desc = "This hand of yours glows with an awesome power!"
 	icon_state = "disintegrate"
 	inhand_icon_state = "disintegrate"
 	lefthand_file = 'icons/mob/inhands/misc/touchspell_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/touchspell_righthand.dmi'
-	name = "god hand"
-	desc = "This hand of yours glows with an awesome power!"
 	slot_flags = null
 	item_flags = ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
@@ -304,6 +311,7 @@
 	damtype = BURN
 	attack_verb_continuous = list("punches", "cross counters", "pummels")
 	attack_verb_simple = list("punch", "cross counter", "pummel")
+	menu_description = "An undroppable hand dealing a decent amount of burn damage. Disappears if the arm holding it is cut off."
 
 /obj/item/nullrod/godhand/Initialize()
 	. = ..()
@@ -320,6 +328,8 @@
 	force = 5
 	slot_flags = ITEM_SLOT_BACK
 	block_chance = 50
+	menu_description = "A red staff which provides a high chance of blocking incoming attacks via a protective red aura around it's user, but deals very low amount of damage. Can be worn only on the back."
+	/// The icon which appears over the mob holding the item
 	var/shield_icon = "shield-red"
 
 /obj/item/nullrod/staff/worn_overlays(mutable_appearance/standing, isinhands)
@@ -332,15 +342,16 @@
 	icon_state = "godstaff-blue"
 	inhand_icon_state = "godstaff-blue"
 	shield_icon = "shield-old"
+	menu_description = "A blue staff which provides a high chance of blocking incoming attacks via a protective blue aura around it's user, but deals very low amount of damage. Can be worn only on the back."
 
 /obj/item/nullrod/claymore
+	name = "holy claymore"
+	desc = "A weapon fit for a crusade!"
 	icon_state = "claymore_gold"
 	inhand_icon_state = "claymore_gold"
 	worn_icon_state = "claymore_gold"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
-	name = "holy claymore"
-	desc = "A weapon fit for a crusade!"
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	block_chance = 30
@@ -348,6 +359,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
+	menu_description = "A sharp claymore which provides a low chance of blocking incoming melee attacks and deals a decent amount of damage. Can be worn on the back or belt."
 
 /obj/item/nullrod/claymore/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(attack_type == PROJECTILE_ATTACK)
@@ -365,26 +377,29 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	hitsound = 'sound/hallucinations/growl1.ogg'
+	menu_description = "A sharp blade which provides a low chance of blocking incoming melee attacks and deals a decent amount of damage. Can be worn on the back or belt."
 
 /obj/item/nullrod/claymore/chainsaw_sword
+	name = "sacred chainsaw sword"
+	desc = "Suffer not a heretic to live."
 	icon_state = "chainswordon"
 	inhand_icon_state = "chainswordon"
 	worn_icon_state = "chainswordon"
-	name = "sacred chainsaw sword"
-	desc = "Suffer not a heretic to live."
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
 	attack_verb_simple = list("saw", "tear", "lacerate", "cut", "chop", "dice")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 	tool_behaviour = TOOL_SAW
 	toolspeed = 1.5 //slower than a real saw
+	menu_description = "A sharp chainsaw sword which provides a low chance of blocking incoming melee attacks and deals a decent amount of damage. Can be used as a slower saw tool. Can be worn on the belt."
 
 /obj/item/nullrod/claymore/glowing
+	name = "force weapon"
+	desc = "The blade glows with the power of faith. Or possibly a battery."
 	icon_state = "swordon"
 	inhand_icon_state = "swordon"
 	worn_icon_state = "swordon"
-	name = "force weapon"
-	desc = "The blade glows with the power of faith. Or possibly a battery."
+	menu_description = "A sharp weapon which provides a low chance of blocking incoming melee attacks and deals a decent amount of damage. Can be worn on the back or belt."
 
 /obj/item/nullrod/claymore/katana
 	name = "\improper Hanzo steel"
@@ -392,6 +407,7 @@
 	icon_state = "katana"
 	inhand_icon_state = "katana"
 	worn_icon_state = "katana"
+	menu_description = "A sharp katana which provides a low chance of blocking incoming melee attacks and deals a decent amount of damage. Can be worn on the back or belt."
 
 /obj/item/nullrod/claymore/multiverse
 	name = "extradimensional blade"
@@ -401,6 +417,7 @@
 	worn_icon_state = "multiverse"
 	slot_flags = ITEM_SLOT_BACK
 	force = 15
+	menu_description = "An odd sharp blade which provides a low chance of blocking incoming melee attacks and deals a random amount of damage, which can range from almost nothing to very high. Can be worn on the back."
 
 /obj/item/nullrod/claymore/multiverse/melee_attack_chain(mob/user, atom/target, params)
 	var/old_force = force
@@ -410,27 +427,28 @@
 
 /obj/item/nullrod/claymore/saber
 	name = "light energy sword"
-	hitsound = 'sound/weapons/blade1.ogg'
+	desc = "If you strike me down, I shall become more robust than you can possibly imagine."
 	icon = 'icons/obj/transforming_energy.dmi'
 	icon_state = "swordblue"
 	inhand_icon_state = "swordblue"
 	worn_icon_state = "swordblue"
 	slot_flags = ITEM_SLOT_BELT
-	desc = "If you strike me down, I shall become more robust than you can possibly imagine."
+	hitsound = 'sound/weapons/blade1.ogg'
+	menu_description = "A sharp energy sword which provides a low chance of blocking incoming melee attacks and deals a decent amount of damage. Can be worn on the belt."
 
 /obj/item/nullrod/claymore/saber/red
 	name = "dark energy sword"
+	desc = "Woefully ineffective when used on steep terrain."
 	icon_state = "swordred"
 	inhand_icon_state = "swordred"
 	worn_icon_state = "swordred"
-	desc = "Woefully ineffective when used on steep terrain."
 
 /obj/item/nullrod/claymore/saber/pirate
 	name = "nautical energy sword"
+	desc = "Convincing HR that your religion involved piracy was no mean feat."
 	icon_state = "cutlass1"
 	inhand_icon_state = "cutlass1"
 	worn_icon_state = "swordred"
-	desc = "Convincing HR that your religion involved piracy was no mean feat."
 
 /obj/item/nullrod/sord
 	name = "\improper UNREAL SORD"
@@ -446,6 +464,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
+	menu_description = "An odd s(w)ord dealing a laughable amount of damage. Can be worn on the belt."
 
 /obj/item/nullrod/sord/suicide_act(mob/user) //a near-exact copy+paste of the actual sord suicide_act()
 	user.visible_message(span_suicide("[user] is trying to impale [user.p_them()]self with [src]! It might be a suicide attempt if it weren't so HOLY."), \
@@ -453,57 +472,62 @@
 	return SHAME
 
 /obj/item/nullrod/scythe
+	name = "reaper scythe"
+	desc = "Ask not for whom the bell tolls..."
 	icon_state = "scythe1"
 	inhand_icon_state = "scythe1"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
-	name = "reaper scythe"
-	desc = "Ask not for whom the bell tolls..."
 	w_class = WEIGHT_CLASS_BULKY
 	armour_penetration = 35
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = SHARP_EDGED
 	attack_verb_continuous = list("chops", "slices", "cuts", "reaps")
 	attack_verb_simple = list("chop", "slice", "cut", "reap")
+	menu_description = "A sharp scythe dealing a decent amount of damage which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
 
 /obj/item/nullrod/scythe/Initialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 70, 110) //the harvest gives a high bonus chance
 
 /obj/item/nullrod/scythe/vibro
+	name = "high frequency blade"
+	desc = "Bad references are the DNA of the soul."
 	icon_state = "hfrequency0"
 	inhand_icon_state = "hfrequency1"
 	worn_icon_state = "hfrequency0"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
-	name = "high frequency blade"
-	desc = "Bad references are the DNA of the soul."
 	attack_verb_continuous = list("chops", "slices", "cuts", "zandatsu's")
 	attack_verb_simple = list("chop", "slice", "cut", "zandatsu")
 	hitsound = 'sound/weapons/rapierhit.ogg'
+	menu_description = "A sharp blade dealing a decent amount of damage which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
 
 /obj/item/nullrod/scythe/spellblade
+	name = "dormant spellblade"
+	desc = "The blade grants the wielder nearly limitless power...if they can figure out how to turn it on, that is."
 	icon_state = "spellblade"
 	inhand_icon_state = "spellblade"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	worn_icon_state = "spellblade"
 	icon = 'icons/obj/guns/magic.dmi'
-	name = "dormant spellblade"
-	desc = "The blade grants the wielder nearly limitless power...if they can figure out how to turn it on, that is."
 	hitsound = 'sound/weapons/rapierhit.ogg'
+	menu_description = "A sharp blade dealing a decent amount of damage which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
 
 /obj/item/nullrod/scythe/talking
+	name = "possessed blade"
+	desc = "When the station falls into chaos, it's nice to have a friend by your side."
 	icon_state = "talking_sword"
 	inhand_icon_state = "talking_sword"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	worn_icon_state = "talking_sword"
-	name = "possessed blade"
-	desc = "When the station falls into chaos, it's nice to have a friend by your side."
 	attack_verb_continuous = list("chops", "slices", "cuts")
 	attack_verb_simple= list("chop", "slice", "cut")
 	hitsound = 'sound/weapons/rapierhit.ogg'
+	menu_description = "A sharp blade dealing a decent amount of damage which partially penetrates armor. Able to awaken a friendly spirit providing guidance. Very effective at butchering bodies. Can be worn on the back."
+	/// If there is a ghost possessing the item
 	var/possessed = FALSE
 
 /obj/item/nullrod/scythe/talking/relaymove(mob/living/user, direction)
@@ -547,12 +571,11 @@
 	return ..()
 
 /obj/item/nullrod/scythe/talking/chainsword
+	name = "possessed chainsaw sword"
+	desc = "Suffer not a heretic to live."
 	icon_state = "chainswordon"
 	inhand_icon_state = "chainswordon"
 	worn_icon_state = "chainswordon"
-	name = "possessed chainsaw sword"
-	desc = "Suffer not a heretic to live."
-	chaplain_spawnable = FALSE
 	force = 30
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
@@ -560,6 +583,8 @@
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 	tool_behaviour = TOOL_SAW
 	toolspeed = 0.5 //faster than normal saw
+	chaplain_spawnable = FALSE
+	menu_description = "A sharp chainsaw sword dealing a very high amount of damage which partially penetrates armor. Able to awaken a friendly spirit providing guidance. Can be used as a faster saw tool. Very effective at butchering bodies. Can be worn on the belt."
 
 /obj/item/nullrod/hammmer
 	name = "relic war hammer"
@@ -572,6 +597,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb_continuous = list("smashes", "bashes", "hammers", "crunches")
 	attack_verb_simple = list("smash", "bash", "hammer", "crunch")
+	menu_description = "A hammer dealing a decent amount of damage. Capable of tapping knees to measure brain health. Can be worn on the belt."
 
 /obj/item/nullrod/hammer/Initialize()
 	. = ..()
@@ -593,6 +619,7 @@
 	hitsound = 'sound/weapons/chainsawhit.ogg'
 	tool_behaviour = TOOL_SAW
 	toolspeed = 2 //slower than a real saw
+	menu_description = "An undroppable sharp hand dealing a decent amount of damage. Can be used as a very slow saw tool. Capable of butchering bodies. Disappears if the arm holding it is cut off."
 
 /obj/item/nullrod/chainsaw/Initialize()
 	. = ..()
@@ -610,6 +637,7 @@
 	sharpness = SHARP_EDGED
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
+	menu_description = "A sharp dagger dealing a decent amount of damage. Fits in pockets. Can be worn on the belt. Honk."
 
 /obj/item/nullrod/pride_hammer
 	name = "Pride-struck Hammer"
@@ -626,6 +654,7 @@
 	attack_verb_continuous = list("attacks", "smashes", "crushes", "splatters", "cracks")
 	attack_verb_simple = list("attack", "smash", "crush", "splatter", "crack")
 	hitsound = 'sound/weapons/blade1.ogg'
+	menu_description = "A hammer dealing a decent amount of damage held back a little by a it's pride. Has a low chance of transferring some of the user's reagents to the target. Capable of tapping knees to measure brain health. Can be worn on the back."
 
 /obj/item/nullrod/pride_hammer/Initialize()
 	. = ..()
@@ -653,6 +682,7 @@
 	attack_verb_continuous = list("whips", "lashes")
 	attack_verb_simple = list("whip", "lash")
 	hitsound = 'sound/weapons/chainhit.ogg'
+	menu_description = "A whip dealing a decent amount of damage. Deals extra damage to vampires. Fits in pockets. Can be worn on the belt."
 
 /obj/item/nullrod/fedora
 	name = "atheist's fedora"
@@ -668,6 +698,7 @@
 	sharpness = SHARP_EDGED
 	attack_verb_continuous = list("enlightens", "redpills")
 	attack_verb_simple = list("enlighten", "redpill")
+	menu_description = "A sharp fedora dealing a very high amount of throw damage. Can also be worn on the head, obviously."
 
 /obj/item/nullrod/armblade
 	name = "dark blessing"
@@ -683,6 +714,7 @@
 	sharpness = SHARP_EDGED
 	wound_bonus = -20
 	bare_wound_bonus = 25
+	menu_description = "An undroppable sharp armblade dealing a decent amount of damage and inflicting deep wounds. Capable of an ineffective butchering of bodies. Disappears if the arm holding it is cut off."
 
 /obj/item/nullrod/armblade/Initialize()
 	. = ..()
@@ -693,6 +725,7 @@
 	name = "unholy blessing"
 	icon_state = "tentacle"
 	inhand_icon_state = "tentacle"
+	menu_description = "An undroppable sharp tentacle dealing a decent amount of damage and inflicting deep wounds. Capable of an ineffective butchering of bodies. Disappears if the arm holding it is cut off."
 
 /obj/item/nullrod/carp
 	name = "carp-sie plushie"
@@ -707,6 +740,8 @@
 	attack_verb_continuous = list("bites", "eats", "fin slaps")
 	attack_verb_simple = list("bite", "eat", "fin slap")
 	hitsound = 'sound/weapons/bite.ogg'
+	menu_description = "A plushie dealing a decent amount of damage held back a little by it's cute form. Capable of blessing one person with the Carp-Sie favor, which grants friendship of wild space carps. Fits in pockets. Can be worn on the belt."
+	/// If the item has already been used to bless someone
 	var/used_blessing = FALSE
 
 /obj/item/nullrod/carp/attack_self(mob/living/user)
@@ -719,10 +754,10 @@
 /obj/item/nullrod/claymore/bostaff //May as well make it a "claymore" and inherit the blocking
 	name = "monk's staff"
 	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts, it is now used to harass the clown."
-	w_class = WEIGHT_CLASS_BULKY
 	force = 15
 	block_chance = 40
 	slot_flags = ITEM_SLOT_BACK
+	w_class = WEIGHT_CLASS_BULKY
 	sharpness = NONE
 	hitsound = "swing_hit"
 	attack_verb_continuous = list("smashes", "slams", "whacks", "thwacks")
@@ -733,6 +768,7 @@
 	worn_icon_state = "bostaff0"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
+	menu_description = "A staff which provides a medium chance of blocking incoming melee attacks and deals a decent amount of damage held back a little by it's wood material. Can be worn on the back."
 
 /obj/item/nullrod/tribal_knife
 	icon_state = "crysknife"
@@ -748,6 +784,7 @@
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	item_flags = SLOWS_WHILE_IN_HAND
+	menu_description = "A sharp knife dealing a decent amount of damage. Randomly speeds or slows it's user at a regular intervals. Capable of butchering bodies. Cannot be worn anywhere."
 
 /obj/item/nullrod/tribal_knife/Initialize(mapload)
 	. = ..()
@@ -779,6 +816,7 @@
 	attack_verb_simple = list("poke", "impale", "pierce", "jab")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	sharpness = SHARP_EDGED
+	menu_description = "A sharp pitchfork dealing a decent amount of damage. Can be worn on the back."
 
 /obj/item/nullrod/egyptian
 	name = "egyptian staff"
@@ -793,6 +831,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb_continuous = list("bashes", "smacks", "whacks")
 	attack_verb_simple = list("bash", "smack", "whack")
+	menu_description = "A staff dealing a decent amount of damage. Can be used as a tool to craft exclusive egyptian items. Easily stored. Can be worn on the back."
 
 /obj/item/nullrod/hypertool
 	name = "hypertool"
@@ -809,6 +848,7 @@
 	attack_verb_continuous = list("pulses", "mends", "cuts")
 	attack_verb_simple = list("pulse", "mend", "cut")
 	hitsound = 'sound/effects/sparks4.ogg'
+	menu_description = "A tool dealing a decent amount of brain damage which partially penetrates armor. Fits in pockets. Can be worn on the belt."
 
 /obj/item/nullrod/spear
 	name = "ancient spear"
@@ -825,3 +865,4 @@
 	attack_verb_continuous = list("stabs", "pokes", "slashes", "clocks")
 	attack_verb_simple = list("stab", "poke", "slash", "clock")
 	hitsound = 'sound/weapons/bladeslice.ogg'
+	menu_description = "A pointy spear dealing a decent amount of damage which penetrates armor a little. Can be worn only on the belt."

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -257,7 +257,7 @@
 		return
 	var/list/display_names = list()
 	var/list/nullrod_icons = list()
-	for(var/rod in subtypesof(/obj/item/nullrod))
+	for(var/rod in typesof(/obj/item/nullrod))
 		var/obj/item/nullrod/rodtype = rod
 		if(initial(rodtype.chaplain_spawnable))
 			var/datum/radial_menu_choice/option = new

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -464,7 +464,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
-	menu_description = "An odd s(w)ord dealing a laughable amount of damage. Can be worn on the belt."
+	menu_description = "An odd s(w)ord dealing a laughable amount of damage. Fits in pockets. Can be worn on the belt."
 
 /obj/item/nullrod/sord/suicide_act(mob/user) //a near-exact copy+paste of the actual sord suicide_act()
 	user.visible_message(span_suicide("[user] is trying to impale [user.p_them()]self with [src]! It might be a suicide attempt if it weren't so HOLY."), \
@@ -501,7 +501,7 @@
 	attack_verb_continuous = list("chops", "slices", "cuts", "zandatsu's")
 	attack_verb_simple = list("chop", "slice", "cut", "zandatsu")
 	hitsound = 'sound/weapons/rapierhit.ogg'
-	menu_description = "A sharp blade dealing which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
+	menu_description = "A sharp blade which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
 
 /obj/item/nullrod/scythe/spellblade
 	name = "dormant spellblade"
@@ -513,7 +513,7 @@
 	worn_icon_state = "spellblade"
 	icon = 'icons/obj/guns/magic.dmi'
 	hitsound = 'sound/weapons/rapierhit.ogg'
-	menu_description = "A sharp blade dealing which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
+	menu_description = "A sharp blade which partially penetrates armor. Very effective at butchering bodies. Can be worn on the back."
 
 /obj/item/nullrod/scythe/talking
 	name = "possessed blade"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -311,7 +311,7 @@
 	damtype = BURN
 	attack_verb_continuous = list("punches", "cross counters", "pummels")
 	attack_verb_simple = list("punch", "cross counter", "pummel")
-	menu_description = "An undroppable god hand dealing a burn damage. Disappears if the arm holding it is cut off."
+	menu_description = "An undroppable god hand dealing burn damage. Disappears if the arm holding it is cut off."
 
 /obj/item/nullrod/godhand/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR does following things:
- Updates radial menu for a null rod reskin variant selection. It will now also include a small button for showing additional information about each given null rod type. No need to wiki dive to find out what each type does.
- Cleans up relevant code a little bit and provides proper documentation.

**Example image:**

![NullrodInfo](https://user-images.githubusercontent.com/43862960/123793969-a0634180-d8e2-11eb-9fa1-087afc2ec897.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Less reliance on the wiki, quality of life for chaplains.

## Changelog
:cl: Arkatos
qol: Updated radial menu for a null rod reskin variant selection. It will now include a small button for showing additional information about each given null rod variant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
