### PR TITLE
Hookup Change Command Name to Create Command Report

### DIFF
--- a/code/modules/admin/verbs/commandreport.dm
+++ b/code/modules/admin/verbs/commandreport.dm
@@ -49,10 +49,13 @@
 	/// The sound that's going to accompany our message.
 	var/played_sound = DEFAULT_ANNOUNCEMENT_SOUND
 	/// A static list of preset names that can be chosen.
-	var/static/list/preset_names = list(CENTCOM_PRESET, SYNDICATE_PRESET, WIZARD_PRESET, CUSTOM_PRESET)
+	var/list/preset_names = list(CENTCOM_PRESET, SYNDICATE_PRESET, WIZARD_PRESET, CUSTOM_PRESET)
 
 /datum/command_report_menu/New(mob/user)
 	ui_user = user
+	if(command_name() != CENTCOM_PRESET)
+		command_name = command_name()
+		preset_names.Insert(1, command_name())
 
 /datum/command_report_menu/ui_state(mob/user)
 	return GLOB.admin_state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds and defaults the contents of `command_name()` to the list of names in the Create Command Report tgui presets if changed from Central Command.

## Why It's Good For The Game

Better for running events. Links the Change Command Name and Create Command Report verbs together in a logical way.

## Changelog
:cl:
fix: Fixed Create Command Report UI lacking an option derived from command_name().
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
