### PR TITLE
Left-Click Combat Mode Harmbaton

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -213,6 +213,10 @@
 		else
 			to_chat(user, span_danger("The baton is still charging!"))
 			return
+	else if(user.combat_mode && !turned_on)
+		..()
+		user.do_attack_animation(M)
+		return
 	else
 		M.visible_message(span_warning("[user] prods [M] with [src]. Luckily it was off."), \
 					span_warning("[user] prods you with [src]. Luckily it was off."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As it says on the tin, one simple change, if you left click while in combat mode but your stun baton is off, it harmbatons, like good ol' times

No Combat Mode + left click still prods non-lethally like normal, right click functions also remain so you can harmbaton with it on as well, and if your in combat mode AND your baton is off, both right and left click will harmbaton, so whichever button you want to use works


(No felinids were harmed in the making of this showcase)

https://user-images.githubusercontent.com/40489693/124902275-c6f33d80-dfb0-11eb-9aa6-53f48bdc1ad8.mp4







<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
being unable to harmbaton with your primary fire button is unintuitive, if your in combat mode and your baton is off and im spamming click on someone, i clearly want to harm them. now you can
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
qol: Stunbatons will now harm-baton on left-click if you are in combat mode and the baton is off
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
