### PR TITLE
Lowers the chances of the space dragon showing up

### DIFF
--- a/code/modules/events/space_dragon.dm
+++ b/code/modules/events/space_dragon.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/space_dragon
 	name = "Spawn Space Dragon"
 	typepath = /datum/round_event/ghost_role/space_dragon
-	weight = 10
+	weight = 7
 	max_occurrences = 1
 	min_players = 20
 	dynamic_should_hijack = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

changes the weight of space dragons from 10 to 7.

THINGS THAT ARE AS COMMON AS SPACE DRAGON SPAWNING USED TO BE:
anomalies!
grid checks!
mice migrations!
mass hallucations!
and more

## Why It's Good For The Game

Space dragons are by far the most common big enemy event, more common than pirates, more common than some of the scarier meteor waves, so on so forth. I think the space dragon is in a pretty bad state of a midround antagonist as it is just a random megafauna dropped onto the station so I'd like to see it less often to keep what little novelty it has intact

## Changelog
:cl:
balance: space dragons are rarer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
