### PR TITLE
Fixes the map sprite for lizard plushes

### DIFF
--- a/code/datums/greyscale/json_configs/plushie_lizard.json
+++ b/code/datums/greyscale/json_configs/plushie_lizard.json
@@ -1,5 +1,5 @@
 {
-	"": [
+	"map_plushie_lizard": [
 		{
 			"type": "icon_state",
 			"icon_state": "plushie_lizard_body",

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -502,7 +502,7 @@
 /obj/item/toy/plush/lizard_plushie
 	name = "lizard plushie"
 	desc = "An adorable stuffed toy that resembles a lizardperson."
-	icon_state = "map_pushie_lizard"
+	icon_state = "map_plushie_lizard"
 	greyscale_config = /datum/greyscale_config/plush_lizard
 	attack_verb_continuous = list("claws", "hisses", "tail slaps")
 	attack_verb_simple = list("claw", "hiss", "tail slap")


### PR DESCRIPTION
## About The Pull Request

This PR fixes the placeholder map sprite for lizard plushes. I included a map sprite in my original GAGS PR but I forgot a single character from the icon_state which made it not work and I didn't realize until after it was merged.
![image](https://user-images.githubusercontent.com/51863163/126855922-904b041c-8a6c-4d62-9532-7038c4888228.png)
Lizard plushes will now show up in map editors, instead of error squares.

Insert no GBP here.

## Why It's Good For The Game

So the mappers know what they're looking at.

## Changelog
:cl: Melbert
fix: The mapped sprite for GAGS Lizard Plushes works, now. Mappers rejoice. 
/:cl:
