### PR TITLE
Makes Harm Alarms not doable anymore

### DIFF
--- a/code/modules/wiremod/components/atom/health.dm
+++ b/code/modules/wiremod/components/atom/health.dm
@@ -20,7 +20,7 @@
 	var/datum/port/output/oxy
 	/// Health
 	var/datum/port/output/health
-	power_usage_per_input = 100
+	power_usage_per_input = 20
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	var/max_range = 5

--- a/code/modules/wiremod/components/atom/health.dm
+++ b/code/modules/wiremod/components/atom/health.dm
@@ -20,7 +20,7 @@
 	var/datum/port/output/oxy
 	/// Health
 	var/datum/port/output/health
-
+	power_usage_per_input = 100
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	var/max_range = 5


### PR DESCRIPTION
## About The Pull Request
makes health circuits hella expensive to the battery charge
## Why It's Good For The Game

backpack harm alarms are bad
Closes #60270
## Changelog
:cl:
balance: make health circuits use 20 charge
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
