### PR TITLE
Makes the occupational corruption device less cryptic

### DIFF
--- a/code/game/objects/items/devices/ocd.dm
+++ b/code/game/objects/items/devices/ocd.dm
@@ -1,11 +1,11 @@
-/obj/item/devices/ocd_device
+/obj/item/devices/bureaucratic_error_remote
 	name = "Occupational Corruption Device"
 	desc = "When you need to make the lives of new-hires that much more confusing, think OCD."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "gangtool-white"
 
-/obj/item/devices/ocd_device/attack_self(mob/user)
+/obj/item/devices/bureaucratic_error_remote/attack_self(mob/user)
 	var/datum/round_event/bureaucratic_error/event = new()
 	event.start()
-	deadchat_broadcast(span_bold(" An OCD has been activated! "))
+	deadchat_broadcast(span_bold("An Occupational Corruption Device has been activated!"))
 	qdel(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1674,7 +1674,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	uplink_box.name = "Uplink Implant Box"
 	new /obj/item/implanter/uplink(uplink_box, purchaser_uplink.uplink_flag)
 	return uplink_box
-	
+
 
 /datum/uplink_item/implants/xray
 	name = "X-ray Vision Implant"
@@ -1934,12 +1934,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/autosurgeon/organ/syndicate/laser_arm
 	restricted_roles = list("Roboticist", "Research Director")
 
-/datum/uplink_item/role_restricted/ocd_device
+/datum/uplink_item/role_restricted/bureaucratic_error_remote
 	name = "Organic Resources Disturbance Inducer"
 	desc = "A device that raises hell in organic resources indirectly. Single use."
 	cost = 2
 	limited_stock = 1
-	item = /obj/item/devices/ocd_device
+	item = /obj/item/devices/bureaucratic_error_remote
 	restricted_roles = list("Head of Personnel", "Quartermaster")
 
 /datum/uplink_item/role_restricted/meathook


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Repaths the Occupational Corruption Device to the more descriptive /obj/item/devices/bureaucratic_error_remote and expands the acronym in the deadchat message for clarity.

## Why It's Good For The Game

Nobody has to wonder what an OCD device is and why it was just activated any more.

## Changelog
:cl:
code: Made the Occupational Corruption Device's deadchat message less cryptic, and repathed it to something more descriptive
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
