### PR TITLE
Increase the number of shots for laser rifles, energy guns and hellfire lasers

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -1,11 +1,11 @@
 /obj/item/ammo_casing/energy/laser
 	projectile_type = /obj/projectile/beam/laser
-	e_cost = 50
+	e_cost = 83
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/hellfire
 	projectile_type = /obj/projectile/beam/laser/hellfire
-	e_cost = 66
+	e_cost = 100
 	select_name = "maim"
 
 /obj/item/ammo_casing/energy/laser/hellfire/antique
@@ -13,7 +13,7 @@
 
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/projectile/beam/laser
-	e_cost = 35
+	e_cost = 62.5
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/old

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -1,10 +1,11 @@
 /obj/item/ammo_casing/energy/laser
 	projectile_type = /obj/projectile/beam/laser
+	e_cost = 50
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/hellfire
 	projectile_type = /obj/projectile/beam/laser/hellfire
-	e_cost = 130
+	e_cost = 66
 	select_name = "maim"
 
 /obj/item/ammo_casing/energy/laser/hellfire/antique
@@ -12,7 +13,7 @@
 
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/projectile/beam/laser
-	e_cost = 71
+	e_cost = 35
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/old


### PR DESCRIPTION
## About The Pull Request

Increases the shot count of Laser rifles (from 14 to 16) Energy guns on Kill (from 10 to 12) and Hellfire lasers(from 8 to 10)

## Why It's Good For The Game

The change from weight class normal to weight class bulky for most ranged weapons largely broke the old and rather silly meta of carrying 4+ laser / energy guns around to handle threats, but it had the unfortunate side effect of dramatically increasing the relative value of reloadable ballistics (where before you would swap out to a fresh energy weapon) and later with the nerfs to shotguns, decreasing the viability of the roundstart armoury for dealing with deadly midrounds like space dragons.

Hopefully boosting up the total shot count available to energy weapons will help their logistical viability compared to ballistics that can be reloaded mid combat, and boost the ability of the station to deal with large external threats without relying on cargo sourced ballistics. At the same time not shifting the lethality of energy weapons in an engagement lasting the same duration of time.

## Changelog
:cl:
balance: Nanotrasen has released experimental new laser lenses for laser rifles, energy guns, and illegal hellfire modkits, increasing the number of shots they can fire from full charge by roughly 20%. 
/:cl:

