### PR TITLE
Fixes vatbeast slapping. 

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
@@ -77,7 +77,12 @@
 	if(.)
 		return
 
-	if(owner.stat)
+	var/mob/living/beast_owner = owner.resolve()
+
+	if(!beast_owner)
+		return
+
+	if(beast_owner.stat)
 		remove_ranged_ability()
 		return
 
@@ -89,10 +94,10 @@
 
 	var/mob/living/living_target = target
 
-	owner.visible_message("<span class='warning>[owner] slaps [living_target] with its tentacle!</span>", span_notice("You slap [living_target] with your tentacle."))
-	playsound(owner, 'sound/effects/assslap.ogg', 90)
+	beast_owner.visible_message("<span class='warning>[beast_owner] slaps [living_target] with its tentacle!</span>", span_notice("You slap [living_target] with your tentacle."))
+	playsound(beast_owner, 'sound/effects/assslap.ogg', 90)
 	var/atom/throw_target = get_edge_target_turf(target, ranged_ability_user.dir)
-	living_target.throw_at(throw_target, 6, 4, owner)
+	living_target.throw_at(throw_target, 6, 4, beast_owner)
 	living_target.apply_damage(30)
 	current_cooldown = world.time + cooldown
 	remove_ranged_ability()

--- a/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
@@ -27,7 +27,7 @@
 
 /mob/living/simple_animal/hostile/vatbeast/Initialize()
 	. = ..()
-	tentacle_slap = new(src)
+	tentacle_slap = new(src, src)
 	AddAbility(tentacle_slap)
 	add_cell_sample()
 	AddComponent(/datum/component/tameable, list(/obj/item/food/fries, /obj/item/food/cheesyfries, /obj/item/food/cornchips, /obj/item/food/carrotfries), tame_chance = 30, bonus_tame_chance = 0, after_tame = CALLBACK(src, .proc/tamed))

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -14,11 +14,11 @@
 	var/action_icon_state = "spell_default"
 	var/action_background_icon_state = "bg_spell"
 	var/base_action = /datum/action/spell_action
-	var/mob/living/owner
+	var/datum/weakref/owner
 
 /obj/effect/proc_holder/Initialize(mapload, mob/living/new_owner)
 	. = ..()
-	owner = new_owner
+	owner = WEAKREF(new_owner)
 	if(has_action)
 		action = new base_action(src)
 

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -16,9 +16,9 @@
 	var/base_action = /datum/action/spell_action
 	var/mob/living/owner
 
-/obj/effect/proc_holder/Initialize(mob/living/owner)
+/obj/effect/proc_holder/Initialize(mapload, mob/living/new_owner)
 	. = ..()
-	src.owner = owner
+	owner = new_owner
 	if(has_action)
 		action = new base_action(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes a bug that caused the vat beast slap ability to runtime and fail.

This was caused by the owner variable on the proc holder never being set.

closes:https://github.com/tgstation/tgstation/issues/56753

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Vatbeasts can finally slap again after 10 months, this is probably the biggest reason to make the mob, so it is essential that it works properly.

![bild](https://user-images.githubusercontent.com/49783092/125444268-98d4fa60-b112-466e-8f9a-c79d995999bc.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Vatbeasts can use their powerful tentacle slap ability again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
