### PR TITLE
Adds USB port to air alarm

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -932,7 +932,7 @@
 		)
 
 		for(var/datum/gas/gas_type as anything in subtypesof(/datum/gas))
-			component_options.Add(gas_type.name)
+			component_options.Add(initial(gas_type.name))
 			options_to_key[gas_type.name] = gas_type
 
 	options = component_options

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -900,6 +900,7 @@
 
 	var/datum/port/output/pressure
 	var/datum/port/output/temperature
+	var/datum/port/output/gas_amount
 
 	var/obj/machinery/airalarm/connected_alarm
 	var/list/options_map
@@ -993,7 +994,7 @@
 		pressure.set_output(round(environment.return_pressure()))
 		temperature.set_output(round(environment.temperature))
 		if(ispath(options_map[current_option]))
-			gas_amount.set_output(round(location.air.gases[options_map[current_option]][MOLES]))
+			gas_amount.set_output(round(environment.gases[options_map[current_option]][MOLES]))
 		return
 
 	var/datum/tlv/tlv = connected_alarm.TLV[options_map[current_option]]

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -949,7 +949,7 @@
 /obj/item/circuit_component/air_alarm/input_received(datum/port/input/port)
 	. = ..()
 
-	if(. || !connected_alarm || !connected_alarm.locked)
+	if(. || !connected_alarm || connected_alarm.locked)
 		return
 
 	if(COMPONENT_TRIGGERED_BY(request_data, port))

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -889,7 +889,7 @@
 
 /obj/item/circuit_component/air_alarm
 	display_name = "Air Alarm"
-	display_desc = "Controls levels of gases and their temperature as well as all vents and scrubbers in the room."
+	desc = "Controls levels of gases and their temperature as well as all vents and scrubbers in the room."
 
 	var/datum/port/input/min_2
 	var/datum/port/input/min_1
@@ -918,23 +918,24 @@
 	gas_amount = add_output_port("Chosen Gas Amount", PORT_TYPE_NUMBER)
 
 /obj/item/circuit_component/air_alarm/populate_options()
-	var/static/list/component_options = list(
-		"Pressure",
-		"Temperature"
-	)
+	var/static/list/component_options
+	var/static/list/options_to_key
+
+	if(!component_options)
+		component_options = list(
+			"Pressure",
+			"Temperature"
+		)
+		options_to_key = list(
+			"Pressure" = "pressure",
+			"Temperature" = "temperature"
+		)
+
+		for(var/datum/gas/gas_type as anything in subtypesof(/datum/gas))
+			component_options.Add(gas_type.name)
+			options_to_key[gas_type.name] = gas_type
+
 	options = component_options
-
-	var/static/list/options_to_key = list(
-		"Pressure" = "pressure",
-		"Temperature" = "temperature"
-	)
-
-	for(var/gas_type in subtypesof(/datum/gas))
-		var/datum/gas/new_gas = new gas_type()
-		component_options.Add(new_gas.name)
-		options_to_key[new_gas.name] = gas_type
-		qdel(new_gas)
-
 	options_map = options_to_key
 
 /obj/item/circuit_component/air_alarm/register_usb_parent(atom/movable/parent)
@@ -961,11 +962,11 @@
 			gas_amount.set_output(round(environment.gases[options_map[current_option]][MOLES]))
 		return
 
-	var/datum/tlv/tlv = connected_alarm.TLV[options_map[current_option]]
-	tlv.min2 = min_2
-	tlv.min1 = min_1
-	tlv.max1 = max_1
-	tlv.max2 = max_2
+	var/datum/tlv/settings = connected_alarm.TLV[options_map[current_option]]
+	settings.min2 = min_2
+	settings.min1 = min_1
+	settings.max1 = max_1
+	settings.max2 = max_2
 
 #undef AALARM_MODE_SCRUBBING
 #undef AALARM_MODE_VENTING

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -985,7 +985,7 @@
 /obj/item/circuit_component/air_alarm/input_received(datum/port/input/port)
 	. = ..()
 
-	if(. || !connected_alarm || !connected_alarm.unlocked)
+	if(. || !connected_alarm || !connected_alarm.locked)
 		return
 
 	if(COMPONENT_TRIGGERED_BY(request_data, port))

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -931,9 +931,9 @@
 			"Temperature" = "temperature"
 		)
 
-		for(var/datum/gas/gas_type as anything in subtypesof(/datum/gas))
-			component_options.Add(initial(gas_type.name))
-			options_to_key[gas_type.name] = gas_type
+		for(var/gas_id in GLOB.meta_gas_info)
+			component_options.Add(GLOB.meta_gas_info[gas_id][META_GAS_NAME])
+			options_to_key[GLOB.meta_gas_info[gas_id][META_GAS_NAME]] = gas_id2path(gas_id)
 
 	options = component_options
 	options_map = options_to_key

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -985,7 +985,7 @@
 /obj/item/circuit_component/air_alarm/input_received(datum/port/input/port)
 	. = ..()
 
-	if(. || !connected_alarm)
+	if(. || !connected_alarm || !connected_alarm.unlocked)
 		return
 
 	if(COMPONENT_TRIGGERED_BY(request_data, port))

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -918,58 +918,22 @@
 	gas_amount = add_output_port("Chosen Gas Amount", PORT_TYPE_NUMBER)
 
 /obj/item/circuit_component/air_alarm/populate_options()
-	var/static/component_options = list(
+	var/static/list/component_options = list(
 		"Pressure",
-		"Temperature",
-		"Oxygen",
-		"Nitrogen",
-		"Carbon Dioxide",
-		"Miasma",
-		"Plasma",
-		"Nitrous Oxide",
-		"BZ",
-		"Hypernoblium",
-		"Water Vapor",
-		"Tritium",
-		"Stimulum",
-		"Nitryl",
-		"Pluoxium",
-		"Freon",
-		"Hydrogen",
-		"Healium",
-		"Proto Nitrate",
-		"Zauker",
-		"Helium",
-		"Antinoblium",
-		"Halon"
+		"Temperature"
 	)
 	options = component_options
 
-	var/static/options_to_key = list(
+	var/static/list/options_to_key = list(
 		"Pressure" = "pressure",
-		"Temperature" = "temperature",
-		"Oxygen" = /datum/gas/oxygen,
-		"Nitrogen" = /datum/gas/nitrogen,
-		"Carbon Dioxide" = /datum/gas/carbon_dioxide,
-		"Miasma" = /datum/gas/miasma,
-		"Plasma" = /datum/gas/plasma,
-		"Nitrous Oxide" = /datum/gas/nitrous_oxide,
-		"BZ" = /datum/gas/bz,
-		"Hypernoblium" = /datum/gas/hypernoblium,
-		"Water Vapor" = /datum/gas/water_vapor,
-		"Tritium" = /datum/gas/tritium,
-		"Stimulum" = /datum/gas/stimulum,
-		"Nitryl" = /datum/gas/nitryl,
-		"Pluoxium" = /datum/gas/pluoxium,
-		"Freon" = /datum/gas/freon,
-		"Hydrogen" = /datum/gas/hydrogen,
-		"Healium" = /datum/gas/healium,
-		"Proto Nitrate" = /datum/gas/proto_nitrate,
-		"Zauker" = /datum/gas/zauker,
-		"Helium" = /datum/gas/helium,
-		"Antinoblium" = /datum/gas/antinoblium,
-		"Halon" = /datum/gas/halon
+		"Temperature" = "temperature"
 	)
+
+	for(var/gas_type in subtypesof(/datum/gas))
+		var/datum/gas/new_gas = new gas_type()
+		component_options.Add(new_gas.name)
+		options_to_key[new_gas.name] = gas_type
+		qdel(new_gas)
 
 	options_map = options_to_key
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows you to control unlocked air alarms using USB

## Why It's Good For The Game

Allows even more autistic atmos setups to be made :)

## Changelog
:cl:
expansion: You can control air alarms using USB now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
