### PR TITLE
Fixes a runtime related to quirk to-chats

### DIFF
--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -63,7 +63,8 @@
 		START_PROCESSING(SSquirks, src)
 
 	if(!quirk_transfer)
-		to_chat(quirk_holder, gain_text)
+		if(gain_text) //Some quirks are silent
+			to_chat(quirk_holder, gain_text)
 		add_unique()
 
 		if(quirk_holder.client)
@@ -85,7 +86,8 @@
 	quirk_holder.quirks -= src
 
 	if(!quirk_transfer)
-		to_chat(quirk_holder, lose_text)
+		if(lose_text) //Some quirks are silent
+			to_chat(quirk_holder, lose_text)
 
 	if(mob_trait)
 		REMOVE_TRAIT(quirk_holder, mob_trait, ROUNDSTART_TRAIT)


### PR DESCRIPTION
## About The Pull Request

I noticed a runtime while testing my other PR! some quirks would call to_chat but had no gain or losetext. I assumed the correct solution would just to sanity check, assuming that its okay that not every quirk has a special text for getting/losing it. let me know if thats a wrong assumption!

## Why It's Good For The Game

Less runtimes is good hopefully!

## Changelog
:cl: GearTinkster
fix: Fixes a runtime related to quirk gain and losetexts
/:cl:

