### PR TITLE
Actually Quantifiably For Realsies This Time Fixes The Curse Of Hunger

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -69,6 +69,7 @@
 //defines
 ///how far a cursed item will still try to chase a target
 #define CURSED_VIEW_RANGE 7
+///chance of the cursed item teleporting
 #define CURSED_ITEM_TELEPORT_CHANCE 4
 //blackboards
 

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -325,6 +325,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_CAN_USE_FLIGHT_POTION "can_use_flight_potion"
 /// This mob overrides certian SSlag_switch measures with this special trait
 #define TRAIT_BYPASS_MEASURES "bypass_lagswitch_measures"
+/// This item has been renamed by the curse announcer
+#define TRAIT_CURSED_NAME_REVEALED "cursed_name_revealed"
 
 #define TRAIT_NOBLEED "nobleed" //This carbon doesn't bleed
 /// This atom can ignore the "is on a turf" check for simple AI datum attacks, allowing them to attack from bags or lockers as long as any other conditions are met
@@ -479,6 +481,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_INTROVERT "introvert"
 #define TRAIT_ANXIOUS "anxious"
 #define TRAIT_INSANITY "insanity"
+#define TRAIT_CURSE "curse"
 
 ///Trait for dryable items
 #define TRAIT_DRYABLE "trait_dryable"

--- a/code/datums/ai/cursed/cursed_controller.dm
+++ b/code/datums/ai/cursed/cursed_controller.dm
@@ -44,12 +44,13 @@
 ///signal called by picking up the pawn, will try to equip to where it should actually be and start the curse
 /datum/ai_controller/cursed/proc/on_equip(datum/source, mob/equipper, slot)
 	SIGNAL_HANDLER
-	INVOKE_ASYNC(src, .proc/try_equipping_to_target_slot, equipper, slot)
+	var/obj/item/item_pawn = pawn
+	var/target_slot = blackboard[BB_TARGET_SLOT]
+	if(slot != target_slot)
+		INVOKE_ASYNC(item_pawn, .proc/try_equipping_to_target_slot, equipper, slot)
 
 /**
- * curse of hunger component; for very hungry items.
- *
- * called when someone grabs the cursed item or the cursed item impacts with a mob it's throwing itself at
+ * try_equipping_to_target_slot is called when someone grabs the cursed item or the cursed item impacts with a mob it's throwing itself at
  * arguments:
  * * curse_victim: whomever we're attaching this to
  * * slot_already_in: the slot the item is already in before this was called, possibly null but at least in hands if picked up

--- a/code/datums/components/curse_of_hunger.dm
+++ b/code/datums/components/curse_of_hunger.dm
@@ -31,7 +31,7 @@
 	var/obj/item/cursed_item = parent
 	RegisterSignal(cursed_item, COMSIG_PARENT_EXAMINE, .proc/on_examine)
 
-	if(cursed_item.slot_flags)
+	if(isclothing(cursed_item) && cursed_item.slot_flags)
 		RegisterSignal(cursed_item, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 	else
 		RegisterSignal(cursed_item, COMSIG_ITEM_PICKUP, .proc/on_pickup)
@@ -83,7 +83,7 @@
 	if(add_dropdel)
 		cursed_item.item_flags |= DROPDEL
 		return
-	if(cursed_item.slot_flags)
+	if(isclothing(cursed_item) && cursed_item.slot_flags)
 		RegisterSignal(cursed_item, COMSIG_ITEM_POST_UNEQUIP, .proc/on_unequip)
 	else
 		RegisterSignal(cursed_item, COMSIG_ITEM_DROPPED, .proc/on_drop)
@@ -100,6 +100,7 @@
 	var/turf/vomit_turf = get_turf(at_least_item)
 	playsound(vomit_turf, 'sound/effects/splat.ogg', 50, TRUE)
 	new /obj/effect/decal/cleanable/vomit(vomit_turf)
+	poison_food_tolerance = FULL_HEALTH
 
 	if(!add_dropdel) //gives a head start for the person to get away from the cursed item before it begins hunting again!
 		addtimer(CALLBACK(src, .proc/seek_new_target), 10 SECONDS)
@@ -112,8 +113,8 @@
 	else if(!isturf(cursed_item.loc))
 		cursed_item.forceMove(get_turf(cursed_item))
 	//only taking the most reasonable slot is fine since it unequips what is there to equip itself.
-	var/targetted_slot = cursed_item.slot_flags ? cursed_item.slot_flags[1] : ITEM_SLOT_HANDS
-	cursed_item.AddElement(/datum/element/cursed, targetted_slot)
+	var/target_slot = (isclothing(cursed_item) && cursed_item.slot_flags) ? cursed_item.get_autoequip_slot() : ITEM_SLOT_HANDS
+	cursed_item.AddElement(/datum/element/cursed, target_slot)
 	cursed_item.visible_message(span_warning("[cursed_item] begins to move on [cursed_item.p_their()] own..."))
 
 /datum/component/curse_of_hunger/process(delta_time)

--- a/code/datums/components/curse_of_hunger.dm
+++ b/code/datums/components/curse_of_hunger.dm
@@ -30,9 +30,8 @@
 	. = ..()
 	var/obj/item/cursed_item = parent
 	RegisterSignal(cursed_item, COMSIG_PARENT_EXAMINE, .proc/on_examine)
-	//checking slot_equipment_priority is the better way to decide if it should be an equip-curse (alternative being if it has slot_flags)
-	//because it needs to know where to equip to (and stuff like buckets and cones can be on_pickup curses despite having slots to equip to)
-	if(cursed_item.slot_equipment_priority)
+
+	if(cursed_item.slot_flags)
 		RegisterSignal(cursed_item, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 	else
 		RegisterSignal(cursed_item, COMSIG_ITEM_PICKUP, .proc/on_pickup)
@@ -84,7 +83,7 @@
 	if(add_dropdel)
 		cursed_item.item_flags |= DROPDEL
 		return
-	if(cursed_item.slot_equipment_priority)
+	if(cursed_item.slot_flags)
 		RegisterSignal(cursed_item, COMSIG_ITEM_POST_UNEQUIP, .proc/on_unequip)
 	else
 		RegisterSignal(cursed_item, COMSIG_ITEM_DROPPED, .proc/on_drop)
@@ -113,7 +112,8 @@
 	else if(!isturf(cursed_item.loc))
 		cursed_item.forceMove(get_turf(cursed_item))
 	//only taking the most reasonable slot is fine since it unequips what is there to equip itself.
-	cursed_item.AddElement(/datum/element/cursed, cursed_item.slot_equipment_priority[1])
+	var/targetted_slot = cursed_item.slot_flags ? cursed_item.slot_flags[1] : ITEM_SLOT_HANDS
+	cursed_item.AddElement(/datum/element/cursed, targetted_slot)
 	cursed_item.visible_message(span_warning("[cursed_item] begins to move on [cursed_item.p_their()] own..."))
 
 /datum/component/curse_of_hunger/process(delta_time)

--- a/code/datums/elements/curse_announcement.dm
+++ b/code/datums/elements/curse_announcement.dm
@@ -26,7 +26,7 @@
 	src.filter_color = filter_color
 	src.new_name = new_name
 	src.fantasy_component = WEAKREF(fantasy_component)
-	if(cursed_item.slot_equipment_priority) //if it can equip somewhere, only go active when it is actually done
+	if(cursed_item.slot_flags) //if it can equip somewhere, only go active when it is actually done
 		RegisterSignal(cursed_item, COMSIG_ITEM_EQUIPPED, .proc/on_equipped)
 	else
 		RegisterSignal(cursed_item, COMSIG_ITEM_PICKUP, .proc/on_pickup)

--- a/code/datums/elements/curse_announcement.dm
+++ b/code/datums/elements/curse_announcement.dm
@@ -45,6 +45,13 @@
 	announce(cursed_item, grabber)
 
 /datum/element/curse_announcement/proc/announce(obj/item/cursed_item, mob/cursed)
+
+	to_chat(cursed, span_userdanger("[announcement_message]"))
+
+	if(HAS_TRAIT(cursed_item, TRAIT_CURSED_NAME_REVEALED))
+		return
+	ADD_TRAIT(cursed_item, TRAIT_CURSED_NAME_REVEALED, TRAIT_CURSE)
+
 	//this is from rpgloot, remove the quality suffix to format the name correctly
 	var/quality_suffix_text
 	var/datum/component/fantasy/perchance_to_dream = fantasy_component.resolve()
@@ -52,13 +59,13 @@
 		quality_suffix_text = " [perchance_to_dream.quality]"
 		cursed_item.name = replacetext(cursed_item.name, quality_suffix_text,"")
 
-	//modifications to the item so it looks cursed
-	to_chat(cursed, span_userdanger("[announcement_message]"))
-	cursed_item.add_filter("cursed_item", 9, list("type" = "outline", "color" = filter_color, "size" = 1))
-	cursed_item.name = "[cursed_item][new_name]"
 
-	//this is from rpgloot, readd the quality suffix
-	if(quality_suffix_text)
-		cursed_item.name += quality_suffix_text
-	cursed_item.RemoveElement(/datum/element/curse_announcement)
+		//modifications to the item so it looks cursed
+		cursed_item.add_filter("cursed_item", 9, list("type" = "outline", "color" = filter_color, "size" = 1))
+		cursed_item.name = "[cursed_item][new_name]"
+
+		//this is from rpgloot, readd the quality suffix
+		if(quality_suffix_text)
+			cursed_item.name += quality_suffix_text
+		cursed_item.RemoveElement(/datum/element/curse_announcement)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -628,6 +628,43 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 	return M.can_equip(src, slot, disable_warning, bypass_equip_delay_self)
 
+/**
+ * This proc asks an item for special slot equipping priority before attempting to iterate through the slots.
+ * Arguments:
+ * * slot_priority: default list of slots to try and equip to in order. you take out and modify slots that it should conditionally not equip to.
+ */
+/obj/item/proc/special_slot_priority(list/slot_priority)
+	return
+
+/**
+ * This proc returns the best slot an item could equip to, even considering special slot priority
+ */
+/obj/item/proc/get_autoequip_slot()
+	var/list/slot_priority = list(
+		ITEM_SLOT_BACK,
+		ITEM_SLOT_ID,
+		ITEM_SLOT_ICLOTHING,
+		ITEM_SLOT_OCLOTHING,
+		ITEM_SLOT_MASK,
+		ITEM_SLOT_HEAD,
+		ITEM_SLOT_NECK,
+		ITEM_SLOT_FEET,
+		ITEM_SLOT_GLOVES,
+		ITEM_SLOT_EARS,
+		ITEM_SLOT_EYES,
+		ITEM_SLOT_BELT,
+		ITEM_SLOT_SUITSTORE,
+		ITEM_SLOT_LPOCKET,
+		ITEM_SLOT_RPOCKET,
+		ITEM_SLOT_DEX_STORAGE,
+	)
+
+	special_slot_priority(slot_priority)
+
+	for(var/slot in slot_priority)
+		if(slot_flags & slot)
+			return slot
+
 /obj/item/verb/verb_pickup()
 	set src in oview(1)
 	set category = "Object"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -169,9 +169,6 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	///In tiles, how far this weapon can reach; 1 for adjacent, which is default
 	var/reach = 1
 
-	///The list of slots by priority. equip_to_appropriate_slot() uses this list. Doesn't matter if a mob type doesn't have a slot. For default list, see [/mob/proc/equip_to_appropriate_slot]
-	var/list/slot_equipment_priority = null
-
 	///Reference to the datum that determines whether dogs can wear the item: Needs to be in /obj/item because corgis can wear a lot of non-clothing items
 	var/datum/dog_fashion/dog_fashion = null
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -407,13 +407,6 @@
 	return FALSE
 
 /**
- * NOTE: ITEM PROC, not for mobs!
- * This proc asks an item for special slot equipping priority before attempting to iterate through the slots.
- */
-/obj/item/proc/special_slot_priority(list/slot_priority)
-	return
-
-/**
  * Reset the attached clients perspective (viewpoint)
  *
  * reset_perspective() set eye to common default : mob on turf, loc otherwise

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -370,34 +370,49 @@
 /**
  * Auto equip the passed in item the appropriate slot based on equipment priority
  *
- * puts the item "W" into an appropriate slot in a human's inventory
+ * puts the item "equipping" into an appropriate slot in a human's inventory
  *
- * returns 0 if it cannot, 1 if successful
+ * returns FALSE if it cannot, TRUE if successful
  */
-/mob/proc/equip_to_appropriate_slot(obj/item/W, qdel_on_fail = FALSE)
-	if(!istype(W))
+/mob/proc/equip_to_appropriate_slot(obj/item/equipping, qdel_on_fail = FALSE)
+	if(!istype(equipping))
 		return FALSE
-	var/slot_priority = W.slot_equipment_priority
+	var/list/slot_priority = list(
+		ITEM_SLOT_BACK,
+		ITEM_SLOT_ID,
+		ITEM_SLOT_ICLOTHING,
+		ITEM_SLOT_OCLOTHING,
+		ITEM_SLOT_MASK,
+		ITEM_SLOT_HEAD,
+		ITEM_SLOT_NECK,
+		ITEM_SLOT_FEET,
+		ITEM_SLOT_GLOVES,
+		ITEM_SLOT_EARS,
+		ITEM_SLOT_EYES,
+		ITEM_SLOT_BELT,
+		ITEM_SLOT_SUITSTORE,
+		ITEM_SLOT_LPOCKET,
+		ITEM_SLOT_RPOCKET,
+		ITEM_SLOT_DEX_STORAGE,
+	)
 
-	if(!slot_priority)
-		slot_priority = list( \
-			ITEM_SLOT_BACK, ITEM_SLOT_ID,\
-			ITEM_SLOT_ICLOTHING, ITEM_SLOT_OCLOTHING,\
-			ITEM_SLOT_MASK, ITEM_SLOT_HEAD, ITEM_SLOT_NECK,\
-			ITEM_SLOT_FEET, ITEM_SLOT_GLOVES,\
-			ITEM_SLOT_EARS, ITEM_SLOT_EYES,\
-			ITEM_SLOT_BELT, ITEM_SLOT_SUITSTORE,\
-			ITEM_SLOT_LPOCKET, ITEM_SLOT_RPOCKET,\
-			ITEM_SLOT_DEX_STORAGE\
-		)
+	equipping.special_slot_priority(slot_priority)
 
 	for(var/slot in slot_priority)
-		if(equip_to_slot_if_possible(W, slot, FALSE, TRUE, TRUE, FALSE, FALSE)) //qdel_on_fail = FALSE; disable_warning = TRUE; redraw_mob = TRUE;
+		if(equip_to_slot_if_possible(equipping, slot, FALSE, TRUE, TRUE, FALSE, FALSE)) //qdel_on_fail = FALSE; disable_warning = TRUE; redraw_mob = TRUE;
 			return TRUE
 
 	if(qdel_on_fail)
-		qdel(W)
+		qdel(equipping)
 	return FALSE
+
+/**
+ * NOTE: ITEM PROC, not for mobs!
+ * This proc asks an item for special slot equipping priority before attempting to iterate through the slots.
+ */
+/obj/item/proc/special_slot_priority(list/slot_priority)
+	return
+
 /**
  * Reset the attached clients perspective (viewpoint)
  *

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -288,14 +288,9 @@
 	. = ..()
 	reagents.flags = initial(reagent_flags)
 
-/obj/item/reagent_containers/glass/bucket/equip_to_best_slot(mob/M)
+/obj/item/reagent_containers/glass/bucket/special_slot_priority(list/slot_priority)
 	if(reagents.total_volume) //If there is water in a bucket, don't quick equip it to the head
-		var/index = slot_equipment_priority.Find(ITEM_SLOT_HEAD)
-		slot_equipment_priority.Remove(ITEM_SLOT_HEAD)
-		. = ..()
-		slot_equipment_priority.Insert(index, ITEM_SLOT_HEAD)
-		return
-	return ..()
+		slot_priority.-= ITEM_SLOT_HEAD
 
 /obj/item/pestle
 	name = "pestle"

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -240,16 +240,6 @@
 	slot_flags = ITEM_SLOT_HEAD
 	resistance_flags = NONE
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 75, ACID = 50) //Weak melee protection, because you can wear it on your head
-	slot_equipment_priority = list( \
-		ITEM_SLOT_BACK, ITEM_SLOT_ID,\
-		ITEM_SLOT_ICLOTHING, ITEM_SLOT_OCLOTHING,\
-		ITEM_SLOT_MASK, ITEM_SLOT_HEAD, ITEM_SLOT_NECK,\
-		ITEM_SLOT_FEET, ITEM_SLOT_GLOVES,\
-		ITEM_SLOT_EARS, ITEM_SLOT_EYES,\
-		ITEM_SLOT_BELT, ITEM_SLOT_SUITSTORE,\
-		ITEM_SLOT_LPOCKET, ITEM_SLOT_RPOCKET,\
-		ITEM_SLOT_DEX_STORAGE
-	)
 
 /obj/item/reagent_containers/glass/bucket/wooden
 	name = "wooden bucket"

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -280,7 +280,7 @@
 
 /obj/item/reagent_containers/glass/bucket/special_slot_priority(list/slot_priority)
 	if(reagents.total_volume) //If there is water in a bucket, don't quick equip it to the head
-		slot_priority.-= ITEM_SLOT_HEAD
+		slot_priority -= ITEM_SLOT_HEAD
 
 /obj/item/pestle
 	name = "pestle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Curse of hunger no longer uses `slot_equipment_priority` as a considered var, now it just uses `slot_flags`.
* slot_equipment_priority was insanely deprecated and unused so I just removed it. Now items that are being equipped are asked if they want to modify the default slot priority order
* no longer gets perma-sick after the first time it drops
* no longer repeatedly adds the cursed name every time you trigger the curse

## Why It's Good For The Game

Good god man I just want this really cool component to work

## Changelog
:cl:
fix: For realsies this time: Curse of hunger WORKS.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
