### PR TITLE
Fixes all R_WALLS being rusty

### DIFF
--- a/code/game/turfs/closed/wall/misc_walls.dm
+++ b/code/game/turfs/closed/wall/misc_walls.dm
@@ -82,9 +82,6 @@
 /turf/closed/wall/rust/Initialize(mapload)
 	. = ..()
 	color = null
-
-/turf/closed/wall/rust/ComponentInitialize()
-	. = ..()
 	AddElement(/datum/element/rust)
 
 /turf/closed/wall/r_wall/rust
@@ -95,9 +92,6 @@
 /turf/closed/wall/r_wall/rust/Initialize(mapload)
 	. = ..()
 	color = null
-
-/turf/closed/wall/r_wall/rust/ComponentInitialize()
-	. = ..()
 	AddElement(/datum/element/rust)
 
 /turf/closed/wall/mineral/bronze

--- a/code/game/turfs/closed/wall/misc_walls.dm
+++ b/code/game/turfs/closed/wall/misc_walls.dm
@@ -92,11 +92,11 @@
 	//and should be removed on initialize
 	color = COLOR_ORANGE_BROWN
 
-/turf/closed/wall/r_wall/Initialize(mapload)
+/turf/closed/wall/r_wall/rust/Initialize(mapload)
 	. = ..()
 	color = null
 
-/turf/closed/wall/r_wall/ComponentInitialize()
+/turf/closed/wall/r_wall/rust/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/rust)
 


### PR DESCRIPTION

## About The Pull Request

A simple code error caused all R_WALLS to be rusty at roundstart. This changes them to be NOT rusty. 

## Why It's Good For The Game

Well, we don't want the station to be rusty and unsmoothed do we?

## Changelog
:cl:
fix: Reinforced walls should now smooth properly.
/:cl:

