### PR TITLE
old timer now ages you faster

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -510,6 +510,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define EYE_DAMAGE "eye_damage"
 #define EAR_DAMAGE "ear_damage"
 #define GENETIC_MUTATION "genetic"
+#define OLD_AGE "old_age"
 #define OBESITY "obesity"
 #define MAGIC_TRAIT "magic"
 #define TRAUMA_TRAIT "trauma"

--- a/code/datums/diseases/advance/symptoms/youth.dm
+++ b/code/datums/diseases/advance/symptoms/youth.dm
@@ -57,3 +57,4 @@ BONUS
 				if(H.age > 21)
 					H.age = 21
 					to_chat(H, span_notice("You feel like you can take on the world!"))
+	M.cure_nearsighted(OLD_AGE) //there's an argument for this falling under the domain of sensory restoration, but if we put it there as well, then we'd probably have to put it in oculine and basically anything that clears nearsightedness other than natural eye regeneration

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2329,7 +2329,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			metabolizer.hair_color = "ccc"
 			metabolizer.update_hair()
 			if(metabolizer.age > 100)
-				metabolizer.become_nearsighted(type)
+				metabolizer.become_nearsighted(OLD_AGE)
 				if(metabolizer.gender == MALE)
 					metabolizer.facial_hairstyle = "Beard (Very Long)"
 					metabolizer.update_hair()

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2322,7 +2322,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/consumable/ethanol/old_timer/on_mob_life(mob/living/carbon/human/metabolizer, delta_time, times_fired)
-	if(DT_PROB(10, delta_time) && istype(metabolizer))
+	if(DT_PROB(50, delta_time) && istype(metabolizer))
 		metabolizer.age += 1
 		if(metabolizer.age > 70)
 			metabolizer.facial_hair_color = "ccc"
@@ -2333,6 +2333,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 				if(metabolizer.gender == MALE)
 					metabolizer.facial_hairstyle = "Beard (Very Long)"
 					metabolizer.update_hair()
+
+				metabolizer.age += 1 //ages you twice as fast once you become >100 years old so that this last effect won't take 30+ minutes to reach
 
 				if(metabolizer.age > 969) //Best not let people get older than this or i might incur G-ds wrath
 					metabolizer.visible_message(span_notice("[metabolizer] becomes older than any man should be.. and crumbles into dust!"))


### PR DESCRIPTION
## About The Pull Request

The Old Timer drink's chance to age you by a year each second is now 50% instead of 10%.

In addition, Old Timer ages people who're over 100 years old twice as fast.

The Eternal Youth symptom can now cure the nearsightedness caused by Old Timer.

## Why It's Good For The Game

https://www.youtube.com/watch?v=A4U2pMRV9_k

Aging a 20 year old to death using Old Timer currently takes around 158 minutes. This PR reduces that time to around 17 and a half minutes, which is ever so slightly more reasonable. I'd be willing to buff Old Timer further, but I'd like to see what our maintainers think about this before trying to triple the aging rate, add movement speed and action speed debuffs, etc.

## Changelog
:cl: ATHATH
balance: Old Timer ages you 5-10x faster now.
balance: The Eternal Youth symptom can now cure the nearsightedness caused by Old Timer.
/:cl: