### PR TITLE
mob/dead/new_player harddel fix

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -32,8 +32,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 	/// Running information about the threat. Can store text or datum entries.
 	var/list/threat_log = list()
-	/// List of roundstart rules used for selecting the rules.
-	var/list/roundstart_rules
 	/// List of latejoin rules used for selecting the rules.
 	var/list/latejoin_rules
 	/// List of midround rules used for selecting the rules.
@@ -364,6 +362,10 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	setup_shown_threat()
 	setup_rulesets()
 
+	//We do this here instead of with the midround rulesets and such because these rules can hang refs
+	//To new_player and such, and we want the datums to just free when the roundstart work is done
+	var/list/roundstart_rules = init_rulesets(/datum/dynamic_ruleset/roundstart)
+
 	for(var/i in GLOB.new_player_list)
 		var/mob/dead/new_player/player = i
 		if(player.ready == PLAYER_READY_TO_PLAY && player.mind && player.check_preferences())
@@ -377,7 +379,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	if(GLOB.dynamic_forced_roundstart_ruleset.len > 0)
 		rigged_roundstart()
 	else
-		roundstart()
+		roundstart(roundstart_rules)
 
 	log_game("DYNAMIC: [round_start_budget] round start budget was left, donating it to midrounds.")
 	threat_log += "[worldtime2text()]: [round_start_budget] round start budget was left, donating it to midrounds."
@@ -402,7 +404,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 /// Initializes the internal ruleset variables
 /datum/game_mode/dynamic/proc/setup_rulesets()
-	roundstart_rules = init_rulesets(/datum/dynamic_ruleset/roundstart)
 	midround_rules = init_rulesets(/datum/dynamic_ruleset/midround)
 	latejoin_rules = init_rulesets(/datum/dynamic_ruleset/latejoin)
 
@@ -445,7 +446,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
 			spend_roundstart_budget(picking_roundstart_rule(rule, scaled_times, forced = TRUE))
 
-/datum/game_mode/dynamic/proc/roundstart()
+/datum/game_mode/dynamic/proc/roundstart(list/roundstart_rules)
 	if (GLOB.dynamic_forced_extended)
 		log_game("DYNAMIC: Starting a round of forced extended.")
 		return TRUE

--- a/code/game/gamemodes/dynamic/dynamic_simulations.dm
+++ b/code/game/gamemodes/dynamic/dynamic_simulations.dm
@@ -119,19 +119,4 @@
 
 	return export
 
-/client/proc/export_dynamic_json()
-	set name = "Export dynamic.json"
-	set category = "Debug"
-
-	var/datum/game_mode/dynamic/dynamic = SSticker.mode
-
-	var/list/export = list()
-	export["Roundstart"] = export_dynamic_json_of(dynamic.roundstart_rules)
-	export["Midround"] = export_dynamic_json_of(dynamic.midround_rules)
-	export["Latejoin"] = export_dynamic_json_of(dynamic.latejoin_rules)
-
-	message_admins("Writing file...")
-	WRITE_FILE(file("[GLOB.log_directory]/dynamic.json"), json_encode(export))
-	message_admins("Writing complete.")
-
 #endif

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -181,7 +181,6 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/print_cards,
 	#ifdef TESTING
 	/client/proc/check_missing_sprites,
-	/client/proc/export_dynamic_json,
 	/client/proc/run_dynamic_simulations,
 	#endif
 	/client/proc/display_sendmaps,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nukes the roundstart ruleset list, since it was causing rule datums to last throughout the round, and cause new_player hard deletes due to uncleared canidates list

![image](https://user-images.githubusercontent.com/58055496/124824074-bf875200-df26-11eb-84d6-dc276631c55b.png)

Potential #11365 fix, not sure yet need to see how things pan out when this is merged.

Sourced from #59996, man I really like this tool

Oh and I had to nuke a portion of @Mothblocks's simulation thing, he said it wasn't really needed anymore tho, so eh?

## Why It's Good For The Game

This might be the last major source of new_player harddels, I'm so happy you have no idea