### PR TITLE
Fix ion carbine parts kit's name and other similar grammar issues

### DIFF
--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -27,7 +27,7 @@
 
 /obj/item/weaponcrafting/gunkit/nuclear
 	name = "advanced energy gun parts kit"
-	desc = "A suitcase containing the necessary gun parts to tranform a standard energy gun into an advaned energy gun."
+	desc = "A suitcase containing the necessary gun parts to tranform a standard energy gun into an advanced energy gun."
 
 /obj/item/weaponcrafting/gunkit/tesla
 	name = "tesla cannon parts kit"
@@ -38,8 +38,8 @@
 	desc = "A suitcase containing the necessary gun parts to turn a laser gun into a x-ray laser gun. Do not point most parts directly towards face."
 
 /obj/item/weaponcrafting/gunkit/ion
-	name = "generic gun parts kit"
-	desc = "A suitcase containing the necessary gun parts to transform a standard laser gun into a ion carbine."
+	name = "ion carbine parts kit"
+	desc = "A suitcase containing the necessary gun parts to transform a standard laser gun into a ion carbine. Perfect against lockers you don't have access to."
 
 /obj/item/weaponcrafting/gunkit/temperature
 	name = "temperature gun parts kit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the ion carbine gun parts kit actually called "ion carbine parts kit".
Also fixes a typo in the spelling of "advanced" for the advanced energy gun parts kit's description.
Also adds some fluff to the ion carbine parts kit similar to the ones for the other guns.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less typos, better names. Fixes #59861 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: Ion carbine gun parts kits are no longer called "generic gun parts kit".
spellcheck: The "advanced" in advanced energy gun parts kit is no longer misspelled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
