### PR TITLE
Fixed bug that teleports AI cards

### DIFF
--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -52,7 +52,7 @@
 	if(stored_card)
 		to_chat(user, span_notice("You remove [stored_card] from [src]."))
 		locked = FALSE
-		if(user)
+		if(Adjacent(user))
 			user.put_in_hands(stored_card)
 		else
 			stored_card.forceMove(drop_location())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this is actually the exact same bug i fixed for a few items back in #55916 

basically, what happens is the current code for the AI intellicard slots is that when you click eject it ONLY tries placing it in your hand, if you have no hands or its occupied it drops on the floor, it does NOT however check if if your adjacent, meaning those with TK can teleport cards right out as long as it has line of sight, same with borgs, and the BIG kicker? if an AI you dont like is being repaired in the AI restorer the roundstart AI can "eject" it which teleports it right to their core on the sat, never to be seen again

all i did was add a simple check to see if the person ejecting is adjacent or not, if not it just places it on the console

i would normally have done it like 

```
stored_card.forceMove(drop_location())
if(Adjacent(user))
	user.put_in_hands(stored_card)
```
as this is the simplest way to do it, however in this particular instance, once the card is ejected its no longer stored on "stored_card" (makes sense) so the adjacency check wont fire to move to the hands, so its done by checking adjacency first then deciding how it will eject from there
	
	
fully tested, it works as intended


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugs suck, teleporting things your not supposed to suck, exploiting bugs to make AI cards vanish to never be seen again also suck
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: AI intellicards can no longer be teleported out of intellicard slots on consoles using telekinesis or silicon access range
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
