### PR TITLE
Fix custom wintercoat hoods not getting GAGS colors

### DIFF
--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -429,6 +429,15 @@
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/custom
 	flags_1 = IS_PLAYER_COLORABLE_1
 
+//In case colors are changed after initialization
+/obj/item/clothing/suit/hooded/wintercoat/custom/set_greyscale(list/colors, new_config, new_worn_config, new_inhand_left, new_inhand_right)
+	. = ..()
+	if(hood)
+		var/list/coat_colors = (SSgreyscale.ParseColorString(greyscale_colors))
+		var/list/new_coat_colors = coat_colors.Copy(1,4)
+		hood.set_greyscale(new_coat_colors) //Adopt the suit's grayscale coloring for visual clarity.
+
+//But also keep old method in case the hood is (re-)created later
 /obj/item/clothing/suit/hooded/wintercoat/custom/MakeHood()
 	. = ..()
 	var/list/coat_colors = (SSgreyscale.ParseColorString(greyscale_colors))

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -433,7 +433,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/custom/set_greyscale(list/colors, new_config, new_worn_config, new_inhand_left, new_inhand_right)
 	. = ..()
 	if(hood)
-		var/list/coat_colors = (SSgreyscale.ParseColorString(greyscale_colors))
+		var/list/coat_colors = SSgreyscale.ParseColorString(greyscale_colors)
 		var/list/new_coat_colors = coat_colors.Copy(1,4)
 		hood.set_greyscale(new_coat_colors) //Adopt the suit's grayscale coloring for visual clarity.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The wintercoat's `MakeHood` proc copies its colors over to the hood. However, when not in alternative mode, the proc fires immediately in `Initialize`, which happens inside `New`. The clothesmate, on the other hand, sets the coat's color only after it's created, at which point the hood already exists.

Because of this, the hood never has its colors set to the ones chosen by the buyer.

This PR adds an additional override to `set_greyscale` that copies the colors over to the hood if there is one. Because the original code for this purpose cuts out hardcoded values out of the list of colors, and I'm unfamiliar with GAGS, this is only coded for the tailored winter coat. If there's a good general way to copy colors over to arbitrary hoods from arbitrary coats, that'd be better.

Fixes #59544

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's a bugfix, hood should be colorable, even the suit-slot-with-hood-up-sprite reflects that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Tailored winter suit hoods are now colored correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
