### PR TITLE
Logs kudzu tray planting in investigate botany instead of its own investigate file

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -571,7 +571,7 @@
 	else if(istype(O, /obj/item/seeds) && !istype(O, /obj/item/seeds/sample))
 		if(!myseed)
 			if(istype(O, /obj/item/seeds/kudzu))
-				investigate_log("had Kudzu planted in it by [key_name(user)] at [AREACOORD(src)]","kudzu")
+				investigate_log("had Kudzu planted in it by [key_name(user)] at [AREACOORD(src)].", INVESTIGATE_BOTANY)
 			if(!user.transferItemToLoc(O, src))
 				return
 			to_chat(user, span_notice("You plant [O]."))


### PR DESCRIPTION
## About The Pull Request

This PR moves the `investigate_log` subject of Kudzu being planted in a tray to `investigate_botany` instead of its own log file.

_All_ the other kudzu logging is in `investigate_botany` so this one was the odd one out. Consistency for logging. Woo.

## Why It's Good For The Game

A bit more consistency for log locations, to help out admins.

## Changelog
:cl: Melbert
admin: Tray planted kudzu will now log in investigate -> botany instead of its own file.
/:cl:
