### PR TITLE
Fix turbine free power exploit

### DIFF
--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -127,14 +127,17 @@
 		return
 	cut_overlays()
 
-	rpm = 0.9* rpm + 0.1 * rpmtarget
-	var/datum/gas_mixture/environment = inturf.return_air()
+	if(istype(inturf, /turf/open))
+		rpm = 0.9 * rpm + 0.1 * rpmtarget
+		var/datum/gas_mixture/environment = inturf.return_air()
 
-	// It's a simplified version taking only 1/10 of the moles from the turf nearby. It should be later changed into a better version
+		// It's a simplified version taking only 1/10 of the moles from the turf nearby. It should be later changed into a better version
 
-	var/transfer_moles = environment.total_moles()/10
-	var/datum/gas_mixture/removed = inturf.remove_air(transfer_moles)
-	gas_contained.merge(removed)
+		var/transfer_moles = environment.total_moles()/10
+		var/datum/gas_mixture/removed = inturf.remove_air(transfer_moles)
+		gas_contained.merge(removed)
+	else
+		rpm = 0.9 * rpm // rpmtarget is basically 0, the intake is completely blocked with no airflow
 
 // RPM function to include compression friction - be advised that too low/high of a compfriction value can make things screwy
 


### PR DESCRIPTION
## About The Pull Request

Fixes the turbine making unlimited power if the intake turf gets blocked by a wall via RCD. This means the turbine stops decaying in RPM completely while producing power, while also not needing any gas present.

## Why It's Good For The Game

I know there's a turbine rework coming up by Ghilker, but I'd rather fix this now rather than wait for the rework while sitting on the exploit.

## Changelog
:cl:
fix: The turbine now behaves correctly if the intake is blocked.
/:cl: