### PR TITLE
Fix blanket cure_blind calls removing quirk and blindfold traits

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -46,24 +46,24 @@
 	} while (0)
 #define REMOVE_TRAIT_NOT_FROM(target, trait, sources) \
 	do { \
-		var/list/_L = target.status_traits; \
-		var/list/_S; \
+		var/list/_traits_list = target.status_traits; \
+		var/list/_sources_list; \
 		if (sources && !islist(sources)) { \
-			_S = list(sources); \
+			_sources_list = list(sources); \
 		} else { \
-			_S = sources\
+			_sources_list = sources\
 		}; \
-		if (_L && _L[trait]) { \
-			for (var/_T in _L[trait]) { \
-				if (!(_T in _S)) { \
-					_L[trait] -= _T \
+		if (_traits_list && _traits_list[trait]) { \
+			for (var/_trait_source in _traits_list[trait]) { \
+				if (!(_trait_source in _sources_list)) { \
+					_traits_list[trait] -= _trait_source \
 				} \
 			};\
-			if (!length(_L[trait])) { \
-				_L -= trait; \
+			if (!length(_traits_list[trait])) { \
+				_traits_list -= trait; \
 				SEND_SIGNAL(target, SIGNAL_REMOVETRAIT(trait), trait); \
 			}; \
-			if (!length(_L)) { \
+			if (!length(_traits_list)) { \
 				target.status_traits = null \
 			}; \
 		} \

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -44,6 +44,30 @@
 			}; \
 		} \
 	} while (0)
+#define REMOVE_TRAIT_NOT_FROM(target, trait, sources) \
+	do { \
+		var/list/_L = target.status_traits; \
+		var/list/_S; \
+		if (sources && !islist(sources)) { \
+			_S = list(sources); \
+		} else { \
+			_S = sources\
+		}; \
+		if (_L && _L[trait]) { \
+			for (var/_T in _L[trait]) { \
+				if (!(_T in _S)) { \
+					_L[trait] -= _T \
+				} \
+			};\
+			if (!length(_L[trait])) { \
+				_L -= trait; \
+				SEND_SIGNAL(target, SIGNAL_REMOVETRAIT(trait), trait); \
+			}; \
+			if (!length(_L)) { \
+				target.status_traits = null \
+			}; \
+		} \
+	} while (0)
 #define REMOVE_TRAITS_NOT_IN(target, sources) \
 	do { \
 		var/list/_L = target.status_traits; \

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -450,7 +450,10 @@
 /////////////////////////////////// TRAIT PROCS ////////////////////////////////////
 
 /mob/living/proc/cure_blind(source)
-	REMOVE_TRAIT(src, TRAIT_BLIND, source)
+	if(source)
+		REMOVE_TRAIT(src, TRAIT_BLIND, source)
+	else
+		REMOVE_TRAIT_NOT_FROM(src, TRAIT_BLIND, list(QUIRK_TRAIT, EYES_COVERED, BLINDFOLD_TRAIT))
 	if(!HAS_TRAIT(src, TRAIT_BLIND))
 		update_blindness()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so when `proc/cure_blind(source)` is called with no source is does not cure blindness from the quirk, blindfolds, or other eye coverings.

## Why It's Good For The Game

Fixes: #59842

## Changelog
:cl:
fix: Fixed fully_heal proc curing blindness from quirks and blindfolds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
