### PR TITLE
Fixes wirecutters worn belt-state.

### DIFF
--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -3,6 +3,7 @@
 	desc = "This cuts wires."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "cutters_map"
+	worn_icon_state = "cutters"
 	inhand_icon_state = "cutters"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'


### PR DESCRIPTION
## About The Pull Request

Gives wirecutters a worn_icon_state, fixing them having a missing texture state. Oversight from their addition to GAGS.

## Why It's Good For The Game

Fixes #60591.
Less ugly missing icons.

## Changelog
:cl:
fix: Wirecutters have their correct belt slot icon again.
/:cl:
