### PR TITLE
Fix automatic evac news broadcast emergency_reason double encode

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -550,7 +550,7 @@ SUBSYSTEM_DEF(ticker)
 			news_message = "We would like to reassure all employees that the reports of a Syndicate backed nuclear attack on [decoded_station_name] are, in fact, a hoax. Have a secure day!"
 		if(STATION_EVACUATED)
 			if(emergency_reason)
-				news_message = "[decoded_station_name] has been evacuated after transmitting the following distress beacon:\n\n[emergency_reason]"
+				news_message = "[decoded_station_name] has been evacuated after transmitting the following distress beacon:\n\n[html_decode(emergency_reason)]"
 			else
 				news_message = "The crew of [decoded_station_name] has been evacuated amid unconfirmed reports of enemy activity."
 		if(BLOB_WIN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I forgot to html_decode the reason when I did it for the station name.

## Why It's Good For The Game

Less:
![dreamseeker_CkOsVnN0Jf](https://user-images.githubusercontent.com/64715958/125535229-06abbe79-5323-4d11-9c13-5a4129608c88.png)

## Changelog
:cl:
fix: Fixed HTML encoding of automatic evac news alerts emergency_reason.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
