### PR TITLE
fixes ghosts not being included in get_hearers_in_view(), again!

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -20,6 +20,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	if(length(CONFIG_GET(keyed_list/cross_server)))
 		add_verb(src, /mob/dead/proc/server_hop)
 	set_focus(src)
+	become_hearing_sensitive()
 	return INITIALIZE_HINT_NORMAL
 
 /mob/dead/canUseStorage()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
thanks to shaps for reporting this
turns out mob/dead/Initialize() doesnt call parent, and mobs are made hearing sensitive in mob/Initialize(), so ghosts yet again werent included in get_hearers_in_view(). now they are! 
![Screenshot_1060](https://user-images.githubusercontent.com/15794172/126052651-e981c78c-4502-4386-830a-620d64aa3deb.png)
now actually tested this time by attacking pun pun then ghosting, on master the red attack text doesnt show for ghosts in view but now it does

with the first pr the issue was because when target was a mob, view() only includes what the mob can see, so i made it always use a turf like it was previously. but the refactor done in the same pr meant that ghosts didnt become hearing sensitive so whoops
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: NanoTrasen has realized that its previous theoretical fix for ghost ears didn't work, not that that's a problem since ghosts don't exist but NanoTrasen has fixed its mistake.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
