### PR TITLE
Fixes an atmos related runtime involving rotating machineries

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -99,11 +99,14 @@
 	if(node1)
 		node1.disconnect(src)
 		nodes[1] = null
-		nullifyPipenet(parents[1])
+		if(parents[1])
+			nullifyPipenet(parents[1])
+
 	if(node2)
 		node2.disconnect(src)
 		nodes[2] = null
-		nullifyPipenet(parents[2])
+		if(parents[2])
+			nullifyPipenet(parents[2])
 
 	if(anchored)
 		SetInitDirections()

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -49,7 +49,8 @@
 		if(node)
 			node.disconnect(src)
 			nodes[1] = null
-			nullifyPipenet(parents[1])
+			if(parents[1])
+				nullifyPipenet(parents[1])
 		atmosinit()
 		node = nodes[1]
 		if(node)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -527,8 +527,9 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 		var/obj/machinery/atmospherics/node = nodes[1]
 		if(node)
 			node.disconnect(src)
-			nodes[1] = null
-		nullifyPipenet(parents[1])
+			nodes[1] = null // This is not strictly necessary, disconnect() already nullifies this node.
+		if(parents[1])
+			nullifyPipenet(parents[1])
 		atmosinit()
 		node = nodes[1]
 		if(node)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -527,7 +527,7 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 		var/obj/machinery/atmospherics/node = nodes[1]
 		if(node)
 			node.disconnect(src)
-			nodes[1] = null // This is not strictly necessary, disconnect() already nullifies this node.
+			nodes[1] = null
 		if(parents[1])
 			nullifyPipenet(parents[1])
 		atmosinit()

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -528,8 +528,9 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 		if(node)
 			node.disconnect(src)
 			nodes[1] = null
-		if(parents[1])
-			nullifyPipenet(parents[1])
+			if(parents[1])
+				nullifyPipenet(parents[1])
+
 		atmosinit()
 		node = nodes[1]
 		if(node)


### PR DESCRIPTION
## About The Pull Request
`nullifyPipenet` is called without checking if `parents[1]` is actually filled. If you use wrench faster than SSair rebuilds pipenets you might get runtimes.

## Why It's Good For The Game
Less runtimes

## Changelog
:cl:
fix: fixed cryocells and hfr runtiming on quick consecutive wrench actions.
/:cl: