### PR TITLE
Fixes bugs with silicons being pushable when anchored/combat mode

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -175,10 +175,10 @@
 		var/mob/living/carbon/human/human = M
 		if(human.combat_mode)
 			return TRUE
-	//if they are a cyborg, and they're not in help intent, block pushing
+	//if they are a cyborg, and they're alive and in combat mode, block pushing
 	if(iscyborg(M))
 		var/mob/living/silicon/robot/borg = M
-		if(borg.combat_mode)
+		if(borg.combat_mode && borg.stat != DEAD)
 			return TRUE
 	//anti-riot equipment is also anti-push
 	for(var/obj/item/I in M.held_items)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -175,6 +175,11 @@
 		var/mob/living/carbon/human/human = M
 		if(human.combat_mode)
 			return TRUE
+	//if they are a cyborg, and they're not in help intent, block pushing
+	if(iscyborg(M))
+		var/mob/living/silicon/robot/borg = M
+		if(borg.combat_mode)
+			return TRUE
 	//anti-riot equipment is also anti-push
 	for(var/obj/item/I in M.held_items)
 		if(!istype(M, /obj/item/clothing))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -384,12 +384,12 @@
 	var/is_anchored = FALSE
 	if(move_resist == MOVE_FORCE_OVERPOWERING)
 		move_resist = MOVE_FORCE_NORMAL
-		status_flags |= CANPUSH //we want the borg to be push-able when un-anchored
+		status_flags |= CANPUSH //we want the core to be push-able when un-anchored
 		REMOVE_TRAIT(src, TRAIT_NO_TELEPORT, AI_ANCHOR_TRAIT)
 	else
 		is_anchored = TRUE
 		move_resist = MOVE_FORCE_OVERPOWERING
-		status_flags &= ~CANPUSH //we dont want the borg to be push-able when anchored
+		status_flags &= ~CANPUSH //we dont want the core to be push-able when anchored
 		ADD_TRAIT(src, TRAIT_NO_TELEPORT, AI_ANCHOR_TRAIT)
 
 	to_chat(src, "<b>You are now [is_anchored ? "" : "un"]anchored.</b>")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -111,6 +111,8 @@
 		return INITIALIZE_HINT_QDEL //Delete AI.
 
 	ADD_TRAIT(src, TRAIT_NO_TELEPORT, AI_ANCHOR_TRAIT)
+	status_flags &= ~CANPUSH //AI starts anchored, so dont push it
+
 	if(L && istype(L, /datum/ai_laws))
 		laws = L
 		laws.associate(src)
@@ -382,10 +384,12 @@
 	var/is_anchored = FALSE
 	if(move_resist == MOVE_FORCE_OVERPOWERING)
 		move_resist = MOVE_FORCE_NORMAL
+		status_flags |= CANPUSH //we want the borg to be push-able when un-anchored
 		REMOVE_TRAIT(src, TRAIT_NO_TELEPORT, AI_ANCHOR_TRAIT)
 	else
 		is_anchored = TRUE
 		move_resist = MOVE_FORCE_OVERPOWERING
+		status_flags &= ~CANPUSH //we dont want the borg to be push-able when anchored
 		ADD_TRAIT(src, TRAIT_NO_TELEPORT, AI_ANCHOR_TRAIT)
 
 	to_chat(src, "<b>You are now [is_anchored ? "" : "un"]anchored.</b>")

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -21,6 +21,7 @@
 
 	set_anchored(FALSE) //unbolt floorbolts
 	status_flags |= CANPUSH //we want it to be pushable when unanchored on death
+	REMOVE_TRAIT(src, TRAIT_NO_TELEPORT, AI_ANCHOR_TRAIT) //removes the anchor trait, because its not anchored anymore
 	move_resist = MOVE_FORCE_NORMAL
 
 	if(eyeobj)

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -20,6 +20,7 @@
 	cameraFollow = null
 
 	set_anchored(FALSE) //unbolt floorbolts
+	status_flags |= CANPUSH //we want it to be pushable when unanchored on death
 	move_resist = MOVE_FORCE_NORMAL
 
 	if(eyeobj)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -22,7 +22,6 @@
 	. = ..()
 
 	locked = FALSE //unlock cover
-	set_combat_mode(FALSE, TRUE) //remove combat mode if dead, so you can swap with dead borgs
 
 	if(!QDELETED(builtInCamera) && builtInCamera.status)
 		builtInCamera.toggle_cam(src,0)

--- a/code/modules/mob/living/silicon/robot/death.dm
+++ b/code/modules/mob/living/silicon/robot/death.dm
@@ -22,6 +22,7 @@
 	. = ..()
 
 	locked = FALSE //unlock cover
+	set_combat_mode(FALSE, TRUE) //remove combat mode if dead, so you can swap with dead borgs
 
 	if(!QDELETED(builtInCamera) && builtInCamera.status)
 		builtInCamera.toggle_cam(src,0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #60076
fixes #60083
when combat mode was introduced the silicons didnt get their stuff updated to apply to it it seems, and they had slightly different checks than humans (used CANPUSH not intent)

basically the AI core now actually removes its CANPUSH flag when anchored (since the AI is always in combat mode for reasons, we just remove its flag, and allow it to be pushed when unanchored)

and added one more check in the block push checks for the cyborgs specifically

also had the AI add its CANPUSH tag when it dies, alongside its unanchoring so it can be pushed when its dead (grab it to swap places with it). and the borg fails its check if its dead as well, so you can swap with dead borg corpses even when you are in harm intent yourself

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bugs bad

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: AI can now no longer be pushed even when anchored, only when dead or unanchored can it be pushed (grab a dead core to swap places)
fix: borgs can now no longer be pushed when in combat mode and alive, you will always swap places with dead borg corpses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
