### PR TITLE
Fixes chasm hallucinations being invisible

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -1332,7 +1332,8 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/effect/hallucination/danger/lava/show_icon()
-	image = image('icons/turf/floors/lava.dmi', src, "lava-0", TURF_LAYER)
+	var/turf/danger_turf = get_turf(src)
+	image = image('icons/turf/floors/lava.dmi', src, "lava-[danger_turf.smoothing_junction || 0]", TURF_LAYER)
 	if(target.client)
 		target.client.images += image
 
@@ -1353,7 +1354,8 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/effect/hallucination/danger/chasm/show_icon()
-	image = image('icons/turf/floors/chasms.dmi', src, "chasms-0", TURF_LAYER)
+	var/turf/danger_turf = get_turf(src)
+	image = image('icons/turf/floors/chasms.dmi', src, "chasms-[danger_turf.smoothing_junction || 0]", TURF_LAYER)
 	if(target.client)
 		target.client.images += image
 

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -1353,8 +1353,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/effect/hallucination/danger/chasm/show_icon()
-	var/turf/target_loc = get_turf(target)
-	image = image('icons/turf/floors/chasms.dmi', src, "chasms-[target_loc.smoothing_junction]", TURF_LAYER)
+	image = image('icons/turf/floors/chasms.dmi', src, "chasms-0", TURF_LAYER)
 	if(target.client)
 		target.client.images += image
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- The chasm hallucination attempted to use the smoothing junction of the floor tile it appeared on. Since this is `null` in most cases this invalidated the icon state and created invisible chasms. This fixes that and brings the lava hallucination into compliance.
- Fixes #59862 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Less completely invisible hardstuns thanks.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The chasm hallucination now visibly indicates the turfs it's effecting again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
