### PR TITLE
Adds the library_report table

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,31 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.14; The query to update the schema revision table is:
+The latest database version is 5.16; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 15);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 16);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 15);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 16);
 
 In any query remember to add a prefix to the table names if you use one.
+
+-----------------------------------------------------
+Version 5.16, 31 July 2021, by Atlanta-Ned
+Added `library_report` table for tracking reported library books and actions taken on them.
+
+```
+DROP TABLE IF EXISTS `library_report`;
+CREATE TABLE `library_action` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `book` int(10) unsigned NOT NULL,
+  `reason` longtext DEFAULT NULL,
+  `ckey` varchar(11) NOT NULL DEFAULT '',
+  `datetime` datetime NOT NULL DEFAULT current_timestamp(),
+  `action` varchar(11) NOT NULL DEFAULT '',
+  `ip_addr` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
+```
+
 
 -----------------------------------------------------
 Version 5.15, 2 June 2021, by Mothblocks

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -10,7 +10,7 @@ In any query remember to add a prefix to the table names if you use one.
 
 -----------------------------------------------------
 Version 5.16, 31 July 2021, by Atlanta-Ned
-Added `library_report` table for tracking reported library books and actions taken on them.
+Added `library_action` table for tracking reported library books and actions taken on them.
 
 ```
 DROP TABLE IF EXISTS `library_action`;

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -13,7 +13,7 @@ Version 5.16, 31 July 2021, by Atlanta-Ned
 Added `library_report` table for tracking reported library books and actions taken on them.
 
 ```
-DROP TABLE IF EXISTS `library_report`;
+DROP TABLE IF EXISTS `library_action`;
 CREATE TABLE `library_action` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `book` int(10) unsigned NOT NULL,

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -263,7 +263,7 @@ CREATE TABLE `library` (
 -- Table structure for table `library_report`
 --
 
-DROP TABLE IF EXISTS `library_report`;
+DROP TABLE IF EXISTS `library_action`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `library_action` (

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -260,6 +260,25 @@ CREATE TABLE `library` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `library_report`
+--
+
+DROP TABLE IF EXISTS `library_report`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `library_action` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `book` int(10) unsigned NOT NULL,
+  `reason` longtext DEFAULT NULL,
+  `ckey` varchar(11) NOT NULL DEFAULT '',
+  `datetime` datetime NOT NULL DEFAULT current_timestamp(),
+  `action` varchar(11) NOT NULL DEFAULT '',
+  `ip_addr` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=27 DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `messages`
 --
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -260,7 +260,7 @@ CREATE TABLE `library` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Table structure for table `library_report`
+-- Table structure for table `library_action`
 --
 
 DROP TABLE IF EXISTS `library_action`;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -260,6 +260,25 @@ CREATE TABLE `SS13_library` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `library_report`
+--
+
+DROP TABLE IF EXISTS `SS13_library_report`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `SS13_library_action` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `book` int(10) unsigned NOT NULL,
+  `reason` longtext DEFAULT NULL,
+  `ckey` varchar(11) NOT NULL DEFAULT '',
+  `datetime` datetime NOT NULL DEFAULT current_timestamp(),
+  `action` varchar(11) NOT NULL DEFAULT '',
+  `ip_addr` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=27 DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `SS13_messages`
 --
 

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -260,7 +260,7 @@ CREATE TABLE `SS13_library` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Table structure for table `library_report`
+-- Table structure for table `SS13_library_action`
 --
 
 DROP TABLE IF EXISTS `SS13_library_action`;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -263,7 +263,7 @@ CREATE TABLE `SS13_library` (
 -- Table structure for table `library_report`
 --
 
-DROP TABLE IF EXISTS `SS13_library_report`;
+DROP TABLE IF EXISTS `SS13_library_action`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `SS13_library_action` (

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
  *
  * make sure you add an update to the schema_version stable in the db changelog
  */
-#define DB_MINOR_VERSION 15
+#define DB_MINOR_VERSION 16
 
 
 //! ## Timing subsystem


### PR DESCRIPTION
There's been a request for a more robust way to moderate the library, and this is part of an effort to work on that. These SQL changes are used by Statbus to handle books reported by players and deleted (or undeleted) by admins. 