### PR TITLE
Fixes spread glowshrooms runtiming on initialize

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -175,7 +175,7 @@
 		if(shroom_count >= place_count)
 			continue
 
-		var/obj/structure/glowshroom/child = new type(new_loc, newseed = myseed.Copy())
+		var/obj/structure/glowshroom/child = new type(new_loc, myseed.Copy())
 		child.generation = generation + 1
 
 /obj/structure/glowshroom/proc/calc_dir(turf/location = loc)


### PR DESCRIPTION
## About The Pull Request

This PR fixes spreaded glowshrooms runtiming on initialize, causing them to fail to init correctly.

## Why It's Good For The Game

Bugfix.

## Changelog
:cl: Melbert
fix: Glowshrooms created from spread now should behave like things that actually exist again.
/:cl:
