### PR TITLE
Icebox and Tram chemistry smartfridges are now preloaded.

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10615,7 +10615,7 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "bjQ" = (
-/obj/machinery/smartfridge/chemistry,
+/obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
 /area/medical/pharmacy)
 "bjR" = (
@@ -37167,7 +37167,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "myc" = (
-/obj/machinery/smartfridge/chemistry,
+/obj/machinery/smartfridge/chemistry/preloaded,
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/medical/pharmacy)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -14172,7 +14172,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "brA" = (
-/obj/machinery/smartfridge/chemistry,
+/obj/machinery/smartfridge/chemistry/preloaded,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "pharmacy_shutters_2";
 	name = "Pharmacy shutters"


### PR DESCRIPTION
## About The Pull Request
Title, they were previously empty.

## Why It's Good For The Game
Fixes a mapping oversight. On all other maps, the pharmacy comes with preloaded smartfridges.

## Changelog
:cl:
fix: Icebox and Tram chemistry smartfridges are now preloaded.
/:cl:
