### PR TITLE
Fixes attach_limb() not calling update_disabled()

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -361,7 +361,8 @@
 		LAZYADD(new_limb_owner.all_scars, scar)
 
 	update_bodypart_damage_state()
-	update_disabled()
+	if(can_be_disabled)
+		update_disabled()
 
 	new_limb_owner.updatehealth()
 	new_limb_owner.update_body()

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -361,6 +361,7 @@
 		LAZYADD(new_limb_owner.all_scars, scar)
 
 	update_bodypart_damage_state()
+	update_disabled()
 
 	new_limb_owner.updatehealth()
 	new_limb_owner.update_body()


### PR DESCRIPTION
## About The Pull Request
In layman terms: Fixes intrinsically paralytic mobs being cured from paralysis just because they got a brand new (prosthetic) limb.
Yes, it's exactly one line, taken from an older PR i made on citadel because of roundstart slimepeople.

## Why It's Good For The Game
This will fix  #59671 and fix #56141.

## Changelog
:cl:
fix: Fixes intrinsically paralytic mobs being cured from their paralysis just because they got a brand new (prosthetic) limb.
/:cl:
