### PR TITLE
New player panel shows the selected char name

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -50,7 +50,8 @@
 
 	var/datum/asset/asset_datum = get_asset_datum(/datum/asset/simple/lobby)
 	asset_datum.send(client)
-	var/list/output = list("<center><p><a href='byond://?src=[REF(src)];show_preferences=1'>Setup Character</a></p>")
+	var/list/output = list("<center><p>Welcome, <b>[client ? client.prefs.real_name : "Unknown User"]</b></p>")
+	output += "<center><p><a href='byond://?src=[REF(src)];show_preferences=1'>Setup Character</a></p>"
 
 	if(SSticker.current_state <= GAME_STATE_PREGAME)
 		switch(ready)


### PR DESCRIPTION
Sometimes we switch characters and forget.
This is a helpful reminder before joining the game with the wrong character/job, if we care about that kind of thing.

## Changelog
:cl:
qol: New player panel now shows the selected character name.
/:cl: