### PR TITLE
Fixes a mind transfer exploit concerning holopara/guardians.

### DIFF
--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -29,15 +29,15 @@
 		return FALSE
 
 	var/mob/living/victim = targets[1] //The target of the spell whos body will be transferred to.
+	if(istype(victim, /mob/living/simple_animal/hostile/guardian))
+		var/mob/living/simple_animal/hostile/guardian/stand = victim
+		if(stand.summoner)
+			victim = stand.summoner
 	var/datum/mind/VM = victim.mind
 	if(victim.anti_magic_check(TRUE, FALSE) || VM.has_antag_datum(/datum/antagonist/wizard) || VM.has_antag_datum(/datum/antagonist/cult) || VM.has_antag_datum(/datum/antagonist/changeling) || VM.has_antag_datum(/datum/antagonist/rev) || victim.key[1] == "@")
 		if(!silent)
 			to_chat(user, span_warning("[victim.p_their(TRUE)] mind is resisting your spell!"))
 		return FALSE
-	if(istype(victim, /mob/living/simple_animal/hostile/guardian))
-		var/mob/living/simple_animal/hostile/guardian/stand = victim
-		if(stand.summoner)
-			victim = stand.summoner
 
 	//You should not be able to enter one of the most powerful side-antags as a fucking wizard.
 	if(istype(victim,/mob/living/simple_animal/hostile/imp/slaughter))


### PR DESCRIPTION
## About The Pull Request
Inverts the positions of the guardian/holoparasite typecheck code and the anti_magic/antag datums one.

## Why It's Good For The Game
This will fix #56962

## Changelog
:cl:
fix: fixes being able to mind transfer into someone protected against it by targetting their holoparasite/guardian.
/:cl:
