### PR TITLE
BRPEDs now empty reagents from containers when they are inserted.

### DIFF
--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -60,7 +60,7 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	SIGNAL_HANDLER
 	if(inserted_component.reagents && length(inserted_component.reagents.reagent_list))
 		inserted_component.reagents.clear_reagents()
-		to_chat(usr, span_notice("\The [src] churns as \the [inserted_component] has its reagents emptied into bluespace."))
+		to_chat(usr, span_notice("[src] churns as [inserted_component] has its reagents emptied into bluespace."))
 
 	if(!istype(inserted_component, /obj/item/stock_parts/cell))
 		return

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -56,12 +56,16 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 
 	RegisterSignal(src, COMSIG_ATOM_ENTERED, .proc/on_part_entered)
 
-/obj/item/storage/part_replacer/bluespace/proc/on_part_entered(datum/source, obj/item/I)
+/obj/item/storage/part_replacer/bluespace/proc/on_part_entered(datum/source, obj/item/inserted_component)
 	SIGNAL_HANDLER
-	if(!istype(I, /obj/item/stock_parts/cell))
+	if(inserted_component.reagents && length(inserted_component.reagents.reagent_list))
+		inserted_component.reagents.clear_reagents()
+		to_chat(usr, span_notice("\The [src] churns as \the [inserted_component] has its reagents emptied into bluespace."))
+
+	if(!istype(inserted_component, /obj/item/stock_parts/cell))
 		return
 
-	var/obj/item/stock_parts/cell/inserted_cell = I
+	var/obj/item/stock_parts/cell/inserted_cell = inserted_component
 
 	if(inserted_cell.rigged || inserted_cell.corrupted)
 		message_admins("[ADMIN_LOOKUPFLW(usr)] has inserted rigged/corrupted [inserted_cell] into [src].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Follow up for #55447 dealing with BRPED exploits.

Purges the reagents from everything that is inserted into a BRPED.

![image](https://user-images.githubusercontent.com/24975989/124386027-2c54df00-dcd0-11eb-9f8e-1d7d34df1200.png)

This fixes an exploit/oversight where players were able to teleport reagent containers wirelessly across the station, including to remotely bomb the station using chemistry as ghost roles like Lavaland Syndicates.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This has started happening often enough that the rule of cool niche knowledge is becoming a mainstream grief tactic.

This has very little counterplay and very little warning. Anyone at any time can teleport a bomb into a machine that will instantly explode. Blowing things up from across the cosmos is bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The Bluespace RPED can no longer teleport chems in reagent containers, instead emptying any reagents from containers inserted into it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
