### PR TITLE
Replaces Hardstuns with knockdown, removes Vomit stunning from Voice of God.

### DIFF
--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -133,43 +133,6 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 /datum/voice_of_god_command/proc/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
 	return
 
-/// This command stuns the listeners.
-/datum/voice_of_god_command/stun
-	trigger = "stop|wait|stand\\s*still|hold\\s*on|halt"
-	cooldown = COOLDOWN_STUN
-
-/datum/voice_of_god_command/stun/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	// Ensure 'as anything' is not used for loops that don't target all living mob types.
-	for(var/mob/living/target as anything in listeners)
-		target.Stun(4 SECONDS * power_multiplier)
-
-/// This command knocks the listeners down.
-/datum/voice_of_god_command/paralyze
-	trigger = "drop|fall|trip|knockdown"
-	cooldown = COOLDOWN_STUN
-
-/datum/voice_of_god_command/paralyze/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/target as anything in listeners)
-		target.Paralyze(4 SECONDS * power_multiplier)
-
-/// This command puts carbon listeners to sleep.
-/datum/voice_of_god_command/sleeping
-	trigger = "sleep|slumber|rest"
-	cooldown = COOLDOWN_STUN
-
-/datum/voice_of_god_command/sleeping/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/carbon/target as anything in listeners)
-		target.Sleeping(2 SECONDS * power_multiplier)
-
-/// This command makes carbon listeners throw up like Mr. Creosote.
-/datum/voice_of_god_command/vomit
-	trigger = "vomit|throw\\s*up|sick"
-	cooldown = COOLDOWN_STUN
-
-/datum/voice_of_god_command/vomit/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
-	for(var/mob/living/carbon/target in listeners)
-		target.vomit(10 * power_multiplier, distance = power_multiplier)
-
 /// This command silences the listeners. Thrice as effective is the user is a mime or curator.
 /datum/voice_of_god_command/silence
 	trigger = "shut\\s*up|silence|be\\s*silent|ssh|quiet|hush"

--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -133,6 +133,24 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 /datum/voice_of_god_command/proc/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
 	return
 
+/// This command knocks the listeners down.
+/datum/voice_of_god_command/paralyze
+	trigger = "drop|fall|trip|knockdown|stop|wait|stand\\s*still|hold\\s*on|halt"
+	cooldown = COOLDOWN_STUN
+
+/datum/voice_of_god_command/paralyze/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
+	for(var/mob/living/target as anything in listeners)
+		target.Knockdown(4 SECONDS * power_multiplier)
+
+/// This command makes carbon listeners throw up like Mr. Creosote.
+/datum/voice_of_god_command/vomit
+	trigger = "vomit|throw\\s*up|sick"
+	cooldown = COOLDOWN_STUN
+
+/datum/voice_of_god_command/vomit/execute(list/listeners, mob/living/user, power_multiplier = 1, message)
+	for(var/mob/living/carbon/target in listeners)
+		target.vomit(10 * power_multiplier, distance = power_multiplier, stun = FALSE)
+
 /// This command silences the listeners. Thrice as effective is the user is a mime or curator.
 /datum/voice_of_god_command/silence
 	trigger = "shut\\s*up|silence|be\\s*silent|ssh|quiet|hush"


### PR DESCRIPTION

## About The Pull Request

See title.

## Why It's Good For The Game

Stuns are bad. AOE stuns are also bad. Buffing security vs AoE stuns doesn't fix the fact that AoE stuns are bad.
Closes #59987 
Wanted to get this up earlier in response to the other PR but didn't want to snipe #60000 by accident or some shit.

## Changelog
:cl:
balance: Removes stuns from Voice of God.
/:cl: