### PR TITLE
Adds a double click shortcut to loading Supplypod presets

### DIFF
--- a/tgui/packages/tgui/interfaces/CentcomPodLauncher.js
+++ b/tgui/packages/tgui/interfaces/CentcomPodLauncher.js
@@ -894,6 +894,7 @@ class PresetsPage extends Component {
             width="100%"
             backgroundColor={`hsl(${preset.hue}, 50%, 50%)`}
             onClick={() => setSelectedPreset(preset.id)}
+            onDblClick={() => this.loadDataFromPreset(preset.id)}
             content={preset.title}
             style={presetIndex === preset.id ? {
               'border-width': '1px',


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds intuitive UI behavior.  

## Why It's Good For The Game

QOL good.

## Changelog
:cl:
qol: Admin Supplypod Presets can now also be loaded by double clicking their label.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
