### PR TITLE
RAM now has an option to select between types. Refactored the any type to be more friendly with circuit code.

### DIFF
--- a/code/__DEFINES/wiremod.dm
+++ b/code/__DEFINES/wiremod.dm
@@ -7,7 +7,7 @@
 // Port types. Determines what the port can connect to
 
 /// Can accept any datatype. Only works for inputs, output types will runtime.
-#define PORT_TYPE_ANY null
+#define PORT_TYPE_ANY "any"
 
 // Fundamental datatypes
 /// String datatype
@@ -25,8 +25,6 @@
 // Other datatypes
 /// Atom datatype
 #define PORT_TYPE_ATOM "entity"
-/// Any datatype (USED ONLY FOR DISPLAY, DO NOT USE)
-#define COMP_TYPE_ANY "any"
 
 
 /// The maximum range between a port and an atom

--- a/code/modules/wiremod/component.dm
+++ b/code/modules/wiremod/component.dm
@@ -132,26 +132,6 @@
 	TRIGGER_CIRCUIT_COMPONENT(src, null)
 
 /**
- * Matches the output port's datatype with the input port's current connected port.
- *
- * Returns true if datatype was changed, otherwise returns false.
- * Arguments:
- * * input_port - The input port to check the connected port from.
- * * output_port - The output port to convert. Warning, this does change the output port.
- */
-/obj/item/circuit_component/proc/match_port_datatype(datum/port/input/input_port, datum/port/output/output_port)
-	if(input_port.connected_port)
-		var/datum/port/connected_port = input_port.connected_port
-		if(connected_port.datatype != output_port.datatype)
-			output_port.set_datatype(connected_port.datatype)
-			return TRUE
-	else
-		output_port.set_datatype(output_port.default_datatype)
-		return TRUE
-	return FALSE
-
-
-/**
  * Adds an input port and returns it
  *
  * Arguments:

--- a/code/modules/wiremod/components/utility/combiner.dm
+++ b/code/modules/wiremod/components/utility/combiner.dm
@@ -16,7 +16,7 @@
 
 /obj/item/circuit_component/combiner/populate_options()
 	var/static/component_options = list(
-		COMP_TYPE_ANY,
+		PORT_TYPE_ANY,
 		PORT_TYPE_STRING,
 		PORT_TYPE_NUMBER,
 		PORT_TYPE_LIST,
@@ -27,12 +27,11 @@
 
 /obj/item/circuit_component/combiner/Initialize()
 	. = ..()
-	current_option = COMP_TYPE_ANY
-	current_type = COMP_TYPE_ANY
+	current_type = current_option
 	for(var/port_id in 1 to input_port_amount)
 		var/letter = ascii2text(text2ascii("A") + (port_id-1))
-		add_input_port(letter, PORT_TYPE_ANY)
-	output_port = add_output_port("Output", PORT_TYPE_ANY)
+		add_input_port(letter, current_option)
+	output_port = add_output_port("Output", current_option)
 
 /obj/item/circuit_component/combiner/Destroy()
 	output_port = null
@@ -40,10 +39,8 @@
 
 /obj/item/circuit_component/combiner/input_received(datum/port/input/port)
 	. = ..()
-	if(current_type != current_option && (current_option != COMP_TYPE_ANY || current_type != PORT_TYPE_ANY))
+	if(current_type != current_option)
 		current_type = current_option
-		if(current_type == COMP_TYPE_ANY)
-			current_type = PORT_TYPE_ANY
 		for(var/datum/port/input/input_port as anything in input_ports)
 			input_port.set_datatype(current_type)
 		output_port.set_datatype(current_type)

--- a/code/modules/wiremod/components/utility/multiplexer.dm
+++ b/code/modules/wiremod/components/utility/multiplexer.dm
@@ -24,7 +24,7 @@
 
 /obj/item/circuit_component/multiplexer/populate_options()
 	var/static/component_options = list(
-		COMP_TYPE_ANY,
+		PORT_TYPE_ANY,
 		PORT_TYPE_STRING,
 		PORT_TYPE_NUMBER,
 		PORT_TYPE_LIST,
@@ -34,13 +34,12 @@
 
 /obj/item/circuit_component/multiplexer/Initialize()
 	. = ..()
-	current_option = COMP_TYPE_ANY
-	current_type = COMP_TYPE_ANY
+	current_type = current_option
 	input_port = add_input_port("Selector", PORT_TYPE_NUMBER, default = 1)
 	multiplexer_inputs = list()
 	for(var/port_id in 1 to input_port_amount)
-		multiplexer_inputs += add_input_port("Port [port_id]", PORT_TYPE_ANY)
-	output_port = add_output_port("Output", PORT_TYPE_ANY)
+		multiplexer_inputs += add_input_port("Port [port_id]", current_type)
+	output_port = add_output_port("Output", current_type)
 
 /obj/item/circuit_component/multiplexer/Destroy()
 	output_port = null
@@ -51,16 +50,14 @@
 
 /obj/item/circuit_component/multiplexer/input_received(datum/port/input/port)
 	. = ..()
-	if(current_type != current_option && (current_option != COMP_TYPE_ANY || current_type != PORT_TYPE_ANY))
+	if(current_type != current_option)
 		current_type = current_option
-		if(current_type == COMP_TYPE_ANY)
-			current_type = PORT_TYPE_ANY
 		for(var/datum/port/input/input_port as anything in multiplexer_inputs)
 			input_port.set_datatype(current_type)
 		output_port.set_datatype(current_type)
 
 	input_port.set_input(clamp(input_port.input_value || 1, 1, input_port_amount), FALSE)
 	if(.)
-		return TRUE
+		return
 	output_port.set_output(multiplexer_inputs[input_port.input_value].input_value)
 

--- a/code/modules/wiremod/components/utility/ram.dm
+++ b/code/modules/wiremod/components/utility/ram.dm
@@ -8,6 +8,7 @@
 /obj/item/circuit_component/ram
 	display_name = "RAM"
 	display_desc = "A component that retains a variable."
+	circuit_flags = CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	/// The input to store
 	var/datum/port/input/input_port
@@ -19,13 +20,27 @@
 	/// The current set value
 	var/datum/port/output/output
 
+	var/current_type
+
+/obj/item/circuit_component/ram/populate_options()
+	var/static/component_options = list(
+		PORT_TYPE_ANY,
+		PORT_TYPE_STRING,
+		PORT_TYPE_NUMBER,
+		PORT_TYPE_LIST,
+		PORT_TYPE_ATOM,
+		PORT_TYPE_SIGNAL,
+	)
+	options = component_options
+
 /obj/item/circuit_component/ram/Initialize()
 	. = ..()
-	input_port = add_input_port("Input", PORT_TYPE_ANY)
+	current_type = current_option
+	input_port = add_input_port("Input", current_type)
 	trigger = add_input_port("Store", PORT_TYPE_SIGNAL)
 	clear = add_input_port("Clear", PORT_TYPE_SIGNAL)
 
-	output = add_output_port("Stored Value", PORT_TYPE_ANY)
+	output = add_output_port("Stored Value", current_type)
 
 /obj/item/circuit_component/ram/Destroy()
 	input_port = null
@@ -36,7 +51,11 @@
 
 /obj/item/circuit_component/ram/input_received(datum/port/input/port)
 	. = ..()
-	match_port_datatype(input_port, output)
+	if(current_type != current_option)
+		current_type = current_option
+		input_port.set_datatype(current_type)
+		output.set_datatype(current_type)
+
 	if(.)
 		return
 
@@ -45,7 +64,7 @@
 		return
 
 	if(!COMPONENT_TRIGGERED_BY(trigger, port))
-		return
+		return TRUE
 
 	var/input_val = input_port.input_value
 

--- a/code/modules/wiremod/integrated_circuit.dm
+++ b/code/modules/wiremod/integrated_circuit.dm
@@ -297,7 +297,7 @@
 			var/datum/port/input/input_port = input_component.input_ports[input_port_id]
 			var/datum/port/output/output_port = output_component.output_ports[output_port_id]
 
-			if(input_port.datatype && !output_port.compatible_datatype(input_port.datatype))
+			if(input_port.datatype != PORT_TYPE_ANY && !output_port.compatible_datatype(input_port.datatype))
 				return
 
 			input_port.register_output_port(output_port)

--- a/code/modules/wiremod/port.dm
+++ b/code/modules/wiremod/port.dm
@@ -155,7 +155,7 @@
 	set_output(null)
 
 /**
- * Determines if a datatype is compatible with this port.
+ * Determines if a datatype is compatible with another port of a different type.
  *
  * Arguments:
  * * other_datatype - The datatype to check


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
RAM now has an option to select between types and an output signal. Refactored the any type to be more friendly with user displays.
Code that includes changing type is no longer hard to read because of snowflake code for the "any" type.
RAM can now more easily act as a constant value component.
RAM also has an output signal because it should and the fact that it doesn't was an oversight when converting everything to use input and output signals.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes code easier to read + RAM can now act as a constant value component.

## Changelog
:cl:
qol: The RAM circuit component now allows you to select the type instead of trying to interpret it, allowing it to be used as a constant value component.
code: Made the any datatype for circuit components much easier to read in code.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
