### PR TITLE
Fix wallet ID access

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -43,21 +43,16 @@
 
 /obj/item/storage/wallet/Exited(atom/movable/gone, direction)
 	. = ..()
-	refreshID(removed = TRUE)
+	if(istype(gone, /obj/item/card/id))
+		refreshID()
 
 /**
  * Calculates the new front ID.
  *
  * Picks the ID card that has the most combined command or higher tier accesses.
- * Arguments:
- * * removed - If this proc was called because a card was removed. There's a chance we don't need to calculate the new front ID if a card was removed.
  */
-/obj/item/storage/wallet/proc/refreshID(removed = FALSE)
+/obj/item/storage/wallet/proc/refreshID()
 	LAZYCLEARLIST(combined_access)
-
-	// If the front_id is still in our wallet an we removed a card, we can return early.
-	if((front_id in src) && removed)
-		return
 
 	front_id = null
 	var/winning_tally = 0
@@ -94,7 +89,8 @@
 
 /obj/item/storage/wallet/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
-	refreshID(removed = FALSE)
+	if(istype(arrived, /obj/item/card/id))
+		refreshID()
 
 /obj/item/storage/wallet/update_overlays()
 	. = ..()

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -56,9 +56,8 @@
 
 	front_id = null
 	var/winning_tally = 0
-	for(var/card in contents)
-		var/obj/item/card/id/id_card = card
-		if(!istype(id_card))
+	for(var/obj/item/card/id/id_card in contents)
+		if(!istype(id_card, /obj/item/card/id))
 			continue
 
 		// Certain IDs can forcibly jump to the front so they can disguise other cards in wallets. Chameleon/Agent ID cards are an example of this.

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -57,9 +57,6 @@
 	front_id = null
 	var/winning_tally = 0
 	for(var/obj/item/card/id/id_card in contents)
-		if(!istype(id_card, /obj/item/card/id))
-			continue
-
 		// Certain IDs can forcibly jump to the front so they can disguise other cards in wallets. Chameleon/Agent ID cards are an example of this.
 		if(HAS_TRAIT(id_card, TRAIT_MAGNETIC_ID_CARD))
 			front_id = id_card


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This fixes #58745.  The wallet behavior with ID cards was pretty badly broken.  

Anytime an object would get removed from a wallet and there was an ID inside it, the `combined_access` list would get cleared and then the function would return before it could remade.  This meant that regardless of the ID cards still inside the wallet, they would grant no access since the list was empty.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This fixes a nasty bug that would appear at roundstart if you spawned with a wallet or if you decided to later grab a wallet and stick your ID inside it for storage.

## Changelog
:cl:
fix: Fixed wallets not granting access for ID cards inside them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
