### PR TITLE
fixes a connect_loc runtime related to abstract_move

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -3,7 +3,7 @@
 	glide_size = 8
 	appearance_flags = TILE_BOUND|PIXEL_SCALE
 
-	///how many times a this movable was moved since Moved() was last called
+	///how many times a this movable had movement procs called on it since Moved() was last called
 	var/move_stacks = 0
 	var/last_move = null
 	var/last_move_time = 0
@@ -363,6 +363,7 @@
  */
 /atom/movable/proc/abstract_move(atom/new_loc)
 	var/atom/old_loc = loc
+	move_stacks++
 	loc = new_loc
 	Moved(old_loc)
 
@@ -561,8 +562,11 @@
 		update_parallax_contents()
 
 	move_stacks--
-	if(move_stacks > 0)
+	if(move_stacks > 0) //we want only the first Moved() call in the stack to send this signal, all the other ones have an incorrect old_loc
 		return
+	if(move_stacks < 0)
+		stack_trace("move_stacks is negative in Moved()!")
+		move_stacks = 0 //setting it to 0 so that we dont get every movable with negative move_stacks runtiming on every movement
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, old_loc, movement_dir, forced, old_locs)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -329,7 +329,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/Move(NewLoc, direct, glide_size_override = 32)
 	if(updatedir)
 		setDir(direct)//only update dir if we actually need it, so overlays won't spin on base sprites that don't have directions of their own
-	var/oldloc = loc
 
 	if(glide_size_override)
 		set_glide_size(glide_size_override)
@@ -337,17 +336,21 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		abstract_move(NewLoc)
 		update_parallax_contents()
 	else
-		abstract_move(get_turf(src))  //Get out of closets and such as a ghost
-		if((direct & NORTH) && y < world.maxy)
-			y++
-		else if((direct & SOUTH) && y > 1)
-			y--
-		if((direct & EAST) && x < world.maxx)
-			x++
-		else if((direct & WEST) && x > 1)
-			x--
+		var/turf/destination = get_turf(src)
 
-	Moved(oldloc, direct)
+		if((direct & NORTH) && y < world.maxy)
+			destination = get_step(destination, NORTH)
+
+		else if((direct & SOUTH) && y > 1)
+			destination = get_step(destination, SOUTH)
+
+		if((direct & EAST) && x < world.maxx)
+			destination = get_step(destination, EAST)
+
+		else if((direct & WEST) && x > 1)
+			destination = get_step(destination, WEST)
+
+		abstract_move(destination)//Get out of closets and such as a ghost
 
 /mob/dead/observer/verb/reenter_corpse()
 	set category = "Ghost"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #59790 
move_stacks is supposed to be incremented at the start of every movement call and decremented in Moved() when the movement is finished. This is so that connect_loc is only sent the first COMSIG_MOVABLE_MOVED signal in the stack, which is the only one with the correct old_loc that is stored in connect_loc. abstract_move() wasnt incrementing move_stacks, so anything that used it would have a negative move_stacks value which means all Moved() calls in the stack updated connect_loc which led to bad index errors
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
less runtimes. this should solve all connect_loc bad index runtimes of this type. it should be able to handle arbitrarily large movement stacks now
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
