### PR TITLE
tcg flippers no longer have the scaling element

### DIFF
--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -399,10 +399,6 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 	material_flags = NONE
 	sideslist = list("nanotrasen", "syndicate")
 
-/obj/item/coin/thunderdome/Initialize()
-	. = ..()
-	AddElement(/datum/element/item_scaling, 0.4, 1)
-
 /obj/item/storage/card_binder
 	name = "card binder"
 	desc = "The perfect way to keep your collection of cards safe and valuable."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
does what the title says

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
they look weird and are hard to pick up with the element
inept agreed with me on this like a year ago i think

## Changelog
:cl:
qol: tcg flippers no longer have the scaling element
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
