### PR TITLE
Makes roundstart stationary air tanks actually have a ratio that is breathable and matches normal air

### DIFF
--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -341,8 +341,8 @@
 
 /obj/machinery/atmospherics/components/tank/air/Initialize()
 	. = ..()
-	FillToPressure(/datum/gas/oxygen, safety_margin=O2_STANDARD)
-	FillToPressure(/datum/gas/nitrogen, safety_margin=N2_STANDARD)
+	FillToPressure(/datum/gas/oxygen, safety_margin=(O2STANDARD * 0.5))
+	FillToPressure(/datum/gas/nitrogen, safety_margin=(N2STANDARD * 0.5))
 
 /obj/machinery/atmospherics/components/tank/carbon_dioxide
 	gas_type = /datum/gas/carbon_dioxide

--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -341,8 +341,8 @@
 
 /obj/machinery/atmospherics/components/tank/air/Initialize()
 	. = ..()
-	FillToPressure(/datum/gas/oxygen, safety_margin=0.1)
-	FillToPressure(/datum/gas/nitrogen, safety_margin=0.5)
+	FillToPressure(/datum/gas/oxygen, safety_margin=O2_STANDARD)
+	FillToPressure(/datum/gas/nitrogen, safety_margin=N2_STANDARD)
 
 /obj/machinery/atmospherics/components/tank/carbon_dioxide
 	gas_type = /datum/gas/carbon_dioxide


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title. Prior to this roundstart stationary air tanks had a ratio of 1:5 between oxygen and nitrogen, ie 16.667% oxygen and 83.333% nitrogen. This fixes that and makes it have 21% oxygen and 79% nitrogen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Air tanks no longer become a trap for the unwary who pump it into distribution or fill rooms with it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Roundstart stationary air tanks now have the proper 21:79 oxygen:nitrogen gas mix that is used throughout the station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
