### PR TITLE
Fixes martial grab combos working while inside objects.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -362,7 +362,7 @@
 
 /mob/living/carbon/human/CtrlClick(mob/user)
 
-	if(!ishuman(user) ||!Adjacent(user) || user.incapacitated())
+	if(!ishuman(user) || !user.CanReach(src) || user.incapacitated())
 		return ..()
 
 	if(world.time < user.next_move)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -346,7 +346,7 @@
 		ML.pulled(src)
 
 /mob/living/CtrlClick(mob/user)
-	if(!isliving(user) || !Adjacent(user) || user.incapacitated())
+	if(!isliving(user) || !user.CanReach(src) || user.incapacitated())
 		return ..()
 
 	if(world.time < user.next_move)


### PR DESCRIPTION
## About The Pull Request
Title. From `Adjacent(user)` to `user.CanReach(src)`.

## Why It's Good For The Game
This will fix #60523.

## Changelog
:cl:
fix: Fixes martial grab combos working while inside objects.
/:cl:
