### PR TITLE
Add Thought output to BCI

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -552,6 +552,8 @@
 ///Mob is trying to open the wires of a target [/atom], from /datum/wires/interactable(): (atom/target)
 #define COMSIG_TRY_WIRES_INTERACT "try_wires_interact"
 	#define COMPONENT_CANT_INTERACT_WIRES (1<<0)
+///from /proc/to_chat: (message)
+#define COMSIG_TO_CHAT "to_chat"
 
 ///from /obj/structure/door/crush(): (mob/living/crushed, /obj/machinery/door/crushing_door)
 #define COMSIG_LIVING_DOORCRUSHED "living_doorcrush"

--- a/code/modules/tgchat/to_chat.dm
+++ b/code/modules/tgchat/to_chat.dm
@@ -64,7 +64,7 @@
  * ```
  */
 /proc/to_chat(
-	target,
+	datum/target,
 	html,
 	type = null,
 	text = null,
@@ -95,4 +95,5 @@
 	if(text) message["text"] = text
 	if(html) message["html"] = html
 	if(avoid_highlighting) message["avoidHighlighting"] = avoid_highlighting
+	SEND_SIGNAL(target, COMSIG_TO_CHAT, message)
 	SSchat.queue(target, message)


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/1489801/127753140-ff794d3f-eb19-408c-9fb1-ecfb91aa7ff2.png)

## Why It's Good For The Game

It's a simple feature, it lets the crafty scientist set up all manner of contingency, it's what a BCI should in real life be able to do.

## Changelog
:cl:
expansion: The BCI can now read your surface thoughts!
/:cl:
