### PR TITLE
Fixes xeno/monkey combat mode rclick attack plus stun

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -244,7 +244,7 @@
 				visible_message(span_danger("[user] tackles [src] down!"), \
 								span_userdanger("[user] tackles you down!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), null, user)
 				to_chat(user, span_danger("You tackle [src] down!"))
-		return
+		return TRUE
 
 	if(!user.combat_mode)
 		..() //shaking
@@ -288,7 +288,7 @@
 			visible_message(span_danger("[user] tackles [src] down!"), \
 							span_userdanger("[user] tackles you down!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), null, user)
 			to_chat(user, span_danger("You tackle [src] down!"))
-		return
+		return TRUE
 
 	if(user.combat_mode)
 		if (w_uniform)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -244,6 +244,7 @@
 				visible_message(span_danger("[user] tackles [src] down!"), \
 								span_userdanger("[user] tackles you down!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), null, user)
 				to_chat(user, span_danger("You tackle [src] down!"))
+		return
 
 	if(!user.combat_mode)
 		..() //shaking
@@ -287,6 +288,7 @@
 			visible_message(span_danger("[user] tackles [src] down!"), \
 							span_userdanger("[user] tackles you down!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), null, user)
 			to_chat(user, span_danger("You tackle [src] down!"))
+		return
 
 	if(user.combat_mode)
 		if (w_uniform)


### PR DESCRIPTION
## About The Pull Request
Title. It's missing return statements.

## Why It's Good For The Game
This will fix #58322.

## Changelog
:cl:
fix: Fixes being able to simultaneously perform an attack and a tackle as a xeno or monkey with right click and combat mode on.
/:cl:
