### PR TITLE
Less absurd sturdiness for railings, more in line with grilles now.

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -5,6 +5,9 @@
 	icon_state = "railing"
 	density = TRUE
 	anchored = TRUE
+	/// armor more or less consistent with grille. max_integrity about one time and a half that of a grille.
+	armor = list(MELEE = 50, BULLET = 70, LASER = 70, ENERGY = 100, BOMB = 10, BIO = 100, RAD = 100, FIRE = 0, ACID = 0)
+	max_integrity = 75
 
 	var/climbable = TRUE
 	///Initial direction of the railing.


### PR DESCRIPTION
## About The Pull Request
railings integrity is now one time and half that of grilles (proportional to their material cost, previously it's 300), and also have the same armor values for further consistency.

## Why It's Good For The Game
Railings are currently titanium levels of sturdy despite being deconstructable with just wirecutters similarly to grilles.

## Changelog
:cl:
balance: Railings integrity has been lowered from 300 (default for structures) to 75 (grilles integrity times 1.5) and their armor changed to match that of grilles.
/:cl:
