### PR TITLE
Fixes an underlay movable lighting runtime

### DIFF
--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -330,7 +330,7 @@
 	range = clamp(CEILING(new_range, 0.5), 1, 6)
 	var/pixel_bounds = ((range - 1) * 64) + 32
 	lumcount_range = CEILING(range, 1)
-	if(overlay_lighting_flags & LIGHTING_ON)
+	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays -= visible_mask
 	visible_mask.icon = light_overlays["[pixel_bounds]"]
 	if(pixel_bounds == 32)
@@ -340,7 +340,7 @@
 	var/matrix/transform = new
 	transform.Translate(-offset, -offset)
 	visible_mask.transform = transform
-	if(overlay_lighting_flags & LIGHTING_ON)
+	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays += visible_mask
 	if(directional)
 		cast_range = clamp(round(new_range * 0.5), 1, 3)
@@ -354,17 +354,17 @@
 	var/new_power = source.light_power
 	set_lum_power(new_power >= 0 ? 0.5 : -0.5)
 	set_alpha = min(230, (abs(new_power) * 120) + 30)
-	if(overlay_lighting_flags & LIGHTING_ON)
+	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays -= visible_mask
 	visible_mask.alpha = set_alpha
-	if(overlay_lighting_flags & LIGHTING_ON)
+	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays += visible_mask
 	if(!directional)
 		return
-	if(overlay_lighting_flags & LIGHTING_ON)
+	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays -= cone
 	cone.alpha = min(200, (abs(new_power) * 90)+20)
-	if(overlay_lighting_flags & LIGHTING_ON)
+	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays += cone
 
 
@@ -372,17 +372,17 @@
 /datum/component/overlay_lighting/proc/set_color(atom/source, old_color)
 	SIGNAL_HANDLER
 	var/new_color = source.light_color
-	if(overlay_lighting_flags & LIGHTING_ON)
+	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays -= visible_mask
 	visible_mask.color = new_color
-	if(overlay_lighting_flags & LIGHTING_ON)
+	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays += visible_mask
 	if(!directional)
 		return
-	if(overlay_lighting_flags & LIGHTING_ON)
+	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays -= cone
 	cone.color = new_color
-	if(overlay_lighting_flags & LIGHTING_ON)
+	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays += cone
 
 


### PR DESCRIPTION
There's no guarantees that a `current_holder` will always exist.
Sometimes the light-emitting objects are away from view, either in nullspace or inside containers.