### PR TITLE
Fixes Holopads moving with holograms active

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -107,6 +107,27 @@ Possible to do for anyone motivated enough:
 			new_disk.forceMove(src)
 			disk = new_disk
 
+/obj/machinery/holopad/Moved(atom/OldLoc, Dir)
+	. = ..()
+	if(!loc)
+		return
+	// move any relevant holograms, basically non-AI, and rays with the pad
+	if(replay_holo)
+		replay_holo.abstract_move(loc)
+	for(var/i in holorays)
+		var/obj/effect/overlay/holoray/ray = holorays[i]
+		ray.abstract_move(loc)
+	var/list/non_call_masters = masters?.Copy()
+	for(var/datum/holocall/holocall as anything in holo_calls)
+		if(!holocall.user || !LAZYACCESS(masters, holocall.user))
+			continue
+		non_call_masters -= holocall.user
+		// moving the eye moves the holo which updates the ray too
+		holocall.eye.setLoc(locate(clamp(x + (holocall.hologram.x - OldLoc.x), 1, world.maxx), clamp(y + (holocall.hologram.y - OldLoc.y), 1, world.maxy), z))
+	for(var/mob/living/holo_master as anything in non_call_masters)
+		var/obj/effect/holo = masters[holo_master]
+		update_holoray(holo_master, holo.loc)
+
 /obj/machinery/holopad/tutorial/attack_hand(mob/user, list/modifiers)
 	if(!istype(user))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

From left to right the hologram sources are an: AI, Holodisk, Holopad caller
![gOqQxgZ80p](https://user-images.githubusercontent.com/64715958/125219101-179cbc00-e279-11eb-899c-5ac0933cca24.gif)
Incase you are wondering this does not allow holograms to bypass valid turf checks when they move.

## Why It's Good For The Game

Hologram rays update properly.

Fixes: #50937

## Changelog
:cl:
qol: Holopad call Holograms now move in sync with their receiver pad.
fix: Fixed a Holodisk replay Hologram bug, and Hologram Rays not updating when the pad is moved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
