### PR TITLE
Fix borgs needing to use tools to activate adjacent portals

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -67,6 +67,10 @@
 	if(Adjacent(user))
 		teleport(user)
 
+/obj/effect/portal/attack_robot(mob/living/user)
+	if(Adjacent(user))
+		teleport(user)
+
 /obj/effect/portal/Initialize(mapload, _lifespan = 0, obj/effect/portal/_linked, automatic_link = FALSE, turf/hard_target_override, atmos_link_override)
 	. = ..()
 	GLOB.portals += src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds an attack check to teleport adjacent borgs just like humans can do.

## Why It's Good For The Game

With my recent changes to portal code if someone is standing on a portal it blocks teleporting via bump, since swap code does funky things with bumpability and forcemove, so borgs must 1) not be a default borg with equip-able tools and 2) select a tool then risk clicking around a human to avoid harm or alt-click to slowly but carefully select the portal. Same story for portals in walls or gbj, default borgs just can't use them.

## Changelog
:cl:
fix: Borgs can now click on adjacent portals (with no module slot active) to use them like humans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
