### PR TITLE
Fixes a runtime and refactors suit jetpacks a bit

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -46,8 +46,11 @@
 		return
 
 	if(!on)
-		turn_on(user)
-		to_chat(user, span_notice("You turn the jetpack on."))
+		if(turn_on(user))
+			to_chat(user, span_notice("You turn the jetpack on."))
+		else
+			to_chat(user, span_notice("You fail to turn the jetpack on."))
+			return
 	else
 		turn_off(user)
 		to_chat(user, span_notice("You turn the jetpack off."))
@@ -58,7 +61,7 @@
 
 /obj/item/tank/jetpack/proc/turn_on(mob/user)
 	if(!allow_thrust(0.01, user))
-		return
+		return FALSE
 	on = TRUE
 	icon_state = "[initial(icon_state)]-on"
 	ion_trail.start()
@@ -66,16 +69,19 @@
 	RegisterSignal(user, COMSIG_MOVABLE_PRE_MOVE, .proc/pre_move_react)
 	if(full_speed)
 		user.add_movespeed_modifier(/datum/movespeed_modifier/jetpack/fullspeed)
+	return TRUE
+
 
 /obj/item/tank/jetpack/proc/turn_off(mob/user)
 	on = FALSE
 	stabilizers = FALSE
 	icon_state = initial(icon_state)
 	ion_trail.stop()
-	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
-	UnregisterSignal(user, COMSIG_MOVABLE_PRE_MOVE)
+	if(user)
+		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
+		UnregisterSignal(user, COMSIG_MOVABLE_PRE_MOVE)
 
-	user.remove_movespeed_modifier(/datum/movespeed_modifier/jetpack/fullspeed)
+		user.remove_movespeed_modifier(/datum/movespeed_modifier/jetpack/fullspeed)
 
 /obj/item/tank/jetpack/proc/move_react(mob/user)
 	SIGNAL_HANDLER
@@ -201,12 +207,21 @@
 	full_speed = FALSE
 	var/datum/gas_mixture/tempair_contents
 	var/obj/item/tank/internals/tank = null
-	var/mob/living/carbon/human/cur_user
+	var/mob/living/carbon/human/active_user = null
+	var/obj/item/clothing/suit/space/hardsuit/active_hardsuit = null
+
 
 /obj/item/tank/jetpack/suit/Initialize()
 	. = ..()
 	STOP_PROCESSING(SSobj, src)
 	tempair_contents = air_contents
+
+
+/obj/item/tank/jetpack/suit/Destroy()
+	if(on)
+		turn_off()
+	return ..()
+
 
 /obj/item/tank/jetpack/suit/attack_self()
 	return
@@ -220,35 +235,72 @@
 	if(!istype(H.s_store, /obj/item/tank/internals))
 		to_chat(user, span_warning("You need a tank in your suit storage!"))
 		return
-	..()
+	return ..()
+
 
 /obj/item/tank/jetpack/suit/turn_on(mob/user)
 	if(!istype(loc, /obj/item/clothing/suit/space/hardsuit) || !ishuman(loc.loc) || loc.loc != user)
-		return
-	var/mob/living/carbon/human/H = user
-	tank = H.s_store
+		return FALSE
+	active_user = user
+	tank = active_user.s_store
 	air_contents = tank.return_air()
+	. = ..()
+	if(!.)
+		active_user = null
+		tank = null
+		air_contents = null
+		return
+	active_hardsuit = loc
+	RegisterSignal(active_hardsuit, COMSIG_MOVABLE_MOVED, .proc/on_hardsuit_moved)
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, .proc/on_moved)
+	RegisterSignal(active_user, COMSIG_PARENT_QDELETING, .proc/on_user_del)
 	START_PROCESSING(SSobj, src)
-	cur_user = user
-	..()
+
 
 /obj/item/tank/jetpack/suit/turn_off(mob/user)
+	STOP_PROCESSING(SSobj, src)
+	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
+	if(active_hardsuit)
+		UnregisterSignal(active_hardsuit, COMSIG_MOVABLE_MOVED)
+		active_hardsuit = null
+	if(active_user)
+		UnregisterSignal(user, COMSIG_PARENT_QDELETING)
+		active_user = null
 	tank = null
 	air_contents = tempair_contents
-	STOP_PROCESSING(SSobj, src)
-	cur_user = null
-	..()
+	return ..()
+
 
 /obj/item/tank/jetpack/suit/process()
-	if(!istype(loc, /obj/item/clothing/suit/space/hardsuit) || !ishuman(loc.loc))
-		turn_off(cur_user)
-		return
 	var/mob/living/carbon/human/H = loc.loc
 	if(!tank || tank != H.s_store)
-		turn_off(cur_user)
+		turn_off(active_user)
 		return
 	excited = TRUE
-	return ..()
+	..()
+
+
+/// Called when the jetpack moves, presumably away from the hardsuit.
+/obj/item/tank/jetpack/suit/proc/on_moved(atom/movable/source, atom/old_loc, movement_dir, forced, list/atom/old_locs)
+	SIGNAL_HANDLER
+	if(istype(loc, /obj/item/clothing/suit/space/hardsuit) && ishuman(loc.loc) && loc.loc == active_user)
+		UnregisterSignal(active_hardsuit, COMSIG_MOVABLE_MOVED)
+		active_hardsuit = loc
+		RegisterSignal(loc, COMSIG_MOVABLE_MOVED, .proc/on_hardsuit_moved)
+		return
+	turn_off(active_user)
+
+
+/// Called when the hardsuit loc moves, presumably away from the human user.
+/obj/item/tank/jetpack/suit/proc/on_hardsuit_moved(atom/movable/source, atom/old_loc, movement_dir, forced, list/atom/old_locs)
+	SIGNAL_HANDLER
+	turn_off(active_user)
+
+
+/// Called when the human wearing the suit that contains this jetpack is deleted.
+/obj/item/tank/jetpack/suit/proc/on_user_del(mob/living/carbon/human/source, force)
+	SIGNAL_HANDLER
+	turn_off(active_user)
 
 
 //Return a jetpack that the mob can use


### PR DESCRIPTION
* Refactors things a little so that it turns off based on events, instead of having to check whether it's in the right loc, and the loc is in the right loc, each time.
* Fixes this runtime:
```
[23:23:14] Runtime in jetpack.dm, line 78: Cannot execute null.remove movespeed modifier().
proc name: turn off (/obj/item/tank/jetpack/proc/turn_off)
src: the hardsuit jetpack upgrade (/obj/item/tank/jetpack/suit)
src.loc: the floor (124,91,2) (/turf/open/floor/iron)
call stack:
the hardsuit jetpack upgrade (/obj/item/tank/jetpack/suit): turn off(null)
the hardsuit jetpack upgrade (/obj/item/tank/jetpack/suit): turn off(null)
the hardsuit jetpack upgrade (/obj/item/tank/jetpack/suit): process(2)
Objects (/datum/controller/subsystem/processing/obj): fire(0)
Objects (/datum/controller/subsystem/processing/obj): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```