### PR TITLE
Better wabbajack polymorph logging

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1164,6 +1164,7 @@
 // Called when we are hit by a bolt of polymorph and changed
 // Generally the mob we are currently in is about to be deleted
 /mob/living/proc/wabbajack_act(mob/living/new_mob)
+	log_game("[key_name(src)] is being wabbajack polymorphed into: [new_mob.name]([new_mob.type]).")
 	new_mob.name = real_name
 	new_mob.real_name = real_name
 

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -288,7 +288,7 @@
 	for(var/obj/item/W in contents)
 		new_mob.equip_to_appropriate_slot(W)
 
-	M.log_message("became [new_mob.real_name]", LOG_ATTACK, color="orange")
+	M.log_message("became [new_mob.name]([new_mob.type])", LOG_ATTACK, color="orange")
 
 	new_mob.set_combat_mode(TRUE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title.

## Why It's Good For The Game

Fixes broken attack logs like:
```
[2021-07-03 18:18:06.273] ATTACK: WaylandSmithy/(Wayland Smithy) became  (Medical (60,65,2))
```

Makes it clearer in the logs why a client was put into another mob seemingly at random especially if the effect is not from a projectile.

## Changelog
:cl:
fix: Fixed and improved wabbajack polymorph logging.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
