### PR TITLE
Use rust-g to url_encode (and other builtin overrides)

### DIFF
--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -38,6 +38,9 @@
 #define RUST_G (__rust_g || __detect_rust_g())
 #endif
 
+/// Gets the version of rust_g
+/proc/rustg_get_version() return call(RUST_G, "get_version")()
+
 /**
  * This proc generates a cellular automata noise grid which can be used in procedural generation methods.
  *
@@ -98,4 +101,12 @@
 #define rustg_sql_connected(handle) call(RUST_G, "sql_connected")(handle)
 #define rustg_sql_disconnect_pool(handle) call(RUST_G, "sql_disconnect_pool")(handle)
 #define rustg_sql_check_query(job_id) call(RUST_G, "sql_check_query")("[job_id]")
+
+#define rustg_url_encode(text) call(RUST_G, "url_encode")(text)
+#define rustg_url_decode(text) call(RUST_G, "url_decode")(text)
+
+#ifdef RUSTG_OVERRIDE_BUILTINS
+	#define url_encode(text) rustg_url_encode(text)
+	#define url_decode(text) rustg_url_decode(text)
+#endif
 

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -7,7 +7,7 @@
 // Override the .dll/.so detection logic with a fixed path or with detection
 // logic of your own.
 //
-// #define RUSTG_OVERRIDE_BUILTINS
+#define RUSTG_OVERRIDE_BUILTINS
 // Enable replacement rust-g functions for certain builtins. Off by default.
 
 #ifndef RUST_G

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -7,7 +7,7 @@
 // Override the .dll/.so detection logic with a fixed path or with detection
 // logic of your own.
 //
-#define RUSTG_OVERRIDE_BUILTINS
+// #define RUSTG_OVERRIDE_BUILTINS
 // Enable replacement rust-g functions for certain builtins. Off by default.
 
 #ifndef RUST_G

--- a/code/__DEFINES/rust_g_overrides.dm
+++ b/code/__DEFINES/rust_g_overrides.dm
@@ -1,0 +1,3 @@
+// RUSTG_OVERRIDE_BUILTINS is not used since the file APIs don't work well over Linux.
+#define url_encode(text) rustg_url_encode(text)
+#define url_decode(text) rustg_url_decode(text)

--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -32,5 +32,5 @@
 // than doing it the normal way.
 // To ensure this is correct, this is unit tested in tgui_create_message.
 #define TGUI_CREATE_MESSAGE(type, payload) ( \
-	"%7b%22type%22%3a%22[type]%22%2c%22payload%22%3a[url_encode(json_encode(payload))]%7d" \
+	"%7b%22type%22%3a%22[type]%22%2c%22payload%22%3a[rustg_url_encode(json_encode(payload))]%7d" \
 )

--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -32,5 +32,5 @@
 // than doing it the normal way.
 // To ensure this is correct, this is unit tested in tgui_create_message.
 #define TGUI_CREATE_MESSAGE(type, payload) ( \
-	"%7b%22type%22%3a%22[type]%22%2c%22payload%22%3a[rustg_url_encode(json_encode(payload))]%7d" \
+	"%7b%22type%22%3a%22[type]%22%2c%22payload%22%3a[url_encode(json_encode(payload))]%7d" \
 )

--- a/code/modules/status_bar/status_bar.dm
+++ b/code/modules/status_bar/status_bar.dm
@@ -17,4 +17,4 @@
 		return
 	client.status_bar_prev_text = text
 	winset(client, "mapwindow.status_bar",
-		"text=[url_encode(text)]&is-visible=[!!text]")
+		"text=[rustg_url_encode(text)]&is-visible=[!!text]")

--- a/code/modules/status_bar/status_bar.dm
+++ b/code/modules/status_bar/status_bar.dm
@@ -17,4 +17,4 @@
 		return
 	client.status_bar_prev_text = text
 	winset(client, "mapwindow.status_bar",
-		"text=[rustg_url_encode(text)]&is-visible=[!!text]")
+		"text=[url_encode(text)]&is-visible=[!!text]")

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -8,7 +8,7 @@ export BYOND_MAJOR=514
 export BYOND_MINOR=1556
 
 #rust_g git tag
-export RUST_G_VERSION=0.4.8
+export RUST_G_VERSION=0.4.9
 
 #node version
 export NODE_VERSION=12

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -122,6 +122,7 @@
 #include "code\__DEFINES\robots.dm"
 #include "code\__DEFINES\role_preferences.dm"
 #include "code\__DEFINES\rust_g.dm"
+#include "code\__DEFINES\rust_g_overrides.dm"
 #include "code\__DEFINES\say.dm"
 #include "code\__DEFINES\shuttles.dm"
 #include "code\__DEFINES\sight.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
url_encode was proven to be really slow. Upgrades our rust-g to support url encoding, then uses it for TGUI_CREATE_MESSAGE.

~~DNM as I want this to be a default feature of rust-g first, and because it's apparently had bugs in the past.~~ This is now ready since 0.4.9.