### PR TITLE
wisps no longer fall in chasms

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -23,7 +23,8 @@
 		/obj/effect/collapse,
 		/obj/effect/particle_effect/ion_trails,
 		/obj/effect/dummy/phased_mob,
-		/obj/effect/mapping_helpers
+		/obj/effect/mapping_helpers,
+		/obj/effect/wisp
 		))
 
 /datum/component/chasm/Initialize(turf/target)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -24,7 +24,7 @@
 		/obj/effect/particle_effect/ion_trails,
 		/obj/effect/dummy/phased_mob,
 		/obj/effect/mapping_helpers,
-		/obj/effect/wisp
+		/obj/effect/wisp,
 		))
 
 /datum/component/chasm/Initialize(turf/target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
prevents wisps from falling in chasms

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
they are flying orbiting magicy wisps, they shouldnt disappear if you fly over chasms with them

## Changelog
:cl:
fix: wisps no longer fall in chasms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
