### PR TITLE
Lets construction bags be put in pockets like they were intended to

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -460,6 +460,7 @@
 	icon_state = "construction_bag"
 	worn_icon_state = "construction_bag"
 	desc = "A bag for storing small construction components."
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
 	resistance_flags = FLAMMABLE
 
 /obj/item/storage/bag/construction/ComponentInitialize()


### PR DESCRIPTION
These bags were litteraly designed to carry the most useless of circuits to manually construct apcs, apc alarms etc
currently they only fit in in belt which is already occupied by your toolbelt so making the item objectively useless to even carry.

## Changelog
:cl: Improvedname
balance: Construction bags fit once more in your pockets
/:cl:
