### PR TITLE
Fixes infinitely recursive beef wellingtons

### DIFF
--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -1256,9 +1256,9 @@
 	venue_value = FOOD_PRICE_EXOTIC
 
 /obj/item/food/beef_wellington/MakeProcessable()
-	AddElement(/datum/element/processable, TOOL_KNIFE,  /obj/item/food/beef_wellington/slice, 3, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE,  /obj/item/food/beef_wellington_slice, 3, 30)
 
-/obj/item/food/beef_wellington/slice
+/obj/item/food/beef_wellington_slice
 	name = "beef wellington slice"
 	desc = "A slice of beef wellington, topped with a rich gravy. Simply delicious."
 	icon_state = "beef_wellington_slice"

--- a/code/modules/food_and_drinks/restaurant/customers/_customer.dm
+++ b/code/modules/food_and_drinks/restaurant/customers/_customer.dm
@@ -408,7 +408,7 @@
 			/obj/item/food/benedict = 5,
 			/obj/item/food/full_english = 2,
 			/obj/item/food/soup/indian_curry = 3,
-			/obj/item/food/beef_wellington/slice = 2,
+			/obj/item/food/beef_wellington_slice = 2,
 		),
 		VENUE_BAR = list(
 			/datum/reagent/consumable/ethanol/ale = 10,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Fixes beef wellington slices being able to be sliced into more beef wellington slices.
- Fixes #60655 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Makes it slightly harder to completely invalidate the chef as a role.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Beef wellingtons cannot be sliced to produce beef wellington slices that can be sliced to produce beef wellington slices that can be sliced to produce beef wellington slices...
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
