### PR TITLE
Monochromacy is now a 2 points negative quirk.

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -22,6 +22,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		SetupQuirks()
 
 	quirk_blacklist = list(list("Blind","Nearsighted"), \
+							list("Blind", "Monochromacy"), \
 							list("Jolly","Depression","Apathetic","Hypersensitive"), \
 							list("Ageusia","Vegetarian","Deviant Tastes"), \
 							list("Ananas Affinity","Ananas Aversion"), \

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -803,3 +803,20 @@
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "bad_touch", /datum/mood_event/very_bad_touch)
 	else
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "bad_touch", /datum/mood_event/bad_touch)
+
+/datum/quirk/monochromatic
+	name = "Monochromacy"
+	desc = "You suffer from full colorblindness, and perceive nearly the entire world in blacks and whites."
+	value = -2
+	medical_record_text = "Patient is afflicted with almost complete color blindness."
+
+/datum/quirk/monochromatic/add()
+	quirk_holder.add_client_colour(/datum/client_colour/monochrome)
+
+/datum/quirk/monochromatic/post_add()
+	if(is_detective_job(quirk_holder.mind.assigned_role))
+		to_chat(quirk_holder, span_boldannounce("Mmm. Nothing's ever clear on this station. It's all shades of gray..."))
+		quirk_holder.playsound_local(quirk_holder, 'sound/ambience/ambidet1.ogg', 50, FALSE)
+
+/datum/quirk/monochromatic/remove()
+	quirk_holder.remove_client_colour(/datum/client_colour/monochrome)

--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -137,23 +137,6 @@
 	species.liked_food = initial(species.liked_food)
 	species.disliked_food = initial(species.disliked_food)
 
-/datum/quirk/monochromatic
-	name = "Monochromacy"
-	desc = "You suffer from full colorblindness, and perceive nearly the entire world in blacks and whites."
-	value = 0
-	medical_record_text = "Patient is afflicted with almost complete color blindness."
-
-/datum/quirk/monochromatic/add()
-	quirk_holder.add_client_colour(/datum/client_colour/monochrome)
-
-/datum/quirk/monochromatic/post_add()
-	if(is_detective_job(quirk_holder.mind.assigned_role))
-		to_chat(quirk_holder, span_boldannounce("Mmm. Nothing's ever clear on this station. It's all shades of gray..."))
-		quirk_holder.playsound_local(quirk_holder, 'sound/ambience/ambidet1.ogg', 50, FALSE)
-
-/datum/quirk/monochromatic/remove()
-	quirk_holder.remove_client_colour(/datum/client_colour/monochrome)
-
 /datum/quirk/phobia
 	name = "Phobia"
 	desc = "You are irrationally afraid of something."


### PR DESCRIPTION
## About The Pull Request
Title. Moved it from  quirks/neutral.dm to quirks/negative.dm and adjusted its value.

## Why It's Good For The Game
Albeit only slightly, the quirk undermines the player, like the bad touch quirk, only ever-present. Pretty much no one takes it except the occasional roleplayer, and even then it's kinda useless for RP. It's originally supposed to be a neutral trait but Xhuis isn't around anymore anyway.
Other somewhat bad quirks such as Foreigner, Vegetarian and Phobia are also neutral despite being maluses. They'll get their own PRs. I have got plenty of qbp. EDIT: Maybe only Foreigner, after the feature freeze is over.

## Changelog
:cl:
balance: Monochromacy is now a 2 points negative quirk.
/:cl:
