### PR TITLE
Makes tanks display their max pressure and only return their analysed contents once

### DIFF
--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -112,6 +112,7 @@
 		. += "<span class='notice'>A pipe port can be opened with a [wrench_hint].</span>"
 	else
 		. += "<span class='notice'>The pipe port can be moved or closed with a [wrench_hint].</span>"
+	. += "<span class='notice'>A holographic sticker on it says that its maximum safe pressure is: [siunit_pressure(max_pressure, 0)].</span>"
 
 /obj/machinery/atmospherics/components/tank/set_custom_materials(list/materials, multiplier)
 	. = ..()
@@ -146,6 +147,9 @@
 
 ///////////////////////////////////////////////////////////////////
 // Pipenet stuff
+
+/obj/machinery/atmospherics/components/tank/return_analyzable_air()
+	return air_contents
 
 /obj/machinery/atmospherics/components/tank/returnAirsForReconcilation(datum/pipeline/requester)
 	. = ..()


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some QOL fixes for the new atmos tanks as described in the title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It is impossible to know tanks' pressure limits currently without code diving. Also stops analyzing tanks returning the same result 4 times, once for each node.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Examining stationary tanks now tells you their pressure limits.
fix: Analyzing stationary tanks no longer gives you the same thing four times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
