### PR TITLE
Minor correction to traitor flavor

### DIFF
--- a/strings/traitor_flavor.json
+++ b/strings/traitor_flavor.json
@@ -3,7 +3,7 @@
 		"introduction": "You are the Tiger Cooperative Fanatic.",
 		"allies": "Only the enlightened Tiger brethren can be trusted; all others must be expelled from this mortal realm!",
 		"goal": "Remember the teachings of Hy-lurgixon; kill first, ask questions later!",
-		"uplink": "You have been provided with a standard uplink to prove yourself to the changeling hive. If you accomplish your tasks, you will be assimilated.",
+		"uplink": "You have been provided with a hy-lurgixon tome to prove yourself to the changeling hive. If you accomplish your tasks, you will be assimilated.",
 		"uplink_name": "hy-lurgixon tome",
 		"ui_theme": "abductor"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Uplink information for Tiger Cooperative Traitors will now mention them getting a hy-lurgixon tome, as they are actually one of the few syndicates to NOT get a standard uplink.

## Why It's Good For The Game

flavor 😋 

feel free to add no GBP to this

## Changelog
:cl:
spellcheck: Tiger Cooperative Traitors now have a slightly better uplink information flavor text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
