### PR TITLE
Change maintenance loot spawns to be invisible post-spawn

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -276,8 +276,7 @@
 	return ..()
 
 /obj/effect/spawner/lootdrop/maintenance/proc/hide()
-	invisibility = INVISIBILITY_OBSERVER
-	alpha = 100
+	invisibility = INVISIBILITY_ABSTRACT
 
 /obj/effect/spawner/lootdrop/maintenance/proc/get_effective_lootcount()
 	var/effective_lootcount = lootcount


### PR DESCRIPTION
A previous commit made maintenance loot spawn effects visibile to
observers, but transparent.

However, in practice this is a lot of visual noise for very little
benefit for observers, so after they've spawned, they disappear, akin to
the old behaviour.

(They are still there, just hidden, but it looks the same to the end
user.)