### PR TITLE
Disable ALL slips until they are fixed AND admin tool shortcomings get resolved.

### DIFF
--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -49,11 +49,12 @@
  */
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
-	if(!isliving(arrived))
+	return
+	/*if(!isliving(arrived))
 		return
 	var/mob/living/victim = arrived
 	if(!(victim.movement_type & FLYING) && victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
-		callback.Invoke(victim)
+		callback.Invoke(victim)*/
 
 /*
  * Gets called when COMSIG_ITEM_EQUIPPED is sent to parent.


### PR DESCRIPTION
Round had an issue with slips on things keeping the tile slippery even when the thing moved to a new tile.

I still haven't found a way to mass remove these from the round.

They aren't qdeleting and got suspended for lag because of these hanging references. 

**Despite the target being marked as qdeleted, the signal is still running and slipping.**

There are no admin tools to handle removing components and **signals** from things, let alone mass removing them.

All of these systemic issues with components and signals must be fixed before I will allow slips back on /tg/ servers. and I may disable more components if they prove to cause issues.

I saw comments about phantom slips on discord over a week ago. Doesn't seem to be a priority, now it is.

Back before this was a component, such issues could be fixed by mass modifying the slippary var. How is this system any better?

## Changelog
:cl:
del: Disabled the slippary component until slips are fixed.
/:cl:

