### PR TITLE
Malf humans, and perfectly functioning ais, round three.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -222,7 +222,8 @@
 		if(length(exclusive_roles))
 			var/exclusive_candidate = FALSE
 			for(var/role in exclusive_roles)
-				if((role in candidate_client.prefs.job_preferences) && !is_banned_from(candidate_player.ckey, role) && !job_is_xp_locked(candidate_player.ckey, role))
+				var/datum/job/job = SSjob.GetJob(role)
+				if((role in candidate_client.prefs.job_preferences) && !is_banned_from(candidate_player.ckey, role) && !job.required_playtime_remaining(candidate_client))
 					exclusive_candidate = TRUE
 					break
 


### PR DESCRIPTION
## About The Pull Request
Fixes mistake made in #59765, that fixed malf humans spawning by making it impossible for any malfunctioning ai to spawn.
That PR used wrong proc, so it always returned TRUE, so the code declined every player candidacy for the antag datum. I changed it for correct proc, and did some basic testing on it.

## Why It's Good For The Game

Lets one of antagonists spawn again

## Changelog
:cl: 
fix: A CABAL of syndicate hackers broke Nanotrasen protections, allowing malfunctions in AI to finally happen again
/:cl:
