### PR TITLE
Adds fridges to exclusion turf of ant spawning.

### DIFF
--- a/code/datums/components/food/decomposition.dm
+++ b/code/datums/components/food/decomposition.dm
@@ -73,7 +73,7 @@
 	if(locate(/obj/machinery/conveyor) in get_turf(food)) // Makes sure no decals spawn on disposals conveyors
 		remove_timer()
 		return
-	if(locate(/obj/structure/closet) in get_turf(food))
+	if(locate(/obj/structure/closet/secure_closet/freezer) in get_turf(food)) // Ants get out of my fridge REEE. 
 		remove_timer()
 		return
 	// If all other checks fail, then begin decomposition.

--- a/code/datums/components/food/decomposition.dm
+++ b/code/datums/components/food/decomposition.dm
@@ -73,6 +73,9 @@
 	if(locate(/obj/machinery/conveyor) in get_turf(food)) // Makes sure no decals spawn on disposals conveyors
 		remove_timer()
 		return
+	if(locate(/obj/structure/closet) in get_turf(food))
+		remove_timer()
+		return
 	// If all other checks fail, then begin decomposition.
 	timerid = addtimer(CALLBACK(src, .proc/decompose), time_remaining, TIMER_STOPPABLE | TIMER_UNIQUE)
 


### PR DESCRIPTION
## About The Pull Request

With the logic of exclusions to ant spawns being elevated surfaces, seems that fridges were forgotten. This includes fridges in the exclusions. 

If enough people want I can make it an exclusion to ALL lockers instead of just fridges, looking at you botany gang.

## Why It's Good For The Game

Fridges being used to store food is common, realistically they will NEVER be touching the floor in a fridge, this fixes things so you can open up your fridge to show food without worrying about ants.

## Changelog
:cl:
fix: Fridges were forgotten in the ant PR
/:cl: