### PR TITLE
Add all antagonists to Orbit menu for admins

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -57,6 +57,10 @@
 	var/list/misc = list()
 	var/list/npcs = list()
 
+	var/antagonist_vision = FALSE
+	if(user.client && check_rights_for(user.client, R_ADMIN))
+		antagonist_vision = TRUE
+
 	var/list/pois = getpois(skip_mindless = TRUE, specify_dead_role = FALSE)
 	for (var/name in pois)
 		var/list/serialized = list()
@@ -87,7 +91,7 @@
 
 				for (var/_A in mind.antag_datums)
 					var/datum/antagonist/A = _A
-					if (A.show_to_ghosts)
+					if (antagonist_vision || A.show_to_ghosts)
 						was_antagonist = TRUE
 						serialized["antag"] = A.name
 						antagonists += list(serialized)
@@ -104,6 +108,7 @@
 	data["ghosts"] = ghosts
 	data["misc"] = misc
 	data["npcs"] = npcs
+	data["all_antagonists"] = antagonist_vision
 	return data
 
 /datum/orbit_menu/ui_assets()

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -87,6 +87,7 @@ export const Orbit = (props, context) => {
     ghosts,
     misc,
     npcs,
+    all_antagonists,
   } = data;
 
   const [searchText, setSearchText] = useLocalState(context, "searchText", "");
@@ -103,6 +104,9 @@ export const Orbit = (props, context) => {
   sortedAntagonists.sort((a, b) => {
     return compareString(a[0], b[0]);
   });
+
+
+  let antagonists_title = all_antagonists ? "All Antagonists" : "Ghost-Visible Antagonists"
 
   const orbitMostRelevant = searchText => {
     for (const source of [
@@ -165,7 +169,7 @@ export const Orbit = (props, context) => {
           </Flex>
         </Section>
         {antagonists.length > 0 && (
-          <Section title="Ghost-Visible Antagonists">
+          <Section title={`${antagonists_title}`}>
             {sortedAntagonists.map(([name, antags]) => (
               <Section key={name} title={name} level={2}>
                 {antags


### PR DESCRIPTION
:cl: coiax
admin: Admins can now see all antagonists on the Orbit menu, not just
ones that are ghost visible.
/:cl:

They already have access to the Check Antagonists verb, so this gives
them a nicer UI to access the same information as before.