### PR TITLE
Replace a number of New() overrides with Initialize()

### DIFF
--- a/code/_onclick/hud/families.dm
+++ b/code/_onclick/hud/families.dm
@@ -10,9 +10,6 @@
 	/// Boolean, have the cops arrived? If so, the icon stops changing and remains the same.
 	var/cops_arrived = 0
 
-/atom/movable/screen/wanted/New()
-	return ..()
-
 /atom/movable/screen/wanted/Initialize()
 	. = ..()
 	update_appearance()

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -266,7 +266,7 @@
 	icon_state = "combat_off"
 	screen_loc = ui_combat_toggle
 
-/atom/movable/screen/combattoggle/New(loc, ...)
+/atom/movable/screen/combattoggle/Initialize()
 	. = ..()
 	update_appearance()
 

--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -378,10 +378,10 @@
 	image_state = "secbot-c"
 	var/victim
 
-/obj/effect/hallucination/simple/securitron/New()
-	name = pick ( "officer Beepsky", "officer Johnson", "officer Pingsky")
-	START_PROCESSING(SSfastprocess,src)
-	..()
+/obj/effect/hallucination/simple/securitron/Initialize()
+	. = ..()
+	name = pick("officer Beepsky", "officer Johnson", "officer Pingsky")
+	START_PROCESSING(SSfastprocess, src)
 
 /obj/effect/hallucination/simple/securitron/process()
 	if(prob(60))

--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -64,12 +64,9 @@
 	else
 		to_chat(user, span_notice("A no server error appears on the screen."))
 
-/obj/machinery/computer/message_monitor/New()
-	..()
-	GLOB.telecomms_list += src
-
 /obj/machinery/computer/message_monitor/Initialize()
 	..()
+	GLOB.telecomms_list += src
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/computer/message_monitor/LateInitialize()

--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -31,11 +31,12 @@
 	var/last_found = null
 	var/last_seen = null
 
-/obj/item/camera_bug/New()
-	..()
+/obj/item/camera_bug/Initialize()
+	. = ..()
 	START_PROCESSING(SSobj, src)
 
 /obj/item/camera_bug/Destroy()
+	STOP_PROCESSING(SSobj, src)
 	get_cameras()
 	for(var/cam_tag in bugged_cameras)
 		var/obj/machinery/camera/camera = bugged_cameras[cam_tag]

--- a/code/game/objects/items/implants/implant_track.dm
+++ b/code/game/objects/items/implants/implant_track.dm
@@ -3,9 +3,9 @@
 	desc = "Track with this."
 	activated = FALSE
 	///for how many deciseconds after user death will the implant work?
-	var/lifespan_postmortem = 6000 
+	var/lifespan_postmortem = 6000
 	///will people implanted with this act as teleporter beacons?
-	var/allow_teleport = TRUE 
+	var/allow_teleport = TRUE
 	///The id of the timer that's qdeleting us
 	var/timerid
 
@@ -23,13 +23,13 @@
 	deltimer(timerid)
 	return ..()
 
-/obj/item/implant/tracking/New()
-	..()
+/obj/item/implant/tracking/Initialize()
+	. = ..()
 	GLOB.tracked_implants += src
 
 /obj/item/implant/tracking/Destroy()
-	. = ..()
 	GLOB.tracked_implants -= src
+	return ..()
 
 /obj/item/implanter/tracking
 	imp_type = /obj/item/implant/tracking

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -102,8 +102,8 @@
 	var/refill_rate = 0.5
 	var/refill_reagent = /datum/reagent/water //Determins what reagent to use for refilling, just in case someone wanted to make a HOLY MOP OF PURGING
 
-/obj/item/mop/advanced/New()
-	..()
+/obj/item/mop/advanced/Initialize()
+	. = ..()
 	START_PROCESSING(SSobj, src)
 
 /obj/item/mop/advanced/attack_self(mob/user)
@@ -125,8 +125,7 @@
 	. += span_notice("The condenser switch is set to <b>[refill_enabled ? "ON" : "OFF"]</b>.")
 
 /obj/item/mop/advanced/Destroy()
-	if(refill_enabled)
-		STOP_PROCESSING(SSobj, src)
+	STOP_PROCESSING(SSobj, src)
 	return ..()
 
 /obj/item/mop/advanced/cyborg

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -217,22 +217,19 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	dir = SOUTH
 	var/id = 1
 
+/obj/structure/bodycontainer/crematorium/Initialize()
+	. = ..()
+	GLOB.crematoriums += src
+	connected = new /obj/structure/tray/c_tray(src)
+	connected.connected = src
+
 /obj/structure/bodycontainer/crematorium/attack_robot(mob/user) //Borgs can't use crematoriums without help
 	to_chat(user, span_warning("[src] is locked against you."))
 	return
 
 /obj/structure/bodycontainer/crematorium/Destroy()
-	GLOB.crematoriums.Remove(src)
+	GLOB.crematoriums -= src
 	return ..()
-
-/obj/structure/bodycontainer/crematorium/New()
-	GLOB.crematoriums.Add(src)
-	..()
-
-/obj/structure/bodycontainer/crematorium/Initialize()
-	. = ..()
-	connected = new /obj/structure/tray/c_tray(src)
-	connected.connected = src
 
 /obj/structure/bodycontainer/crematorium/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	id = "[port.id]_[id]"

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -3,7 +3,7 @@
 
 // A place where tube pods stop, and people can get in or out.
 // Mappers: use "Generate Instances from Directions" for this
-//  one.
+// one.
 
 
 /obj/structure/transit_tube/station
@@ -21,8 +21,8 @@
 	var/base_icon = "station0"
 	var/boarding_dir //from which direction you can board the tube
 
-/obj/structure/transit_tube/station/New()
-	..()
+/obj/structure/transit_tube/station/Initialize()
+	. = ..()
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/transit_tube/station/Destroy()

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -184,9 +184,9 @@
 	var/corrupt_delay = 50
 	var/last_corrupt = 0
 
-/obj/structure/destructible/cult/pylon/New()
+/obj/structure/destructible/cult/pylon/Initialize()
+	. = ..()
 	START_PROCESSING(SSfastprocess, src)
-	..()
 
 /obj/structure/destructible/cult/pylon/Destroy()
 	STOP_PROCESSING(SSfastprocess, src)


### PR DESCRIPTION
- Multiple New() have been replaced with Initialize() or combined with
  existing Initialize()
- Some STOP_PROCESSING macros have been added to Destroy procs.

---

These were all selected from #59600, and are hopefully all non-controversial.