### PR TITLE
Fixed phantom slipping caused by mk-clown shoes bananas

### DIFF
--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -42,14 +42,14 @@
 	else
 		RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/Slip)
 
-/datum/component/slippery/InheritComponent(datum/component/slippery/C, i_am_original, knockdown, lube_flags = NONE, datum/callback/callback, paralyze, force_drop = FALSE, slot_whitelist)
-	if(C)
-		knockdown = C.knockdown_time
-		lube_flags = C.lube_flags
-		callback = C.callback
-		paralyze = C.paralyze_time
-		force_drop = C.force_drop_items
-		slot_whitelist = C.slot_whitelist
+/datum/component/slippery/InheritComponent(datum/component/slippery/component, i_am_original, knockdown, lube_flags = NONE, datum/callback/callback, paralyze, force_drop = FALSE, slot_whitelist)
+	if(component)
+		knockdown = component.knockdown_time
+		lube_flags = component.lube_flags
+		callback = component.callback
+		paralyze = component.paralyze_time
+		force_drop = component.force_drop_items
+		slot_whitelist = component.slot_whitelist
 
 	src.knockdown_time = max(knockdown, 0)
 	src.paralyze_time = max(paralyze, 0)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -1,5 +1,6 @@
 /// Slippery component, for making anything slippery. Of course.
 /datum/component/slippery
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 	/// If the slip forces you to drop held items.
 	var/force_drop_items = FALSE
 	/// How long the slip keeps you knocked down.
@@ -41,6 +42,22 @@
 	else
 		RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/Slip)
 
+/datum/component/slippery/InheritComponent(datum/component/slippery/C, i_am_original, knockdown, lube_flags = NONE, datum/callback/callback, paralyze, force_drop = FALSE, slot_whitelist)
+	if(C)
+		knockdown = C.knockdown_time
+		lube_flags = C.lube_flags
+		callback = C.callback
+		paralyze = C.paralyze_time
+		force_drop = C.force_drop_items
+		slot_whitelist = C.slot_whitelist
+
+	src.knockdown_time = max(knockdown, 0)
+	src.paralyze_time = max(paralyze, 0)
+	src.force_drop_items = force_drop
+	src.lube_flags = lube_flags
+	src.callback = callback
+	if(slot_whitelist)
+		src.slot_whitelist = slot_whitelist
 /*
  * The proc that does the sliping. Invokes the slip callback we have set.
  *


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Closes #59410

Synthesized banana peels would make a new /datum/component/slippery, and because it was highlander, it would fuck up due to some issues with the cleanup code for the old /datum/component/slipper component running after the new component had already set up their code.

The solution was this was to move the component to have the COMPONENT_DUPE_UNIQUE_PASSARGS dupe_mode.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bugfixes be good

## Changelog
:cl:
fix: Fixed phantom slipping caused by synthesized banana peels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
