### PR TITLE
removes TRAIT_RESTRAINED from xeno nests

### DIFF
--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -65,12 +65,14 @@
 			span_hear("You hear squelching..."))
 
 /obj/structure/bed/nest/post_buckle_mob(mob/living/M)
+	ADD_TRAIT(M, TRAIT_HANDS_BLOCKED, type)
 	M.pixel_y = M.base_pixel_y
 	M.pixel_x = M.base_pixel_x + 2
 	M.layer = BELOW_MOB_LAYER
 	add_overlay(nest_overlay)
 
 /obj/structure/bed/nest/post_unbuckle_mob(mob/living/M)
+	REMOVE_TRAIT(M, TRAIT_HANDS_BLOCKED, type)
 	M.pixel_x = M.base_pixel_x + M.body_position_pixel_x_offset
 	M.pixel_y = M.base_pixel_y + M.body_position_pixel_y_offset
 	M.layer = initial(M.layer)

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -65,14 +65,12 @@
 			span_hear("You hear squelching..."))
 
 /obj/structure/bed/nest/post_buckle_mob(mob/living/M)
-	ADD_TRAIT(M, TRAIT_RESTRAINED, type)
 	M.pixel_y = M.base_pixel_y
 	M.pixel_x = M.base_pixel_x + 2
 	M.layer = BELOW_MOB_LAYER
 	add_overlay(nest_overlay)
 
 /obj/structure/bed/nest/post_unbuckle_mob(mob/living/M)
-	REMOVE_TRAIT(M, TRAIT_RESTRAINED, type)
 	M.pixel_x = M.base_pixel_x + M.body_position_pixel_x_offset
 	M.pixel_y = M.base_pixel_y + M.body_position_pixel_y_offset
 	M.layer = initial(M.layer)


### PR DESCRIPTION

## About The Pull Request
fixes #60673

## Why It's Good For The Game

currently you need to unbuckle twice to get out of a xeno nest and this fixes it without nerfing the timer in half
## Changelog
:cl:
fix: You no longer need to unbuckle twice from xenomorph nests to be free
/:cl: