### PR TITLE
Documents antag_datum.dm

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -299,7 +299,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 			return FALSE
 	return TRUE
 
-/// List if ["Command"] = CALLBACK(), user will be appeneded to callback arguments on execution
+/// List of ["Command"] = CALLBACK(), user will be appeneded to callback arguments on execution
 /datum/antagonist/proc/get_admin_commands()
 	. = list()
 


### PR DESCRIPTION

## About The Pull Request

So, was casually scrolling through some antag datums, someone had an ahelp or something on live, right
And I start reading some of theses procs we have on various antag datums, thinking, hunh, some of these are rather vague
So I take a look at antag_datum.dm, right
Not a single variable, proc, or line has been properly autodoc'd
Well, I don't think we're remove all of antagonist code anytime soon, so I got to writing.

## Why It's Good For The Game
This documents the entire file correctly with autodocs, because I like being able to know what maybe a handful of these procs do before the technical debt crushes us like a big crunch.

## Changelog
Unneeded as there are no player facing changes.