### PR TITLE
Fixes a null to_chat runtime

### DIFF
--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -85,7 +85,7 @@
 
 	quirk_holder.quirks -= src
 
-	if(!quirk_transfer)
+	if(!quirk_transfer && lose_text)
 		to_chat(quirk_holder, lose_text)
 
 	if(mob_trait)


### PR DESCRIPTION
Not every quirk has a loss text, and now we make null messages runtime.