### PR TITLE
Improves Chat Highlighting: allow more symbols, match word/case toggle

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -523,9 +523,9 @@ GLOBAL_LIST_EMPTY(species_list)
 				var/turf_link = TURF_LINK(M, turf_target)
 				rendered_message = "[turf_link] [message]"
 
-			to_chat(M, rendered_message)
+			to_chat(M, rendered_message, avoid_highlighting = speaker_key == M.key)
 		else
-			to_chat(M, message)
+			to_chat(M, message, avoid_highlighting = speaker_key == M.key)
 
 //Used in chemical_mob_spawn. Generates a random mob based on a given gold_core_spawnable value.
 /proc/create_random_mob(spawn_location, mob_class = HOSTILE_SPAWN)

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -186,7 +186,7 @@
 	var/list/message_mods = data["mods"]
 	var/rendered = virt.compose_message(virt, language, message, frequency, spans)
 	for(var/atom/movable/hearer in receive)
-		hearer.Hear(rendered, virt, language, message, frequency, spans, message_mods)
+		hearer.Hear(rendered, virt.source, language, message, frequency, spans, message_mods)
 
 	// This following recording is intended for research and feedback in the use of department radio channels
 	if(length(receive))

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -186,7 +186,7 @@
 	var/list/message_mods = data["mods"]
 	var/rendered = virt.compose_message(virt, language, message, frequency, spans)
 	for(var/atom/movable/hearer in receive)
-		hearer.Hear(rendered, virt.source, language, message, frequency, spans, message_mods)
+		hearer.Hear(rendered, virt, language, message, frequency, spans, message_mods)
 
 	// This following recording is intended for research and feedback in the use of department radio channels
 	if(length(receive))

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -254,6 +254,13 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 	var/deaf_message
 	var/deaf_type
+	var/avoid_highlight
+	if(istype(speaker, /atom/movable/virtualspeaker))
+		var/atom/movable/virtualspeaker/virt = speaker
+		avoid_highlight = src == virt.source
+	else
+		avoid_highlight = src == speaker
+
 	if(HAS_TRAIT(speaker, TRAIT_SIGN_LANG)) //Checks if speaker is using sign language
 		deaf_message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
 		if(speaker != src)
@@ -272,7 +279,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 		message = deaf_message
 
-		show_message(message, MSG_VISUAL, deaf_message, deaf_type, avoid_highlighting = speaker == src)
+		show_message(message, MSG_VISUAL, deaf_message, deaf_type, avoid_highlight)
 		return message
 
 	if(speaker != src)
@@ -290,7 +297,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	// Recompose message for AI hrefs, language incomprehension.
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
 
-	show_message(message, MSG_AUDIBLE, deaf_message, deaf_type, avoid_highlighting = speaker == src)
+	show_message(message, MSG_AUDIBLE, deaf_message, deaf_type, avoid_highlight)
 	return message
 
 /mob/living/send_speech(message, message_range = 6, obj/source = src, bubble_type = bubble_icon, list/spans, datum/language/message_language=null, list/message_mods = list())

--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -117,7 +117,8 @@ export const chatMiddleware = store => {
       const settings = selectSettings(store.getState());
       chatRenderer.setHighlight(
         settings.highlightText,
-        settings.highlightColor);
+        settings.highlightColor,
+        settings.matchCase);
       return;
     }
     if (type === 'roundrestart') {

--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -118,6 +118,7 @@ export const chatMiddleware = store => {
       chatRenderer.setHighlight(
         settings.highlightText,
         settings.highlightColor,
+        settings.matchWord,
         settings.matchCase);
       return;
     }

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -170,7 +170,7 @@ class ChatRenderer {
     }
   }
 
-  setHighlight(text, color, matchCase) {
+  setHighlight(text, color, matchWord, matchCase) {
     if (!text || !color) {
       this.highlightRegex = null;
       this.highlightColor = null;
@@ -190,7 +190,9 @@ class ChatRenderer {
       this.highlightColor = null;
       return;
     }
-    this.highlightRegex = new RegExp('(' + lines.join('|') + ')', `g${matchCase ? '' : 'i'}`);
+    const pattern = `${(matchWord ? '\\b' : '')}(${lines.join('|')})${(matchWord ? '\\b' : '')}`;
+    const flags = 'g' + (matchCase ? '' : 'i');
+    this.highlightRegex = new RegExp(pattern, flags);
     this.highlightColor = color;
   }
 

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -170,21 +170,19 @@ class ChatRenderer {
     }
   }
 
-  setHighlight(text, color) {
+  setHighlight(text, color, matchCase) {
     if (!text || !color) {
       this.highlightRegex = null;
       this.highlightColor = null;
       return;
     }
-    const allowedRegex = /^[a-z0-9_\-\s]+$/ig;
     const lines = String(text)
       .split(',')
-      .map(str => str.trim())
+      // eslint-disable-next-line no-useless-escape
+      .map(str => str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'))
       .filter(str => (
         // Must be longer than one character
         str && str.length > 1
-        // Must be alphanumeric (with some punctuation)
-        && allowedRegex.test(str)
       ));
     // Nothing to match, reset highlighting
     if (lines.length === 0) {
@@ -192,7 +190,7 @@ class ChatRenderer {
       this.highlightColor = null;
       return;
     }
-    this.highlightRegex = new RegExp('(' + lines.join('|') + ')', 'gi');
+    this.highlightRegex = new RegExp('(' + lines.join('|') + ')', `g${matchCase ? '' : 'i'}`);
     this.highlightColor = color;
   }
 

--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -179,7 +179,7 @@ class ChatRenderer {
     const lines = String(text)
       .split(',')
       // eslint-disable-next-line no-useless-escape
-      .map(str => str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'))
+      .map(str => str.trim().replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'))
       .filter(str => (
         // Must be longer than one character
         str && str.length > 1

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -136,13 +136,6 @@ export const SettingsGeneral = (props, context) => {
         <Flex mb={1} color="label" align="baseline">
           <Flex.Item grow={1}>
             Highlight text (comma separated):
-            <Button.Checkbox
-              checked={matchCase}
-              onClick={() => dispatch(updateSettings({
-                matchCase: !matchCase,
-              }))}>
-              Match Case
-            </Button.Checkbox>
           </Flex.Item>
           <Flex.Item shrink={0}>
             <ColorBox mr={1} color={highlightColor} />
@@ -154,6 +147,13 @@ export const SettingsGeneral = (props, context) => {
               onInput={(e, value) => dispatch(updateSettings({
                 highlightColor: value,
               }))} />
+            <Button.Checkbox
+              checked={matchCase}
+              onClick={() => dispatch(updateSettings({
+                matchCase: !matchCase,
+              }))}>
+              Match case
+            </Button.Checkbox>
           </Flex.Item>
         </Flex>
         <TextArea

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -56,6 +56,7 @@ export const SettingsGeneral = (props, context) => {
     lineHeight,
     highlightText,
     highlightColor,
+    matchWord,
     matchCase,
   } = useSelector(context, selectSettings);
   const dispatch = useDispatch(context);
@@ -147,12 +148,20 @@ export const SettingsGeneral = (props, context) => {
               onInput={(e, value) => dispatch(updateSettings({
                 highlightColor: value,
               }))} />
+            Match:
+            <Button.Checkbox
+              checked={matchWord}
+              onClick={() => dispatch(updateSettings({
+                matchWord: !matchWord,
+              }))}>
+              Word
+            </Button.Checkbox>
             <Button.Checkbox
               checked={matchCase}
               onClick={() => dispatch(updateSettings({
                 matchCase: !matchCase,
               }))}>
-              Match case
+              Case
             </Button.Checkbox>
           </Flex.Item>
         </Flex>

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -148,21 +148,6 @@ export const SettingsGeneral = (props, context) => {
               onInput={(e, value) => dispatch(updateSettings({
                 highlightColor: value,
               }))} />
-            Match:
-            <Button.Checkbox
-              checked={matchWord}
-              onClick={() => dispatch(updateSettings({
-                matchWord: !matchWord,
-              }))}>
-              Word
-            </Button.Checkbox>
-            <Button.Checkbox
-              checked={matchCase}
-              onClick={() => dispatch(updateSettings({
-                matchCase: !matchCase,
-              }))}>
-              Case
-            </Button.Checkbox>
           </Flex.Item>
         </Flex>
         <TextArea
@@ -171,6 +156,20 @@ export const SettingsGeneral = (props, context) => {
           onChange={(e, value) => dispatch(updateSettings({
             highlightText: value,
           }))} />
+        <Button.Checkbox
+          checked={matchWord}
+          onClick={() => dispatch(updateSettings({
+            matchWord: !matchWord,
+          }))}>
+          Match word
+        </Button.Checkbox>
+        <Button.Checkbox
+          checked={matchCase}
+          onClick={() => dispatch(updateSettings({
+            matchCase: !matchCase,
+          }))}>
+          Match case
+        </Button.Checkbox>
       </Box>
       <Divider />
       <Box>

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -158,6 +158,8 @@ export const SettingsGeneral = (props, context) => {
           }))} />
         <Button.Checkbox
           checked={matchWord}
+          tooltipPosition="bottom-start"
+          tooltip="Not compatible with punctuation."
           onClick={() => dispatch(updateSettings({
             matchWord: !matchWord,
           }))}>

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -56,6 +56,7 @@ export const SettingsGeneral = (props, context) => {
     lineHeight,
     highlightText,
     highlightColor,
+    matchCase,
   } = useSelector(context, selectSettings);
   const dispatch = useDispatch(context);
   const [freeFont, setFreeFont] = useLocalState(context, "freeFont", false);
@@ -134,7 +135,14 @@ export const SettingsGeneral = (props, context) => {
       <Box>
         <Flex mb={1} color="label" align="baseline">
           <Flex.Item grow={1}>
-            Highlight words (comma separated):
+            Highlight text (comma separated):
+            <Button.Checkbox
+              checked={matchCase}
+              onClick={() => dispatch(updateSettings({
+                matchCase: !matchCase,
+              }))}>
+              Match Case
+            </Button.Checkbox>
           </Flex.Item>
           <Flex.Item shrink={0}>
             <ColorBox mr={1} color={highlightColor} />

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -16,6 +16,7 @@ const initialState = {
   adminMusicVolume: 0.5,
   highlightText: '',
   highlightColor: '#ffdd44',
+  matchWord: false,
   matchCase: false,
   view: {
     visible: false,

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -16,6 +16,7 @@ const initialState = {
   adminMusicVolume: 0.5,
   highlightText: '',
   highlightColor: '#ffdd44',
+  matchCase: false,
   view: {
     visible: false,
     activeTab: SETTINGS_TABS[0].id,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now this is what I call quality of life stuff.

Fixes: #57782 but I'm not sure why exactly.

Before:
<details>
<summary>Multiple cases</summary>

![image](https://user-images.githubusercontent.com/64715958/125159941-4575e980-e12f-11eb-8c4b-bc18ba7eb1f4.png)

</details>
<details>
<summary>False positives</summary>

![image](https://user-images.githubusercontent.com/64715958/125163371-b0302080-e141-11eb-9d5e-ed7406c822ed.png)

</details>
After:
<details>
<summary>Multiple cases</summary>

![image](https://user-images.githubusercontent.com/64715958/125163476-30ef1c80-e142-11eb-93bd-ea779d954483.png)

</details>
<details>
<summary>Match whole word only</summary>

![image](https://user-images.githubusercontent.com/64715958/125173701-62cda680-e175-11eb-973b-75deba5fd6cb.png)

</details>


## Why It's Good For The Game

Fix good. Better chat experience.

## Changelog
:cl:
qol: Chat Highlighting now works with more symbols and can be case sensitive and/or match whole words only.
fix: Fixed Chat Highlighting only working for the first comma separated entry.
fix: Your own messages sent over a radio and dchat now properly avoid_highlighting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
