### PR TITLE
Makes the syndicate mask fireproof and acid proof.

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -145,6 +145,7 @@
 	desc = "A close-fitting tactical mask that can be connected to an air supply."
 	icon_state = "syndicate"
 	strip_delay = 60
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/clothing/mask/gas/clown_hat


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Does as the title says; this, in my opinion is technically unintended behaviour being fixed. The syndicate gas-mask can currently suffer from many issues during combat mode hardsuits (elite or otherwise) that make it near worthless.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nukies having their gas-mask burnt off in an elite syndicate suit is hilarious, but also massively griefy considering (carbon dioxide flood) or (nitrous oxide flood) basically making it a free-kill if they stay on fire long enough, such as the cases involving welding fuel + napalm spray bottles.

Also hopefully curtails people abusing the fact blood-red hardsuits are not fireproof. This'll probably be PR'd out in the future.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Syndicate masks are now fire + acid proof
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
