### PR TITLE
Fixes OOC heart commendations not saving between rounds

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -209,10 +209,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	READ_FILE(S["pda_style"], pda_style)
 	READ_FILE(S["pda_color"], pda_color)
 
-	// Custom hotkeys
-	READ_FILE(S["key_bindings"], key_bindings)
-	check_keybindings()
-	// hearted
+	// OOC commendations
 	READ_FILE(S["hearted_until"], hearted_until)
 	if(hearted_until > world.realtime)
 		hearted = TRUE
@@ -225,6 +222,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		if(ispath(path)) //whatever typepath fails this check probably doesn't exist anymore
 			parsed_favs += path
 	favorite_outfits = uniqueList(parsed_favs)
+
+	// Custom hotkeys
+	READ_FILE(S["key_bindings"], key_bindings)
+	check_keybindings() // this apparently fails every time and overwrites any unloaded prefs with the default values, so don't load anything after this line or it won't actually save
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I recently fixed OOC commendation poll prompts not being sent to players, but it then came to my attention afterwards that the hearted values would be gone by the beginning of the next round. I thought I broke the preference saving with my last PR, but it was actually #59492.

Said PR added a call to save_preferences() to the check_keybindings() proc any time loading failed, and as it would appear, it failed to load every single time it was called and would immediately save the user's prefs every time they joined the game. Since it came before all of the preferences were loaded (like hearted), this meant that those values would immediately be overridden as nulls before they could be loaded

Really, someone should look into why check_keybindings is still failing every time people join, but I know mothblocks is working on a total pref overhaul so I trust that to their very capable hands. This PR simply moves check_keybindings to after all the prefs are loaded so it can't break any of them. This might also fix favorite outfits as well, if those are broken.

Fixes: #59774
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes Commendations work
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: OOC heart commendations once again properly save and persist between rounds!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
