### PR TITLE
Fixes difficulties with placing lattices on multiz maps.

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -50,6 +50,7 @@
 #ifdef LOWMEMORYMODE
 #define FORCE_MAP "_maps/runtimestation.json"
 #endif
+#define FORCE_MAP "_maps/multiz_debug.json"
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 514

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -50,7 +50,6 @@
 #ifdef LOWMEMORYMODE
 #define FORCE_MAP "_maps/runtimestation.json"
 #endif
-#define FORCE_MAP "_maps/multiz_debug.json"
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 514

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -7,7 +7,7 @@
 #ifdef DEBUG
 #define USE_CUSTOM_ERROR_HANDLER
 #endif
-
+#define FORCE_MAP "_maps/multiz_debug.json"
 #ifdef TESTING
 #define DATUMVAR_DEBUGGING_MODE
 

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -7,7 +7,7 @@
 #ifdef DEBUG
 #define USE_CUSTOM_ERROR_HANDLER
 #endif
-#define FORCE_MAP "_maps/multiz_debug.json"
+
 #ifdef TESTING
 #define DATUMVAR_DEBUGGING_MODE
 

--- a/code/datums/elements/openspace_item_click_handler.dm
+++ b/code/datums/elements/openspace_item_click_handler.dm
@@ -1,0 +1,25 @@
+/**
+ * allow players to easily use items such as iron rods, rcds on open space without
+ * having to pixelhunt for portions not occupied by object or mob visuals.
+ */
+/datum/element/openspace_item_click_handler
+	element_flags = ELEMENT_DETACH
+
+/datum/element/openspace_item_click_handler/Attach(datum/target)
+	..()
+	if(!isitem(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_ITEM_AFTERATTACK, .proc/on_afterattack)
+
+/datum/element/openspace_item_click_handler/Detach(datum/source)
+	UnregisterSignal(source, COMSIG_ITEM_AFTERATTACK)
+	..()
+
+/datum/element/openspace_item_click_handler/proc/on_afterattack(item/source, atom/target, mob/user, proximity_flag, click_parameters)
+	if(target.z == user.z)
+		return
+	var/turf/turf_above = get_step_multiz(target, UP)
+	if(turf_above?.z == user.z)
+		user.next_click = null  // reset the cooldown and try again on the turf above.
+		user.ClickOn(turf_above, click_parameters)
+	return

--- a/code/datums/elements/openspace_item_click_handler.dm
+++ b/code/datums/elements/openspace_item_click_handler.dm
@@ -6,20 +6,20 @@
 	element_flags = ELEMENT_DETACH
 
 /datum/element/openspace_item_click_handler/Attach(datum/target)
-	..()
+	. = ..()
 	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
 	RegisterSignal(target, COMSIG_ITEM_AFTERATTACK, .proc/on_afterattack)
 
 /datum/element/openspace_item_click_handler/Detach(datum/source)
 	UnregisterSignal(source, COMSIG_ITEM_AFTERATTACK)
-	..()
+	return ..()
 
-/datum/element/openspace_item_click_handler/proc/on_afterattack(item/source, atom/target, mob/user, proximity_flag, click_parameters)
+//Invokes the proctype with a turf above as target.
+/datum/element/openspace_item_click_handler/proc/on_afterattack(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
+	SIGNAL_HANDLER
 	if(target.z == user.z)
 		return
 	var/turf/turf_above = get_step_multiz(target, UP)
 	if(turf_above?.z == user.z)
-		user.next_click = null  // reset the cooldown and try again on the turf above.
-		user.ClickOn(turf_above, click_parameters)
-	return
+		INVOKE_ASYNC(source, /obj/item.proc/handle_openspace_click, turf_above, user, user.CanReach(turf_above, source), click_parameters)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1185,3 +1185,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if(ismob(loc))
 		var/mob/mob_loc = loc
 		mob_loc.regenerate_icons()
+
+/// Called on [/datum/element/openspace_item_click_handler/proc/on_afterattack]. Check the relative file for information.
+/obj/item/proc/handle_openspace_click(turf/target, mob/user, proximity_flag, click_parameters)
+	stack_trace("Undefined handle_openspace_click() behaviour. Ascertain the openspace_item_click_handler element has been attached to the right item and that its proc override doesn't call parent.")

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -270,6 +270,10 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 
 	return getHologramIcon(grille_icon)
 
+/obj/item/construction/rcd/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/openspace_item_click_handler)
+
 /obj/item/construction/rcd/ui_action_click(mob/user, actiontype)
 	if (!COOLDOWN_FINISHED(src, destructive_scan_cooldown))
 		to_chat(user, span_warning("[src] lets out a low buzz."))

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -186,6 +186,8 @@ RLD
 	return .
 
 /obj/item/construction/proc/range_check(atom/A, mob/user)
+	if(A.z != user.z)
+		return
 	if(!(A in view(7, get_turf(user))))
 		to_chat(user, span_warning("The \'Out of Range\' light on [src] blinks red."))
 		return FALSE
@@ -273,6 +275,11 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 /obj/item/construction/rcd/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/openspace_item_click_handler)
+
+/obj/item/construction/rcd/handle_openspace_click(turf/target, mob/user, proximity_flag, click_parameters)
+	if(proximity_flag)
+		mode = construction_mode
+		rcd_create(target, user)
 
 /obj/item/construction/rcd/ui_action_click(mob/user, actiontype)
 	if (!COOLDOWN_FINISHED(src, destructive_scan_cooldown))
@@ -871,6 +878,10 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 		pre_attack_secondary(target, user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
+/obj/item/construction/rcd/arcd/handle_openspace_click(turf/target, mob/user, proximity_flag, click_parameters)
+	if(ranged && range_check(target, user))
+		mode = construction_mode
+		rcd_create(target, user)
 
 /obj/item/construction/rcd/arcd/rcd_create(atom/A, mob/user)
 	. = ..()

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -18,6 +18,10 @@
 	var/holosign_type = /obj/structure/holosign/wetsign
 	var/holocreator_busy = FALSE //to prevent placing multiple holo barriers at once
 
+/obj/item/holosign_creator/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/openspace_item_click_handler)
+
 /obj/item/holosign_creator/examine(mob/user)
 	. = ..()
 	if(!signs)

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -22,6 +22,9 @@
 	. = ..()
 	AddElement(/datum/element/openspace_item_click_handler)
 
+/obj/item/holosign_creator/handle_openspace_click(turf/target, mob/user, proximity_flag, click_parameters)
+	afterattack(target, user, proximity_flag, click_parameters)
+
 /obj/item/holosign_creator/examine(mob/user)
 	. = ..()
 	if(!signs)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -39,6 +39,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 /obj/item/stack/rods/Initialize(mapload, new_amount, merge = TRUE, list/mat_override=null, mat_amt=1)
 	. = ..()
 	update_appearance()
+	AddElement(/datum/element/openspace_item_click_handler)
 
 /obj/item/stack/rods/get_main_recipes()
 	. = ..()

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -41,6 +41,10 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	update_appearance()
 	AddElement(/datum/element/openspace_item_click_handler)
 
+/obj/item/stack/rods/handle_openspace_click(turf/target, mob/user, proximity_flag, click_parameters)
+	if(proximity_flag)
+		target.attackby(src, user, click_parameters)
+
 /obj/item/stack/rods/get_main_recipes()
 	. = ..()
 	. += GLOB.rod_recipes

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -720,6 +720,7 @@
 #include "code\datums\elements\light_eater.dm"
 #include "code\datums\elements\movetype_handler.dm"
 #include "code\datums\elements\obj_regen.dm"
+#include "code\datums\elements\openspace_item_click_handler.dm"
 #include "code\datums\elements\pet_bonus.dm"
 #include "code\datums\elements\plant_backfire.dm"
 #include "code\datums\elements\point_of_interest.dm"


### PR DESCRIPTION
## About The Pull Request
Title. Because of mob and object visuals under open space being able to be hovered over with the cursor and examined and in general acting as entities distint from the turf holding them it tends to be hard or even impossible to build floor and catwalks over these turfs. This PR aims to fix it with a basically simple, more-convenient-than-a-painstaking-refactor and easy to apply element (edit: and proc).

## Why It's Good For The Game
This will fix #59484.

## Changelog
:cl:
fix: Fixes some hardships with placing lattice on multiz maps.
/:cl:
