### PR TITLE
Changed Kilostation's Solars

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -56170,6 +56170,9 @@
 /obj/item/solar_assembly,
 /obj/item/stack/sheet/glass/fifty,
 /obj/structure/closet/crate/engineering/electrical,
+/obj/structure/sign/warning/xeno_mining{
+	pixel_x = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "jPk" = (
@@ -87131,7 +87134,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/computer/shuttle/mining/common,
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "wZx" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -12530,7 +12530,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box,
-/obj/machinery/defibrillator_mount/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "aPH" = (
@@ -17176,9 +17175,6 @@
 "bbK" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
-	pixel_x = -22
-	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bbL" = (
@@ -37019,11 +37015,6 @@
 	},
 /area/maintenance/port/aft)
 "cxk" = (
-/obj/machinery/power/solar_control{
-	dir = 4;
-	id = "aftport";
-	name = "Port Quarter Solar Control"
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -37033,6 +37024,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/structure/frame/computer{
+	anchored = 1;
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -42000,7 +41995,12 @@
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "dxK" = (
-/turf/closed/wall,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cmoprivacy";
+	name = "Office Privacy Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/command/heads_quarters/cmo)
 "dyi" = (
 /obj/effect/landmark/start/bartender,
@@ -43364,6 +43364,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"ehM" = (
+/mob/living/simple_animal/hostile/carp{
+	environment_smash = 0
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/space/nearstation)
 "eih" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -56138,19 +56144,26 @@
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
 "jPh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/xeno_mining{
-	pixel_x = 32
-	},
 /obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/closet/crate/engineering/electrical,
+/turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "jPk" = (
 /obj/structure/table/glass,
@@ -65808,6 +65821,9 @@
 /area/service/chapel/office)
 "nXj" = (
 /obj/machinery/atmospherics/components/binary/valve,
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
+	pixel_y = 26
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -70882,7 +70898,9 @@
 /area/cargo/miningoffice)
 "pZk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/electrolyzer,
+/obj/structure/table,
+/obj/item/extinguisher/mini,
+/obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "pZn" = (
@@ -74156,6 +74174,11 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/hallway/primary/port)
+"rtX" = (
+/obj/effect/turf_decal/box,
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel/airless,
+/area/solars/starboard/aft)
 "rtZ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -79413,6 +79436,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"tMV" = (
+/obj/item/circuitboard/computer/solar_control,
+/turf/open/floor/plating/asteroid/airless,
+/area/space/nearstation)
 "tNa" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
@@ -87077,23 +87104,22 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "wYW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable,
 /obj/machinery/computer/shuttle/mining/common,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "wZx" = (
@@ -104315,7 +104341,7 @@ aeu
 aeU
 aeU
 coy
-aeU
+ehM
 aDS
 nBm
 bFI
@@ -104384,7 +104410,7 @@ cmU
 aeU
 aeU
 aeU
-aeU
+tMV
 aDS
 vOE
 bFI
@@ -109209,7 +109235,7 @@ avB
 aWm
 eqk
 eWO
-dxK
+eWO
 eWO
 dxK
 eWO
@@ -131898,10 +131924,10 @@ aeu
 aUz
 cmU
 nRr
-nRr
-nRr
-nRr
-nRr
+rtX
+rtX
+rtX
+rtX
 kuv
 nRr
 nRr
@@ -132413,15 +132439,15 @@ aeU
 cmU
 nRr
 nRr
-nRr
-nRr
-nRr
+rtX
+rtX
+rtX
 kuv
 nRr
 nRr
 nRr
-nRr
-nRr
+rtX
+rtX
 acm
 aeo
 acm
@@ -132926,7 +132952,7 @@ aeU
 cmU
 nRr
 nRr
-nRr
+rtX
 nRr
 nRr
 xOh
@@ -133442,12 +133468,12 @@ nRr
 nRr
 nRr
 nRr
-nRr
+rtX
 xOh
 kuv
 xOh
-nRr
-nRr
+rtX
+rtX
 nRr
 nRr
 nRr
@@ -133959,9 +133985,9 @@ nRr
 nRr
 nRr
 kuv
-nRr
-nRr
-nRr
+rtX
+rtX
+rtX
 nRr
 nRr
 acm

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -43366,7 +43366,9 @@
 /area/security/prison)
 "ehM" = (
 /mob/living/simple_animal/hostile/carp{
-	environment_smash = 0
+	environment_smash = 0;
+	name = "Tuna";
+	real_name = "Tuna"
 	},
 /turf/open/floor/plating/asteroid/airless,
 /area/space/nearstation)
@@ -50070,6 +50072,11 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"heK" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/item/stack/sheet/glass,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "hfo" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -82583,6 +82590,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"vcT" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/sheet/glass,
+/turf/open/space/basic,
+/area/solars/port/aft)
 "vdd" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/hangover,
@@ -102350,7 +102362,7 @@ tnI
 oUy
 aau
 aeU
-cmU
+heK
 jOe
 jOe
 jOe
@@ -102866,7 +102878,7 @@ asO
 cmU
 cmU
 foo
-foo
+vcT
 foo
 foo
 foo
@@ -104410,7 +104422,7 @@ cmU
 aeU
 aeU
 aeU
-tMV
+aeU
 aDS
 vOE
 bFI
@@ -104666,7 +104678,7 @@ acK
 cmU
 aeU
 aUz
-aeU
+tMV
 aeU
 cnS
 cuU

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -12530,6 +12530,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box,
+/obj/machinery/defibrillator_mount/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/exam_room)
 "aPH" = (
@@ -41995,12 +41996,7 @@
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "dxK" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cmoprivacy";
-	name = "Office Privacy Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/command/heads_quarters/cmo)
 "dyi" = (
 /obj/effect/landmark/start/bartender,
@@ -56173,6 +56169,12 @@
 /obj/structure/sign/warning/xeno_mining{
 	pixel_x = 32
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "jPk" = (
@@ -71083,6 +71085,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
+"qeN" = (
+/obj/structure/sign/warning/securearea,
+/obj/structure/sign/warning/xeno_mining{
+	pixel_x = 32
+	},
+/turf/closed/wall,
+/area/engineering/gravity_generator)
 "qeS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -109249,7 +109258,7 @@ avB
 aWm
 eqk
 eWO
-eWO
+dxK
 eWO
 dxK
 eWO
@@ -128596,7 +128605,7 @@ lsw
 lsw
 dtq
 xyp
-qSF
+qeN
 lsw
 bOb
 cFs

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -17176,6 +17176,9 @@
 "bbK" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
+	pixel_x = -22
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bbL" = (
@@ -65833,9 +65836,6 @@
 /area/service/chapel/office)
 "nXj" = (
 /obj/machinery/atmospherics/components/binary/valve,
-/obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
-	pixel_y = 26
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -70910,9 +70910,7 @@
 /area/cargo/miningoffice)
 "pZk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/extinguisher/mini,
-/obj/item/storage/toolbox/emergency,
+/obj/machinery/electrolyzer,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "pZn" = (
@@ -71085,13 +71083,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen)
-"qeN" = (
-/obj/structure/sign/warning/securearea,
-/obj/structure/sign/warning/xeno_mining{
-	pixel_x = 32
-	},
-/turf/closed/wall,
-/area/engineering/gravity_generator)
 "qeS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -87131,7 +87122,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -87143,6 +87133,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/computer/shuttle/mining/common,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "wZx" = (
@@ -128605,7 +128598,7 @@ lsw
 lsw
 dtq
 xyp
-qeN
+qSF
 lsw
 bOb
 cFs


### PR DESCRIPTION
## About The Pull Request

Changed Kilostation's solars to be more like Meta's. This will hopefully make wiring the solars more interesting and less monotonous as it's not just putting wire in a straight line down, in addition to each solar doing a different thing.

Medbay's solar now starts with a Space Carp that cannot destroy stuff.
Security's solar now doesn't have a solar computer, instead having an empty computer frame and the circuitboard nearby. There is also 2 glass nearby as well.
Engineering's solar now starts partially built, with a box with assembly and glass nearby.
Science's solars weren't changed.

:cl:
expansion: Kilostation Medbay's solar now starts with a Space Carp that cannot destroy stuff.
expansion: Kilostation Security's solar now doesn't have a solar computer, instead having an empty computer frame and the circuitboard nearby. There is also 2 glass nearby as well.
expansion: Kilostation Engineering's solar now starts partially built, with a box with assembly and glass nearby.
/:cl:
