### PR TITLE
QoL changes for launchpad usb connection and fixes it not working with null x/y offset inputs

### DIFF
--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -35,7 +35,7 @@
 
 /obj/item/circuit_component/bluespace_launchpad/Initialize()
 	. = ..()
-	launchpad_id = add_input_port("Launchpad ID", PORT_TYPE_NUMBER, FALSE)
+	launchpad_id = add_input_port("Launchpad ID", PORT_TYPE_NUMBER, FALSE, default = 1)
 	x_pos = add_input_port("X offset", PORT_TYPE_NUMBER, FALSE)
 	y_pos = add_input_port("Y offset", PORT_TYPE_NUMBER, FALSE)
 	send_trigger = add_input_port("Send", PORT_TYPE_SIGNAL)
@@ -86,27 +86,13 @@
 	if(isnull(the_pad))
 		return
 
-	var/x_dest = x_pos.input_value
-	if(isnull(x_dest))
-		return
-
-	var/y_dest = y_pos.input_value
-	if(isnull(y_dest))
-		return
-
-	if(x_dest > the_pad.range || y_dest > the_pad.range)
-		why_fail.set_output("Cannot go that far! Current maximum reach: [the_pad.range]")
-		on_fail.set_output(COMPONENT_SIGNAL)
-		return
-
 	var/checks = attached_console.teleport_checks(the_pad)
-
 	if(!isnull(checks))
 		why_fail.set_output(checks)
 		on_fail.set_output(COMPONENT_SIGNAL)
 		return
 
-	the_pad.set_offset(x_dest, y_dest)
+	the_pad.set_offset(x_pos.input_value, y_pos.input_value)
 
 	if(COMPONENT_TRIGGERED_BY(send_trigger, port))
 		the_pad.doteleport(null, TRUE, alternate_log_name = parent.get_creator())

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -91,14 +91,13 @@
 		on_fail.set_output(COMPONENT_SIGNAL)
 		return
 
-	var/current_launchpad = launchpad_id.input_value
-	if(isnull(current_launchpad) || current_launchpad < 1 || current_launchpad > length(attached_console.launchpads))
-		why_fail.set_output("Invalid launchpad selected!")
-		on_fail.set_output(COMPONENT_SIGNAL)
+	if(!launchpad_id.input_value)
 		return
 
-	var/obj/machinery/launchpad/the_pad = attached_console.launchpads[current_launchpad]
+	var/obj/machinery/launchpad/the_pad = KEYBYINDEX(attached_console.launchpads, launchpad_id.input_value)
 	if(isnull(the_pad))
+		why_fail.set_output("Invalid launchpad selected!")
+		on_fail.set_output(COMPONENT_SIGNAL)
 		return
 
 	the_pad.set_offset(x_pos.input_value, y_pos.input_value)

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -92,7 +92,9 @@
 		return
 
 	var/current_launchpad = launchpad_id.input_value
-	if(isnull(current_launchpad))
+	if(isnull(current_launchpad) || current_launchpad < 1 || current_launchpad > length(attached_console.launchpads))
+		why_fail.set_output("Invalid launchpad selected!")
+		on_fail.set_output(COMPONENT_SIGNAL)
 		return
 
 	var/obj/machinery/launchpad/the_pad = attached_console.launchpads[current_launchpad]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
See title.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
If null x/y offsets are passed, it won't update the telepad's x/y offsets.
This fixes a problem with the x/y offsets not being updated if 1 of the x/y offsets is null.

## Changelog
:cl:
fix: Fixed the launchpad usb connection not working with null x/y offset inputs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
