### PR TITLE
Fix honkstaff not being affected by antimagic

### DIFF
--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -22,7 +22,6 @@
 	var/mob/M = target
 	if(istype(M))
 		if(M.anti_magic_check())
-			src.impact_effect_type = null
 			return BULLET_ACT_BLOCK
 		else
 			M.slip(100, M.loc, GALOSHES_DONT_HELP|SLIDE, 0, FALSE)

--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -21,7 +21,11 @@
 	. = ..()
 	var/mob/M = target
 	if(istype(M))
-		M.slip(100, M.loc, GALOSHES_DONT_HELP|SLIDE, 0, FALSE)
+		if(M.anti_magic_check())
+			src.impact_effect_type = null
+			return BULLET_ACT_BLOCK
+		else
+			M.slip(100, M.loc, GALOSHES_DONT_HELP|SLIDE, 0, FALSE)
 
 // Mime
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #59903

all it does is add a check before slipping, if you have anti-magic you dont get slipped by the magic incorporeal flying bananas, simple.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: anti-magic now prevents you slipping from the magic flying incorporeal bananas fired by the honks staff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
