### PR TITLE
Fixes malfunctioning borgs not defending against emag

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -335,7 +335,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	to_chat(user, span_notice("You emag [src]'s interface."))
 	emag_cooldown = world.time + 100
 
-	if(connected_ai && connected_ai.mind && connected_ai.mind.has_antag_datum(/datum/antagonist/traitor))
+	if(connected_ai && connected_ai.mind && connected_ai.mind.has_antag_datum(/datum/antagonist/malf_ai))
 		to_chat(src, span_danger("ALERT: Foreign software execution prevented."))
 		logevent("ALERT: Foreign software execution prevented.")
 		to_chat(connected_ai, span_danger("ALERT: Cyborg unit \[[src]\] successfully defended against subversion."))


### PR DESCRIPTION

## About The Pull Request
Changes the antag datum that cyborgs check to protect from malf. Artifact of malf ai split that resulted in malf borgs being emagable, which is a simple recipe that can break rounds.

## Why It's Good For The Game

Fixes broken mechanic. Stops emag from giving out all malf secrets.

## Changelog
:cl:
fix: Syndicate hackers outsmarted another group of syndicate hackers, and updated defensive protocols of cyborgs slaved to malfunctioning ais, once again letting them defend against emags
/:cl:

