### PR TITLE
Removes required_shells var on circuit components not allowing them to be placed in an integrated circuit.

### DIFF
--- a/code/modules/wiremod/component.dm
+++ b/code/modules/wiremod/component.dm
@@ -235,7 +235,7 @@
 
 	if(length(required_shells))
 		. += create_ui_notice("Supported Shells:", "green", "notes-medical")
-		for(var/atom/movable/shell in required_shells)
+		for(var/atom/movable/shell as anything in required_shells)
 			. += create_ui_notice(initial(shell.name), "green", "plus-square")
 
 	if(length(input_ports))

--- a/code/modules/wiremod/component.dm
+++ b/code/modules/wiremod/component.dm
@@ -50,7 +50,7 @@
 	// Whether the component is removable or not. Only affects user UI
 	var/removable = TRUE
 
-	// Defines which shells can accept this component. If set to null then all shells can use it.
+	// Defines which shells support this component. Only used as an informational guide, does not restrict placing these components in circuits.
 	var/required_shells = null
 
 /obj/item/circuit_component/Initialize()
@@ -211,11 +211,6 @@
 
 /// Called when this component is about to be added to an integrated_circuit.
 /obj/item/circuit_component/proc/add_to(obj/item/integrated_circuit/added_to)
-	if(required_shells && LAZYLEN(required_shells))
-		for(var/shell_type in required_shells)
-			if(istype(added_to, shell_type) || istype(added_to.loc, shell_type))
-				return TRUE
-		return FALSE
 	return TRUE
 
 /// Called when this component is removed from an integrated_circuit.
@@ -238,6 +233,10 @@
 	if(!removable)
 		. += create_ui_notice("Unremovable", "red", "lock")
 
+	if(length(required_shells))
+		. += create_ui_notice("Supported Shells:", "green", "notes-medical")
+		for(var/atom/movable/shell in required_shells)
+			. += create_ui_notice(initial(shell.name), "green", "plus-square")
 
 	if(length(input_ports))
 		. += create_ui_notice("Power Usage Per Input: [power_usage_per_input]", "orange", "bolt")

--- a/code/modules/wiremod/components/hud/counter_overlay.dm
+++ b/code/modules/wiremod/components/hud/counter_overlay.dm
@@ -32,8 +32,9 @@
 	image_pixel_y = add_input_port("Y-Axis Shift", PORT_TYPE_NUMBER)
 
 /obj/item/circuit_component/counter_overlay/register_shell(atom/movable/shell)
-	bci = shell
-	RegisterSignal(shell, COMSIG_ORGAN_REMOVED, .proc/on_organ_removed)
+	if(istype(shell, /obj/item/organ/cyberimp/bci))
+		bci = shell
+		RegisterSignal(shell, COMSIG_ORGAN_REMOVED, .proc/on_organ_removed)
 
 /obj/item/circuit_component/counter_overlay/unregister_shell(atom/movable/shell)
 	bci = null

--- a/code/modules/wiremod/components/hud/object_overlay.dm
+++ b/code/modules/wiremod/components/hud/object_overlay.dm
@@ -72,8 +72,9 @@
 	options_map = options_to_icons
 
 /obj/item/circuit_component/object_overlay/register_shell(atom/movable/shell)
-	bci = shell
-	RegisterSignal(shell, COMSIG_ORGAN_REMOVED, .proc/on_organ_removed)
+	if(istype(shell, /obj/item/organ/cyberimp/bci))
+		bci = shell
+		RegisterSignal(shell, COMSIG_ORGAN_REMOVED, .proc/on_organ_removed)
 
 /obj/item/circuit_component/object_overlay/unregister_shell(atom/movable/shell)
 	bci = null

--- a/code/modules/wiremod/components/hud/target_intercept.dm
+++ b/code/modules/wiremod/components/hud/target_intercept.dm
@@ -23,8 +23,9 @@
 	clicked_atom = add_output_port("Targeted Object", PORT_TYPE_ATOM)
 
 /obj/item/circuit_component/target_intercept/register_shell(atom/movable/shell)
-	bci = shell
-	RegisterSignal(shell, COMSIG_ORGAN_REMOVED, .proc/on_organ_removed)
+	if(istype(shell, /obj/item/organ/cyberimp/bci))
+		bci = shell
+		RegisterSignal(shell, COMSIG_ORGAN_REMOVED, .proc/on_organ_removed)
 
 /obj/item/circuit_component/target_intercept/unregister_shell(atom/movable/shell)
 	bci = null

--- a/code/modules/wiremod/components/hud/target_intercept.dm
+++ b/code/modules/wiremod/components/hud/target_intercept.dm
@@ -62,4 +62,3 @@
 /obj/item/circuit_component/target_intercept/get_ui_notices()
 	. = ..()
 	. += create_ui_notice("Target Interception Cooldown: [DisplayTimeText(intercept_cooldown)]", "orange", "stopwatch")
-	. += create_ui_notice("Only usable in BCI circuits", "orange", "info")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This change is buggy and has several bugs because of how integrated circuits is designed. I overlooked this change in a PR but I would've pointed it out if I had checked the PR.

This current check can already be easily bypassed by simply placing the integrated circuit in the shell, adding the component, and then removing it from a shell, meaning you can cause runtimes by inserting it into an unsupported shell.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This improves the code quality of circuits by keeping consistent with the behaviour that a circuit component should simply not work if placed on an unsupported type, rather than trying to outright stop it from being inserted in.

/obj/item/circuit_component/proc/add_to is a proc that should not return false if it is checking the state of the integrated circuit because integrated circuits can have their states change at any time which makes it easily possible to bypass any checks you may be checking for. It means we'd need to write more code for circuit components when the code to already do these checks exists.

In the future, after the freeze, we could look at implementing a proper warning system to prevent people from trying to use incompatible circuit components in an integrated circuit with a shell that does not support it.

## Changelog
:cl:
code: Improves BCI code by removing an easily bypassable `add_to` check for circuit components and implementing proper typechecking in the addable BCI components
fix: Fixed the UI notices about the supported types not showing up on all BCI components
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
