### PR TITLE
Fixes cargo manifest exports.

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -69,6 +69,8 @@ Then the player gets the profit from selling his own wasted time.
 	var/message = ""
 	/// Cost of item, in cargo credits. Must not allow for infinite price dupes, see above.
 	var/cost = 1
+	/// whether this export can have a negative impact on the cargo budget or not
+	var/allow_negative_cost = FALSE
 	/// coefficient used in marginal price calculation that roughly corresponds to the inverse of price elasticity, or "quantity elasticity"
 	var/k_elasticity = 1/30
 	/// The multiplier of the amount sold shown on the report. Useful for exports, such as material, which costs are not strictly per single units sold.
@@ -146,7 +148,7 @@ Then the player gets the profit from selling his own wasted time.
 	///Utilized in the pricetag component. Splits the object's profit when it has a pricetag by the specified amount.
 	var/profit_ratio = 0
 
-	if(amount <=0 || the_cost <=0)
+	if(amount <=0 || (the_cost <=0 && !allow_negative_cost))
 		return FALSE
 	if(dry_run == FALSE)
 		if(SEND_SIGNAL(O, COMSIG_ITEM_SOLD, item_value = get_cost(O, apply_elastic)) & COMSIG_ITEM_SPLIT_VALUE)

--- a/code/modules/cargo/exports/manifest.dm
+++ b/code/modules/cargo/exports/manifest.dm
@@ -42,6 +42,7 @@
 /datum/export/manifest_error
 	unit_name = "erroneously approved manifest"
 	export_types = list(/obj/item/paper/fluff/jobs/cargo/manifest)
+	allow_negative_cost = TRUE
 
 /datum/export/manifest_error/applies_to(obj/O)
 	if(!..())
@@ -60,9 +61,10 @@
 // Erroneously denied manifest.
 // Substracts the package cost minus the cost of crate.
 /datum/export/manifest_correct_denied
-	cost = CARGO_CRATE_VALUE
+	cost = -CARGO_CRATE_VALUE
 	unit_name = "erroneously denied manifest"
 	export_types = list(/obj/item/paper/fluff/jobs/cargo/manifest)
+	allow_negative_cost = TRUE
 
 /datum/export/manifest_correct_denied/applies_to(obj/O)
 	if(!..())

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -61,8 +61,8 @@
 	P.update_appearance()
 	return P
 
-/datum/supply_order/proc/generateManifest(obj/container, owner, packname) //generates-the-manifests.
-	var/obj/item/paper/fluff/jobs/cargo/manifest/P = new(container, id, 0)
+/datum/supply_order/proc/generateManifest(obj/container, owner, packname, cost_override) //generates-the-manifests.
+	var/obj/item/paper/fluff/jobs/cargo/manifest/P = new(container, id, cost_override || pack.cost)
 
 	var/station_name = (P.errors & MANIFEST_ERROR_NAME) ? new_station_name() : station_name()
 
@@ -118,8 +118,8 @@
 	generateManifest(C, account_holder, pack)
 	return C
 
-/datum/supply_order/proc/generateCombo(miscbox, misc_own, misc_contents)
+/datum/supply_order/proc/generateCombo(miscbox, misc_own, misc_contents, misc_cost)
 	for (var/I in misc_contents)
 		new I(miscbox)
-	generateManifest(miscbox, misc_own, "")
+	generateManifest(miscbox, misc_own, "", misc_cost)
 	return

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -61,8 +61,8 @@
 	P.update_appearance()
 	return P
 
-/datum/supply_order/proc/generateManifest(obj/container, owner, packname, cost_override) //generates-the-manifests.
-	var/obj/item/paper/fluff/jobs/cargo/manifest/P = new(container, id, cost_override || pack.cost)
+/datum/supply_order/proc/generateManifest(obj/container, owner, packname, cost) //generates-the-manifests.
+	var/obj/item/paper/fluff/jobs/cargo/manifest/P = new(container, id, cost)
 
 	var/station_name = (P.errors & MANIFEST_ERROR_NAME) ? new_station_name() : station_name()
 
@@ -115,7 +115,7 @@
 	else
 		account_holder = "Cargo"
 	var/obj/structure/closet/crate/C = pack.generate(A, paying_account)
-	generateManifest(C, account_holder, pack)
+	generateManifest(C, account_holder, pack, pack.cost)
 	return C
 
 /datum/supply_order/proc/generateCombo(miscbox, misc_own, misc_contents, misc_cost)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -93,6 +93,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	var/list/obj/miscboxes = list() //miscboxes are combo boxes that contain all goody orders grouped
 	var/list/misc_order_num = list() //list of strings of order numbers, so that the manifest can show all orders in a box
 	var/list/misc_contents = list() //list of lists of items that each box will contain
+	var/list/misc_costs = list() //list of overall costs sustained by each buyer.
 
 	var/list/empty_turfs = list()
 	for(var/place in shuttle_areas)
@@ -190,12 +191,13 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			var/datum/supply_order/our_order = O
 			for (var/item in our_order.pack.contains)
 				misc_contents[buyer] += item
+			misc_costs[buyer] += our_order.pack.cost
 			misc_order_num[buyer] = "[misc_order_num[buyer]]#[our_order.id]  "
 
 	for(var/I in miscboxes)
 		var/datum/supply_order/SO = new/datum/supply_order()
 		SO.id = misc_order_num[I]
-		SO.generateCombo(miscboxes[I], I, misc_contents[I])
+		SO.generateCombo(miscboxes[I], I, misc_contents[I], misc_costs[I])
 		qdel(SO)
 
 	SSeconomy.import_total += value


### PR DESCRIPTION
## About The Pull Request
Currently, all manifests have 0 `order_cost` regardless of supply pack, all exports with negative costs aren't sold, and the `manifest_correct_denied` export cost isn't a negative integer.

## Why It's Good For The Game
This will fix #57862.

## Changelog
:cl:
fix: All cargo manifest exports should now work as expected. No more gaining money from selling erroneously denied manifests and not gaining/losing money from incorrect manifests.
/:cl:
