### PR TITLE
Soapstone messages are coloured by vote count instead of randomly

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -75,6 +75,13 @@
 #define COLOR_DARK_BROWN "#997C4F"
 #define COLOR_ORANGE_BROWN "#a9734f"
 
+//Color defines used by the soapstone (based on readability against grey tiles)
+#define COLOR_SOAPSTONE_FAIL "#b2b2b2"
+#define COLOR_SOAPSTONE_BRONZE "#FE8001"
+#define COLOR_SOAPSTONE_SILVER "#FFFFFF"
+#define COLOR_SOAPSTONE_GOLD "#FFD900"
+#define COLOR_SOAPSTONE_PLATINUM "#00ffee"
+
 #define COLOR_GREEN_GRAY       "#99BB76"
 #define COLOR_RED_GRAY         "#B4696A"
 #define COLOR_PALE_BLUE_GRAY   "#98C5DF"

--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -76,7 +76,8 @@
 #define COLOR_ORANGE_BROWN "#a9734f"
 
 //Color defines used by the soapstone (based on readability against grey tiles)
-#define COLOR_SOAPSTONE_IRON "#b2b2b2"
+#define COLOR_SOAPSTONE_PLASTIC "#b2b2b2"
+#define COLOR_SOAPSTONE_IRON "#a19d94"
 #define COLOR_SOAPSTONE_BRONZE "#FE8001"
 #define COLOR_SOAPSTONE_SILVER "#FFFFFF"
 #define COLOR_SOAPSTONE_GOLD "#FFD900"

--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -76,11 +76,11 @@
 #define COLOR_ORANGE_BROWN "#a9734f"
 
 //Color defines used by the soapstone (based on readability against grey tiles)
-#define COLOR_SOAPSTONE_FAIL "#b2b2b2"
+#define COLOR_SOAPSTONE_IRON "#b2b2b2"
 #define COLOR_SOAPSTONE_BRONZE "#FE8001"
 #define COLOR_SOAPSTONE_SILVER "#FFFFFF"
 #define COLOR_SOAPSTONE_GOLD "#FFD900"
-#define COLOR_SOAPSTONE_PLATINUM "#00ffee"
+#define COLOR_SOAPSTONE_DIAMOND "#00ffee"
 
 #define COLOR_GREEN_GRAY       "#99BB76"
 #define COLOR_RED_GRAY         "#B4696A"

--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -76,8 +76,8 @@
 #define COLOR_ORANGE_BROWN "#a9734f"
 
 //Color defines used by the soapstone (based on readability against grey tiles)
-#define COLOR_SOAPSTONE_PLASTIC "#b2b2b2"
-#define COLOR_SOAPSTONE_IRON "#a19d94"
+#define COLOR_SOAPSTONE_PLASTIC "#a19d94"
+#define COLOR_SOAPSTONE_IRON "#b2b2b2"
 #define COLOR_SOAPSTONE_BRONZE "#FE8001"
 #define COLOR_SOAPSTONE_SILVER "#FFFFFF"
 #define COLOR_SOAPSTONE_GOLD "#FFD900"

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -1,3 +1,10 @@
+#define POINT_THRESHOLD_PLASTIC -INFINITY
+#define POINT_THRESHOLD_IRON 1
+#define POINT_THRESHOLD_BRONZE 15
+#define POINT_THRESHOLD_SILVER 30
+#define POINT_THRESHOLD_GOLD 45
+#define POINT_THRESHOLD_DIAMOND 60
+
 /obj/item/soapstone
 	name = "soapstone"
 	desc = "Leave informative messages for the crew, including the crew of future shifts!\nEven if out of uses, it can still be used to remove messages.\n(Not suitable for engraving on shuttles, off station or on cats. Side effects may include prompt beatings, psychotic clown incursions, and/or orbital bombardment.)"
@@ -155,19 +162,19 @@ but only permanently removed with the curator's soapstone.
 /obj/structure/chisel_message/update_icon()
 	. = ..()
 
-	var/newcolor = COLOR_SOAPSTONE_IRON
+	var/newcolor = COLOR_SOAPSTONE_PLASTIC
 	switch(like_keys.len - dislike_keys.len)
-		if(-INFINITY to -1)
+		if(POINT_THRESHOLD_PLASTIC to POINT_THRESHOLD_IRON-1)
 			newcolor = COLOR_SOAPSTONE_PLASTIC
-		if(0 to 14)
+		if(POINT_THRESHOLD_IRON to POINT_THRESHOLD_BRONZE-1)
 			newcolor = COLOR_SOAPSTONE_IRON
-		if(15 to 29)
+		if(POINT_THRESHOLD_BRONZE to POINT_THRESHOLD_SILVER-1)
 			newcolor = COLOR_SOAPSTONE_BRONZE
-		if(30 to 44)
+		if(POINT_THRESHOLD_SILVER to POINT_THRESHOLD_GOLD-1)
 			newcolor = COLOR_SOAPSTONE_SILVER
-		if(45 to 59)
+		if(POINT_THRESHOLD_GOLD to POINT_THRESHOLD_DIAMOND-1)
 			newcolor = COLOR_SOAPSTONE_GOLD
-		if(60 to INFINITY)
+		if(POINT_THRESHOLD_DIAMOND to INFINITY)
 			newcolor = COLOR_SOAPSTONE_DIAMOND
 
 	add_atom_colour("[newcolor]", FIXED_COLOUR_PRIORITY)
@@ -176,17 +183,17 @@ but only permanently removed with the curator's soapstone.
 
 /obj/structure/chisel_message/update_name()
 	switch(like_keys.len - dislike_keys.len)
-		if(-INFINITY to -1)
-			name = "[initial(name)]"
-		if(0 to 14)
+		if(POINT_THRESHOLD_PLASTIC to POINT_THRESHOLD_IRON-1)
+			name = "plastic [initial(name)]"
+		if(POINT_THRESHOLD_IRON to POINT_THRESHOLD_BRONZE-1)
 			name = "iron [initial(name)]"
-		if(15 to 29)
+		if(POINT_THRESHOLD_BRONZE to POINT_THRESHOLD_SILVER-1)
 			name = "bronze [initial(name)]"
-		if(30 to 44)
+		if(POINT_THRESHOLD_SILVER to POINT_THRESHOLD_GOLD-1)
 			name = "silver [initial(name)]"
-		if(45 to 59)
+		if(POINT_THRESHOLD_GOLD to POINT_THRESHOLD_DIAMOND-1)
 			name = "gold [initial(name)]"
-		if(60 to INFINITY)
+		if(POINT_THRESHOLD_DIAMOND to INFINITY)
 			name = "diamond [initial(name)]"
 	return ..()
 

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -158,7 +158,7 @@ but only permanently removed with the curator's soapstone.
 	var/newcolor = COLOR_SOAPSTONE_BRONZE
 	switch(like_keys.len - dislike_keys.len)
 		if(-INFINITY to 0)
-			newcolor = COLOR_SOAPSTONE_FAIL
+			newcolor = COLOR_SOAPSTONE_IRON
 			name = "[initial(name)]"
 		if(1 to 10)
 			newcolor = COLOR_SOAPSTONE_BRONZE
@@ -170,8 +170,8 @@ but only permanently removed with the curator's soapstone.
 			newcolor = COLOR_SOAPSTONE_GOLD
 			name = "gold [initial(name)]"
 		if(31 to INFINITY)
-			newcolor = COLOR_SOAPSTONE_PLATINUM
-			name = "platinum [initial(name)]"
+			newcolor = COLOR_SOAPSTONE_DIAMOND
+			name = "diamond [initial(name)]"
 
 	add_atom_colour("[newcolor]", FIXED_COLOUR_PRIORITY)
 	set_light_color("[newcolor]")

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -159,7 +159,7 @@ but only permanently removed with the curator's soapstone.
 	switch(like_keys.len - dislike_keys.len)
 		if(-INFINITY to -1)
 			newcolor = COLOR_SOAPSTONE_PLASTIC
-		if(1 to 14)
+		if(0 to 14)
 			newcolor = COLOR_SOAPSTONE_IRON
 		if(15 to 29)
 			newcolor = COLOR_SOAPSTONE_BRONZE
@@ -178,7 +178,7 @@ but only permanently removed with the curator's soapstone.
 	switch(like_keys.len - dislike_keys.len)
 		if(-INFINITY to -1)
 			name = "[initial(name)]"
-		if(1 to 14)
+		if(0 to 14)
 			name = "iron [initial(name)]"
 		if(15 to 29)
 			name = "bronze [initial(name)]"

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -155,27 +155,40 @@ but only permanently removed with the curator's soapstone.
 /obj/structure/chisel_message/update_icon()
 	. = ..()
 
-	var/newcolor = COLOR_SOAPSTONE_BRONZE
+	var/newcolor = COLOR_SOAPSTONE_IRON
 	switch(like_keys.len - dislike_keys.len)
-		if(-INFINITY to 0)
+		if(-INFINITY to -1)
+			newcolor = COLOR_SOAPSTONE_PLASTIC
+		if(1 to 14)
 			newcolor = COLOR_SOAPSTONE_IRON
-			name = "[initial(name)]"
-		if(1 to 10)
+		if(15 to 29)
 			newcolor = COLOR_SOAPSTONE_BRONZE
-			name = "bronze [initial(name)]"
-		if(11 to 20)
+		if(30 to 44)
 			newcolor = COLOR_SOAPSTONE_SILVER
-			name = "silver [initial(name)]"
-		if(21 to 30)
+		if(45 to 59)
 			newcolor = COLOR_SOAPSTONE_GOLD
-			name = "gold [initial(name)]"
-		if(31 to INFINITY)
+		if(60 to INFINITY)
 			newcolor = COLOR_SOAPSTONE_DIAMOND
-			name = "diamond [initial(name)]"
 
 	add_atom_colour("[newcolor]", FIXED_COLOUR_PRIORITY)
 	set_light_color("[newcolor]")
 	set_light(1)
+
+/obj/structure/chisel_message/update_name()
+	switch(like_keys.len - dislike_keys.len)
+		if(-INFINITY to -1)
+			name = "[initial(name)]"
+		if(1 to 14)
+			name = "iron [initial(name)]"
+		if(15 to 29)
+			name = "bronze [initial(name)]"
+		if(30 to 44)
+			name = "silver [initial(name)]"
+		if(45 to 59)
+			name = "gold [initial(name)]"
+		if(60 to INFINITY)
+			name = "diamond [initial(name)]"
+	return ..()
 
 /obj/structure/chisel_message/proc/pack()
 	var/list/data = list()

--- a/code/modules/library/soapstone.dm
+++ b/code/modules/library/soapstone.dm
@@ -154,10 +154,27 @@ but only permanently removed with the curator's soapstone.
 
 /obj/structure/chisel_message/update_icon()
 	. = ..()
-	var/hash = md5(hidden_message)
-	var/newcolor = copytext_char(hash, 1, 7)
-	add_atom_colour("#[newcolor]", FIXED_COLOUR_PRIORITY)
-	set_light_color("#[newcolor]")
+
+	var/newcolor = COLOR_SOAPSTONE_BRONZE
+	switch(like_keys.len - dislike_keys.len)
+		if(-INFINITY to 0)
+			newcolor = COLOR_SOAPSTONE_FAIL
+			name = "[initial(name)]"
+		if(1 to 10)
+			newcolor = COLOR_SOAPSTONE_BRONZE
+			name = "bronze [initial(name)]"
+		if(11 to 20)
+			newcolor = COLOR_SOAPSTONE_SILVER
+			name = "silver [initial(name)]"
+		if(21 to 30)
+			newcolor = COLOR_SOAPSTONE_GOLD
+			name = "gold [initial(name)]"
+		if(31 to INFINITY)
+			newcolor = COLOR_SOAPSTONE_PLATINUM
+			name = "platinum [initial(name)]"
+
+	add_atom_colour("[newcolor]", FIXED_COLOUR_PRIORITY)
+	set_light_color("[newcolor]")
 	set_light(1)
 
 /obj/structure/chisel_message/proc/pack()
@@ -287,4 +304,5 @@ but only permanently removed with the curator's soapstone.
 				qdel(src)
 				return
 
+	update_appearance()
 	persists = like_keys.len - dislike_keys.len > delete_at


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![](https://i.imgur.com/4O8z2Fs.png)
(this is outdated, messages start on the left and at 1 vote change to the one second from the left)

- Each soapstone message receives one of six colours based on its vote count (plastic, iron, bronze, silver, gold, diamond)
- The colours rename the message (e.g. "iron engraved message") to make the system self-explanatory
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The only quality indicator we have for these is the vote count. There are a lot of engravings to examine to find the ones with high vote counts. This makes it so you can spot them at a glance and rewards players for making contributions people like.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: cacogen
add: Soapstone engravings change colour and name (e.g. diamond engraved message) based off of their score
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
