### PR TITLE
Important Moth Related Tramstation Fix

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -42588,6 +42588,9 @@
 /obj/structure/chair/sofa/right{
 	dir = 8
 	},
+/obj/item/toy/plush/moth{
+	name = "Moffgomery Mofferson"
+	},
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
 "mnj" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A piece of job critical equipment is missing from the Tramstation's psychologist office. Central Command has authorized the distribution of one moth plush from the corporate stockpile to remedy this. Guard it well.

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/66576896/125815468-e3c3bd55-ad70-40bf-ab15-e43ea1c3b4c7.png)

We're on a timer here. God only knows what they will do if their demands aren't met.

## Changelog
:cl:
fix: One standard moth plushie has been issued to the tramstation psychologist's office.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
