### PR TITLE
optimizes get_hearers_in_view()

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -213,7 +213,7 @@
 
 	return
 
-/// Returns a list of hearers in view(view_radius) from source (ignoring luminosity).
+/// Returns a list of hearers in view(view_radius) from source (ignoring luminosity). recursively checks contents for hearers
 /proc/get_hearers_in_view(view_radius, atom/source)
 
 	var/turf/center_turf = get_turf(source)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -213,38 +213,69 @@
 
 	return
 
+/// Returns a list of hearers in view(R) from source (ignoring luminosity).
 /proc/get_hearers_in_view(R, atom/source)
-	// Returns a list of hearers in view(R) from source (ignoring luminosity). Used in saycode.
-	var/turf/T = get_turf(source)
+
+	var/turf/center_turf = get_turf(source)
 	. = list()
-	if(!T)
+	if(!center_turf)
 		return
 	var/list/processing_list = list()
 	if (R == 0) // if the range is zero, we know exactly where to look for, we can skip view
-		processing_list += T.contents // We can shave off one iteration by assuming turfs cannot hear
-	else  // A variation of get_hear inlined here to take advantage of the compiler's fastpath for obj/mob in view
-		var/lum = T.luminosity
-		T.luminosity = 6 // This is the maximum luminosity
-		for(var/mob/M in view(R, T))
-			processing_list += M
-		for(var/obj/O in view(R, T))
-			processing_list += O
-		T.luminosity = lum
+		processing_list += center_turf.contents // We can shave off one iteration by assuming turfs cannot hear
+	else
+		var/lum = center_turf.luminosity
+		center_turf.luminosity = 6 // This is the maximum luminosity
+		var/target = source.loc == center_turf ? source : center_turf //this is reasonably faster if true, and very slightly slower if false
+		for(var/atom/movable/movable in view(R, target))
+			if(movable.flags_1 & HEAR_1) //dont add the movables returned by view() to processing_list to reduce recursive iterations, just check them
+				. += movable
+				SEND_SIGNAL(movable, COMSIG_ATOM_HEARER_IN_VIEW, processing_list, .)
+			processing_list += movable.contents
+		center_turf.luminosity = lum
 
 	var/i = 0
-	while(i < length(processing_list)) // recursive_hear_check inlined here
-		var/atom/A = processing_list[++i]
-		if(A.flags_1 & HEAR_1)
-			. += A
-			SEND_SIGNAL(A, COMSIG_ATOM_HEARER_IN_VIEW, processing_list, .)
-		processing_list += A.contents
+	while(i < length(processing_list)) // recursive_hear_check inlined here, the large majority of the work is in this part for big contents trees
+		var/atom/atom_to_check = processing_list[++i]
+		if(atom_to_check.flags_1 & HEAR_1)
+			. += atom_to_check
+			SEND_SIGNAL(atom_to_check, COMSIG_ATOM_HEARER_IN_VIEW, processing_list, .)
+		processing_list += atom_to_check.contents
+
+/// Returns a list of mob exclusive hearers in view(R) from source (ignoring luminosity).
+/proc/get_mob_hearers_in_view(R, atom/source)
+
+	var/turf/center_turf = get_turf(source)
+	. = list()
+	if(!center_turf)
+		return
+	var/list/processing_list = list()
+	if (R == 0) // if the range is zero, we know exactly where to look for, we can skip view
+		processing_list += center_turf.contents // We can shave off one iteration by assuming turfs cannot hear
+	else
+		var/lum = center_turf.luminosity
+		center_turf.luminosity = 6 // This is the maximum luminosity
+		var/target = source.loc == center_turf ? source : center_turf //this is reasonably faster if true, and very slightly slower if false
+		for(var/atom/movable/movable in view(R, target))
+			if(movable.flags_1 & HEAR_1) //dont add the movables returned by view() to processing_list to reduce recursive iterations, just check them
+				. += movable
+				SEND_SIGNAL(movable, COMSIG_ATOM_HEARER_IN_VIEW, processing_list, .)
+			processing_list += movable.contents
+		center_turf.luminosity = lum
+
+	var/i = 0
+	while(i < length(processing_list)) // recursive_hear_check inlined here, the large majority of the work is in this part for big contents trees
+		var/atom/atom_to_check = processing_list[++i]
+		if(atom_to_check.flags_1 & HEAR_1)
+			. += atom_to_check
+			SEND_SIGNAL(atom_to_check, COMSIG_ATOM_HEARER_IN_VIEW, processing_list, .)
+		processing_list += atom_to_check.contents
 
 /proc/get_mobs_in_radio_ranges(list/obj/item/radio/radios)
 	. = list()
 	// Returns a list of mobs who can hear any of the radios given in @radios
 	for(var/obj/item/radio/R in radios)
-		if(R)
-			. |= get_hearers_in_view(R.canhear_range, R)
+		. |= get_hearers_in_view(R.canhear_range, R)
 
 #define SIGNV(X) ((X<0)?-1:1)
 

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -213,21 +213,21 @@
 
 	return
 
-/// Returns a list of hearers in view(R) from source (ignoring luminosity).
-/proc/get_hearers_in_view(R, atom/source)
+/// Returns a list of hearers in view(view_radius) from source (ignoring luminosity).
+/proc/get_hearers_in_view(view_radius, atom/source)
 
 	var/turf/center_turf = get_turf(source)
 	. = list()
 	if(!center_turf)
 		return
 	var/list/processing_list = list()
-	if (R == 0) // if the range is zero, we know exactly where to look for, we can skip view
+	if (view_radius == 0) // if the range is zero, we know exactly where to look for, we can skip view
 		processing_list += center_turf.contents // We can shave off one iteration by assuming turfs cannot hear
 	else
 		var/lum = center_turf.luminosity
 		center_turf.luminosity = 6 // This is the maximum luminosity
 		var/target = source.loc == center_turf ? source : center_turf //this is reasonably faster if true, and very slightly slower if false
-		for(var/atom/movable/movable in view(R, target))
+		for(var/atom/movable/movable in view(view_radius, target))
 			if(movable.flags_1 & HEAR_1) //dont add the movables returned by view() to processing_list to reduce recursive iterations, just check them
 				. += movable
 				SEND_SIGNAL(movable, COMSIG_ATOM_HEARER_IN_VIEW, processing_list, .)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -242,35 +242,6 @@
 			SEND_SIGNAL(atom_to_check, COMSIG_ATOM_HEARER_IN_VIEW, processing_list, .)
 		processing_list += atom_to_check.contents
 
-/// Returns a list of mob exclusive hearers in view(R) from source (ignoring luminosity).
-/proc/get_mob_hearers_in_view(R, atom/source)
-
-	var/turf/center_turf = get_turf(source)
-	. = list()
-	if(!center_turf)
-		return
-	var/list/processing_list = list()
-	if (R == 0) // if the range is zero, we know exactly where to look for, we can skip view
-		processing_list += center_turf.contents // We can shave off one iteration by assuming turfs cannot hear
-	else
-		var/lum = center_turf.luminosity
-		center_turf.luminosity = 6 // This is the maximum luminosity
-		var/target = source.loc == center_turf ? source : center_turf //this is reasonably faster if true, and very slightly slower if false
-		for(var/atom/movable/movable in view(R, target))
-			if(movable.flags_1 & HEAR_1) //dont add the movables returned by view() to processing_list to reduce recursive iterations, just check them
-				. += movable
-				SEND_SIGNAL(movable, COMSIG_ATOM_HEARER_IN_VIEW, processing_list, .)
-			processing_list += movable.contents
-		center_turf.luminosity = lum
-
-	var/i = 0
-	while(i < length(processing_list)) // recursive_hear_check inlined here, the large majority of the work is in this part for big contents trees
-		var/atom/atom_to_check = processing_list[++i]
-		if(atom_to_check.flags_1 & HEAR_1)
-			. += atom_to_check
-			SEND_SIGNAL(atom_to_check, COMSIG_ATOM_HEARER_IN_VIEW, processing_list, .)
-		processing_list += atom_to_check.contents
-
 /proc/get_mobs_in_radio_ranges(list/obj/item/radio/radios)
 	. = list()
 	// Returns a list of mobs who can hear any of the radios given in @radios

--- a/code/datums/elements/decals/_decal.dm
+++ b/code/datums/elements/decals/_decal.dm
@@ -137,6 +137,14 @@
 	SIGNAL_HANDLER
 
 	overlay_list += pic
+	var/true_alpha = pic.alpha
+	pic.alpha = 1
+	overlay_list += pic
+	overlay_list += pic
+	overlay_list += pic
+	overlay_list += pic
+	overlay_list += pic
+	pic.alpha = true_alpha
 
 /datum/element/decal/proc/clean_react(datum/source, clean_types)
 	SIGNAL_HANDLER

--- a/code/datums/elements/decals/_decal.dm
+++ b/code/datums/elements/decals/_decal.dm
@@ -137,14 +137,6 @@
 	SIGNAL_HANDLER
 
 	overlay_list += pic
-	var/true_alpha = pic.alpha
-	pic.alpha = 1
-	overlay_list += pic
-	overlay_list += pic
-	overlay_list += pic
-	overlay_list += pic
-	overlay_list += pic
-	pic.alpha = true_alpha
 
 /datum/element/decal/proc/clean_react(datum/source, clean_types)
 	SIGNAL_HANDLER

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -35,12 +35,11 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 /atom/movable/proc/can_speak()
 	//SHOULD_BE_PURE(TRUE)
-	return 1
+	return TRUE
 
 /atom/movable/proc/send_speech(message, range = 7, obj/source = src, bubble_type, list/spans, datum/language/message_language = null, list/message_mods = list())
 	var/rendered = compose_message(src, message_language, message, , spans, message_mods)
-	for(var/_AM in get_hearers_in_view(range, source))
-		var/atom/movable/AM = _AM
+	for(var/atom/movable/AM as anything in get_hearers_in_view(range, source))
 		AM.Hear(rendered, src, message_language, message, , spans, message_mods)
 
 /atom/movable/proc/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), face_name = FALSE)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -153,10 +153,8 @@
 		return FALSE
 	pulse(FALSE)
 	audible_message("<span class='infoplain'>[icon2html(src, hearers(src))] *beep* *beep* *beep*</span>", null, hearing_range)
-	for(var/CHM in get_hearers_in_view(hearing_range, src))
-		if(ismob(CHM))
-			var/mob/LM = CHM
-			LM.playsound_local(get_turf(src), 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
+	for(var/mob/hearing_mob in get_hearers_in_view(hearing_range, src))
+		hearing_mob.playsound_local(get_turf(src), 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
 	next_activate =  world.time + 30
 
 /obj/item/assembly/infra/proc/switchListener(turf/newloc)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -66,10 +66,8 @@
 		return FALSE
 	pulse(FALSE)
 	audible_message("<span class='infoplain'>[icon2html(src, hearers(src))] *beep* *beep* *beep*</span>", null, hearing_range)
-	for(var/CHM in get_hearers_in_view(hearing_range, src))
-		if(ismob(CHM))
-			var/mob/LM = CHM
-			LM.playsound_local(get_turf(src), 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
+	for(var/mob/hearing_mob in get_hearers_in_view(hearing_range, src))
+		hearing_mob.playsound_local(get_turf(src), 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
 	next_activate = world.time + 30
 	return TRUE
 

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -152,10 +152,8 @@
 
 	pulse(TRUE)
 	audible_message("<span class='infoplain'>[icon2html(src, hearers(src))] *beep* *beep* *beep*</span>", null, hearing_range)
-	for(var/CHM in get_hearers_in_view(hearing_range, src))
-		if(ismob(CHM))
-			var/mob/LM = CHM
-			LM.playsound_local(get_turf(src), 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
+	for(var/mob/hearing_mob in get_hearers_in_view(hearing_range, src))
+		hearing_mob.playsound_local(get_turf(src), 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
 	return TRUE
 
 /obj/item/assembly/signaler/proc/set_frequency(new_frequency)

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -58,10 +58,8 @@
 		return FALSE
 	pulse(FALSE)
 	audible_message("<span class='infoplain'>[icon2html(src, hearers(src))] *beep* *beep* *beep*</span>", null, hearing_range)
-	for(var/CHM in get_hearers_in_view(hearing_range, src))
-		if(ismob(CHM))
-			var/mob/LM = CHM
-			LM.playsound_local(get_turf(src), 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
+	for(var/mob/hearing_mob in get_hearers_in_view(hearing_range, src))
+		hearing_mob.playsound_local(get_turf(src), 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
 	if(loop)
 		timing = TRUE
 	update_appearance()

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -312,20 +312,19 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 				to_chat(src, "<span class='warning'>You can't sign at the moment!</span.?>")
 				return FALSE
 	if(client) //client is so that ghosts don't have to listen to mice
-		for(var/_M in GLOB.player_list)
-			var/mob/M = _M
-			if(QDELETED(M)) //Some times nulls and deleteds stay in this list. This is a workaround to prevent ic chat breaking for everyone when they do.
+		for(var/mob/player_mob as anything in GLOB.player_list)
+			if(QDELETED(player_mob)) //Some times nulls and deleteds stay in this list. This is a workaround to prevent ic chat breaking for everyone when they do.
 				continue //Remove if underlying cause (likely byond issue) is fixed. See TG PR #49004.
-			if(M.stat != DEAD) //not dead, not important
+			if(player_mob.stat != DEAD) //not dead, not important
 				continue
-			if(get_dist(M, src) > 7 || M.z != z) //they're out of range of normal hearing
+			if(get_dist(player_mob, src) > 7 || player_mob.z != z) //they're out of range of normal hearing
 				if(eavesdrop_range)
-					if(!(M.client.prefs.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off
+					if(!(player_mob.client.prefs.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off
 						continue
-				else if(!(M.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
+				else if(!(player_mob.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
 					continue
-			listening |= M
-			the_dead[M] = TRUE
+			listening |= player_mob
+			the_dead[player_mob] = TRUE
 
 	var/eavesdropping
 	var/eavesrendered
@@ -334,12 +333,11 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		eavesrendered = compose_message(src, message_language, eavesdropping, , spans, message_mods)
 
 	var/rendered = compose_message(src, message_language, message, , spans, message_mods)
-	for(var/_AM in listening)
-		var/atom/movable/AM = _AM
-		if(eavesdrop_range && get_dist(source, AM) > message_range && !(the_dead[AM]))
-			AM.Hear(eavesrendered, src, message_language, eavesdropping, , spans, message_mods)
+	for(var/atom/movable/listening_movable as anything in listening)
+		if(eavesdrop_range && get_dist(source, listening_movable) > message_range && !(the_dead[listening_movable]))
+			listening_movable.Hear(eavesrendered, src, message_language, eavesdropping, , spans, message_mods)
 		else
-			AM.Hear(rendered, src, message_language, message, , spans, message_mods)
+			listening_movable.Hear(rendered, src, message_language, message, , spans, message_mods)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_LIVING_SAY_SPECIAL, src, message)
 
 	//speech bubble


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
i noticed that get_hearers_in_view() checks for both /obj and /mob separately in two different view() calls which isnt necessary since there arent lighting objects on every tile anymore. then i noticed that the majority of the procs work was in the recursive step so i made two optimizations to reduce the amount of recursive iterations as much as possible. one is to call view() on the source atom directly if its loc is a turf since that makes view() return its contents as well as the contents of loc, and the other being that the movables returned by view() arent processed by the recursive step at all theyre just checked for hearing and then their contents are added to the recursive step.

in the benchmarking screenshots get_hearers_in_view_fast_two() is the proc that became the new version of get_hearers_in_view()
![Screenshot_386](https://user-images.githubusercontent.com/15794172/125010089-b4ade980-e01a-11eb-980d-0b8935be2920.png)
called on a player mob directly which i suspect to be the most common call of get_hearers_in_view(), the optimized version was 1.6x faster than the base version
![Screenshot_387](https://user-images.githubusercontent.com/15794172/125010263-0e161880-e01b-11eb-8dd7-9dc9b745d848.png)
called on the backpack inside the players contents, in this case the check for if loc == turf made this proc slightly slower than just using the turf always but was still 1.3x faster than the base version.

if there are any ideas on reducing the number of recursive steps on average im all ears. i think i could make area_sensitive_contents into a more general list and include hearing movables in it to entirely get rid of the recursive step but without refactoring how that and hearing works this PR is still good
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![Screenshot_385](https://user-images.githubusercontent.com/15794172/125011372-2dae4080-e01d-11eb-8445-7fcea0e142cb.png)
get_hearers_in_view() is a moderately expensive proc at highpop, now its faster. especially so for player mobs with loc == a turf which i suspect is the majority of the time its called looking at the code
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
