### PR TITLE
Fixes density when fireman carrying

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -179,6 +179,7 @@
 	unequip_buckle_inhands(parent)
 	var/mob/living/carbon/human/H = parent
 	H.remove_movespeed_modifier(/datum/movespeed_modifier/human_carry)
+	former_rider.set_density(!former_rider.body_position)
 	return ..()
 
 /// If the carrier shoves the person they're carrying, force the carried mob off

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -179,7 +179,6 @@
 	unequip_buckle_inhands(parent)
 	var/mob/living/carbon/human/H = parent
 	H.remove_movespeed_modifier(/datum/movespeed_modifier/human_carry)
-	former_rider.set_density(TRUE)
 	return ..()
 
 /// If the carrier shoves the person they're carrying, force the carried mob off

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -941,14 +941,7 @@
 		visible_message(span_warning("[src] fails to fireman carry [target]!"))
 		return
 
-	if(target.loc != loc)
-		var/old_density = density
-		density = FALSE // Hacky and doesn't use set_density()
-		step_towards(target, loc)
-		density = old_density // Avoid changing density directly in normal circumstances, without the setter.
-
-	if(target.loc == loc)
-		return buckle_mob(target, TRUE, TRUE, CARRIER_NEEDS_ARM)
+	return buckle_mob(target, TRUE, TRUE, CARRIER_NEEDS_ARM)
 
 /mob/living/carbon/human/proc/piggyback(mob/living/carbon/target)
 	if(!can_piggyback(target))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -978,9 +978,9 @@
 	var/turf/T = get_turf(src)
 	if(M.loc != T)
 		var/old_density = density
-		density = FALSE // Hacky and doesn't use set_density()
+		set_density(FALSE)
 		var/can_step = step_towards(M, T)
-		density = old_density // Avoid changing density directly in normal circumstances, without the setter.
+		set_density(old_density) // Avoid changing density directly in normal circumstances, without the setter.
 		if(!can_step)
 			return FALSE
 	return ..()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -978,9 +978,9 @@
 	var/turf/T = get_turf(src)
 	if(M.loc != T)
 		var/old_density = density
-		set_density(FALSE)
+		density = FALSE // Hacky and doesn't use set_density()
 		var/can_step = step_towards(M, T)
-		set_density(old_density) // Avoid changing density directly in normal circumstances, without the setter.
+		density = old_density // Avoid changing density directly in normal circumstances, without the setter.
 		if(!can_step)
 			return FALSE
 	return ..()


### PR DESCRIPTION
## About The Pull Request

I made an issue yesterday - #59886 about this, but wanted to try to figure this out myself because it's personally a massive problem.

While ``former_rider.set_density(TRUE)`` is the only problem here as far as I can see, I didn't see any problems with deleting the lines in human.dm because its handled in their parent.

## Why It's Good For The Game

Bugs are bad and so is code copypaste.

## Changelog
:cl:
fix: You can now put people in coffins again after fireman carrying them.
/:cl: