### PR TITLE
Fixes stationary tanks starting out with 5000L instead of 2500L

### DIFF
--- a/code/datums/mergers/_merger.dm
+++ b/code/datums/mergers/_merger.dm
@@ -51,9 +51,7 @@
 	if(origin == thing && length(members))
 		origin = pick(members)
 
-/datum/merger/proc/AddMember(atom/thing, connected_dir)
-	if(thing == origin)
-		return
+/datum/merger/proc/AddMember(atom/thing, connected_dir) // note that this fires for the origin of the merger as well
 	SEND_SIGNAL(thing, COMSIG_MERGER_ADDING, src)
 	RegisterSignal(thing, refresh_signals, .proc/QueueRefresh)
 	if(!thing.mergers)

--- a/code/datums/mergers/_merger.dm
+++ b/code/datums/mergers/_merger.dm
@@ -52,6 +52,8 @@
 		origin = pick(members)
 
 /datum/merger/proc/AddMember(atom/thing, connected_dir)
+	if(thing == origin)
+		return
 	SEND_SIGNAL(thing, COMSIG_MERGER_ADDING, src)
 	RegisterSignal(thing, refresh_signals, .proc/QueueRefresh)
 	if(!thing.mergers)

--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -214,6 +214,8 @@
 		leaver.update_appearance()
 
 	for(var/obj/machinery/atmospherics/components/tank/joiner as anything in joining_members)
+		if(joiner == src)
+			continue
 		var/datum/gas_mixture/joiner_share = joiner.air_contents
 		if(joiner_share)
 			air_contents.merge(joiner_share)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR fixes the issue of lone stationary tanks starting out with a volume of 5000L instead of 2500L
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prior to this, the first stationary tank in a group you placed down would have 5000L, while the second, third, etc. would add 2500L each to make it 7500L and 10000L for two and three tanks respectively.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes lone stationary tanks having 5000L instead of 2500L volume.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
