### PR TITLE
Fixes a stray mismatched area in meta med

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -49796,7 +49796,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/coldroom)
+/area/medical/cryo)
 "onR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/8881105/127069809-eff5d853-2a55-4334-aa01-2764e26679f1.png)

## Why It's Good For The Game

Fix

## Changelog
:cl:
fix: Meta medbay now has all its areas set correctly
/:cl: