### PR TITLE
Fixes rust heretics healing with Leeching Walk (+ some minor code improvement) 

### DIFF
--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -73,20 +73,23 @@
 
 /datum/eldritch_knowledge/rust_regen/on_gain(mob/user)
 	. = ..()
-	RegisterSignal(user,COMSIG_MOVABLE_MOVED,.proc/on_move)
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/on_move)
 
 /datum/eldritch_knowledge/rust_regen/proc/on_move(mob/mover)
 	SIGNAL_HANDLER
 
-	var/atom/mover_turf = get_turf(mover)
+	var/turf/mover_turf = get_turf(mover)
 	if(HAS_TRAIT(mover_turf, TRAIT_RUSTY))
-		ADD_TRAIT(mover,TRAIT_STUNRESISTANCE,type)
+		ADD_TRAIT(mover, TRAIT_STUNRESISTANCE, type)
 		return
 
-	REMOVE_TRAIT(mover,TRAIT_STUNRESISTANCE,type)
+	REMOVE_TRAIT(mover, TRAIT_STUNRESISTANCE, type)
 
 /datum/eldritch_knowledge/rust_regen/on_life(mob/user)
-	. = ..()
+	var/turf/our_turf = get_turf(user)
+	if(!HAS_TRAIT(our_turf, TRAIT_RUSTY) || !isliving(user))
+		return
+
 	var/mob/living/living_user = user
 	living_user.adjustBruteLoss(-2, FALSE)
 	living_user.adjustFireLoss(-2, FALSE)

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -86,6 +86,7 @@
 	REMOVE_TRAIT(mover, TRAIT_STUNRESISTANCE, type)
 
 /datum/eldritch_knowledge/rust_regen/on_life(mob/user)
+	. = ..()
 	var/turf/our_turf = get_turf(user)
 	if(!HAS_TRAIT(our_turf, TRAIT_RUSTY) || !isliving(user))
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes #60576

The "fix pr" for rust heretics not healing off of the rust component... just removed the check for rust. so they healed on every life tick regardless. 

This pr restores the check for rusty turfs, and improves leeching walk code slightly 

## Why It's Good For The Game

Infinite, free healing regardless of rust status? Not in my house

## Changelog
:cl: Melbert
fix: Rust Heretics now need to stand on Rust to heal again, instead of passive free healing
/:cl:

