### PR TITLE
Small Kilo and Delta station QOL Medbay changes

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -37759,6 +37759,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/defibrillator_mount/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "enj" = (
@@ -38776,6 +38777,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/defibrillator_mount/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "eDl" = (
@@ -63688,6 +63690,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"lsy" = (
+/obj/structure/cable,
+/turf/closed/wall,
+/area/security/checkpoint/medical)
 "lsG" = (
 /turf/open/floor/iron,
 /area/security/prison)
@@ -65614,8 +65620,8 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/structure/mirror/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "lUX" = (
@@ -83545,7 +83551,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/defibrillator_mount/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "qwx" = (
@@ -158090,11 +158096,11 @@ cPC
 cRd
 cRc
 cUG
-cUG
+lsy
 cUG
 ryr
 cRc
-cUG
+lsy
 cUG
 dfD
 dhm

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -41997,10 +41997,6 @@
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "dxK" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cmoprivacy";
-	name = "Office Privacy Shutters"
-	},
 /turf/closed/wall,
 /area/command/heads_quarters/cmo)
 "dyi" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -12530,6 +12530,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box,
+/obj/machinery/defibrillator_mount/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "aPH" = (
@@ -42000,8 +42001,7 @@
 	id = "cmoprivacy";
 	name = "Office Privacy Shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/command/heads_quarters/cmo)
 "dyi" = (
 /obj/effect/landmark/start/bartender,
@@ -109215,7 +109215,7 @@ avB
 aWm
 eqk
 eWO
-eWO
+dxK
 eWO
 dxK
 eWO


### PR DESCRIPTION
Sorry if I fucked this up or something, this is my first PR and map change.

## About The Pull Request

Small Kilo and delta QOL changes for medbay
changes are shown in the images below (color coded)

![github](https://user-images.githubusercontent.com/79808856/125007893-f914a600-e069-11eb-94e5-9c1c3cb90278.png)

![Github2](https://user-images.githubusercontent.com/79808856/125008080-66283b80-e06a-11eb-96fa-e75211a1ce53.png)

## Why It's Good For The Game

You were unable to put defib holders on the windows that were there, replaced them with walls and added defib holders so you can easily access them without moving/wearing a defib on your back
(Also moved a fire extinguisher cabinet up by one tile so the defib holder can stay there alone)


## Changelog
:cl: Guestify
qol: replaced a couple of windows with walls in kilo and delta medbay, added a couple of defib holders that can be easily accessed

/:cl:
