### PR TITLE
fucking SEXTUPLES ALL TURF DECALS to test for if they affect maptick (like what i did before but more)

### DIFF
--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -46,3 +46,9 @@
 	if(!istype(T)) //you know this will happen somehow
 		CRASH("Turf decal initialized in an object/nullspace")
 	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, alpha, color, null, FALSE, null)
+
+	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 1, color, null, FALSE, null)
+	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 1, color, null, FALSE, null)
+	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 1, color, null, FALSE, null)
+	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 1, color, null, FALSE, null)
+	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 1, color, null, FALSE, null)

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -48,7 +48,7 @@
 	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, alpha, color, null, FALSE, null)
 
 	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 1, color, null, FALSE, null)
-	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 1, color, null, FALSE, null)
-	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 1, color, null, FALSE, null)
-	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 1, color, null, FALSE, null)
-	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 1, color, null, FALSE, null)
+	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 2, color, null, FALSE, null)
+	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 3, color, null, FALSE, null)
+	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 4, color, null, FALSE, null)
+	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, 5, color, null, FALSE, null)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
https://github.com/tgstation/tgstation/issues/53798 meant to test this, last time i did a test merge on this issue i got only a 0.07 maptick per person increase by doubling the number of turf decals over 65 rounds (0.882 for the 65 rounds before the test merge, 0.94 for the test merge, all on manuel). however im still unsure if what we got was within reasonable variance over 65 rounds since lummox says that overlays should have a null maptick cost and i cut off the test earlier than i wanted because of oom concerns, which doesnt apply now due to LAA on the servers. 

according to @LemonInTheDark this is our current maptick per person floor and ceiling. The variance is much lower now than when i last tried this thanks to 1556 and underlay lighting
![Maptick_variance](https://user-images.githubusercontent.com/15794172/124747495-d605bd00-ded6-11eb-854c-bb3a08f485ee.png)
if there really is a 5-10% difference on maptick caused by doubling turf decals, we should be able to be absolutely certain of it with 150-200 rounds of this test merged

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
science
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
