### PR TITLE
Rework hot sprint double dipping prevention to be trait based

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -353,6 +353,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Trait used by fugu glands to avoid double buffing
 #define TRAIT_FUGU_GLANDED "fugu_glanded"
 
+/// Trait applied to [/datum/mind] to stop someone from using the cursed hot springs to polymorph more than once.
+#define TRAIT_HOT_SPRING_CURSED "hot_spring_cursed"
+
 // METABOLISMS
 // Various jobs on the station have historically had better reactions
 // to various drinks and foodstuffs. Security liking donuts is a classic

--- a/code/modules/ruins/icemoonruin_code/hotsprings.dm
+++ b/code/modules/ruins/icemoonruin_code/hotsprings.dm
@@ -1,5 +1,3 @@
-GLOBAL_LIST_EMPTY(cursed_minds)
-
 /**
  * Turns whoever enters into a mob or random person
  *
@@ -22,12 +20,12 @@ GLOBAL_LIST_EMPTY(cursed_minds)
 	if(!isliving(arrived))
 		return
 	var/mob/living/L = arrived
-	if(!L.client || L.incorporeal_move)
+	if(!L.client || L.incorporeal_move || !L.mind)
 		return
-	if(GLOB.cursed_minds[L.mind])
+	if(HAS_TRAIT(L.mind, TRAIT_HOT_SPRING_CURSED)) // no double dipping
 		return
-	GLOB.cursed_minds[L.mind] = TRUE
-	RegisterSignal(L.mind, COMSIG_PARENT_QDELETING, .proc/remove_from_cursed)
+
+	ADD_TRAIT(L.mind, TRAIT_HOT_SPRING_CURSED, TRAIT_GENERIC)
 	var/random_choice = pick("Mob", "Appearance")
 	switch(random_choice)
 		if("Mob")
@@ -44,14 +42,6 @@ GLOBAL_LIST_EMPTY(cursed_minds)
 			H.set_species(random_race)
 			H.dna.update_dna_identity()
 			L = H
-	var/turf/T = find_safe_turf()
+	var/turf/T = find_safe_turf(extended_safety_checks = TRUE, dense_atoms = FALSE)
 	L.forceMove(T)
 	to_chat(L, span_notice("You blink and find yourself in [get_area_name(T)]."))
-
-/**
- * Deletes minds from the cursed minds list after their deletion
- *
- */
-/turf/open/water/cursed_spring/proc/remove_from_cursed(datum/mind/M)
-	SIGNAL_HANDLER
-	GLOB.cursed_minds -= M


### PR DESCRIPTION
Instead of having a global list of minds that have used the hot spring,
we use a trait on the mind datum instead.