### PR TITLE
Revert "Only blend areas when it's actually needed"

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -165,8 +165,9 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 	. = ..()
 
+	blend_mode = BLEND_MULTIPLY // Putting this in the constructor so that it stops the icons being screwed up in the map editor.
+
 	if(!IS_DYNAMIC_LIGHTING(src))
-		blend_mode = BLEND_MULTIPLY
 		add_overlay(/obj/effect/fullbright)
 
 	reg_in_areas_in_z()

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -10,14 +10,12 @@
 
 	if (IS_DYNAMIC_LIGHTING(src))
 		cut_overlay(/obj/effect/fullbright)
-		blend_mode = BLEND_DEFAULT
 		for (var/turf/T in src)
 			if (IS_DYNAMIC_LIGHTING(T))
 				T.lighting_build_overlay()
 
 	else
 		add_overlay(/obj/effect/fullbright)
-		blend_mode = BLEND_MULTIPLY
 		for (var/turf/T in src)
 			if (T.lighting_object)
 				T.lighting_clear_overlay()


### PR DESCRIPTION
## About The Pull Request

Reverts #60237 because it broke area overlay machine. If you need examples, look at lavaland ash storms

## Why It's Good For The Game

Mining in ash storms even with ash-proof gear is impossible because you don't see shit, it's all just plain grey and we don't even know if it's the only thing that was broken because nobody cares enough to report