### PR TITLE
Robotic console warmup and cooldown

### DIFF
--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -57,6 +57,10 @@
 
 #define BORG_LAMP_CD_RESET -1 //special value to reset cyborg's lamp_cooldown
 
+#define BORG_DETONATION_DELAY 60 SECONDS//deciseconds from locking a cyborg before its ready to blow
+#define BORG_UNLOCK_DELAY 30 SECONDS //Time it takes to unlock a cyborg
+#define CONSOLE_LOCK_COOLDOWN 60 SECONDS //cooldown the console has on locking a cyborg
+
 /// Defines for whether or not module slots are broken.
 #define BORG_MODULE_ALL_DISABLED (1<<0)
 #define BORG_MODULE_TWO_DISABLED (1<<1)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -99,7 +99,10 @@
 					message_admins(span_notice("[ADMIN_LOOKUPFLW(usr)] [!R.lockcharge ? "locked down" : "released"] [ADMIN_LOOKUPFLW(R)]!"))
 					log_game("[key_name(usr)] [!R.lockcharge ? "locked down" : "released"] [key_name(R)]!")
 					to_chat(usr,!R.lockcharge ? span_alert("Arming up internal detonation charge, please wait [BORG_DETONATION_DELAY/10] seconds") : span_notice("Releasing lockdown, it will take [BORG_UNLOCK_DELAY/10] seconds"))
-					addtimer(CALLBACK(R, /mob/living/silicon/robot/proc/SetLockdown, !R.lockcharge), BORG_UNLOCK_DELAY)
+					if(R.lockcharge)
+						addtimer(CALLBACK(R, /mob/living/silicon/robot/proc/SetLockdown, FALSE), BORG_UNLOCK_DELAY)
+					else
+						R.SetLockdown(TRUE)
 					to_chat(R, R.lockcharge ? span_notice("Your lockdown is being lifted!") : span_alert("You have been locked down!"))
 					if(R.connected_ai)
 						to_chat(R.connected_ai, "[!R.lockcharge ? span_notice("NOTICE - Cyborg lockdown is being lifted") : span_alert("ALERT - Cyborg lockdown detected")]: <a href='?src=[REF(R.connected_ai)];track=[html_encode(R.name)]'>[R.name]</a><br>")

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -100,7 +100,7 @@
 					log_game("[key_name(usr)] [!R.lockcharge ? "locked down" : "released"] [key_name(R)]!")
 					to_chat(usr,!R.lockcharge ? span_alert("Arming up internal detonation charge, please wait [BORG_DETONATION_DELAY/10] seconds") : span_notice("Releasing lockdown, it will take [BORG_UNLOCK_DELAY/10] seconds"))
 					addtimer(CALLBACK(R, /mob/living/silicon/robot/proc/SetLockdown, !R.lockcharge), BORG_UNLOCK_DELAY)
-					to_chat(R, !R.lockcharge ? span_notice("Your lockdown is being lifted!") : span_alert("You have been locked down!"))
+					to_chat(R, R.lockcharge ? span_notice("Your lockdown is being lifted!") : span_alert("You have been locked down!"))
 					if(R.connected_ai)
 						to_chat(R.connected_ai, "[!R.lockcharge ? span_notice("NOTICE - Cyborg lockdown is being lifted") : span_alert("ALERT - Cyborg lockdown detected")]: <a href='?src=[REF(R.connected_ai)];track=[html_encode(R.name)]'>[R.name]</a><br>")
 			else

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -385,13 +385,14 @@
 		add_overlay(head_overlay)
 	update_fire()
 
-/mob/living/silicon/robot/proc/self_destruct()
-	if(emagged)
-		QDEL_NULL(mmi)
-		explosion(src, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 4, flame_range = 2)
-	else
-		explosion(src, devastation_range = -1, light_impact_range = 2)
-	gib()
+/mob/living/silicon/robot/proc/self_destruct(is_silicon)
+	if(is_silicon||lockcharge&&lastlocked+BORG_DETONATION_DELAY<world.time)
+		if(emagged)
+			QDEL_NULL(mmi)
+			explosion(src, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 4, flame_range = 2)
+		else
+			explosion(src, devastation_range = -1, light_impact_range = 2)
+		gib()
 
 /mob/living/silicon/robot/proc/UnlinkSelf()
 	set_connected_ai(null)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -425,8 +425,10 @@
 		state = TRUE
 	if(state)
 		throw_alert("locked", /atom/movable/screen/alert/locked)
+		lastlocked = world.time
 	else
 		clear_alert("locked")
+		lastunlocked = world.time
 	set_lockcharge(state)
 
 

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -94,6 +94,12 @@
 	var/scrambledcodes = FALSE
 	///Boolean of whether the borg is locked down or not
 	var/lockcharge = FALSE
+	//Time this unit was locked, used in calculating if it can be detonated
+	var/lastlocked = 0
+	//Is the unit being unlocked
+	var/isunlocking = FALSE
+	//last time the unit was unlocked, used to calculate cooldown
+	var/lastunlocked = 0
 
 	///Random serial number generated for each cyborg upon its initialization
 	var/ident = 0

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -78,16 +78,21 @@ const Cyborgs = (props, context) => {
               })} />
             <Button.Confirm
               icon="bomb"
-              disabled={!cyborg.locked_down&&!cyborg.can_blow}
-              content={!cyborg.can_blow&&cyborg.locked_down
-                ?"Arming up"
-                :"Detonate"}
-              color={cyborg.can_blow ? "bad"
-                :cyborg.locked_down ? "yellow" : "grey"}
-              onClick={() => act(cyborg.can_blow
-                ?'killbot' : "", {
-                ref: cyborg.ref,
-              })} />
+              disabled={!cyborg.locked_down && !cyborg.can_blow}
+              content={!cyborg.can_blow && cyborg.locked_down
+                ? "Arming up" : "Detonate"}
+              color={cyborg.can_blow
+                ? "bad"
+                : cyborg.locked_down
+                  ? "yellow"
+                  : "grey"}
+              onClick={() => {
+                if (cyborg.can_blow) {
+                  act('killbot', {
+                    ref: cyborg.ref,
+                  });
+                }
+              }} />
           </>
         )}>
         <LabeledList>

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -70,6 +70,7 @@ const Cyborgs = (props, context) => {
             )}
             <Button.Confirm
               icon={cyborg.locked_down ? 'unlock' : 'lock'}
+              disabled={!cyborg.can_lock&&!cyborg.locked_down}
               color={cyborg.locked_down ? 'good' : 'default'}
               content={cyborg.locked_down ? "Release" : "Lockdown"}
               onClick={() => act('stopbot', {
@@ -77,9 +78,14 @@ const Cyborgs = (props, context) => {
               })} />
             <Button.Confirm
               icon="bomb"
-              content="Detonate"
-              color="bad"
-              onClick={() => act('killbot', {
+              disabled={!cyborg.locked_down&&!cyborg.can_blow}
+              content={!cyborg.can_blow&&cyborg.locked_down
+                ?"Arming up"
+                :"Detonate"}
+              color={cyborg.can_blow ? "bad"
+                :cyborg.locked_down ? "yellow" : "grey"}
+              onClick={() => act(cyborg.can_blow&&cyborg.locked_down
+                ?'killbot' : "", {
                 ref: cyborg.ref,
               })} />
           </>

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -84,7 +84,7 @@ const Cyborgs = (props, context) => {
                 :"Detonate"}
               color={cyborg.can_blow ? "bad"
                 :cyborg.locked_down ? "yellow" : "grey"}
-              onClick={() => act(cyborg.can_blow&&cyborg.locked_down
+              onClick={() => act(cyborg.can_blow
                 ?'killbot' : "", {
                 ref: cyborg.ref,
               })} />


### PR DESCRIPTION

## About The Pull Request
Makes robotic console less op in dealing with cyborgs, without removing its ability to cripple malfunctions, and destroy emagged cyborgs. Hackmd with my thought process: https://hackmd.io/EE9s9BWdSXOi2wpOy8WKtg 
Detonation now requires 60 seconds of lockdown before its possible, with the exception of silicons detonating silicons. Unlocking now takes 30 seconds if done via robotics console, to make it still a 30 second stun, and to require quick reactions to stop detonation. It also gives 60 second cooldown between remote lockdowns, to prevent spamming, and to prevent it from permament lockdown.
Draft for now, since i still need to check if my monkey brain didnt leave a stupid mistake in there, since i checked almost everything
## Why It's Good For The Game
Being able to remotely thanos snap all cyborgs on z-level wasnt very fun for the cyborg players, ais, and anyone in victimity of the cyborg. Leaves the console as strong weapon against rogue ais, but not the absolute death sentence it was before for malfs

## Changelog
:cl:
balance: makes robotic console have a warm up period for cyborg detonation, and makes remote unlocking take 30 seconds
/:cl:


