### PR TITLE
Fixes soulstones accidentally granting all languages to the damned stone instead of the spirit

### DIFF
--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -335,29 +335,29 @@
 	newstruct.cancel_camera()
 
 
-/obj/item/soulstone/proc/init_shade(mob/living/carbon/human/T, mob/user, message_user = FALSE, mob/shade_controller)
+/obj/item/soulstone/proc/init_shade(mob/living/carbon/human/dusted_victim, mob/user, message_user = FALSE, mob/shade_controller)
 	if(!shade_controller)
-		shade_controller = T
-	new /obj/effect/decal/remains/human(T.loc) //Spawns a skeleton
-	T.stop_sound_channel(CHANNEL_HEARTBEAT)
-	T.invisibility = INVISIBILITY_ABSTRACT
-	T.dust_animation()
-	var/mob/living/simple_animal/shade/S = new /mob/living/simple_animal/shade(src)
-	S.AddComponent(/datum/component/soulstoned, src)
-	S.name = "Shade of [T.real_name]"
-	S.real_name = "Shade of [T.real_name]"
-	S.key = shade_controller.key
-	S.copy_languages(T, LANGUAGE_MIND)//Copies the old mobs languages into the new mob holder.
+		shade_controller = dusted_victim
+	new /obj/effect/decal/remains/human(dusted_victim.loc) //Spawns a skeleton
+	dusted_victim.stop_sound_channel(CHANNEL_HEARTBEAT)
+	dusted_victim.invisibility = INVISIBILITY_ABSTRACT
+	dusted_victim.dust_animation()
+	var/mob/living/simple_animal/shade/soulstone_spirit = new /mob/living/simple_animal/shade(src)
+	soulstone_spirit.AddComponent(/datum/component/soulstoned, src)
+	soulstone_spirit.name = "Shade of [dusted_victim.real_name]"
+	soulstone_spirit.real_name = "Shade of [dusted_victim.real_name]"
+	soulstone_spirit.key = shade_controller.key
+	soulstone_spirit.copy_languages(dusted_victim, LANGUAGE_MIND)//Copies the old mobs languages into the new mob holder.
 	if(user)
-		S.copy_languages(user, LANGUAGE_MASTER)
-	S.update_atom_languages()
-	grant_all_languages(FALSE, FALSE, TRUE) //Grants omnitongue
+		soulstone_spirit.copy_languages(user, LANGUAGE_MASTER)
+	soulstone_spirit.update_atom_languages()
+	soulstone_spirit.grant_all_languages(FALSE, FALSE, TRUE) //Grants omnitongue
 	if(user)
-		S.faction |= "[REF(user)]" //Add the master as a faction, allowing inter-mob cooperation
+		soulstone_spirit.faction |= "[REF(user)]" //Add the master as a faction, allowing inter-mob cooperation
 	if(user && IS_CULTIST(user))
-		S.mind.add_antag_datum(/datum/antagonist/cult)
-	S.cancel_camera()
-	name = "soulstone: Shade of [T.real_name]"
+		soulstone_spirit.mind.add_antag_datum(/datum/antagonist/cult)
+	soulstone_spirit.cancel_camera()
+	name = "soulstone: Shade of [dusted_victim.real_name]"
 	switch(theme)
 		if(THEME_HOLY)
 			icon_state = "purified_soulstone2"
@@ -367,11 +367,11 @@
 			icon_state = "soulstone2"
 	if(user)
 		if(IS_CULTIST(user))
-			to_chat(S, "Your soul has been captured! You are now bound to the cult's will. Help them succeed in their goals at all costs.")
+			to_chat(soulstone_spirit, "Your soul has been captured! You are now bound to the cult's will. Help them succeed in their goals at all costs.")
 		else if(role_check(user))
-			to_chat(S, "Your soul has been captured! You are now bound to [user.real_name]'s will. Help [user.p_them()] succeed in [user.p_their()] goals at all costs.")
+			to_chat(soulstone_spirit, "Your soul has been captured! You are now bound to [user.real_name]'s will. Help [user.p_them()] succeed in [user.p_their()] goals at all costs.")
 		if(message_user)
-			to_chat(user, "[span_info("<b>Capture successful!</b>:")] [T.real_name]'s soul has been ripped from [T.p_their()] body and stored within [src].")
+			to_chat(user, "[span_info("<b>Capture successful!</b>:")] [dusted_victim.real_name]'s soul has been ripped from [dusted_victim.p_their()] body and stored within [src].")
 
 
 /obj/item/soulstone/proc/getCultGhost(mob/living/carbon/human/T, mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Grant all languages was being called on the fucking object instead of the mob, lmao

## Why It's Good For The Game

fix

## Changelog
:cl:
fix: fixes soulstones granting themselves every language... instead of the spirit inside. lol.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
