### PR TITLE
fixes the speed of vapes and makes them use delta_time

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -1031,12 +1031,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	var/mob/living/carbon/vaper = loc
 	if(!iscarbon(vaper) || src != vaper.wear_mask)
-		reagents.remove_any(REAGENTS_METABOLISM * delta_time)
+		reagents.remove_any(REAGENTS_METABOLISM * delta_time * 0.5)
 		return
 
 	if(reagents.get_reagent_amount(/datum/reagent/fuel))
 		//HOT STUFF
-		vaper.adjust_fire_stacks(2 * delta_time)
+		vaper.adjust_fire_stacks(2 * delta_time * 0.5)
 		vaper.IgniteMob()
 
 	if(reagents.get_reagent_amount(/datum/reagent/toxin/plasma)) // the plasma explodes when exposed to fire
@@ -1045,8 +1045,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		e.start()
 		qdel(src)
 
-	if(!reagents.trans_to(vaper, REAGENTS_METABOLISM * delta_time, methods = INGEST, ignore_stomach = TRUE))
-		reagents.remove_any(REAGENTS_METABOLISM * delta_time)
+	if(!reagents.trans_to(vaper, REAGENTS_METABOLISM * delta_time * 0.5, methods = INGEST, ignore_stomach = TRUE))
+		reagents.remove_any(REAGENTS_METABOLISM * delta_time * 0.5)
 
 /obj/item/clothing/mask/vape/process(delta_time)
 	var/mob/living/M = loc

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -1036,7 +1036,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	if(reagents.get_reagent_amount(/datum/reagent/fuel))
 		//HOT STUFF
-		vaper.adjust_fire_stacks(2 * delta_time * 0.5)
+		vaper.adjust_fire_stacks(delta_time * 1)
 		vaper.IgniteMob()
 
 	if(reagents.get_reagent_amount(/datum/reagent/toxin/plasma)) // the plasma explodes when exposed to fire

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -929,7 +929,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	/// The amount of time between emagged or super drags.
 	var/dragtime = 8 SECONDS
 	/// A cooldown to prevent spamming smoke clouds nonstop when emagged or on super mode.
-	COOLDOWN_DECLARE(drag_cooldown)
+	COOLDOWN_DECLARE(super_drag_cooldown)
 	/// Whether the resevoir is open and we can add reagents.
 	var/screw = FALSE
 	/// Whether the vape has been overloaded to spread smoke.


### PR DESCRIPTION
## About The Pull Request

The creator of https://github.com/tgstation/tgstation/pull/59578 misinterpreted drag_cooldown as being the cooldown for all vape reagent transfers instead of the cooldown for just the big smoke clouds made by super and emagged vapes. As a result, all vapes had their effective reagent transfer rates cut from 0.2u every ~second to 0.2u every ~EIGHT seconds.

This PR fixes that error by moving handle_reagents() to above the cooldown check and renames drag_cooldown to super_drag_cooldown so that it won't be repeated.

Also, I made the vape version of handle_reagents() account for delta_time.

None of these changes affect cigarettes.

## Why It's Good For The Game

This (significant!) change was not mentioned anywhere in the PR body, changelog, or comments of https://github.com/tgstation/tgstation/pull/59578, so I can only assume that it was unintentional. If making topped up vapes last for over an hour each WAS intentional, feel free to correct me in the comments, Oroboros.

I could theoretically make the chance for an emagged vape to explode when puffed use delta_time, but it's already behind an 8 second cooldown anyway and I don't want to accidentally bork that probability due to a misunderstanding of how DT_PROB() works.

## Changelog
:cl: ATHATH
fix: An unintentional change to the frequency at which vapes transferred their reagents at has been fixed, and full vapes should no longer last for over an hour each.
code: Vapes now account for delta_time in their reagent transfers, making them more consistent.
/:cl: