### PR TITLE
Ascends the "lobstrosities can finish charging even while dead" issue  into a feature.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -647,7 +647,7 @@
 					blocked = TRUE
 			if(!blocked)
 				/// even in death they can be dangerous. This should clarify it.
-				var/dead_hogboar_msg = stat == DEAD ? "In the throes of death " : ""
+				var/dead_hogboar_msg = stat == DEAD ? "In the throes of death, " : ""
 				L.visible_message(span_danger("[dead_hogboar_msg][src] charges on [L]!"), span_userdanger("[dead_hogboar_msg][src] charges into you!"))
 				L.Knockdown(knockdown_time)
 			else

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -646,7 +646,9 @@
 				if(H.check_shields(src, 0, "the [name]", attack_type = LEAP_ATTACK))
 					blocked = TRUE
 			if(!blocked)
-				L.visible_message(span_danger("[src] charges on [L]!"), span_userdanger("[src] charges into you!"))
+				/// even in death they can be dangerous. This should clarify it.
+				var/dead_hogboar_msg = stat == DEAD ? "In the throes of death " : ""
+				L.visible_message(span_danger("[dead_hogboar_msg][src] charges on [L]!"), span_userdanger("[dead_hogboar_msg][src] charges into you!"))
 				L.Knockdown(knockdown_time)
 			else
 				Stun((knockdown_time * 2), ignore_canstun = TRUE)


### PR DESCRIPTION
## About The Pull Request
Alternative "fix" to #60035, text courtesy of RaveRadbury (see issue).

## Why It's Good For The Game
Some people said the bug is cool so eh, I'll let you choose what you want to do with it. This will close #60035 and close #60113.

## Changelog
:cl: 
fix: Added some bits of text to the giant tarantula/lobstrosity's charger attack should they die in the process, hopefully clarifying that not even death can stop these ultraviolent critters from their bodyslamming tasks.
/:cl:
