### PR TITLE
Fixes an examine() runtime

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -113,7 +113,7 @@
 	return ..()
 
 /obj/machinery/camera/examine(mob/user)
-	. += ..()
+	. = ..()
 	if(isEmpProof(TRUE)) //don't reveal it's upgraded if was done via MALF AI Upgrade Camera Network ability
 		. += "It has electromagnetic interference shielding installed."
 	else

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -254,8 +254,8 @@
 	..()
 
 /obj/item/card/mining_point_card/examine(mob/user)
-	..()
-	to_chat(user, span_alert("There's [points] point\s on the card."))
+	. = ..()
+	. += span_alert("There's [points] point\s on the card.")
 
 /obj/item/storage/backpack/duffelbag/mining_conscript
 	name = "mining conscription kit"


### PR DESCRIPTION
It was using the old examine method, before the list compilation refactor, and not preserving the parent call.
Also did another minor cleanup.

```
[23:15:53] Runtime in mob.dm, line 471: Cannot execute null.Join().
verb name: Examine (/mob/verb/examinate)
usr: CKEY/(Mob Name)
usr.loc: (Mining Office (177,153,2))
src: Mob Name (/mob/living/carbon/human)
src.loc: the floor (177,153,2) (/turf/open/floor/iron)
call stack:
Mob Name (/mob/living/carbon/human): Examine(the mining points card (/obj/item/card/mining_point_card))
the mining points card (/obj/item/card/mining_point_card): ShiftClick(Mob Name (/mob/living/carbon/human))
Mob Name (/mob/living/carbon/human): ShiftClickOn(the mining points card (/obj/item/card/mining_point_card))
Mob Name (/mob/living/carbon/human): ClickOn(the mining points card (/obj/item/card/mining_point_card), "icon-x=22;icon-y=17;left=1;shi...")
the mining points card (/obj/item/card/mining_point_card): Click(the floor (176,154,2) (/turf/open/floor/iron), "mapwindow.map", "icon-x=22;icon-y=17;left=1;shi...")
CKEY (/client): Click(the mining points card (/obj/item/card/mining_point_card), the floor (176,154,2) (/turf/open/floor/iron), "mapwindow.map", "icon-x=22;icon-y=17;left=1;shi...")
```