### PR TITLE
Updates Seed Extractor Examine

### DIFF
--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -76,7 +76,7 @@
 /obj/machinery/seed_extractor/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
-		. += span_notice("The status display reads: Extracting <b>[seed_multiplier]</b> seed(s) per piece of produce.<br>Machine can store up to <b>[max_seeds]%</b> seeds.")
+		. += span_notice("The status display reads: Extracting <b>[1 * seed_multiplier] to [4 * seed_multiplier]</b> seed(s) per piece of produce.<br>Machine can store up to <b>[max_seeds]</b> seeds.")
 
 /obj/machinery/seed_extractor/attackby(obj/item/O, mob/living/user, params)
 

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -76,7 +76,7 @@
 /obj/machinery/seed_extractor/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
-		. += span_notice("The status display reads: Extracting <b>[1 * seed_multiplier] to [4 * seed_multiplier]</b> seed(s) per piece of produce.<br>Machine can store up to <b>[max_seeds]</b> seeds.")
+		. += span_notice("The status display reads: Extracting <b>[seed_multiplier] to [seed_multiplier * 4]</b> seed(s) per piece of produce.<br>Machine can store up to <b>[max_seeds]</b> seeds.")
 
 /obj/machinery/seed_extractor/attackby(obj/item/O, mob/living/user, params)
 
@@ -206,4 +206,3 @@
 					found_seed.forceMove(drop_location())
 					visible_message(span_notice("[found_seed] falls onto the floor."), null, span_hear("You hear a soft clatter."), COMBAT_MESSAGE_RANGE)
 				. = TRUE
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #60008

Seed Extractor examine text is now accurate for what it actually does, the way seed potential amount is calculated is a random number between 1 and 4 multiplied by the seed_multiplier, the multiplier is simply based on the manipulator tier (1-4). to get the text to display what your potential seeds ACTUALLY are rather than just the seed_multiplier, its shows 1 x seed_multiplier to 4 x seed_multiplier

also removed the % from the total storage since thats a hard number, not a percentage

tier 1 (base)
![image](https://user-images.githubusercontent.com/40489693/124374374-cb45f080-dc68-11eb-9478-cfcd7da58f89.png)

tier 2
![image](https://user-images.githubusercontent.com/40489693/124374381-d1d46800-dc68-11eb-8a85-d26b7710f6f2.png)

tier 3
![image](https://user-images.githubusercontent.com/40489693/124374385-d6991c00-dc68-11eb-8bcd-bd60e7c8c4f1.png)

tier 4
![image](https://user-images.githubusercontent.com/40489693/124374388-dac53980-dc68-11eb-96d0-b4441f9f7d8f.png)



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
consistency

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: the examine text on the Seed Extractor now accurately displays the amount of seeds you may potentially get
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
