### PR TITLE
Fix Restaurant Portals from breaking when their Venue changes.

### DIFF
--- a/code/modules/food_and_drinks/restaurant/_venue.dm
+++ b/code/modules/food_and_drinks/restaurant/_venue.dm
@@ -186,8 +186,8 @@
 	if(linked_venue && linked_venue.restaurant_portal) //We're already linked, unlink us.
 		if(linked_venue.open)
 			linked_venue.close()
-		linked_venue.restaurant_portal.linked_venue = null
 		linked_venue.restaurant_portal = null
+		linked_venue = null
 
 	linked_venue = chosen_venue
 	linked_venue.restaurant_portal = src


### PR DESCRIPTION
## About The Pull Request

Fixes the issue with Restaurant portals being brickable, raised in #60560.

## Why It's Good For The Game

Stops someone accidentally or intentionally ruining Service's fun by breaking the Restaurant Portals via using their ID to change the portal's venue.

**Note:** I don't actually know if the code that sets the lines to null is even required. I have made no effort to improve the code itself, I am simply fixing the issue whilst keeping parity. I just moved a line around and changed how it's referenced, as the current way causes a null ref.

## Changelog
:cl:
fix: fixed issue where restaurant portals would stop working after having their venue changed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
