### PR TITLE
Fixes analyzer issues with tanks, removes a hidden 800L volume "buffer" from them (and makes them more easily var-editable)

### DIFF
--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -59,7 +59,9 @@
 
 /obj/machinery/atmospherics/components/tank/Initialize()
 	. = ..()
-
+	for (var/datum/gas_mixture/airs_ports in airs)
+		airs_ports.volume = 0 // so that all gas shows up on the analyzer properly, these nodes aren't actually needed for functionality here
+	
 	if(!knob_overlays)
 		knob_overlays = list()
 		for(var/dir in GLOB.cardinals)

--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -59,7 +59,7 @@
 
 /obj/machinery/atmospherics/components/tank/Initialize()
 	. = ..()
-	for (var/datum/gas_mixture/airs_ports in airs)
+	for (var/datum/gas_mixture/airs_ports as anything in airs)
 		airs_ports.volume = 0 // so that all gas shows up on the analyzer properly, these nodes aren't actually needed for functionality here
 	
 	if(!knob_overlays)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This sets the default air ports (ie nodes) of the stationary pressure tank to have 0 volume.
This makes the volume of the pressure tank actually 2500 L (although note another bug currently affects volume making it actually have 5000 L which I am in the process of attempting to fix it) rather than 2500 L and a hidden 800 L from the four port nodes.
**(Note: The analyzer fix part complements #59946 and only works if that is merged as well)**
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
With #59946 alone, using an analyzer on a stationary tank would either give you the gas mix of the air contents (2500 L (currently bugged as 5000 L)), or without #59946, the four nodes totalling 800 L, each node having 200 L of gas. This makes it incredibly unintuitive (and outright impossible without you knowing about this bug) to find the actual amount of moles that the tank contains.
This also means that when var-editing, no gas "disappears" into the nodes. Currently let's say you varedited a tank with 2000 moles of gas to 3000 moles by var-editing the air_contents' datum/gas_mixture, when you refresh the object, it wouldn't display as 3000 moles but something slighly less like perhaps 2800.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Analyzers now more correctly display the mole count of gas of stationary pressure tanks.
fix: Removes a hidden 800 L "buffer" of gas in the nodes of stationary pressure tanks.
admin: Variable-editing the air_contents of stationary pressure tanks is now more intuitive and gas no longe "disappears" after doing so.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
