### PR TITLE
fix buckling to a vehicle not setting your initial sprite position correctly

### DIFF
--- a/code/datums/components/riding/riding.dm
+++ b/code/datums/components/riding/riding.dm
@@ -60,6 +60,7 @@
 	. = ..()
 	RegisterSignal(parent, COMSIG_ATOM_DIR_CHANGE, .proc/vehicle_turned)
 	RegisterSignal(parent, COMSIG_MOVABLE_UNBUCKLE, .proc/vehicle_mob_unbuckle)
+	RegisterSignal(parent, COMSIG_MOVABLE_BUCKLE, .proc/vehicle_mob_buckle)
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/vehicle_moved)
 	RegisterSignal(parent, COMSIG_MOVABLE_BUMP, .proc/vehicle_bump)
 
@@ -83,6 +84,14 @@
 	rider.updating_glide_size = TRUE
 	if(!movable_parent.has_buckled_mobs())
 		qdel(src)
+
+/// This proc is called when a rider buckles, allowing for offsets to be set properly
+/datum/component/riding/proc/vehicle_mob_buckle(datum/source, mob/living/rider, force = FALSE)
+	SIGNAL_HANDLER
+
+	var/atom/movable/movable_parent = parent
+	handle_vehicle_layer(movable_parent.dir)
+	handle_vehicle_offsets(movable_parent.dir)
 
 /// Some ridable atoms may want to only show on top of the rider in certain directions, like wheelchairs
 /datum/component/riding/proc/handle_vehicle_layer(dir)

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -68,6 +68,12 @@
 	rider.Knockdown(4 SECONDS)
 	living_parent.unbuckle_mob(rider)
 
+/datum/component/riding/creature/vehicle_mob_buckle(datum/source, mob/living/rider, force = FALSE)
+	// Ensure that the /mob/post_buckle_mob(mob/living/M) does not mess us up with layers
+	// If we do not do this override we'll be stuck with the above proc (+ 0.1)-ing our rider's layer incorrectly
+	rider.layer = initial(rider.layer)
+	return ..()
+
 /datum/component/riding/creature/vehicle_mob_unbuckle(mob/living/living_parent, mob/living/former_rider, force = FALSE)
 	if(istype(living_parent) && istype(former_rider))
 		living_parent.log_message("is no longer being ridden by [former_rider]", LOG_ATTACK, color="pink")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

currently if you buckle onto a vehicle your sprite is not adjusted until you move, this corrects that behaviour

![ezgif com-gif-maker](https://user-images.githubusercontent.com/10467687/124368893-3e853d80-dc3c-11eb-9337-8bf7d9cb007c.gif)

as a technical note i had to put a workaround for ``post_buckle_mob(...)`` because of its behavior with trying to prevent z level fighting, which is not helpful for the improved behavior of buckling. i did not remove it outright as it can still support non-rider-component-driven-mobs that have buckling

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

this has always bugged me a lot

resolves #59998 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: bobbahbrown
fix: Buckling to a vehicle will no longer wait until you move to set your position on the vehicle properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
