### PR TITLE
Cultists using Twisted Construction no longer spawn a catatonic construct

### DIFF
--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -279,6 +279,7 @@
 		if(CONSTRUCT_JUGGERNAUT)
 			if(IS_CULTIST(creator))
 				makeNewConstruct(/mob/living/simple_animal/hostile/construct/juggernaut, target, creator, cultoverride, loc_override) // ignore themes, the actual giving of cult info is in the makeNewConstruct proc
+				return
 			switch(theme)
 				if(THEME_WIZARD)
 					makeNewConstruct(/mob/living/simple_animal/hostile/construct/juggernaut/mystic, target, creator, cultoverride, loc_override)
@@ -289,6 +290,7 @@
 		if(CONSTRUCT_WRAITH)
 			if(IS_CULTIST(creator))
 				makeNewConstruct(/mob/living/simple_animal/hostile/construct/wraith, target, creator, cultoverride, loc_override) // ignore themes, the actual giving of cult info is in the makeNewConstruct proc
+				return
 			switch(theme)
 				if(THEME_WIZARD)
 					makeNewConstruct(/mob/living/simple_animal/hostile/construct/wraith/mystic, target, creator, cultoverride, loc_override)
@@ -299,6 +301,7 @@
 		if(CONSTRUCT_ARTIFICER)
 			if(IS_CULTIST(creator))
 				makeNewConstruct(/mob/living/simple_animal/hostile/construct/artificer, target, creator, cultoverride, loc_override) // ignore themes, the actual giving of cult info is in the makeNewConstruct proc
+				return
 			switch(theme)
 				if(THEME_WIZARD)
 					makeNewConstruct(/mob/living/simple_animal/hostile/construct/artificer/mystic, target, creator, cultoverride, loc_override)


### PR DESCRIPTION
## About The Pull Request

When a shade is put in a construct shell, it calls;
make_new_construct_from_class(construct_class, THEME_CULT, candidate, user, FALSE, T)

the proc it calls has a switch for theme, but also has a snowflake check for Cultists (to give them the antag datum), the cult check in the switch is non cultists making a cult shard, but the cultist check doesnt return, so because cults have a snowflake check & a theme, it spawns the cultist construct, then instead of stopping, continues on to make a second non cult one.

This fixes it for a cultist using a shade on a construct body, offering them via offer rune and on Twisted Construction.

## Why It's Good For The Game

Making a construct to kill the AI in a top secret base only to be revealed by a catatonic construct that wont go away with a simple conceal presence.

## Changelog
:cl:
fix: Cultists using Twisted Construction on a Cyborg will no longer spawn 2 constructs.
/:cl: