### PR TITLE
Fixes AI holopad runetext, right click interact, call reject button

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -445,8 +445,11 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 	for(var/I in holo_calls)
 		var/datum/holocall/HC = I
-		if(HC.connected_holopad == src && speaker != HC.hologram)
-			HC.user.Hear(message, speaker, message_language, raw_message, radio_freq, spans, message_mods)
+		if(HC.connected_holopad == src)
+			if(speaker == HC.hologram && HC.user.client?.prefs.chat_on_map)
+				HC.user.create_chat_message(speaker, message_language, raw_message, spans)
+			else
+				HC.user.Hear(message, speaker, message_language, raw_message, radio_freq, spans, message_mods)
 
 	if(outgoing_call?.hologram && speaker == outgoing_call.user)
 		outgoing_call.hologram.say(raw_message)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -290,6 +290,12 @@ Possible to do for anyone motivated enough:
 			if(!QDELETED(call_to_disconnect))
 				call_to_disconnect.Disconnect(src)
 				return TRUE
+		if("rejectall")
+			for(var/datum/holocall/call_to_reject as anything in holo_calls)
+				if(call_to_reject.connected_holopad == src) // do not kill the current connection
+					continue
+				call_to_reject.Disconnect(src)
+			return TRUE
 		if("disk_eject")
 			if(disk && !replay_mode)
 				disk.forceMove(drop_location())

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -242,6 +242,11 @@ Possible to do for anyone motivated enough:
 
 	switch(action)
 		if("AIrequest")
+			if(isAI(usr))
+				var/mob/living/silicon/ai/ai_user = usr
+				ai_user.eyeobj.setLoc(get_turf(src))
+				to_chat(usr, span_info("AIs can not request AI presence. Jumping instead."))
+				return
 			if(last_request + 200 < world.time)
 				last_request = world.time
 				to_chat(usr, span_info("You requested an AI's presence."))
@@ -334,7 +339,6 @@ Possible to do for anyone motivated enough:
 		var/datum/holocall/HC = I
 		HC.Disconnect(src)
 
-//do not allow AIs to answer calls or people will use it to meta the AI sattelite
 /obj/machinery/holopad/attack_ai(mob/living/silicon/ai/user)
 	if (!istype(user))
 		return
@@ -349,6 +353,11 @@ Possible to do for anyone motivated enough:
 		activate_holo(user)
 	else//If there is a hologram, remove it.
 		clear_holo(user)
+
+/obj/machinery/holopad/attack_ai_secondary(mob/user, list/modifiers)
+	if(_try_interact(user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
 
 /obj/machinery/holopad/process()
 	if(LAZYLEN(masters))

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -71,3 +71,5 @@
 /datum/job/ai/config_check()
 	return CONFIG_GET(flag/allow_ai)
 
+/datum/job/ai/radio_help_message(mob/M)
+	to_chat(M, "<b>Prefix your message with :b to speak with cyborgs and other AIs.</b>")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -833,10 +833,16 @@
 	var/hrefpart = "<a href='?src=[REF(src)];track=[html_encode(namepart)]'>"
 	var/jobpart = "Unknown"
 
-	if (iscarbon(speaker))
-		var/mob/living/carbon/S = speaker
-		if(S.job)
-			jobpart = "[S.job]"
+	if (isliving(speaker))
+		var/mob/living/living_speaker = speaker
+		if(living_speaker.job)
+			jobpart = "[living_speaker.job]"
+	if (istype(speaker, /obj/effect/overlay/holo_pad_hologram))
+		var/obj/effect/overlay/holo_pad_hologram/holo = speaker
+		if(holo.Impersonation?.job)
+			jobpart = "[holo.Impersonation.job]"
+		else if(usr.job) // not great, but AI holograms have no other usable ref
+			jobpart = "[usr.job]"
 
 	var/rendered = "<i><span class='game say'>[start][span_name("[hrefpart][namepart] ([jobpart])</a> ")]<span class='message'>[treated_message]</span></span></i>"
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -841,7 +841,7 @@
 		var/obj/effect/overlay/holo_pad_hologram/holo = speaker
 		if(holo.Impersonation?.job)
 			jobpart = "[holo.Impersonation.job]"
-		else if(usr.job) // not great, but AI holograms have no other usable ref
+		else if(usr?.job) // not great, but AI holograms have no other usable ref
 			jobpart = "[usr.job]"
 
 	var/rendered = "<i><span class='game say'>[start][span_name("[hrefpart][namepart] ([jobpart])</a> ")]<span class='message'>[treated_message]</span></span></i>"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -126,9 +126,8 @@
 	to_chat(src, "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>")
 	to_chat(src, "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>")
 	to_chat(src, "To use something, simply click on it.")
-	to_chat(src, "Use say :b to speak to your cyborgs through binary.")
 	to_chat(src, "For department channels, use the following say commands:")
-	to_chat(src, ":o - AI Private, :c - Command, :s - Security, :e - Engineering, :u - Supply, :v - Service, :m - Medical, :n - Science.")
+	to_chat(src, ":o - AI Private, :c - Command, :s - Security, :e - Engineering, :u - Supply, :v - Service, :m - Medical, :n - Science, :h - Holopad.")
 	show_laws()
 	to_chat(src, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
 

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -31,17 +31,17 @@
 	if (!message)
 		return
 
-	var/obj/machinery/holopad/T = current
-	if(istype(T) && T.masters[src])//If there is a hologram and its master is the user.
-		var/turf/padturf = get_turf(T)
+	var/obj/machinery/holopad/active_pad = current
+	if(istype(active_pad) && active_pad.masters[src])//If there is a hologram and its master is the user.
+		var/obj/effect/overlay/holo_pad_hologram/ai_holo = active_pad.masters[src]
+		var/turf/padturf = get_turf(active_pad)
 		var/padloc
 		if(padturf)
 			padloc = AREACOORD(padturf)
 		else
 			padloc = "(UNKNOWN)"
 		src.log_talk(message, LOG_SAY, tag="HOLOPAD in [padloc]")
-		send_speech(message, 7, T, MODE_ROBOT, message_language = language)
-		to_chat(src, "<i><span class='game say'>Holopad transmitted, [span_name("[real_name]")] <span class='message robot'>\"[message]\"</span></span></i>")
+		ai_holo.say(message, language = language)
 	else
 		to_chat(src, span_alert("No holopad connected."))
 

--- a/tgui/packages/tgui/interfaces/Holopad.js
+++ b/tgui/packages/tgui/interfaces/Holopad.js
@@ -9,7 +9,7 @@ export const Holopad = (props, context) => {
   } = data;
   return (
     <Window
-      width={480}
+      width={440}
       height={245}>
       {!!calling && (
         <Modal
@@ -96,16 +96,18 @@ const HolopadContent = (props, context) => {
                   onClick={() => act(call.connected
                     ? 'disconnectcall'
                     : 'connectcall', { holopad: call.ref })} />
-                {!call.connected && (
-                  <Button
-                    icon="phone-slash"
-                    content="Reject"
-                    color="bad"
-                    onClick={() => act('disconnectcall', { holopad: call.ref })} />
-                )}
               </LabeledList.Item>
             );
           }))}
+          {holo_calls.filter(call => !call.connected).length > 0 && (
+            <LabeledList.Item key="reject">
+              <Button
+                icon="phone-slash"
+                content="Reject incoming call(s)"
+                color="bad"
+                onClick={() => act('rejectall')} />
+            </LabeledList.Item>
+          )}
         </LabeledList>
       </Section>
       <Section

--- a/tgui/packages/tgui/interfaces/Holopad.js
+++ b/tgui/packages/tgui/interfaces/Holopad.js
@@ -9,7 +9,7 @@ export const Holopad = (props, context) => {
   } = data;
   return (
     <Window
-      width={440}
+      width={480}
       height={245}>
       {!!calling && (
         <Modal
@@ -96,6 +96,13 @@ const HolopadContent = (props, context) => {
                   onClick={() => act(call.connected
                     ? 'disconnectcall'
                     : 'connectcall', { holopad: call.ref })} />
+                {!call.connected && (
+                  <Button
+                    icon="phone-slash"
+                    content="Reject"
+                    color="bad"
+                    onClick={() => act('disconnectcall', { holopad: call.ref })} />
+                )}
               </LabeledList.Item>
             );
           }))}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See changelog.

![image](https://user-images.githubusercontent.com/64715958/125210295-c4fcd900-e253-11eb-8d33-8707e775749a.png)
![image](https://user-images.githubusercontent.com/64715958/125231424-8e44b400-e28f-11eb-8f68-20df38f93664.png)


## Why It's Good For The Game

Better Holopad functionality.

Fixes: #53053
Closes: #39252 holopad transmissions are in-fact already shown on the player panel:
![image](https://user-images.githubusercontent.com/64715958/125210255-6a637d00-e253-11eb-9cac-deb1f258ef7e.png)


## Changelog
:cl:
qol: Holopad incoming calls can now be rejected.
qol: AI secondary attack now opens Holopad UIs.
fix: Fixed connected Holopad callers not seeing their own runechat text.
fix: Fixed AI hologram transmit runechat text.
fix: Fixed the AI radio help message giving false info about the generic department key.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
