### PR TITLE
Change the computer in Kilo's Mining Office

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -70014,12 +70014,18 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "nbI" = (
-/obj/machinery/computer/cargo/request,
+/obj/machinery/computer/cargo,
 /obj/effect/turf_decal/tile/purple{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
@@ -98853,6 +98859,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "ury" = (


### PR DESCRIPTION
Title. The computer in Kilo's Mining Office was a Supply REQUEST Console, not a Supply Console. Only miners and cargo personnel could enter that room, so fixed that. Also a small fix in the tilings on the mining dock.

## Changelog
:cl:
fix: Changed the computer in Kilo's mining office. 
fix: A small issue on the tiling in the mining dock.
/:cl:

