### PR TITLE
Gives Revenant the ability to orbit adjacent things with secondary attack

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -98,7 +98,7 @@
 		var/atom/movable/movable_parent = parent
 		orbiter.glide_size = movable_parent.glide_size
 
-	orbiter.forceMove(get_turf(parent))
+	orbiter.abstract_move(get_turf(parent))
 	to_chat(orbiter, span_notice("Now orbiting [parent]."))
 
 /datum/component/orbiter/proc/end_orbit(atom/movable/orbiter, refreshing=FALSE)
@@ -136,7 +136,7 @@
 	for(var/atom/movable/movable_orbiter as anything in orbiter_list)
 		if(QDELETED(movable_orbiter) || movable_orbiter.loc == newturf)
 			continue
-		movable_orbiter.forceMove(newturf)
+		movable_orbiter.abstract_move(newturf)
 		if(CHECK_TICK && master.loc != curloc)
 			// We moved again during the checktick, cancel current operation
 			break

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -98,7 +98,7 @@
 		var/atom/movable/movable_parent = parent
 		orbiter.glide_size = movable_parent.glide_size
 
-	orbiter.abstract_move(get_turf(parent))
+	orbiter.forceMove(get_turf(parent))
 	to_chat(orbiter, span_notice("Now orbiting [parent]."))
 
 /datum/component/orbiter/proc/end_orbit(atom/movable/orbiter, refreshing=FALSE)
@@ -136,7 +136,7 @@
 	for(var/atom/movable/movable_orbiter as anything in orbiter_list)
 		if(QDELETED(movable_orbiter) || movable_orbiter.loc == newturf)
 			continue
-		movable_orbiter.abstract_move(newturf)
+		movable_orbiter.forceMove(newturf)
 		if(CHECK_TICK && master.loc != curloc)
 			// We moved again during the checktick, cancel current operation
 			break

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -348,7 +348,7 @@
 	stasis = FALSE
 
 /mob/living/simple_animal/revenant/orbit(atom/target)
-	setDir(2)//reset dir so the right directional sprites show up
+	setDir(SOUTH)//reset dir so the right directional sprites show up
 	return ..()
 
 /mob/living/simple_animal/revenant/Moved(atom/OldLoc)

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -348,7 +348,7 @@
 	stasis = FALSE
 
 /mob/living/simple_animal/revenant/orbit(atom/target)
-	setDir(SOUTH)//reset dir so the right directional sprites show up
+	setDir(SOUTH) // reset dir so the right directional sprites show up
 	return ..()
 
 /mob/living/simple_animal/revenant/Moved(atom/OldLoc)
@@ -357,10 +357,12 @@
 	if(incorporeal_move_check(src))
 		return ..()
 
+	// back back back it up, the orbitee went somewhere revenant cannot
 	orbiting?.end_orbit(src)
-	abstract_move(OldLoc) // back back back it up, gross but maybe someday there'll be a jaunt orbit component
+	abstract_move(OldLoc) // gross but maybe orbit component will be able to check pre move in the future
 
 /mob/living/simple_animal/revenant/stop_orbit(datum/component/orbiter/orbits)
+	// reset the simple_flying animation
 	animate(src, pixel_y = 2, time = 1 SECONDS, loop = -1, flags = ANIMATION_RELATIVE)
 	animate(pixel_y = -2, time = 1 SECONDS, flags = ANIMATION_RELATIVE)
 	return ..()

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -252,7 +252,6 @@
 		return
 	if(time <= 0)
 		return
-	end_orbit()
 	revealed = TRUE
 	invisibility = 0
 	incorporeal_move = FALSE
@@ -263,13 +262,13 @@
 		to_chat(src, span_revenwarning("You have been revealed!"))
 		unreveal_time = unreveal_time + time
 	update_spooky_icon()
+	orbiting?.end_orbit(src)
 
 /mob/living/simple_animal/revenant/proc/stun(time)
 	if(!src)
 		return
 	if(time <= 0)
 		return
-	end_orbit()
 	notransform = TRUE
 	if(!unstun_time)
 		to_chat(src, span_revendanger("You cannot move!"))
@@ -278,6 +277,7 @@
 		to_chat(src, span_revenwarning("You cannot move!"))
 		unstun_time = unstun_time + time
 	update_spooky_icon()
+	orbiting?.end_orbit(src)
 
 /mob/living/simple_animal/revenant/proc/update_spooky_icon()
 	if(revealed)
@@ -349,7 +349,6 @@
 
 /mob/living/simple_animal/revenant/orbit(atom/target)
 	setDir(2)//reset dir so the right directional sprites show up
-	ADD_TRAIT(src, TRAIT_NO_FLOATING_ANIM, "revenant_orbit")
 	return ..()
 
 /mob/living/simple_animal/revenant/Moved(atom/OldLoc)
@@ -358,18 +357,13 @@
 	if(incorporeal_move_check(src))
 		return ..()
 
-	end_orbit()
+	orbiting?.end_orbit(src)
 	abstract_move(OldLoc) // back back back it up, gross but maybe someday there'll be a jaunt orbit component
 
 /mob/living/simple_animal/revenant/stop_orbit(datum/component/orbiter/orbits)
-	REMOVE_TRAIT(src, TRAIT_NO_FLOATING_ANIM, "revenant_orbit")
+	animate(src, pixel_y = 2, time = 1 SECONDS, loop = -1, flags = ANIMATION_RELATIVE)
+	animate(pixel_y = -2, time = 1 SECONDS, flags = ANIMATION_RELATIVE)
 	return ..()
-
-/// Ends the revenants orbit if it has one
-/mob/living/simple_animal/revenant/proc/end_orbit()
-	if(!orbiting)
-		return
-	orbiting?.end_orbit(src)
 
 /// Incorporeal move check: blocked by holy-watered tiles and salt piles.
 /mob/living/simple_animal/revenant/proc/incorporeal_move_check(atom/destination)
@@ -383,7 +377,7 @@
 		if(stepTurf.turf_flags & NOJAUNT)
 			to_chat(src, span_warning("Some strange aura is blocking the way."))
 			return
-		if (locate(/obj/effect/blessing, stepTurf))
+		if(locate(/obj/effect/blessing, stepTurf))
 			to_chat(src, span_warning("Holy energies block your path!"))
 			return
 	return TRUE

--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -369,15 +369,16 @@
 /mob/living/simple_animal/revenant/proc/incorporeal_move_check(atom/destination)
 	var/turf/open/floor/stepTurf = get_turf(destination)
 	if(stepTurf)
-		for(var/obj/effect/decal/cleanable/food/salt/S in stepTurf)
-			to_chat(src, span_warning("[S] bars your passage!"))
+		var/obj/effect/decal/cleanable/food/salt/salt = locate() in stepTurf
+		if(salt)
+			to_chat(src, span_warning("[salt] bars your passage!"))
 			reveal(20)
 			stun(20)
 			return
 		if(stepTurf.turf_flags & NOJAUNT)
 			to_chat(src, span_warning("Some strange aura is blocking the way."))
 			return
-		if(locate(/obj/effect/blessing, stepTurf))
+		if(locate(/obj/effect/blessing) in stepTurf)
 			to_chat(src, span_warning("Holy energies block your path!"))
 			return
 	return TRUE

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -7,6 +7,9 @@
 	if(LAZYACCESS(modifiers, ALT_CLICK))
 		AltClickNoInteract(src, A)
 		return
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+		ranged_secondary_attack(A, modifiers)
+		return
 
 	if(ishuman(A))
 		if(A in drained_mobs)
@@ -14,6 +17,13 @@
 		else if(in_range(src, A))
 			Harvest(A)
 
+/mob/living/simple_animal/revenant/ranged_secondary_attack(atom/target, modifiers)
+	if(revealed || notransform || inhibited || !Adjacent(target) || !incorporeal_move_check(target))
+		return
+	var/icon/I = icon(target.icon,target.icon_state,target.dir)
+	var/orbitsize = (I.Width()+I.Height())*0.5
+	orbitsize -= (orbitsize/world.icon_size)*(world.icon_size*0.25)
+	orbit(target, orbitsize)
 
 //Harvest; activated by clicking the target, will try to drain their essence.
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -248,8 +248,9 @@
 		if(INCORPOREAL_MOVE_JAUNT) //Incorporeal move, but blocked by holy-watered tiles and salt piles.
 			var/turf/open/floor/stepTurf = get_step(L, direct)
 			if(stepTurf)
-				for(var/obj/effect/decal/cleanable/food/salt/S in stepTurf)
-					to_chat(L, span_warning("[S] bars your passage!"))
+				var/obj/effect/decal/cleanable/food/salt/salt = locate() in stepTurf
+				if(salt)
+					to_chat(L, span_warning("[salt] bars your passage!"))
 					if(isrevenant(L))
 						var/mob/living/simple_animal/revenant/R = L
 						R.reveal(20)
@@ -258,7 +259,7 @@
 				if(stepTurf.turf_flags & NOJAUNT)
 					to_chat(L, span_warning("Some strange aura is blocking the way."))
 					return
-				if (locate(/obj/effect/blessing, stepTurf))
+				if(locate(/obj/effect/blessing) in stepTurf)
 					to_chat(L, span_warning("Holy energies block your path!"))
 					return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Leverages right click to give Revenant something I felt it should have had when first implemented, but I can understand now it's not a low effort undertaking with the snowflakeness of incorporeal jaunt code that only runs on Move() 🤮 

I put a lot of care into making sure this won't break or bypass jaunting counters like holy water and salt.

## Why It's Good For The Game

Grief ghost can orbit potential victims between hauntings. Telepathic broadcast targets can not move out of sight while you are composing a message if you can just orbit them.

## Changelog
:cl:
qol: Revenants can orbit adjacent people and things with Right Click, unless they are stunned, revealed, blocked by salt etc..
code: Improved Jaunt Move checks a little bit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
