### PR TITLE
Non-changeling spawned headslugs now burst non-antag changeling variant again

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -42,7 +42,8 @@
 #define ROLE_FAMILIES "Familes Antagonists"
 #define ROLE_SYNDICATE_CYBERSUN "Cybersun Space Syndicate" //Ghost role syndi from Forgottenship ruin
 #define ROLE_SYNDICATE_CYBERSUN_CAPTAIN "Cybersun Space Syndicate Captain" //Forgottenship captain syndie
-#define ROLE_FREE_GOLEM "Free Golem" 
+#define ROLE_FREE_GOLEM "Free Golem"
+#define ROLE_HEADSLUG_CHANGELING "Headslug Changeling"
 
 /// This defines the antagonists you can operate with in the settings.
 /// Keys are the antagonist, values are the number of days since the player's

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -692,3 +692,19 @@
 
 	return parts.Join("<br>")
 
+// Changelings spawned from non-changeling headslugs (IE, due to being transformed into a headslug as a non-ling). Weaker than a normal changeling.
+/datum/antagonist/changeling/headslug
+	name = "Headslug Changeling"
+	show_in_antagpanel = FALSE
+	give_objectives = FALSE
+
+	geneticpoints = 5
+	total_geneticspoints = 5
+	chem_charges = 10
+	chem_storage = 50
+	total_chem_storage = 50
+
+/datum/antagonist/changeling/headslug/greet()
+	if(you_are_greet)
+		to_chat(owner, span_boldannounce("You are a fresh changeling birthed from a headslug! You are not quite as powerful as a full changeling, and are not a full antagonist."))
+	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ling_aler.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -705,6 +705,9 @@
 	total_chem_storage = 50
 
 /datum/antagonist/changeling/headslug/greet()
+	var/policy = get_policy(ROLE_HEADSLUG_CHANGELING)
 	if(you_are_greet)
-		to_chat(owner, span_boldannounce("You are a fresh changeling birthed from a headslug! You are not quite as powerful as a full changeling, and are not a full antagonist."))
+		to_chat(owner, span_boldannounce("You are a fresh changeling birthed from a headslug! You aren't as strong as a normal changeling, as you are newly born."))
+	if(policy)
+		to_chat(owner, policy)
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ling_aler.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -697,6 +697,7 @@
 	name = "Headslug Changeling"
 	show_in_antagpanel = FALSE
 	give_objectives = FALSE
+	soft_antag = TRUE
 
 	geneticpoints = 5
 	total_geneticspoints = 5

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -69,23 +69,23 @@
 		qdel(src)
 
 /obj/item/organ/body_egg/changeling_egg/proc/Pop()
-	var/mob/living/carbon/human/species/monkey/M = new(owner)
+	var/mob/living/carbon/human/species/monkey/spawned_monkey = new(owner)
 
 	for(var/obj/item/organ/I in src)
-		I.Insert(M, 1)
+		I.Insert(spawned_monkey, 1)
 
 	if(origin && (origin.current ? (origin.current.stat == DEAD) : origin.get_ghost()))
-		origin.transfer_to(M)
-		var/datum/antagonist/changeling/C = origin.has_antag_datum(/datum/antagonist/changeling)
-		if(!C)
-			C = origin.add_antag_datum(/datum/antagonist/changeling)
-		if(C.can_absorb_dna(owner))
-			C.add_new_profile(owner)
+		origin.transfer_to(spawned_monkey)
+		spawned_monkey.key = origin.key
+		var/datum/antagonist/changeling/changeling_datum = origin.has_antag_datum(/datum/antagonist/changeling)
+		if(!changeling_datum)
+			changeling_datum = origin.add_antag_datum(/datum/antagonist/changeling/headslug)
+		if(changeling_datum.can_absorb_dna(owner))
+			changeling_datum.add_new_profile(owner)
 
 		var/datum/action/changeling/humanform/hf = new
-		C.purchasedpowers += hf
-		C.regain_powers()
-		M.key = origin.key
+		changeling_datum.purchasedpowers += hf
+		changeling_datum.regain_powers()
 	owner.gib()
 
 #undef EGG_INCUBATION_TIME


### PR DESCRIPTION
## About The Pull Request

This PR makes it so changelings spawned from headslugs that weren't originally changelings (IE, headslugs from a mob getting transformed into one) get a no-objectives, non-antag variant of changeling, as they did in the past.

Prior to #59489 headslugs that bursted into a FRESH changeling became a xenobio changelings, which weren't antags and got no objectives. That PR removed xenobio ling officially meaning headslugs that bursted into a fresh changeling become full on changeling antags. 

As headslugs are in the icebox mutation pool of creatures you can get, this meant you could get full changeling antag status, complete with objectives.

Now, if a headslug bursts from a mind that wasn't already a changeling, they become a "headslug changeling", which is weaker than a normal changeling and not an antagonist (no objectives).

Normal changeling headslugs are unaffected.

## Why It's Good For The Game

Getting free changeling antag status from being transformed into a headslug is no good.

## Changelog
:cl: Melbert
fix: Changelings birthed from headslugs that weren't already changelings (for example, from the icebox mutation pool) are no longer full changeling antagonists, but instead are a weaker, non-antagonist changeling variant (as they were in the past). 
/:cl:

