### PR TITLE
Medhuds allow you to see the remaining damage on tend wounds surgeries.

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -142,7 +142,7 @@
 	var/estimated_remaining_steps = target.getBruteLoss() / brute_healed
 	var/progress_text
 
-	if((locate(/obj/item/healthanalyzer) in user.held_items) || HAS_TRAIT(user, DATA_HUD_MEDICAL_ADVANCED))
+	if((locate(/obj/item/healthanalyzer) in user.held_items) || HAS_TRAIT(user, TRAIT_MEDICAL_HUD))
 		progress_text = ". Remaining brute: <font color='#ff3333'>[target.getBruteLoss()]</font>"
 	else
 		switch(estimated_remaining_steps)
@@ -207,7 +207,7 @@
 	var/estimated_remaining_steps = target.getFireLoss() / burn_healed
 	var/progress_text
 
-	if((locate(/obj/item/healthanalyzer) in user.held_items) || HAS_TRAIT(user, DATA_HUD_MEDICAL_ADVANCED))
+	if((locate(/obj/item/healthanalyzer) in user.held_items) || HAS_TRAIT(user, TRAIT_MEDICAL_HUD))
 		progress_text = ". Remaining burn: <font color='#ff9933'>[target.getFireLoss()]</font>"
 	else
 		switch(estimated_remaining_steps)
@@ -275,7 +275,7 @@
 
 	var/progress_text
 
-	if((locate(/obj/item/healthanalyzer) in user.held_items) || HAS_TRAIT(user, DATA_HUD_MEDICAL_ADVANCED))
+	if((locate(/obj/item/healthanalyzer) in user.held_items) || HAS_TRAIT(user, TRAIT_MEDICAL_HUD))
 		if(target.getBruteLoss())
 			progress_text = ". Remaining brute: <font color='#ff3333'>[target.getBruteLoss()]</font>"
 		if(target.getFireLoss())

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -142,7 +142,7 @@
 	var/estimated_remaining_steps = target.getBruteLoss() / brute_healed
 	var/progress_text
 
-	if(locate(/obj/item/healthanalyzer) in user.held_items)
+	if((locate(/obj/item/healthanalyzer) in user.held_items) || HAS_TRAIT(user, DATA_HUD_MEDICAL_ADVANCED))
 		progress_text = ". Remaining brute: <font color='#ff3333'>[target.getBruteLoss()]</font>"
 	else
 		switch(estimated_remaining_steps)
@@ -207,7 +207,7 @@
 	var/estimated_remaining_steps = target.getFireLoss() / burn_healed
 	var/progress_text
 
-	if(locate(/obj/item/healthanalyzer) in user.held_items)
+	if((locate(/obj/item/healthanalyzer) in user.held_items) || HAS_TRAIT(user, DATA_HUD_MEDICAL_ADVANCED))
 		progress_text = ". Remaining burn: <font color='#ff9933'>[target.getFireLoss()]</font>"
 	else
 		switch(estimated_remaining_steps)
@@ -275,7 +275,7 @@
 
 	var/progress_text
 
-	if(locate(/obj/item/healthanalyzer) in user.held_items)
+	if((locate(/obj/item/healthanalyzer) in user.held_items) || HAS_TRAIT(user, DATA_HUD_MEDICAL_ADVANCED))
 		if(target.getBruteLoss())
 			progress_text = ". Remaining brute: <font color='#ff3333'>[target.getBruteLoss()]</font>"
 		if(target.getFireLoss())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Medhuds let you see the remaining damage while doing tend wounds.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes a somewhat obscure feature more accessible and easy to use. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: Medhuds allow you to see how much damage remains in tend wounds surgeries, like medical analyzers do when held in the offhand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
