### PR TITLE
Removes Destroy overrides from most circuit components

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -34,11 +34,6 @@
 	. = ..()
 	records = add_output_port("Crew Monitoring Data", PORT_TYPE_TABLE)
 
-/obj/item/circuit_component/medical_console_data/Destroy()
-	records = null
-	return ..()
-
-
 /obj/item/circuit_component/medical_console_data/register_usb_parent(atom/movable/parent)
 	. = ..()
 	if(istype(parent, /obj/machinery/computer/crew))

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -46,18 +46,6 @@
 	why_fail = add_output_port("Fail reason", PORT_TYPE_STRING)
 	on_fail = add_output_port("Failed", PORT_TYPE_SIGNAL)
 
-/obj/item/circuit_component/bluespace_launchpad/Destroy()
-	launchpad_id = null
-	x_pos = null
-	y_pos = null
-	send_trigger = null
-	retrieve_trigger = null
-	sent = null
-	retrieved = null
-	on_fail = null
-	why_fail = null
-	return ..()
-
 /obj/item/circuit_component/bluespace_launchpad/register_usb_parent(atom/movable/parent)
 	. = ..()
 	if(istype(parent, /obj/machinery/computer/launchpad))

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -44,12 +44,6 @@
 	records = add_output_port("Security Records", PORT_TYPE_TABLE)
 	on_fail = add_output_port("Failed", PORT_TYPE_SIGNAL)
 
-/obj/item/circuit_component/arrest_console_data/Destroy()
-	records = null
-	on_fail = null
-	return ..()
-
-
 /obj/item/circuit_component/arrest_console_data/register_usb_parent(atom/movable/parent)
 	. = ..()
 	if(istype(parent, /obj/machinery/computer/secure_data))
@@ -149,13 +143,6 @@
 	new_status = add_input_port("New Status", PORT_TYPE_STRING)
 	new_status_set = add_output_port("Set Status", PORT_TYPE_STRING)
 	on_fail = add_output_port("Failed", PORT_TYPE_SIGNAL)
-
-/obj/item/circuit_component/arrest_console_arrest/Destroy()
-	targets = null
-	new_status = null
-	new_status_set = null
-	on_fail = null
-	return ..()
 
 /obj/item/circuit_component/arrest_console_arrest/input_received(datum/port/input/port)
 	. = ..()

--- a/code/game/machinery/computer/tram_controls.dm
+++ b/code/game/machinery/computer/tram_controls.dm
@@ -139,14 +139,6 @@
 	UnregisterSignal(computer.tram_part, list(COMSIG_TRAM_SET_TRAVELLING, COMSIG_TRAM_TRAVEL))
 	return ..()
 
-/obj/item/circuit_component/tram_controls/Destroy()
-	new_destination = null
-	trigger_move = null
-	location = null
-	travelling_output = null
-	computer = null
-	return ..()
-
 /obj/item/circuit_component/tram_controls/input_received(datum/port/input/port)
 	. = ..()
 	if (.)

--- a/code/modules/wiremod/components/abstract/compare.dm
+++ b/code/modules/wiremod/components/abstract/compare.dm
@@ -38,13 +38,6 @@
 /obj/item/circuit_component/compare/proc/load_custom_ports()
 	return
 
-/obj/item/circuit_component/compare/Destroy()
-	true = null
-	false = null
-	result = null
-	compare = null
-	return ..()
-
 /obj/item/circuit_component/compare/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/action/light.dm
+++ b/code/modules/wiremod/components/action/light.dm
@@ -35,15 +35,6 @@
 
 	on = add_input_port("On", PORT_TYPE_NUMBER)
 
-
-/obj/item/circuit_component/light/Destroy()
-	red = null
-	green = null
-	blue = null
-	brightness = null
-	on = null
-	return ..()
-
 /obj/item/circuit_component/light/register_shell(atom/movable/shell)
 	. = ..()
 	TRIGGER_CIRCUIT_COMPONENT(src, null)

--- a/code/modules/wiremod/components/action/mmi.dm
+++ b/code/modules/wiremod/components/action/mmi.dm
@@ -53,16 +53,6 @@
 
 /obj/item/circuit_component/mmi/Destroy()
 	remove_current_brain()
-	message = null
-	send = null
-	eject = null
-	north = null
-	east = null
-	south = null
-	west = null
-	attack = null
-	secondary_attack = null
-	clicked_atom = null
 	return ..()
 
 /obj/item/circuit_component/mmi/input_received(datum/port/input/port)

--- a/code/modules/wiremod/components/action/pathfind.dm
+++ b/code/modules/wiremod/components/action/pathfind.dm
@@ -44,21 +44,6 @@
 	failed = add_output_port("Failed", PORT_TYPE_SIGNAL)
 	reason_failed = add_output_port("Fail reason", PORT_TYPE_STRING)
 
-/obj/item/circuit_component/pathfind/Destroy()
-	input_X = null
-	input_Y = null
-	id_card = null
-
-	output = null
-	finished = null
-	failed = null
-	reason_failed = null
-
-	path = null
-	old_dest = null
-	next_turf = null
-	return ..()
-
 /obj/item/circuit_component/pathfind/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/action/pull.dm
+++ b/code/modules/wiremod/components/action/pull.dm
@@ -15,10 +15,6 @@
 	. = ..()
 	target = add_input_port("Target", PORT_TYPE_ATOM)
 
-/obj/item/circuit_component/pull/Destroy()
-	target = null
-	return ..()
-
 /obj/item/circuit_component/pull/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/action/radio.dm
+++ b/code/modules/wiremod/components/action/radio.dm
@@ -34,10 +34,7 @@
 	trigger_output = add_output_port("Received", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/radio/Destroy()
-	freq = null
-	code = null
 	SSradio.remove_object(src, current_freq)
-	radio_connection = null
 	return ..()
 
 /obj/item/circuit_component/radio/input_received(datum/port/input/port)

--- a/code/modules/wiremod/components/action/soundemitter.dm
+++ b/code/modules/wiremod/components/action/soundemitter.dm
@@ -29,11 +29,6 @@
 	volume = add_input_port("Volume", PORT_TYPE_NUMBER, default = 35)
 	frequency = add_input_port("Frequency", PORT_TYPE_NUMBER, default = 0)
 
-/obj/item/circuit_component/soundemitter/Destroy()
-	frequency = null
-	volume = null
-	return ..()
-
 /obj/item/circuit_component/soundemitter/populate_options()
 	var/static/component_options = list(
 		COMP_SOUND_BUZZ,

--- a/code/modules/wiremod/components/action/speech.dm
+++ b/code/modules/wiremod/components/action/speech.dm
@@ -22,11 +22,6 @@
 	. = ..()
 	message = add_input_port("Message", PORT_TYPE_STRING, FALSE)
 
-
-/obj/item/circuit_component/speech/Destroy()
-	message = null
-	return ..()
-
 /obj/item/circuit_component/speech/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/atom/direction.dm
+++ b/code/modules/wiremod/components/atom/direction.dm
@@ -39,11 +39,6 @@
 	south = add_output_port("South", PORT_TYPE_SIGNAL)
 	west = add_output_port("West", PORT_TYPE_SIGNAL)
 
-/obj/item/circuit_component/direction/Destroy()
-	input_port = null
-	output = null
-	return ..()
-
 /obj/item/circuit_component/direction/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/atom/gps.dm
+++ b/code/modules/wiremod/components/atom/gps.dm
@@ -21,12 +21,6 @@
 	y_pos = add_output_port("Y", PORT_TYPE_NUMBER)
 	z_pos = add_output_port("Z", PORT_TYPE_NUMBER)
 
-/obj/item/circuit_component/gps/Destroy()
-	x_pos = null
-	y_pos = null
-	z_pos = null
-	return ..()
-
 /obj/item/circuit_component/gps/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/atom/health.dm
+++ b/code/modules/wiremod/components/atom/health.dm
@@ -39,15 +39,6 @@
 	oxy = add_output_port("Suffocation Damage", PORT_TYPE_NUMBER)
 	health = add_output_port("Health", PORT_TYPE_NUMBER)
 
-/obj/item/circuit_component/health/Destroy()
-	input_port = null
-	brute = null
-	burn = null
-	toxin = null
-	oxy = null
-	health = null
-	return ..()
-
 /obj/item/circuit_component/health/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/atom/hear.dm
+++ b/code/modules/wiremod/components/atom/hear.dm
@@ -24,15 +24,6 @@
 	trigger_port = add_output_port("Triggered", PORT_TYPE_SIGNAL)
 	become_hearing_sensitive(ROUNDSTART_TRAIT)
 
-
-
-/obj/item/circuit_component/hear/Destroy()
-	message_port = null
-	language_port = null
-	speaker_port = null
-	trigger_port = null
-	return ..()
-
 /obj/item/circuit_component/hear/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods)
 	if(speaker == parent?.shell)
 		return

--- a/code/modules/wiremod/components/atom/self.dm
+++ b/code/modules/wiremod/components/atom/self.dm
@@ -14,10 +14,6 @@
 	. = ..()
 	output = add_output_port("Self", PORT_TYPE_ATOM)
 
-/obj/item/circuit_component/self/Destroy()
-	output = null
-	return ..()
-
 /obj/item/circuit_component/self/register_shell(atom/movable/shell)
 	output.set_output(shell)
 

--- a/code/modules/wiremod/components/atom/species.dm
+++ b/code/modules/wiremod/components/atom/species.dm
@@ -21,11 +21,6 @@
 
 	output = add_output_port("Species", PORT_TYPE_STRING)
 
-/obj/item/circuit_component/species/Destroy()
-	input_port = null
-	output = null
-	return ..()
-
 /obj/item/circuit_component/species/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/list/concat.dm
+++ b/code/modules/wiremod/components/list/concat.dm
@@ -24,12 +24,6 @@
 
 	output = add_output_port("Output", PORT_TYPE_STRING)
 
-/obj/item/circuit_component/concat_list/Destroy()
-	list_port = null
-	separator = null
-	output = null
-	return ..()
-
 /obj/item/circuit_component/concat_list/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/list/get_column.dm
+++ b/code/modules/wiremod/components/list/get_column.dm
@@ -23,12 +23,6 @@
 	column_name = add_input_port("Column Name", PORT_TYPE_STRING)
 	output_list = add_output_port("Output", PORT_TYPE_LIST)
 
-/obj/item/circuit_component/get_column/Destroy()
-	received_table = null
-	column_name = null
-	output_list = null
-	return ..()
-
 /obj/item/circuit_component/get_column/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/list/index.dm
+++ b/code/modules/wiremod/components/list/index.dm
@@ -22,12 +22,6 @@
 
 	output = add_output_port("Value", PORT_TYPE_ANY)
 
-/obj/item/circuit_component/index/Destroy()
-	list_port = null
-	index_port = null
-	output = null
-	return ..()
-
 /obj/item/circuit_component/index/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/list/index_table.dm
+++ b/code/modules/wiremod/components/list/index_table.dm
@@ -24,12 +24,6 @@
 
 	output_list = add_output_port("Output", PORT_TYPE_LIST)
 
-/obj/item/circuit_component/index_table/Destroy()
-	received_table = null
-	target_index = null
-	output_list = null
-	return ..()
-
 /obj/item/circuit_component/index_table/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/list/select.dm
+++ b/code/modules/wiremod/components/list/select.dm
@@ -41,13 +41,6 @@
 
 	filtered_table = add_output_port("Output", PORT_TYPE_TABLE)
 
-/obj/item/circuit_component/select/Destroy()
-	received_table = null
-	column_name = null
-	comparison_input = null
-	filtered_table = null
-	return ..()
-
 /obj/item/circuit_component/select/input_received(datum/port/input/port)
 	. = ..()
 	switch(current_option)

--- a/code/modules/wiremod/components/list/split.dm
+++ b/code/modules/wiremod/components/list/split.dm
@@ -24,12 +24,6 @@
 	separator = add_input_port("Seperator", PORT_TYPE_STRING)
 	output = add_output_port("Output", PORT_TYPE_LIST)
 
-/obj/item/circuit_component/split/Destroy()
-	input_port = null
-	separator = null
-	output = null
-	return ..()
-
 /obj/item/circuit_component/split/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/math/arithmetic.dm
+++ b/code/modules/wiremod/components/math/arithmetic.dm
@@ -35,10 +35,6 @@
 
 	output = add_output_port("Output", PORT_TYPE_NUMBER)
 
-/obj/item/circuit_component/arithmetic/Destroy()
-	output = null
-	return ..()
-
 /obj/item/circuit_component/arithmetic/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/math/length.dm
+++ b/code/modules/wiremod/components/math/length.dm
@@ -20,11 +20,6 @@
 
 	output = add_output_port("Length", PORT_TYPE_NUMBER)
 
-/obj/item/circuit_component/length/Destroy()
-	input_port = null
-	output = null
-	return ..()
-
 /obj/item/circuit_component/length/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/math/not.dm
+++ b/code/modules/wiremod/components/math/not.dm
@@ -20,11 +20,6 @@
 
 	result = add_output_port("Result", PORT_TYPE_NUMBER)
 
-/obj/item/circuit_component/not/Destroy()
-	input_port = null
-	result = null
-	return ..()
-
 /obj/item/circuit_component/not/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/math/random.dm
+++ b/code/modules/wiremod/components/math/random.dm
@@ -24,12 +24,6 @@
 
 	output = add_output_port("Output", PORT_TYPE_NUMBER)
 
-/obj/item/circuit_component/random/Destroy()
-	minimum = null
-	maximum = null
-	output = null
-	return ..()
-
 /obj/item/circuit_component/random/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/sensors/pressuresensor.dm
+++ b/code/modules/wiremod/components/sensors/pressuresensor.dm
@@ -16,10 +16,6 @@
 	. = ..()
 	result = add_output_port("Result", PORT_TYPE_NUMBER)
 
-/obj/item/circuit_component/tempsensor/Destroy()
-	result = null
-	return ..()
-
 /obj/item/circuit_component/pressuresensor/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/sensors/tempsensor.dm
+++ b/code/modules/wiremod/components/sensors/tempsensor.dm
@@ -16,10 +16,6 @@
 	. = ..()
 	result = add_output_port("Result", PORT_TYPE_NUMBER)
 
-/obj/item/circuit_component/tempsensor/Destroy()
-	result = null
-	return ..()
-
 /obj/item/circuit_component/tempsensor/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/string/concat.dm
+++ b/code/modules/wiremod/components/string/concat.dm
@@ -22,10 +22,6 @@
 
 	output = add_output_port("Output", PORT_TYPE_STRING)
 
-/obj/item/circuit_component/concat/Destroy()
-	output = null
-	return ..()
-
 /obj/item/circuit_component/concat/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/string/textcase.dm
+++ b/code/modules/wiremod/components/string/textcase.dm
@@ -27,11 +27,6 @@
 	input_port = add_input_port("Input", PORT_TYPE_STRING)
 	output = add_output_port("Output", PORT_TYPE_STRING)
 
-/obj/item/circuit_component/textcase/Destroy()
-	input_port = null
-	output = null
-	return ..()
-
 /obj/item/circuit_component/textcase/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/string/tonumber.dm
+++ b/code/modules/wiremod/components/string/tonumber.dm
@@ -21,11 +21,6 @@
 
 	output = add_output_port("Output", PORT_TYPE_NUMBER)
 
-/obj/item/circuit_component/tonumber/Destroy()
-	input_port = null
-	output = null
-	return ..()
-
 /obj/item/circuit_component/tonumber/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/string/tostring.dm
+++ b/code/modules/wiremod/components/string/tostring.dm
@@ -23,11 +23,6 @@
 
 	output = add_output_port("Output", PORT_TYPE_STRING)
 
-/obj/item/circuit_component/tostring/Destroy()
-	input_port = null
-	output = null
-	return ..()
-
 /obj/item/circuit_component/tostring/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/utility/clock.dm
+++ b/code/modules/wiremod/components/utility/clock.dm
@@ -34,8 +34,6 @@
 		stop_process()
 
 /obj/item/circuit_component/clock/Destroy()
-	on = null
-	signal = null
 	stop_process()
 	return ..()
 

--- a/code/modules/wiremod/components/utility/combiner.dm
+++ b/code/modules/wiremod/components/utility/combiner.dm
@@ -33,10 +33,6 @@
 		add_input_port(letter, current_option)
 	output_port = add_output_port("Output", current_option)
 
-/obj/item/circuit_component/combiner/Destroy()
-	output_port = null
-	return ..()
-
 /obj/item/circuit_component/combiner/input_received(datum/port/input/port)
 	. = ..()
 	if(current_type != current_option)

--- a/code/modules/wiremod/components/utility/delay.dm
+++ b/code/modules/wiremod/components/utility/delay.dm
@@ -22,12 +22,6 @@
 
 	output = add_output_port("Result", PORT_TYPE_SIGNAL)
 
-/obj/item/circuit_component/delay/Destroy()
-	output = null
-	trigger = null
-	delay_amount = null
-	return ..()
-
 /obj/item/circuit_component/delay/input_received(datum/port/input/port)
 	. = ..()
 	if(.)

--- a/code/modules/wiremod/components/utility/multiplexer.dm
+++ b/code/modules/wiremod/components/utility/multiplexer.dm
@@ -41,13 +41,6 @@
 		multiplexer_inputs += add_input_port("Port [port_id]", current_type)
 	output_port = add_output_port("Output", current_type)
 
-/obj/item/circuit_component/multiplexer/Destroy()
-	output_port = null
-	multiplexer_inputs.Cut()
-	multiplexer_inputs = null
-	return ..()
-
-
 /obj/item/circuit_component/multiplexer/input_received(datum/port/input/port)
 	. = ..()
 	if(current_type != current_option)

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -80,20 +80,6 @@
 	bolted = add_output_port("Bolted", PORT_TYPE_SIGNAL)
 	unbolted = add_output_port("Unbolted", PORT_TYPE_SIGNAL)
 
-/obj/item/circuit_component/airlock/Destroy()
-	bolt = null
-	unbolt = null
-	open = null
-	close = null
-	is_open = null
-	is_bolted = null
-	opened = null
-	closed = null
-	bolted = null
-	unbolted = null
-	attached_airlock = null
-	return ..()
-
 /obj/item/circuit_component/airlock/register_shell(atom/movable/shell)
 	. = ..()
 	if(istype(shell, /obj/machinery/door/airlock))

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -61,11 +61,7 @@
 	signal = add_output_port("Signal", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/bci_action/Destroy()
-	button_name = null
-	signal = null
-
 	QDEL_NULL(bci_action)
-
 	return ..()
 
 /obj/item/circuit_component/bci_action/populate_options()
@@ -181,14 +177,6 @@
 
 /obj/item/circuit_component/bci_core/Destroy()
 	QDEL_NULL(charge_action)
-
-	message = null
-	send_message_signal = null
-
-	user_port = null
-
-	user = null
-
 	return ..()
 
 /obj/item/circuit_component/bci_core/register_shell(atom/movable/shell)

--- a/code/modules/wiremod/shell/compact_remote.dm
+++ b/code/modules/wiremod/shell/compact_remote.dm
@@ -31,10 +31,6 @@
 	. = ..()
 	signal = add_output_port("Signal", PORT_TYPE_SIGNAL)
 
-/obj/item/circuit_component/compact_remote/Destroy()
-	signal = null
-	return ..()
-
 /obj/item/circuit_component/compact_remote/register_shell(atom/movable/shell)
 	RegisterSignal(shell, COMSIG_ITEM_ATTACK_SELF, .proc/send_trigger)
 

--- a/code/modules/wiremod/shell/controller.dm
+++ b/code/modules/wiremod/shell/controller.dm
@@ -36,12 +36,6 @@
 	alt = add_output_port("Alternate Signal", PORT_TYPE_SIGNAL)
 	right = add_output_port("Extra Signal", PORT_TYPE_SIGNAL)
 
-/obj/item/circuit_component/controller/Destroy()
-	signal = null
-	alt = null
-	right = null
-	return ..()
-
 /obj/item/circuit_component/controller/register_shell(atom/movable/shell)
 	RegisterSignal(shell, COMSIG_ITEM_ATTACK_SELF, .proc/send_trigger)
 	RegisterSignal(shell, COMSIG_CLICK_ALT, .proc/send_alternate_signal)

--- a/code/modules/wiremod/shell/moneybot.dm
+++ b/code/modules/wiremod/shell/moneybot.dm
@@ -79,11 +79,6 @@
 	attached_bot.add_money(-to_dispense)
 	new /obj/item/holochip(drop_location(), to_dispense)
 
-/obj/item/circuit_component/money_dispenser/Destroy()
-	dispense_amount = null
-	attached_bot = null
-	return ..()
-
 /obj/item/circuit_component/money_bot
 	display_name = "Money Bot"
 	var/obj/structure/money_bot/attached_bot
@@ -117,13 +112,6 @@
 	))
 	total_money.set_output(null)
 	attached_bot = null
-	return ..()
-
-/obj/item/circuit_component/money_bot/Destroy()
-	attached_bot = null
-	total_money = null
-	money_input = null
-	money_trigger = null
 	return ..()
 
 /obj/item/circuit_component/money_bot/proc/handle_money_insert(atom/source, obj/item/item, mob/living/attacker)

--- a/code/modules/wiremod/shell/scanner.dm
+++ b/code/modules/wiremod/shell/scanner.dm
@@ -41,12 +41,6 @@
 	attacking = add_output_port("Scanned Entity", PORT_TYPE_ATOM)
 	signal = add_output_port("Scanned", PORT_TYPE_SIGNAL)
 
-/obj/item/circuit_component/wiremod_scanner/Destroy()
-	attacker = null
-	attacking = null
-	signal = null
-	return ..()
-
 /obj/item/circuit_component/wiremod_scanner/register_shell(atom/movable/shell)
 	RegisterSignal(shell, COMSIG_ITEM_AFTERATTACK, .proc/handle_afterattack)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This removes most Destroy overrides for circuit components. @Gurkenglas brought my attention to this and I think it's a worthwhile change.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The destroy override was unneeded and unnecessarily increased the length of code. These references should get cleared up anyways if the object successfully GC's anyways.

## Changelog
:cl:
code: Removes some unnecessary code bloat from the circuit component files.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
