### PR TITLE
Fixes a roundstart uplink implanting runtime

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -252,7 +252,7 @@
 	SIGNAL_HANDLER
 
 	var/mob/user = arguments[2]
-	owner = user.key
+	owner = user?.key
 	if(owner && !purchase_log)
 		LAZYINITLIST(GLOB.uplink_purchase_logs_by_key)
 		if(GLOB.uplink_purchase_logs_by_key[owner])


### PR DESCRIPTION
There's no guarantee there will be a user making the implanting, such as it's the case of roundstart equipping.

```
[2021-07-14 23:15:29.788] runtime error: Cannot read null.key
 - proc name: implanting (/datum/component/uplink/proc/implanting)
 -   source file: uplink.dm,251
 -   usr: null
 -   src: syndicate uplink (/datum/component/uplink)
 -   call stack:
 - syndicate uplink (/datum/component/uplink): implanting(the uplink implant (/obj/item/implant/uplink/starting), /list (/list))
 - the uplink implant (/obj/item/implant/uplink/starting):  SendSignal("implant_implanting", /list (/list))
 - the uplink implant (/obj/item/implant/uplink/starting): implant(Leonard Lebowski (/mob/living/carbon/human), null, 1, 0)
 - Leonard Lebowski (/datum/mind): equip traitor("The Syndicate", 0, Traitor (/datum/antagonist/traitor))
 - Traitor (/datum/antagonist/traitor): equip()
 - Traitor (/datum/antagonist/traitor): on gain()
 - world: ImmediateInvokeAsync(Traitor (/datum/antagonist/traitor), /datum/antagonist/proc/on_gain (/datum/antagonist/proc/on_gain))
 - Leonard Lebowski (/datum/mind): add antag datum(/datum/antagonist/traitor (/datum/antagonist/traitor), null)
 - Traitors (/datum/dynamic_ruleset/roundstart/traitor): execute()
 - /datum/game_mode/dynamic (/datum/game_mode/dynamic): execute roundstart rule(Traitors (/datum/dynamic_ruleset/roundstart/traitor))
 - /datum/callback (/datum/callback): InvokeAsync()
 - Timer (/datum/controller/subsystem/timer): fire(0)
 - Timer (/datum/controller/subsystem/timer): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop()
 - Master (/datum/controller/master): StartProcessing(0)
 - ```

No player-facing changes.