### PR TITLE
Fix even more excess html encoded text

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -120,20 +120,19 @@
 /// Used to get a properly sanitized input, of max_length
 /// no_trim is self explanatory but it prevents the input from being trimed if you intend to parse newlines or whitespace.
 /proc/stripped_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN, no_trim=FALSE)
-	var/name = input(user, message, title, default) as text|null
-
+	var/input_text = input(user, message, title, default) as text|null
 	if(no_trim)
-		return copytext(html_encode(name), 1, max_length)
+		return copytext(html_decode(strip_html(input_text)), 1, max_length) //strip encodes so decode to remove stinky html chars
 	else
-		return trim(html_encode(name), max_length) //trim is "outside" because html_encode can expand single symbols into multiple symbols (such as turning < into &lt;)
+		return trim(html_decode(strip_html(input_text)), max_length) //trim is "outside" because html_encode can expand single symbols into multiple symbols (such as turning < into &lt;)
 
 // Used to get a properly sanitized multiline input, of max_length
 /proc/stripped_multiline_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN, no_trim=FALSE)
-	var/name = input(user, message, title, default) as message|null
+	var/input_text = input(user, message, title, default) as message|null
 	if(no_trim)
-		return copytext(html_encode(name), 1, max_length)
+		return copytext(html_decode(strip_html(input_text)), 1, max_length)
 	else
-		return trim(html_encode(name), max_length)
+		return trim(html_decode(strip_html(input_text)), max_length)
 
 #define NO_CHARS_DETECTED 0
 #define SPACES_DETECTED 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Change `stripped_input()` so it no longer returns pre encoded text often stored in vars resulting in a bunch of second order encoding problems.

## Why It's Good For The Game

Fixes the bugs listed below and probably many others too.
- ![dreamseeker_EtpbJk1Tn0](https://user-images.githubusercontent.com/64715958/124372209-0e3e9e80-dc3e-11eb-8838-5e1d6f334a72.png)
- Positronic Brain Alt-click text input if you put any characters that `html_encode()` does funnies to they come back for editing in their encoded form.
- Traitor Panel memory text acts the same as above. Make the mistake of using single or double quotes and editing it again becomes a nightmare.

## Changelog
:cl:
fix: Fixed text from stripped_input returning in html encoded form.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
