### PR TITLE
Refactor magic mirror setup; adds mirror DMDOC

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -306,9 +306,8 @@
 	desc = "Turn and face, for you have power without grace."
 
 /obj/structure/mirror/magic/badmin/setup_choosable_races()
-	for(var/speciestype in subtypesof(/datum/species))
-		var/datum/species/S = speciestype
-		if(initial(S.changesource_flags) & MIRROR_BADMIN)
-			choosable_races += initial(S.id)
+	for(var/datum/species/speciestype as anything in subtypesof(/datum/species))
+		if(initial(speciestype.changesource_flags) & MIRROR_BADMIN)
+			choosable_races += initial(speciestype.id)
 
 	choosable_races = sortList(choosable_races)

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -109,16 +109,15 @@
 /obj/structure/mirror/magic/pride //Pride's mirror: Used in the Pride ruin.
 	name = "pride's mirror"
 	desc = "Pride cometh before the..."
-	icon_state = "magic_mirror"
 
-/obj/structure/mirror/magic/pride/New()
+/obj/structure/mirror/magic/pride/setup_choosable_races()
 	for(var/speciestype in subtypesof(/datum/species))
 		var/datum/species/S = speciestype
 		if(initial(S.changesource_flags) & MIRROR_PRIDE)
 			choosable_races += initial(S.id)
-	..()
+	choosable_races = sortList(choosable_races)
 
-/obj/structure/mirror/magic/pride/curse(mob/user)
+/obj/structure/mirror/magic/pride/after_use(mob/user)
 	user.visible_message(span_danger("<B>The ground splits beneath [user] as [user.p_their()] hand leaves the mirror!</B>"), \
 	span_notice("Perfect. Much better! Now <i>nobody</i> will be able to resist yo-"))
 


### PR DESCRIPTION
- Magical mirrors now have an overridable proc for setting their
  choosable races.
- Magical mirrors no longer use New().
- Lesser and badmin magical mirrors have slightly different
  descriptions.
- Adds some DMDOC comments to some mirror procs.

---

I don't think the slight tweaking of mirror descriptions that most people will never see deserves a changelog.