### PR TITLE
Removes some of the cyborgs OP range it shouldnt have

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -370,6 +370,11 @@
 		if(panel_open && !(interaction_flags_machine & INTERACT_MACHINE_OPEN) && !(interaction_flags_machine & INTERACT_MACHINE_OPEN_SILICON))
 			return FALSE
 
+		if(iscyborg(user))
+			var/mob/living/silicon/robot/cyborg = user
+			if(!cyborg.can_interact_with(src))
+				return FALSE //cyborgs dont get unlimited range
+
 		return TRUE //silicons don't care about petty mortal concerns like needing to be next to a machine to use it
 
 	if(living_user.incapacitated()) //idk why silicons aren't supposed to care about incapacitation when interacting with machines, but it was apparently like this before


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cyborgs are coded to have a 7 tile (technically 8 if you count both the tile your on and the targets on) range, however the can_interact check overrides this and lets all silicons unlimited range, i added one extra check there to ensure cyborgs are actually in range, if you want your machine to have unlimited borg range you can use another proc that ignores borg range or just have your interact specifically check if its a borg and override their range if so

theres several procs that manage interaction range so SOME items like buttons, apc interfaces and such, have 100% unlimited range for borgs atm even after this fix, however can_interact() is used in a LOT of places so this already fixes several issues such as using pipes through cameras (how syndie borgs on nukie shuttle can plasmaflood the station before even going to the station)

this video shows that borgs on camera consoles can no longer interact with piping or anything with this one check added in, they cant open apc interfaces too (cant open interfaces while in a camera interface) but CAN use hot keys to lock and unlock apcs as you can notice, doors however use can_interact so borgs cannot mess with doors through cameras either


https://user-images.githubusercontent.com/40489693/128005922-336c34ac-0f52-4a55-94f5-bfe8061c8cd1.mp4



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes #60643
might fix others but after some searching for 10 mins cant find any issues related to this but im sure a few more likely exist just dont have "borg" in the name
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: Nanotrasen expert roboticists have found an error in cyborg programming which allows them to interact with things farther than they are supposed to. some of those errors have been squashed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
