### PR TITLE
Fixes a bug with pronoun swapping inside of names

### DIFF
--- a/code/datums/dog_fashion.dm
+++ b/code/datums/dog_fashion.dm
@@ -63,18 +63,18 @@
 	emote_see = list("coughs up a furball", "stretches")
 	emote_hear = list("purrs")
 	speak = list("Purrr", "Meow!", "MAOOOOOW!", "HISSSSS", "MEEEEEEW")
-	desc = "It's a cute little kitty-cat! ... wait ... what the hell?"
+	desc = "They're a cute little kitty-cat! ... wait ... what the hell?"
 
 /datum/dog_fashion/head/rabbit
 	name = "Hoppy"
-	emote_see = list("twitches its nose", "hops around a bit")
-	desc = "This is Hoppy. It's a corgi-...urmm... bunny rabbit."
+	emote_see = list("twitches their nose", "hops around a bit")
+	desc = "This is Hoppy. They're a corgi-...urmm... bunny rabbit."
 
 /datum/dog_fashion/head/beret
 	name = "Yann"
 	desc = "Mon dieu! C'est un chien!"
 	speak = list("le woof!", "le bark!", "JAPPE!!")
-	emote_see = list("cowers in fear.", "surrenders.", "plays dead.","looks as though there is a wall in front of him.")
+	emote_see = list("cowers in fear.", "surrenders.", "plays dead.","looks as though there is a wall in front of them.")
 
 
 /datum/dog_fashion/head/detective
@@ -90,7 +90,7 @@
 /datum/dog_fashion/head/pirate
 	name = "Pirate-title Pirate-name"
 	desc = "Yaarghh!! Thar' be a scurvy dog!"
-	emote_see = list("hunts for treasure.","stares coldly...","gnashes his tiny corgi teeth!")
+	emote_see = list("hunts for treasure.","stares coldly...","gnashes their tiny corgi teeth!")
 	emote_hear = list("growls ferociously!", "snarls.")
 	speak = list("Arrrrgh!!","Grrrrrr!")
 
@@ -137,8 +137,8 @@
 /datum/dog_fashion/head/santa
 	name = "Santa's Corgi Helper"
 	emote_hear = list("barks Christmas songs.", "yaps merrily!")
-	emote_see = list("looks for presents.", "checks his list.")
-	desc = "He's very fond of milk and cookies."
+	emote_see = list("looks for presents.", "checks their list.")
+	desc = "They're very fond of milk and cookies."
 
 /datum/dog_fashion/head/cargo_tech
 	name = "Corgi Tech REAL_NAME"
@@ -147,7 +147,7 @@
 /datum/dog_fashion/head/reindeer
 	name = "REAL_NAME the red-nosed Corgi"
 	emote_hear = list("lights the way!", "illuminates.", "yaps!")
-	desc = "He has a very shiny nose."
+	desc = "They have a very shiny nose."
 
 /datum/dog_fashion/head/sombrero
 	name = "Segnor REAL_NAME"
@@ -159,7 +159,7 @@
 
 /datum/dog_fashion/head/hop
 	name = "Lieutenant REAL_NAME"
-	desc = "Can actually be trusted to not run off on his own."
+	desc = "Can actually be trusted to not run off on their own."
 
 /datum/dog_fashion/head/deathsquad
 	name = "Trooper REAL_NAME"

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -173,7 +173,7 @@
 	if(findtext(msg, "them"))
 		msg = replacetext(msg, "them", user.p_them())
 	if(findtext(msg, "they"))
-		msg = replacetext(message, "they", user.p_they())
+		msg = replacetext(msg, "they", user.p_they())
 	if(findtext(msg, "%s"))
 		msg = replacetext(msg, "%s", user.p_s())
 	return msg
@@ -270,13 +270,6 @@
 */
 /mob/proc/manual_emote(text) //Just override the song and dance
 	. = TRUE
-	if(findtext(text, "their"))
-		text = replacetext(text, "their", p_their())
-	if(findtext(text, "them"))
-		text = replacetext(text, "them", p_them())
-	if(findtext(text, "%s"))
-		text = replacetext(text, "%s", p_s())
-
 	if(stat != CONSCIOUS)
 		return
 

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1133,7 +1133,7 @@
 				if(1)
 					H.say(pick("oof.", "ouch.", "my bones.", "oof ouch.", "oof ouch my bones."), forced = /datum/reagent/toxin/bonehurtingjuice)
 				if(2)
-					H.manual_emote(pick("oofs silently.", "looks like their bones hurt.", "grimaces, as though their bones hurt."))
+					H.manual_emote(pick("oofs silently.", "looks like [H.p_their()] bones hurt.", "grimaces, as though [H.p_their()] bones hurt."))
 				if(3)
 					to_chat(H, span_warning("Your bones hurt!"))
 		if(chem.overdosed)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -111,7 +111,7 @@
 				if(1)
 					H.say(pick("oof.", "ouch.", "my bones.", "oof ouch.", "oof ouch my bones."), forced = /datum/reagent/toxin/bonehurtingjuice)
 				if(2)
-					H.manual_emote(pick("oofs silently.", "looks like their bones hurt.", "grimaces, as though their bones hurt."))
+					H.manual_emote(pick("oofs silently.", "looks like [H.p_their()] bones hurt.", "grimaces, as though [H.p_their()] bones hurt."))
 				if(3)
 					to_chat(H, span_warning("Your bones hurt!"))
 		if(chem.overdosed)

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -57,7 +57,7 @@
 				if(1)
 					H.say(pick("oof.", "ouch.", "my bones.", "oof ouch.", "oof ouch my bones."), forced = /datum/reagent/toxin/bonehurtingjuice)
 				if(2)
-					H.manual_emote(pick("oofs silently.", "looks like their bones hurt.", "grimaces, as though their bones hurt."))
+					H.manual_emote(pick("oofs silently.", "looks like [H.p_their()] bones hurt.", "grimaces, as though [H.p_their()] bones hurt."))
 				if(3)
 					to_chat(H, span_warning("Your bones hurt!"))
 		if(chem.overdosed)

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -9,7 +9,7 @@
 	speak = list("Meow!", "Esp!", "Purr!", "HSSSSS")
 	speak_emote = list("purrs", "meows")
 	emote_hear = list("meows.", "mews.")
-	emote_see = list("shakes its head.", "shivers.")
+	emote_see = list("shakes their head.", "shivers.")
 	speak_chance = 1
 	turns_per_move = 5
 	see_in_dark = 6
@@ -60,7 +60,7 @@
 
 /mob/living/simple_animal/pet/cat/space
 	name = "space cat"
-	desc = "It's a cat... in space!"
+	desc = "They're a cat... in space!"
 	icon_state = "spacecat"
 	icon_living = "spacecat"
 	icon_dead = "spacecat_dead"
@@ -71,7 +71,7 @@
 
 /mob/living/simple_animal/pet/cat/breadcat
 	name = "bread cat"
-	desc = "It's a cat... with a bread!"
+	desc = "They're a cat... with a bread!"
 	icon_state = "breadcat"
 	icon_living = "breadcat"
 	icon_dead = "breadcat_dead"
@@ -209,10 +209,10 @@
 /mob/living/simple_animal/pet/cat/Life(delta_time = SSMOBS_DT, times_fired)
 	if(!stat && !buckled && !client)
 		if(DT_PROB(0.5, delta_time))
-			manual_emote(pick("stretches out for a belly rub.", "wags its tail.", "lies down."))
+			manual_emote(pick("stretches out for a belly rub.", "wags [p_their()] tail.", "lies down."))
 			set_resting(TRUE)
 		else if(DT_PROB(0.5, delta_time))
-			manual_emote(pick("sits down.", "crouches on its hind legs.", "looks alert."))
+			manual_emote(pick("sits down.", "crouches on [p_their()] hind legs.", "looks alert."))
 			set_resting(TRUE)
 			icon_state = "[icon_living]_sit"
 			collar_type = "[initial(collar_type)]_sit"
@@ -221,7 +221,7 @@
 				manual_emote(pick("gets up and meows.", "walks around.", "stops resting."))
 				set_resting(FALSE)
 			else
-				manual_emote(pick("grooms its fur.", "twitches its whiskers.", "shakes out its coat."))
+				manual_emote(pick("grooms [p_their()] fur.", "twitches [p_their()] whiskers.", "shakes out [p_their()] coat."))
 
 	//MICE!
 	if((src.loc) && isturf(src.loc))
@@ -241,7 +241,7 @@
 					break
 			for(var/obj/item/toy/cattoy/T in view(1,src))
 				if (T.cooldown < (world.time - 400))
-					manual_emote("bats \the [T] around with its paw!")
+					manual_emote("bats \the [T] around with \his paw!")
 					T.cooldown = world.time
 
 	..()
@@ -275,7 +275,7 @@
 
 /mob/living/simple_animal/pet/cat/cak //I told you I'd do it, Remie
 	name = "Keeki"
-	desc = "It's a cat made out of cake."
+	desc = "She is a cat made out of cake."
 	icon_state = "cak"
 	icon_living = "cak"
 	icon_dead = "cak_dead"
@@ -288,7 +288,7 @@
 	response_harm_continuous = "takes a bite out of"
 	response_harm_simple = "take a bite out of"
 	attacked_sound = 'sound/items/eatfood.ogg'
-	deathmessage = "loses its false life and collapses!"
+	deathmessage = "loses her false life and collapses!"
 	deathsound = "bodyfall"
 	held_state = "cak"
 

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -327,7 +327,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 			to_chat(user, span_warning("You can't shave this corgi, [p_they()] has already been shaved!"))
 			return
 		if (nofur)
-			to_chat(user, span_warning("You can't shave this corgi, [p_they()] doesn't have a fur coat!"))
+			to_chat(user, span_warning("You can't shave this corgi, [p_they()] [p_do()]n't have a fur coat!"))
 			return
 		user.visible_message(span_notice("[user] starts to shave [src] using \the [O]."), span_notice("You start to shave [src] using \the [O]..."))
 		if(do_after(user, 50, target = src))

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -11,7 +11,7 @@
 	speak = list("YAP", "Woof!", "Bark!", "AUUUUUU")
 	speak_emote = list("barks", "woofs")
 	emote_hear = list("barks!", "woofs!", "yaps.","pants.")
-	emote_see = list("shakes its head.", "chases its tail.","shivers.")
+	emote_see = list("shakes their head.", "chases their tail.","shivers.")
 	faction = list("neutral")
 	see_in_dark = 5
 	speak_chance = 1
@@ -37,7 +37,7 @@
 /mob/living/simple_animal/pet/dog/corgi
 	name = "\improper corgi"
 	real_name = "corgi"
-	desc = "It's a corgi."
+	desc = "They're a corgi."
 	icon_state = "corgi"
 	icon_living = "corgi"
 	icon_dead = "corgi_dead"
@@ -84,7 +84,7 @@
 /mob/living/simple_animal/pet/dog/pug
 	name = "\improper pug"
 	real_name = "pug"
-	desc = "It's a pug."
+	desc = "They're a pug."
 	icon = 'icons/mob/pets.dmi'
 	icon_state = "pug"
 	icon_living = "pug"
@@ -104,7 +104,7 @@
 /mob/living/simple_animal/pet/dog/bullterrier
 	name = "\improper bull terrier"
 	real_name = "bull terrier"
-	desc = "It's a bull terrier."
+	desc = "They're a bull terrier."
 	icon = 'icons/mob/pets.dmi'
 	icon_state = "bullterrier"
 	icon_living = "bullterrier"
@@ -116,7 +116,7 @@
 
 /mob/living/simple_animal/pet/dog/corgi/exoticcorgi
 	name = "Exotic Corgi"
-	desc = "As cute as it is colorful!"
+	desc = "As cute as they are colorful!"
 	icon = 'icons/mob/pets.dmi'
 	icon_state = "corgigrey"
 	icon_living = "corgigrey"
@@ -324,10 +324,10 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 /mob/living/simple_animal/pet/dog/corgi/attackby(obj/item/O, mob/user, params)
 	if (istype(O, /obj/item/razor))
 		if (shaved)
-			to_chat(user, span_warning("You can't shave this corgi, it's already been shaved!"))
+			to_chat(user, span_warning("You can't shave this corgi, [p_they()] has already been shaved!"))
 			return
 		if (nofur)
-			to_chat(user, span_warning("You can't shave this corgi, it doesn't have a fur coat!"))
+			to_chat(user, span_warning("You can't shave this corgi, [p_they()] doesn't have a fur coat!"))
 			return
 		user.visible_message(span_notice("[user] starts to shave [src] using \the [O]."), span_notice("You start to shave [src] using \the [O]..."))
 		if(do_after(user, 50, target = src))
@@ -399,7 +399,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 	speak = list("YAP", "Woof!", "Bark!", "AUUUUUU")
 	speak_emote = list("barks", "woofs")
 	emote_hear = list("barks!", "woofs!", "yaps.","pants.")
-	emote_see = list("shakes its head.", "chases its tail.","shivers.")
+	emote_see = list("shakes [p_their()] head.", "chases [p_their()] tail.","shivers.")
 	desc = initial(desc)
 	set_light(0)
 
@@ -416,7 +416,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 	name = "Ian"
 	real_name = "Ian" //Intended to hold the name without altering it.
 	gender = MALE
-	desc = "It's the HoP's beloved corgi."
+	desc = "He's the HoP's beloved corgi."
 	response_help_continuous = "pets"
 	response_help_simple = "pet"
 	response_disarm_continuous = "bops"
@@ -589,7 +589,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 /mob/living/simple_animal/pet/dog/corgi/puppy
 	name = "\improper corgi puppy"
 	real_name = "corgi"
-	desc = "It's a corgi puppy!"
+	desc = "They're a corgi puppy!"
 	icon_state = "puppy"
 	icon_living = "puppy"
 	icon_dead = "puppy_dead"
@@ -610,13 +610,14 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 	name = "Ian"
 	real_name = "Ian"
 	gender = MALE
-	desc = "It's the HoP's beloved corgi puppy."
+	desc = "He's the HoP's beloved corgi puppy."
 
 
 /mob/living/simple_animal/pet/dog/corgi/puppy/void //Tribute to the corgis born in nullspace
 	name = "\improper void puppy"
 	real_name = "voidy"
 	desc = "A corgi puppy that has been infused with deep space energy. It's staring back..."
+	gender = NEUTER
 	icon_state = "void_puppy"
 	icon_living = "void_puppy"
 	icon_dead = "void_puppy_dead"

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -8,7 +8,7 @@
 	speak = list("EHEHEHEHEH","eh?")
 	speak_emote = list("brays")
 	emote_hear = list("brays.")
-	emote_see = list("shakes its head.", "stamps a foot.", "glares around.")
+	emote_see = list("shakes their head.", "stamps a foot.", "glares around.")
 	speak_chance = 1
 	turns_per_move = 5
 	see_in_dark = 6
@@ -110,7 +110,7 @@
 	speak = list("moo?","moo","MOOOOOO")
 	speak_emote = list("moos","moos hauntingly")
 	emote_hear = list("brays.")
-	emote_see = list("shakes its head.")
+	emote_see = list("shakes her head.")
 	speak_chance = 1
 	turns_per_move = 5
 	see_in_dark = 6
@@ -230,7 +230,7 @@
 	speak = list("Cherp.","Cherp?","Chirrup.","Cheep!")
 	speak_emote = list("cheeps")
 	emote_hear = list("cheeps.")
-	emote_see = list("pecks at the ground.","flaps its tiny wings.")
+	emote_see = list("pecks at the ground.","flaps her tiny wings.")
 	density = FALSE
 	speak_chance = 2
 	turns_per_move = 2
@@ -289,7 +289,7 @@
 	speak = list("Cluck!","BWAAAAARK BWAK BWAK BWAK!","Bwaak bwak.")
 	speak_emote = list("clucks","croons")
 	emote_hear = list("clucks.")
-	emote_see = list("pecks at the ground.","flaps its wings viciously.")
+	emote_see = list("pecks at the ground.","flaps her wings viciously.")
 	density = FALSE
 	speak_chance = 2
 	turns_per_move = 3
@@ -321,7 +321,7 @@
 	AddComponent(/datum/component/egg_layer,\
 		/obj/item/food/egg,\
 		list(/obj/item/food/grown/wheat),\
-		feed_messages = list("[p_they()] clucks happily."),\
+		feed_messages = list("She clucks happily."),\
 		lay_messages = EGG_LAYING_MESSAGES,\
 		eggs_left = 0,\
 		eggs_added_from_eating = rand(1, 4),\
@@ -365,7 +365,7 @@
 	speak = list("Weeeeeeee?","Weeee","WEOOOOOOOOOO")
 	speak_emote = list("grunts","grunts lowly")
 	emote_hear = list("brays.")
-	emote_see = list("shakes its head.")
+	emote_see = list("shakes her head.")
 	speak_chance = 1
 	turns_per_move = 5
 	see_in_dark = 6

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -1,7 +1,7 @@
 //Foxxy
 /mob/living/simple_animal/pet/fox
 	name = "fox"
-	desc = "It's a fox."
+	desc = "They're a fox."
 	icon = 'icons/mob/pets.dmi'
 	icon_state = "fox"
 	icon_living = "fox"
@@ -9,7 +9,7 @@
 	speak = list("Ack-Ack","Ack-Ack-Ack-Ackawoooo","Geckers","Awoo","Tchoff")
 	speak_emote = list("geckers", "barks")
 	emote_hear = list("howls.","barks.")
-	emote_see = list("shakes its head.", "shivers.")
+	emote_see = list("shakes their head.", "shivers.")
 	speak_chance = 1
 	turns_per_move = 5
 	see_in_dark = 6

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_animal/mouse
 	name = "mouse"
-	desc = "It's a nasty, ugly, evil, disease-ridden rodent."
+	desc = "They're a nasty, ugly, evil, disease-ridden rodent."
 	icon_state = "mouse_gray"
 	icon_living = "mouse_gray"
 	icon_dead = "mouse_gray_dead"
@@ -60,7 +60,7 @@
 			M.name = name
 			if(toast)
 				M.add_atom_colour("#3A3A3A", FIXED_COLOUR_PRIORITY)
-				M.desc = "It's toast."
+				M.desc = "They're toast."
 		qdel(src)
 	else
 		SSmobs.cheeserats -= src // remove play controlled mouse also
@@ -143,7 +143,7 @@
  */
 /mob/living/simple_animal/mouse/proc/evolve()
 	var/mob/living/simple_animal/hostile/regalrat/regalrat = new /mob/living/simple_animal/hostile/regalrat/controlled(loc)
-	visible_message(span_warning("[src] devours the cheese! He morphs into something... greater!"))
+	visible_message(span_warning("[src] devours the cheese! They morphs into something... greater!"))
 	INVOKE_ASYNC(regalrat, /atom/movable/proc/say, "RISE, MY SUBJECTS! SCREEEEEEE!")
 	if(mind)
 		mind.transfer_to(regalrat)
@@ -191,7 +191,7 @@
 
 /obj/item/food/deadmouse
 	name = "dead mouse"
-	desc = "It looks like somebody dropped the bass on it. A lizard's favorite meal."
+	desc = "They look like somebody dropped the bass on it. A lizard's favorite meal."
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "mouse_gray_dead"
 	bite_consumption = 3
@@ -207,7 +207,7 @@
 /obj/item/food/deadmouse/examine(mob/user)
 	. = ..()
 	if (reagents?.has_reagent(/datum/reagent/yuck) || reagents?.has_reagent(/datum/reagent/fuel))
-		. += span_warning("It's dripping with fuel and smells terrible.")
+		. += span_warning("They're dripping with fuel and smells terrible.")
 
 /obj/item/food/deadmouse/attackby(obj/item/I, mob/living/user, params)
 	if(I.get_sharpness() && user.combat_mode)
@@ -216,7 +216,7 @@
 			to_chat(user, span_notice("You butcher [src]."))
 			qdel(src)
 		else
-			to_chat(user, span_warning("You need to put [src] on a surface to butcher it!"))
+			to_chat(user, span_warning("You need to put [src] on a surface to butcher them!"))
 	else
 		return ..()
 

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -143,7 +143,7 @@
  */
 /mob/living/simple_animal/mouse/proc/evolve()
 	var/mob/living/simple_animal/hostile/regalrat/regalrat = new /mob/living/simple_animal/hostile/regalrat/controlled(loc)
-	visible_message(span_warning("[src] devours the cheese! They morphs into something... greater!"))
+	visible_message(span_warning("[src] devours the cheese! They morph into something... greater!"))
 	INVOKE_ASYNC(regalrat, /atom/movable/proc/say, "RISE, MY SUBJECTS! SCREEEEEEE!")
 	if(mind)
 		mind.transfer_to(regalrat)

--- a/code/modules/mob/living/simple_animal/friendly/penguin.dm
+++ b/code/modules/mob/living/simple_animal/friendly/penguin.dm
@@ -1,6 +1,7 @@
 //Penguins
 
 /mob/living/simple_animal/pet/penguin
+	gender = MALE
 	response_help_continuous = "pets"
 	response_help_simple = "pet"
 	response_disarm_continuous = "bops"
@@ -10,7 +11,7 @@
 	speak = list("Gah Gah!", "NOOT NOOT!", "NOOT!", "Noot", "noot", "Prah!", "Grah!")
 	speak_emote = list("squawks", "gakkers")
 	emote_hear = list("squawk!", "gakkers!", "noots.","NOOTS!")
-	emote_see = list("shakes its beak.", "flaps it's wings.","preens itself.")
+	emote_see = list("shakes his beak.", "flaps his wings.","preens himself.")
 	faction = list("penguin")
 	minbodytemp = 0
 	see_in_dark = 5
@@ -29,7 +30,7 @@
 /mob/living/simple_animal/pet/penguin/emperor
 	name = "Emperor penguin"
 	real_name = "penguin"
-	desc = "Emperor of all they survey."
+	desc = "Emperor of all he surveys."
 	icon_state = "penguin"
 	icon_living = "penguin"
 	icon_dead = "penguin_dead"

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -1,10 +1,9 @@
 /mob/living/simple_animal/hostile/regalrat
 	name = "feral regal rat"
-	desc = "An evolved rat, created through some strange science. It leads nearby rats with deadly efficiency to protect its kingdom. Not technically a king."
+	desc = "An evolved rat, created through some strange science. They lead nearby rats with deadly efficiency to protect their kingdom. Not technically a king."
 	icon_state = "regalrat"
 	icon_living = "regalrat"
 	icon_dead = "regalrat_dead"
-	gender = NEUTER
 	speak_chance = 0
 	turns_per_move = 5
 	maxHealth = 70
@@ -47,7 +46,7 @@
 	QDEL_NULL(riot)
 
 /mob/living/simple_animal/hostile/regalrat/proc/get_player()
-	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the Royal Rat, cheesey be his crown?", ROLE_SENTIENCE, FALSE, 100, POLL_IGNORE_SENTIENCE_POTION)
+	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the Royal Rat, cheesey be their crown?", ROLE_SENTIENCE, FALSE, 100, POLL_IGNORE_SENTIENCE_POTION)
 	if(LAZYLEN(candidates) && !mind)
 		var/mob/dead/observer/C = pick(candidates)
 		key = C.key
@@ -79,9 +78,9 @@
 	if(istype(user,/mob/living/simple_animal/hostile/rat))
 		var/mob/living/simple_animal/hostile/rat/ratself = user
 		if(ratself.faction_check_mob(src, TRUE))
-			. += span_notice("This is your king. Long live his majesty!")
+			. += span_notice("This is your king. Long live their majesty!")
 		else
-			. += span_warning("This is a false king! Strike him down!")
+			. += span_warning("This is a false king! Strike them down!")
 	else if(user != src && istype(user,/mob/living/simple_animal/hostile/regalrat))
 		. += span_warning("Who is this foolish false king? This will not stand!")
 
@@ -198,21 +197,21 @@
 			to_chat(owner,span_warning("There's too many mice on this station to beckon a new one! Find them first!"))
 			return
 		new /mob/living/simple_animal/mouse(owner.loc)
-		owner.visible_message(span_warning("[owner] commands a mouse to its side!"))
+		owner.visible_message(span_warning("[owner] commands a mouse to their side!"))
 	else
-		owner.visible_message(span_warning("[owner] commands its army to action, mutating them into rats!"))
+		owner.visible_message(span_warning("[owner] commands their army to action, mutating them into rats!"))
 	StartCooldown()
 
 /mob/living/simple_animal/hostile/rat
 	name = "rat"
-	desc = "It's a nasty, ugly, evil, disease-ridden rodent with anger issues."
+	desc = "They're a nasty, ugly, evil, disease-ridden rodent with anger issues."
 	icon_state = "mouse_gray"
 	icon_living = "mouse_gray"
 	icon_dead = "mouse_gray_dead"
 	speak = list("Skree!","SKREEE!","Squeak?")
 	speak_emote = list("squeaks")
 	emote_hear = list("Hisses.")
-	emote_see = list("runs in a circle.", "stands on its hind legs.")
+	emote_see = list("runs in a circle.", "stands on their hind legs.")
 	melee_damage_lower = 3
 	melee_damage_upper = 5
 	obj_damage = 5
@@ -270,7 +269,7 @@
 		if(ratking.faction_check_mob(src, TRUE))
 			. += span_notice("This rat serves under you.")
 		else
-			. += span_warning("This peasant serves a different king! Strike him down!")
+			. += span_warning("This peasant serves a different king! Strike them down!")
 
 /mob/living/simple_animal/hostile/rat/CanAttack(atom/the_target)
 	if(istype(the_target,/mob/living/simple_animal))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -168,6 +168,7 @@
 	icon_state = "honkhulk"
 	icon_living = "honkhulk"
 	move_resist = INFINITY
+	gender = MALE
 	response_help_continuous = "tries desperately to appease"
 	response_help_simple = "try desperately to appease"
 	response_disarm_continuous = "foolishly pushes"
@@ -196,6 +197,7 @@
 	desc = "A real lunkhead who somehow gets all the girls."
 	icon_state = "chlown"
 	icon_living = "chlown"
+	gender = MALE
 	response_help_continuous = "submits to"
 	response_help_simple = "submit to"
 	response_disarm_continuous = "tries to assert dominance over"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/frog.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/frog.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_animal/hostile/retaliate/frog
 	name = "frog"
-	desc = "It seems a little sad."
+	desc = "They seem a little sad."
 	icon_state = "frog"
 	icon_living = "frog"
 	icon_dead = "frog_dead"
@@ -37,7 +37,7 @@
 
 	if(prob(1))
 		name = "rare frog"
-		desc = "It seems a little smug."
+		desc = "They seem a little smug."
 		icon_state = "rare_frog"
 		icon_living = "rare_frog"
 		icon_dead = "rare_frog_dead"

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -28,7 +28,7 @@
 
 /mob/living/simple_animal/parrot
 	name = "parrot"
-	desc = "The parrot squawks, \"It's a Parrot! BAWWK!\"" //'
+	desc = "The parrot squawks, \"They're a Parrot! BAWWK!\"" //'
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "parrot_fly"
 	icon_living = "parrot_fly"
@@ -42,7 +42,7 @@
 	speak = list("Hi!","Hello!","Cracker?","BAWWWWK george mellons griffing me!")
 	speak_emote = list("squawks","says","yells")
 	emote_hear = list("squawks.","bawks!")
-	emote_see = list("flutters its wings.")
+	emote_see = list("flutters their wings.")
 
 	speak_chance = 1 //1% (1 in 100) chance every tick; So about once per 150 seconds, assuming an average tick is 1.5s
 	turns_per_move = 5

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1130,7 +1130,7 @@
 			if(1)
 				M.say(pick("oof.", "ouch.", "my bones.", "oof ouch.", "oof ouch my bones."), forced = /datum/reagent/toxin/bonehurtingjuice)
 			if(2)
-				M.manual_emote(pick("oofs silently.", "looks like their bones hurt.", "grimaces, as though their bones hurt."))
+				M.manual_emote(pick("oofs silently.", "looks like [M.p_their()] bones hurt.", "grimaces, as though [M.p_their()] bones hurt."))
 			if(3)
 				to_chat(M, span_warning("Your bones hurt!"))
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #60253
the above issue showcased a really weird issue with "manual_emote()" which took an emote and then changed the pronoun mid-use, which on its own is ok, but some mobs include *names* with their emote, hence changing "pronouns" in the middle of peoples names

this method of using manual_emote() is dumb because theres already a proc for changing pronouns in a string, as well as dedicated procs for inserting the correct pronoun for the given mob DIRECTLY in the emote string itself

so what I did was *remove* the part of the code in manual_emote() that swapped pronouns, it wasnt needed, and instead went to every single emote string that used it and used the [p_they()] procs to get the correct pronouns.

while i was at it, i also touched up descriptions and other miscallaneous emotes and mob communication to get rid of "It's". mobs are by default plural, they arent objects, instead replaced with "they're" etc... a mobs and mob subtypes gender WAS respected

also gave the male gender to two very specific clown mobs which are clearly coded male. gave the void_corgi a neuter gender, since its description makes it a reference to the "void stares back" phrase, which makes it genderless as the void is not a noun.

EDIT: oh, and i did fix an issue with the replace_pronouns() proc, which uses "msg" as its var, but one if statement was "message". 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes bug, helps standardize mobs gender as default plural rather than an object
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: Fixes a bug where emotes such as a carp gnash will mess up a name if the name contains a pronoun within it
fix: Fixed an incorrect variable in a var that manages pronouns
spellcheck: Updated some Simple Mob examines and emotes to default to plural (they) rather than object (it)
spellcheck: two clown mobs (Clown Hulk, and Clown Chad) are now explicitly male. one Corgi type (Void) is neuter (it)
spellcheck: many animals like cows and chickens are hardcoded female, but uses neutral pronouns in examines and emotes, updated that to be explicitly she pronouns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
