### PR TITLE
 wormhole projectors now fire blue wormholes with lmb and orange ones with rmb.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -207,6 +207,9 @@
 
 /obj/item/gun/afterattack(atom/target, mob/living/user, flag, params)
 	. = ..()
+	return fire_gun(target, user, flag, params)
+
+/obj/item/gun/proc/fire_gun(atom/target, mob/living/user, flag, params)
 	if(QDELETED(target))
 		return
 	if(firing_burst)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -178,7 +178,7 @@
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	fire_sound = shot.fire_sound
 	fire_delay = shot.delay
-	if (shot.select_name)
+	if (shot.select_name && user)
 		balloon_alert(user, "set to [shot.select_name]")
 	chambered = null
 	recharge_newshot(TRUE)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -4,23 +4,35 @@
 	desc = "A basic energy-based gun."
 	icon = 'icons/obj/guns/energy.dmi'
 
-	var/obj/item/stock_parts/cell/cell //What type of power cell this uses
+	/// What type of power cell this uses
+	var/obj/item/stock_parts/cell/cell
 	var/cell_type = /obj/item/stock_parts/cell
-	var/modifystate = FALSE ///if the weapon has custom icons for individual ammo types it can switch between. ie disabler beams, taser, laser/lethals, ect.
+	///if the weapon has custom icons for individual ammo types it can switch between. ie disabler beams, taser, laser/lethals, ect.
+	var/modifystate = FALSE
 	var/list/ammo_type = list(/obj/item/ammo_casing/energy)
-	var/select = 1 //The state of the select fire switch. Determines from the ammo_type list what kind of shot is fired next.
-	var/can_charge = TRUE //Can it be charged in a recharger?
-	var/automatic_charge_overlays = TRUE //Do we handle overlays with base update_icon()?
+	///The state of the select fire switch. Determines from the ammo_type list what kind of shot is fired next.
+	var/select = 1
+	///If the user can select the firemode through attack_self.
+	var/can_select = TRUE
+	///Can it be charged in a recharger?
+	var/can_charge = TRUE
+	///Do we handle overlays with base update_icon()?
+	var/automatic_charge_overlays = TRUE
 	var/charge_sections = 4
 	ammo_x_offset = 2
-	var/shaded_charge = FALSE //if this gun uses a stateful charge bar for more detail
-	var/single_shot_type_overlay = TRUE //If this gun has a "this is loaded with X" overlay alongside chargebars and such
-	var/display_empty = TRUE //Should we give an overlay to empty guns?
+	///if this gun uses a stateful charge bar for more detail
+	var/shaded_charge = FALSE
+	///If this gun has a "this is loaded with X" overlay alongside chargebars and such
+	var/single_shot_type_overlay = TRUE
+	///Should we give an overlay to empty guns?
+	var/display_empty = TRUE
 	var/selfcharge = 0
 	var/charge_timer = 0
 	var/charge_delay = 8
-	var/use_cyborg_cell = FALSE //whether the gun's cell drains the cyborg user's cell to recharge
-	var/dead_cell = FALSE //set to true so the gun is given an empty cell
+	///whether the gun's cell drains the cyborg user's cell to recharge
+	var/use_cyborg_cell = FALSE
+	///set to true so the gun is given an empty cell
+	var/dead_cell = FALSE
 
 /obj/item/gun/energy/emp_act(severity)
 	. = ..()
@@ -118,9 +130,8 @@
 		update_appearance()
 
 /obj/item/gun/energy/attack_self(mob/living/user as mob)
-	if(ammo_type.len > 1)
+	if(ammo_type.len > 1 && can_select)
 		select_fire(user)
-		update_appearance()
 
 /obj/item/gun/energy/can_shoot()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
@@ -172,7 +183,6 @@
 	chambered = null
 	recharge_newshot(TRUE)
 	update_appearance()
-	return
 
 /obj/item/gun/energy/update_icon_state()
 	var/skip_inhand = initial(inhand_icon_state) //only build if we aren't using a preset inhand icon

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -250,15 +250,15 @@
 				WH.gun = WEAKREF(src)
 
 /obj/item/gun/energy/wormhole_projector/afterattack(atom/target, mob/living/user, flag, params)
-	var/list/modifiers = params2list(params)
-	if(!LAZYACCESS(modifiers, RIGHT_CLICK) && select == AMMO_SELECT_ORANGE) //left click to fire blue wormholes.
+	if(select == AMMO_SELECT_ORANGE) //Last fired in right click mode. Switch to blue wormhole (left click).
 		select_fire()
 	return ..()
 
 /obj/item/gun/energy/wormhole_projector/afterattack_secondary(atom/target, mob/living/user, flag, params)
-	if(select == AMMO_SELECT_BLUE) //right click to fire blue wormholes.
+	if(select == AMMO_SELECT_BLUE) //Last fired in left click mode. Switch to orange wormhole (right click).
 		select_fire()
-	return ..()
+	fire_gun(target, user, flag, params)
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
 
 /obj/item/gun/energy/wormhole_projector/proc/on_portal_destroy(obj/effect/portal/P)
 	SIGNAL_HANDLER

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -196,10 +196,14 @@
 	force = 15
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma/adv)
 
+#define AMMO_SELECT_BLUE 1
+#define AMMO_SELECT_ORANGE 2
+
 /obj/item/gun/energy/wormhole_projector
 	name = "bluespace wormhole projector"
 	desc = "A projector that emits high density quantum-coupled bluespace beams. Requires a bluespace anomaly core to function. Fits in a bag."
 	ammo_type = list(/obj/item/ammo_casing/energy/wormhole, /obj/item/ammo_casing/energy/wormhole/orange)
+	can_select = FALSE // left-click for blue, right-click for orange.
 	w_class = WEIGHT_CLASS_NORMAL
 	inhand_icon_state = null
 	icon_state = "wormhole_projector"
@@ -209,6 +213,10 @@
 	var/obj/effect/portal/p_orange
 	var/atmos_link = FALSE
 	var/firing_core = FALSE
+
+/obj/item/gun/energy/wormhole_projector/examine(mob/user)
+	. = ..()
+	. += span_notice("<b>Left-click</b> to fire blue wormholes and <b><font color=orange>right-click</font></b> to fire orange wormholes.")
 
 /obj/item/gun/energy/wormhole_projector/attackby(obj/item/C, mob/user)
 	if(istype(C, /obj/item/assembly/signaler/anomaly/bluespace))
@@ -241,9 +249,16 @@
 			if(istype(WH))
 				WH.gun = WEAKREF(src)
 
-/obj/item/gun/energy/wormhole_projector/process_chamber()
-	..()
-	select_fire()
+/obj/item/gun/energy/wormhole_projector/afterattack(atom/target, mob/living/user, flag, params)
+	var/list/modifiers = params2list(params)
+	if(!LAZYACCESS(modifiers, RIGHT_CLICK) && select == AMMO_SELECT_ORANGE) //left click to fire blue wormholes.
+		select_fire()
+	return ..()
+
+/obj/item/gun/energy/wormhole_projector/afterattack_secondary(atom/target, mob/living/user, flag, params)
+	if(select == AMMO_SELECT_BLUE) //right click to fire blue wormholes.
+		select_fire()
+	return ..()
 
 /obj/item/gun/energy/wormhole_projector/proc/on_portal_destroy(obj/effect/portal/P)
 	SIGNAL_HANDLER
@@ -288,6 +303,9 @@
 
 /obj/item/gun/energy/wormhole_projector/core_inserted
 	firing_core = TRUE
+
+#undef AMMO_SELECT_BLUE
+#undef AMMO_SELECT_ORANGE
 
 /* 3d printer 'pseudo guns' for borgs */
 


### PR DESCRIPTION
## About The Pull Request
Changed the way the wormhole projector works to be easier to use.

## Why It's Good For The Game
Fikou wanted it.
![yea_i_use_whitemode_problems_question_mark](https://user-images.githubusercontent.com/42542238/127671888-b45fe16f-c708-48ec-ae9e-c82785a044a8.png)

Also fixing a runtime and removing a redundant `update_appearance` call. Tested.

## Changelog
:cl:
qol: Wormhole projectors now fire blue wormholes with left mouse btton and orange ones with right mouse button.
/:cl:
