### PR TITLE
componentized spirit item possession

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -185,6 +185,10 @@
 ///from obj/machinery/bsa/full/proc/fire(): ()
 #define COMSIG_ATOM_BSA_BEAM "atom_bsa_beam_pass"
 	#define COMSIG_ATOM_BLOCKS_BSA_BEAM (1<<0)
+///from base of atom/relaymove(): (mob/living/user, direction)
+#define COMSIG_ATOM_RELAYMOVE "atom_relaymove"
+	///prevents the "you cannot move while buckled! message"
+	#define COMSIG_BLOCK_RELAYMOVE (1<<0)
 
 ///from [/datum/controller/subsystem/explosions/proc/explode]: (/list(/atom, devastation_range, heavy_impact_range, light_impact_range, flame_range, flash_range, adminlog, ignorecap, silent, smoke))
 #define COMSIG_ATOM_EXPLODE "atom_explode"
@@ -851,6 +855,11 @@
 #define COMSIG_MINE_TRIGGERED "minegoboom"
 ///from [/obj/structure/closet/supplypod/proc/preOpen]:
 #define COMSIG_SUPPLYPOD_LANDED "supplypodgoboom"
+
+///from /obj/item/storage/book/bible/afterattack(): (mob/user, proximity)
+#define COMSIG_BIBLE_SMACKED "bible_smacked"
+	///stops the bible chain from continuing. When all of the effects of the bible smacking have been moved to a signal we can kill this
+	#define COMSIG_END_BIBLE_CHAIN (1<<0)
 
 ///Closets
 ///From base of [/obj/structure/closet/proc/insert]: (atom/movable/inserted)

--- a/code/datums/components/spirit_holding.dm
+++ b/code/datums/components/spirit_holding.dm
@@ -24,7 +24,7 @@
 	RegisterSignal(parent, COMSIG_PARENT_QDELETING, .proc/on_destroy)
 
 /datum/component/spirit_holding/UnregisterFromParent()
-	UnregisterSignal(parent, list(COMSIG_PARENT_EXAMINE, COMSIG_ITEM_ATTACK_SELF))
+	UnregisterSignal(parent, list(COMSIG_PARENT_EXAMINE, COMSIG_ITEM_ATTACK_SELF, COMSIG_PARENT_QDELETING))
 
 ///signal fired on examining the parent
 /datum/component/spirit_holding/proc/on_examine(datum/source, mob/user, list/examine_list)

--- a/code/datums/components/spirit_holding.dm
+++ b/code/datums/components/spirit_holding.dm
@@ -1,0 +1,121 @@
+/**
+ * spirit holding component; for items to have spirits inside of them for "advice"
+ *
+ * Used for the possessed blade and fantasy affixes
+ */
+/datum/component/spirit_holding
+	///bool on if this component is currently polling for observers to inhabit the item
+	var/attempting_awakening = FALSE
+	///mob contained in the item.
+	var/mob/living/simple_animal/shade/bound_spirit
+
+/datum/component/spirit_holding/Initialize()
+	if(!ismovable(parent)) //you may apply this to mobs, i take no responsibility for how that works out
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/spirit_holding/Destroy(force, silent)
+	. = ..()
+	if(bound_spirit)
+		QDEL_NULL(bound_spirit)
+
+/datum/component/spirit_holding/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)
+	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SELF, .proc/on_attack_self)
+	RegisterSignal(parent, COMSIG_PARENT_QDELETING, .proc/on_destroy)
+
+/datum/component/spirit_holding/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_PARENT_EXAMINE, COMSIG_ITEM_ATTACK_SELF))
+
+///signal fired on examining the parent
+/datum/component/spirit_holding/proc/on_examine(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+	if(!bound_spirit)
+		examine_list += span_notice("[parent] sleeps. Use [parent] in your hands to attempt to awaken it.")
+		return
+	examine_list += span_notice("[parent] is alive.")
+
+///signal fired on self attacking parent
+/datum/component/spirit_holding/proc/on_attack_self(datum/source, mob/user)
+	SIGNAL_HANDLER
+	INVOKE_ASYNC(src, .proc/attempt_spirit_awaken, user)
+
+/**
+ * attempt_spirit_awaken: called from on_attack_self, polls ghosts to possess the item in the form
+ * of a mob sitting inside the item itself
+ *
+ * Arguments:
+ * * awakener: user who interacted with the blade
+ */
+/datum/component/spirit_holding/proc/attempt_spirit_awaken(mob/awakener)
+	if(attempting_awakening)
+		to_chat(awakener, span_warning("You are already trying to awaken [parent]!"))
+		return
+	if(!(GLOB.ghost_role_flags & GHOSTROLE_STATION_SENTIENCE))
+		to_chat(awakener, span_warning("Anomalous otherworldly energies block you from awakening [parent]!"))
+		return
+
+	attempting_awakening = TRUE
+	to_chat(awakener, span_notice("You attempt to wake the spirit of [parent]..."))
+
+	var/list/candidates = pollGhostCandidates("Do you want to play as the spirit of [awakener.real_name]'s blade?", ROLE_PAI, FALSE, 100, POLL_IGNORE_POSSESSED_BLADE)
+	if(!LAZYLEN(candidates))
+		to_chat(awakener, span_warning("[parent] is dormant. Maybe you can try again later."))
+		attempting_awakening = FALSE
+		return
+
+	var/mob/dead/observer/chosen_spirit = pick(candidates)
+	bound_spirit = new(parent)
+	bound_spirit.ckey = chosen_spirit.ckey
+	bound_spirit.fully_replace_character_name(null, "The spirit of [parent]")
+	bound_spirit.status_flags |= GODMODE
+	bound_spirit.copy_languages(awakener, LANGUAGE_MASTER) //Make sure the sword can understand and communicate with the awakener.
+	bound_spirit.update_atom_languages()
+	bound_spirit.grant_all_languages(FALSE, FALSE, TRUE) //Grants omnitongue
+	var/input = sanitize_name(stripped_input(bound_spirit, "What are you named?", ,"", MAX_NAME_LEN))
+	if(parent && input)
+		parent = input
+		bound_spirit.fully_replace_character_name(null, "The spirit of [input]")
+
+	//prevents awakening it again + new signals for a now-possessed item
+	attempting_awakening = FALSE
+	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_SELF)
+	RegisterSignal(parent, COMSIG_ATOM_RELAYMOVE, .proc/block_buckle_message)
+	RegisterSignal(parent, COMSIG_BIBLE_SMACKED, .proc/on_bible_smacked)
+
+///signal fired from a mob moving inside the parent
+/datum/component/spirit_holding/proc/block_buckle_message(datum/source, mob/living/user, direction)
+	SIGNAL_HANDLER
+	return COMSIG_BLOCK_RELAYMOVE
+
+/datum/component/spirit_holding/proc/on_bible_smacked(datum/source, mob/living/user, direction)
+	SIGNAL_HANDLER
+	INVOKE_ASYNC(src, .proc/attempt_exorcism, user)
+
+/**
+ * attempt_exorcism: called from on_bible_smacked, takes time and if successful
+ * resets the item to a pre-possessed state
+ *
+ * Arguments:
+ * * exorcist: user who is attempting to remove the spirit
+ */
+/datum/component/spirit_holding/proc/attempt_exorcism(mob/exorcist)
+	var/atom/movable/exorcised_movable = parent
+	to_chat(exorcist, span_notice("You begin to exorcise [parent]..."))
+	playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,TRUE)
+	if(!do_after(exorcist, 4 SECONDS, target = exorcised_movable))
+		return
+	playsound(src,'sound/effects/pray_chaplain.ogg',60,TRUE)
+	UnregisterSignal(exorcised_movable, list(COMSIG_ATOM_RELAYMOVE, COMSIG_BIBLE_SMACKED))
+	RegisterSignal(exorcised_movable, COMSIG_ITEM_ATTACK_SELF, .proc/on_attack_self)
+	to_chat(bound_spirit, span_userdanger("You were exorcised!"))
+	QDEL_NULL(bound_spirit)
+	exorcised_movable.name = initial(exorcised_movable.name)
+	exorcist.visible_message(span_notice("[exorcist] exorcises [exorcised_movable]!"), \
+						span_notice("You successfully exorcise [exorcised_movable]!"))
+	return COMSIG_END_BIBLE_CHAIN
+
+///signal fired from parent being destroyed
+/datum/component/spirit_holding/proc/on_destroy(datum/source)
+	SIGNAL_HANDLER
+	to_chat(bound_spirit, span_userdanger("You were destroyed!"))
+	QDEL_NULL(bound_spirit)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -765,6 +765,8 @@
  * as the [buckle_message_cooldown][/atom/var/buckle_message_cooldown] has expired (50 ticks)
  */
 /atom/proc/relaymove(mob/living/user, direction)
+	if(SEND_SIGNAL(src, COMSIG_ATOM_RELAYMOVE, user, direction) & COMSIG_BLOCK_RELAYMOVE)
+		return
 	if(buckle_message_cooldown <= world.time)
 		buckle_message_cooldown = world.time + 50
 		to_chat(user, span_warning("You can't move while buckled to [src]!"))

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -443,48 +443,10 @@
 	attack_verb_simple= list("chop", "slice", "cut")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	menu_description = "A sharp blade which partially penetrates armor. Able to awaken a friendly spirit to provide guidance. Very effective at butchering bodies. Can be worn on the back."
-	/// If there is a ghost possessing the item
-	var/possessed = FALSE
 
-/obj/item/nullrod/scythe/talking/relaymove(mob/living/user, direction)
-	return //stops buckled message spam for the ghost.
-
-/obj/item/nullrod/scythe/talking/attack_self(mob/living/user)
-	if(possessed)
-		return
-	if(!(GLOB.ghost_role_flags & GHOSTROLE_STATION_SENTIENCE))
-		to_chat(user, span_notice("Anomalous otherworldly energies block you from awakening the blade!"))
-		return
-
-	to_chat(user, span_notice("You attempt to wake the spirit of the blade..."))
-
-	possessed = TRUE
-
-	var/list/mob/dead/observer/candidates = pollGhostCandidates("Do you want to play as the spirit of [user.real_name]'s blade?", ROLE_PAI, FALSE, 100, POLL_IGNORE_POSSESSED_BLADE)
-
-	if(LAZYLEN(candidates))
-		var/mob/dead/observer/C = pick(candidates)
-		var/mob/living/simple_animal/shade/S = new(src)
-		S.ckey = C.ckey
-		S.fully_replace_character_name(null, "The spirit of [name]")
-		S.status_flags |= GODMODE
-		S.copy_languages(user, LANGUAGE_MASTER) //Make sure the sword can understand and communicate with the user.
-		S.update_atom_languages()
-		grant_all_languages(FALSE, FALSE, TRUE) //Grants omnitongue
-		var/input = sanitize_name(stripped_input(S,"What are you named?", ,"", MAX_NAME_LEN))
-
-		if(src && input)
-			name = input
-			S.fully_replace_character_name(null, "The spirit of [input]")
-	else
-		to_chat(user, span_warning("The blade is dormant. Maybe you can try again later."))
-		possessed = FALSE
-
-/obj/item/nullrod/scythe/talking/Destroy()
-	for(var/mob/living/simple_animal/shade/S in contents)
-		to_chat(S, span_userdanger("You were destroyed!"))
-		qdel(S)
-	return ..()
+/obj/item/nullrod/scythe/talking/Initialize()
+	. = ..()
+	AddComponent(/datum/component/spirit_holding)
 
 /obj/item/nullrod/scythe/talking/chainsword
 	name = "possessed chainsaw sword"

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -184,34 +184,36 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 		M.visible_message(span_danger("[user] smacks [M]'s lifeless corpse with [src]."))
 		playsound(src.loc, "punch", 25, TRUE, -1)
 
-/obj/item/storage/book/bible/afterattack(atom/A, mob/user, proximity)
+/obj/item/storage/book/bible/afterattack(atom/bible_smacked, mob/user, proximity)
 	. = ..()
 	if(!proximity)
 		return
-	if(isfloorturf(A))
+	if(SEND_SIGNAL(bible_smacked, COMSIG_BIBLE_SMACKED, user, proximity) & COMSIG_END_BIBLE_CHAIN)
+		return
+	if(isfloorturf(bible_smacked))
 		to_chat(user, span_notice("You hit the floor with the bible."))
 		if(user.mind && (user.mind.holy_role))
 			for(var/obj/effect/rune/R in orange(2,user))
 				R.invisibility = 0
 	if(user?.mind?.holy_role)
-		if(A.reagents && A.reagents.has_reagent(/datum/reagent/water)) // blesses all the water in the holder
-			to_chat(user, span_notice("You bless [A]."))
-			var/water2holy = A.reagents.get_reagent_amount(/datum/reagent/water)
-			A.reagents.del_reagent(/datum/reagent/water)
-			A.reagents.add_reagent(/datum/reagent/water/holywater,water2holy)
-		if(A.reagents && A.reagents.has_reagent(/datum/reagent/fuel/unholywater)) // yeah yeah, copy pasted code - sue me
-			to_chat(user, span_notice("You purify [A]."))
-			var/unholy2clean = A.reagents.get_reagent_amount(/datum/reagent/fuel/unholywater)
-			A.reagents.del_reagent(/datum/reagent/fuel/unholywater)
-			A.reagents.add_reagent(/datum/reagent/water/holywater,unholy2clean)
-		if(istype(A, /obj/item/storage/book/bible) && !istype(A, /obj/item/storage/book/bible/syndicate))
-			to_chat(user, span_notice("You purify [A], conforming it to your belief."))
-			var/obj/item/storage/book/bible/B = A
+		if(bible_smacked.reagents && bible_smacked.reagents.has_reagent(/datum/reagent/water)) // blesses all the water in the holder
+			to_chat(user, span_notice("You bless [bible_smacked]."))
+			var/water2holy = bible_smacked.reagents.get_reagent_amount(/datum/reagent/water)
+			bible_smacked.reagents.del_reagent(/datum/reagent/water)
+			bible_smacked.reagents.add_reagent(/datum/reagent/water/holywater,water2holy)
+		if(bible_smacked.reagents && bible_smacked.reagents.has_reagent(/datum/reagent/fuel/unholywater)) // yeah yeah, copy pasted code - sue me
+			to_chat(user, span_notice("You purify [bible_smacked]."))
+			var/unholy2clean = bible_smacked.reagents.get_reagent_amount(/datum/reagent/fuel/unholywater)
+			bible_smacked.reagents.del_reagent(/datum/reagent/fuel/unholywater)
+			bible_smacked.reagents.add_reagent(/datum/reagent/water/holywater,unholy2clean)
+		if(istype(bible_smacked, /obj/item/storage/book/bible) && !istype(bible_smacked, /obj/item/storage/book/bible/syndicate))
+			to_chat(user, span_notice("You purify [bible_smacked], conforming it to your belief."))
+			var/obj/item/storage/book/bible/B = bible_smacked
 			B.name = name
 			B.icon_state = icon_state
 			B.inhand_icon_state = inhand_icon_state
-	if(istype(A, /obj/item/cult_bastard) && !IS_CULTIST(user))
-		var/obj/item/cult_bastard/sword = A
+	if(istype(bible_smacked, /obj/item/cult_bastard) && !IS_CULTIST(user))
+		var/obj/item/cult_bastard/sword = bible_smacked
 		to_chat(user, span_notice("You begin to exorcise [sword]."))
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,TRUE)
 		if(do_after(user, 40, target = sword))
@@ -231,8 +233,8 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			new /obj/item/nullrod/claymore(get_turf(sword))
 			user.visible_message(span_notice("[user] purifies [sword]!"))
 			qdel(sword)
-	else if(istype(A, /obj/item/soulstone) && !IS_CULTIST(user))
-		var/obj/item/soulstone/SS = A
+	else if(istype(bible_smacked, /obj/item/soulstone) && !IS_CULTIST(user))
+		var/obj/item/soulstone/SS = bible_smacked
 		if(SS.theme == THEME_HOLY)
 			return
 		to_chat(user, span_notice("You begin to exorcise [SS]."))
@@ -250,20 +252,6 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 				EX.icon_state = "ghost1"
 				EX.name = "Purified [initial(EX.name)]"
 			user.visible_message(span_notice("[user] purifies [SS]!"))
-	else if(istype(A, /obj/item/nullrod/scythe/talking))
-		var/obj/item/nullrod/scythe/talking/sword = A
-		to_chat(user, span_notice("You begin to exorcise [sword]..."))
-		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,TRUE)
-		if(do_after(user, 40, target = sword))
-			playsound(src,'sound/effects/pray_chaplain.ogg',60,TRUE)
-			for(var/mob/living/simple_animal/shade/S in sword.contents)
-				to_chat(S, span_userdanger("You were destroyed by the exorcism!"))
-				qdel(S)
-			sword.possessed = FALSE //allows the chaplain (or someone else) to reroll a new spirit for their sword
-			sword.name = initial(sword.name)
-			REMOVE_TRAIT(sword, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT) //in case the "sword" is a possessed dummy
-			user.visible_message(span_notice("[user] exorcises [sword]!"), \
-								span_notice("You successfully exorcise [sword]!"))
 
 /obj/item/storage/book/bible/booze
 	desc = "To be applied to the head repeatedly."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -577,6 +577,7 @@
 #include "code\datums\components\spawner.dm"
 #include "code\datums\components\spill.dm"
 #include "code\datums\components\spinny.dm"
+#include "code\datums\components\spirit_holding.dm"
 #include "code\datums\components\squeak.dm"
 #include "code\datums\components\stationloving.dm"
 #include "code\datums\components\stationstuck.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Refactors the behavior of `/obj/item/nullrod/scythe/talking` into a documented `/datum/component/spirit_holding`

## Why It's Good For The Game

refactor!

## Changelog
:cl:
refactor: refactored spirit possession used in the possessed blade into a component. now ANYTHING could be possessed if you so desire!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
