### PR TITLE
makes the tram more powerful than you can ever imagine

### DIFF
--- a/code/controllers/subsystem/processing/tramprocess.dm
+++ b/code/controllers/subsystem/processing/tramprocess.dm
@@ -2,4 +2,5 @@ PROCESSING_SUBSYSTEM_DEF(tramprocess)
 	name = "Tram Process"
 	wait = 1
 	/// only used on maps with trams, so only enabled by such.
+	flags = SS_TICKER
 	can_fire = FALSE

--- a/code/controllers/subsystem/processing/tramprocess.dm
+++ b/code/controllers/subsystem/processing/tramprocess.dm
@@ -1,6 +1,6 @@
 PROCESSING_SUBSYSTEM_DEF(tramprocess)
 	name = "Tram Process"
 	wait = 1
-	/// only used on maps with trams, so only enabled by such.
 	flags = SS_TICKER
+	// only used on maps with trams, so only enabled by such.
 	can_fire = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
tram is TOO WEAK, this pr STRENGTHENS IT. it now fires every tick instead of every decisecond, making it twice as fast and actually useful for getting around tramstation
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
tram is fucking RUNNING speed currently, now theres a reason to use it
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: tram is now twice as fast, pray it doesnt get faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
