### PR TITLE
Fixes inhand holder jank separating pAIs holoforms from their shells.

### DIFF
--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -53,17 +53,18 @@
 		if(del_on_release && !destroying)
 			qdel(src)
 		return FALSE
+	var/mob/living/released_mob = held_mob
+	held_mob = null // stops the held mob from being release()'d twice.
 	if(isliving(loc))
 		var/mob/living/L = loc
 		if(display_messages)
-			to_chat(L, span_warning("[held_mob] wriggles free!"))
+			to_chat(L, span_warning("[released_mob] wriggles free!"))
 		L.dropItemToGround(src)
-	held_mob.forceMove(get_turf(held_mob))
-	held_mob.reset_perspective()
-	held_mob.setDir(SOUTH)
+	released_mob.forceMove(drop_location())
+	released_mob.reset_perspective()
+	released_mob.setDir(SOUTH)
 	if(display_messages)
-		held_mob.visible_message(span_warning("[held_mob] uncurls!"))
-	held_mob = null
+		released_mob.visible_message(span_warning("[released_mob] uncurls!"))
 	if(del_on_release && !destroying)
 		qdel(src)
 	return TRUE

--- a/code/modules/mob/living/silicon/pai/pai_shell.dm
+++ b/code/modules/mob/living/silicon/pai/pai_shell.dm
@@ -58,7 +58,7 @@
 	stop_pulling()
 	if(istype(loc, /obj/item/clothing/head/mob_holder))
 		var/obj/item/clothing/head/mob_holder/MH = loc
-		MH.release()
+		MH.release(display_messages = FALSE)
 	if(client)
 		client.perspective = EYE_PERSPECTIVE
 		client.eye = card


### PR DESCRIPTION
## About The Pull Request
Title. This was caused by a release() being called twice because of a dropItemToGround() call in the middle of it...
release() --> dropItemToGround() --> dropped() --> release(), got it?

## Why It's Good For The Game
This will fix #47825

## Changelog
:cl:
fix: Fixes inhand holder jank separating pAIs holoforms from their shells in some occasions.
/:cl:
