### PR TITLE
Wizard gets bonus points if they go random.

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -877,3 +877,5 @@
 		if(entry.limit)
 			entry.limit--
 		uses -= entry.cost
+
+	can_refund = FALSE

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -78,6 +78,8 @@
 /datum/spellbook_entry/proc/CanRefund(mob/living/carbon/human/user,obj/item/spellbook/book)
 	if(!refundable)
 		return FALSE
+	if(!book.can_refund)
+		return FALSE
 	if(!S)
 		S = new spell_type()
 	for(var/obj/effect/proc_holder/spell/aspell in user.mind.spell_list)
@@ -660,7 +662,16 @@
 	throw_range = 5
 	w_class = WEIGHT_CLASS_TINY
 	var/uses = 10
-	var/temp = null
+
+	/// The bonus that you get from going semi-random.
+	var/semi_random_bonus = 2
+
+	/// The bonus that you get from going full random.
+	var/full_random_bonus = 5
+
+	/// Determines if this spellbook can refund anything.
+	var/can_refund = TRUE
+
 	var/mob/living/carbon/human/owner
 	var/list/entries = list()
 
@@ -689,6 +700,10 @@
 	. = ..()
 
 /obj/item/spellbook/attackby(obj/item/O, mob/user, params)
+	if(!can_refund)
+		to_chat(user, span_warning("You can't refund anything!"))
+		return
+
 	if(istype(O, /obj/item/antag_spawner/contract))
 		var/obj/item/antag_spawner/contract/contract = O
 		if(contract.used)
@@ -734,6 +749,8 @@
 	var/list/data = list()
 	data["owner"] = owner
 	data["points"] = uses
+	data["semi_random_bonus"] = initial(uses) + semi_random_bonus
+	data["full_random_bonus"] = initial(uses) + full_random_bonus
 	return data
 
 //This is a MASSIVE amount of data, please be careful if you remove it from static.
@@ -789,10 +806,10 @@
 		return
 	switch(action)
 		if("semirandomize")
-			semirandomize(wizard)
+			semirandomize(wizard, semi_random_bonus)
 			update_static_data(wizard) //update statics!
 		if("randomize")
-			randomize(wizard)
+			randomize(wizard, full_random_bonus)
 			update_static_data(wizard) //update statics!
 		else //some loadout
 			wizard_loadout(wizard, action)
@@ -829,7 +846,7 @@
 	if(uses)
 		stack_trace("Wizard Loadout \"[loadout]\" does not use 10 wizard spell slots. Stop scamming players out.")
 
-/obj/item/spellbook/proc/semirandomize(mob/living/carbon/human/wizard)
+/obj/item/spellbook/proc/semirandomize(mob/living/carbon/human/wizard, bonus_to_give = 0)
 	var/list/needed_cats = list("Offensive", "Mobility")
 	var/list/shuffled_entries = shuffle(entries)
 	for(var/i in 1 to 2)
@@ -845,15 +862,18 @@
 					uses -= entry.cost
 				break
 	//we have given two specific category spells to the wizard. the rest are completely random!
-	randomize(wizard)
+	randomize(wizard, bonus_to_give = bonus_to_give)
 
-/obj/item/spellbook/proc/randomize(mob/living/carbon/human/wizard)
+/obj/item/spellbook/proc/randomize(mob/living/carbon/human/wizard, bonus_to_give = 0)
 	var/list/entries_copy = entries.Copy()
-	while(uses > 0)
-		var/datum/spellbook_entry/entry = pick_n_take(entries_copy)
-		if(entry?.CanBuy(wizard,src))
-			if(entry.Buy(wizard,src))
-				entry.refundable = FALSE //once you go random, you never go back
-				if(entry.limit)
-					entry.limit--
-				uses -= entry.cost
+	uses += bonus_to_give
+	while(uses > 0 && length(entries_copy))
+		var/datum/spellbook_entry/entry = pick(entries_copy)
+		if(!entry?.CanBuy(wizard,src) || !entry.Buy(wizard,src))
+			entries_copy -= entry
+			continue
+
+		entry.refundable = FALSE //once you go random, you never go back
+		if(entry.limit)
+			entry.limit--
+		uses -= entry.cost

--- a/tgui/packages/tgui/interfaces/Spellbook.js
+++ b/tgui/packages/tgui/interfaces/Spellbook.js
@@ -309,7 +309,7 @@ const lineHeightRandomize = 6;
 
 const Randomize = (props, context) => {
   const { act, data } = useBackend(context);
-  const { points } = data;
+  const { points, semi_random_bonus, full_random_bonus } = data;
   return (
     <Stack fill vertical>
       {points < 10 && (
@@ -317,6 +317,7 @@ const Randomize = (props, context) => {
       )}
       <Stack.Item grow mt={10}>
         Semi-Randomize will ensure you at least get some mobility and lethality.
+        Guaranteed to have {semi_random_bonus} points worth of spells.
       </Stack.Item>
       <Stack.Item>
         <Button.Confirm
@@ -331,6 +332,7 @@ const Randomize = (props, context) => {
       </Stack.Item>
       <Stack.Item>
         Full Random will give you anything. There&apos;s no going back, either!
+        Guaranteed to have {full_random_bonus} points worth of spells.
       </Stack.Item>
       <Stack.Item>
         <NoticeBox danger>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Wizard gets bonus points if they go random.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Encourages players to go full random and enjoy the chaos of spells that they may get instead of choosing a meta. Gives an actual benefit to choosing random rather than "challenge", as if anyone on ss13 will try handicap themselves as a very rare antag  if such handicap doesn't give some sort of benefit.

## Changelog
:cl:
balance: Wizard gets bonus points for choosing the randomized options in their spellbook. They will get 15 points worth of spells if they choose "Full random" and they will get 12 points worth of spells if they choose "Semi random".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
