### PR TITLE
Exorcises a leftover devil var from /datum/mind

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -51,7 +51,6 @@
 	var/list/antag_datums
 	var/antag_hud_icon_state = null //this mind's ANTAG_HUD should have this icon_state
 	var/datum/atom_hud/antag/antag_hud = null //this mind's antag HUD
-	var/damnation_type = 0
 	var/holy_role = NONE //is this person a chaplain or admin role allowed to use bibles, Any rank besides 'NONE' allows for this.
 
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)


### PR DESCRIPTION
## About The Pull Request

Removes an unused, leftover devil var from `/datum/mind`.

## Why It's Good For The Game

It's 2021 and we still have devil-code in the codebase.

## Changelog

Not player facing. Variable was completely unused for like a year now.