### PR TITLE
Fixes duffelbag curse and curse of hunger code in general.

### DIFF
--- a/code/datums/components/curse_of_hunger.dm
+++ b/code/datums/components/curse_of_hunger.dm
@@ -123,11 +123,13 @@
 	if(!poison_food_tolerance)
 		cursed.dropItemToGround(cursed_item, TRUE)
 		return
-	hunger++
-	if((hunger <= HUNGER_THRESHOLD_TRY_EATING) && prob(20))
+	hunger += delta_time
+	if((hunger <= HUNGER_THRESHOLD_TRY_EATING) || prob(80))
 		return
+
+	var/list/locations_to_check = (cursed.contents + cursed_item.contents)
 	//check hungry enough to eat something!
-	for(var/obj/item/food in cursed.contents)
+	for(var/obj/item/food in locations_to_check)
 		if(!IS_EDIBLE(food))
 			continue
 		food.forceMove(cursed.loc)

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -152,6 +152,8 @@
 						   span_danger("You feel something attaching itself to you, and a strong desire to discuss your [elaborate_backstory] at length!"))
 
 	ADD_TRAIT(duffelvictim, TRAIT_DUFFEL_CURSE_PROOF, CURSED_ITEM_TRAIT(conjuredduffel.name))
+	conjuredduffel.pickup(duffelvictim)
+	conjuredduffel.forceMove(duffelvictim)
 	if(duffelvictim.dropItemToGround(duffelvictim.back))
 		duffelvictim.equip_to_slot_if_possible(conjuredduffel, ITEM_SLOT_BACK, TRUE, TRUE)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Duffelbag curse code was clearly untested because it would eat you half the time when activated, and wouldn't active half the time.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed the duffelbag curse and curse of hunger code in general.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
