### PR TITLE
Corrects the grammar of your glasses getting knocked off

### DIFF
--- a/code/datums/components/knockoff.dm
+++ b/code/datums/components/knockoff.dm
@@ -50,7 +50,7 @@
 		return
 	if(!wearer.dropItemToGround(item))
 		return
-	wearer.visible_message(span_warning("[wearer]'s [item.name] gets knocked off!"),span_userdanger("Your [item.name] was knocked off!"))
+	wearer.visible_message(span_warning("[wearer]'s [item.name] gets knocked off!"),span_userdanger("Your [item.name] are knocked off!"))
 
 
 /datum/component/knockoff/proc/OnEquipped(datum/source, mob/living/carbon/human/H,slot)

--- a/code/datums/components/knockoff.dm
+++ b/code/datums/components/knockoff.dm
@@ -50,7 +50,7 @@
 		return
 	if(!wearer.dropItemToGround(item))
 		return
-	wearer.visible_message(span_warning("[wearer]'s [item.name] gets knocked off!"),span_userdanger("Your [item.name] are knocked off!"))
+	wearer.visible_message(span_warning("[wearer]'s [item.name] gets knocked off!"),span_userdanger("Your [item.name] were knocked off!"))
 
 
 /datum/component/knockoff/proc/OnEquipped(datum/source, mob/living/carbon/human/H,slot)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #59686 
changes a was to a were

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
your prescription glasses was knocked off just doesn't sound quite right

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: grammar regarding your nerdy glasses getting knocked off is now correct
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
