### PR TITLE
Fix incorporeal movers procing containment field effects

### DIFF
--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -72,7 +72,9 @@
 /obj/machinery/field/containment/proc/on_entered(datum/source, atom/movable/AM)
 	SIGNAL_HANDLER
 	if(isliving(AM))
-		shock(AM)
+		var/mob/living/L = AM
+		if(!L.incorporeal_move)
+			shock(AM)
 
 	if(ismachinery(AM) || isstructure(AM) || ismecha(AM))
 		bump_field(AM)

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -72,8 +72,8 @@
 /obj/machinery/field/containment/proc/on_entered(datum/source, atom/movable/AM)
 	SIGNAL_HANDLER
 	if(isliving(AM))
-		var/mob/living/L = AM
-		if(!L.incorporeal_move)
+		var/mob/living/living_moving_through_field = AM
+		if(!living_moving_through_field.incorporeal_move)
 			shock(AM)
 
 	if(ismachinery(AM) || isstructure(AM) || ismecha(AM))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

Revenant uses `incorporeal_move` for example.

## Why It's Good For The Game

Fix good.

## Changelog
:cl:
fix: Fixed incorporeal movers procing containment field effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
