### PR TITLE
Circuit component descriptions and module names are now visible to the naked eye.

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -22,7 +22,7 @@
 
 /obj/item/circuit_component/medical_console_data
 	display_name = "Crew Monitoring Data"
-	display_desc = "Outputs the medical statuses of people on the crew monitoring computer, where it can then be filtered with a Select Query component."
+	desc = "Outputs the medical statuses of people on the crew monitoring computer, where it can then be filtered with a Select Query component."
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	/// The records retrieved

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -18,7 +18,7 @@
 
 /obj/item/circuit_component/bluespace_launchpad
 	display_name = "Bluespace Launchpad Console"
-	display_desc = "Teleports anything to and from any location on the station. Doesn't use actual GPS coordinates, but rather offsets from the launchpad itself. Can only go as far as the launchpad can go, which depends on its parts."
+	desc = "Teleports anything to and from any location on the station. Doesn't use actual GPS coordinates, but rather offsets from the launchpad itself. Can only go as far as the launchpad can go, which depends on its parts."
 
 	var/datum/port/input/launchpad_id
 	var/datum/port/input/x_pos

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -28,7 +28,7 @@
 
 /obj/item/circuit_component/arrest_console_data
 	display_name = "Security Records Data"
-	display_desc = "Outputs the security records data, where it can then be filtered with a Select Query component"
+	desc = "Outputs the security records data, where it can then be filtered with a Select Query component"
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	/// The records retrieved
@@ -101,7 +101,7 @@
 
 /obj/item/circuit_component/arrest_console_arrest
 	display_name = "Security Records Set Status"
-	display_desc = "Receives a table to use to set people's arrest status. Table should be from the security records data component. If New Status port isn't set, the status will be decided by the options."
+	desc = "Receives a table to use to set people's arrest status. Table should be from the security records data component. If New Status port isn't set, the status will be decided by the options."
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	/// The targets to set the status of.

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -88,7 +88,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 
 /obj/item/circuit_component/digital_valve
 	display_name = "Digital Valve"
-	display_desc = "The interface for communicating with a digital valve."
+	desc = "The interface for communicating with a digital valve."
 
 	var/obj/machinery/atmospherics/components/binary/valve/digital/attached_valve
 

--- a/code/modules/explorer_drone/exploration_site.dm
+++ b/code/modules/explorer_drone/exploration_site.dm
@@ -150,7 +150,7 @@ GLOBAL_LIST_EMPTY(exploration_sites)
 /datum/exploration_site/proc/display_name()
 	return revealed ? name : "Anomaly"
 
-/datum/exploration_site/proc/description()
+/datum/exploration_site/proc/display_description()
 	if(!revealed)
 		return "No Data"
 	var/list/descriptions = list(description)
@@ -167,7 +167,7 @@ GLOBAL_LIST_EMPTY(exploration_sites)
 	.["ref"] = ref(src)
 	.["name"] = display_name()
 	.["coordinates"] = coordinates
-	.["description"] = description()
+	.["description"] = display_description()
 	.["distance"] = distance
 	.["revealed"] = revealed
 	.["point_scan_complete"] = point_scan_complete

--- a/code/modules/explorer_drone/exploration_site.dm
+++ b/code/modules/explorer_drone/exploration_site.dm
@@ -150,7 +150,7 @@ GLOBAL_LIST_EMPTY(exploration_sites)
 /datum/exploration_site/proc/display_name()
 	return revealed ? name : "Anomaly"
 
-/datum/exploration_site/proc/display_description()
+/datum/exploration_site/proc/description()
 	if(!revealed)
 		return "No Data"
 	var/list/descriptions = list(description)
@@ -167,7 +167,7 @@ GLOBAL_LIST_EMPTY(exploration_sites)
 	.["ref"] = ref(src)
 	.["name"] = display_name()
 	.["coordinates"] = coordinates
-	.["description"] = display_description()
+	.["description"] = description()
 	.["distance"] = distance
 	.["revealed"] = revealed
 	.["point_scan_complete"] = point_scan_complete

--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -41,7 +41,7 @@
 	. = ..()
 	if(build_path)
 		var/obj/item/circuit_component/component_path = build_path
-		desc = initial(component_path.display_desc)
+		desc = initial(component_path.desc)
 
 /datum/design/component/arithmetic
 	name = "Arithmetic Component"

--- a/code/modules/wiremod/component.dm
+++ b/code/modules/wiremod/component.dm
@@ -17,7 +17,7 @@
 	var/display_name = "Generic"
 
 	/// The description of the component shown on the UI
-	var/display_desc = "A generic component"
+	var/desc = "A generic component"
 
 	/// The integrated_circuit that this component is attached to.
 	var/obj/item/integrated_circuit/parent

--- a/code/modules/wiremod/component.dm
+++ b/code/modules/wiremod/component.dm
@@ -16,9 +16,6 @@
 	/// The name of the component shown on the UI
 	var/display_name = "Generic"
 
-	/// The description of the component shown on the UI
-	var/desc = "A generic component"
-
 	/// The integrated_circuit that this component is attached to.
 	var/obj/item/integrated_circuit/parent
 

--- a/code/modules/wiremod/components/abstract/module.dm
+++ b/code/modules/wiremod/components/abstract/module.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/module
 	display_name = "Module"
-	display_desc = "A component that has other components within it, acting like a function. Use it in your hand to control the amount of input and output ports it has, as well as being able to access the integrated circuit contained inside."
+	desc = "A component that has other components within it, acting like a function. Use it in your hand to control the amount of input and output ports it has, as well as being able to access the integrated circuit contained inside."
 
 	var/obj/item/integrated_circuit/module/internal_circuit
 
@@ -47,7 +47,7 @@
 
 /obj/item/circuit_component/module_input
 	display_name = "Input"
-	display_desc = "A component that receives data from the module it is attached to"
+	desc = "A component that receives data from the module it is attached to"
 
 	removable = FALSE
 
@@ -60,7 +60,7 @@
 
 /obj/item/circuit_component/module_output
 	display_name = "Output"
-	display_desc = "A component that outputs data to the module it is attached to."
+	desc = "A component that outputs data to the module it is attached to."
 
 	removable = FALSE
 

--- a/code/modules/wiremod/components/abstract/module.dm
+++ b/code/modules/wiremod/components/abstract/module.dm
@@ -28,6 +28,7 @@
 /obj/item/integrated_circuit/module/set_display_name(new_name)
 	. = ..()
 	attached_module.display_name = new_name
+	attached_module.name = "module ([new_name])"
 
 /obj/item/integrated_circuit/module/load_component(type)
 	if(!attached_module)

--- a/code/modules/wiremod/components/action/light.dm
+++ b/code/modules/wiremod/components/action/light.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/light
 	display_name = "Light"
-	display_desc = "A component that emits a light of a specific brightness and colour. Requires a shell."
+	desc = "A component that emits a light of a specific brightness and colour. Requires a shell."
 
 	/// The colours of the light
 	var/datum/port/input/red

--- a/code/modules/wiremod/components/action/mmi.dm
+++ b/code/modules/wiremod/components/action/mmi.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/mmi
 	display_name = "Man-Machine Interface"
-	display_desc = "A component that allows MMI to enter shells to send output signals."
+	desc = "A component that allows MMI to enter shells to send output signals."
 
 	/// The message to send to the MMI in the shell.
 	var/datum/port/input/message

--- a/code/modules/wiremod/components/action/pathfind.dm
+++ b/code/modules/wiremod/components/action/pathfind.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/pathfind
 	display_name = "Pathfinder"
-	display_desc = "When triggered, the next step to the target's location as an entity. This can be used with the direction component and the drone shell to make it move on its own. The Id Card input port is for considering ID access when pathing, it does not give the shell actual access."
+	desc = "When triggered, the next step to the target's location as an entity. This can be used with the direction component and the drone shell to make it move on its own. The Id Card input port is for considering ID access when pathing, it does not give the shell actual access."
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	var/datum/port/input/input_X

--- a/code/modules/wiremod/components/action/pull.dm
+++ b/code/modules/wiremod/components/action/pull.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/pull
 	display_name = "Start Pulling"
-	display_desc = "A component that can force the shell to pull entities. Only works for drone shells."
+	desc = "A component that can force the shell to pull entities. Only works for drone shells."
 
 	/// Frequency input
 	var/datum/port/input/target

--- a/code/modules/wiremod/components/action/radio.dm
+++ b/code/modules/wiremod/components/action/radio.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/radio
 	display_name = "Radio"
-	display_desc = "A component that can listen and send frequencies. If set to private, the component will only receive signals from other components attached to circuitboards with the same owner id."
+	desc = "A component that can listen and send frequencies. If set to private, the component will only receive signals from other components attached to circuitboards with the same owner id."
 
 	/// Frequency input
 	var/datum/port/input/freq

--- a/code/modules/wiremod/components/action/soundemitter.dm
+++ b/code/modules/wiremod/components/action/soundemitter.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/soundemitter
 	display_name = "Sound Emitter"
-	display_desc = "A component that emits a sound when it receives an input. The frequency is a multiplier which determines the speed at which the sound is played"
+	desc = "A component that emits a sound when it receives an input. The frequency is a multiplier which determines the speed at which the sound is played"
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	/// Volume of the sound when played

--- a/code/modules/wiremod/components/action/speech.dm
+++ b/code/modules/wiremod/components/action/speech.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/speech
 	display_name = "Speech"
-	display_desc = "A component that sends a message. Requires a shell."
+	desc = "A component that sends a message. Requires a shell."
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	/// The message to send

--- a/code/modules/wiremod/components/atom/direction.dm
+++ b/code/modules/wiremod/components/atom/direction.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/direction
 	display_name = "Get Direction"
-	display_desc = "A component that returns the direction of itself and an entity."
+	desc = "A component that returns the direction of itself and an entity."
 
 	/// The input port
 	var/datum/port/input/input_port

--- a/code/modules/wiremod/components/atom/gps.dm
+++ b/code/modules/wiremod/components/atom/gps.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/gps
 	display_name = "Internal GPS"
-	display_desc = "A component that returns the xyz co-ordinates of itself."
+	desc = "A component that returns the xyz co-ordinates of itself."
 
 	/// The result from the output
 	var/datum/port/output/x_pos

--- a/code/modules/wiremod/components/atom/health.dm
+++ b/code/modules/wiremod/components/atom/health.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/health
 	display_name = "Get Health"
-	display_desc = "A component that returns the health of an organism."
+	desc = "A component that returns the health of an organism."
 
 	/// The input port
 	var/datum/port/input/input_port

--- a/code/modules/wiremod/components/atom/hear.dm
+++ b/code/modules/wiremod/components/atom/hear.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/hear
 	display_name = "Voice Activator"
-	display_desc = "A component that listens for messages. Requires a shell."
+	desc = "A component that listens for messages. Requires a shell."
 
 	/// The message heard
 	var/datum/port/output/message_port

--- a/code/modules/wiremod/components/atom/self.dm
+++ b/code/modules/wiremod/components/atom/self.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/self
 	display_name = "Self"
-	display_desc = "A component that returns the current shell."
+	desc = "A component that returns the current shell."
 
 	/// The shell this component is attached to.
 	var/datum/port/output/output

--- a/code/modules/wiremod/components/atom/species.dm
+++ b/code/modules/wiremod/components/atom/species.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/species
 	display_name = "Get Species"
-	display_desc = "A component that returns the species of its input."
+	desc = "A component that returns the species of its input."
 
 	/// The input port
 	var/datum/port/input/input_port

--- a/code/modules/wiremod/components/list/concat.dm
+++ b/code/modules/wiremod/components/list/concat.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/concat_list
 	display_name = "Concatenate List"
-	display_desc = "A component that joins up a list with a separator into a single string."
+	desc = "A component that joins up a list with a separator into a single string."
 
 	/// The input port
 	var/datum/port/input/list_port

--- a/code/modules/wiremod/components/list/get_column.dm
+++ b/code/modules/wiremod/components/list/get_column.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/get_column
 	display_name = "Get Column"
-	display_desc = "Gets the column of a table and returns it as a regular list."
+	desc = "Gets the column of a table and returns it as a regular list."
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	/// The list to perform the filter on

--- a/code/modules/wiremod/components/list/index.dm
+++ b/code/modules/wiremod/components/list/index.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/index
 	display_name = "Index List"
-	display_desc = "A component that returns the value of a list at a given index."
+	desc = "A component that returns the value of a list at a given index."
 
 	/// The input port
 	var/datum/port/input/list_port

--- a/code/modules/wiremod/components/list/index_table.dm
+++ b/code/modules/wiremod/components/list/index_table.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/index_table
 	display_name = "Index Table"
-	display_desc = "Gets the row of a table using the index inputted. Will return no value if the index is invalid or a proper table is not returned."
+	desc = "Gets the row of a table using the index inputted. Will return no value if the index is invalid or a proper table is not returned."
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	/// The list to perform the filter on

--- a/code/modules/wiremod/components/list/select.dm
+++ b/code/modules/wiremod/components/list/select.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/select
 	display_name = "Select Query"
-	display_desc = "A component used with USB cables that can perform select queries on a list based on the column name selected. The values are then compared with the comparison input."
+	desc = "A component used with USB cables that can perform select queries on a list based on the column name selected. The values are then compared with the comparison input."
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	/// The list to perform the filter on

--- a/code/modules/wiremod/components/list/split.dm
+++ b/code/modules/wiremod/components/list/split.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/split
 	display_name = "Split"
-	display_desc = "Splits a string by the separator, turning it into a list"
+	desc = "Splits a string by the separator, turning it into a list"
 
 	/// The input port
 	var/datum/port/input/input_port

--- a/code/modules/wiremod/components/math/arithmetic.dm
+++ b/code/modules/wiremod/components/math/arithmetic.dm
@@ -6,7 +6,7 @@
  */
 /obj/item/circuit_component/arithmetic
 	display_name = "Arithmetic"
-	display_desc = "General arithmetic component with arithmetic capabilities."
+	desc = "General arithmetic component with arithmetic capabilities."
 
 	/// The amount of input ports to have
 	var/input_port_amount = 4

--- a/code/modules/wiremod/components/math/comparison.dm
+++ b/code/modules/wiremod/components/math/comparison.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/compare/comparison
 	display_name = "Comparison"
-	display_desc = "A component that compares two objects."
+	desc = "A component that compares two objects."
 
 	input_port_amount = 2
 	var/current_type = PORT_TYPE_ANY

--- a/code/modules/wiremod/components/math/length.dm
+++ b/code/modules/wiremod/components/math/length.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/length
 	display_name = "Length"
-	display_desc = "A component that returns the length of its input."
+	desc = "A component that returns the length of its input."
 
 	/// The input port
 	var/datum/port/input/input_port

--- a/code/modules/wiremod/components/math/logic.dm
+++ b/code/modules/wiremod/components/math/logic.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/compare/logic
 	display_name = "Logic"
-	display_desc = "A component with 'and' and 'or' capabilities."
+	desc = "A component with 'and' and 'or' capabilities."
 
 /obj/item/circuit_component/compare/logic/populate_options()
 	var/static/component_options = list(

--- a/code/modules/wiremod/components/math/not.dm
+++ b/code/modules/wiremod/components/math/not.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/not
 	display_name = "Not"
-	display_desc = "A component that inverts its input."
+	desc = "A component that inverts its input."
 
 	/// The input port
 	var/datum/port/input/input_port

--- a/code/modules/wiremod/components/math/random.dm
+++ b/code/modules/wiremod/components/math/random.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/random
 	display_name = "Random"
-	display_desc = "A component that returns random values."
+	desc = "A component that returns random values."
 
 	/// The minimum value that the random number can be
 	var/datum/port/input/minimum

--- a/code/modules/wiremod/components/sensors/pressuresensor.dm
+++ b/code/modules/wiremod/components/sensors/pressuresensor.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/pressuresensor
 	display_name = "Pressure Sensor"
-	display_desc = "Outputs the current pressure of the tile"
+	desc = "Outputs the current pressure of the tile"
 
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 

--- a/code/modules/wiremod/components/sensors/tempsensor.dm
+++ b/code/modules/wiremod/components/sensors/tempsensor.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/tempsensor
 	display_name = "Temperature Sensor"
-	display_desc = "Outputs the current temperature of the tile"
+	desc = "Outputs the current temperature of the tile"
 
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 

--- a/code/modules/wiremod/components/string/concat.dm
+++ b/code/modules/wiremod/components/string/concat.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/concat
 	display_name = "Concatenate"
-	display_desc = "A component that combines strings."
+	desc = "A component that combines strings."
 
 	/// The amount of input ports to have
 	var/input_port_amount = 4

--- a/code/modules/wiremod/components/string/contains.dm
+++ b/code/modules/wiremod/components/string/contains.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/compare/contains
 	display_name = "String Contains"
-	display_desc = "Checks if a string contains a word/letter"
+	desc = "Checks if a string contains a word/letter"
 
 	input_port_amount = 0
 

--- a/code/modules/wiremod/components/string/textcase.dm
+++ b/code/modules/wiremod/components/string/textcase.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/textcase
 	display_name = "Text Case"
-	display_desc = "A component that makes its input uppercase or lowercase."
+	desc = "A component that makes its input uppercase or lowercase."
 
 	/// The input port
 	var/datum/port/input/input_port

--- a/code/modules/wiremod/components/string/tonumber.dm
+++ b/code/modules/wiremod/components/string/tonumber.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/tonumber
 	display_name = "To Number"
-	display_desc = "A component that converts its input (a string) to a number. If there's text in the input, it'll only consider it if it starts with a number. It will take that number and ignore the rest."
+	desc = "A component that converts its input (a string) to a number. If there's text in the input, it'll only consider it if it starts with a number. It will take that number and ignore the rest."
 
 	/// The input port
 	var/datum/port/input/input_port

--- a/code/modules/wiremod/components/string/tostring.dm
+++ b/code/modules/wiremod/components/string/tostring.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/tostring
 	display_name = "To String"
-	display_desc = "A component that converts its input to text."
+	desc = "A component that converts its input to text."
 
 	/// The input port
 	var/datum/port/input/input_port

--- a/code/modules/wiremod/components/utility/clock.dm
+++ b/code/modules/wiremod/components/utility/clock.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/clock
 	display_name = "Clock"
-	display_desc = "A component that repeatedly fires."
+	desc = "A component that repeatedly fires."
 
 	/// Whether the clock is on or not
 	var/datum/port/input/on

--- a/code/modules/wiremod/components/utility/combiner.dm
+++ b/code/modules/wiremod/components/utility/combiner.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/combiner
 	display_name = "Combiner"
-	display_desc = "A component that combines multiple inputs to provide 1 output."
+	desc = "A component that combines multiple inputs to provide 1 output."
 
 	/// The amount of input ports to have
 	var/input_port_amount = 4

--- a/code/modules/wiremod/components/utility/delay.dm
+++ b/code/modules/wiremod/components/utility/delay.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/delay
 	display_name = "Delay"
-	display_desc = "A component that delays a signal by a specified duration."
+	desc = "A component that delays a signal by a specified duration."
 
 	/// Amount to delay by
 	var/datum/port/input/delay_amount

--- a/code/modules/wiremod/components/utility/multiplexer.dm
+++ b/code/modules/wiremod/components/utility/multiplexer.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/multiplexer
 	display_name = "Multiplexer"
-	display_desc = "A component that allows you to selectively choose which input port provides an output. The first port is the selector and takes a number between 1 and the maximum port amount."
+	desc = "A component that allows you to selectively choose which input port provides an output. The first port is the selector and takes a number between 1 and the maximum port amount."
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	/// The port to select from, goes from 1 to input_port_amount

--- a/code/modules/wiremod/components/utility/ram.dm
+++ b/code/modules/wiremod/components/utility/ram.dm
@@ -7,7 +7,7 @@
  */
 /obj/item/circuit_component/ram
 	display_name = "RAM"
-	display_desc = "A component that retains a variable."
+	desc = "A component that retains a variable."
 	circuit_flags = CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	/// The input to store

--- a/code/modules/wiremod/components/utility/typecheck.dm
+++ b/code/modules/wiremod/components/utility/typecheck.dm
@@ -5,7 +5,7 @@
  */
 /obj/item/circuit_component/compare/typecheck
 	display_name = "Typecheck"
-	display_desc = "A component that checks the type of its input."
+	desc = "A component that checks the type of its input."
 
 	input_port_amount = 1
 

--- a/code/modules/wiremod/integrated_circuit.dm
+++ b/code/modules/wiremod/integrated_circuit.dm
@@ -485,10 +485,6 @@
 /obj/item/integrated_circuit/proc/set_display_name(new_name)
 	display_name = new_name
 
-/obj/item/integrated_circuit/module/set_display_name(new_name)
-	..()
-	name = "module ([new_name])"
-
 /**
  * Returns the creator of the integrated circuit. Used in admin messages and other related things.
  */

--- a/code/modules/wiremod/integrated_circuit.dm
+++ b/code/modules/wiremod/integrated_circuit.dm
@@ -266,7 +266,7 @@
 		examined = examined_component.resolve()
 
 	.["examined_name"] = examined?.display_name
-	.["examined_desc"] = examined?.display_desc
+	.["examined_desc"] = examined?.desc
 	.["examined_notices"] = examined?.get_ui_notices()
 	.["examined_rel_x"] = examined_rel_x
 	.["examined_rel_y"] = examined_rel_y

--- a/code/modules/wiremod/integrated_circuit.dm
+++ b/code/modules/wiremod/integrated_circuit.dm
@@ -7,6 +7,7 @@
  */
 /obj/item/integrated_circuit
 	name = "integrated circuit"
+	desc = "By inserting components and a cell into this, wiring them up, and putting them into a shell, anyone can pretend to be a programmer."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "integrated_circuit"
 	inhand_icon_state = "electronic"

--- a/code/modules/wiremod/integrated_circuit.dm
+++ b/code/modules/wiremod/integrated_circuit.dm
@@ -484,6 +484,10 @@
 /obj/item/integrated_circuit/proc/set_display_name(new_name)
 	display_name = new_name
 
+/obj/item/integrated_circuit/module/set_display_name(new_name)
+	..()
+	name = "module ([new_name])"
+
 /**
  * Returns the creator of the integrated circuit. Used in admin messages and other related things.
  */

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -35,7 +35,7 @@
 
 /obj/item/circuit_component/airlock
 	display_name = "Airlock"
-	display_desc = "The general interface with an airlock. Includes general statuses of the airlock"
+	desc = "The general interface with an airlock. Includes general statuses of the airlock"
 
 	/// Called when attack_hand is called on the shell.
 	var/obj/machinery/door/airlock/attached_airlock

--- a/code/modules/wiremod/shell/bot.dm
+++ b/code/modules/wiremod/shell/bot.dm
@@ -23,7 +23,7 @@
 
 /obj/item/circuit_component/bot
 	display_name = "Bot"
-	display_desc = "Triggers when someone interacts with the bot."
+	desc = "Triggers when someone interacts with the bot."
 
 	/// Called when attack_hand is called on the shell.
 	var/datum/port/output/signal

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -35,11 +35,11 @@
 
 /obj/item/circuit_component/bci
 	display_name = "Brain-Computer Interface"
-	display_desc = "Used to receive inputs for the brain-computer interface. User is presented with three buttons."
+	desc = "Used to receive inputs for the brain-computer interface. User is presented with three buttons."
 
 /obj/item/circuit_component/bci_action
 	display_name = "BCI Action"
-	display_desc = "Represents an action the user can take when implanted with the brain-computer interface."
+	desc = "Represents an action the user can take when implanted with the brain-computer interface."
 
 	/// The name to use for the button
 	var/datum/port/input/button_name
@@ -155,7 +155,7 @@
 
 /obj/item/circuit_component/bci_core
 	display_name = "BCI Core"
-	display_desc = "Controls the core operations of the BCI."
+	desc = "Controls the core operations of the BCI."
 
 	/// A reference to the action button to look at charge/get info
 	var/datum/action/innate/bci_charge_action/charge_action

--- a/code/modules/wiremod/shell/compact_remote.dm
+++ b/code/modules/wiremod/shell/compact_remote.dm
@@ -22,7 +22,7 @@
 
 /obj/item/circuit_component/compact_remote
 	display_name = "Compact Remote"
-	display_desc = "Used to receive inputs from the compact remote shell. Use the shell in hand to trigger the output signal."
+	desc = "Used to receive inputs from the compact remote shell. Use the shell in hand to trigger the output signal."
 
 	/// Called when attack_self is called on the shell.
 	var/datum/port/output/signal

--- a/code/modules/wiremod/shell/controller.dm
+++ b/code/modules/wiremod/shell/controller.dm
@@ -23,7 +23,7 @@
 
 /obj/item/circuit_component/controller
 	display_name = "Controller"
-	display_desc = "Used to receive inputs from the controller shell. Use the shell in hand to trigger the output signal. Alt-click for the alternate signal. Right click for the extra signal."
+	desc = "Used to receive inputs from the controller shell. Use the shell in hand to trigger the output signal. Alt-click for the alternate signal. Right click for the extra signal."
 
 	/// The three separate buttons that are called in attack_hand on the shell.
 	var/datum/port/output/signal

--- a/code/modules/wiremod/shell/drone.dm
+++ b/code/modules/wiremod/shell/drone.dm
@@ -27,7 +27,7 @@
 
 /obj/item/circuit_component/bot_circuit
 	display_name = "Drone"
-	display_desc = "Used to send movement output signals to the drone shell."
+	desc = "Used to send movement output signals to the drone shell."
 
 	/// The inputs to allow for the drone to move
 	var/datum/port/input/north

--- a/code/modules/wiremod/shell/moneybot.dm
+++ b/code/modules/wiremod/shell/moneybot.dm
@@ -38,7 +38,7 @@
 
 /obj/item/circuit_component/money_dispenser
 	display_name = "Money Dispenser"
-	display_desc = "Used to dispense money from the money bot. Money is taken from the internal storage of money."
+	desc = "Used to dispense money from the money bot. Money is taken from the internal storage of money."
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	/// The amount of money to dispense
@@ -82,7 +82,7 @@
 /obj/item/circuit_component/money_bot
 	display_name = "Money Bot"
 	var/obj/structure/money_bot/attached_bot
-	display_desc = "Used to receive input signals when money is inserted into the money bot shell and also keep track of the total money in the shell."
+	desc = "Used to receive input signals when money is inserted into the money bot shell and also keep track of the total money in the shell."
 
 	/// Total money in the shell
 	var/datum/port/output/total_money

--- a/code/modules/wiremod/shell/scanner.dm
+++ b/code/modules/wiremod/shell/scanner.dm
@@ -22,7 +22,7 @@
 
 /obj/item/circuit_component/wiremod_scanner
 	display_name = "Scanner"
-	display_desc = "Used to receive scanned entities from the scanner."
+	desc = "Used to receive scanned entities from the scanner."
 
 	/// Called when afterattack is called on the shell.
 	var/datum/port/output/signal


### PR DESCRIPTION
## About The Pull Request

`display_desc` is now `desc`. `module/set_display_name` now updates `name`.

## Why It's Good For The Game

Unified purposes are good. In particular, inventory management is easier if my different modules have different names.

## Changelog
:cl:
qol: Circuit component descriptions and module names are now visible to the naked eye.
/:cl: