### PR TITLE
sentient elites no longer become weaker after every challenge

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -288,7 +288,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		mychild.times_won++
 		mychild.maxHealth = mychild.maxHealth * 0.5
 		mychild.health = mychild.maxHealth
-	if(times_won == 1)
+	if(mychild.times_won == 1)
 		mychild.playsound_local(get_turf(mychild), 'sound/effects/magic.ogg', 40, 0)
 		to_chat(mychild, span_boldwarning("As the life in the activator's eyes fade, the forcefield around you dies out and you feel your power subside.\nDespite this inferno being your home, you feel that you aren't welcome here anymore.\nWithout any guidance, your purpose is now for you to decide."))
 		to_chat(mychild, "<b>Your maximum health total has been halved, but you can now heal by standing on your tumor. \nBear in mind that if anyone interacts with your tumor, you'll be resummoned here to carry out another fight with a temporarily restored maximum health total.\nAlso, be wary of your fellow Lavaland inhabitants, as they likely won't be happy to see you!</b>")

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -286,10 +286,11 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	if(!mychild || !istype(mychild))
 		return
 	mychild.revive(full_heal = TRUE, admin_revive = TRUE)
-	if(boosted)
-		mychild.times_won++
-		mychild.maxHealth = mychild.maxHealth * 0.4
-		mychild.health = mychild.maxHealth
+	if(!boosted)
+		return
+	mychild.times_won++
+	mychild.maxHealth = mychild.maxHealth * 0.4
+	mychild.health = mychild.maxHealth
 	if(mychild.times_won == 1)
 		mychild.playsound_local(get_turf(mychild), 'sound/effects/magic.ogg', 40, 0)
 		to_chat(mychild, span_boldwarning("As the life in the activator's eyes fade, the forcefield around you dies out and you feel your power subside.\nDespite this inferno being your home, you feel that you aren't welcome here anymore.\nWithout any guidance, your purpose is now for you to decide."))

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -11,8 +11,8 @@
 	robust_searching = TRUE
 	ranged_ignores_vision = TRUE
 	ranged = TRUE
-	maxHealth = 800 //this number is temporarily multiplied by 2.5x during the boss battle
-	health = 800
+	maxHealth = 1000
+	health = 1000
 	obj_damage = 30
 	vision_range = 6
 	aggro_vision_range = 18

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -11,6 +11,8 @@
 	robust_searching = TRUE
 	ranged_ignores_vision = TRUE
 	ranged = TRUE
+	maxHealth = 800 //this number is temporarily multiplied by 2.5x during the boss battle
+	health = 800
 	obj_damage = 30
 	vision_range = 6
 	aggro_vision_range = 18
@@ -185,7 +187,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	playsound(loc,'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
 	mychild.revive(full_heal = TRUE, admin_revive = TRUE)
 	if(boosted)
-		mychild.maxHealth = mychild.maxHealth * 2
+		mychild.maxHealth = mychild.maxHealth * 2.5
 		mychild.health = mychild.maxHealth
 		notify_ghosts("\A [mychild] has been challenged in \the [get_area(src)]!", source = mychild, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Lavaland Elite challenged")
 
@@ -267,7 +269,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		qdel(src)
 		return
 	if(mychild && istype(mychild)) //because we just checked for !boosted, we don't need to check for boosted here
-		mychild.maxHealth = mychild.maxHealth * 0.5
+		mychild.maxHealth = mychild.maxHealth * 0.4
 		mychild.health = mychild.maxHealth
 	var/lootpick = rand(1, 2)
 	if(lootpick == 1 && mychild && istype(mychild) && mychild.loot_drop != null)
@@ -286,17 +288,17 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	mychild.revive(full_heal = TRUE, admin_revive = TRUE)
 	if(boosted)
 		mychild.times_won++
-		mychild.maxHealth = mychild.maxHealth * 0.5
+		mychild.maxHealth = mychild.maxHealth * 0.4
 		mychild.health = mychild.maxHealth
 	if(mychild.times_won == 1)
 		mychild.playsound_local(get_turf(mychild), 'sound/effects/magic.ogg', 40, 0)
 		to_chat(mychild, span_boldwarning("As the life in the activator's eyes fade, the forcefield around you dies out and you feel your power subside.\nDespite this inferno being your home, you feel that you aren't welcome here anymore.\nWithout any guidance, your purpose is now for you to decide."))
-		to_chat(mychild, "<b>Your maximum health total has been halved, but you can now heal by standing on your tumor. \nBear in mind that if anyone interacts with your tumor, you'll be resummoned here to carry out another fight with a temporarily restored maximum health total.\nAlso, be wary of your fellow Lavaland inhabitants, as they likely won't be happy to see you!</b>")
+		to_chat(mychild, "<b>Your maximum health total has been greatly reduced, but you can now heal by standing on your tumor. \nBear in mind that if anyone interacts with your tumor, you'll be resummoned here to carry out another fight with a temporarily restored maximum health total.\nAlso, be wary of your fellow Lavaland inhabitants, as they likely won't be happy to see you!</b>")
 		to_chat(mychild, "<span class='big bold'>Note that you are a lavaland monster, and thus not allied to the station. You should not cooperate or act friendly with any station crew unless under extreme circumstances!</span>")
 
 /obj/item/tumor_shard
 	name = "tumor shard"
-	desc = "A strange, sharp, crystal shard from an odd tumor on Lavaland. Stabbing the corpse of a lavaland elite with this will revive them and make them completely loyal to you, assuming their soul still lingers. Note that the tumor ritual only doubles the maximum health of empowered elites for the duration of the ritual, so a revived elite might not be as durable as you remember it being."
+	desc = "A strange, sharp, crystal shard from an odd tumor on Lavaland. Stabbing the corpse of a lavaland elite with this will revive them and make them completely loyal to you, assuming their soul still lingers. Note that the tumor ritual only bolsters the maximum health total of empowered elites for the duration of the ritual, so a revived elite might not be as durable as you remember it being."
 	icon = 'icons/obj/lavaland/artefacts.dmi'
 	icon_state = "crevice_shard"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
@@ -322,7 +324,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 			to_chat(E, "<span class='userdanger'>You have been revived by [user]. While you can't speak to them, you owe [user] a great debt. Assist [user.p_them()] in achieving [user.p_their()] goals, regardless of risk.</span")
 		else
 			to_chat(E, "<span class='userdanger'>You have been revived by [user] and owe them a great debt. Assist [user.p_them()] in achieving [user.p_their()] goals, regardless of risk.</span")
-		to_chat(E, "<span class='big bold'>Note that you now share the loyalties of [user].  You are expected to not intentionally sabotage their faction unless commanded to!</span>")
+		to_chat(E, "<span class='big bold'>Note that you now share the loyalties of [user]. You are expected to not intentionally sabotage their faction unless commanded to!</span>")
 		E.desc = "[E.desc] This one appears appears unusually calm and friendly."
 		E.sentience_type = SENTIENCE_ORGANIC
 		qdel(src)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/goliath_broodmother.dm
@@ -26,8 +26,6 @@
 	icon_dead = "egg_sac"
 	icon_gib = "syndicate_gib"
 	health_doll_icon = "broodmother"
-	maxHealth = 1000
-	health = 1000
 	melee_damage_lower = 30
 	melee_damage_upper = 30
 	armour_penetration = 30

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -25,8 +25,6 @@
 	icon_dead = "herald_dying"
 	icon_gib = "syndicate_gib"
 	health_doll_icon = "herald"
-	maxHealth = 1000
-	health = 1000
 	melee_damage_lower = 20
 	melee_damage_upper = 20
 	attack_verb_continuous = "preaches to"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/legionnaire.dm
@@ -25,8 +25,6 @@
 	icon_dead = "legionnaire_dead"
 	icon_gib = "syndicate_gib"
 	health_doll_icon = "legionnaire"
-	maxHealth = 1000
-	health = 1000
 	melee_damage_lower = 35
 	melee_damage_upper = 35
 	attack_verb_continuous = "slashes its arms at"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora.dm
@@ -25,8 +25,6 @@
 	icon_dead = "pandora_dead"
 	icon_gib = "syndicate_gib"
 	health_doll_icon = "pandora"
-	maxHealth = 1000
-	health = 1000
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	attack_verb_continuous = "smashes into the side of"


### PR DESCRIPTION
## About The Pull Request

Previously, recalling an empowered tumor elite would double its maximum health, but after finishing its challenge, that elite would receive a 0.4x multiplier to their maximum health, making them weaker with every challenge.

Also, using a tumor shard on an elite who had already been killed, sharded, and re-killed would reduce their maximum health total again, making them abnormally weak.

I've resolved this issue by replacing the 2x on-recall maxHealth multiplier that elites get with a 2.5x one, adjusting the base maxHealth values of elites accordingly, and moving the maximum health reduction from the tumor shard's afterattack() proc to the onEliteLoss() proc.

To be clear, both mid-ritual elites and post-ritual elites should have the same maxHealth totals that they had before. This PR just corrects the health totals of post-rematch and post-double revival elites.

I've made some grammar fixes to some of the elite messages and added some sanity checks as well.

Elites and miners can no longer tie in the tumor ritual.

The health and maxHealth values of lavaland elites have been moved up to the generic lavaland elite mob, since they all used a base health and maxHealth of 1000 anyway.

The times_won variable is now stored in each elite rather than each tumor. This means that if a victorious sapient elite crawls back into their tumor and a new one is summoned later, the new elite will receive the message that it's supposed to for winning its first fight.

## Why It's Good For The Game

2 * 0.4 = 0.8, not 1.

## Changelog
:cl: ATHATH
fix: Sapient Lavaland elites no longer get weaker every time someone challenges them.
fix: Sharding a Lavaland elite who has already been killed, sharded, and re-killed will no longer make them much weaker than they are supposed to be.
fix: Lavaland elites can no longer tie with a challenger in the tumor ritual.
fix: The times_won variable is now stored in each Lavaland elite rather than each tumor. This means that if a victorious sapient elite crawls back into their tumor and a new one is summoned later, the new elite will receive the message that it is supposed to for winning its first fight.
spellcheck: Some Lavaland elite-related messages have been tweaked.
/:cl:
