### PR TITLE
Add support for GAGS to design asset list generation

### DIFF
--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -377,9 +377,15 @@
 				if (machine)
 					item = machine
 
-			icon_file = initial(item.icon)
-			icon_state = initial(item.icon_state)
+			// Check for GAGS support where necessary
+			var/greyscale_config = initial(item.greyscale_config)
+			var/greyscale_colors = initial(item.greyscale_colors)
+			if (greyscale_config && greyscale_colors)
+				icon_file = SSgreyscale.GetColoredIconByType(greyscale_config, greyscale_colors)
+			else
+				icon_file = initial(item.icon)
 
+			icon_state = initial(item.icon_state)
 			if(!(icon_state in icon_states(icon_file)))
 				warning("design [D] with icon '[icon_file]' missing state '[icon_state]'")
 				continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds support for greyscale icons to be used in asset list generation for designs.

Closes #60365.

![2021-07-21_14-22-49](https://user-images.githubusercontent.com/10467687/126532980-79bfeaab-a057-4d11-80f9-5a593b802903.png)
![2021-07-21_14-22-58](https://user-images.githubusercontent.com/10467687/126532988-b3fc572f-df87-4d43-8ebc-f2f8396b6994.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Resolves the following warning, and ensures that icons are generated for janicart upgrades on the R&D console.
```
## WARNING: design /datum/design/buffer_upgrade with icon 'icons/obj/items_and_weapons.dmi' missing state 'janicart_upgrade'
## WARNING: design /datum/design/vacuum_upgrade with icon 'icons/obj/items_and_weapons.dmi' missing state 'janicart_upgrade'
```


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Research consoles now correctly show GAGS-ified icons properly. No more missing janicart upgrades!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
