### PR TITLE
Absorbing DNA as a changeling no longer overrides the changeling's original DNA, or any objective related DNA

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -363,11 +363,9 @@
 		return TRUE
 	return FALSE
 
-
 /datum/antagonist/changeling/proc/create_initial_profile()
-	var/mob/living/carbon/C = owner.current //only carbons have dna now, so we have to typecaste
-	if(ishuman(C))
-		add_new_profile(C)
+	if(ishuman(owner.current))
+		add_new_profile(owner.current, TRUE)
 
 /datum/antagonist/changeling/apply_innate_effects(mob/living/mob_override)
 	//Brains optional.

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -53,7 +53,13 @@
 	to_chat(target, span_userdanger("You are absorbed by the changeling!"))
 
 	if(!changeling.has_dna(target.dna))
-		changeling.add_new_profile(target)
+		var/important_dna = FALSE
+		for(var/datum/objective/found_objective as anything in user.mind.get_all_objectives())
+			if(found_objective.target && found_objective.target == target.mind)
+				important_dna = TRUE
+				break
+
+		changeling.add_new_profile(target, important_dna)
 		changeling.trueabsorbs++
 
 	if(user.nutrition < NUTRITION_LEVEL_WELL_FED)

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -176,7 +176,13 @@
 	log_combat(user, target, "stung", "extraction sting")
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(!(changeling.has_dna(target.dna)))
-		changeling.add_new_profile(target)
+		var/important_dna = FALSE
+		for(var/datum/objective/found_objective as anything in user.mind.get_all_objectives())
+			if(found_objective.target && found_objective.target == target.mind)
+				important_dna = TRUE
+				break
+
+		changeling.add_new_profile(target, important_dna)
 	return TRUE
 
 /datum/action/changeling/sting/mute

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -81,7 +81,7 @@
 		if(!changeling_datum)
 			changeling_datum = origin.add_antag_datum(/datum/antagonist/changeling/headslug)
 		if(changeling_datum.can_absorb_dna(owner))
-			changeling_datum.add_new_profile(owner)
+			changeling_datum.add_new_profile(owner, TRUE)
 
 		var/datum/action/changeling/humanform/hf = new
 		changeling_datum.purchasedpowers += hf


### PR DESCRIPTION
## About The Pull Request

A changing's initial DNA, and any DNA they obtain related to any of their objectives, will now be marked as `protected`, which means the changeling will not lose the DNA if they surpass their DNA limit.

## Why It's Good For The Game

It's not very fun for the changeling to lose their initial disguise, and it's less fun to lose the disguise of the person who you need to pretend to be for your objective. 

## Changelog
:cl: Melbert
qol: Changelings will now never lose their initial dna disguise, as well as any dna disguises they obtain related to their objectives, if they absorb more than seven strands of DNA.
/:cl:
