### PR TITLE
Adds a autofocus arg to tgui_alert

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -369,7 +369,7 @@
 	if(flashwindow)
 		window_flash(M.client)
 	var/list/answers = ignore_category ? list("Yes", "No", "Never for this round") : list("Yes", "No")
-	switch(tgui_alert(M, Question, "A limited-time offer!", answers, poll_time, FALSE))
+	switch(tgui_alert(M, Question, "A limited-time offer!", answers, poll_time, autofocus = FALSE))
 		if("Yes")
 			to_chat(M, span_notice("Choice registered: Yes."))
 			if(time_passed + poll_time <= world.time)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -369,7 +369,7 @@
 	if(flashwindow)
 		window_flash(M.client)
 	var/list/answers = ignore_category ? list("Yes", "No", "Never for this round") : list("Yes", "No")
-	switch(tgui_alert(M, Question, "A limited-time offer!", answers, timeout=poll_time))
+	switch(tgui_alert(M, Question, "A limited-time offer!", answers, poll_time, FALSE))
 		if("Yes")
 			to_chat(M, span_notice("Choice registered: Yes."))
 			if(time_passed + poll_time <= world.time)

--- a/code/modules/tgui/tgui_alert.dm
+++ b/code/modules/tgui/tgui_alert.dm
@@ -146,8 +146,8 @@
 	/// The callback to be invoked by the tgui_modal upon having a choice made.
 	var/datum/callback/callback
 
-/datum/tgui_modal/async/New(mob/user, message, title, list/buttons, callback, timeout)
-	..(user, message, title, buttons, timeout)
+/datum/tgui_modal/async/New(mob/user, message, title, list/buttons, callback, timeout, autofocus)
+	..(user, message, title, buttons, timeout, autofocus)
 	src.callback = callback
 
 /datum/tgui_modal/async/Destroy(force, ...)

--- a/code/modules/tgui/tgui_alert.dm
+++ b/code/modules/tgui/tgui_alert.dm
@@ -8,8 +8,9 @@
  * * title - The of the alert modal, shown on the top of the TGUI window.
  * * buttons - The options that can be chosen by the user, each string is assigned a button on the UI.
  * * timeout - The timeout of the alert, after which the modal will close and qdel itself. Set to zero for no timeout.
+ * * autofocus - The bool that controls if this alert should grab window focus.
  */
-/proc/tgui_alert(mob/user, message = null, title = null, list/buttons = list("Ok"), timeout = 0)
+/proc/tgui_alert(mob/user, message = null, title = null, list/buttons = list("Ok"), timeout = 0, autofocus = TRUE)
 	if (!user)
 		user = usr
 	if (!istype(user))
@@ -18,7 +19,7 @@
 			user = client.mob
 		else
 			return
-	var/datum/tgui_modal/alert = new(user, message, title, buttons, timeout)
+	var/datum/tgui_modal/alert = new(user, message, title, buttons, timeout, autofocus)
 	alert.ui_interact(user)
 	alert.wait()
 	if (alert)
@@ -36,8 +37,9 @@
  * * buttons - The options that can be chosen by the user, each string is assigned a button on the UI.
  * * callback - The callback to be invoked when a choice is made.
  * * timeout - The timeout of the alert, after which the modal will close and qdel itself. Disabled by default, can be set to seconds otherwise.
+ * * autofocus - The bool that controls if this alert should grab window focus.
  */
-/proc/tgui_alert_async(mob/user, message = null, title = null, list/buttons = list("Ok"), datum/callback/callback, timeout = 0)
+/proc/tgui_alert_async(mob/user, message = null, title = null, list/buttons = list("Ok"), datum/callback/callback, timeout = 0, autofocus = TRUE)
 	if (!user)
 		user = usr
 	if (!istype(user))
@@ -46,7 +48,7 @@
 			user = client.mob
 		else
 			return
-	var/datum/tgui_modal/async/alert = new(user, message, title, buttons, callback, timeout)
+	var/datum/tgui_modal/async/alert = new(user, message, title, buttons, callback, timeout, autofocus)
 	alert.ui_interact(user)
 
 /**
@@ -68,13 +70,16 @@
 	var/start_time
 	/// The lifespan of the tgui_modal, after which the window will close and delete itself.
 	var/timeout
+	/// The bool that controls if this model should grab window focus
+	var/autofocus
 	/// Boolean field describing if the tgui_modal was closed by the user.
 	var/closed
 
-/datum/tgui_modal/New(mob/user, message, title, list/buttons, timeout)
+/datum/tgui_modal/New(mob/user, message, title, list/buttons, timeout, autofocus)
 	src.title = title
 	src.message = message
 	src.buttons = buttons.Copy()
+	src.autofocus = autofocus
 	if (timeout)
 		src.timeout = timeout
 		start_time = world.time
@@ -110,7 +115,8 @@
 	. = list(
 		"title" = title,
 		"message" = message,
-		"buttons" = buttons
+		"buttons" = buttons,
+		"autofocus" = autofocus
 	)
 
 	if(timeout)

--- a/code/modules/tgui/tgui_alert.dm
+++ b/code/modules/tgui/tgui_alert.dm
@@ -70,7 +70,7 @@
 	var/start_time
 	/// The lifespan of the tgui_modal, after which the window will close and delete itself.
 	var/timeout
-	/// The bool that controls if this model should grab window focus
+	/// The bool that controls if this modal should grab window focus
 	var/autofocus
 	/// Boolean field describing if the tgui_modal was closed by the user.
 	var/closed

--- a/tgui/packages/tgui/interfaces/AlertModal.js
+++ b/tgui/packages/tgui/interfaces/AlertModal.js
@@ -27,7 +27,7 @@ export class AlertModal extends Component {
 
   componentDidMount() {
     const { data } = useBackend(this.context);
-    const { buttons } = data;
+    const { buttons, autofocus } = data;
     const { current } = this.state;
     const button = this.buttonRefs[current].current;
 
@@ -36,7 +36,9 @@ export class AlertModal extends Component {
       this.buttonRefs.push(createRef());
     }
 
-    setTimeout(() => button.focus(), 1);
+    if (autofocus) {
+      setTimeout(() => button.focus(), 1);
+    }
   }
 
   setCurrent(current, isArrowKey) {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See changelog.

## Why It's Good For The Game

Fixes: #59517 High Priority issue means this gets the label too right? 😋 

## Changelog
:cl:
qol: Poll Candidates alerts no longer steal window focus, like ghost role rolls and cult leadership votes.
code: Added an autofocus argument to tgui_alert, defaults on, that can be used to prevent accidental inputs from surprise alerts when used.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
