### PR TITLE
Change VV to order by higher level types first

### DIFF
--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -87,10 +87,20 @@
 				value = L[key]
 			variable_html += debug_variable(i, value, 0, L)
 	else
-		names = sortList(names)
-		for(var/V in names)
-			if(D.can_vv_get(V))
-				variable_html += D.vv_get_var(V)
+		log_world("Opening vv_explorer.json")
+		var/raw_vv_explorer = file2text("data/vv_explorer.json")
+		log_world("JSON decoding vv_explorer")
+		var/vv_explorer = safe_json_decode(raw_vv_explorer)
+		log_world("JSON decoding complete.")
+		var/list/annotated_variables = vv_explorer[D.type]
+		// Looks roughly like
+		// {"/obj/item/candle": ["lit", "wax_type"], "/obj/item": ["w_class"]}
+
+
+		for(var/parent_type in annotated_variables)
+			for(var/variable_name in annotated_variables[parent_type])
+				if(D.can_vv_get(variable_name))
+					variable_html += D.vv_get_var(variable_name)
 
 	var/html = {"
 <html>

--- a/tools/test_vv_explorer.py
+++ b/tools/test_vv_explorer.py
@@ -1,0 +1,69 @@
+import pytest
+
+import vv_explorer
+
+def test_parse_dm_text():
+    dm_text = "\n".join([
+        "/obj/item/candle",
+        "	w_class = WEIGHT_CLASS_SMALL",
+        "	var/lit = TRUE",
+    ])
+
+    assert vv_explorer.parse_dm_text(dm_text) == {
+        "/obj/item/candle": ["lit"]
+    }
+
+
+@pytest.mark.parametrize(
+    "corpus,expected",
+    [
+        ("// This is a comment", False),
+        ("/obj/item/candle", True),
+        ("/mob/living/proc/death()", False),
+        ("/** check_damage_thresholds", False),
+    ]
+)
+def test_typepath_regex(corpus, expected):
+    assert bool(vv_explorer.TYPE_DEFINITION_REGEX.match(corpus)) is expected
+
+
+@pytest.mark.parametrize(
+    "corpus,expected",
+    [
+        ("// This is a comment", False),
+        ("/obj/item/candle", False),
+        ("/mob/living/proc/death()", True),
+    ]
+)
+def test_proc_regex(corpus, expected):
+    assert bool(vv_explorer.PROC_DEFINITION_REGEX.match(corpus)) is expected
+
+
+@pytest.mark.parametrize(
+    "corpus,expected",
+    [
+        ("// This is a comment", False),
+        ("/obj/item/candle", False),
+        ("/mob/living/proc/death()", False),
+        ("\tvar/lit = TRUE", True),
+    ]
+)
+def test_var_regex(corpus, expected):
+    assert bool(vv_explorer.VAR_DEFINITION_REGEX.match(corpus)) is expected
+
+
+def test_var_list_regex():
+    line = "\tvar/list/food_reagents = list(/datum/reagent/consumable/nutriment = 5)"
+    match = vv_explorer.VAR_DEFINITION_REGEX.match(line)
+    assert match.group("varname") == "food_reagents"
+
+
+@pytest.mark.parametrize(
+    "typepath,parent_tree",
+    [
+        ("/datum/brain_trauma", ["/datum/brain_trauma", "/datum"]),
+        ("/obj/item/candle", ["/obj/item/candle", "/obj/item", "/obj", "/atom/movable", "/atom", "/datum"]),
+    ]
+)
+def test_parent_tree(typepath, parent_tree):
+    assert vv_explorer.get_parent_tree(typepath) == parent_tree

--- a/tools/vv_explorer.py
+++ b/tools/vv_explorer.py
@@ -1,0 +1,116 @@
+import argparse
+import pathlib
+import re
+import logging
+import json
+from pprint import pprint
+
+Typepath = str
+Variable = str
+
+def make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dme_file", help="tgstation.dme file", type=pathlib.Path)
+    parser.add_argument("-o", "--output", type=pathlib.Path, default="vv_explorer.json")
+    return parser
+
+MANUAL_PARENT_TYPES = {
+    "/area": "/atom",
+    "/turf": "/atom",
+    "/obj": "/atom/movable",
+    "/mob": "/atom/movable",
+    "/atom": "/datum",
+    "/client": "/datum",
+}
+
+
+TYPE_DEFINITION_REGEX = re.compile(r"^(?P<typepath>(/[^/()*]+)+)$")
+PROC_DEFINITION_REGEX = re.compile(r"^(/[^/()*]+)+\(")
+VAR_DEFINITION_REGEX = re.compile(r"^(\t| +)var/([^/= ]+/)*(?P<varname>[^/= ]+)")
+
+
+def parse_dm_text(dm_text: str) -> dict[Typepath, list[Variable]]:
+    typepaths = {}
+    current_type = None
+    for line in dm_text.split("\n"):
+        # Type definition
+        if match := TYPE_DEFINITION_REGEX.match(line):
+            current_type = match.group("typepath")
+            logging.debug(f"Found type definition for {current_type}")
+        # Proc definition
+        elif PROC_DEFINITION_REGEX.match(line):
+            current_type = None
+        # Variable definition inside type def
+        elif current_type and (match := VAR_DEFINITION_REGEX.match(line)):
+            variable_name = match.group("varname")
+            try:
+                typepaths[current_type].append(variable_name)
+            except KeyError:
+                typepaths[current_type] = [variable_name]
+
+            typepaths[current_type].sort()
+    return typepaths
+
+
+def parse_dme(dme_text: str, basepath: pathlib.Path) -> list[pathlib.Path]:
+    paths = []
+    for line in dme_text.split("\n"):
+        if match := re.match('#include "([^"]+)"', line):
+            combined = basepath / pathlib.PureWindowsPath(match.group(1))
+            paths.append(combined)
+
+    return paths
+
+
+def get_parent_tree(typepath: Typepath) -> list[Typepath]:
+    tree = [typepath]
+    while True:
+        if typepath in MANUAL_PARENT_TYPES:
+            typepath = MANUAL_PARENT_TYPES[typepath]
+        else:
+            parts = typepath.split("/")
+            typepath = "/".join(parts[:-1])
+
+        if not typepath:
+            break
+
+        tree.append(typepath)
+    return tree
+
+def generate_annotated_type_tree(
+    typepaths: dict[Typepath, list[Variable]]
+) -> dict[Typepath, dict[Variable, list[Typepath]]]:
+    type_tree = {}
+
+    for typepath, variables in typepaths.items():
+        type_tree[typepath] = {}
+
+        parent_tree = get_parent_tree(typepath)
+        for parent_typepath in parent_tree:
+            type_tree[typepath][parent_typepath] = typepaths.get(parent_typepath, [])
+
+    return type_tree
+
+if __name__ == "__main__":
+
+    args = make_parser().parse_args()
+    dm_files = []
+    with open(args.dme_file) as f:
+        dm_files = parse_dme(f.read(), args.dme_file.parent)
+
+    all_typepaths = {}
+
+    for dm_file in dm_files:
+        with open(dm_file) as f:
+            dm_text = f.read()
+        additional_typepaths = parse_dm_text(dm_text)
+        for typepath, variable_list in additional_typepaths.items():
+            try:
+                all_typepaths[typepath].extend(variable_list)
+            except:
+                all_typepaths[typepath] = list(variable_list)
+
+    #annotated_tree = generate_annotated_type_tree(all_typepaths)
+    with open(args.output, "w") as f:
+        #json.dump(annotated_tree, f, indent=2)
+        json.dump(all_typepaths, f, indent=2)


### PR DESCRIPTION
The aim is to order the variables in VV based on the most recent
definitions.

Most of the time when you open VV, you care about the top most, and very
rarely `gc_collected` on /datum.

---

This is work in process, opening this PR to allow for collaboration.