### PR TITLE
fixes potential holodeck bee infinite chem exploit

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -67,6 +67,8 @@
 	AddComponent(/datum/component/swarming)
 
 /mob/living/simple_animal/hostile/bee/mob_pickup(mob/living/L)
+	if(flags_1 & HOLOGRAM_1)
+		return
 	var/obj/item/clothing/head/mob_holder/destructible/holder = new(get_turf(src), src, held_state, head_icon, held_lh, held_rh, worn_slot_flags)
 	var/list/reee = list(/datum/reagent/consumable/nutriment/vitamin = 5)
 	if(beegent)

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -87,6 +87,8 @@
 	if(beehome)
 		beehome.bees -= src
 		beehome = null
+	if((flags_1 & HOLOGRAM_1))
+		return ..()
 	var/obj/item/trash/bee/bee_to_eat = new(loc)
 	bee_to_eat.pixel_x = pixel_x
 	bee_to_eat.pixel_y = pixel_y
@@ -95,7 +97,7 @@
 		bee_to_eat.reagents.add_reagent(beegent.type, 5)
 	bee_to_eat.update_appearance()
 	beegent = null
-	..()
+	return ..()
 
 
 /mob/living/simple_animal/hostile/bee/examine(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
its possible to create infinite chems from holodeck bees by killing htem and grinding their corpses, now they dont leave corpses
edit: and you cant put them in your hands either
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: you can no longer get infinite chems from holodeck bees
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
