### PR TITLE
Your funds are now actually able to be safe with CRAB-17. Removes the do_after from swiping your card on CRAB-17.

### DIFF
--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -69,14 +69,11 @@
 		if(!card.registered_account.being_dumped)
 			to_chat(user, span_warning("It appears that your funds are safe from draining!"))
 			return
-		if(do_after(user, 40, target = src))
-			if(!card.registered_account.being_dumped)
-				return
-			to_chat(user, span_warning("You quickly cash out your funds to a more secure banking location. Funds are safu.")) // This is a reference and not a typo
-			card.registered_account.being_dumped = FALSE
-			if(check_if_finished())
-				qdel(src)
-				return
+		to_chat(user, span_warning("You quickly cash out your funds to a more secure banking location. Funds are safu.")) // This is a reference and not a typo
+		card.registered_account.being_dumped = FALSE
+		if(check_if_finished())
+			qdel(src)
+			return
 	else
 		return ..()
 


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

Fixes #60118

## Changelog
:cl:
fix: Fixes not actually being able to cash out of CRAB-17 due to the device moving rapidly.
/:cl:

