### PR TITLE
Stops (blob) mobs from falling through blob structures on open space.

### DIFF
--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -10,6 +10,7 @@
 	layer = BELOW_MOB_LAYER
 	pass_flags_self = PASSBLOB
 	CanAtmosPass = ATMOS_PASS_PROC
+	obj_flags = CAN_BE_HIT|BLOCK_Z_OUT_DOWN // stops blob mobs from falling on multiz.
 	/// How many points the blob gets back when it removes a blob of that type. If less than 0, blob cannot be removed.
 	var/point_return = 0
 	max_integrity = BLOB_REGULAR_MAX_HP


### PR DESCRIPTION
## About The Pull Request
I have seen this happen once on icebox and, as part of the ghost crowd cheering for the blob, I have felt kinda bitter.

## Why It's Good For The Game
Blob tiles occupy entire turfs, making it impossible to tell whether a hole is there or not without over-meticolous shift or alt clicking, are dense, and also it makes sense since blob tiles are blob mobs' turf, their higher ground.

## Changelog
:cl:
qol: Stops (blob and otherwise) mobs from falling through blob tiles on open space.
/:cl:
