### PR TITLE
Rework maintenance loot spawners to fire at roundstart

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -348,3 +348,6 @@ GLOBAL_LIST_INIT(ratking_coins, list(//Coins: Used by the regal rat mob when spa
 			/obj/item/coin/silver,
 			/obj/item/coin/plastic,
 			/obj/item/coin/titanium))
+
+// List of all maintenance loot spawners, for easy finding at roundstart.
+GLOBAL_LIST_EMPTY(maintenance_loot_spawners)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -127,6 +127,7 @@ SUBSYSTEM_DEF(mapping)
 	setup_map_transitions()
 	generate_station_area_list()
 	initialize_reserved_level(transit.z_value)
+	SSticker.OnRoundstart(CALLBACK(src, .proc/spawn_maintenance_loot))
 	return ..()
 
 /datum/controller/subsystem/mapping/proc/wipe_reservations(wipe_safety_delay = 100)
@@ -590,3 +591,10 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		isolated_ruins_z = add_new_zlevel("Isolated Ruins/Reserved", list(ZTRAIT_RESERVED = TRUE, ZTRAIT_ISOLATED_RUINS = TRUE))
 		initialize_reserved_level(isolated_ruins_z.z_value)
 	return isolated_ruins_z.z_value
+
+/datum/controller/subsystem/mapping/proc/spawn_maintenance_loot()
+	for(var/obj/effect/spawner/lootdrop/maintenance/spawner as anything in GLOB.maintenance_loot_spawners)
+		CHECK_TICK
+
+		spawner.spawn_loot()
+		spawner.hide()

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -276,7 +276,7 @@
 
 /obj/effect/spawner/lootdrop/maintenance/Destroy()
 	GLOB.maintenance_loot_spawners -= src
-	. = ..()
+	return ..()
 
 /obj/effect/spawner/lootdrop/maintenance/proc/hide()
 	invisibility = INVISIBILITY_OBSERVER

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -19,10 +19,7 @@
 
 ///If the spawner has any loot defined, randomly picks some and spawns it. Does not cleanup the spawner.
 /obj/effect/spawner/lootdrop/proc/spawn_loot(lootcount_override)
-	var/lootcount = src.lootcount
-
-	if(!isnull(lootcount_override))
-		lootcount = lootcount_override
+	var/lootcount = isnull(lootcount_override) ? src.lootcount : lootcount_override
 
 	if(loot?.len)
 		var/loot_spawned = 0
@@ -293,8 +290,10 @@
 
 	return effective_lootcount
 
-/obj/effect/spawner/lootdrop/maintenance/spawn_loot()
-	. = ..(get_effective_lootcount())
+/obj/effect/spawner/lootdrop/maintenance/spawn_loot(lootcount_override)
+	if(isnull(lootcount_override))
+		lootcount_override = get_effective_lootcount()
+	. = ..()
 
 	// In addition, closets that are closed will have the maintenance loot inserted inside.
 	for(var/obj/structure/closet/closet in get_turf(src))


### PR DESCRIPTION
- Maintenance loot spawners now fire at roundstart, rather than during
  the initialization of the Atoms subsystem.
- Maintenance loot spawners do not qdel themselves during the spawning
  process, but persist, and merely hide themselves from living players.

This is prepatory refactoring of maintenance loot spawning, to
accomplish the following proposed ideas. Note that none of these ideas
are actually done in this commit.

- Later events that spawn more maintenance loot using the same spawners.
- Allowing admins to add/remove traits like "Filled up maintenance" in
  pre-round and have them take effect.

As a cute side effect, this lets preround observers look at the
colourful maintenance loot dice icons before the round starts. Observers
can continue to see the loot dice post-round, but they are deliberately
very faint.