### PR TITLE
Reduces the cooldown of Mansus Link from 30 seconds to 6 seconds

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -539,7 +539,7 @@
 	name = "Mansus Link"
 	desc = "Piercing through reality, connecting minds. This spell allows you to add people to a Mansus Net, allowing them to communicate with each other from afar."
 	school = SCHOOL_FORBIDDEN
-	charge_max = 300
+	charge_max = 6 SECONDS
 	clothes_req = FALSE
 	invocation = "PI'RC' TH' M'ND"
 	invocation_type = "whisper"


### PR DESCRIPTION
## About The Pull Request

See the title.

## Why It's Good For The Game

Mansus Link is the spell that raw prophets use to add creatures to their telepathic network. It requires a 6 second do_after() to complete, yet has a cooldown of 30 seconds. Raw prophets of the same heretic do NOT share the same telepathic network, so a heretic can't simply make more raw prophets to reduce the amount of time that a new heretic monster has to spend for Mansus Link to come off of cooldown. This results in Mansus Link largely failing to fulfill its purpose.

An alternative solution would be to make it so that if a raw prophet links another raw prophet into their mansus network, the two networks merge into one network. That's beyond my current coding ability, though, since the code for mansus networks is (fittingly) an eldritch abomination.

## Changelog
:cl: ATHATH
qol: The cooldown of the Mansus Link spell (the spell that raw prophets use to add creatures to their telepathic network) has been reduced from 30 seconds to 6 seconds.
/:cl: