### PR TITLE
Lazy fix for wizards spawning without a spellbook when they roll the die of fate and missing a limb

### DIFF
--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -311,13 +311,13 @@
 	back = /obj/item/storage/backpack
 	backpack_contents = list(
 		/obj/item/storage/box/survival = 1,
+		/obj/item/spellbook = 1,
 )
 	ears = /obj/item/radio/headset
 	head = /obj/item/clothing/head/wizard
 	shoes = /obj/item/clothing/shoes/sandal/magic
 	r_pocket = /obj/item/teleportation_scroll
 	l_hand = /obj/item/staff
-	r_hand = /obj/item/spellbook
 
 /datum/outfit/wizard/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -323,7 +323,7 @@
 	if(visualsOnly)
 		return
 
-	var/obj/item/spellbook/S = locate() in H.held_items
+	var/obj/item/spellbook/S = locate() in H.back
 	if(S)
 		S.owner = H
 


### PR DESCRIPTION
Lazy fix for #57953 also may relate to #58920
Makes the wizard spellbook spawn in their backpack instead of their hands, which may fixes any inconsisties without missing limbs and it not spawning

## Changelog
:cl:
fix: fixes wizard failing to spawn without a spellbook when you roll a d20
/:cl: