### PR TITLE
Disconnects AI's from their shell if hit by Twisted Construction

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -623,6 +623,7 @@
 					return
 			else
 				uses--
+				candidate.undeploy()
 				to_chat(user, span_warning("A dark cloud emanates from you hand and swirls around [candidate] - twisting it into a construct shell!"))
 				new /obj/structure/constructshell(T)
 				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))


### PR DESCRIPTION
## About The Pull Request

If you use Twisted Construction on an AI's shell, it deletes the shell and ghosts the AI, this disconnects them from the shell beforehand to avoid that.

Also it's been tested in-game;
![image](https://user-images.githubusercontent.com/53777086/127781833-0f8f317e-1b7c-4c6c-b774-a03f3bb5c09c.png)

## Why It's Good For The Game

Imagine having an SSD AI because they decided to yell at robotics in the first 15 minutes of a round for a shell, only to be twisted constructed on.

Closes #56391

## Changelog
:cl:
fix: Using Twisted Construction on an AI shell no longer ghosts the AI
/:cl: