### PR TITLE
Fixes All-In-One Grinder board name

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -436,7 +436,7 @@
 	build_path = /obj/machinery/rnd/production/protolathe/department
 
 /obj/item/circuitboard/machine/reagentgrinder
-	name = "Machine Design (All-In-One Grinder)"
+	name = "All-In-One Grinder (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/reagentgrinder/constructed
 	req_components = list(


### PR DESCRIPTION
Fixing my mistake from 3 years ago

Renames the circuit board for All-In-One Grinder from "Machine Design (All-In-One Grinder)" to "All-In-One Grinder (Machine Board)"

:cl:
spellcheck: Circuit board for All-In-One Grinder is now named appropriately
/:cl: