### PR TITLE
Replaces morph set_varspeed() calls with movespeed modifiers. Makes it better.

### DIFF
--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -8,7 +8,6 @@
 	icon_state = "morph"
 	icon_living = "morph"
 	icon_dead = "morph_dead"
-	speed = 2
 	combat_mode = TRUE
 	stop_automated_movement = 1
 	status_flags = CANPUSH
@@ -109,7 +108,7 @@
 	//Morphed is weaker
 	melee_damage_lower = melee_damage_disguised
 	melee_damage_upper = melee_damage_disguised
-	set_varspeed(0)
+	add_movespeed_modifier(/datum/movespeed_modifier/morph_disguised)
 
 	med_hud_set_health()
 	med_hud_set_status() //we're an object honest
@@ -137,7 +136,7 @@
 	//Baseline stats
 	melee_damage_lower = initial(melee_damage_lower)
 	melee_damage_upper = initial(melee_damage_upper)
-	set_varspeed(initial(speed))
+	remove_movespeed_modifier(/datum/movespeed_modifier/morph_disguised)
 
 	med_hud_set_health()
 	med_hud_set_status() //we are not an object

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -123,3 +123,6 @@
 
 /datum/movespeed_modifier/dragon_depression
 	multiplicative_slowdown = 5
+
+/datum/movespeed_modifier/morph_disguised
+	multiplicative_slowdown = 1


### PR DESCRIPTION
## About The Pull Request
The guy who made morphs probably didn't read the comment on simple_animal/var/speed and thought that higher was faster and not the other way around. Also it's an ugly old variable surpassed by movespeed modifiers datums.

## Why It's Good For The Game
This will fix #57202.

## Changelog
:cl:
fix: Fixed morph speed being slower while undisguised and some old code related to it.
/:cl:
