### PR TITLE
Add Revenant, Sentient Disease, Space Pirates, and Obsessed to Dynamic

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -863,6 +863,7 @@
 /datum/dynamic_ruleset/midround/pirates/execute()
 	//A lot of pirate code is baked into the event directly, so let's just make a copy of the event and opt to run it.
 	var/datum/round_event_control/pirates/pirate_event = new/datum/round_event_control/pirates
+	pirate_event.dynamic_should_hijack = FALSE
 	pirate_event.runEvent()
 	return ..()
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -762,6 +762,110 @@
 	create_midwife_eggs(spawncount)
 	return ..()
 
+//////////////////////////////////////////////
+//                                          //
+//           REVENANT  (GHOST)              //
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/midround/from_ghosts/revenant
+	name = "Revenant"
+	antag_datum = /datum/antagonist/revenant
+	antag_flag = "Revenant"
+	antag_flag_override = ROLE_REVENANT
+	enemy_roles = list("Security Officer", "Detective", "Head of Security", "Captain")
+	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_candidates = 1
+	weight = 4
+	cost = 10
+	requirements = list(101,101,101,70,50,40,20,15,10,10)
+	repeatable = TRUE
+	var/list/spawn_locs = list()
+	var/rev_spawn_threshold = 20
+
+/datum/dynamic_ruleset/midround/from_ghosts/revenant/acceptable(population=0, threat=0)
+	var/deadMobs = 0
+	for(var/mob/M in GLOB.dead_mob_list)
+		deadMobs++
+	if(deadMobs < rev_spawn_threshold)
+		return FALSE
+	return ..()
+
+/datum/dynamic_ruleset/midround/from_ghosts/revenant/execute()
+	for(var/mob/living/L in GLOB.dead_mob_list) //look for any dead bodies
+		var/turf/T = get_turf(L)
+		if(T && is_station_level(T.z))
+			spawn_locs += T
+	if(!spawn_locs.len || spawn_locs.len < 15) //look for any morgue trays, crematoriums, ect if there weren't alot of dead bodies on the station to pick from
+		for(var/obj/structure/bodycontainer/bc in GLOB.bodycontainers)
+			var/turf/T = get_turf(bc)
+			if(T && is_station_level(T.z))
+				spawn_locs += T
+	if(!spawn_locs.len) //If we can't find any valid spawnpoints, try the carp spawns
+		for(var/obj/effect/landmark/carpspawn/L in GLOB.landmarks_list)
+			if(isturf(L.loc))
+				spawn_locs += L.loc
+	if(!spawn_locs.len) //If we can't find THAT, then just give up and cry
+		return FALSE
+	. = ..()
+
+/datum/dynamic_ruleset/midround/from_ghosts/revenant/generate_ruleset_body(mob/applicant)
+	var/mob/living/simple_animal/revenant/revvie = new(pick(spawn_locs))
+	revvie.key = applicant.key
+	message_admins("[ADMIN_LOOKUPFLW(revvie)] has been made into a revenant by the midround ruleset.")
+	log_game("[key_name(revvie)] was spawned as a revenant by the midround ruleset.")
+	return revvie
+
+//////////////////////////////////////////////
+//                                          //
+//       SENTIENT DISEASE (GHOST)           //
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/midround/from_ghosts/sentient_disease
+	name = "Sentient Disease"
+	antag_datum = /datum/antagonist/disease
+	antag_flag = "Sentient Disease"
+	antag_flag_override = ROLE_ALIEN
+	required_candidates = 1
+	weight = 4
+	cost = 10
+	requirements = list(101,101,101,80,60,50,30,20,10,10)
+	repeatable = TRUE
+	var/list/spawn_locs = list()
+
+/datum/dynamic_ruleset/midround/from_ghosts/sentient_disease/generate_ruleset_body(mob/applicant)
+	var/mob/camera/disease/virus = new /mob/camera/disease(SSmapping.get_station_center())
+	virus.key = applicant.key
+	INVOKE_ASYNC(virus, /mob/camera/disease/proc/pick_name)
+	message_admins("[ADMIN_LOOKUPFLW(virus)] has been made into a sentient disease by the midround ruleset.")
+	log_game("[key_name(virus)] was spawned as a sentient disease by the midround ruleset.")
+	return virus
+
+//////////////////////////////////////////////
+//                                          //
+//       SPACE PIRATES     (GHOST)          //
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/midround/pirates
+	name = "Space Pirates"
+	antag_flag = "Space Pirates"
+	required_type = /mob/dead/observer
+	enemy_roles = list("Security Officer", "Detective", "Head of Security", "Captain")
+	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_candidates = 3
+	weight = 4
+	cost = 10
+	requirements = list(101,101,101,80,60,50,30,20,10,10)
+	repeatable = TRUE
+
+/datum/dynamic_ruleset/midround/pirates/execute()
+	//A lot of pirate code is baked into the event directly, so let's just make a copy of the event and opt to run it.
+	var/datum/round_event_control/pirates/pirate_event = new/datum/round_event_control/pirates
+	pirate_event.runEvent()
+	return ..()
+
 /// Probability the AI going malf will be accompanied by an ion storm announcement and some ion laws.
 #undef MALF_ION_PROB
 /// The probability to replace an existing law with an ion law instead of adding a new ion law.

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -870,7 +870,7 @@
 	..()
 	candidates = living_players
 	for(var/mob/living/carbon/human/candidate in candidates)
-		if(!candidate.getorgan(/obj/item/organ/brain) || candidate.mind.has_antag_datum(/datum/antagonist/obsessed) || candidate.stat == DEAD || (!candidate.client || !(ROLE_OBSESSED in candidate.client.prefs.be_special)) || !SSjob.GetJob(candidate.mind.assigned_role) || candidate.mind.assigned_role in GLOB.nonhuman_positions)
+		if(!candidate.getorgan(/obj/item/organ/brain) || candidate.mind.has_antag_datum(/datum/antagonist/obsessed) || candidate.stat == DEAD || !candidate.client || !(ROLE_OBSESSED in candidate.client.prefs.be_special) || !SSjob.GetJob(candidate.mind.assigned_role) || candidate.mind.assigned_role in GLOB.nonhuman_positions)
 			candidates -= candidate
 
 /datum/dynamic_ruleset/midround/obsessed/execute()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -856,7 +856,6 @@
 	name = "Obsessed"
 	antag_datum = /datum/antagonist/obsessed
 	antag_flag = ROLE_OBSESSED
-	protected_roles = list("Prisoner", "Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	restricted_roles = list("Cyborg", "AI", "Positronic Brain")
 	enemy_roles = list("Security Officer", "Detective", "Head of Security", "Captain")
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -870,12 +870,14 @@
 	..()
 	candidates = living_players
 	for(var/mob/living/carbon/human/candidate in candidates)
-		if(!candidate.getorgan(/obj/item/organ/brain) || \
-		candidate.mind.has_antag_datum(/datum/antagonist/obsessed) || \
-		candidate.stat == DEAD || !candidate.client || \
-		!(ROLE_OBSESSED in candidate.client.prefs.be_special) || \
-		!SSjob.GetJob(candidate.mind.assigned_role) || \
-		(candidate.mind.assigned_role in GLOB.nonhuman_positions))
+		if( \
+			!candidate.getorgan(/obj/item/organ/brain) \
+			|| candidate.mind.has_antag_datum(/datum/antagonist/obsessed) \
+			|| candidate.stat == DEAD \
+			|| !(ROLE_OBSESSED in candidate.client?.prefs?.be_special) \
+			|| !SSjob.GetJob(candidate.mind.assigned_role) \
+			|| (candidate.mind.assigned_role in GLOB.nonhuman_positions) \
+		)
 			candidates -= candidate
 
 /datum/dynamic_ruleset/midround/obsessed/execute()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -870,7 +870,12 @@
 	..()
 	candidates = living_players
 	for(var/mob/living/carbon/human/candidate in candidates)
-		if(!candidate.getorgan(/obj/item/organ/brain) || candidate.mind.has_antag_datum(/datum/antagonist/obsessed) || candidate.stat == DEAD || !candidate.client || !(ROLE_OBSESSED in candidate.client.prefs.be_special) || !SSjob.GetJob(candidate.mind.assigned_role) || candidate.mind.assigned_role in GLOB.nonhuman_positions)
+		if(!candidate.getorgan(/obj/item/organ/brain) || \
+		candidate.mind.has_antag_datum(/datum/antagonist/obsessed) || \
+		candidate.stat == DEAD || !candidate.client || \
+		!(ROLE_OBSESSED in candidate.client.prefs.be_special) || \
+		!SSjob.GetJob(candidate.mind.assigned_role) || \
+		(candidate.mind.assigned_role in GLOB.nonhuman_positions))
 			candidates -= candidate
 
 /datum/dynamic_ruleset/midround/obsessed/execute()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -762,12 +762,7 @@
 	create_midwife_eggs(spawncount)
 	return ..()
 
-//////////////////////////////////////////////
-//                                          //
-//           REVENANT  (GHOST)              //
-//                                          //
-//////////////////////////////////////////////
-
+/// Revenant ruleset
 /datum/dynamic_ruleset/midround/from_ghosts/revenant
 	name = "Revenant"
 	antag_datum = /datum/antagonist/revenant
@@ -780,48 +775,41 @@
 	cost = 10
 	requirements = list(101,101,101,70,50,40,20,15,10,10)
 	repeatable = TRUE
+	var/dead_mobs_required = 20
+	var/need_extra_spawns_value = 15
 	var/list/spawn_locs = list()
-	var/rev_spawn_threshold = 20
 
 /datum/dynamic_ruleset/midround/from_ghosts/revenant/acceptable(population=0, threat=0)
-	var/deadMobs = 0
-	for(var/mob/M in GLOB.dead_mob_list)
-		deadMobs++
-	if(deadMobs < rev_spawn_threshold)
+	if(GLOB.dead_mob_list.len < dead_mobs_required)
 		return FALSE
 	return ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/revenant/execute()
-	for(var/mob/living/L in GLOB.dead_mob_list) //look for any dead bodies
-		var/turf/T = get_turf(L)
-		if(T && is_station_level(T.z))
-			spawn_locs += T
-	if(!spawn_locs.len || spawn_locs.len < 15) //look for any morgue trays, crematoriums, ect if there weren't alot of dead bodies on the station to pick from
-		for(var/obj/structure/bodycontainer/bc in GLOB.bodycontainers)
-			var/turf/T = get_turf(bc)
-			if(T && is_station_level(T.z))
-				spawn_locs += T
+	for(var/mob/living/corpse in GLOB.dead_mob_list) //look for any dead bodies
+		var/turf/corpse_turf = get_turf(corpse)
+		if(corpse_turf && is_station_level(corpse_turf.z))
+			spawn_locs += corpse_turf
+	if(!spawn_locs.len || spawn_locs.len < need_extra_spawns_value) //look for any morgue trays, crematoriums, ect if there weren't alot of dead bodies on the station to pick from
+		for(var/obj/structure/bodycontainer/corpse_container in GLOB.bodycontainers)
+			var/turf/container_turf = get_turf(corpse_container)
+			if(container_turf && is_station_level(container_turf.z))
+				spawn_locs += container_turf
 	if(!spawn_locs.len) //If we can't find any valid spawnpoints, try the carp spawns
-		for(var/obj/effect/landmark/carpspawn/L in GLOB.landmarks_list)
-			if(isturf(L.loc))
-				spawn_locs += L.loc
+		for(var/obj/effect/landmark/carpspawn/carp_spawnpoint in GLOB.landmarks_list)
+			if(isturf(carp_spawnpoint.loc))
+				spawn_locs += carp_spawnpoint.loc
 	if(!spawn_locs.len) //If we can't find THAT, then just give up and cry
 		return FALSE
 	. = ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/revenant/generate_ruleset_body(mob/applicant)
-	var/mob/living/simple_animal/revenant/revvie = new(pick(spawn_locs))
-	revvie.key = applicant.key
-	message_admins("[ADMIN_LOOKUPFLW(revvie)] has been made into a revenant by the midround ruleset.")
-	log_game("[key_name(revvie)] was spawned as a revenant by the midround ruleset.")
-	return revvie
+	var/mob/living/simple_animal/revenant/revenant = new(pick(spawn_locs))
+	revenant.key = applicant.key
+	message_admins("[ADMIN_LOOKUPFLW(revenant)] has been made into a revenant by the midround ruleset.")
+	log_game("[key_name(revenant)] was spawned as a revenant by the midround ruleset.")
+	return revenant
 
-//////////////////////////////////////////////
-//                                          //
-//       SENTIENT DISEASE (GHOST)           //
-//                                          //
-//////////////////////////////////////////////
-
+/// Sentient Disease ruleset
 /datum/dynamic_ruleset/midround/from_ghosts/sentient_disease
 	name = "Sentient Disease"
 	antag_datum = /datum/antagonist/disease
@@ -832,7 +820,6 @@
 	cost = 10
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
 	repeatable = TRUE
-	var/list/spawn_locs = list()
 
 /datum/dynamic_ruleset/midround/from_ghosts/sentient_disease/generate_ruleset_body(mob/applicant)
 	var/mob/camera/disease/virus = new /mob/camera/disease(SSmapping.get_station_center())
@@ -842,13 +829,8 @@
 	log_game("[key_name(virus)] was spawned as a sentient disease by the midround ruleset.")
 	return virus
 
-//////////////////////////////////////////////
-//                                          //
-//       SPACE PIRATES     (GHOST)          //
-//                                          //
-//////////////////////////////////////////////
-
-/datum/dynamic_ruleset/midround/pirates
+/// Space Pirates ruleset
+/datum/dynamic_ruleset/midround/from_ghosts/pirates
 	name = "Space Pirates"
 	antag_flag = "Space Pirates"
 	required_type = /mob/dead/observer
@@ -860,11 +842,44 @@
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
 	repeatable = TRUE
 
+/datum/dynamic_ruleset/midround/from_ghosts/pirates/acceptable(population=0, threat=0)
+	if (!SSmapping.empty_space)
+		return FALSE
+	return ..()
+
 /datum/dynamic_ruleset/midround/pirates/execute()
-	//A lot of pirate code is baked into the event directly, so let's just make a copy of the event and opt to run it.
-	var/datum/round_event_control/pirates/pirate_event = new/datum/round_event_control/pirates
-	pirate_event.dynamic_should_hijack = FALSE
-	pirate_event.runEvent()
+	send_pirate_threat()
+	return ..()
+
+/// Obsessed ruleset
+/datum/dynamic_ruleset/midround/obsessed
+	name = "Obsessed"
+	antag_datum = /datum/antagonist/obsessed
+	antag_flag = ROLE_OBSESSED
+	protected_roles = list("Prisoner", "Security Officer", "Warden", "Detective", "Head of Security", "Captain")
+	restricted_roles = list("Cyborg", "AI", "Positronic Brain")
+	enemy_roles = list("Security Officer", "Detective", "Head of Security", "Captain")
+	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_candidates = 1
+	weight = 4
+	cost = 10
+	requirements = list(101,101,101,80,60,50,30,20,10,10)
+	repeatable = TRUE
+
+/datum/dynamic_ruleset/midround/obsessed/trim_candidates()
+	..()
+	candidates = living_players
+	for(var/mob/living/carbon/human/candidate in candidates)
+		if(!candidate.getorgan(/obj/item/organ/brain) || candidate.mind.has_antag_datum(/datum/antagonist/obsessed) || candidate.stat == DEAD || (!candidate.client || !(ROLE_OBSESSED in candidate.client.prefs.be_special)) || !SSjob.GetJob(candidate.mind.assigned_role) || candidate.mind.assigned_role in GLOB.nonhuman_positions)
+			candidates -= candidate
+
+/datum/dynamic_ruleset/midround/obsessed/execute()
+	if(!candidates || !candidates.len)
+		return FALSE
+	var/mob/living/carbon/human/obsessed = pick_n_take(candidates)
+	obsessed.gain_trauma(/datum/brain_trauma/special/obsessed)
+	message_admins("[ADMIN_LOOKUPFLW(obsessed)] has been made Obsessed by the midround ruleset.")
+	log_game("[key_name(obsessed)] was made Obsessed by the midround ruleset.")
 	return ..()
 
 /// Probability the AI going malf will be accompanied by an ion storm announcement and some ion laws.

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -1,10 +1,9 @@
 /datum/round_event_control/pirates
 	name = "Space Pirates"
 	typepath = /datum/round_event/pirates
-	weight = 8
+	weight = 10
 	max_occurrences = 1
-	min_players = 10
-	earliest_start = 30 MINUTES
+	min_players = 20
 	dynamic_should_hijack = TRUE
 
 #define PIRATES_ROGUES "Rogues"
@@ -14,81 +13,64 @@
 /datum/round_event_control/pirates/preRunEvent()
 	if (!SSmapping.empty_space)
 		return EVENT_CANT_RUN
-
 	return ..()
 
-/datum/round_event/pirates
-	startWhen = 60 //2 minutes to answer
-	var/datum/comm_message/threat
-	var/payoff = 0
-	var/payoff_min = 20000
-	var/paid_off = FALSE
-	var/pirate_type
-	var/ship_template
+/datum/round_event/pirates/start()
+	send_pirate_threat()
+
+/proc/send_pirate_threat()
+	var/pirate_type = pick(PIRATES_ROGUES, PIRATES_SILVERSCALES, PIRATES_DUTCHMAN)
+	var/ship_template = null
 	var/ship_name = "Space Privateers Association"
-	var/shuttle_spawned = FALSE
-
-/datum/round_event/pirates/setup()
-	pirate_type = pick(PIRATES_ROGUES, PIRATES_SILVERSCALES, PIRATES_DUTCHMAN)
-	switch(pirate_type)
-		if(PIRATES_ROGUES)
-			ship_name = pick(strings(PIRATE_NAMES_FILE, "rogue_names"))
-		if(PIRATES_SILVERSCALES)
-			ship_name = pick(strings(PIRATE_NAMES_FILE, "silverscale_names"))
-		if(PIRATES_DUTCHMAN)
-			ship_name = "Flying Dutchman"
-
-/datum/round_event/pirates/announce(fake)
+	var/payoff_min = 20000
+	var/payoff = 0
+	var/initial_send_time = world.time
+	var/response_max_time = 2 MINUTES
 	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
-	if(fake)
-		return
-	threat = new
+	var/datum/comm_message/threat = new
 	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	if(D)
 		payoff = max(payoff_min, FLOOR(D.account_balance * 0.80, 1000))
 	switch(pirate_type)
 		if(PIRATES_ROGUES)
+			ship_name = pick(strings(PIRATE_NAMES_FILE, "rogue_names"))
 			ship_template = /datum/map_template/shuttle/pirate/default
 			threat.title = "Sector protection offer"
 			threat.content = "Hey, pal, this is the [ship_name]. Can't help but notice you're rocking a wild and crazy shuttle there with NO INSURANCE! Crazy. What if something happened to it, huh?! We've done a quick evaluation on your rates in this sector and we're offering [payoff] to cover for your shuttle in case of any disaster."
 			threat.possible_answers = list("Purchase Insurance.","Reject Offer.")
 		if(PIRATES_SILVERSCALES)
+			ship_name = pick(strings(PIRATE_NAMES_FILE, "silverscale_names"))
 			ship_template = /datum/map_template/shuttle/pirate/silverscale
 			threat.title = "Tribute to high society"
 			threat.content = "This is the [ship_name]. The Silver Scales wish for some tribute from your plebeian lizards. [payoff] credits should do the trick."
 			threat.possible_answers = list("We'll pay.","Tribute? Really? Go away.")
 		if(PIRATES_DUTCHMAN)
+			ship_name = "Flying Dutchman"
 			ship_template = /datum/map_template/shuttle/pirate/dutchman
 			threat.title = "Business proposition"
 			threat.content = "Ahoy! This be the [ship_name]. Cough up [payoff] credits or you'll walk the plank."
 			threat.possible_answers = list("We'll pay.","We will not be extorted.")
-	threat.answer_callback = CALLBACK(src,.proc/answered)
+	threat.answer_callback = CALLBACK(GLOBAL_PROC, .proc/pirates_answered, threat, payoff, ship_name, initial_send_time, response_max_time, ship_template)
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/spawn_pirates, threat, ship_template, FALSE), response_max_time)
 	SScommunications.send_message(threat,unique = TRUE)
-
-/datum/round_event/pirates/proc/answered()
+	
+/proc/pirates_answered(datum/comm_message/threat, payoff, ship_name, initial_send_time, response_max_time, ship_template)
+	if(world.time > initial_send_time + response_max_time)
+		priority_announce("Too late to beg for mercy!",sender_override = ship_name)
+		return
 	if(threat && threat.answered == 1)
 		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
 		if(D)
 			if(D.adjust_money(-payoff))
 				priority_announce("Thanks for the credits, landlubbers.",sender_override = ship_name)
-				paid_off = TRUE
 				return
 			else
 				priority_announce("Trying to cheat us? You'll regret this!",sender_override = ship_name)
-	if(!shuttle_spawned)
-		spawn_shuttle()
-	else
-		priority_announce("Too late to beg for mercy!",sender_override = ship_name)
+				spawn_pirates(threat, ship_template, TRUE)
 
-/datum/round_event/pirates/start()
-	if(threat && !threat.answered)
-		threat.possible_answers = list("Too late")
-		threat.answered = 1
-	if(!paid_off && !shuttle_spawned)
-		spawn_shuttle()
-
-/datum/round_event/pirates/proc/spawn_shuttle()
-	shuttle_spawned = TRUE
+/proc/spawn_pirates(datum/comm_message/threat, ship_template, skip_answer_check)
+	if(!skip_answer_check && threat?.answered == 1)
+		return
 
 	var/list/candidates = pollGhostCandidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR)
 	shuffle_inplace(candidates)
@@ -110,9 +92,9 @@
 				var/mob/our_candidate = candidates[1]
 				spawner.create(our_candidate)
 				candidates -= our_candidate
-				announce_to_ghosts(our_candidate)
+				notify_ghosts("The pirate ship has an object of interest: [our_candidate]!", source=our_candidate, action=NOTIFY_ORBIT, header="Something's Interesting!")
 			else
-				announce_to_ghosts(spawner)
+				notify_ghosts("The pirate ship has an object of interest: [spawner]!", source=spawner, action=NOTIFY_ORBIT, header="Something's Interesting!")
 
 	priority_announce("Unidentified armed ship detected near the station.")
 


### PR DESCRIPTION
## About The Pull Request

This PR adds Revenant, Space Pirates, Sentient Disease, and Obsessed to dynamic's midround rulesets.  Seeing as they are the only midround antagonists missing, it is about time they got added to the roster.  Now the only one excluded is Slaughter Demon, and we can keep it that way.

And fugitives.  But some elbow work has to go in there before they're ready to go.

## Why It's Good For The Game

We need more variety in the midround rulesets to prevent constant repeats of the same midround antags, and they should have been here earlier, as there's no reason to exclude them from the dynamic ruleset selection.

## Changelog
:cl:
refactor: Revenant, Sentient Disease, Space Pirates, and Obsessed have been registered into dynamic mode.
/:cl: