### PR TITLE
Fixes issue where Plexagon HR Core app doesn't allow de-prioritising jobs.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -102,8 +102,6 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 		if("PRG_priority")
-			if(length(SSjob.prioritized_jobs) >= 5)
-				return
 			var/priority_target = params["target"]
 			var/datum/job/j = SSjob.GetJob(priority_target)
 			if(!j || !can_edit_job(j))
@@ -113,7 +111,10 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			if(j in SSjob.prioritized_jobs)
 				SSjob.prioritized_jobs -= j
 			else
-				SSjob.prioritized_jobs += j
+				if(length(SSjob.prioritized_jobs) < 5)
+					SSjob.prioritized_jobs += j
+				else
+					computer.say("Error: CentCom employment protocols restrict prioritising more than 5 jobs.")
 			playsound(computer, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 			return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Due to some duff logic, the Plexagon HR Core app cannot de-prioritise jobs when 5 or more jobs are prioritised due to an errant early return.

The appropriate if checks have been moved to a more appropriate position in the logic chain and the computer now vocally announces the error state when it occurs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex bug.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed a bug preventing the Plexagon HR Core app from de-prioritising jobs when 5 or more jobs were prioritised.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
