### PR TITLE
Fixes lizard and moth preferences missing chunks

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -401,7 +401,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "</td>"
 					mutant_category = 0
 
-			if(pref_species.mutant_bodyparts["snout"])
+			if(pref_species.external_organs[/obj/item/organ/external/snout])
 				if(!mutant_category)
 					dat += APPEARANCE_CATEGORY_COLUMN
 
@@ -414,7 +414,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "</td>"
 					mutant_category = 0
 
-			if(pref_species.mutant_bodyparts["horns"])
+			if(pref_species.external_organs[/obj/item/organ/external/horns])
 				if(!mutant_category)
 					dat += APPEARANCE_CATEGORY_COLUMN
 
@@ -427,7 +427,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "</td>"
 					mutant_category = 0
 
-			if(pref_species.mutant_bodyparts["frills"])
+			if(pref_species.external_organs[/obj/item/organ/external/frills])
 				if(!mutant_category)
 					dat += APPEARANCE_CATEGORY_COLUMN
 
@@ -479,7 +479,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "</td>"
 					mutant_category = 0
 
-			if(pref_species.mutant_bodyparts["moth_wings"])
+			if(pref_species.external_organs[/obj/item/organ/external/wings/moth])
 				if(!mutant_category)
 					dat += APPEARANCE_CATEGORY_COLUMN
 
@@ -492,7 +492,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					dat += "</td>"
 					mutant_category = 0
 
-			if(pref_species.mutant_bodyparts["moth_antennae"])
+			if(pref_species.external_organs[/obj/item/organ/external/antennae])
 				if(!mutant_category)
 					dat += APPEARANCE_CATEGORY_COLUMN
 


### PR DESCRIPTION
Preferences were apparently dependent on species_feature list, one which I changed. Preferences for the ported organs now uses external_organs

:cl:
fix: fix some moth and lizard preferences missing
/:cl:

closes #60117
