### PR TITLE
Fix Tram ghost magnet and other cases of observer forceMove

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -656,18 +656,18 @@ so as to remain in compliance with the most up-to-date laws."
 		return
 	if(!target)
 		return
-	var/mob/dead/observer/dead_owner = owner
-	if(!istype(dead_owner))
+	var/mob/dead/observer/ghost_owner = owner
+	if(!istype(ghost_owner))
 		return
 	switch(action)
 		if(NOTIFY_ATTACK)
-			target.attack_ghost(dead_owner)
+			target.attack_ghost(ghost_owner)
 		if(NOTIFY_JUMP)
 			var/turf/target_turf = get_turf(target)
 			if(target_turf && isturf(target_turf))
-				dead_owner.forceMove(target_turf)
+				ghost_owner.abstract_move(target_turf)
 		if(NOTIFY_ORBIT)
-			dead_owner.ManualFollow(target)
+			ghost_owner.ManualFollow(target)
 
 //OBJECT-BASED
 

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -13,7 +13,7 @@
 
 	// Otherwise jump
 	else if(A.loc)
-		forceMove(get_turf(A))
+		abstract_move(get_turf(A))
 		update_parallax_contents()
 
 /mob/dead/observer/ClickOn(atom/A, params)
@@ -77,5 +77,5 @@
 
 /obj/machinery/teleport/hub/attack_ghost(mob/user)
 	if(power_station?.engaged && power_station.teleporter_console && power_station.teleporter_console.target)
-		user.forceMove(get_turf(power_station.teleporter_console.target))
+		user.abstract_move(get_turf(power_station.teleporter_console.target))
 	return ..()

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -133,7 +133,7 @@
 		qdel(src)
 
 	var/atom/curloc = master.loc
-	for(var/atom/movable/movable_orbiter in orbiter_list)
+	for(var/atom/movable/movable_orbiter as anything in orbiter_list)
 		if(QDELETED(movable_orbiter) || movable_orbiter.loc == newturf)
 			continue
 		movable_orbiter.abstract_move(newturf)

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -98,7 +98,7 @@
 		var/atom/movable/movable_parent = parent
 		orbiter.glide_size = movable_parent.glide_size
 
-	orbiter.forceMove(get_turf(parent))
+	orbiter.abstract_move(get_turf(parent))
 	to_chat(orbiter, span_notice("Now orbiting [parent]."))
 
 /datum/component/orbiter/proc/end_orbit(atom/movable/orbiter, refreshing=FALSE)
@@ -133,11 +133,10 @@
 		qdel(src)
 
 	var/atom/curloc = master.loc
-	for(var/i in orbiter_list)
-		var/atom/movable/thing = i
-		if(QDELETED(thing) || thing.loc == newturf)
+	for(var/atom/movable/movable_orbiter in orbiter_list)
+		if(QDELETED(movable_orbiter) || movable_orbiter.loc == newturf)
 			continue
-		thing.forceMove(newturf)
+		movable_orbiter.abstract_move(newturf)
 		if(CHECK_TICK && master.loc != curloc)
 			// We moved again during the checktick, cancel current operation
 			break

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -72,9 +72,13 @@
 	if(SEND_SIGNAL(destturf, COMSIG_ATOM_INTERCEPT_TELEPORT, channel, curturf, destturf))
 		return FALSE
 
+	if(isobserver(teleatom))
+		teleatom.abstract_move(destturf)
+		return TRUE
+
 	tele_play_specials(teleatom, curturf, effectin, asoundin)
 	var/success = teleatom.forceMove(destturf)
-	if (success)
+	if(success)
 		log_game("[key_name(teleatom)] has teleported from [loc_name(curturf)] to [loc_name(destturf)]")
 		tele_play_specials(teleatom, destturf, effectout, asoundout)
 

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -89,12 +89,14 @@
 	return TRUE
 
 /proc/tele_play_specials(atom/movable/teleatom, atom/location, datum/effect_system/effect, sound)
-	if (location && !isobserver(teleatom))
-		if (sound)
-			playsound(location, sound, 60, TRUE)
-		if (effect)
-			effect.attach(location)
-			effect.start()
+	if(!location)
+		return
+
+	if(sound)
+		playsound(location, sound, 60, TRUE)
+	if(effect)
+		effect.attach(location)
+		effect.start()
 
 // Safe location finder
 /proc/find_safe_turf(zlevel, list/zlevels, extended_safety_checks = FALSE, dense_atoms = TRUE)

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -83,12 +83,7 @@
 	if(user.pulling)
 		AM = user.pulling
 		AM.forceMove(T)
-
-	if(isobserver(user))
-		user.abstract_move(T)
-	else
-		user.forceMove(T)
-
+	user.forceMove(T)
 	if(AM)
 		user.start_pulling(AM)
 

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -83,7 +83,12 @@
 	if(user.pulling)
 		AM = user.pulling
 		AM.forceMove(T)
-	user.forceMove(T)
+
+	if(isobserver(user))
+		user.abstract_move(T)
+	else
+		user.forceMove(T)
+
 	if(AM)
 		user.start_pulling(AM)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -349,6 +349,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	Moved(oldloc, direct)
 
+/mob/dead/observer/forceMove(atom/destination)
+	abstract_move(destination) // move like the wind
+	return TRUE
+
 /mob/dead/observer/verb/reenter_corpse()
 	set category = "Ghost"
 	set name = "Re-enter Corpse"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replace ghost procs uses of `forceMove()` with `abstract_move()` and override for all other generic `forceMove()` cases like ladders etc..

Reduce portal type checks and log spam.

## Why It's Good For The Game

Without it trying to break an orbit started on the tram goes like this:
![KiIPSFa95l](https://user-images.githubusercontent.com/64715958/124401003-72fc0680-dcdb-11eb-8019-242912ae3caa.gif)

Fixes: #59376
Fixes: #59776 as proximity checkers also use `COMSIG_ATOM_ENTERED`
Fixes: #59473

## Changelog
:cl:
fix: Fixed Tram ghost magnet and other cases of observer forceMove.
code: Renamed some observer code vars for better readability. Portals check types less.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
