### PR TITLE
Contractor pods won't land on groundless turfs such as chasms or open space anymore.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -527,21 +527,16 @@
 
 // Find an obstruction free turf that's within the range of the center. Can also condition on if it is of a certain area type.
 /proc/find_obstruction_free_location(range, atom/center, area/specific_area)
-	var/list/turfs = RANGE_TURFS(range, center)
 	var/list/possible_loc = list()
 
-	for(var/turf/found_turf in turfs)
-		var/area/turf_area = get_area(found_turf)
-
+	for(var/turf/found_turf as anything in RANGE_TURFS(range, center))
 		// We check if both the turf is a floor, and that it's actually in the area.
 		// We also want a location that's clear of any obstructions.
-		if (specific_area)
-			if (!istype(turf_area, specific_area))
-				continue
+		if (specific_area && !istype(get_area(found_turf), specific_area))
+			continue
 
-		if (!isspaceturf(found_turf))
-			if (!found_turf.is_blocked_turf())
-				possible_loc.Add(found_turf)
+		if (!isgroundlessturf(found_turf) && !found_turf.is_blocked_turf())
+			possible_loc.Add(found_turf)
 
 	// Need at least one free location.
 	if (possible_loc.len < 1)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -529,7 +529,7 @@
 /proc/find_obstruction_free_location(range, atom/center, area/specific_area)
 	var/list/possible_loc = list()
 
-	for(var/turf/found_turf as anything in RANGE_TURFS(range, center))
+	for(var/turf/found_turf in RANGE_TURFS(range, center))
 		// We check if both the turf is a floor, and that it's actually in the area.
 		// We also want a location that's clear of any obstructions.
 		if (specific_area && !istype(get_area(found_turf), specific_area))


### PR DESCRIPTION
## About The Pull Request
Title. Improved the `find_obstruction_free_location` proc in the process.

## Why It's Good For The Game
This will fix #57656.

## Changelog
:cl:
fix: Contractor pods won't land on groundless turfs such as chasms, lava or open space anymore.
/:cl:
