### PR TITLE
Fixes a plumbing harddel

### DIFF
--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -212,6 +212,7 @@
 			for(var/obj/machinery/duct/duct in get_step(parent, D))
 				if(duct.duct_layer == ducting_layer)
 					duct.remove_connects(turn(D, 180))
+					duct.neighbours.Remove(parent)
 					duct.update_appearance()
 
 ///settle wherever we are, and start behaving like a piece of plumbing


### PR DESCRIPTION
Plumbing machinery (showers, all the plumbing machines, etc) we're being tracked in a ducts neighbours list for connections. It used to be only for ducts and they forgot to change the behaviour on deletion (or disabling in this case) to include those plumbing machines 

:cl:
fix: fixes a plumbing harddel
/:cl:

God what idiot wrote this
