### PR TITLE
Fixes area zones in icebox circuit lab

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -17948,7 +17948,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/maintenance/starboard/aft)
+/area/science/misc_lab)
 "chH" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -26015,7 +26015,7 @@
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
-/area/maintenance/starboard/aft)
+/area/science/misc_lab)
 "gaT" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -52738,7 +52738,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/maintenance/starboard/aft)
+/area/science/misc_lab)
 "vdE" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -57234,7 +57234,7 @@
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/maintenance/starboard/aft)
+/area/science/misc_lab)
 "xGS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/directional/west,
@@ -104039,7 +104039,7 @@ tJy
 uWL
 hFE
 gaD
-mtK
+bQZ
 bTC
 uTB
 cmo
@@ -104296,7 +104296,7 @@ dov
 wgT
 dov
 chC
-mtK
+bQZ
 mIV
 iLm
 iLm
@@ -104809,8 +104809,8 @@ iGi
 xWW
 jpx
 rbd
-cNW
-mtK
+bPN
+bQZ
 qUz
 cNW
 cNW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> The Icebox circuit lab has a few tiles near the door that are considered part of Aft Starboard Maintenance. This doesn't have very big impacts on gameplay but it does cause there to be a weird shielded area in the circuit lab during radstorms.

Before 
![before](https://user-images.githubusercontent.com/74441292/126699001-9d566e62-74ba-42ed-80c2-a09deacddb7f.png)

After
![after](https://user-images.githubusercontent.com/74441292/126699049-c8747766-d38a-4571-ac2c-3ce21083afc7.png)


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> It looks weird to have randomly shielded tiles outside of maintenance during rad storms.


## Changelog
:cl:

fix: There are no longer maintenance zone tiles inside the circuits lab on icebox.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
