### PR TITLE
Fixed a small oversight in Kilo's Bedroom

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -56715,7 +56715,6 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/computer/shuttle/mining/common,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
@@ -87100,6 +87099,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/computer/shuttle/mining/common,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "wZx" = (


### PR DESCRIPTION
Near the bedrooms, on the room to the right of the holodeck there was a medkit that was completely unacessible. Moved the computer to the left to make it accessible.

## Changelog
:cl:

fix: Inaccessible medkit in Kilostation dorms is now reachable

/:cl:
