### PR TITLE
Large cardboard box icon fix

### DIFF
--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -15,6 +15,7 @@
 	icon_state = "agentbox"
 	max_integrity = 1 // "This dumb box shouldn't take more than one hit to make it vanish."
 	move_speed_multiplier = 0.5
+	enable_door_overlay = FALSE
 
 /obj/structure/closet/cardboard/agent/proc/go_invisible()
 	animate(src, , alpha = 0, time = 20)

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -16,7 +16,6 @@
 	close_sound = 'sound/machines/cardboard_box.ogg'
 	open_sound_volume = 35
 	close_sound_volume = 35
-	enable_door_overlay = FALSE
 	var/move_speed_multiplier = 1
 	var/move_delay = FALSE
 	var/egged = 0

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -16,6 +16,7 @@
 	close_sound = 'sound/machines/cardboard_box.ogg'
 	open_sound_volume = 35
 	close_sound_volume = 35
+	has_closed_overlay = FALSE
 	var/move_speed_multiplier = 1
 	var/move_delay = FALSE
 	var/egged = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR fixes an issue where large cardboard boxes showed an incorrect icon when they were open.

The problem was that `enable_door_overlay` was set to FALSE for all cardboard boxes, which is incorrect as boxes have open overlays when they are open. The only exception is the agentbox, which has none as it gets deleted upon getting opened. Simply moving the FALSE variable there fixes the issue.

I also set `has_closed_overlay = FALSE` for all cardboard boxes, because they do not have any special closed overlays and tests would be failing otherwise.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugfix.

## Changelog
:cl: Arkatos
fix: Large cardboard boxes will now show a proper icon when they are open.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
