### PR TITLE
Takes away SHARP_EDGED from the Moonlight Greatsword easter egg.

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -882,7 +882,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	block_chance = 20
-	sharpness = SHARP_EDGED
 	force = 14
 	throwforce = 12
 	hitsound = 'sound/weapons/bladeslice.ogg'


### PR DESCRIPTION
## About The Pull Request
See title.
## Why It's Good For The Game
Free sharp edged weapons is a nightmare for balance. This can easily put someone to crit with just a few hits due to the wounds system. Considering these weapons are freely available on 2 maps by just welding a wall down from maintenance, they shouldn't be this strong.
## Changelog
:cl:
balance: The Moonlight Greatsword is now dull.
/:cl:

Additionally, what the hell is this a reference to?
