### PR TITLE
Adds the ability to connect cameras to circuits

### DIFF
--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -259,7 +259,7 @@
 			picture.log_to_file()
 
 
-// Code related to the USB-implementation of the camera
+/// Code related to the USB-implementation of the camera
 /obj/item/circuit_component/camera
 	display_name = "Camera"
 

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -191,7 +191,7 @@
 	if(ismob(user))
 		var/mob/mob_user = user
 		viewlist = getviewsize(mob_user.client.view)
-		viewc = mob_user.client.eye
+		viewc = mob_user.client?.eye
 	else
 		viewlist = getviewsize(world.view)
 		viewc = target


### PR DESCRIPTION
## About The Pull Request

This PR lets you connect cameras to circuits through USB-cables, allowing you to take photos with circuits. Fun for when you're playing as obsessed or want to make something like an automatic photo capturing device. Currently it takes photo's at the position of the camera.

I looked at the code that was there for valves and tram controls, please let me know if I missed anything!

## Why It's Good For The Game

It seemed like a fun addition for circuits that can be used to achieve your obsessed objectives or to make fun machines like a prisoner-intake system! :D

## Changelog
:cl: GearTinkster
expansion: You can now connect cameras to circuits using USB cables!
/:cl:

![image](https://user-images.githubusercontent.com/84903631/123841804-4bd6bb00-d910-11eb-9f4f-1486bad092bb.png)

