### PR TITLE
Fixes SDQL spell list vars and missing variable names

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_spells_and_items.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_spells_and_items.dm
@@ -766,7 +766,7 @@
 
 /datum/give_sdql_spell/proc/rename_list_var(list_name, list_var, new_name)
 	if(!new_name)
-		alert = "You can't give a list an empty string for a name!"
+		alert = "You can't give a list variable an empty string for a name!"
 		return
 	if(list_var == new_name)
 		return

--- a/code/modules/admin/verbs/SDQL2/SDQL_spells_and_items.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_spells_and_items.dm
@@ -765,6 +765,9 @@
 			list_vars[list_name][list_var]["value"] = value
 
 /datum/give_sdql_spell/proc/rename_list_var(list_name, list_var, new_name)
+	if(!new_name)
+		alert = "You can't give a list an empty string for a name!"
+		return
 	if(list_var == new_name)
 		return
 	if(list_name in list_vars)
@@ -774,7 +777,9 @@
 			if(new_name in list_vars[list_name])
 				alert = "There is already a variable named [new_name] in [list_name]!"
 			else
+				var/old_val = list_vars[list_name][list_var]
 				list_vars[list_name][ind] = new_name
+				list_vars[list_name][new_name] = old_val
 
 /datum/give_sdql_spell/proc/change_list_var_type(list_name, list_var, var_type)
 	if(list_name in list_vars)

--- a/tgui/packages/tgui/interfaces/SDQLSpellMenu.js
+++ b/tgui/packages/tgui/interfaces/SDQLSpellMenu.js
@@ -472,6 +472,8 @@ const WrapInTooltip = (props, context) => {
         {children}
       </Tooltip>
     );
+  } else {
+    return children;
   }
 };
 
@@ -522,7 +524,6 @@ const SDQLSpellInput = (props, context) => {
     case 'string':
       return (
         <Input
-          width="100%"
           fluid
           value={saved_vars[name] ?? default_value}
           onChange={(e, value) => act('variable', { name, value })}


### PR DESCRIPTION
## About The Pull Request

At least partially fixes #60304. Also fixes an unrelated issue that resulted in some variable inputs not being labeled with their name.

## Why It's Good For The Game

Corrects some mistakes I made when initially making SDQL spells.

## Changelog
:cl:
fix: Editing the names of list variables in SDQL spells works now.
fix: The names of certain SDQL spell variables now appear in the menu.
/:cl:
