### PR TITLE
Fix wallet storage to not allow screwdrivers to be stored inside

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -885,7 +885,6 @@
 		/obj/item/reagent_containers/dropper = 1,
 		/obj/item/reagent_containers/syringe = 1,
 		/obj/item/reagent_containers/pill/maintenance = 1,
-		/obj/item/screwdriver = 1,
 		list(
 			/obj/item/stamp = 50,
 			/obj/item/stamp/denied = 50,

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -37,9 +37,7 @@
 		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/reagent_containers/pill,
-		/obj/item/screwdriver,
-		/obj/item/stamp),
-		list(/obj/item/screwdriver/power))
+		/obj/item/stamp))
 
 /obj/item/storage/wallet/Exited(atom/movable/gone, direction)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This fixes some strange behavior with wallets where you can store screwdrivers and power drills.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Being able to store a screwdriver inside a small container like a wallet doesn't make any sense.

## Changelog
:cl:
fix: Fixed wallet storage to not allow screwdrivers to be stored inside
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
