### PR TITLE
Fix cursed spring ruin acting as a polymorph teleport forwarder

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_hotsprings.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_hotsprings.dmm
@@ -7,7 +7,7 @@
 /area/icemoon/surface/outdoors/unexplored)
 "c" = (
 /turf/open/water/cursed_spring,
-/area/icemoon/surface/outdoors)
+/area/icemoon/surface/outdoors/noteleport)
 "d" = (
 /obj/item/paper/crumpled{
 	info = "When one falls into this hot spring, they shall forever be turned into..."

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -170,6 +170,9 @@
 	name = "Icemoon Wastes"
 	outdoors = TRUE
 
+/area/icemoon/surface/outdoors/noteleport // for places like the cursed spring water
+	area_flags = UNIQUE_AREA | FLORA_ALLOWED | NO_ALERTS | NOTELEPORT
+
 /area/icemoon/surface/outdoors/labor_camp
 	name = "Icemoon Labor Camp"
 	area_flags = UNIQUE_AREA | NO_ALERTS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Puts the cursed spring water in an area with the `NOTELEPORT` flag. 

## Why It's Good For The Game

Stepping into random portals is never a good idea, but you should at least be safe from going on a double teleport + polymorph ride in the span of 1 tick that will leave you someplace random with no idea of what just happened.

## Changelog
:cl:
fix: Fixed the cursed spring water double teleport polymorph machine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
