### PR TITLE
Regenerates the CTF map each time a CTF round ends

### DIFF
--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -452,25 +452,8 @@
 
 	notify_ghosts("[name] has been activated!", source = src, action=NOTIFY_ORBIT, header = "CTF has been activated")
 
-	if(!arena_reset)
-		reset_the_arena()
-		arena_reset = TRUE
-
 /obj/machinery/capture_the_flag/proc/reset_the_arena()
-	var/area/ctf_area = get_area(src)
-	var/static/list/ctf_object_typecache = typecacheof(list(
-				/obj/machinery,
-				/obj/effect/ctf,
-				/obj/item/ctf
-			))
-	for(var/atom/movable/area_movable in ctf_area)
-		if (ismob(area_movable))
-			continue
-		if(isstructure(area_movable))
-			var/obj/structure/ctf_structure = area_movable
-			ctf_structure.repair_damage(ctf_structure.max_integrity - ctf_structure.get_integrity())
-		else if(!is_type_in_typecache(area_movable, ctf_object_typecache))
-			qdel(area_movable)
+	new /obj/effect/landmark/ctf(get_turf(GLOB.ctf_spawner))
 
 
 /obj/machinery/capture_the_flag/proc/stop_ctf()
@@ -484,6 +467,7 @@
 	team_members.Cut()
 	spawned_mobs.Cut()
 	recently_dead_ckeys.Cut()
+	reset_the_arena()
 
 /obj/machinery/capture_the_flag/proc/instagib_mode()
 	for(var/obj/machinery/capture_the_flag/CTF in GLOB.machines)

--- a/code/modules/capture_the_flag/ctf_map_loading.dm
+++ b/code/modules/capture_the_flag/ctf_map_loading.dm
@@ -9,7 +9,7 @@ GLOBAL_DATUM(ctf_spawner, /obj/effect/landmark/ctf)
 	if(GLOB.ctf_spawner)
 		qdel(GLOB.ctf_spawner)
 	GLOB.ctf_spawner = src
-	load_map()
+	INVOKE_ASYNC(src, .proc/load_map)
 
 /obj/effect/landmark/ctf/Destroy()
 	if(map_bounds)

--- a/code/modules/capture_the_flag/ctf_map_loading.dm
+++ b/code/modules/capture_the_flag/ctf_map_loading.dm
@@ -1,25 +1,49 @@
+GLOBAL_DATUM(ctf_spawner, /obj/effect/landmark/ctf)
+
 /obj/effect/landmark/ctf
 	name = "CTF Map Spawner"
+	var/list/map_bounds
 
 /obj/effect/landmark/ctf/Initialize(mapload)
 	. = ..()
-	INVOKE_ASYNC(src, .proc/load_map)
+	if(GLOB.ctf_spawner)
+		qdel(GLOB.ctf_spawner)
+	GLOB.ctf_spawner = src
+	load_map()
+
+/obj/effect/landmark/ctf/Destroy()
+	if(map_bounds)
+		for(var/turf/ctf_turf in block(
+			locate(
+				map_bounds[MAP_MINX],
+				map_bounds[MAP_MINY],
+				map_bounds[MAP_MINZ],
+			),
+			locate(
+				map_bounds[MAP_MAXX],
+				map_bounds[MAP_MAXY],
+				map_bounds[MAP_MAXZ],
+			)
+		))
+			ctf_turf.empty()
+	GLOB.ctf_spawner = null
+	return ..()
 
 /obj/effect/landmark/ctf/proc/load_map()
-	
+
 	var/list/map_options = subtypesof(/datum/map_template/ctf)
 	var/turf/spawn_area = get_turf(src)
 	var/datum/map_template/ctf/current_map
 
 	current_map = pick(map_options)
-	current_map = new current_map
+	current_map = new current_map()
 
 	if(!spawn_area)
 		CRASH("No spawn area detected for CTF!")
 	else if(!current_map)
 		CRASH("No map prepared")
-	var/list/bounds = current_map.load(spawn_area, TRUE)
-	if(!bounds)
+	map_bounds = current_map.load(spawn_area, TRUE)
+	if(!map_bounds)
 		CRASH("Loading CTF map failed!")
 
 /datum/map_template/ctf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Regenerates the CTF map each time a CTF round ends
Also this'll choose a different map as well as a byproduct of the fix.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugfixes because the map would previously delete objects that shouldn't be deleted.

## Changelog
:cl:
fix: CTF will no longer delete objects on CTF maps that shouldn't be deleted and it'll also successfully regenerate the map once a CTF round ends.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
