### PR TITLE
Test merge pr to disable admin profiler access

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -59,8 +59,8 @@ GLOBAL_PROTECT(href_token)
 	rank = R
 	admin_signature = "Nanotrasen Officer #[rand(0,9)][rand(0,9)][rand(0,9)]"
 	href_token = GenerateToken()
-	if(R.rights & R_DEBUG) //grant profile access
-		world.SetConfig("APP/admin", ckey, "role=admin")
+	/*if(R.rights & R_DEBUG) //grant profile access
+		world.SetConfig("APP/admin", ckey, "role=admin")*/
 	//only admins with +ADMIN start admined
 	if(protected)
 		GLOB.protected_admins[target] = src


### PR DESCRIPTION
debian visor -> debian vm -> docker image -> tgs:

**profiler on**: `Initializations complete within 430.3 seconds!`

**profiler off**: `Initializations complete within 53.4 seconds!`

This is a quick fix for campbell until I can decide on next steps. rather then have the profiler button be a lag switch for admins not in the know.