### PR TITLE
fix filtering clown/mime plasmaman air

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -48,9 +48,9 @@
 	has_filter = TRUE
 	return TRUE
 
-/obj/item/clothing/mask/gas/crowbar_act(mob/living/user, obj/item/tool)
+/obj/item/clothing/mask/gas/attackby_secondary(obj/item/weapon, mob/user, params)
 	if(!has_filter || !max_filters)
-		return
+		return ..()
 	for(var/i in 1 to max_filters)
 		var/obj/item/gas_filter/filter = locate() in src
 		if(!filter)

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -14,10 +14,12 @@
 	var/max_filters = 1
 	///List to keep track of each filter
 	var/list/gas_filters
+	///Is the filter allowed to spawn from the start?
+	var/starting_filter = TRUE
 
 /obj/item/clothing/mask/gas/Initialize()
 	. = ..()
-	if(!max_filters)
+	if(!max_filters || !starting_filter)
 		return
 	for(var/i in 1 to max_filters)
 		var/obj/item/gas_filter/filter = new(src)
@@ -35,16 +37,28 @@
 	if(LAZYLEN(gas_filters) > 0)
 		. += "<span class='notice'>Currently there [LAZYLEN(gas_filters) == 1 ? "is" : "are"] [LAZYLEN(gas_filters)] filter\s with [get_filter_durability()]% durability.</span>"
 
-/obj/item/clothing/mask/gas/attackby(obj/item/filter, mob/user)
-	if(!istype(filter, /obj/item/gas_filter))
+/obj/item/clothing/mask/gas/attackby(obj/item/tool, mob/user)
+	if(!istype(tool, /obj/item/gas_filter))
 		return ..()
 	if(LAZYLEN(gas_filters) >= max_filters)
 		return ..()
-	if(!user.transferItemToLoc(filter, src))
+	if(!user.transferItemToLoc(tool, src))
 		return ..()
-	LAZYADD(gas_filters, filter)
+	LAZYADD(gas_filters, tool)
 	has_filter = TRUE
 	return TRUE
+
+/obj/item/clothing/mask/gas/crowbar_act(mob/living/user, obj/item/tool)
+	if(!has_filter || !max_filters)
+		return
+	for(var/i in 1 to max_filters)
+		var/obj/item/gas_filter/filter = locate() in src
+		if(!filter)
+			continue
+		user.transferItemToLoc(filter, user.loc)
+		LAZYREMOVE(gas_filters, filter)
+	if(LAZYLEN(gas_filters) <= 0)
+		has_filter = FALSE
 
 ///Check _masks.dm for this one
 /obj/item/clothing/mask/gas/consume_filter(datum/gas_mixture/breath)
@@ -145,6 +159,7 @@
 	actions_types = list(/datum/action/item_action/adjust)
 	dog_fashion = /datum/dog_fashion/head/clown
 	species_exception = list(/datum/species/golem/bananium)
+	starting_filter = FALSE
 	var/list/clownmask_designs = list()
 
 /obj/item/clothing/mask/gas/clown_hat/Initialize(mapload)
@@ -189,6 +204,7 @@
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
 	species_exception = list(/datum/species/golem/bananium)
+	starting_filter = FALSE
 
 /obj/item/clothing/mask/gas/mime
 	name = "mime mask"
@@ -201,6 +217,7 @@
 	resistance_flags = FLAMMABLE
 	actions_types = list(/datum/action/item_action/adjust)
 	species_exception = list(/datum/species/golem)
+	starting_filter = FALSE
 	var/list/mimemask_designs = list()
 
 /obj/item/clothing/mask/gas/mime/Initialize(mapload)
@@ -251,6 +268,7 @@
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
 	species_exception = list(/datum/species/golem)
+	starting_filter = FALSE
 
 /obj/item/clothing/mask/gas/cyborg
 	name = "cyborg visor"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -15,15 +15,20 @@
 	///List to keep track of each filter
 	var/list/gas_filters
 	///Is the filter allowed to spawn from the start?
-	var/starting_filter = TRUE
+	var/plasmaman_type = FALSE
 
 /obj/item/clothing/mask/gas/Initialize()
 	. = ..()
-	if(!max_filters || !starting_filter)
+	if(!max_filters)
 		return
+
+	var/filter_type = /obj/item/gas_filter
+	if(plasmaman_type)
+		filter_type = /obj/item/gas_filter/plasmaman
+
 	for(var/i in 1 to max_filters)
-		var/obj/item/gas_filter/filter = new(src)
-		LAZYADD(gas_filters, filter)
+		new filter_type(src)
+		LAZYADD(gas_filters, filter_type)
 	has_filter = TRUE
 
 /obj/item/clothing/mask/gas/Destroy()
@@ -159,8 +164,10 @@
 	actions_types = list(/datum/action/item_action/adjust)
 	dog_fashion = /datum/dog_fashion/head/clown
 	species_exception = list(/datum/species/golem/bananium)
-	starting_filter = FALSE
 	var/list/clownmask_designs = list()
+
+/obj/item/clothing/mask/gas/clown_hat/plasmaman
+	plasmaman_type = TRUE
 
 /obj/item/clothing/mask/gas/clown_hat/Initialize(mapload)
 	.=..()
@@ -204,7 +211,6 @@
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
 	species_exception = list(/datum/species/golem/bananium)
-	starting_filter = FALSE
 
 /obj/item/clothing/mask/gas/mime
 	name = "mime mask"
@@ -217,8 +223,10 @@
 	resistance_flags = FLAMMABLE
 	actions_types = list(/datum/action/item_action/adjust)
 	species_exception = list(/datum/species/golem)
-	starting_filter = FALSE
 	var/list/mimemask_designs = list()
+
+/obj/item/clothing/mask/gas/mime/plasmaman
+	plasmaman_type = TRUE
 
 /obj/item/clothing/mask/gas/mime/Initialize(mapload)
 	.=..()
@@ -268,7 +276,6 @@
 	flags_cover = MASKCOVERSEYES
 	resistance_flags = FLAMMABLE
 	species_exception = list(/datum/species/golem)
-	starting_filter = FALSE
 
 /obj/item/clothing/mask/gas/cyborg
 	name = "cyborg visor"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -15,20 +15,16 @@
 	///List to keep track of each filter
 	var/list/gas_filters
 	///Is the filter allowed to spawn from the start?
-	var/plasmaman_type = FALSE
+	var/starting_filter_type = /obj/item/gas_filter
 
 /obj/item/clothing/mask/gas/Initialize()
 	. = ..()
 	if(!max_filters)
 		return
 
-	var/filter_type = /obj/item/gas_filter
-	if(plasmaman_type)
-		filter_type = /obj/item/gas_filter/plasmaman
-
 	for(var/i in 1 to max_filters)
-		new filter_type(src)
-		LAZYADD(gas_filters, filter_type)
+		new starting_filter_type(src)
+		LAZYADD(gas_filters, starting_filter_type)
 	has_filter = TRUE
 
 /obj/item/clothing/mask/gas/Destroy()
@@ -167,7 +163,7 @@
 	var/list/clownmask_designs = list()
 
 /obj/item/clothing/mask/gas/clown_hat/plasmaman
-	plasmaman_type = TRUE
+	starting_filter_type = /obj/item/gas_filter/plasmaman
 
 /obj/item/clothing/mask/gas/clown_hat/Initialize(mapload)
 	.=..()
@@ -226,7 +222,7 @@
 	var/list/mimemask_designs = list()
 
 /obj/item/clothing/mask/gas/mime/plasmaman
-	plasmaman_type = TRUE
+	starting_filter_type = /obj/item/gas_filter/plasmaman
 
 /obj/item/clothing/mask/gas/mime/Initialize(mapload)
 	.=..()

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -14,17 +14,17 @@
 	var/max_filters = 1
 	///List to keep track of each filter
 	var/list/gas_filters
-	///Is the filter allowed to spawn from the start?
+	///Type of filter that spawns on roundstart
 	var/starting_filter_type = /obj/item/gas_filter
 
 /obj/item/clothing/mask/gas/Initialize()
 	. = ..()
-	if(!max_filters)
+	if(!max_filters || !starting_filter_type)
 		return
 
 	for(var/i in 1 to max_filters)
-		new starting_filter_type(src)
-		LAZYADD(gas_filters, starting_filter_type)
+		var/obj/item/gas_filter/inserted_filter = new starting_filter_type(src)
+		LAZYADD(gas_filters, inserted_filter)
 	has_filter = TRUE
 
 /obj/item/clothing/mask/gas/Destroy()

--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -167,7 +167,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/mime
 	gloves = /obj/item/clothing/gloves/color/plasmaman/white
 	head = /obj/item/clothing/head/helmet/space/plasmaman/mime
-	mask = /obj/item/clothing/mask/gas/mime
+	mask = /obj/item/clothing/mask/gas/mime/plasmaman
 
 /datum/outfit/plasmaman/clown
 	name = "Clown Plasmaman"
@@ -175,7 +175,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/clown
 	gloves = /obj/item/clothing/gloves/color/plasmaman/clown
 	head = /obj/item/clothing/head/helmet/space/plasmaman/clown
-	mask = /obj/item/clothing/mask/gas/clown_hat
+	mask = /obj/item/clothing/mask/gas/clown_hat/plasmaman
 
 /datum/outfit/plasmaman/captain
 	name = "Captain Plasmaman"
@@ -269,4 +269,4 @@
 	uniform = /obj/item/clothing/under/plasmaman/clown
 	gloves = /obj/item/clothing/gloves/color/plasmaman/clown
 	head = /obj/item/clothing/head/helmet/space/plasmaman/clown
-	mask = /obj/item/clothing/mask/gas/clown_hat
+	mask = /obj/item/clothing/mask/gas/clown_hat/plasmaman


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix an issue where a plasmaman mime/clown would just die due to the mask they are wearing having a filter.
clown and mime masks no longer have filters from the start but a filter can be applied later
qol: filters can be removed with rightclick
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fix issue with clown/mime plasmamans and allow filters to be removed
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed issue where plasmaman clown and mime would die to the filtered plasma, clown and mime masks no longer have filters roundstart
qol: filters can be removed with rclick
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
