### PR TITLE
photocopier and carbon paper copying now share a common proc.

### DIFF
--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -4,12 +4,9 @@
 	inhand_icon_state = "paper"
 	show_written_words = FALSE
 	var/copied = FALSE
-	var/iscopy = FALSE
 
 /obj/item/paper/carbon/update_icon_state()
-	if(iscopy)
-		icon_state = "cpaper"
-	else if(copied)
+	if(copied)
 		icon_state = "paper"
 	else
 		icon_state = "paper_stack"
@@ -19,30 +16,21 @@
 
 /obj/item/paper/carbon/examine()
 	. = ..()
-	if(copied || iscopy)
+	if(copied)
 		return
 	. += span_notice("Right-click to tear off the carbon-copy (you must use both hands).")
 
 /obj/item/paper/carbon/proc/removecopy(mob/living/user)
-	if(copied || iscopy)
+	if(copied)
 		to_chat(user, span_notice("There are no more carbon copies attached to this paper!"))
-	else
-		var/obj/item/paper/carbon/C = src
-		var/copycontents = C.info
-		var/obj/item/paper/carbon/Copy = new /obj/item/paper/carbon(user.loc)
+		return
 
-		if(info)
-			copycontents = replacetext(copycontents, "<font face=\"[PEN_FONT]\" color=", "<font face=\"[PEN_FONT]\" nocolor=")
-			copycontents = replacetext(copycontents, "<font face=\"[CRAYON_FONT]\" color=", "<font face=\"[CRAYON_FONT]\" nocolor=")
-			Copy.info += copycontents
-			Copy.info += "</font>"
-			Copy.name = "Copy - [C.name]"
-		to_chat(user, span_notice("You tear off the carbon-copy!"))
-		C.copied = TRUE
-		Copy.iscopy = TRUE
-		Copy.update_icon_state()
-		C.update_icon_state()
-		user.put_in_hands(Copy)
+	var/obj/item/paper/carbon/copy = copy(/obj/item/paper/carbon_copy, loc.drop_location(), FALSE)
+	copy.name = "\improper Copy - [name]"
+	to_chat(user, span_notice("You tear off the carbon-copy!"))
+	copied = TRUE
+	update_icon_state()
+	user.put_in_hands(copy)
 
 /obj/item/paper/carbon/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
@@ -52,3 +40,6 @@
 	if(loc == user && user.is_holding(src))
 		removecopy(user)
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/paper/carbon_copy
+	icon_state = "cpaper"

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -63,20 +63,23 @@
 
 /**
  * This proc copies this sheet of paper to a new
- * sheet,  Makes it nice and easy for carbon and
- * the copyer machine
+ * sheet. Used by carbon papers and the photocopier machine.
  */
-/obj/item/paper/proc/copy()
-	var/obj/item/paper/N = new(arglist(args))
-	N.info = info
-	N.color = color
-	N.update_icon_state()
-	N.stamps = stamps
-	N.stamped = stamped.Copy()
-	N.form_fields = form_fields.Copy()
-	N.field_counter = field_counter
-	copy_overlays(N, TRUE)
-	return N
+/obj/item/paper/proc/copy(paper_type = /obj/item/paper, atom/location = loc, colored = TRUE)
+	var/obj/item/paper/new_paper = new paper_type (location)
+	if(colored)
+		new_paper.color = color
+		new_paper.info = info
+	else //This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
+		var/static/greyscale_info = regex("<font face=\"([PEN_FONT]|[CRAYON_FONT])\" color=", "i")
+		new_paper.info = replacetext(info, greyscale_info, "<font face=\"$1\" nocolor=")
+	new_paper.stamps = stamps?.Copy()
+	new_paper.stamped = stamped?.Copy()
+	new_paper.form_fields = form_fields.Copy()
+	new_paper.field_counter = field_counter
+	new_paper.update_icon_state()
+	copy_overlays(new_paper, TRUE)
+	return new_paper
 
 /**
  * This proc sets the text of the paper and updates the

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -120,7 +120,7 @@
 		return
 	if(istype(src, /obj/item/paper/carbon))
 		var/obj/item/paper/carbon/Carbon = src
-		if(!Carbon.iscopy && !Carbon.copied)
+		if(!Carbon.copied)
 			to_chat(user, span_notice("Take off the carbon copy first."))
 			return
 	//Origami Master

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -230,24 +230,13 @@
 /obj/machinery/photocopier/proc/make_paper_copy()
 	if(!paper_copy)
 		return
-	var/obj/item/paper/copied_paper = new(loc)
+	var/obj/item/paper/copied_paper = paper_copy.copy(/obj/item/paper, loc, FALSE)
 	give_pixel_offset(copied_paper)
-	if(toner_cartridge.charges > 10) // Lots of toner, make it dark.
-		copied_paper.info = "<font color = #101010>"
-	else // No toner? shitty copies for you!
-		copied_paper.info = "<font color = #808080>"
 
-	var/copied_info = paper_copy.info
-	copied_info = replacetext(copied_info, "<font face=\"[PEN_FONT]\" color=", "<font face=\"[PEN_FONT]\" nocolor=") //state of the art techniques in action
-	copied_info = replacetext(copied_info, "<font face=\"[CRAYON_FONT]\" color=", "<font face=\"[CRAYON_FONT]\" nocolor=") //This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
-	copied_paper.info += copied_info
-	copied_paper.info += "</font>"
+	//the font color dependant on the amount of toner left.
+	copied_paper.info = "<font color = [toner_cartridge.charges > 10 ? "#101010" : "#808080"]>[copied_paper.info]</font>"
 	copied_paper.name = paper_copy.name
-	copied_paper.update_appearance()
-	copied_paper.stamps = paper_copy.stamps
-	if(paper_copy.stamped)
-		copied_paper.stamped = paper_copy.stamped.Copy()
-	copied_paper.copy_overlays(paper_copy, TRUE)
+
 	toner_cartridge.charges -= PAPER_TONER_USE
 
 /**


### PR DESCRIPTION
## About The Pull Request
Puts the previously unused `/obj/item/paper/proc/copy` proc to use, with some modifications.

## Why It's Good For The Game
This will fix #60308.

## Changelog
:cl:
fix: Fixed copies of stamped papers sharing the same `stamps` list.
/:cl:
