### PR TITLE
default instakill rifle doesnt delete itself

### DIFF
--- a/code/modules/capture_the_flag/ctf_classes.dm
+++ b/code/modules/capture_the_flag/ctf_classes.dm
@@ -61,7 +61,7 @@
 
 /datum/outfit/ctf/instagib
 	name = "CTF Instagib (Solo)"
-	r_hand = /obj/item/gun/energy/laser/instakill
+	r_hand = /obj/item/gun/energy/laser/instakill/ctf
 	shoes = /obj/item/clothing/shoes/jackboots/fast
 	icon_state = "ctf_instakill"
 	class_description = "General purpose combat class. Armed with a laser rifle and backup pistol."
@@ -99,7 +99,7 @@
 
 /datum/outfit/ctf/red/instagib
 	name = "CTF Instagib (Red)"
-	r_hand = /obj/item/gun/energy/laser/instakill/red
+	r_hand = /obj/item/gun/energy/laser/instakill/ctf/red
 	shoes = /obj/item/clothing/shoes/jackboots/fast
 	team_radio_freq = FREQ_CTF_RED
 
@@ -134,7 +134,7 @@
 
 /datum/outfit/ctf/blue/instagib
 	name = "CTF Instagib (Blue)"
-	r_hand = /obj/item/gun/energy/laser/instakill/blue
+	r_hand = /obj/item/gun/energy/laser/instakill/ctf/blue
 	shoes = /obj/item/clothing/shoes/jackboots/fast
 	team_radio_freq = FREQ_CTF_BLUE
 
@@ -169,7 +169,7 @@
 
 /datum/outfit/ctf/green/instagib
 	name = "CTF Instagib (Green)"
-	r_hand = /obj/item/gun/energy/laser/instakill/green
+	r_hand = /obj/item/gun/energy/laser/instakill/ctf/green
 	shoes = /obj/item/clothing/shoes/jackboots/fast
 	team_radio_freq = FREQ_CTF_GREEN
 
@@ -204,7 +204,7 @@
 
 /datum/outfit/ctf/yellow/instagib
 	name = "CTF Instagib (Yellow)"
-	r_hand = /obj/item/gun/energy/laser/instakill/yellow
+	r_hand = /obj/item/gun/energy/laser/instakill/ctf/yellow
 	shoes = /obj/item/clothing/shoes/jackboots/fast
 	team_radio_freq = FREQ_CTF_YELLOW
 

--- a/code/modules/capture_the_flag/ctf_equipment.dm
+++ b/code/modules/capture_the_flag/ctf_equipment.dm
@@ -162,12 +162,12 @@
 	ammo_x_offset = 2
 	shaded_charge = FALSE
 
-/obj/item/gun/energy/laser/instakill/Initialize()
-	. = ..()
-	AddElement(/datum/element/delete_on_drop)
-
 /obj/item/gun/energy/laser/instakill/emp_act() //implying you could stop the instagib
 	return
+
+/obj/item/gun/energy/laser/instakill/ctf/Initialize()
+	. = ..()
+	AddElement(/datum/element/delete_on_drop)
 
 /obj/item/ammo_casing/energy/instakill
 	projectile_type = /obj/projectile/beam/instakill
@@ -279,7 +279,7 @@
 
 
 // Instakill
-/obj/item/gun/energy/laser/instakill/red
+/obj/item/gun/energy/laser/instakill/ctf/red
 	desc = "A specialized ASMD laser-rifle, capable of flat-out disintegrating most targets in a single hit. This one has a red design."
 	icon_state = "instagibred"
 	inhand_icon_state = "instagibred"
@@ -338,7 +338,7 @@
 
 
 // Instakill
-/obj/item/gun/energy/laser/instakill/blue
+/obj/item/gun/energy/laser/instakill/ctf/blue
 	desc = "A specialized ASMD laser-rifle, capable of flat-out disintegrating most targets in a single hit. This one has a blue design."
 	icon_state = "instagibblue"
 	inhand_icon_state = "instagibblue"
@@ -404,7 +404,7 @@
 
 
 // Instakill
-/obj/item/gun/energy/laser/instakill/green
+/obj/item/gun/energy/laser/instakill/ctf/green
 	desc = "A specialized ASMD laser-rifle, capable of flat-out disintegrating most targets in a single hit. This one has a green design."
 	icon_state = "instagibgreen"
 	inhand_icon_state = "instagibgreen"
@@ -470,7 +470,7 @@
 
 
 // Instakill
-/obj/item/gun/energy/laser/instakill/yellow
+/obj/item/gun/energy/laser/instakill/ctf/yellow
 	desc = "A specialized ASMD laser-rifle, capable of flat-out disintegrating most targets in a single hit. This one has a yellow design."
 	icon_state = "instagibyellow"
 	inhand_icon_state = "instagibyellow"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
adds a ctf subtype of the instakill rifle, the default one doesnt delete itself on drop anymore

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
this sucks if you use the instakill rifle for admin abuse

## Changelog
:cl:
admin: default instakill rifle doesnt delete itself
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
