### PR TITLE
Adds a double click shortcut for loading equipment

### DIFF
--- a/tgui/packages/tgui/interfaces/SelectEquipment.js
+++ b/tgui/packages/tgui/interfaces/SelectEquipment.js
@@ -151,7 +151,12 @@ const OutfitDisplay = (props, context) => {
           content={entry.name}
           title={entry.path || entry.name}
           selected={getOutfitKey(entry) === current_outfit}
-          onClick={() => act('preview', { path: getOutfitKey(entry) })} />
+          onClick={() => act('preview', {
+            path: getOutfitKey(entry),
+          })}
+          onDblClick={() => act('applyoutfit', {
+            path: getOutfitKey(entry),
+          })} />
       ))}
       {currentTab === "Custom" && (
         <Button


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

You can now load equipment outright by double clicking the corresponding equipment button in the Select Equipment UI. Very useful if you do not care about preview or you just want to quickly switch between equipment sets. This also brings it closer to the old behavior before TGUI, where you could also quickly load equipment set directly by double clicking the corresponding entry in the input list.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Quality of life.

## Changelog
:cl: Arkatos
qol: You can now load equipment outright by double clicking the corresponding equipment button in the Select Equipment UI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
