### PR TITLE
Removed duplicate QM stamp in Icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -22504,7 +22504,6 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/item/stamp/qm,
 /obj/item/pen/red,
 /obj/item/pen{
 	pixel_x = 4;
@@ -51870,7 +51869,6 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/stamp/qm,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -54832,6 +54830,7 @@
 "wnf" = (
 /obj/structure/table,
 /obj/structure/cable,
+/obj/item/stamp/qm,
 /turf/open/floor/carpet,
 /area/cargo/qm)
 "wnj" = (


### PR DESCRIPTION
Title.
There were 2 QM stamps in Icebox; I deleted one of them and moved the other to be on another desk. It previously was under objects roundstart, so I moved to an empty table.

## Changelog
:cl:
fix: Removed the duplicate QM stamp on Icebox
/:cl:
