### PR TITLE
Fixes Thermal Vision Bug

### DIFF
--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -95,6 +95,13 @@
 
 	user_mob.adjustOrganLoss(ORGAN_SLOT_EYES, eye_damage)
 
+/datum/mutation/human/thermal/on_losing(mob/living/carbon/human/owner, mob/user = usr)
+	if(..())
+		return
+	REMOVE_TRAIT(owner, TRAIT_THERMAL_VISION, GENETIC_MUTATION)
+	owner.update_sight()
+	to_chat(user, text("<span class='notice'>You can no longer see the heat rising off of your skin...</span>"))
+
 ///X-ray Vision lets you see through walls.
 /datum/mutation/human/xray
 	name = "X Ray Vision"

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -100,7 +100,7 @@
 		return
 	REMOVE_TRAIT(owner, TRAIT_THERMAL_VISION, GENETIC_MUTATION)
 	owner.update_sight()
-	to_chat(user, text("<span class='notice'>You can no longer see the heat rising off of your skin...</span>"))
+	to_chat(user, span_notice("You can no longer see the heat rising off of your skin..."))
 
 ///X-ray Vision lets you see through walls.
 /datum/mutation/human/xray

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -40,6 +40,7 @@
 	quality = POSITIVE
 	difficulty = 18
 	text_gain_indication = "<span class='notice'>You can see the heat rising off of your skin...</span>"
+	text_lose_indication = "<span class='notice'>You can no longer see the heat rising off of your skin...</span>"
 	time_coeff = 2
 	instability = 25
 	synchronizer_coeff = 1
@@ -100,7 +101,6 @@
 		return
 	REMOVE_TRAIT(owner, TRAIT_THERMAL_VISION, GENETIC_MUTATION)
 	owner.update_sight()
-	to_chat(user, text("<span class='notice'>You can no longer see the heat rising off of your skin...</span>"))
 
 ///X-ray Vision lets you see through walls.
 /datum/mutation/human/xray

--- a/code/datums/mutations/sight.dm
+++ b/code/datums/mutations/sight.dm
@@ -96,7 +96,7 @@
 
 	user_mob.adjustOrganLoss(ORGAN_SLOT_EYES, eye_damage)
 
-/datum/mutation/human/thermal/on_losing(mob/living/carbon/human/owner, mob/user = usr)
+/datum/mutation/human/thermal/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	REMOVE_TRAIT(owner, TRAIT_THERMAL_VISION, GENETIC_MUTATION)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #60013

nearly all mutations have a check for "on_losing", but thermal vision lost that check when it changed function (i assume the coder who did that assumed the timer on it would work even when the mutation was lost... it doesnt)

now, when you lose the mutation, wether from the console, mutadone, or god himself, you get a message in chat "you can no longer see the heat rising off your skin..." and you lose the thermal vision alongside the mutation

and yes, ive tested this in game, it works
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

it isnt cool activating the thermal vision, removing the mutation, but then keeping the thermal vision permanently without any downsides
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: Removing the Thermal Vision mutation will now remove the active vision as well
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
