### PR TITLE
Fixes rad collectors ignoring access requirements for locking.

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -111,6 +111,7 @@
 	else if(item.GetID())
 		if(!allowed(user))
 			to_chat(user, span_danger("Access denied."))
+			return TRUE
 		if(!active)
 			to_chat(user, span_warning("The controls can only be locked when \the [src] is active!"))
 			return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Adds an early return that was missing from rad collector code.
- Fixes #60645 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Rad collectors were supposed to do this. Now they do.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed rad collectors ignoring letting anyone (un)lock them with their ID.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
