### PR TITLE
Fix hand teleporter and other portals looping forever

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -5,7 +5,6 @@
 // effectout: effect to show right after teleportation
 // asoundin: soundfile to play before teleportation
 // asoundout: soundfile to play after teleportation
-// forceMove: if false, teleport will use Move() proc (dense objects will prevent teleportation)
 // no_effects: disable the default effectin/effectout of sparks
 // forced: whether or not to ignore no_teleport
 /proc/do_teleport(atom/movable/teleatom, atom/destination, precision=null, datum/effect_system/effectin=null, datum/effect_system/effectout=null, asoundin=null, asoundout=null, no_effects=FALSE, channel=TELEPORT_CHANNEL_BLUESPACE, forced = FALSE)

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -8,7 +8,7 @@
 // forceMove: if false, teleport will use Move() proc (dense objects will prevent teleportation)
 // no_effects: disable the default effectin/effectout of sparks
 // forced: whether or not to ignore no_teleport
-/proc/do_teleport(atom/movable/teleatom, atom/destination, precision=null, forceMove = TRUE, datum/effect_system/effectin=null, datum/effect_system/effectout=null, asoundin=null, asoundout=null, no_effects=FALSE, channel=TELEPORT_CHANNEL_BLUESPACE, forced = FALSE)
+/proc/do_teleport(atom/movable/teleatom, atom/destination, precision=null, datum/effect_system/effectin=null, datum/effect_system/effectout=null, asoundin=null, asoundout=null, no_effects=FALSE, channel=TELEPORT_CHANNEL_BLUESPACE, forced = FALSE)
 	// teleporting most effects just deletes them
 	var/static/list/delete_atoms = typecacheof(list(
 		/obj/effect,
@@ -74,7 +74,7 @@
 		return FALSE
 
 	tele_play_specials(teleatom, curturf, effectin, asoundin)
-	var/success = forceMove ? teleatom.forceMove(destturf) : teleatom.Move(destturf)
+	var/success = teleatom.forceMove(destturf)
 	if (success)
 		log_game("[key_name(teleatom)] has teleported from [loc_name(curturf)] to [loc_name(destturf)]")
 		tele_play_specials(teleatom, destturf, effectout, asoundout)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -51,11 +51,13 @@
 		teleport(user)
 		return TRUE
 
-/obj/effect/portal/Bumped(atom/movable/bumber)
-	if(!teleport(bumber)) // if they fail to teleport try to move them past
-		density = FALSE
-		bumber.Move(src, bumber.dir)
-		density = TRUE
+/obj/effect/portal/CanAllowThrough(atom/movable/mover, border_dir)
+	. = ..()
+	if(HAS_TRAIT(mover, TRAIT_NO_TELEPORT) && !force_teleport)
+		return TRUE
+
+/obj/effect/portal/Bumped(atom/movable/bumper)
+	teleport(bumper)
 
 /obj/effect/portal/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -48,7 +48,7 @@
 	return ..()
 
 /obj/effect/portal/attackby(obj/item/W, mob/user, params)
-	if(user && (Adjacent(user) || get_turf(user) == get_turf(src)))
+	if(user && Adjacent(user))
 		teleport(user)
 		return TRUE
 

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -64,7 +64,7 @@
 	. = ..()
 	if(.)
 		return
-	if(Adjacent(user) || get_turf(user) == get_turf(src))
+	if(Adjacent(user))
 		teleport(user)
 
 /obj/effect/portal/Initialize(mapload, _lifespan = 0, obj/effect/portal/_linked, automatic_link = FALSE, turf/hard_target_override, atmos_link_override)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -17,6 +17,7 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "portal"
 	anchored = TRUE
+	density = TRUE // dense for receiving bumbs
 	layer = HIGH_OBJ_LAYER
 	var/mech_sized = FALSE
 	var/obj/effect/portal/linked
@@ -46,32 +47,22 @@
 	return ..()
 
 /obj/effect/portal/attackby(obj/item/W, mob/user, params)
-	if(user)
-		if(get_turf(user) == get_turf(src))
-			teleport(user)
-			return TRUE
-		if(Adjacent(user))
-			user.Move(get_turf(src))
-			return TRUE
+	if(user && (Adjacent(user) || get_turf(user) == get_turf(src)))
+		teleport(user)
+		return TRUE
 
-/obj/effect/portal/attack_tk(mob/user)
-	return
-
-/obj/effect/portal/Cross(atom/movable/crosser)
-	if(isobserver(crosser))
-		return ..()
-	if(teleport(crosser))
-		return FALSE // stop the cross or the allowed teleport fails
-	return ..()
+/obj/effect/portal/Bumped(atom/movable/bumber)
+	if(!teleport(bumber)) // if they fail to teleport try to move them past
+		density = FALSE
+		bumber.Move(src, bumber.dir)
+		density = TRUE
 
 /obj/effect/portal/attack_hand(mob/user, list/modifiers)
 	. = ..()
 	if(.)
 		return
-	if(get_turf(user) == get_turf(src))
+	if(Adjacent(user) || get_turf(user) == get_turf(src))
 		teleport(user)
-	if(Adjacent(user))
-		user.Move(get_turf(src))
 
 /obj/effect/portal/Initialize(mapload, _lifespan = 0, obj/effect/portal/_linked, automatic_link = FALSE, turf/hard_target_override, atmos_link_override)
 	. = ..()

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -30,7 +30,8 @@
 	var/allow_anchored = FALSE
 	var/innate_accuracy_penalty = 0
 	var/last_effect = 0
-	var/force_teleport = FALSE //Does this portal bypass teleport restrictions? like TRAIT_NO_TELEPORT and NOTELEPORT flasg
+	/// Does this portal bypass teleport restrictions? like TRAIT_NO_TELEPORT and NOTELEPORT flags.
+	var/force_teleport = FALSE
 
 /obj/effect/portal/anom
 	name = "wormhole"

--- a/code/game/objects/items/devices/swapper.dm
+++ b/code/game/objects/items/devices/swapper.dm
@@ -104,8 +104,8 @@
 	var/target_B = B.drop_location()
 
 	//TODO: add a sound effect or visual effect
-	if(do_teleport(A, target_B, forceMove = TRUE, channel = TELEPORT_CHANNEL_QUANTUM))
-		do_teleport(B, target_A, forceMove = TRUE, channel = TELEPORT_CHANNEL_QUANTUM)
+	if(do_teleport(A, target_B, channel = TELEPORT_CHANNEL_QUANTUM))
+		do_teleport(B, target_A, channel = TELEPORT_CHANNEL_QUANTUM)
 		if(ismob(B))
 			var/mob/M = B
 			to_chat(M, span_warning("[linked_swapper] activates, and you find yourself somewhere else."))

--- a/code/game/objects/items/scrolls.dm
+++ b/code/game/objects/items/scrolls.dm
@@ -60,7 +60,7 @@
 		to_chat(user, span_warning("The spell matrix was unable to locate a suitable teleport destination for an unknown reason. Sorry."))
 		return
 
-	if(do_teleport(user, pick(L), forceMove = TRUE, channel = TELEPORT_CHANNEL_MAGIC, forced = TRUE))
+	if(do_teleport(user, pick(L), channel = TELEPORT_CHANNEL_MAGIC, forced = TRUE))
 		smoke.start()
 		uses--
 		if(!uses)

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -248,8 +248,9 @@
 	RegisterSignal(portal1, COMSIG_PARENT_QDELETING, .proc/on_portal_destroy)
 	RegisterSignal(portal2, COMSIG_PARENT_QDELETING, .proc/on_portal_destroy)
 
-	if(CanPass(user, get_step(user, user.dir)))
-		portal1.forceMove(get_step(user, user.dir))
+	var/turf/check_turf = get_turf(get_step(user, user.dir))
+	if(check_turf.CanPass(user, get_dir(check_turf, user)))
+		portal1.forceMove(check_turf)
 	active_portal_pairs[portal1] = portal2
 
 	investigate_log("was used by [key_name(user)] at [AREACOORD(user)] to create a portal pair with destinations [AREACOORD(portal1)] and [AREACOORD(portal2)].", INVESTIGATE_PORTAL)

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -248,7 +248,8 @@
 	RegisterSignal(portal1, COMSIG_PARENT_QDELETING, .proc/on_portal_destroy)
 	RegisterSignal(portal2, COMSIG_PARENT_QDELETING, .proc/on_portal_destroy)
 
-	try_move_adjacent(portal1, user.dir)
+	if(CanPass(user, get_step(user, user.dir)))
+		portal1.forceMove(get_step(user, user.dir))
 	active_portal_pairs[portal1] = portal2
 
 	investigate_log("was used by [key_name(user)] at [AREACOORD(user)] to create a portal pair with destinations [AREACOORD(portal1)] and [AREACOORD(portal2)].", INVESTIGATE_PORTAL)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -422,7 +422,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 			continue
 		if(!A.anchored)
 			movedsomething = TRUE
-			if(do_teleport(A, target, forceMove = TRUE, channel = TELEPORT_CHANNEL_CULT))
+			if(do_teleport(A, target, channel = TELEPORT_CHANNEL_CULT))
 				movesuccess = TRUE
 	if(movedsomething)
 		..()

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -62,7 +62,7 @@
 /obj/item/melee/sickly_blade/attack_self(mob/user)
 	var/turf/safe_turf = find_safe_turf(zlevels = z, extended_safety_checks = TRUE)
 	if(IS_HERETIC(user) || IS_HERETIC_MONSTER(user))
-		if(do_teleport(user, safe_turf, forceMove = TRUE, channel = TELEPORT_CHANNEL_MAGIC))
+		if(do_teleport(user, safe_turf, channel = TELEPORT_CHANNEL_MAGIC))
 			to_chat(user,span_warning("As you shatter [src], you feel a gust of energy flow through your body. The Rusted Hills heard your call..."))
 		else
 			to_chat(user,span_warning("You shatter [src], but your plea goes unanswered."))

--- a/code/modules/spells/spell_types/area_teleport.dm
+++ b/code/modules/spells/spell_types/area_teleport.dm
@@ -69,7 +69,7 @@
 				tempL.Remove(attempt)
 
 		if(!success)
-			do_teleport(target, L, forceMove = TRUE, channel = TELEPORT_CHANNEL_MAGIC)
+			do_teleport(target, L, channel = TELEPORT_CHANNEL_MAGIC)
 			playsound(get_turf(user), sound2, 50,TRUE)
 
 /obj/effect/proc_holder/spell/targeted/area_teleport/invocation(area/chosenarea = null,mob/living/user = usr)

--- a/code/modules/spells/spell_types/turf_teleport.dm
+++ b/code/modules/spells/spell_types/turf_teleport.dm
@@ -42,5 +42,5 @@
 		if(!picked || !isturf(picked))
 			return
 
-		if(do_teleport(user, picked, forceMove = TRUE, channel = TELEPORT_CHANNEL_MAGIC))
+		if(do_teleport(user, picked, channel = TELEPORT_CHANNEL_MAGIC))
 			playsound(get_turf(user), sound1, 50,TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes portals use `Bumped()` instead of `COMSIG_ATOM_ENTERED` for detecting atoms crossing the event horizon.

Removes unused and potential loop causing `forceMove` argument from `do_teleport()`

## Why It's Good For The Game

Fixes: #59892

Portals in dense objects can now be walked into.

## Changelog
:cl:
fix: Fixed an infinite loop bug with portal teleports. The cake is a stack overflow.
fix: Fixed portals layer so they appear over most other objects.
fix: Fixed hand teleporter portals moving in zero gravity.
qol: Portals on dense objects no longer require clicking to enter and can be walked into.
qol: Portals you are standing on may be entered by clicking even with a tool in hand.
code: Removed an unused teleport arg that may cause issues with new portal code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
