### PR TITLE
Fixes the mech mounted teleporter not working.

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -15,7 +15,7 @@
 
 /obj/item/mecha_parts/mecha_equipment/teleporter/action(mob/source, atom/target, params)
 	var/area/ourarea = get_area(src)
-	if(!action_checks(target) || ourarea & NOTELEPORT)
+	if(!action_checks(target) || ourarea.area_flags & NOTELEPORT)
 		return
 	var/turf/T = get_turf(target)
 	if(T && (loc.z == T.z) && (get_dist(loc, T) <= teleport_range))


### PR DESCRIPTION
## About The Pull Request
Title. A mistake was made during #53637 that's gone unreported until a few days ago considering how underused and not timeworthy the mech teleporter is.

## Why It's Good For The Game
This will fix #60063.

## Changelog
:cl:
fix: Fixes the mech mounted teleporter.
/:cl:
