### PR TITLE
Spraycans actually empty if used below 2 units while colouring lights.

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -766,7 +766,7 @@
 
 			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 			SEND_SIGNAL(target, COMSIG_OBJ_PAINTED, color_is_dark)
-		. = use_charges(user, 2, FALSE)
+		. = use_charges(user, 2, requires_full = FALSE)
 		reagents.trans_to(target, ., volume_multiplier, transfered_by = user, methods = VAPOR)
 
 		if(pre_noise || post_noise)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -766,7 +766,7 @@
 
 			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 			SEND_SIGNAL(target, COMSIG_OBJ_PAINTED, color_is_dark)
-		. = use_charges(user, 2)
+		. = use_charges(user, 2, FALSE)
 		reagents.trans_to(target, ., volume_multiplier, transfered_by = user, methods = VAPOR)
 
 		if(pre_noise || post_noise)


### PR DESCRIPTION
## About The Pull Request

Closes #49389

Adds a flag to let the spraycan fully empty instead of skipping that step and lighting you paint a light anyways.

## Why It's Good For The Game

You should probably need more than one spraycan to paint every light on the station.

## Changelog
:cl: Domitius
fix: One spraycan can no longer colour every light on the station.
/:cl:
