### PR TITLE
adds a suicide for space helmets, fixes some other suicides

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -41,12 +41,12 @@
 /obj/item/storage/box/suicide_act(mob/living/carbon/user)
 	var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
 	if(myhead)
-		user.visible_message(span_suicide("[user] puts [user.p_their()] head into \the [src], and begins closing it! It looks like [user.p_theyre()] trying to commit suicide!"))
+		user.visible_message(span_suicide("[user] puts [user.p_their()] head into \the [src] and begins closing it! It looks like [user.p_theyre()] trying to commit suicide!"))
 		myhead.dismember()
-		myhead.forceMove(src)//force your enemies to kill themselves with your head collection box!
+		myhead.forceMove(src) //force your enemies to kill themselves with your head collection box!
 		playsound(user, "desecration-01.ogg", 50, TRUE, -1)
 		return BRUTELOSS
-	user.visible_message(span_suicide("[user] beating [user.p_them()]self with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+	user.visible_message(span_suicide("[user] is beating [user.p_them()]self with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 
 /obj/item/storage/box/update_overlays()

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -633,7 +633,17 @@
 	return ..()
 
 /obj/item/storage/organbox/suicide_act(mob/living/carbon/user)
-	user.visible_message(span_suicide("[user] is putting [user.p_theyre()] head inside the [src], it looks like [user.p_theyre()] trying to commit suicide!"))
+	if(HAS_TRAIT(user, TRAIT_RESISTCOLD)) //if they're immune to cold, just do the box suicide
+		var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
+		if(myhead)
+			user.visible_message(span_suicide("[user] puts [user.p_their()] head into \the [src] and begins closing it! It looks like [user.p_theyre()] trying to commit suicide!"))
+			myhead.dismember()
+			myhead.forceMove(src) //force your enemies to kill themselves with your head collection box!
+			playsound(user, "desecration-01.ogg", 50, TRUE, -1)
+			return BRUTELOSS
+		user.visible_message(span_suicide("[user] is beating [user.p_them()]self with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+		return BRUTELOSS
+	user.visible_message(span_suicide("[user] is putting [user.p_their()] head inside the [src], it looks like [user.p_theyre()] trying to commit suicide!"))
 	user.adjust_bodytemperature(-300)
 	user.apply_status_effect(/datum/status_effect/freon)
-	return (OXYLOSS)
+	return FIRELOSS

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -257,4 +257,20 @@
 	if(cell)
 		cell.emp_act(severity)
 
+/obj/item/clothing/head/helmet/space/suicide_act(mob/living/carbon/user)
+	var/datum/gas_mixture/environment = user.loc.return_air()
+	if(HAS_TRAIT(user, TRAIT_RESISTCOLD) || !environment || environment.return_temperature() >= user.get_body_temp_cold_damage_limit())
+		user.visible_message(span_suicide("[user] is beating [user.p_them()]self with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+		return BRUTELOSS
+	user.say("You want proof? I'll give you proof! Here's proof of what'll happen to you if you stay here with your stuff!", forced = "space helmet suicide")
+	user.visible_message(span_suicide("[user] is removing [user.p_their()] helmet to make a point! Yo, holy shit, [user.p_they()] dead!")) //the use of p_they() instead of p_their() here is intentional
+	user.adjust_bodytemperature(-300)
+	user.apply_status_effect(/datum/status_effect/freon)
+	if(!ishuman(user))
+		return FIRELOSS
+	var/mob/living/carbon/human/humanafterall = user
+	var/datum/disease/advance/cold/pun = new //in the show, arnold survives his stunt, but catches a cold because of it
+	humanafterall.ForceContractDisease(pun, FALSE, TRUE) //this'll show up on health analyzers and the like
+	return FIRELOSS
+
 #undef THERMAL_REGULATOR_COST


### PR DESCRIPTION
## About The Pull Request

The grammar of the box and organ box suicides has been slightly improved.

Attempting to performing an organ box suicide while you're immune to cold now makes you perform a box suicide with it instead.

Successfully performing the non-cold immune variant of the organ box suicide now causes you to die of burn damage, not brute damage.

A special suicide has been added to space helmets. It has a special variant for if you attempt it in a cold environment (while not immune to cold).

Sadly, Byond is currently down, so I can't test this PR right now. I'll edit this message once I've fully tested this PR.

## Why It's Good For The Game

https://www.youtube.com/watch?v=GQPJpi6dd6g

## Changelog
:cl: ATHATH
spellcheck: The grammar of the box and organ box suicides has been slightly improved.
add: Attempting to performing an organ box suicide while you're immune to cold now makes you perform a box suicide with it instead.
fix: Successfully performing the non-cold immune variant of the organ box suicide now causes you to die of burn damage, not brute damage.
add: A special suicide has been added to space helmets. It has a special variant for if you attempt it in a cold environment (while not immune to cold).
/:cl: