### PR TITLE
Fixes perspective issue with classic baton

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -274,7 +274,7 @@
 
 	add_fingerprint(user)
 	if((HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(50))
-		user.visible_message("<span class ='userdanger'>You accidentally hit yourself over the head with [src]!</span>", "<span class='danger'>[user] accidentally hits [user.p_them()]self over the head with [src]! What a doofus!</span>")
+		user.visible_message(span_danger("[user] accidentally hits [user.p_them()]self over the head with [src]! What a doofus!"), span_userdanger("You accidentally hit yourself over the head with [src]!"))
 
 		if(iscyborg(user))
 			if(affect_cyborg)


### PR DESCRIPTION
## About The Pull Request

Swaps the messages to the right perspective when you hit yourself with the classic baton due to the clumsy trait.

## Why It's Good For The Game

bug fix

## Changelog
:cl:
fix: Clumsily hitting yourself with the classic baton now gives you the message with the appropriate perspective
/:cl: