### PR TITLE
Fixes species layers being wonky

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -50,11 +50,6 @@
 #define EXTERNAL_BEHIND (1 << 3)
 #define ALL_EXTERNAL_OVERLAYS EXTERNAL_FRONT | EXTERNAL_ADJACENT | EXTERNAL_BEHIND
 
-//The layer external organs draw. These are drawn on the limbs, so the layers are relative to the limb theyre being drawn on
-#define EXTERNAL_FRONT_LAYER 2
-#define EXTERNAL_ADJACENT_LAYER 1
-#define EXTERNAL_BEHIND_LAYER -1
-
 //Human Overlay Index Shortcuts for alternate_worn_layer, layers
 //Because I *KNOW* somebody will think layer+1 means "above"
 //IT DOESN'T OK, IT MEANS "UNDER"

--- a/code/modules/surgery/organs/stomach/external/_external_organs.dm
+++ b/code/modules/surgery/organs/stomach/external/_external_organs.dm
@@ -102,22 +102,22 @@
 */
 /obj/item/organ/external/proc/mutant_bodyparts_layertext(layer)
 	switch(layer)
-		if(EXTERNAL_BEHIND_LAYER)
+		if(BODY_BEHIND_LAYER)
 			return "_BEHIND"
-		if(EXTERNAL_ADJACENT_LAYER)
+		if(BODY_ADJ_LAYER)
 			return "_ADJ"
-		if(EXTERNAL_FRONT_LAYER)
+		if(BODY_FRONT_LAYER)
 			return "_FRONT"
 
 ///Converts a bitflag to the right layer. I'd love to make this a static index list, but byond made an attempt on my life when i did
 /obj/item/organ/external/proc/bitflag_to_layer(layer)
 	switch(layer)
 		if(EXTERNAL_BEHIND)
-			return EXTERNAL_BEHIND_LAYER
+			return BODY_BEHIND_LAYER
 		if(EXTERNAL_ADJACENT)
-			return EXTERNAL_ADJACENT_LAYER
+			return BODY_ADJ_LAYER
 		if(EXTERNAL_FRONT)
-			return EXTERNAL_FRONT_LAYER
+			return BODY_FRONT_LAYER
 
 ///Because all the preferences have names like "Beautiful Sharp Snout" we need to get the sprite datum with the actual important info
 /obj/item/organ/external/proc/get_sprite_datum(sprite)


### PR DESCRIPTION
I messed around with layer defines because it was necessary at the time, but I fixed the original issue and never reverted the defines. I tested it and glasses go over snouts now

Closes #60098 (I think? the issue is extremely vague)

:cl:
fix: glasses arent horribly embedded in lizard snouts anymore
/:cl: