### PR TITLE
Fix blob overmind spawns

### DIFF
--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -71,12 +71,22 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 /mob/camera/blob/proc/validate_location()
 	var/turf/T = get_turf(src)
-	if(!is_valid_turf(T) && LAZYLEN(GLOB.blobstart))
+	if(is_valid_turf(T))
+		return
+
+	if(LAZYLEN(GLOB.blobstart))
 		var/list/blobstarts = shuffle(GLOB.blobstart)
 		for(var/_T in blobstarts)
 			if(is_valid_turf(_T))
 				T = _T
 				break
+	else // no blob starts so look for an alternate
+		for(var/i in 1 to 16)
+			var/turf/picked_safe = find_safe_turf()
+			if(is_valid_turf(picked_safe))
+				T = picked_safe
+				break
+
 	if(!T)
 		CRASH("No blobspawnpoints and blob spawned in nullspace.")
 	forceMove(T)
@@ -102,7 +112,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 
 /mob/camera/blob/proc/is_valid_turf(turf/T)
 	var/area/A = get_area(T)
-	if((A && !(A.area_flags & BLOBS_ALLOWED)) || !T || !is_station_level(T.z) || isspaceturf(T))
+	if((A && !(A.area_flags & BLOBS_ALLOWED)) || !T || !is_station_level(T.z) || isgroundlessturf(T))
 		return FALSE
 	return TRUE
 
@@ -293,7 +303,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 			return FALSE
 	else
 		var/area/A = get_area(NewLoc)
-		if(isspaceturf(NewLoc) || istype(A, /area/shuttle)) //if unplaced, can't go on shuttles or space tiles
+		if(isgroundlessturf(NewLoc) || istype(A, /area/shuttle)) //if unplaced, can't go on shuttles or goundless tiles
 			return FALSE
 		forceMove(NewLoc)
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes sure blob spawn code has an extra branch to make picking a valid turf without `GLOB.blobstart` possible.

Changes some `isspaceturf()` checks to `isgroundlessturf()` because `/turf/open/openspace` exists all around places like tram station.

## Why It's Good For The Game

Seems like some of these issues might already be gone from my testing, but these changes will make doubly sure.

Fixes: #34073
Fixes: #48339
Fixes: #50574

## Changelog
:cl:
fix: Fixed unplaced blob overmind spawning in places it can not move.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
