### PR TITLE
Thrownthing datum refactor: you can now throw stuff at mobs lying on the floor.

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -116,14 +116,13 @@ SUBSYSTEM_DEF(throwing)
 	var/atom/movable/actual_target = initial_target?.resolve()
 
 	if(dist_travelled) //to catch sneaky things moving on our tile while we slept
-		for(var/thing in get_turf(thrownthing))
-			var/atom/movable/in_the_way = thing
-			if (in_the_way == thrownthing || (in_the_way == thrower && !ismob(thrownthing)))
+		for(var/atom/movable/obstacle as anything in get_turf(thrownthing))
+			if (obstacle == thrownthing || (obstacle == thrower && !ismob(thrownthing)))
 				continue
-			if(in_the_way.pass_flags_self & LETPASSTHROW)
+			if(obstacle.pass_flags_self & LETPASSTHROW)
 				continue
-			if (in_the_way == actual_target || (in_the_way.density && !(in_the_way.flags_1 & ON_BORDER_1)))
-				finalize(TRUE, in_the_way)
+			if (obstacle == actual_target || (obstacle.density && !(obstacle.flags_1 & ON_BORDER_1)))
+				finalize(TRUE, obstacle)
 				return
 
 	var/atom/step
@@ -173,11 +172,10 @@ SUBSYSTEM_DEF(throwing)
 		return
 	thrownthing.throwing = null
 	if (!hit)
-		for (var/thing in get_turf(thrownthing)) //looking for our target on the turf we land on.
-			var/atom/A = thing
-			if (A == target)
+		for (var/atom/movable/obstacle as anything in get_turf(thrownthing)) //looking for our target on the turf we land on.
+			if (obstacle == target)
 				hit = TRUE
-				thrownthing.throw_impact(A, src)
+				thrownthing.throw_impact(obstacle, src)
 				if(QDELETED(thrownthing)) //throw_impact can delete things, such as glasses smashing
 					return //deletion should already be handled by on_thrownthing_qdel()
 				break

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -42,6 +42,7 @@ SUBSYSTEM_DEF(throwing)
 
 /datum/thrownthing
 	var/atom/movable/thrownthing
+	var/datum/weakref/initial_target
 	var/turf/target_turf
 	var/target_zone
 	var/init_dir
@@ -65,11 +66,13 @@ SUBSYSTEM_DEF(throwing)
 	var/last_move = 0
 
 
-/datum/thrownthing/New(thrownthing, target_turf, init_dir, maxrange, speed, thrower, diagonals_first, force, gentle, callback, target_zone)
+/datum/thrownthing/New(thrownthing, target, init_dir, maxrange, speed, thrower, diagonals_first, force, gentle, callback, target_zone)
 	. = ..()
 	src.thrownthing = thrownthing
 	RegisterSignal(thrownthing, COMSIG_PARENT_QDELETING, .proc/on_thrownthing_qdel)
-	src.target_turf = target_turf
+	src.target_turf = get_turf(target)
+	if(target_turf != target)
+		src.initial_target = WEAKREF(target)
 	src.init_dir = init_dir
 	src.maxrange = maxrange
 	src.speed = speed
@@ -87,6 +90,7 @@ SUBSYSTEM_DEF(throwing)
 	thrownthing.throwing = null
 	thrownthing = null
 	thrower = null
+	initial_target = null
 	if(callback)
 		QDEL_NULL(callback) //It stores a reference to the thrownthing, its source. Let's clean that.
 	return ..()
@@ -109,9 +113,18 @@ SUBSYSTEM_DEF(throwing)
 		delayed_time += world.time - last_move
 		return
 
-	if (dist_travelled && hitcheck()) //to catch sneaky things moving on our tile while we slept
-		finalize()
-		return
+	var/atom/movable/actual_target = initial_target?.resolve()
+
+	if(dist_travelled) //to catch sneaky things moving on our tile while we slept
+		for(var/thing in get_turf(thrownthing))
+			var/atom/movable/in_the_way = thing
+			if (in_the_way == thrownthing || (in_the_way == thrower && !ismob(thrownthing)))
+				continue
+			if(in_the_way.pass_flags_self & LETPASSTHROW)
+				continue
+			if (in_the_way == actual_target || (in_the_way.density && !(in_the_way.flags_1 & ON_BORDER_1)))
+				finalize(TRUE, in_the_way)
+				return
 
 	var/atom/step
 
@@ -138,13 +151,16 @@ SUBSYSTEM_DEF(throwing)
 			finalize()
 			return
 
-		AM.Move(step, get_dir(AM, step), DELAY_TO_GLIDE_SIZE(1 / speed))
-
-		if (!AM.throwing) // we hit something during our move
-			finalize(hit = TRUE)
+		if(!AM.Move(step, get_dir(AM, step), DELAY_TO_GLIDE_SIZE(1 / speed))) // we hit something during our move...
+			if(AM.throwing) // ...but finalize() wasn't called on Bump() because of a higher level definition that doesn't always call parent.
+				finalize()
 			return
 
 		dist_travelled++
+
+		if(actual_target && !(actual_target.pass_flags_self & LETPASSTHROW) && actual_target.loc == AM.loc) // we crossed a movable with no density (e.g. a mouse or APC) we intend to hit anyway.
+			finalize(TRUE, actual_target)
+			return
 
 		if (dist_travelled > MAX_THROWING_DIST)
 			finalize()
@@ -190,15 +206,3 @@ SUBSYSTEM_DEF(throwing)
 		SEND_SIGNAL(thrownthing, COMSIG_MOVABLE_THROW_LANDED, src)
 
 	qdel(src)
-
-/datum/thrownthing/proc/hit_atom(atom/A)
-	finalize(hit=TRUE, target=A)
-
-/datum/thrownthing/proc/hitcheck()
-	for (var/thing in get_turf(thrownthing))
-		var/atom/movable/AM = thing
-		if (AM == thrownthing || (AM == thrower && !ismob(thrownthing)))
-			continue
-		if (AM.density && !(AM.pass_flags_self & LETPASSTHROW) && !(AM.flags_1 & ON_BORDER_1))
-			finalize(hit=TRUE, target=AM)
-			return TRUE

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -640,7 +640,7 @@
 	SEND_SIGNAL(src, COMSIG_MOVABLE_BUMP, A)
 	. = ..()
 	if(!QDELETED(throwing))
-		throwing.hit_atom(A)
+		throwing.finalize(hit = TRUE, target = A)
 		. = TRUE
 		if(QDELETED(A))
 			return
@@ -876,7 +876,7 @@
 	else
 		target_zone = thrower.zone_selected
 
-	var/datum/thrownthing/TT = new(src, get_turf(target), get_dir(src, target), range, speed, thrower, diagonals_first, force, gentle, callback, target_zone)
+	var/datum/thrownthing/TT = new(src, target, get_dir(src, target), range, speed, thrower, diagonals_first, force, gentle, callback, target_zone)
 
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -109,6 +109,8 @@
 		apply_damage(thrown_item.throwforce, thrown_item.damtype, zone, armor, sharpness = thrown_item.get_sharpness(), wound_bonus = (nosell_hit * CANT_WOUND))
 		if(QDELETED(src)) //Damage can delete the mob.
 			return
+		if(body_position == LYING_DOWN) // physics says it's significantly harder to push someone by constantly chucking random furniture at them if they are down on the floor.
+			hitpush = FALSE
 		return ..()
 
 	playsound(loc, 'sound/weapons/genhit.ogg', 50, TRUE, -1) //Item sounds are handled in the item itself


### PR DESCRIPTION
## About The Pull Request
Title. I refactored it with the intention to allow thrown things to hit movables with no density (except those with the letpassthrow flag, otherwise it'll fuck with tables). 
I also expunged some procs that were only called in one place and moved the relative portions of code where the call was.
Some redundant finalize() calls were also removed. The `initial_target` is a weakref var, but I can change it to a movable one and use the `COMSIG_PARENT_QDELETING` signal to clear it if you want me to.

Oh yea, I have also tested it, though you can expect a few relatively small issues or oversights that'll get fixed as things go because this is a change to a core feature of the game.

## Why It's Good For The Game
Quality of life. Thrown projectiles currently only hit movables that a character can bump into, and that sucks.

## Changelog
:cl:
refactor: refactored the thrownthing datum a little.
qol: you can now throw stuff at movables with no density, such as mobs lying on the floor, mice, APCs, light bulbs etcetera etcetera.
/:cl:
