### PR TITLE
Fixes cutting open heads dropping hidden organs

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -124,6 +124,10 @@
 			if(istype(head_item, /obj/item/reagent_containers/pill))
 				for(var/datum/action/item_action/hands_free/activate_pill/pill_action in head_item.actions)
 					qdel(pill_action)
+			if(istype(head_item, /obj/item/organ))
+				var/obj/item/organ/organ = head_item
+				if(organ.organ_flags & ORGAN_UNREMOVABLE)
+					continue
 			head_item.forceMove(head_turf)
 	eyes = null
 	ears = null

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -124,7 +124,7 @@
 			if(istype(head_item, /obj/item/reagent_containers/pill))
 				for(var/datum/action/item_action/hands_free/activate_pill/pill_action in head_item.actions)
 					qdel(pill_action)
-			if(istype(head_item, /obj/item/organ))
+			else if(istype(head_item, /obj/item/organ))
 				var/obj/item/organ/organ = head_item
 				if(organ.organ_flags & ORGAN_UNREMOVABLE)
 					continue


### PR DESCRIPTION
closes #60234

:cl:
fix: cutting open heads wont drop horns, frills etc on the ground (you could literally stick it into a human to give them frills but nooooooo you wanted to report the bug)
/:cl:

Don't hit me with that no prb label. The bug is that organs with the unremovable flag were removable if you cut open a dismembered head, I just awoke the bug by actually using the flag

Also yes it's a dumb fix, but organ code is dumb. I want to rework how organs are stored eventually when I get to it which is when I'll clean this up. (I also want to rework external organs again to just be datums attached to organs but hush)