### PR TITLE
Fixes binary chat avoid_highlighting

### DIFF
--- a/code/modules/mob/living/silicon/silicon_say.dm
+++ b/code/modules/mob/living/silicon/silicon_say.dm
@@ -10,9 +10,9 @@
 		if(M.binarycheck())
 			if(isAI(M))
 				var/renderedAI = span_binarysay("Robotic Talk, <a href='?src=[REF(M)];track=[html_encode(name)]'>[span_name("[name] ([desig])")]</a> <span class='message'>[message_a]</span>")
-				to_chat(M, renderedAI)
+				to_chat(M, renderedAI, avoid_highlighting = src == M)
 			else
-				to_chat(M, span_binarysay("[rendered]"))
+				to_chat(M, span_binarysay("[rendered]"), avoid_highlighting = src == M)
 		if(isobserver(M))
 			var/following = src
 			// If the AI talks on binary chat, we still want to follow


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds avoid_highlighting args to binary radio to_chat() calls.

## Why It's Good For The Game

Fixes more self highlights.

## Changelog
🆑
fix: Fixed Chat Highlighting working on your own Binary messages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
