### PR TITLE
Fireball wands can no longer be recharged with anomalous crystal for an infinite fireball spam

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -705,7 +705,7 @@ GLOBAL_DATUM(blackbox, /obj/machinery/smartfridge/black_box)
 	activation_method = ACTIVATE_TOUCH
 	cooldown_add = 50
 	activation_sound = 'sound/magic/timeparadox2.ogg'
-	var/static/list/banned_items_typecache = typecacheof(list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear, /obj/projectile, /obj/item/spellbook))
+	var/static/list/banned_items_typecache = typecacheof(list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear, /obj/projectile, /obj/item/spellbook, /obj/item/gun/magic/wand/fireball))
 
 /obj/machinery/anomalous_crystal/refresher/ActivationReaction(mob/user, method)
 	if(..())


### PR DESCRIPTION

## About The Pull Request
makes it so the colossus crystal can no longer refresh the fireball wand.
## Why It's Good For The Game
its not very fun to be at receiving side of an infinite fireball spamming miner, regardless as antag or fighting against antag miner who can use this wand to technically just 1 shot all threats coming at him at a forever rate i'm only adding the fireball wand because it can be comboed' with a colossus crystal by default miner fauna spawn ( other wands require you to have a wizard that has
1.) bought staffs
2.) has been defeated
chances of which are very low ( and most of the time rewarding enough for defeating a wizard)

## Changelog
:cl:
balance: Fireball wands can no longer be recharged by the anomalous crystal.
/:cl: