### PR TITLE
Fixes CTF completely breaking on restart

### DIFF
--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -231,9 +231,17 @@
 	var/static/list/people_who_want_to_play = list()
 	var/game_area = /area/ctf
 
+	/// This variable is needed because of ctf shitcode + we need to make sure we're deleting the current ctf landmark that spawned us in and not a new one.
+	var/obj/effect/landmark/ctf/ctf_landmark
+
 /obj/machinery/capture_the_flag/Initialize()
 	. = ..()
 	AddElement(/datum/element/point_of_interest)
+	ctf_landmark = GLOB.ctf_spawner
+
+/obj/machinery/capture_the_flag/Destroy()
+	ctf_landmark = null
+	return ..()
 
 /obj/machinery/capture_the_flag/process(delta_time)
 	for(var/i in spawned_mobs)
@@ -453,7 +461,11 @@
 	notify_ghosts("[name] has been activated!", source = src, action=NOTIFY_ORBIT, header = "CTF has been activated")
 
 /obj/machinery/capture_the_flag/proc/reset_the_arena()
-	new /obj/effect/landmark/ctf(get_turf(GLOB.ctf_spawner))
+	if(!ctf_landmark)
+		return
+
+	if(ctf_landmark == GLOB.ctf_spawner)
+		new /obj/effect/landmark/ctf(get_turf(GLOB.ctf_spawner))
 
 
 /obj/machinery/capture_the_flag/proc/stop_ctf()

--- a/code/modules/capture_the_flag/medieval_sim/medisim_game.dm
+++ b/code/modules/capture_the_flag/medieval_sim/medisim_game.dm
@@ -18,6 +18,22 @@
 	. = ..()
 	toggle_id_ctf(null, game_id, automated = TRUE)//only one machine runs the victory proc, start_ctf proc would break the other machine
 
+/obj/machinery/capture_the_flag/medisim/reset_the_arena()
+	var/area/ctf_area = get_area(src)
+	var/static/list/ctf_object_typecache = typecacheof(list(
+				/obj/machinery,
+				/obj/effect/ctf,
+				/obj/item/ctf
+			))
+	for(var/atom/movable/area_movable in ctf_area)
+		if (ismob(area_movable))
+			continue
+		if(isstructure(area_movable))
+			var/obj/structure/ctf_structure = area_movable
+			ctf_structure.repair_damage(ctf_structure.max_integrity - ctf_structure.get_integrity())
+		else if(!is_type_in_typecache(area_movable, ctf_object_typecache))
+			qdel(area_movable)
+
 /obj/machinery/capture_the_flag/medisim/spawn_team_member(client/new_team_member)
 	. = ..()
 	if(!.)

--- a/code/modules/capture_the_flag/medieval_sim/medisim_game.dm
+++ b/code/modules/capture_the_flag/medieval_sim/medisim_game.dm
@@ -18,21 +18,9 @@
 	. = ..()
 	toggle_id_ctf(null, game_id, automated = TRUE)//only one machine runs the victory proc, start_ctf proc would break the other machine
 
+// We don't clean up for the medisim.
 /obj/machinery/capture_the_flag/medisim/reset_the_arena()
-	var/area/ctf_area = get_area(src)
-	var/static/list/ctf_object_typecache = typecacheof(list(
-				/obj/machinery,
-				/obj/effect/ctf,
-				/obj/item/ctf
-			))
-	for(var/atom/movable/area_movable in ctf_area)
-		if (ismob(area_movable))
-			continue
-		if(isstructure(area_movable))
-			var/obj/structure/ctf_structure = area_movable
-			ctf_structure.repair_damage(ctf_structure.max_integrity - ctf_structure.get_integrity())
-		else if(!is_type_in_typecache(area_movable, ctf_object_typecache))
-			qdel(area_movable)
+	return
 
 /obj/machinery/capture_the_flag/medisim/spawn_team_member(client/new_team_member)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
CTF borked because multiple CTF things can call stop_ctf which lead to the map constantly getting regenerated. I should've caught this in my first bugfix but didn't realise there was an admin way to stop CTF (I was using proccall)
This fixes that.

Someone slap no GBP on this please

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Code not broke

## Changelog
:cl:
fix: Fixed CTF breaking when it restarts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
