### PR TITLE
voice of god is now affected by ear protection, its vomit command no longer stuns, fixes no big text

### DIFF
--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -33,11 +33,8 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 /proc/voice_of_god(message, mob/living/user, list/span_list, base_multiplier = 1, include_speaker = FALSE, message_admins = TRUE)
 	var/log_message = uppertext(message)
 	var/is_cultie = IS_CULTIST(user)
-	if(LAZYLEN(span_list))
-		if(is_cultie)
-			span_list = list("narsiesmall")
-		else
-			span_list = list()
+	if(LAZYLEN(span_list) && is_cultie)
+		span_list = list("narsiesmall")
 
 	if(!user.say(message, spans = span_list, sanitize = FALSE))
 		return

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -101,7 +101,11 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 
 	for(var/datum/voice_of_god_command/command as anything in GLOB.voice_of_god_commands)
 		if(findtext(message, command.trigger))
-			. = command.execute(listeners, user, power_multiplier, message) || command.cooldown
+			. = command.cooldown
+			var/iteration = 1
+			for(var/mob/living/target as anything in listeners)
+				command.execute(target, user, power_multiplier, message, iteration)
+				iteration++
 			break
 
 	if(message_admins)
@@ -122,108 +126,125 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 	if(is_regex)
 		trigger = regex(trigger)
 
+#define SOUNDBANG_PROTECTION_MULTIPLIER 0.5
 /*
  * What happens when the command is triggered.
  * If a return value is set, it'll be used in place of the 'cooldown' var.
  * Args:
  * * listeners: the list of living mobs who are affected by the command.
  * * user: the one who casted Voice of God
- * * power_multiplier: multiplies the power of the command, most times.
+ * * .: multiplies the power of the command, most times.
  */
-/datum/voice_of_god_command/proc/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	return
+/datum/voice_of_god_command/proc/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	var/real_multiplier = power_multiplier
+	var/ear_protect = 1 + target.get_ear_protection()
+	if(ear_protect)
+		real_multiplier /= ear_protect
+	if(iscarbon(target))
+		var/list/reflist = list(1)
+		SEND_SIGNAL(target, COMSIG_CARBON_SOUNDBANG, reflist)
+		var/intensity = reflist[1]
+		if(!intensity)
+			real_multiplier *= SOUNDBANG_PROTECTION_MULTIPLIER
+	return real_multiplier
 
 /// This command stuns the listeners.
 /datum/voice_of_god_command/stun
 	trigger = "stop|wait|stand\\s*still|hold\\s*on|halt"
 	cooldown = COOLDOWN_STUN
 
-/datum/voice_of_god_command/stun/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	// Ensure 'as anything' is not used for loops that don't target all living mob types.
-	for(var/mob/living/target as anything in listeners)
-		target.Stun(4 SECONDS * power_multiplier)
+/datum/voice_of_god_command/stun/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.Stun(4 SECONDS * .)
 
 /// This command knocks the listeners down.
 /datum/voice_of_god_command/paralyze
 	trigger = "drop|fall|trip|knockdown"
 	cooldown = COOLDOWN_STUN
 
-/datum/voice_of_god_command/paralyze/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		target.Paralyze(4 SECONDS * power_multiplier)
+/datum/voice_of_god_command/paralyze/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.Paralyze(4 SECONDS * .)
 
 /// This command puts carbon listeners to sleep.
 /datum/voice_of_god_command/sleeping
 	trigger = "sleep|slumber|rest"
 	cooldown = COOLDOWN_STUN
 
-/datum/voice_of_god_command/sleeping/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/carbon/target as anything in listeners)
-		target.Sleeping(2 SECONDS * power_multiplier)
+/datum/voice_of_god_command/sleeping/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.Sleeping(2 SECONDS * .)
 
 /// This command makes carbon listeners throw up like Mr. Creosote.
 /datum/voice_of_god_command/vomit
 	trigger = "vomit|throw\\s*up|sick"
 	cooldown = COOLDOWN_STUN
 
-/datum/voice_of_god_command/vomit/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/carbon/target in listeners)
-		target.vomit(10 * power_multiplier, distance = power_multiplier)
+/datum/voice_of_god_command/vomit/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/carbon_target = target
+		carbon_target.vomit(10 * ., stun = FALSE, distance = power_multiplier)
 
 /// This command silences the listeners. Thrice as effective is the user is a mime or curator.
 /datum/voice_of_god_command/silence
 	trigger = "shut\\s*up|silence|be\\s*silent|ssh|quiet|hush"
 	cooldown = COOLDOWN_STUN
 
-/datum/voice_of_god_command/silence/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
+/datum/voice_of_god_command/silence/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
 	if(user.mind && (user.mind.assigned_role == "Curator" || user.mind.assigned_role == "Mime"))
 		power_multiplier *= 3
-	for(var/mob/living/carbon/target in listeners)
-		target.silent += (10 * power_multiplier)
+	if(iscarbon(target))
+		var/mob/living/carbon/carbon_target = target
+		carbon_target.silent += (10 * .)
 
 /// This command makes the listeners see others as corgis, carps, skellies etcetera etcetera.
 /datum/voice_of_god_command/hallucinate
 	trigger = "see\\s*the\\s*truth|hallucinate"
 
-/datum/voice_of_god_command/hallucinate/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/carbon/target in listeners)
-		new /datum/hallucination/delusion(target, TRUE, null, 150 * power_multiplier, 0)
+/datum/voice_of_god_command/hallucinate/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	if(iscarbon(target))
+		new /datum/hallucination/delusion(target, TRUE, null, 150 * ., 0)
 
 /// This command wakes up the listeners.
 /datum/voice_of_god_command/wake_up
 	trigger = "wake\\s*up|awaken"
 	cooldown = COOLDOWN_DAMAGE
 
-/datum/voice_of_god_command/wake_up/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		target.SetSleeping(0)
+/datum/voice_of_god_command/wake_up/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.SetSleeping(0)
 
 /// This command heals the listeners for 10 points of total damage.
 /datum/voice_of_god_command/heal
 	trigger = "live|heal|survive|mend|life|heroes\\s*never\\s*die"
 	cooldown = COOLDOWN_DAMAGE
 
-/datum/voice_of_god_command/heal/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		target.heal_overall_damage(10 * power_multiplier, 10 * power_multiplier)
+/datum/voice_of_god_command/heal/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.heal_overall_damage(10 * ., 10 * .)
 
 /// This command applies 15 points of brute damage to the listeners. There's subtle theological irony in this being more powerful than healing.
 /datum/voice_of_god_command/brute
 	trigger = "die|suffer|hurt|pain|death"
 	cooldown = COOLDOWN_DAMAGE
 
-/datum/voice_of_god_command/brute/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		target.apply_damage(15 * power_multiplier, def_zone = BODY_ZONE_CHEST, wound_bonus = CANT_WOUND)
+/datum/voice_of_god_command/brute/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.apply_damage(15 * ., def_zone = BODY_ZONE_CHEST, wound_bonus = CANT_WOUND)
 
 /// This command makes carbon listeners bleed from a random body part.
 /datum/voice_of_god_command/bleed
 	trigger = "bleed|there\\s*will\\s*be\\s*blood"
 	cooldown = COOLDOWN_DAMAGE
 
-/datum/voice_of_god_command/bleed/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/carbon/human/target in listeners)
-		var/obj/item/bodypart/chosen_part = pick(target.bodyparts)
+/datum/voice_of_god_command/bleed/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/carbon_target = target
+		var/obj/item/bodypart/chosen_part = pick(carbon_target.bodyparts)
 		chosen_part.generic_bleedstacks += 5
 
 /// This command sets the listeners ablaze.
@@ -231,87 +252,80 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 	trigger = "burn|ignite"
 	cooldown = COOLDOWN_DAMAGE
 
-/datum/voice_of_god_command/burn/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		target.adjust_fire_stacks(1 * power_multiplier)
-		target.IgniteMob()
+/datum/voice_of_god_command/burn/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.adjust_fire_stacks(1 * .)
+	target.IgniteMob()
 
 /// This command heats the listeners up like boiling water.
 /datum/voice_of_god_command/hot
 	trigger = "heat|hot|hell"
 	cooldown = COOLDOWN_DAMAGE
 
-/datum/voice_of_god_command/hot/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		target.adjust_bodytemperature(50 * power_multiplier)
+/datum/voice_of_god_command/hot/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.adjust_bodytemperature(50 * .)
 
 /// This command cools the listeners down like freezing water.
 /datum/voice_of_god_command/cold
 	trigger = "cold|chill|freeze"
 	cooldown = COOLDOWN_DAMAGE
 
-/datum/voice_of_god_command/cold/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		target.adjust_bodytemperature(-50 * power_multiplier)
+/datum/voice_of_god_command/cold/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.adjust_bodytemperature(-50 * .)
 
 /// This command throws the listeners away from the user.
 /datum/voice_of_god_command/repulse
 	trigger = "shoo|go\\s*away|leave\\s*me\\s*alone|begone|flee|fus\\s*ro\\s*dah|get\\s*away|repulse"
 	cooldown = COOLDOWN_DAMAGE
 
-/datum/voice_of_god_command/repulse/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		var/throwtarget = get_edge_target_turf(user, get_dir(user, get_step_away(target, user)))
-		target.throw_at(throwtarget, 3 * power_multiplier, 1 * power_multiplier)
+/datum/voice_of_god_command/repulse/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	var/throwtarget = get_edge_target_turf(user, get_dir(user, get_step_away(target, user)))
+	target.throw_at(throwtarget, 3 * ., 1 * .)
 
 /// This command throws the listeners at the user.
 /datum/voice_of_god_command/attract
 	trigger = "come\\s*here|come\\s*to\\s*me|get\\s*over\\s*here|attract"
 	cooldown = COOLDOWN_DAMAGE
 
-/datum/voice_of_god_command/attract/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		target.throw_at(get_step_towards(user, target), 3 * power_multiplier, 1 * power_multiplier)
+/datum/voice_of_god_command/attract/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.throw_at(get_step_towards(user, target), 3 * ., 1 * .)
 
 /// This command forces the listeners to say their true name (so masks and hoods won't help).
 /datum/voice_of_god_command/who_are_you
 	trigger = "who\\s*are\\s*you|say\\s*your\\s*name|state\\s*your\\s*name|identify"
 
-/datum/voice_of_god_command/who_are_you/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	var/iteration = 1
-	for(var/mob/living/target as anything in listeners)
-		addtimer(CALLBACK(target, /atom/movable/proc/say, target.real_name), 0.5 SECONDS * iteration)
-		iteration++
+/datum/voice_of_god_command/who_are_you/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	addtimer(CALLBACK(target, /atom/movable/proc/say, target.real_name), 0.5 SECONDS * iteration)
 
 /// This command forces the listeners to say the user's name
 /datum/voice_of_god_command/say_my_name
 	trigger = "say\\s*my\\s*name|who\\s*am\\s*i"
 
-/datum/voice_of_god_command/say_my_name/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	var/iteration = 1
-	for(var/mob/living/target as anything in listeners)
-		addtimer(CALLBACK(target, /atom/movable/proc/say, user.name), 0.5 SECONDS * iteration)
-		iteration++
+/datum/voice_of_god_command/say_my_name/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	addtimer(CALLBACK(target, /atom/movable/proc/say, user.name), 0.5 SECONDS * iteration)
 
 /// This command forces the listeners to say "Who's there?".
 /datum/voice_of_god_command/knock_knock
 	trigger = "knock\\s*knock"
 
-/datum/voice_of_god_command/knock_knock/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	var/iteration = 1
-	for(var/mob/living/target as anything in listeners)
-		addtimer(CALLBACK(target, /atom/movable/proc/say, "Who's there?"), 0.5 SECONDS * iteration)
-		iteration++
+/datum/voice_of_god_command/knock_knock/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	addtimer(CALLBACK(target, /atom/movable/proc/say, "Who's there?"), 0.5 SECONDS * iteration)
 
 /// This command forces silicon listeners to state all their laws.
 /datum/voice_of_god_command/state_laws
 	trigger = "state\\s*(your)?\\s*laws"
 
-/datum/voice_of_god_command/state_laws/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	var/iteration = 0
-	for(var/mob/living/silicon/target in listeners)
+/datum/voice_of_god_command/state_laws/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	if(issilicon(target))
 		addtimer(CALLBACK(target, /mob/living/silicon/proc/statelaws, TRUE), (3 SECONDS * iteration) + 0.5 SECONDS)
-		iteration++
 
 /// This command forces the listeners to take step in a direction chosen by the user, otherwise a random cardinal one.
 /datum/voice_of_god_command/move
@@ -321,8 +335,8 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 	var/static/left_words = regex("left|west|port")
 	var/static/right_words = regex("right|east|starboard")
 
-/datum/voice_of_god_command/move/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	var/iteration = 1
+/datum/voice_of_god_command/move/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
 	var/direction
 	if(findtext(message, up_words))
 		direction = NORTH
@@ -332,119 +346,116 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 		direction = WEST
 	else if(findtext(message, right_words))
 		direction = EAST
-	for(var/mob/living/target as anything in listeners)
-		addtimer(CALLBACK(GLOBAL_PROC, .proc/_step, target, direction || pick(GLOB.cardinals)), 1 SECONDS * (iteration - 1))
-		iteration++
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/_step, target, direction || pick(GLOB.cardinals)), 1 SECONDS * (iteration - 1))
 
 /// This command forces the listeners to switch to walk intent.
 /datum/voice_of_god_command/walk
 	trigger = "slow\\s*down"
 
-/datum/voice_of_god_command/walk/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		if(target.m_intent != MOVE_INTENT_WALK)
-			target.toggle_move_intent()
+/datum/voice_of_god_command/walk/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	if(target.m_intent != MOVE_INTENT_WALK)
+		target.toggle_move_intent()
 
 /// This command forces the listeners to switch to run intent.
 /datum/voice_of_god_command/run
 	trigger = "run"
 	is_regex = FALSE
 
-/datum/voice_of_god_command/walk/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		if(target.m_intent != MOVE_INTENT_RUN)
-			target.toggle_move_intent()
+/datum/voice_of_god_command/walk/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	if(target.m_intent != MOVE_INTENT_RUN)
+		target.toggle_move_intent()
 
 /// This command turns the listeners' throw mode on.
 /datum/voice_of_god_command/throw_catch
 	trigger = "throw|catch"
 
-/datum/voice_of_god_command/throw_catch/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/carbon/target in listeners)
-		target.throw_mode_on(THROW_MODE_TOGGLE)
+/datum/voice_of_god_command/throw_catch/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/carbon_target = target
+		carbon_target.throw_mode_on(THROW_MODE_TOGGLE)
 
 /// This command forces the listeners to say a brain damage line.
 /datum/voice_of_god_command/speak
 	trigger = "speak|say\\s*something"
 
-/datum/voice_of_god_command/speak/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	var/iteration = 1
-	for(var/mob/living/target in listeners)
-		addtimer(CALLBACK(target, /atom/movable/proc/say, pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage")), 0.5 SECONDS * iteration)
-		iteration++
+/datum/voice_of_god_command/speak/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	addtimer(CALLBACK(target, /atom/movable/proc/say, pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage")), 0.5 SECONDS * iteration)
 
 /// This command forces the listeners to get the fuck up, resetting all stuns.
 /datum/voice_of_god_command/getup
 	trigger = "get\\s*up"
 	cooldown = COOLDOWN_DAMAGE
 
-/datum/voice_of_god_command/getup/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		target.set_resting(FALSE)
-		target.SetAllImmobility(0)
+/datum/voice_of_god_command/getup/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.set_resting(FALSE)
+	target.SetAllImmobility(0)
 
 /// This command forces each listener to buckle to a chair found on the same tile.
 /datum/voice_of_god_command/sit
 	trigger = "sit"
 	is_regex = FALSE
 
-/datum/voice_of_god_command/sit/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		var/obj/structure/chair/chair = locate(/obj/structure/chair) in get_turf(target)
-		chair?.buckle_mob(target)
+/datum/voice_of_god_command/sit/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	var/obj/structure/chair/chair = locate(/obj/structure/chair) in get_turf(target)
+	if(chair)
+		chair.buckle_mob(target)
 
 /// This command forces each listener to unbuckle from whatever they are buckled to.
 /datum/voice_of_god_command/stand
 	trigger = "stand"
 	is_regex = FALSE
 
-/datum/voice_of_god_command/stand/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		target.buckled?.unbuckle_mob(target)
+/datum/voice_of_god_command/stand/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.buckled?.unbuckle_mob(target)
 
 /// This command forces the listener to do the jump emote 3/4 of the times or reply "HOW HIGH?!!".
 /datum/voice_of_god_command/jump
 	trigger = "jump"
 	is_regex = FALSE
 
-/datum/voice_of_god_command/jump/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	var/iteration = 1
-	for(var/mob/living/target as anything in listeners)
-		if(prob(25))
-			addtimer(CALLBACK(target, /atom/movable/proc/say, "HOW HIGH?!!"), 0.5 SECONDS * iteration)
-		else
-			addtimer(CALLBACK(target, /mob/living/.proc/emote, "jump"), 0.5 SECONDS * iteration)
-		iteration++
+/datum/voice_of_god_command/jump/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	if(prob(25))
+		addtimer(CALLBACK(target, /atom/movable/proc/say, "HOW HIGH?!!"), 0.5 SECONDS * iteration)
+	else
+		addtimer(CALLBACK(target, /mob/living/.proc/emote, "jump"), 0.5 SECONDS * iteration)
 
 ///This command plays a bikehorn sound after 2 seconds and a half have passed, and also slips listeners if the user is a clown.
 /datum/voice_of_god_command/honk
 	trigger = "ho+nk"
 
-/datum/voice_of_god_command/honk/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
+/datum/voice_of_god_command/honk/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, get_turf(user), 'sound/items/bikehorn.ogg', 300, 1), 2.5 SECONDS)
 	if(user.mind?.assigned_role == "Clown")
 		. = COOLDOWN_STUN //it slips.
-		for(var/mob/living/carbon/target in listeners)
-			target.slip(14 SECONDS * power_multiplier)
+		if(iscarbon(target))
+			var/mob/living/carbon/carbon_target = target
+			carbon_target.slip(14 SECONDS * .)
 
 ///This command spins the listeners 1800° degrees clockwise.
 /datum/voice_of_god_command/multispin
 	trigger = "like\\s*a\\s*record\\s*baby|right\\s*round"
 
-/datum/voice_of_god_command/multispin/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		target.SpinAnimation(speed = 10, loops = 5)
+/datum/voice_of_god_command/multispin/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	target.SpinAnimation(speed = 10, loops = 5)
 
 /// Supertype of all those commands that make people emote and nothing else. Fuck copypasta.
 /datum/voice_of_god_command/emote
 	/// The emote to run.
 	var/emote_name = "dance"
 
-/datum/voice_of_god_command/emote/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	var/iteration = 1
-	for(var/mob/living/target as anything in listeners)
-		addtimer(CALLBACK(target, /mob/living/.proc/emote, emote_name), 0.5 SECONDS * iteration)
-		iteration++
+/datum/voice_of_god_command/emote/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
+	. = ..()
+	addtimer(CALLBACK(target, /mob/living/.proc/emote, emote_name), 0.5 SECONDS * iteration)
 
 /datum/voice_of_god_command/emote/flip
 	trigger = "flip|rotate|revolve|roll|somersault"

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -178,7 +178,6 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 /// This command makes carbon listeners throw up like Mr. Creosote.
 /datum/voice_of_god_command/vomit
 	trigger = "vomit|throw\\s*up|sick"
-	cooldown = COOLDOWN_STUN
 
 /datum/voice_of_god_command/vomit/execute(mob/living/target, mob/living/user, power_multiplier = 1, message, iteration = 1)
 	. = ..()

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -1,7 +1,7 @@
 #define COOLDOWN_STUN 120 SECONDS
 #define COOLDOWN_DAMAGE 60 SECONDS
 #define COOLDOWN_MEME 30 SECONDS
-#define COOLDOWN_NONE 1 SECONDS
+#define COOLDOWN_NONE 10 SECONDS
 
 /// Used to stop listeners with silly or clown-esque (first) names such as "Honk" or "Flip" from screwing up certain commands.
 GLOBAL_DATUM(all_voice_of_god_triggers, /regex)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
voice of god is now affected by ear protection like the natural one by xenos or borgs or the one from security bowman headsets, so with bowmans commands will be half as effective, be it the bad ones like die or the good ones like heal
vomit is no longer a stun, it is hardcoded to be 8 seconds so i couldnt really rebalance it, cooldown reduced back to 30 seconds
from the code side: the commands are completely recoded, instead of the commands running a look through every victim, the main voice of god does that and calls the command on the target
in the vog refactor, accidentally the span function was broken, now it only changes your spans if youre a cultist, instead of always changing your spans to an empty list. since its fixed the cooldown for text messages has been heightened back to 10 seconds, like it used to be

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
ear protection: an aoe stun on the entire security team is bad and it makes sense for it to be protected against
vomit: an 8 second stun is kinda way too long, you literally need to be a cultist or chaplain to reach that amount of stun with the STUN command

## Changelog
:cl:
balance: voice of god is now affected by ear protection, its vomit command no longer stuns
fix: fixes voice of god not giving you big colossus text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
