### PR TITLE
gravity filter now gets removed if gravity is normal

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -186,6 +186,8 @@
 	if(gravity > STANDARD_GRAVITY)
 		gravity_animate()
 		handle_high_gravity(gravity, delta_time, times_fired)
+	else if(get_filter("gravity"))
+		remove_filter("gravity")
 
 /mob/living/proc/gravity_animate()
 	if(!get_filter("gravity"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
gravity filter should now get removed if you go back to normal gravity
should semi-fix #60182, the blur will still break stuff if you are under high gravity

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
ah

## Changelog
:cl:
fix: grav anomalies will no longer permanently make you unclickable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
