### PR TITLE
Removes plasteel as a custom material for tanks to prevent bugs

### DIFF
--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -10,7 +10,7 @@
 	density = TRUE
 	layer = ABOVE_WINDOW_LAYER
 
-	custom_materials = list(/datum/material/alloy/plasteel=4000, /datum/material/iron=20000)
+	custom_materials = list(/datum/material/iron=20000) // plasteel is not a material to prevent two bugs: one where the default pressure is 1.5 times higher as plasteel's material modifier is added, and a second one where the tank names could be "plasteel plasteel" tanks
 	material_flags = MATERIAL_GREYSCALE | MATERIAL_ADD_PREFIX | MATERIAL_AFFECT_STATISTICS
 
 	pipe_flags = PIPING_ONE_PER_TURF
@@ -538,7 +538,6 @@
 		return
 	var/obj/machinery/atmospherics/components/tank/new_tank = new(build_location)
 	var/list/new_custom_materials = list()
-	new_custom_materials[/datum/material/alloy/plasteel] = 4000
 	new_custom_materials[material_end_product] = 20000
 	new_tank.set_custom_materials(new_custom_materials)
 	to_chat(user, "<span class='notice'>[new_tank] has been sealed and is ready to accept gases.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title. This PR removes plasteel from being a default custom material for pressure tanks. (Plasteel pressure tanks will still have plasteel and all its properties)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This fixes two bugs:
1: The default maximum pressure, even for iron tanks in reality was 30000kPa as the plasteel as a custom material would affect it.
2: If you made a plasteel tank, it would display as "plasteel plasteel pressure tank", and in general even with iron it would display it as an "iron plasteel pressure tank" which seems incredibly unwieldy.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Stationary pressure tanks now properly have their base pressure at 20000kPa.
fix: Stationary pressure tanks now do not name themselves as "plasteel plasteel pressure tank".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
