### PR TITLE
Soapstone & engraved message fixes

### DIFF
--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -56,8 +56,8 @@
 		return
 	playsound(loc, 'sound/items/gavel.ogg', 50, TRUE, -1)
 	user.visible_message(span_notice("[user] starts engraving a message into [T]..."), span_notice("You start engraving a message into [T]..."), span_hear("You hear a chipping sound."))
-	if(can_use() && do_after(user, tool_speed, target = T) && can_use()) //This looks messy but it's actually really clever!
-		if(!locate(/obj/structure/chisel_message) in T)
+	if(do_after(user, tool_speed, target = T))
+		if(can_use() && !locate(/obj/structure/chisel_message) in T)
 			user.visible_message(span_notice("[user] leaves a message for future spacemen!"), span_notice("You engrave a message into [T]!"), span_hear("You hear a chipping sound."))
 			playsound(loc, 'sound/items/gavel.ogg', 50, TRUE, -1)
 			var/obj/structure/chisel_message/M = new(T)
@@ -205,10 +205,15 @@ but only permanently removed with the curator's soapstone.
 	if(persists)
 		SSpersistence.SaveChiselMessage(src)
 	SSpersistence.chisel_messages -= src
-	. = ..()
+	return ..()
 
 /obj/structure/chisel_message/interact()
 	return
+
+/obj/structure/chisel_message/ui_status(mob/user)
+	if(isobserver(user)) // ignore proximity restrictions if we're an observer
+		return UI_INTERACTIVE
+	return ..()
 
 /obj/structure/chisel_message/ui_state(mob/user)
 	return GLOB.always_state
@@ -234,6 +239,10 @@ but only permanently removed with the curator's soapstone.
 		data["admin_mode"] = TRUE
 		data["creator_key"] = creator_key
 		data["creator_name"] = creator_name
+	else
+		data["admin_mode"] = FALSE
+		data["creator_key"] = null
+		data["creator_name"] = null
 
 	return data
 

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -56,8 +56,8 @@
 		return
 	playsound(loc, 'sound/items/gavel.ogg', 50, TRUE, -1)
 	user.visible_message(span_notice("[user] starts engraving a message into [T]..."), span_notice("You start engraving a message into [T]..."), span_hear("You hear a chipping sound."))
-	if(do_after(user, tool_speed, target = T))
-		if(can_use() && !locate(/obj/structure/chisel_message) in T)
+	if(can_use() && do_after(user, tool_speed, target = T) && can_use()) //This looks messy but it's actually really clever!
+		if(!locate(/obj/structure/chisel_message) in T)
 			user.visible_message(span_notice("[user] leaves a message for future spacemen!"), span_notice("You engrave a message into [T]!"), span_hear("You hear a chipping sound."))
 			playsound(loc, 'sound/items/gavel.ogg', 50, TRUE, -1)
 			var/obj/structure/chisel_message/M = new(T)
@@ -65,7 +65,7 @@
 			remove_use()
 
 /obj/item/soapstone/proc/can_use()
-	return remaining_uses == -1 || remaining_uses >= 0
+	return remaining_uses == -1 || remaining_uses > 0
 
 /obj/item/soapstone/proc/remove_use()
 	if(remaining_uses <= 0)

--- a/tgui/packages/tgui/interfaces/EngravedMessage.js
+++ b/tgui/packages/tgui/interfaces/EngravedMessage.js
@@ -1,6 +1,6 @@
 import { decodeHtmlEntities } from 'common/string';
 import { useBackend } from '../backend';
-import { Box, Button, Grid, LabeledList, Section } from '../components';
+import { Box, Button, LabeledList, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 export const EngravedMessage = (props, context) => {
@@ -30,8 +30,8 @@ export const EngravedMessage = (props, context) => {
             mb={2}>
             {decodeHtmlEntities(hidden_message)}
           </Box>
-          <Grid>
-            <Grid.Column>
+          <Stack>
+            <Stack.Item grow={1.05}>
               <Button
                 fluid
                 icon="arrow-up"
@@ -42,8 +42,8 @@ export const EngravedMessage = (props, context) => {
                 fontSize="16px"
                 lineHeight="24px"
                 onClick={() => act('like')} />
-            </Grid.Column>
-            <Grid.Column>
+            </Stack.Item>
+            <Stack.Item grow={1}>
               <Button
                 fluid
                 icon="circle"
@@ -53,8 +53,8 @@ export const EngravedMessage = (props, context) => {
                 fontSize="16px"
                 lineHeight="24px"
                 onClick={() => act('neutral')} />
-            </Grid.Column>
-            <Grid.Column>
+            </Stack.Item>
+            <Stack.Item grow={1.05}>
               <Button
                 fluid
                 icon="arrow-down"
@@ -65,8 +65,8 @@ export const EngravedMessage = (props, context) => {
                 fontSize="16px"
                 lineHeight="24px"
                 onClick={() => act('dislike')} />
-            </Grid.Column>
-          </Grid>
+            </Stack.Item>
+          </Stack>
         </Section>
         <Section>
           <LabeledList>
@@ -75,7 +75,6 @@ export const EngravedMessage = (props, context) => {
             </LabeledList.Item>
           </LabeledList>
         </Section>
-        <Section />
         {!!admin_mode && (
           <Section
             title="Admin Panel"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR fixes and improves a few things regarding soapstones and engraved messages:

- Observers can now interact with the engraved messages from any distance instead of having to be next to them to rate them, which was rather unintuitive and unnecessary. This also solves problems where admin observers were unable to delete them without being next to them or activating AI interact mode.
- Fixed a case where you could make more engraved messages than your soapstone had uses by queing them fast enough.
- Cleaned up engraved message UI code a little bit - removed an unnecessary section and replaced deprecated `<Grid>` with `<Stack>`. Looks practically the same.
- Minor code improvements.

<details>
  <summary>Example image of the cleaned up UI</summary>

![NewSoapMessage](https://user-images.githubusercontent.com/43862960/124632331-88606480-de84-11eb-8616-20ae696b7ec2.png)

</details>

Fixes #59731

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugfixes.

## Changelog
:cl: Arkatos
qol: Observers can now interact with the engraved messages from any distance. Rate them!
fix: Fixed a case where you could make more engraved messages than your soapstone had uses by queing them fast enough.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
