### PR TITLE
Fixes Fit Viewport being forced onto all connecting clients regardless of their manual Auto Fit preference

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -446,7 +446,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	view_size = new(src, getScreenSize(prefs.widescreenpref))
 	view_size.resetFormat()
 	view_size.setZoomMode()
-	fit_viewport()
 	Master.UpdateTickRate()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CLIENT_CONNECT, src)
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -78,8 +78,7 @@
 	if(client)
 		if(client.view_size)
 			client.view_size.resetToDefault() // Resets the client.view in case it was changed.
-		else
-			client.change_view(getScreenSize(client.prefs.widescreenpref))
+		client.change_view(getScreenSize(client.prefs.widescreenpref))
 
 		if(client.player_details.player_actions.len)
 			for(var/datum/action/A in client.player_details.player_actions)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -78,7 +78,8 @@
 	if(client)
 		if(client.view_size)
 			client.view_size.resetToDefault() // Resets the client.view in case it was changed.
-		client.change_view(getScreenSize(client.prefs.widescreenpref))
+		else
+			client.change_view(getScreenSize(client.prefs.widescreenpref))
 
 		if(client.player_details.player_actions.len)
 			for(var/datum/action/A in client.player_details.player_actions)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removed a single line calling `fit_viewport()` when clients connect with no consideration for preference.

Big thank you to Lemontato for learning me on the methods of `change_view` madness despite my ineptitude and seeming to be on totally different wavelengths today.

## Why It's Good For The Game

Fix Preference. Pixel perfect users big annoyance goes bye bye.

## Changelog
:cl:
fix: Fixed all clients being forced to Fit Viewport regardless of their Auto Fit Viewport preference being set to manual. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
