### PR TITLE
Revert "makes the tram more powerful than you can ever imagine"

### DIFF
--- a/code/controllers/subsystem/processing/tramprocess.dm
+++ b/code/controllers/subsystem/processing/tramprocess.dm
@@ -1,6 +1,5 @@
 PROCESSING_SUBSYSTEM_DEF(tramprocess)
 	name = "Tram Process"
 	wait = 1
-	flags = SS_TICKER
-	// only used on maps with trams, so only enabled by such.
+	/// only used on maps with trams, so only enabled by such.
 	can_fire = FALSE


### PR DESCRIPTION
Reverts tgstation/tgstation#60381

During a round with this active on tram, tick usage went up to 40% which is massive for a subsystem that is on SS_TICKER. This means that this subsystem alone is using 40% of the cpu time every tick that the tram is moving, leaving every other subsystem and procs with 60% cpu time or less.

Tram should not really be using SS_TICKER and it's a bad idea overall to have something like the tram fire every tick because it gives little time for the other subsystems to fire if it's using 40% of the tick time every tick every time it moves. Though the proc itself won't overtime, it will force other procs to overtime as a result of the cpu time it uses each tick.

It just seems bad overall to be giving a lowpriority subsystem (which is also pretty expensive to fire()) high priority as well as making it fire every tick for the excuse of speed. If the tram wants to be faster, it should be made more efficient and probably refactored to not have to move a lot of stuff every second because that's inefficient and not really optimal.

If we want to have a fast tram, we shouldn't take cheap and easy solutions to make it happen. People should do proper refactors  to make sure performance doesn't suffer for a low priority thing.