### PR TITLE
Corrects the grammar of spectral blade ghost notifications

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -874,7 +874,7 @@
 		return
 	to_chat(user, span_notice("You call out for aid, attempting to summon spirits to your side."))
 
-	notify_ghosts("[user] is raising [user.p_their()] [src], calling for your help!",
+	notify_ghosts("[user] is raising [user.p_their()] [src.name], calling for your help!",
 		enter_link="<a href=?src=[REF(src)];orbit=1>(Click to help)</a>",
 		source = user, ignore_key = POLL_IGNORE_SPECTRAL_BLADE, header = "Spectral blade")
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -874,7 +874,7 @@
 		return
 	to_chat(user, span_notice("You call out for aid, attempting to summon spirits to your side."))
 
-	notify_ghosts("[user] is raising [user.p_their()] [src.name], calling for your help!",
+	notify_ghosts("[user] is raising [user.p_their()] [name], calling for your help!",
 		enter_link="<a href=?src=[REF(src)];orbit=1>(Click to help)</a>",
 		source = user, ignore_key = POLL_IGNORE_SPECTRAL_BLADE, header = "Spectral blade")
 


### PR DESCRIPTION
## About The Pull Request

Uses `src.name` instead of `src` in the spectral blade's ghost notifications so that you see "his/her/their spectral blade" instead of "his/her/their the spectral blade".

## Why It's Good For The Game

Better grammar

## Changelog
:cl:
spellcheck: The notification that ghosts receive when someone raises a spectral blade no longer contains an incorrect usage of the word "the"
/:cl:
