### PR TITLE
Standard bananium floor is now viable for clown decoration. It doesn't slip.

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_mineral.dm
+++ b/code/game/objects/items/stacks/tiles/tile_mineral.dm
@@ -95,12 +95,13 @@
 /obj/item/stack/tile/mineral/bananium
 	name = "bananium tile"
 	singular_name = "bananium floor tile"
-	desc = "A tile made out of bananium, HOOOOOOOOONK!"
+	desc = "A non-slippery tile made out of bananium, HOOOOOOOOONK!"
 	icon_state = "tile_bananium"
 	inhand_icon_state = "tile-bananium"
 	turf_type = /turf/open/floor/mineral/bananium
 	mineralType = "bananium"
 	mats_per_unit = list(/datum/material/bananium=MINERAL_MATERIAL_AMOUNT*0.25)
+	material_flags = MATERIAL_NO_EFFECTS //The slippery comp makes it unpractical for good clown decor. The material tiles should still slip.
 	merge_type = /obj/item/stack/tile/mineral/bananium
 
 /obj/item/stack/tile/mineral/abductor

--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -200,6 +200,7 @@
 	floor_tile = /obj/item/stack/tile/mineral/bananium
 	icons = list("bananium","bananium_dam")
 	custom_materials = list(/datum/material/bananium = 500)
+	material_flags = MATERIAL_NO_EFFECTS //The slippery comp makes it unpractical for good clown decor. The custom mat one should still slip.
 	var/sound_cooldown = 0
 
 /turf/open/floor/mineral/bananium/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)


### PR DESCRIPTION
## About The Pull Request
Title. It now has the MATERIAL_NO_EFFECTS flag.

## Why It's Good For The Game
Please give #60573 a read if you can.
It allows players (and mappers) to create areas tiled with this mineral turf without worrying about people having to crawl over it. It's also more annoying than debilitating when it comes to exploring deep space. Players can still rush a honker mech in less than 20 minutes if they want to and the sci dept hasn't gone to hell in a handbasket, so this is not a powercreep. The clown dome in lavaland is perhaps the only ruin that has reason to be so slippery, though it already has its own special turf that fun-slides people around.
And if you really want to slip people, you can still lay around custom material bananium floor tiles or, if you are mapping, make a subtype without the no effects material flag. This should close #60573.

## Changelog
:cl:
balance: Standard bananium floor is now viable for clown decoration and isn't slippery. Custom bananium floor tiles can be used to slip people though.
/:cl:
