### PR TITLE
Disables decals completely to see their impact on maptick when completely gone.

### DIFF
--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -45,4 +45,3 @@
 	var/turf/T = loc
 	if(!istype(T)) //you know this will happen somehow
 		CRASH("Turf decal initialized in an object/nullspace")
-	T.AddElement(/datum/element/decal, icon, icon_state, dir, null, null, alpha, color, null, FALSE, null)


### PR DESCRIPTION
![Discord_1XbP75R0qS](https://user-images.githubusercontent.com/4081722/126029740-988ed65d-654c-4fe4-b4bf-60a850fc326a.png)

I'm curious about this too so i figure we can give this a go as well since we're done with the super-decal test.