### PR TITLE
Always draws mothwings

### DIFF
--- a/code/modules/surgery/organs/stomach/external/wings.dm
+++ b/code/modules/surgery/organs/stomach/external/wings.dm
@@ -170,6 +170,9 @@
 /obj/item/organ/external/wings/moth/get_global_feature_list()
 	return GLOB.moth_wings_list
 
+/obj/item/organ/external/wings/moth/can_draw_on_bodypart(mob/living/carbon/human/human)
+	return TRUE
+
 /obj/item/organ/external/wings/moth/Insert(mob/living/carbon/reciever, special, drop_if_replaced)
 	. = ..()
 


### PR DESCRIPTION
I didn't realize moth wings were supposed to go over EVA suits and everything, so here it is again
Reverts an unintended balance change
:cl:
fix: apparently mothwings were supposed to go above spacesuits, oops
/:cl:

closes #60131