### PR TITLE
Revert "makes it so classic baton can stamcrit again"

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -197,7 +197,7 @@
 	/// Can we stun cyborgs?
 	var/affect_cyborg = FALSE
 	/// "On" sound, played when switching between able to stun or not.
-	var/on_sound
+	var/on_sound 
 	/// The path of the default sound to play when we stun something.
 	var/on_stun_sound = 'sound/effects/woodhit.ogg'
 	/// Do we animate the "hit" when stunning something?
@@ -332,7 +332,7 @@
 			playsound(get_turf(src), 'sound/effects/bang.ogg', 10, TRUE) //bonk
 	else
 		target.Knockdown(knockdown_time)
-		target.apply_damage(stamina_damage, STAMINA)
+		target.apply_damage(stamina_damage, STAMINA, BODY_ZONE_CHEST)
 		additional_effects_non_cyborg(target, user)
 
 		playsound(get_turf(src), on_stun_sound, 75, TRUE, -1)

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -197,7 +197,7 @@
 	/// Can we stun cyborgs?
 	var/affect_cyborg = FALSE
 	/// "On" sound, played when switching between able to stun or not.
-	var/on_sound 
+	var/on_sound
 	/// The path of the default sound to play when we stun something.
 	var/on_stun_sound = 'sound/effects/woodhit.ogg'
 	/// Do we animate the "hit" when stunning something?


### PR DESCRIPTION
PR that's being reverted: https://github.com/tgstation/tgstation/pull/60321

![image](https://user-images.githubusercontent.com/42606352/126408317-39197c53-b26a-40de-8ff3-0c103b154d4a.png)
![image](https://user-images.githubusercontent.com/42606352/126408337-c4cc27af-9284-4729-a597-1c179bce50b2.png)
![image](https://user-images.githubusercontent.com/42606352/126408366-6c986f9e-041a-47f1-af98-52ea163f764b.png)

If Seris02 would like to defend and/or explain their change in the comments, they can feel free to. Sadly, they're not in /tg/cord, from what I can tell, so I couldn't contact them before making this PR.

## Changelog
:cl: ATHATH
fix: Classic batons (and their subtypes) no longer spread their stamina damage across multiple body parts.
/:cl: