### PR TITLE
Balloon alert for energy gun swap mode

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -160,7 +160,7 @@
 	fire_sound = shot.fire_sound
 	fire_delay = shot.delay
 	if (shot.select_name)
-		to_chat(user, span_notice("[src] is now set to [shot.select_name]."))
+		balloon_alert(user, "set to [shot.select_name]")
 	chambered = null
 	recharge_newshot(TRUE)
 	update_appearance()


### PR DESCRIPTION
## About The Pull Request

Makes energy guns use balloon alerts for swapping mode.
![image](https://user-images.githubusercontent.com/51863163/126027737-4730c901-8c48-4fa1-a283-45a491eb4e2b.png)


## Why It's Good For The Game

Often times you're swapping between energy gun modes, you're looking at the screen, and not chat.

## Changelog
:cl: Melbert
qol: Energy Guns use balloon alerts when swapping mode
/:cl:
