### PR TITLE
Smart pipe balance - mapped pipes change

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -14,7 +14,7 @@ RPD
 
 GLOBAL_LIST_INIT(atmos_pipe_recipes, list(
 	"Pipes" = list(
-		new /datum/pipe_info/pipe("Pipe", /obj/machinery/atmospherics/pipe/smart, TRUE),
+		new /datum/pipe_info/pipe("Pipe", /obj/machinery/atmospherics/pipe/smart/constructed, TRUE),
 		new /datum/pipe_info/pipe("Layer Adapter", /obj/machinery/atmospherics/pipe/layer_manifold, TRUE),
 		new /datum/pipe_info/pipe("Color Adapter", /obj/machinery/atmospherics/pipe/color_adapter, TRUE),
 		new /datum/pipe_info/pipe("Bridge Pipe", /obj/machinery/atmospherics/pipe/bridge_pipe, TRUE),
@@ -489,7 +489,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 							queued_p_dir,
 							null,
 							GLOB.pipe_paint_colors[paint_color],
-							ispath(queued_p_type, /obj/machinery/atmospherics/pipe/smart) ? p_init_dir : null,
+							ispath(queued_p_type, /obj/machinery/atmospherics/pipe/smart/constructed) ? p_init_dir : null,
 						)
 						if(queued_p_flipped && istype(pipe_type, /obj/item/pipe/trinary/flippable))
 							var/obj/item/pipe/trinary/flippable/F = pipe_type

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -11,6 +11,16 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 	construction_type = /obj/item/pipe/quaternary
 	pipe_state = "manifold4w"
 	connection_num = 0
+	///Is the pipe mapped on roundstart? 
+	var/mapped = TRUE
+
+/obj/machinery/atmospherics/pipe/smart/constructed
+	mapped = FALSE
+
+/obj/machinery/atmospherics/pipe/smart/LateInitialize()
+	. = ..()
+	if(mapped)
+		SetInitDirections(dir)
 
 /obj/machinery/atmospherics/pipe/smart/update_pipe_icon()
 	icon = 'icons/obj/atmospherics/pipes/pipes_bitmask.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
All the mapped pipes set up their connectable direction to the ones already connected and disable all the others. This will help in preventing issues where under floor pipes connect in unwanted ways. 

The pipes are still able to connect to the constructed ones but only from the already made direction. 

You might require a bit more work to modify the basic setups but this will tremendously boost the new and old players experience with pipes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Many players (both old and new) have issues with invisible pipes that are under floors and connect in unwanted ways, while I believe that using simple tools like t-ray goggles and device will help you prevent wrong pipes from being placed in the wrong place it seems that the majority of people are still not using them. 
I hope thil will prevent unwanted delamination, waste to distro connections and other issues 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: mapped pipes setup their available connection to only their current directions, preventing unwanted connections from the usual incompetent engineer/atmos tech
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
