### PR TITLE
Fixes smartfridges not being able to dispense things with \improper or \proper in the name.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -219,28 +219,19 @@
 			if(QDELETED(src) || QDELETED(usr) || !usr.Adjacent(src)) // Sanity checkin' in case stupid stuff happens while we wait for input()
 				return FALSE
 
-			if(desired == 1 && Adjacent(usr) && !issilicon(usr))
-				for(var/obj/item/O in src)
-					if(O.name == params["name"])
-						if(O in component_parts)
-							CRASH("Attempted removal of [O] component_part from vending machine via vending interface.")
-						dispense(O, usr)
-						break
-				if (visible_contents)
-					update_appearance()
-				return TRUE
-
-			for(var/obj/item/O in src)
+			for(var/obj/item/dispensed_item in src)
 				if(desired <= 0)
 					break
-				if(O.name == params["name"])
-					if(O in component_parts)
-						CRASH("Attempted removal of [O] component_part from vending machine via vending interface.")
-					dispense(O, usr)
+				if(format_text(dispensed_item.name) == format_text(params["name"]))
+					if(dispensed_item in component_parts)
+						CRASH("Attempted removal of [dispensed_item] component_part from vending machine via vending interface.")
+					dispense(dispensed_item, usr)
 					desired--
+
 			if (visible_contents)
 				update_appearance()
 			return TRUE
+
 	return FALSE
 
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -215,6 +215,8 @@
 				desired = text2num(params["amount"])
 			else
 				desired = input("How many items?", "How many items would you like to take out?", 1) as null|num
+				if(isnull(desired))
+					desired = 0
 
 			if(QDELETED(src) || QDELETED(usr) || !usr.Adjacent(src)) // Sanity checkin' in case stupid stuff happens while we wait for input()
 				return FALSE

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -224,7 +224,7 @@
 					break
 				if(format_text(dispensed_item.name) == format_text(params["name"]))
 					if(dispensed_item in component_parts)
-						CRASH("Attempted removal of [dispensed_item] component_part from vending machine via vending interface.")
+						CRASH("Attempted removal of [dispensed_item] component_part from smartfridge via smartfridge interface.")
 					dispense(dispensed_item, usr)
 					desired--
 

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -215,8 +215,8 @@
 				desired = text2num(params["amount"])
 			else
 				desired = input("How many items?", "How many items would you like to take out?", 1) as null|num
-				if(isnull(desired))
-					desired = 0
+				if(!desired)
+					return FALSE
 
 			if(QDELETED(src) || QDELETED(usr) || !usr.Adjacent(src)) // Sanity checkin' in case stupid stuff happens while we wait for input()
 				return FALSE
@@ -224,6 +224,9 @@
 			for(var/obj/item/dispensed_item in src)
 				if(desired <= 0)
 					break
+				// Grab the first item in contents which name matches our passed name.
+				// format_text() is used here to strip \improper and \proper from both names,
+				// which is required for correct string comparison between them.
 				if(format_text(dispensed_item.name) == format_text(params["name"]))
 					if(dispensed_item in component_parts)
 						CRASH("Attempted removal of [dispensed_item] component_part from smartfridge via smartfridge interface.")


### PR DESCRIPTION
## About The Pull Request

This PR fixes the inability for smartfridges to dispense items which specified `\proper` or `\improper` in their name. There are more details to the bug in the issue report, but this PR fixes it by using the `format_text` proc when comparing the names, which strips strings of the `\improper` and `\proper` tags so they can compare accurately. 

This PR also cleans up a slight about of the smartfridge code. For some reason it had a unique case for needing to dispense only one item, but the loop is the same for both cases.

Fixes #58899. 

## Why It's Good For The Game

Botany can now store all things in their fridge to prevent ants.

## Changelog
:cl: Melbert
fix: Some things that wouldn't dispense themselves from smartfridges now will properly give themselves up. Some examples include Roses, Nettles / Deathnettles, and Salad of Edens.
/:cl:

