### PR TITLE
Fixes Entertainment Monitors

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -273,7 +273,7 @@
 	network = list("thunder")
 	density = FALSE
 	circuit = null
-	interaction_flags_atom = NONE  // interact() is called by BigClick()
+	interaction_flags_atom = INTERACT_ATOM_UI_INTERACT | INTERACT_ATOM_NO_FINGERPRINT_INTERACT | INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND | INTERACT_MACHINE_REQUIRES_SIGHT
 	var/icon_state_off = "entertainment_blank"
 	var/icon_state_on = "entertainment"
 


### PR DESCRIPTION
:cl: Bawhoppen
fix: Entertainment monitors now work again!
/:cl:

Fixes: https://github.com/tgstation/tgstation/issues/54607

This was broken for a little while it seems due to changes in how interactions work. 