### PR TITLE
Returns default AI behavior cooldown to .8 seconds

### DIFF
--- a/code/datums/ai/_ai_behavior.dm
+++ b/code/datums/ai/_ai_behavior.dm
@@ -4,8 +4,8 @@
 	var/required_distance = 1
 	///Flags for extra behavior
 	var/behavior_flags = NONE
-	///Cooldown between actions performances
-	var/action_cooldown = 0
+	///Cooldown between actions performances, defaults to the value of CLICK_CD_MELEE because that seemed like a nice standard for the speed of AI behavior
+	var/action_cooldown = 8
 
 /// Called by the ai controller when first being added. Additional arguments depend on the behavior type.
 /// Return FALSE to cancel

--- a/code/datums/ai/_ai_behavior.dm
+++ b/code/datums/ai/_ai_behavior.dm
@@ -5,7 +5,7 @@
 	///Flags for extra behavior
 	var/behavior_flags = NONE
 	///Cooldown between actions performances, defaults to the value of CLICK_CD_MELEE because that seemed like a nice standard for the speed of AI behavior
-	var/action_cooldown = 0.8 SECONDS
+	var/action_cooldown = CLICK_CD_MELEE
 
 /// Called by the ai controller when first being added. Additional arguments depend on the behavior type.
 /// Return FALSE to cancel

--- a/code/datums/ai/_ai_behavior.dm
+++ b/code/datums/ai/_ai_behavior.dm
@@ -5,7 +5,7 @@
 	///Flags for extra behavior
 	var/behavior_flags = NONE
 	///Cooldown between actions performances, defaults to the value of CLICK_CD_MELEE because that seemed like a nice standard for the speed of AI behavior
-	var/action_cooldown = 8
+	var/action_cooldown = 0.8 SECONDS
 
 /// Called by the ai controller when first being added. Additional arguments depend on the behavior type.
 /// Return FALSE to cancel


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
#60249 was a very nice (and sorta funnily numbered) PR that added a lot more flexibility to the AI datum system, but for whatever reason @ma44 effectively changed how often behaviors run from every 0.8 seconds to 0.1 seconds without actually accounting for how running eight times as often might affect existing AI. The harass dog AI behavior, for example, is currently able to crit someone with ~20 attacks in 2 seconds.

This sets the default behavior cooldown to the old behavior subsystem's wait of 0.8 seconds, which should hopefully return the old behavior and provide a saner default for the future. There might be side effects here with co-opting an existing var of action_cooldown, so reviews are welcome.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Behaviors running 10 times a second by default is kinda nuts and overkill
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Ryll/Shaps
fix: Default AI behavior cooldowns have been returned back to 0,8 seconds instead of 0.1 seconds, meaning Ian will no longer disembowel you with 20 attacks in 2 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
