### PR TITLE
Fixes multiple mapping errors

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1594,7 +1594,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "ahS" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/machinery/light/directional/east,
@@ -3154,7 +3154,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "asD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/barsign{
@@ -5934,7 +5934,7 @@
 	pixel_x = -26
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "aPQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -6346,7 +6346,7 @@
 "aST" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "aSY" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/red{
@@ -6734,7 +6734,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "aXx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7193,6 +7193,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bcG" = (
@@ -7721,7 +7722,7 @@
 /obj/structure/training_machine,
 /obj/item/target/syndicate,
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "bfR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -12259,7 +12260,7 @@
 	},
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "bNM" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "justicechamber";
@@ -19582,7 +19583,7 @@
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
-/area/science/misc_lab/range)
+/area/science/mixing)
 "cBR" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -29716,13 +29717,10 @@
 /turf/open/floor/plating,
 /area/science/research/abandoned)
 "dAw" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron,
 /area/science/mixing)
 "dAx" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -31257,6 +31255,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/science/mixing)
 "dHm" = (
@@ -32514,7 +32513,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "dMt" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small/directional/south,
@@ -37379,7 +37378,7 @@
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "emw" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/carpet,
@@ -39118,7 +39117,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "eMt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -40746,7 +40745,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "ffH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -41189,7 +41188,6 @@
 /area/science/storage)
 "fno" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -42544,7 +42542,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "fGF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -43315,7 +43313,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "fUZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow,
@@ -45071,7 +45069,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "gvf" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -45549,7 +45547,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "gDw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -48297,7 +48295,6 @@
 /area/cargo/warehouse)
 "huK" = (
 /obj/effect/landmark/start/scientist,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -48676,7 +48673,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "hAI" = (
 /obj/structure/window,
 /obj/structure/sink{
@@ -49347,7 +49344,7 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "hJb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -51173,7 +51170,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "ifX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -52544,16 +52541,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"izv" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/science/misc_lab/range)
 "izG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -53715,7 +53702,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "iPI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -55695,7 +55682,6 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -55709,7 +55695,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
@@ -56164,7 +56149,6 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "jAR" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -56173,7 +56157,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "jAZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -58942,7 +58926,7 @@
 "kot" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "koD" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -61443,7 +61427,7 @@
 /area/security/warden)
 "kVu" = (
 /turf/closed/wall,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "kVD" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -61675,7 +61659,7 @@
 "kYl" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "kYo" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/north,
@@ -61799,7 +61783,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "kZE" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -62326,7 +62310,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "lfw" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -62376,7 +62360,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "lgs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62926,7 +62910,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "lmL" = (
 /turf/closed/wall,
 /area/engineering/supermatter/room)
@@ -63250,7 +63234,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "lrc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -64385,7 +64369,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "lHI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
@@ -64918,7 +64902,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "lPn" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -65773,7 +65757,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "mat" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
@@ -66432,7 +66416,6 @@
 /area/engineering/supermatter/room)
 "mkm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -68165,7 +68148,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "mHf" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -68549,7 +68532,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "mLO" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -68781,7 +68764,7 @@
 /obj/machinery/research/explosive_compressor,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "mPp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -69410,7 +69393,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "mYA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -70567,6 +70550,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "nkL" = (
@@ -72155,15 +72139,8 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "nGy" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/closed/wall/r_wall,
+/area/science/misc_lab/range)
 "nGD" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -72204,7 +72181,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "nGZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -73091,7 +73068,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -73105,7 +73081,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "nSD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73528,11 +73504,19 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "nXC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "nXD" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch/directional/west,
@@ -75045,7 +75029,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "ooH" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Hallway - Starboard";
@@ -75996,7 +75980,7 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "oBs" = (
 /turf/closed/wall,
 /area/cargo/qm)
@@ -76163,7 +76147,7 @@
 	pixel_x = 28
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "oDC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -76351,7 +76335,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "oFV" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -76629,6 +76613,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "oIv" = (
@@ -78052,7 +78038,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "paN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79408,13 +79394,12 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/light_switch/directional/east{
 	pixel_y = 26
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "puL" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -82210,7 +82195,7 @@
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "qhm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84428,7 +84413,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "qKx" = (
 /obj/machinery/power/tesla_coil,
 /obj/effect/turf_decal/bot,
@@ -86089,7 +86074,6 @@
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "rev" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -86107,7 +86091,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "rew" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -86136,7 +86120,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "reB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -87122,7 +87106,7 @@
 /obj/machinery/door/poddoor/massdriver_toxins,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "rsL" = (
 /obj/structure/plaque/static_plaque/atmos,
 /turf/closed/wall,
@@ -88414,7 +88398,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "rLP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -88549,7 +88533,7 @@
 /obj/item/gun/energy/laser/practice,
 /obj/item/gun/energy/laser/practice,
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "rMV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -89473,8 +89457,20 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "saw" = (
-/turf/closed/wall/r_wall,
-/area/science/misc_lab/range)
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/science/mixing)
 "say" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/camera{
@@ -89621,21 +89617,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"scS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/science/mixing)
 "scY" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
@@ -89873,7 +89854,7 @@
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
-/area/science/misc_lab/range)
+/area/science/mixing)
 "sfo" = (
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/engine/vacuum,
@@ -90219,7 +90200,7 @@
 "skA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "skH" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/brown,
@@ -91651,7 +91632,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "sCo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -92262,7 +92243,7 @@
 /obj/item/clothing/glasses/science,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "sJv" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -92899,7 +92880,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "sTm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -93066,7 +93047,7 @@
 "sUT" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "sUU" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow,
@@ -93456,7 +93437,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "sYF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -93893,14 +93874,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"tew" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "teB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -95102,7 +95075,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "txh" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -98092,8 +98065,6 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "ujY" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -98104,7 +98075,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "ukj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/purple,
@@ -99148,7 +99119,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "uyh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown,
@@ -100319,7 +100290,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "uMi" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -100579,7 +100550,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "uRC" = (
 /obj/structure/bonfire,
 /obj/item/reagent_containers/food/drinks/bottle/orangejuice{
@@ -103262,7 +103233,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "vFR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -103287,7 +103258,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "vGx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -105162,7 +105133,7 @@
 "weA" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "weH" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -105352,7 +105323,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "whY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -106067,7 +106038,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "wss" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -110742,7 +110713,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "xKt" = (
 /obj/structure/filingcabinet/employment,
 /obj/machinery/airalarm/directional/east,
@@ -110771,7 +110742,7 @@
 /area/service/hydroponics)
 "xKO" = (
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/science/misc_lab/range)
 "xKQ" = (
 /obj/item/kirbyplants/random,
 /obj/structure/disposalpipe/segment{
@@ -111650,7 +111621,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/science/mixing)
 "xYc" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -137023,11 +136994,11 @@ nPM
 nPM
 nPM
 nPM
-gSi
-gSi
-gSi
-gSi
-gSi
+nGy
+nGy
+nGy
+nGy
+nGy
 dhQ
 dhQ
 dhQ
@@ -137280,11 +137251,11 @@ pfQ
 caE
 crF
 rOQ
-gSi
+nGy
 map
 vGv
 lmF
-gSi
+nGy
 dul
 dvZ
 dxH
@@ -137537,11 +137508,11 @@ moY
 caE
 iod
 qKy
-gSi
+nGy
 mLI
 bfJ
 aST
-gSi
+nGy
 djs
 dlf
 dxI
@@ -137794,11 +137765,11 @@ moY
 caE
 wMH
 qpq
-gSi
+nGy
 uRm
 xKO
 aST
-gSi
+nGy
 dlg
 dli
 xwx
@@ -138051,11 +138022,11 @@ kEw
 caE
 qpq
 qpq
-gSi
+nGy
 mLI
 xKO
 mGu
-gSi
+nGy
 dum
 dli
 dpZ
@@ -138308,11 +138279,11 @@ laE
 xsp
 jER
 muj
-gSi
+nGy
 mLI
 sSW
 aST
-gSi
+nGy
 yjc
 lEl
 dxJ
@@ -138565,11 +138536,11 @@ aiu
 caE
 qpq
 dwo
-gSi
+nGy
 gve
 uMh
 nGU
-gSi
+nGy
 dun
 lEl
 dxK
@@ -138822,11 +138793,11 @@ joJ
 caE
 xMn
 ccN
-gSi
+nGy
 lPk
 xKi
 ffG
-gSi
+nGy
 duo
 dmu
 eMD
@@ -139079,11 +139050,11 @@ oAw
 caE
 cea
 iyK
-gSi
+nGy
 oBr
 ifR
 dMi
-gSi
+nGy
 dup
 dlg
 dxL
@@ -139336,11 +139307,11 @@ hST
 caE
 cea
 cea
-gSi
+nGy
 kYl
 oox
 bNG
-gSi
+nGy
 duq
 dlh
 dxM
@@ -139593,11 +139564,11 @@ joJ
 caE
 uCC
 ceb
-gSi
+nGy
 rMT
 oox
 qhk
-gSi
+nGy
 dur
 xze
 dxN
@@ -139850,11 +139821,11 @@ joJ
 caE
 caE
 caE
-gSi
+nGy
 sUT
 fGC
-gSi
-gSi
+nGy
+nGy
 dus
 dwa
 dom
@@ -140890,14 +140861,14 @@ cxO
 mbI
 caE
 aad
-saw
+drP
 skA
 skA
-saw
+drP
 skA
-saw
+drP
 eMn
-saw
+drP
 dOa
 dOM
 aad
@@ -141154,7 +141125,7 @@ hIQ
 aPJ
 skA
 asu
-saw
+drP
 dOb
 ert
 ert
@@ -141405,13 +141376,13 @@ oFE
 cOj
 aad
 skA
-nXC
+xmt
 lra
 lHp
 iPA
 weA
 rsF
-saw
+drP
 dOc
 ert
 yiM
@@ -141661,14 +141632,14 @@ dzo
 mbI
 caE
 aaa
-saw
+drP
 emq
 cBP
 mYu
 rLO
 skA
 hAH
-saw
+drP
 dOd
 ert
 iKu
@@ -141925,7 +141896,7 @@ qKr
 sJb
 kot
 aXp
-saw
+drP
 dOe
 hmH
 yli
@@ -142178,11 +142149,11 @@ aaa
 skA
 twD
 uxQ
-izv
+jAR
 mPo
 skA
 lft
-saw
+drP
 dLW
 fTa
 elW
@@ -142432,14 +142403,14 @@ cxO
 oFE
 caE
 aad
-saw
+drP
 puE
 ujY
 jAR
 whX
 oDB
 sCm
-saw
+drP
 qHZ
 kwQ
 bce
@@ -142689,14 +142660,14 @@ dzp
 pxk
 caE
 caE
-saw
-saw
-saw
+drP
+drP
+drP
 nSA
-saw
-saw
-saw
-saw
+drP
+drP
+drP
+drP
 uSp
 hmH
 etl
@@ -143718,11 +143689,11 @@ drP
 drP
 drP
 drP
-saw
-saw
+drP
+drP
 rew
-saw
-saw
+drP
+drP
 dLS
 dNw
 fGR
@@ -144484,8 +144455,8 @@ ote
 qzP
 dwi
 huK
-rMd
-uqv
+nXC
+saw
 hEu
 qkc
 hCm
@@ -144740,7 +144711,7 @@ drR
 dtl
 lMO
 dtl
-tew
+dtl
 dtl
 dtl
 bcD
@@ -144997,7 +144968,7 @@ drT
 dtm
 iQK
 lXF
-nGy
+vAb
 vAb
 vAb
 nkD
@@ -145768,7 +145739,7 @@ exE
 oIE
 lyU
 fpQ
-scS
+yiv
 eMJ
 yiv
 gNS

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -15446,7 +15446,7 @@
 "ccN" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
-/area/science/misc_lab)
+/area/maintenance/port)
 "ccU" = (
 /obj/effect/spawner/randomsnackvend,
 /obj/machinery/light/directional/west,
@@ -18479,7 +18479,7 @@
 /obj/item/screwdriver,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/maintenance/port)
 "crG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -28831,7 +28831,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/maintenance/port)
 "dwt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -40328,9 +40328,9 @@
 "faI" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/camera{
-	c_tag = "MiniSat Service Bay";
+	c_tag = "Science Maintnence";
 	dir = 8;
-	network = list("minisat");
+	network = list("ss13","rd");
 	start_active = 1
 	},
 /obj/structure/cable,
@@ -51739,14 +51739,9 @@
 /area/command/gateway)
 "iod" = (
 /obj/structure/table/reinforced,
-/obj/machinery/camera{
-	c_tag = "Science - Experimentation Lab";
-	name = "science camera";
-	network = list("ss13","rd")
-	},
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/maintenance/port)
 "iog" = (
 /obj/item/clothing/suit/hazardvest{
 	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
@@ -52508,9 +52503,8 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "iyK" = (
-/obj/effect/turf_decal/tile/purple,
-/turf/closed/wall/r_wall,
-/area/science/misc_lab)
+/turf/open/floor/iron,
+/area/maintenance/port)
 "iyX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56470,7 +56464,7 @@
 "jER" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/maintenance/port)
 "jES" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -66343,11 +66337,6 @@
 	},
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
-"mhV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/science/misc_lab)
 "mhX" = (
 /obj/machinery/camera{
 	c_tag = "Art Gallery";
@@ -67372,7 +67361,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/maintenance/port)
 "muI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
@@ -72672,10 +72661,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"nNa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/science/misc_lab)
 "nNm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/filingcabinet/filingcabinet,
@@ -84454,7 +84439,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/maintenance/port)
 "qKC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -88682,7 +88667,7 @@
 "rOQ" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/maintenance/port)
 "rPb" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
@@ -92076,6 +92061,10 @@
 	pixel_y = -26
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/machinery/computer/security/telescreen/rd{
+	dir = 4;
+	pixel_x = -26
+	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "sGN" = (
@@ -99601,7 +99590,7 @@
 	},
 /obj/structure/rack,
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/maintenance/port)
 "uCT" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -100957,10 +100946,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"uWD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/misc_lab)
 "uWH" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
@@ -107219,9 +107204,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/aisat/exterior)
-"wId" = (
-/turf/open/floor/plating,
-/area/science/misc_lab)
 "wIn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -107440,7 +107422,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/maintenance/port)
 "wMU" = (
 /obj/machinery/button/flasher{
 	id = "Cell 5";
@@ -109555,7 +109537,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/science/misc_lab)
+/area/maintenance/port)
 "xsP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -137295,7 +137277,7 @@ iuP
 exk
 swm
 pfQ
-tCh
+caE
 crF
 rOQ
 gSi
@@ -137552,7 +137534,7 @@ cjq
 ced
 wXQ
 moY
-tCh
+caE
 iod
 qKy
 gSi
@@ -137809,9 +137791,9 @@ cMY
 cMY
 ceb
 moY
-tCh
+caE
 wMH
-nNa
+qpq
 gSi
 uRm
 xKO
@@ -138066,9 +138048,9 @@ cNd
 cMY
 cea
 kEw
-tCh
-nNa
-nNa
+caE
+qpq
+qpq
 gSi
 mLI
 xKO
@@ -138580,8 +138562,8 @@ xtH
 cMY
 deX
 aiu
-tCh
-nNa
+caE
+qpq
 dwo
 gSi
 gve
@@ -138837,8 +138819,8 @@ lvo
 cMY
 deX
 joJ
-tCh
-mhV
+caE
+xMn
 ccN
 gSi
 lPk
@@ -139094,9 +139076,9 @@ xXC
 cMY
 deY
 oAw
-tCh
-wId
-xKO
+caE
+cea
+iyK
 gSi
 oBr
 ifR
@@ -139351,9 +139333,9 @@ enx
 cMY
 cjp
 hST
-tCh
-wId
-wId
+caE
+cea
+cea
 gSi
 kYl
 oox
@@ -139608,10 +139590,10 @@ dcd
 cMY
 deZ
 joJ
-tCh
+caE
 uCC
-uWD
-iyK
+ceb
+gSi
 rMT
 oox
 qhk
@@ -139865,9 +139847,9 @@ rMk
 cMY
 deX
 joJ
-tCh
-tCh
-tCh
+caE
+caE
+caE
 gSi
 sUT
 fGC

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -12834,7 +12834,7 @@
 /area/medical/medbay/aft)
 "bvB" = (
 /obj/machinery/camera{
-	c_tag = "Genetics Access";
+	c_tag = "Med-Sci Access";
 	dir = 8;
 	network = list("ss13","medbay","rd");
 	pixel_y = -22

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10434,7 +10434,8 @@
 /area/science/research)
 "biS" = (
 /obj/machinery/camera{
-	c_tag = "Research Division Access"
+	c_tag = "Research Division Access";
+	network = list("ss13","rd")
 	},
 /obj/structure/sink{
 	dir = 8;
@@ -12364,7 +12365,8 @@
 /area/hallway/primary/central)
 "btA" = (
 /obj/machinery/camera{
-	c_tag = "Research Division West"
+	c_tag = "Research Division West";
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -12671,7 +12673,8 @@
 "bvf" = (
 /obj/machinery/camera{
 	c_tag = "Research Division North";
-	dir = 8
+	dir = 8;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white/side{
 	dir = 9
@@ -12833,7 +12836,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Access";
 	dir = 8;
-	network = list("ss13","medbay");
+	network = list("ss13","medbay","rd");
 	pixel_y = -22
 	},
 /turf/open/floor/iron/white,
@@ -15415,7 +15418,7 @@
 "bLc" = (
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
-	name = "Test Chamber Monitor";
+	name = "Xenobio Monitor";
 	network = list("xeno");
 	pixel_x = 26
 	},
@@ -17150,8 +17153,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/computer/camera_advanced/xenobio{
-	dir = 1;
-	networks = list("xeno_pens")
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
@@ -22066,7 +22068,9 @@
 	},
 /obj/machinery/keycard_auth/directional/south,
 /obj/machinery/camera/autoname{
-	dir = 1
+	c_tag = "Research Directors Office";
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
@@ -24322,7 +24326,9 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname{
-	dir = 1
+	c_tag = "Toxins Storage";
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -24369,7 +24375,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens Observation - Starboard Aft";
 	dir = 8;
-	network = list("ss13","rd","xeno_pens")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/openspace,
 /area/science/xenobiology)
@@ -28018,7 +28024,8 @@
 /obj/item/crowbar/large,
 /obj/machinery/camera{
 	c_tag = "Mech Bay";
-	dir = 1
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -30376,7 +30383,8 @@
 "iFt" = (
 /obj/machinery/camera{
 	c_tag = "Toxins Launch Room Access";
-	dir = 1
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
@@ -39580,7 +39588,7 @@
 "nLm" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab Entrance";
-	network = list("ss13","rd")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/openspace,
 /area/science/xenobiology)
@@ -42757,7 +42765,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens Observation - Starboard Fore";
 	dir = 8;
-	network = list("ss13","rd","xeno_pens")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/openspace,
 /area/science/xenobiology)
@@ -43279,7 +43287,7 @@
 /area/service/library)
 "pOq" = (
 /obj/machinery/camera{
-	c_tag = "Circuits Lab";
+	c_tag = "Research Division East";
 	dir = 4;
 	network = list("ss13","rd")
 	},
@@ -47983,9 +47991,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "swQ" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	networks = list("xeno_pens")
-	},
+/obj/machinery/computer/camera_advanced/xenobio,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "swV" = (
@@ -50176,6 +50182,11 @@
 /area/security/office)
 "tJy" = (
 /obj/machinery/component_printer,
+/obj/machinery/camera{
+	c_tag = "Circuits Lab";
+	dir = 4;
+	network = list("ss13","rd")
+	},
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -56890,7 +56901,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens Observation - Port Fore";
 	dir = 4;
-	network = list("ss13","rd","xeno_pens")
+	network = list("ss13","rd","xeno")
 	},
 /obj/machinery/light/directional/west,
 /turf/open/openspace,
@@ -58387,7 +58398,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens Observation - Port Aft";
 	dir = 4;
-	network = list("ss13","rd","xeno_pens")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/openspace,
 /area/science/xenobiology)
@@ -106852,8 +106863,8 @@ bpE
 bpE
 bpE
 bpE
-boB
-boB
+bhA
+bhA
 pLE
 qSi
 sql

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -1568,7 +1568,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens - Starboard Aft";
 	dir = 8;
-	network = list("ss13","rd","xeno_pens")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -1846,7 +1846,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens - Port Aft";
 	dir = 4;
-	network = list("ss13","rd","xeno_pens")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -2447,7 +2447,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens Hall - Fore";
 	dir = 6;
-	network = list("ss13","rd","xeno_pens")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -4414,7 +4414,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens - Starboard Fore";
 	dir = 8;
-	network = list("ss13","rd","xeno_pens")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -4722,7 +4722,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens - Starboard Mid";
 	dir = 8;
-	network = list("ss13","rd","xeno_pens")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -4776,7 +4776,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens - Port Mid";
 	dir = 4;
-	network = list("ss13","rd","xeno_pens")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -4988,7 +4988,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Pens - Port Fore";
 	dir = 4;
-	network = list("ss13","rd","xeno_pens")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -5013,7 +5013,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Kill Chamber";
 	dir = 4;
-	network = list("ss13","rd","xeno_pens")
+	network = list("ss13","rd","xeno")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -39301,7 +39301,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "cIb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -41356,7 +41356,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/module_duplicator,
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "dkX" = (
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall/rust,
@@ -41467,7 +41467,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "dpC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/blood/old,
@@ -41689,7 +41689,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "dtq" = (
 /turf/closed/wall/rust,
 /area/engineering/gravity_generator)
@@ -42286,7 +42286,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/science/test_area)
+/area/science/misc_lab)
 "dIT" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/cargo{
@@ -46147,7 +46147,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "fuC" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -49092,7 +49092,7 @@
 "gJJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/science/test_area)
+/area/science/misc_lab)
 "gJT" = (
 /obj/structure/chair/sofa/right{
 	color = "#c45c57";
@@ -49534,7 +49534,7 @@
 /area/engineering/supermatter/room)
 "gVX" = (
 /turf/closed/wall/rust,
-/area/science/test_area)
+/area/science/misc_lab)
 "gWx" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -51257,7 +51257,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "hNl" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/rust,
@@ -51761,7 +51761,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "hYb" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -52200,7 +52200,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "igh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -54018,7 +54018,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "iTK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/west,
@@ -54121,7 +54121,7 @@
 /obj/item/compact_remote,
 /obj/item/compact_remote,
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "iUy" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -61101,7 +61101,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "lRG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/structure/grille,
@@ -62796,6 +62796,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"mDd" = (
+/turf/closed/wall/r_wall,
+/area/science/misc_lab)
 "mDG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -64196,7 +64199,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/science/test_area)
+/area/science/misc_lab)
 "nmc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -68230,7 +68233,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "paZ" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/cable,
@@ -68288,7 +68291,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "pbw" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -68302,7 +68305,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "pbW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -70911,7 +70914,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "qaY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71331,7 +71334,7 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "qlU" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -71471,7 +71474,7 @@
 "qoN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/rust,
-/area/science/test_area)
+/area/science/misc_lab)
 "qoR" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall/rust,
@@ -74813,7 +74816,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "rKt" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -75963,7 +75966,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "slN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -76938,7 +76941,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "sLL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -79415,7 +79418,7 @@
 	},
 /obj/machinery/research/explosive_compressor,
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "tNt" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
@@ -79614,7 +79617,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "tQw" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -80007,7 +80010,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "tZH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -80783,7 +80786,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "upp" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/effect/turf_decal/stripes/line{
@@ -82568,7 +82571,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/science/test_area)
+/area/science/misc_lab)
 "ver" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -83611,7 +83614,7 @@
 "vAx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/science/test_area)
+/area/science/misc_lab)
 "vAL" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/event_spawn,
@@ -85068,7 +85071,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "wjo" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -85512,7 +85515,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "wrh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -87302,7 +87305,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "xfU" = (
 /obj/item/circuitboard/computer/solar_control,
 /turf/open/floor/plating/asteroid/airless,
@@ -87719,7 +87722,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "xpP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -88488,7 +88491,7 @@
 /area/cargo/miningoffice)
 "xEu" = (
 /turf/closed/wall,
-/area/science/test_area)
+/area/science/misc_lab)
 "xEE" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -88979,7 +88982,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron/dark,
-/area/science/test_area)
+/area/science/misc_lab)
 "xQT" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/emcloset,
@@ -89075,7 +89078,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "xSr" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
@@ -89586,7 +89589,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
-/area/science/test_area)
+/area/science/misc_lab)
 "yfb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -132491,7 +132494,7 @@ beo
 hdj
 aOT
 bbi
-caT
+mDd
 xpL
 pbn
 tNe

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14278,7 +14278,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Central West";
 	dir = 8;
-	network = list("ss13","rd")
+	network = list("ss13","rd","xeno")
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/button/door/directional/east{
@@ -14633,7 +14633,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera{
 	c_tag = "Science Hallway - Central";
-	dir = 4
+	dir = 4;
+	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -15554,7 +15555,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Science Break Room";
-	dir = 4
+	dir = 4;
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -19015,7 +19017,8 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/camera{
 	c_tag = "Science Toxins Launch 2";
-	dir = 8
+	dir = 8;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
@@ -19914,7 +19917,8 @@
 /obj/item/stock_parts/cell/high,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/camera{
-	c_tag = "Science Mechbay"
+	c_tag = "Science Mechbay";
+	network = list("ss13","rd")
 	},
 /obj/machinery/button/door/directional/north{
 	id = "mechbay";
@@ -21285,7 +21289,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Central South";
 	dir = 6;
-	network = list("ss13","rd")
+	network = list("ss13","rd","xeno")
 	},
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/white,
@@ -21442,7 +21446,8 @@
 /area/service/chapel/office)
 "eHX" = (
 /obj/machinery/camera{
-	c_tag = "Science Robotics Workshop"
+	c_tag = "Science Robotics Workshop";
+	network = list("ss13","rd")
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -23877,7 +23882,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Fore";
 	dir = 4;
-	network = list("ss13","rd")
+	network = list("ss13","rd","xeno")
 	},
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
@@ -25094,7 +25099,8 @@
 /obj/machinery/light/small/directional/north,
 /obj/machinery/camera{
 	c_tag = "Science Toxins Corridor";
-	dir = 4
+	dir = 4;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
@@ -25277,7 +25283,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Central North";
 	dir = 1;
-	network = list("ss13","rd")
+	network = list("ss13","rd","xeno")
 	},
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/white,
@@ -25484,7 +25490,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Science Hallway - West";
-	dir = 4
+	dir = 4;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -26496,7 +26503,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Science Admin";
-	dir = 4
+	dir = 4;
+	network = list("ss13","rd")
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
@@ -26663,7 +26671,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/camera{
-	c_tag = "Science Hallway - Research"
+	c_tag = "Science Hallway - Research";
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -26829,7 +26838,8 @@
 "gyI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
-	c_tag = "Science Robotics Office"
+	c_tag = "Science Robotics Office";
+	network = list("ss13","rd")
 	},
 /obj/item/radio/intercom/directional/north,
 /obj/item/storage/firstaid{
@@ -27008,7 +27018,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Science Genetics";
-	dir = 4
+	dir = 4;
+	network = list("ss13","rd")
 	},
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
@@ -28449,7 +28460,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Science Toxins Lab";
-	dir = 1
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/siding{
@@ -28673,7 +28685,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Science Toxins Mix";
-	dir = 1
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
@@ -28876,7 +28889,7 @@
 /obj/machinery/camera{
 	c_tag = "Cytology - Secure Pen";
 	dir = 4;
-	network = list("ss13","rd")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/cytology)
@@ -39265,7 +39278,7 @@
 /obj/machinery/camera{
 	c_tag = "Cytology Lab - Worklab";
 	dir = 4;
-	network = list("ss13","rd")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/holofloor/dark,
 /area/science/cytology)
@@ -39335,7 +39348,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Airlock";
 	dir = 4;
-	network = list("ss13","rd")
+	network = list("ss13","rd","xeno")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -39566,7 +39579,8 @@
 "kYf" = (
 /obj/machinery/camera{
 	c_tag = "RD Observation Cage";
-	dir = 1
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
 /area/command/heads_quarters/rd)
@@ -40510,7 +40524,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/camera{
-	c_tag = "Science Lobby"
+	c_tag = "Science Lobby";
+	network = list("ss13","rd")
 	},
 /obj/machinery/vending/modularpc,
 /turf/open/floor/iron/white,
@@ -42428,6 +42443,16 @@
 	name = "Toxins Containment Control";
 	pixel_x = 6;
 	req_access_txt = "30"
+	},
+/obj/machinery/button/door/directional/north{
+	id = "rdoffice";
+	name = "Privacy Control";
+	pixel_y = 34;
+	req_access_txt = "30"
+	},
+/obj/machinery/computer/security/telescreen/rd{
+	pixel_x = 31;
+	pixel_y = 30
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
@@ -49209,7 +49234,8 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/camera{
 	c_tag = "Science Maintenance Corridor";
-	dir = 8
+	dir = 8;
+	network = list("ss13","rd")
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53160,7 +53186,8 @@
 "ppA" = (
 /obj/machinery/camera{
 	c_tag = "Science Toxins Secure";
-	dir = 4
+	dir = 4;
+	network = list("ss13","rd")
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /obj/item/radio/intercom/directional/west{
@@ -59086,7 +59113,8 @@
 "rqT" = (
 /obj/machinery/camera{
 	c_tag = "Science Petting Zoo";
-	dir = 8
+	dir = 8;
+	network = list("ss13","rd")
 	},
 /obj/structure/frame/computer{
 	anchored = 1;
@@ -60608,7 +60636,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Science Research";
-	dir = 1
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -61714,7 +61743,8 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Science Entry";
-	dir = 1
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -63478,7 +63508,8 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/camera{
 	c_tag = "Science Toxins Secure 2";
-	dir = 8
+	dir = 8;
+	network = list("ss13","rd")
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
@@ -65143,7 +65174,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Central East";
 	dir = 4;
-	network = list("ss13","rd")
+	network = list("ss13","rd","xeno")
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
@@ -66604,7 +66635,8 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/camera{
-	c_tag = "Science Research Office"
+	c_tag = "Science Research Office";
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
 /area/science/lab)
@@ -66837,7 +66869,8 @@
 "tQb" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #1";
-	dir = 4
+	dir = 4;
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -69023,7 +69056,8 @@
 /area/science/cytology)
 "uzH" = (
 /obj/machinery/camera{
-	c_tag = "Science Firing Range"
+	c_tag = "Science Firing Range";
+	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
@@ -72450,7 +72484,8 @@
 /obj/structure/table,
 /obj/machinery/camera{
 	c_tag = "Science Toxins Launch";
-	dir = 1
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /obj/machinery/computer/pod/old/mass_driver_controller/toxinsdriver{
 	pixel_y = -24
@@ -73147,7 +73182,7 @@
 	pixel_x = -8
 	},
 /turf/open/floor/iron/white,
-/area/science/misc_lab/range)
+/area/science/misc_lab)
 "vRT" = (
 /obj/machinery/light/directional/south,
 /obj/item/stack/sheet/cardboard{
@@ -74611,7 +74646,8 @@
 "wqM" = (
 /obj/machinery/camera{
 	c_tag = "Science Hallway - Admin";
-	dir = 1
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75593,12 +75629,6 @@
 	department = "Research Director's Desk";
 	departmentType = 5;
 	name = "Research Director's Requests Console"
-	},
-/obj/machinery/button/door/directional/north{
-	id = "rdoffice";
-	name = "Privacy Control";
-	pixel_x = -8;
-	req_access_txt = "30"
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9346,7 +9346,6 @@
 	},
 /area/maintenance/port/fore)
 "bIO" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
@@ -18726,7 +18725,7 @@
 	req_access_txt = "8"
 	},
 /turf/open/floor/plating,
-/area/science/mixing)
+/area/maintenance/starboard/aft)
 "dNN" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
@@ -19150,7 +19149,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 10
 	},
@@ -22586,13 +22584,6 @@
 	dir = 1
 	},
 /area/engineering/main)
-"eYI" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "eYN" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -24043,13 +24034,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
-"fyr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "fys" = (
 /obj/structure/table/glass,
 /obj/item/folder/blue,
@@ -25013,7 +24997,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Fuel Pipe to Filter"
@@ -25363,9 +25346,7 @@
 /turf/open/floor/engine/cult,
 /area/service/library)
 "fVN" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/north,
-/obj/machinery/power/apc/auto_name/north,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
@@ -25412,7 +25393,6 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "fXt" = (
-/obj/structure/cable,
 /obj/item/food/cracker,
 /obj/item/food/cracker{
 	pixel_x = 9;
@@ -26230,7 +26210,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "gls" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -28194,7 +28173,6 @@
 /turf/open/floor/iron/white,
 /area/medical/abandoned)
 "gZq" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -32094,7 +32072,6 @@
 	dir = 8;
 	name = "emergency shower"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/requests_console/directional/east{
 	department = "Atmospherics";
@@ -40873,7 +40850,6 @@
 /area/medical/virology)
 "lsw" = (
 /obj/machinery/meter,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -41863,7 +41839,6 @@
 /turf/open/floor/wood,
 /area/cargo/qm)
 "lMm" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -43246,7 +43221,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -44388,7 +44362,6 @@
 /obj/machinery/door/window/northleft{
 	name = "Petting Zoo"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -50270,7 +50243,6 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "otl" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -53943,7 +53915,6 @@
 /area/service/hydroponics)
 "pCC" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -63544,7 +63515,6 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "sOg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -64489,7 +64459,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -67727,7 +67696,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ufw" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
 	dir = 1
 	},
@@ -69279,11 +69247,6 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"uDl" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/grass,
-/area/science/research)
 "uDq" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -73362,7 +73325,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -73747,7 +73709,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
@@ -79014,13 +78975,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"xPA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xPF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -113713,8 +113667,8 @@ scO
 crR
 crR
 crR
-cyK
-cyK
+nOc
+nOc
 dNG
 nOc
 nOc
@@ -114740,7 +114694,7 @@ gEE
 nFC
 idk
 idk
-cyK
+crR
 tXF
 kEC
 eCn
@@ -117811,7 +117765,7 @@ crZ
 cgo
 mvj
 fXt
-uDl
+oTI
 mAN
 niR
 bih
@@ -122154,13 +122108,13 @@ tbd
 gls
 bIO
 pCC
-fyr
-grx
-xPA
+slA
+lye
+tHX
 isF
 otl
 lsw
-eYI
+fJd
 xoQ
 sMi
 yiS

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -25425,6 +25425,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/north,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
 "fXO" = (
@@ -54545,6 +54546,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"pOY" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/science/misc_lab/range)
 "pPb" = (
 /mob/living/simple_animal/chicken{
 	name = "Featherbottom";
@@ -69059,6 +69065,7 @@
 	c_tag = "Science Firing Range";
 	network = list("ss13","rd")
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
 "uzL" = (
@@ -114969,7 +114976,7 @@ paq
 quV
 pbs
 cuZ
-pcn
+pOY
 oxa
 cFB
 pcn

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -38249,10 +38249,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
-"kBo" = (
-/obj/effect/spawner/lootdrop/donkpockets,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "kBC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
@@ -50348,7 +50344,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/starboard/secondary)
 "ovg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -116773,7 +116769,7 @@ odO
 hrc
 dee
 quV
-kBo
+jAh
 ouU
 oUQ
 ovj
@@ -117547,7 +117543,7 @@ uOq
 tfU
 bTe
 chC
-alq
+ovj
 ovj
 ovj
 ovj

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -24259,7 +24259,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/science/misc_lab)
+/area/maintenance/starboard/secondary)
 "fBA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -24370,6 +24370,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"fCV" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/science/misc_lab/range)
 "fCY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -54546,11 +54551,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
-"pOY" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/science/misc_lab/range)
 "pPb" = (
 /mob/living/simple_animal/chicken{
 	name = "Featherbottom";
@@ -114976,7 +114976,7 @@ paq
 quV
 pbs
 cuZ
-pOY
+fCV
 oxa
 cFB
 pcn

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -138,7 +138,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Genetics Pen";
 	dir = 1;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
@@ -2243,7 +2243,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Break Room";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/cafeteria{
@@ -4023,7 +4023,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology Lower North";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd","xeno")
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
@@ -6973,7 +6973,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Lower Main North";
 	dir = 1;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
@@ -10565,7 +10565,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology Airlock";
 	dir = 9;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
@@ -14163,7 +14163,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Lobby";
 	dir = 9;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
@@ -22003,7 +22003,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Toxins North";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
@@ -22804,7 +22804,8 @@
 	},
 /obj/machinery/camera/motion{
 	c_tag = "Secure - AI Upload Access";
-	dir = 5
+	dir = 5;
+	network = list("ss13","aiupload")
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
@@ -24540,7 +24541,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "Science Camera Monitor";
-	network = list("ss13","science");
+	network = list("ss13","rd");
 	pixel_y = -28
 	},
 /turf/open/floor/iron,
@@ -26617,6 +26618,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/science/research)
 "gqc" = (
@@ -28850,7 +28852,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology West";
 	dir = 5;
-	network = list("ss13","science")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -30590,7 +30592,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology Lower East";
 	dir = 8;
-	network = list("ss13","science")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -33198,7 +33200,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Security Outpost";
 	dir = 1;
-	network = list("ss13","science","Security")
+	network = list("ss13","rd","Security")
 	},
 /obj/effect/landmark/start/depsec/science,
 /obj/structure/reagent_dispensers/peppertank/directional/south,
@@ -34209,7 +34211,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Research Director's Office";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light/directional/north,
 /obj/item/folder/white,
@@ -35816,7 +35818,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Toxins Burn Chamber";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
@@ -35988,7 +35990,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Lower Power Hatch";
 	dir = 1;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -36790,7 +36792,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Restroom";
 	dir = 1;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/freezer,
 /area/science/research)
@@ -37521,7 +37523,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Main Lower Right";
 	dir = 5;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -38615,7 +38617,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Left Entry Airlock";
 	dir = 5;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
 /area/science/research)
@@ -38625,7 +38627,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Toxins Launch Room";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
@@ -39743,8 +39745,9 @@
 	name = "Circuit Laboratory";
 	req_access_txt = "47"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/maintenance/starboard/secondary)
+/area/science/misc_lab)
 "lll" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41330,7 +41333,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Cytology Lab";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/cytology)
@@ -41875,7 +41878,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Mech Bay";
 	dir = 5;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
@@ -44455,7 +44458,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Main Upper Left";
 	dir = 9;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -44643,7 +44646,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Lower Main South";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
@@ -45647,7 +45650,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Experimentor Lab Testing Range";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
 /area/science/explab)
@@ -47124,6 +47127,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "omZ" = (
@@ -47383,7 +47387,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/science/misc_lab)
+/area/maintenance/starboard/secondary)
 "orw" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
@@ -47486,7 +47490,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Main Lower Left";
 	dir = 9;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -47897,7 +47901,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Cytology Pen";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
 /area/science/cytology)
@@ -48139,7 +48143,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Robotics North";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
@@ -49072,7 +49076,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - AI Station Access";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
 /area/science/research)
@@ -49422,9 +49426,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -49585,6 +49586,11 @@
 	dir = 10
 	},
 /obj/machinery/module_duplicator,
+/obj/machinery/camera{
+	c_tag = "Circuits Lab";
+	dir = 4;
+	network = list("ss13","rd")
+	},
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "pil" = (
@@ -50103,7 +50109,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Upper Power Hatch";
 	dir = 1;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plating,
 /area/science/research)
@@ -54634,7 +54640,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Main Central";
 	dir = 1;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -55000,7 +55006,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology Kill Room";
 	dir = 1;
-	network = list("ss13","science")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
@@ -55037,7 +55043,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology South";
 	dir = 1;
-	network = list("ss13","science")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -55045,7 +55051,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology Lower Containment Chamber";
 	dir = 1;
-	network = list("ss13","science")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -55116,7 +55122,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology Lower South";
 	dir = 9;
-	network = list("ss13","science")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -55365,7 +55371,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Toxins Misc Storage";
 	dir = 8;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
@@ -56718,7 +56724,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Server Room";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
@@ -57031,7 +57037,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Experimentor Lab";
 	dir = 1;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
@@ -58433,7 +58439,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Main Upper Right";
 	dir = 5;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -59540,7 +59546,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Maintenance Intersection";
 	dir = 9;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
@@ -59692,7 +59698,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Toxins Canister Storage";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
@@ -60352,7 +60358,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology Lower West";
 	dir = 4;
-	network = list("ss13","science")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
@@ -61862,7 +61868,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Main AI Access Hall";
 	dir = 9;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -62437,6 +62443,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/science/research)
 "ufF" = (
@@ -65486,7 +65493,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Right Entry Airlock";
 	dir = 9;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
 /area/science/research)
@@ -66212,7 +66219,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Toxins South";
 	dir = 9;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
@@ -66801,7 +66808,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - AI Station Access Exterior";
 	dir = 1;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
 /area/science/research)
@@ -67385,7 +67392,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Genetics";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/dark,
 /area/science/genetics)
@@ -67831,7 +67838,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology East";
 	dir = 9;
-	network = list("ss13","science")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -68628,7 +68635,7 @@
 /obj/machinery/camera{
 	c_tag = "Science - Research & Development";
 	dir = 6;
-	network = list("ss13","science")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science/lab)
@@ -119010,7 +119017,7 @@ aRL
 aRL
 aRL
 aRL
-sQi
+aRL
 der
 der
 der

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2320,7 +2320,7 @@
 "aiw" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "aix" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -6615,7 +6615,7 @@
 "avN" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "avO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron,
@@ -6948,7 +6948,7 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "awO" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -12323,6 +12323,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "aUv" = (
@@ -15763,7 +15764,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "bZi" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
@@ -20120,6 +20121,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "dKk" = (
@@ -21799,6 +21801,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "esv" = (
@@ -23107,7 +23110,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "eVL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -29002,6 +29005,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"hir" = (
+/turf/open/floor/iron,
+/area/science/storage)
 "hiz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30050,6 +30056,9 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/service/bar)
+"hDo" = (
+/turf/closed/wall/r_wall,
+/area/science/storage)
 "hDp" = (
 /obj/item/shovel,
 /obj/item/storage/bag/ore,
@@ -30299,6 +30308,15 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"hIv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "hIw" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -34380,7 +34398,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "joB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -34581,7 +34599,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "jsj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
@@ -35220,6 +35238,10 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"jFU" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/science/storage)
 "jGh" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -37698,7 +37720,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "kxu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -41559,8 +41581,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "lWe" = (
 /obj/effect/loot_site_spawner,
 /obj/item/relic,
@@ -42216,6 +42239,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"mlx" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/science/storage)
 "mlz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -50338,6 +50368,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "pwP" = (
@@ -50451,7 +50482,7 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "pzD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50553,8 +50584,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "pCt" = (
 /obj/structure/window/reinforced{
 	pixel_y = 2
@@ -58649,6 +58681,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "sOF" = (
@@ -59701,7 +59734,7 @@
 	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "tiB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60298,8 +60331,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "tsF" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/decal/cleanable/dirt,
@@ -61196,6 +61230,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"tJT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/science/storage)
 "tJX" = (
 /obj/machinery/lapvend,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -61240,7 +61278,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "tKy" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -65546,7 +65584,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron,
-/area/science/mixing)
+/area/science/storage)
 "vvI" = (
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -70621,6 +70659,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "xmN" = (
@@ -71444,6 +71483,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "xDE" = (
@@ -118738,13 +118778,13 @@ aHI
 veY
 adS
 adS
-mSi
-mSi
-mSi
-mSi
-mSi
-mSi
-mSi
+hDo
+hDo
+hDo
+hDo
+hDo
+hDo
+hDo
 fbR
 wUd
 sOv
@@ -118995,13 +119035,13 @@ jlO
 sct
 adS
 aae
-mSi
+hDo
 jor
 jrY
 pzh
 vvo
-vvo
-mSi
+mlx
+hDo
 fbR
 fKH
 pwI
@@ -119252,13 +119292,13 @@ osD
 exW
 adS
 aae
-mSi
+hDo
 avN
-frL
-hWi
-hWi
+jFU
+hir
+hir
 lVH
-mSi
+hDo
 plm
 iPd
 xmK
@@ -119509,16 +119549,16 @@ adS
 adS
 adS
 aae
-mSi
+hDo
 tiz
-okR
-okR
-okR
+tJT
+tJT
+tJT
 tsp
 pCs
-tls
-tls
-tls
+hIv
+hIv
+hIv
 tls
 vVz
 cbi
@@ -119766,13 +119806,13 @@ aae
 aae
 aae
 aae
-mSi
+hDo
 kxo
 kxo
-hWi
-hWi
+hir
+hir
 aiw
-mSi
+hDo
 okC
 ewK
 ako
@@ -120023,13 +120063,13 @@ aae
 aae
 aae
 aae
-mSi
+hDo
 jor
 kxo
 eVK
 bYW
 awN
-mSi
+hDo
 mSi
 mSi
 mSi
@@ -120280,13 +120320,13 @@ aae
 aae
 aae
 aae
-mSi
+hDo
 jor
 kxo
 tKp
 bYW
 bYW
-mSi
+hDo
 fYH
 fYH
 axo
@@ -120537,13 +120577,13 @@ aae
 aae
 aae
 aae
-mSi
-mSi
-mSi
-mSi
-mSi
-mSi
-mSi
+hDo
+hDo
+hDo
+hDo
+hDo
+hDo
+hDo
 fYH
 fjs
 hWi

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -317,7 +317,7 @@
 /obj/machinery/computer/security/telescreen/rd
 	name = "\improper Research Director's telescreen"
 	desc = "Used for watching the AI and the RD's goons from the safety of his office."
-	network = list("rd", "aicore", "aiupload", "minisat", "xeno", "test")
+	network = list("rd", "aicore", "aiupload", "minisat", "xeno", "test", "toxins")
 
 /obj/machinery/computer/security/telescreen/research
 	name = "research telescreen"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1: random purple square on a wall on delta firing range
![image](https://user-images.githubusercontent.com/40489693/127499618-fbf9b4e8-9f1a-4557-803a-a77f645b04b8.png)


2: one extra tox range area on meta sci (its there so the firing range has an APC, but the new area for the circuit room needs an APC now as well, so i just added another APC in the firing range so both rooms have one)
Its also not got a maint area over its maint door
![image](https://user-images.githubusercontent.com/40489693/127499675-805af5ae-ea7d-4884-a1a3-f64d52959b72.png)


3: a maint room in sci maint on delta is still science, made it maint area
![image](https://user-images.githubusercontent.com/40489693/127499747-7a05d3a1-5978-4bc4-8809-2275ef61cb6b.png)


4: maint room on delta sci maint has a camera still
![image](https://user-images.githubusercontent.com/40489693/127499790-d01cd50b-4079-4cc3-abcb-ba4cc7549059.png)


5: two stray RnD areas behind science area and genetics area on icebox
![image](https://user-images.githubusercontent.com/40489693/127499838-7a785060-8d9e-45e7-b357-c33d94a00182.png)


6: random maint area in a non-maint door on tram
![image](https://user-images.githubusercontent.com/40489693/127499881-01715b33-655f-4f81-8789-1f780c2df076.png)


7: two scrubbers in the new tram circuit room as well as missing fire alarm/firelock, and even a camera
![image](https://user-images.githubusercontent.com/40489693/127500038-2370d63e-b915-497f-8789-ff7688600404.png)


8: icebox snowpit camera says circuit lab when its not the circuit lab
![image](https://user-images.githubusercontent.com/40489693/127500100-ef83ca5f-6f06-4d5f-b4b7-1c1d21e4e3f3.png)


9: idek what to say about this, delta sci maint has a minisat camera???
![image](https://user-images.githubusercontent.com/40489693/127500146-34a215ad-9a44-4e3a-950a-875838f55502.png)


10: Mapdiffbot failed on me for no reason, so in an effort to restart the bot i pushed another change in metamaint to re-align the areas to the door/walls
![image](https://user-images.githubusercontent.com/40489693/127506612-dece7c85-fbfa-4756-b2f1-a9457a1af9b7.png)


11: the access on icebox between science and medbay had a camera called "Genetics Access" when its not related to genetics anymore, changed its name to "Med-Sci Access"
![image](https://user-images.githubusercontent.com/40489693/127507899-d366469f-98c5-4535-9ba2-4d6839245d9d.png)


12: kilo station and delta have their toxins launch pad use the test site area, this is a unique area and allows blobs to spawn and can be a cult spawn, its not meant to be used for anything but the toxins actual test site, changed them to use toxins mixing area like all the other maps on delta, but tox_misc (misc lab, which is currently used for circuits) on kilo, since circuits are located there
![image](https://user-images.githubusercontent.com/40489693/127728682-bbfd0206-977d-4fc5-963b-abff3b61b737.png)


13: tram station uses the exact same area for the entirety of toxins except the mix chamber, i made the storage area use the actual dedicated tox storage area and added an APC for it
![image](https://user-images.githubusercontent.com/40489693/127728756-04de1484-cca4-449d-9bd7-d976725599e6.png)


14: delta toxins has 2 redundant APCs in toxins, now that the launcher room is connected to the same area as this room it now has 3, i removed all 3 current APCs in the two rooms (same area) and added a single one in the main mix room near the upper door into tox storage
![image](https://user-images.githubusercontent.com/40489693/127729410-9e8c79e9-e9e7-4bc2-85ef-1189666b798c.png)


15: delta toxins main room never actually had an air alarm, only the one for the chamber, wow, how was this never noticed? now that the main mix room and the launch site share the same area, they now share an air alarm, i moved the air alarm from the launch room to just next to the lower left door of the main room however
![image](https://user-images.githubusercontent.com/40489693/127729598-ae6c1ba4-65c1-4e77-88a3-dac749d66060.png)


16: meta toxins launch room doesnt have maint area above the maint door, added 3 maint areas above the door and the 2 walls above it to keep it clean
![image](https://user-images.githubusercontent.com/40489693/127729581-f50e4755-b6e3-458e-bda7-3660009c28f1.png)


17: this is a redundant APC now that its now part of the larger science area, removed the one in the petting zoo
![image](https://user-images.githubusercontent.com/40489693/127729648-5d991146-f592-48e8-a5a0-6e71532ae26d.png)


18: this wire no longer goes anywhere, as the wire for the APC is now connected above, removed redundant wire
![image](https://user-images.githubusercontent.com/40489693/127729703-4f89b319-03de-4d00-9cf1-177c6d383f09.png)


19: now that every map, except delta, now longer uses the transit tube area for the transit tube area (why??) theres a redundant wire here on meta transittube room since the APC was since removed from it, removed it
![image](https://user-images.githubusercontent.com/40489693/127729843-86591c66-028c-403c-8de1-bdcf525a5d16.png)


20: delta firing range is using the same area as the new circuit room, when it should be using the dedicated science firing range area, swapped
![image](https://user-images.githubusercontent.com/40489693/127730052-00b7c95c-9d4c-4114-af21-a42124670a30.png)



other misc fixes:

1. tram science cameras used a network ID that didnt match with the RD camera telescreen, fixed
2. meta and delta RD offices didnt have their camera telescreen, fixed
3. half of iceboxes science cameras had no name or network IDs set, fixed
4. icebox xenobio slime console and their cameras had their network var OVERWRITTEN to exclusively use only xenobio cameras, this is a HUGE sneaky balance change because this means that even if you use cerulean blueprints you can never use the slime cameras outside of xenobio, **FIXED**


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: Tram's RD telescreen can now view their dept cameras again
fix: Delta and Meta RD offices now have a RD telescreen again
fix: Delta science maint room no longer has a stray minisat camera
fix: icebox science cameras now properly named and networked
fix: removed stray purple tiles on walls in delta, removed a science camera from a maintence room on delta, made it proper maint area
fix: icebox xenobio slime consoles no longer have a unique network for them, you may now use cerulean blueprints to use the slime consoles anywhere on the station again
fix: delta toxins room added its missing air alarm for the room itself, moved the APC, removed a redundant second APC, toxins mix lab and toxins launch room now share an APC and air alarm
fix: trams toxins storage room now uses its correct area, added an APC to power the room
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
