### PR TITLE
Give ghosts the ability to examine BCIs

### DIFF
--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -236,6 +236,7 @@
 	user_port.set_output(owner)
 	user = WEAKREF(owner)
 
+	RegisterSignal(owner, COMSIG_PARENT_EXAMINE, .proc/on_examine)
 	RegisterSignal(owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, .proc/on_borg_charge)
 	RegisterSignal(owner, COMSIG_LIVING_ELECTROCUTE_ACT, .proc/on_electrocute)
 
@@ -246,6 +247,7 @@
 	user = null
 
 	UnregisterSignal(owner, list(
+		COMSIG_PARENT_EXAMINE,
 		COMSIG_PROCESS_BORGCHARGER_OCCUPANT,
 		COMSIG_LIVING_ELECTROCUTE_ACT,
 	))
@@ -269,6 +271,19 @@
 
 	parent.cell.give(shock_damage * 2)
 	to_chat(source, span_notice("You absorb some of the shock into your [parent.name]!"))
+
+/obj/item/circuit_component/bci_core/proc/on_examine(datum/source, mob/mob, list/examine_text)
+	if (isobserver(mob))
+		examine_text += span_notice("[source.p_they(capitalized = TRUE)] [source.p_have()] <a href='?src=[REF(src)];open_bci=1'>\a [parent] implanted in [source.p_them()]</a>.")
+
+/obj/item/circuit_component/bci_core/Topic(href, list/href_list)
+	..()
+
+	if (!isobserver(usr))
+		return
+
+	if (href_list["open_bci"])
+		parent.attack_ghost(usr)
 
 /datum/action/innate/bci_charge_action
 	name = "Check BCI Charge"

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -273,6 +273,8 @@
 	to_chat(source, span_notice("You absorb some of the shock into your [parent.name]!"))
 
 /obj/item/circuit_component/bci_core/proc/on_examine(datum/source, mob/mob, list/examine_text)
+	SIGNAL_HANDLER
+
 	if (isobserver(mob))
 		examine_text += span_notice("[source.p_they(capitalized = TRUE)] [source.p_have()] <a href='?src=[REF(src)];open_bci=1'>\a [parent] implanted in [source.p_them()]</a>.")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Examining a mob with a BCI inside them will now give you the ability to look at it. Helpful for admins, but also keeps in line with every other circuit shell.

## Changelog
:cl:
qol: Ghosts can now examine BCIs inside hosts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
