### PR TITLE
Delta Station Mining Shuttle No Longer Has Two Doors

### DIFF
--- a/_maps/shuttles/mining_delta.dmm
+++ b/_maps/shuttles/mining_delta.dmm
@@ -85,9 +85,6 @@
 	port_direction = 8;
 	width = 7
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/shuttle/mining)
 "j" = (

--- a/_maps/shuttles/mining_delta.dmm
+++ b/_maps/shuttles/mining_delta.dmm
@@ -116,21 +116,6 @@
 	},
 /turf/open/floor/iron,
 /area/shuttle/mining)
-"m" = (
-/obj/machinery/door/airlock/shuttle{
-	name = "Mining Shuttle Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/shuttle/mining)
 "n" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -317,7 +302,7 @@ a
 a
 a
 b
-m
+b
 b
 a
 a


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
what the title says

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
its useless and its annoying and kills you with fastmos
![image](https://user-images.githubusercontent.com/23585223/125718994-0b90f8e9-511f-4e24-9abe-087532a38b33.png)
the shuttle docks on the same side either way

## Changelog
:cl:
del: deletes a door from deltastation mining shuttle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
