### PR TITLE
Only blend areas when it's actually needed

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -165,9 +165,8 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 	. = ..()
 
-	blend_mode = BLEND_MULTIPLY // Putting this in the constructor so that it stops the icons being screwed up in the map editor.
-
 	if(!IS_DYNAMIC_LIGHTING(src))
+		blend_mode = BLEND_MULTIPLY
 		add_overlay(/obj/effect/fullbright)
 
 	reg_in_areas_in_z()

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -10,12 +10,14 @@
 
 	if (IS_DYNAMIC_LIGHTING(src))
 		cut_overlay(/obj/effect/fullbright)
+		blend_mode = BLEND_DEFAULT
 		for (var/turf/T in src)
 			if (IS_DYNAMIC_LIGHTING(T))
 				T.lighting_build_overlay()
 
 	else
 		add_overlay(/obj/effect/fullbright)
+		blend_mode = BLEND_MULTIPLY
 		for (var/turf/T in src)
 			if (T.lighting_object)
 				T.lighting_clear_overlay()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Blend multiply will only be applied when the area actually needs the lighting

## Why It's Good For The Game

It mildly inconvenienced me when I discovered no it is not blend default by default and that changing it otherwise does nothing

## Changelog
Not player facing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
