### PR TITLE
Reverts Entered() passing dir instead of old loc

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -134,9 +134,9 @@
 #define COMSIG_ATOM_UPDATED_ICON "atom_updated_icon"
 ///from base of [/atom/proc/smooth_icon]: ()
 #define COMSIG_ATOM_SMOOTHED_ICON "atom_smoothed_icon"
-///from base of atom/Entered(): (atom/movable/arrived, direction)
+///from base of atom/Entered(): (atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 #define COMSIG_ATOM_ENTERED "atom_entered"
-/// Sent from the atom that just Entered src. From base of atom/Entered(): (/atom/destination, direction)
+/// Sent from the atom that just Entered src. From base of atom/Entered(): (/atom/destination, atom/old_loc, list/atom/old_locs)
 #define COMSIG_ATOM_ENTERING "atom_entering"
 ///from base of atom/Exit(): (/atom/movable/leaving, direction)
 #define COMSIG_ATOM_EXIT "atom_exit"
@@ -369,7 +369,7 @@
 
 ///from base of area/proc/power_change(): ()
 #define COMSIG_AREA_POWER_CHANGE "area_power_change"
-///from base of area/Entered(): (atom/movable/arrived, direction)
+///from base of area/Entered(): (atom/movable/arrived, area/old_area)
 #define COMSIG_AREA_ENTERED "area_entered"
 ///from base of area/Exited(): (atom/movable/gone, direction)
 #define COMSIG_AREA_EXITED "area_exited"

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -310,7 +310,7 @@ have ways of interacting with a specific mob and control it.
 			var/mob/living/carbon/human/H = thrown_by
 			retaliate(H)
 
-/datum/ai_controller/monkey/proc/on_entered(datum/source, atom/movable/arrived, direction)
+/datum/ai_controller/monkey/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 	var/mob/living/living_pawn = pawn
 	if(!IS_DEAD_OR_INCAP(living_pawn) && isliving(arrived))

--- a/code/datums/components/acid.dm
+++ b/code/datums/components/acid.dm
@@ -201,7 +201,7 @@
 
 
 /// Handles searing the feet of whoever walks over this without protection. Only active if the parent is a turf.
-/datum/component/acid/proc/on_entered(datum/source, atom/movable/arrived, direction)
+/datum/component/acid/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 
 	if(!isliving(arrived))

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -148,7 +148,7 @@
 	)
 	AddElement(/datum/element/connect_loc_behalf, parent, loc_connections)
 
-/datum/component/butchering/recycler/proc/on_entered(datum/source, atom/movable/arrived, direction)
+/datum/component/butchering/recycler/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 
 	if(!isliving(arrived))

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -31,7 +31,7 @@
 	target_turf = target
 	START_PROCESSING(SSobj, src) // process on create, in case stuff is still there
 
-/datum/component/chasm/proc/Entered(datum/source, atom/movable/arrived, direction)
+/datum/component/chasm/proc/Entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 
 	START_PROCESSING(SSobj, src)

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -439,7 +439,7 @@ Behavior that's still missing from this component that original food items had t
 
 
 ///Ability to feed food to puppers
-/datum/component/edible/proc/on_entered(datum/source, atom/movable/arrived, direction)
+/datum/component/edible/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 	SEND_SIGNAL(parent, COMSIG_FOOD_CROSSED, arrived, bitecount)
 

--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -109,7 +109,7 @@
 		var/obj/item/I = parent
 		I.permeability_coefficient = old_permeability
 
-/datum/component/infective/proc/try_infect_crossed(datum/source, atom/movable/arrived, direction)
+/datum/component/infective/proc/try_infect_crossed(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 
 	if(isliving(arrived))

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -114,7 +114,7 @@
 	rot_react(source, react_to, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 
 /// Triggered when something enters the component's parent.
-/datum/component/rot/proc/on_entered(datum/source, atom/movable/arrived, direction)
+/datum/component/rot/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 	rot_react(source, arrived)
 

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -130,7 +130,7 @@
 	return COMPONENT_CANCEL_BLOB_ACT
 
 /// Triggered when something enters the component's parent.
-/datum/component/singularity/proc/on_entered(datum/source, atom/movable/arrived, direction)
+/datum/component/singularity/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 	consume(source, arrived)
 

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -47,7 +47,7 @@
  * source - the source of the signal
  * AM - the atom/movable that is being slipped.
  */
-/datum/component/slippery/proc/Slip(datum/source, atom/movable/arrived, direction)
+/datum/component/slippery/proc/Slip(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 	if(!isliving(arrived))
 		return
@@ -106,7 +106,7 @@
  * source - the source of the signal
  * AM - the atom/movable that slipped on us.
  */
-/datum/component/slippery/proc/Slip_on_wearer(datum/source, atom/movable/arrived, direction)
+/datum/component/slippery/proc/Slip_on_wearer(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 
 	if(holder.body_position == LYING_DOWN && !holder.buckled)

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -87,7 +87,7 @@
 	else
 		steps++
 
-/datum/component/squeak/proc/play_squeak_crossed(datum/source, atom/movable/arrived, direction)
+/datum/component/squeak/proc/play_squeak_crossed(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 
 	if(isitem(arrived))

--- a/code/datums/components/swarming.dm
+++ b/code/datums/components/swarming.dm
@@ -25,7 +25,7 @@
 	swarm_members = null
 	return ..()
 
-/datum/component/swarming/proc/join_swarm(datum/source, atom/movable/arrived, direction)
+/datum/component/swarming/proc/join_swarm(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 
 	var/datum/component/swarming/other_swarm = arrived.GetComponent(/datum/component/swarming)

--- a/code/datums/elements/caltrop.dm
+++ b/code/datums/elements/caltrop.dm
@@ -39,7 +39,7 @@
 	else
 		RegisterSignal(get_turf(target), COMSIG_ATOM_ENTERED, .proc/on_entered)
 
-/datum/element/caltrop/proc/on_entered(datum/source, atom/movable/arrived, direction)
+/datum/element/caltrop/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 
 	if(!prob(probability))

--- a/code/game/area/ai_monitored.dm
+++ b/code/game/area/ai_monitored.dm
@@ -14,7 +14,7 @@
 
 //Only need to use one camera
 
-/area/ai_monitored/Entered(atom/movable/arrived, direction)
+/area/ai_monitored/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if (ismob(arrived) && motioncameras.len)
 		for(var/X in motioncameras)
@@ -22,7 +22,7 @@
 			cam.newTarget(arrived)
 			return
 
-/area/ai_monitored/Exited(atom/movable/gone, direction)
+/area/ai_monitored/Exited(atom/movable/gone, atom/old_loc, list/atom/old_locs)
 	..()
 	if (ismob(gone) && motioncameras.len)
 		for(var/X in motioncameras)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -596,9 +596,9 @@ GLOBAL_LIST_EMPTY(teleportlocs)
  *
  * If the area has ambience, then it plays some ambience music to the ambience channel
  */
-/area/Entered(atom/movable/arrived, direction)
+/area/Entered(atom/movable/arrived, area/old_area)
 	set waitfor = FALSE
-	SEND_SIGNAL(src, COMSIG_AREA_ENTERED, arrived, direction)
+	SEND_SIGNAL(src, COMSIG_AREA_ENTERED, arrived, old_area)
 	for(var/atom/movable/recipient as anything in arrived.area_sensitive_contents)
 		SEND_SIGNAL(recipient, COMSIG_ENTER_AREA, src)
 	if(!isliving(arrived))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1319,9 +1319,9 @@
  *
  * Default behaviour is to send the [COMSIG_ATOM_ENTERED]
  */
-/atom/Entered(atom/movable/arrived, direction)
-	SEND_SIGNAL(src, COMSIG_ATOM_ENTERED, arrived, direction)
-	SEND_SIGNAL(arrived, COMSIG_ATOM_ENTERING, src, direction)
+/atom/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	SEND_SIGNAL(src, COMSIG_ATOM_ENTERED, arrived, old_loc, old_locs)
+	SEND_SIGNAL(arrived, COMSIG_ATOM_ENTERING, src, old_loc, old_locs)
 
 /**
  * An atom is attempting to exit this atom's contents

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -434,11 +434,11 @@
 
 	if(new_locs) // Same here, only if multi-tile.
 		for(var/atom/entered_loc as anything in (new_locs - old_locs))
-			entered_loc.Entered(src, direction)
+			entered_loc.Entered(src, oldloc, old_locs)
 	else
-		newloc.Entered(src, direction)
+		newloc.Entered(src, oldloc, old_locs)
 	if(oldarea != newarea)
-		newarea.Entered(src, direction)
+		newarea.Entered(src, oldarea)
 
 	Moved(oldloc, direction, FALSE, old_locs)
 
@@ -634,7 +634,7 @@
 		for(var/atom/movable/location as anything in get_nested_locs(src) + src)
 			LAZYREMOVE(location.area_sensitive_contents, gone.area_sensitive_contents)
 
-/atom/movable/Entered(atom/movable/arrived, direction)
+/atom/movable/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(arrived.area_sensitive_contents)
 		for(var/atom/movable/location as anything in get_nested_locs(src) + src)
@@ -702,9 +702,9 @@
 			var/dest_z = (destturf ? destturf.z : null)
 			if (old_z != dest_z)
 				onTransitZ(old_z, dest_z)
-			destination.Entered(src, movement_dir)
+			destination.Entered(src, oldloc)
 			if(destarea && old_area != destarea)
-				destarea.Entered(src, movement_dir)
+				destarea.Entered(src, old_area)
 
 		. = TRUE
 

--- a/code/game/objects/effects/effect_system/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/effects_smoke.dm
@@ -140,7 +140,7 @@
 		M.emote("cough")
 		return TRUE
 
-/obj/effect/particle_effect/smoke/bad/proc/on_entered(datum/source, atom/movable/arrived, direction)
+/obj/effect/particle_effect/smoke/bad/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 	if(istype(arrived, /obj/projectile/beam))
 		var/obj/projectile/beam/beam = arrived

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -372,7 +372,7 @@
 		I_copy.layer = FLOAT_LAYER
 		. += I_copy
 
-/obj/item/storage/bag/tray/Entered(atom/movable/arrived, direction)
+/obj/item/storage/bag/tray/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	update_appearance()
 

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -62,7 +62,7 @@
 	is_open = TRUE
 	update_appearance()
 
-/obj/item/storage/fancy/Entered(atom/movable/arrived, direction)
+/obj/item/storage/fancy/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	is_open = TRUE
 	update_appearance()

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -57,7 +57,7 @@
 			visible_message(span_warning("\The [src] is broken by [user] with an electromagnetic card!"))
 			return
 
-/obj/item/storage/lockbox/Entered(atom/movable/arrived, direction)
+/obj/item/storage/lockbox/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	open = TRUE
 	update_appearance()

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -91,7 +91,7 @@
 	update_appearance(UPDATE_ICON)
 	update_slot_icon()
 
-/obj/item/storage/wallet/Entered(atom/movable/arrived, direction)
+/obj/item/storage/wallet/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	refreshID(removed = FALSE)
 

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -79,7 +79,7 @@
 	. = ..()
 	AddComponent(/datum/component/wet_floor, TURF_WET_SUPERLUBE, INFINITY, 0, INFINITY, TRUE)
 
-/turf/open/indestructible/honk/Entered(atom/movable/arrived, direction)
+/turf/open/indestructible/honk/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(ismob(arrived))
 		playsound(src, sound, 50, TRUE)

--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -202,7 +202,7 @@
 	custom_materials = list(/datum/material/bananium = 500)
 	var/sound_cooldown = 0
 
-/turf/open/floor/mineral/bananium/Entered(atom/movable/arrived, direction)
+/turf/open/floor/mineral/bananium/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(.)
 		return
@@ -258,7 +258,7 @@
 	var/last_event = 0
 	var/active = null
 
-/turf/open/floor/mineral/uranium/Entered(atom/movable/arrived, direction)
+/turf/open/floor/mineral/uranium/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(.)
 		return

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -36,7 +36,7 @@
 /turf/open/lava/airless
 	initial_gas_mix = AIRLESS_ATMOS
 
-/turf/open/lava/Entered(atom/movable/arrived, direction)
+/turf/open/lava/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	if(burn_stuff(arrived))
 		START_PROCESSING(SSobj, src)
 

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -158,7 +158,7 @@
 		else
 			to_chat(user, span_warning("The plating is going to need some support! Place metal rods first."))
 
-/turf/open/space/Entered(atom/movable/arrived, direction)
+/turf/open/space/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(!arrived || src != arrived.loc)
 		return

--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -26,7 +26,7 @@
 /turf/open/space/transit/east
 	dir = EAST
 
-/turf/open/space/transit/Entered(atom/movable/arrived, direction)
+/turf/open/space/transit/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(!locate(/obj/structure/lattice) in src)
 		throw_atom(arrived)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	visibilityChanged()
 
 	for(var/atom/movable/content as anything in src)
-		Entered(content, NONE)
+		Entered(content, null)
 
 	var/area/A = loc
 	if(!IS_DYNAMIC_LIGHTING(src) && IS_DYNAMIC_LIGHTING(A))
@@ -343,7 +343,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	return TRUE
 
 
-/turf/open/Entered(atom/movable/arrived, direction)
+/turf/open/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	..()
 	//melting
 	if(isobj(arrived) && air && air.temperature > T0C)

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -258,7 +258,7 @@
 		T.active_hotspot = null
 	return ..()
 
-/obj/effect/hotspot/proc/on_entered(datum/source, atom/movable/arrived, direction)
+/obj/effect/hotspot/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 	if(isliving(arrived))
 		var/mob/living/immolated = arrived

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -474,7 +474,7 @@
 		A.addMember(src)
 	SSair.add_to_rebuild_queue(src)
 
-/obj/machinery/atmospherics/Entered(atom/movable/arrived, direction)
+/obj/machinery/atmospherics/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	if(istype(arrived, /mob/living))
 		var/mob/living/L = arrived
 		L.ventcrawl_layer = piping_layer

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -122,7 +122,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if((atom_crossed_over.density || isliving(atom_crossed_over)) && !QDELETED(atom_crossed_over))
 		Bump(atom_crossed_over)
 
-/obj/effect/immovablerod/proc/on_entering_atom(datum/source, atom/destination, direction)
+/obj/effect/immovablerod/proc/on_entering_atom(datum/source, atom/destination, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 	if(destination.density && isturf(destination))
 		Bump(destination)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -478,7 +478,7 @@
 
 	for(var/datum/spacevine_mutation/SM in SV.mutations)
 		SM.on_birth(SV)
-	location.Entered(SV, NONE)
+	location.Entered(SV, null)
 	return SV
 
 /datum/spacevine_controller/proc/VineDestroyed(obj/structure/spacevine/S)

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -114,7 +114,7 @@
 	. = ..()
 	countEggs()
 
-/obj/item/storage/basket/easter/Entered(atom/movable/arrived, direction)
+/obj/item/storage/basket/easter/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	countEggs()
 

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -48,7 +48,7 @@
 	* target - the atom that just moved onto the `source` turf.
 	* oldLoc - the old location that `target` was at before moving onto `source`.
 */
-/obj/machinery/mineral/proc/pickup_item(datum/source, atom/movable/target, direction)
+/obj/machinery/mineral/proc/pickup_item(datum/source, atom/movable/target, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 
 	return

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -187,7 +187,7 @@
 	update_body()
 	if(isturf(loc))
 		var/turf/T = loc
-		T.Entered(src, NONE)
+		T.Entered(src, null)
 
 //Ayy lmao
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -763,7 +763,7 @@ GLOBAL_DATUM(blackbox, /obj/machinery/smartfridge/black_box)
 		holder_animal = loc
 	START_PROCESSING(SSobj, src)
 
-/obj/structure/closet/stasis/Entered(atom/movable/arrived, direction)
+/obj/structure/closet/stasis/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	if(isliving(arrived) && holder_animal)
 		var/mob/living/L = arrived
 		L.notransform = 1

--- a/code/modules/ruins/icemoonruin_code/hotsprings.dm
+++ b/code/modules/ruins/icemoonruin_code/hotsprings.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_EMPTY(cursed_minds)
 	planetary_atmos = TRUE
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
 
-/turf/open/water/cursed_spring/Entered(atom/movable/arrived, direction)
+/turf/open/water/cursed_spring/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(!isliving(arrived))
 		return

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -261,7 +261,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	icon_state = base_icon_state
 	return ..()
 
-/turf/open/space/bluespace/Entered(atom/movable/arrived, direction)
+/turf/open/space/bluespace/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(parentSphere && arrived.forceMove(get_turf(parentSphere)))
 		do_sparks(3, FALSE, get_turf(arrived))
@@ -358,7 +358,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	var/datum/turf_reservation/reservation
 	var/turf/storageTurf
 
-/area/hilbertshotel/Entered(atom/movable/arrived, direction)
+/area/hilbertshotel/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(istype(arrived, /obj/item/hilbertshotel))
 		relocate(arrived)
@@ -446,7 +446,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	var/roomNumber
 	var/obj/item/hilbertshotel/parentSphere
 
-/obj/item/abstracthotelstorage/Entered(atom/movable/arrived, direction)
+/obj/item/abstracthotelstorage/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(ismob(arrived))
 		var/mob/M = arrived


### PR DESCRIPTION
As requested by @Kylerace
This passes the `old_locs` list, which will only be instantiated and populated should the source be a multi-tile object (almost never).

This should have no in-game effects as it is.