### PR TITLE
small refactor to can_interact() so that borg range is fully respected

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -325,8 +325,6 @@
 	return
 
 /atom/proc/ShiftClick(mob/user)
-	if(!can_interact(user))
-		return FALSE
 	var/flags = SEND_SIGNAL(src, COMSIG_CLICK_SHIFT, user)
 	if(user.client && (user.client.eye == user || user.client.eye == user.loc || flags & COMPONENT_ALLOW_EXAMINATE))
 		user.examinate(src)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -325,6 +325,8 @@
 	return
 
 /atom/proc/ShiftClick(mob/user)
+	if(!can_interact(user))
+		return FALSE
 	var/flags = SEND_SIGNAL(src, COMSIG_CLICK_SHIFT, user)
 	if(user.client && (user.client.eye == user || user.client.eye == user.loc || flags & COMPONENT_ALLOW_EXAMINATE))
 		user.examinate(src)
@@ -339,6 +341,8 @@
 	return
 
 /atom/proc/CtrlClick(mob/user)
+	if(!can_interact(user))
+		return FALSE
 	SEND_SIGNAL(src, COMSIG_CLICK_CTRL, user)
 	SEND_SIGNAL(user, COMSIG_MOB_CTRL_CLICKED, src)
 	var/mob/living/ML = user
@@ -386,6 +390,8 @@
 	A.AltClick(src)
 
 /atom/proc/AltClick(mob/user)
+	if(!can_interact(user))
+		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_CLICK_ALT, user) & COMPONENT_CANCEL_CLICK_ALT)
 		return
 	var/turf/T = get_turf(src)
@@ -402,6 +408,8 @@
 
 ///The base proc of when something is right clicked on when alt is held
 /atom/proc/alt_click_secondary(mob/user)
+	if(!can_interact(user))
+		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_CLICK_ALT_SECONDARY, user) & COMPONENT_CANCEL_CLICK_ALT_SECONDARY)
 		return
 
@@ -428,6 +436,8 @@
 	return
 
 /atom/proc/CtrlShiftClick(mob/user)
+	if(!can_interact(user))
+		return FALSE
 	SEND_SIGNAL(src, COMSIG_CLICK_CTRL_SHIFT, user)
 	return
 

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -145,6 +145,9 @@
 		ui.open()
 
 /obj/machinery/sleeper/AltClick(mob/user)
+	. = ..()
+	if(!can_interact(user))
+		return
 	if(!user.canUseTopic(src, !issilicon(user)))
 		return
 	if(state_open)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -146,8 +146,6 @@
 
 /obj/machinery/sleeper/AltClick(mob/user)
 	. = ..()
-	if(!can_interact(user))
-		return
 	if(!user.canUseTopic(src, !issilicon(user)))
 		return
 	if(state_open)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -343,16 +343,8 @@
 	if((machine_stat & (NOPOWER|BROKEN)) && !(interaction_flags_machine & INTERACT_MACHINE_OFFLINE)) // Check if the machine is broken, and if we can still interact with it if so
 		return FALSE
 
-	if(isAdminGhostAI(user))
-		return TRUE //if you're an admin, you probably know what you're doing (or at least have permission to do what you're doing)
-
-	if(!isliving(user))
-		return FALSE //no ghosts in the machine allowed, sorry
-
 	if(SEND_SIGNAL(user, COMSIG_TRY_USE_MACHINE, src) & COMPONENT_CANT_USE_MACHINE_INTERACT)
 		return FALSE
-
-	var/mob/living/living_user = user
 
 	var/is_dextrous = FALSE
 	if(isanimal(user))
@@ -370,10 +362,9 @@
 		if(panel_open && !(interaction_flags_machine & INTERACT_MACHINE_OPEN) && !(interaction_flags_machine & INTERACT_MACHINE_OPEN_SILICON))
 			return FALSE
 
-		return TRUE //silicons don't care about petty mortal concerns like needing to be next to a machine to use it
+		return user.can_interact_with(src) //AIs don't care about petty mortal concerns like needing to be next to a machine to use it, but borgs do care somewhat
 
-	if(living_user.incapacitated()) //idk why silicons aren't supposed to care about incapacitation when interacting with machines, but it was apparently like this before
-		return FALSE
+	. = ..()
 
 	if((interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SIGHT) && user.is_blind())
 		to_chat(user, span_warning("This machine requires sight to use."))
@@ -384,11 +375,6 @@
 
 	if(interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SILICON) //if the user was a silicon, we'd have returned out earlier, so the user must not be a silicon
 		return FALSE
-
-	if(!Adjacent(user)) // Next make sure we are next to the machine unless we have telekinesis
-		var/mob/living/carbon/carbon_user = living_user
-		if(!istype(carbon_user) || !carbon_user.has_dna() || !carbon_user.dna.check_mutation(TK))
-			return FALSE
 
 	return TRUE // If we passed all of those checks, woohoo! We can interact with this machine.
 

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -346,6 +346,9 @@
 	if(SEND_SIGNAL(user, COMSIG_TRY_USE_MACHINE, src) & COMPONENT_CANT_USE_MACHINE_INTERACT)
 		return FALSE
 
+	if(!isliving(user))
+		return FALSE //no ghosts allowed, sorry
+
 	var/is_dextrous = FALSE
 	if(isanimal(user))
 		var/mob/living/simple_animal/user_as_animal = user

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -117,5 +117,7 @@
 
 /obj/machinery/computer/AltClick(mob/user)
 	. = ..()
+	if(!can_interact(user))
+		return
 	if(!user.canUseTopic(src, !issilicon(user)) || !is_operational)
 		return

--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -641,6 +641,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	circuit = /obj/item/circuitboard/computer/arcade/amputation
 
 /obj/machinery/computer/arcade/amputation/attack_hand(mob/user, list/modifiers)
+	. = ..()
 	if(!iscarbon(user))
 		return
 	var/mob/living/carbon/c_user = user

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -199,6 +199,9 @@
 
 /obj/machinery/computer/scan_consolenew/AltClick(mob/user)
 	// Make sure the user can interact with the machine.
+	. = ..()
+	if(!can_interact(user))
+		return
 	if(!user.canUseTopic(src, !issilicon(user)))
 		return
 

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -98,6 +98,7 @@
 
 //defib interaction
 /obj/machinery/defibrillator_mount/attack_hand(mob/living/user, list/modifiers)
+	. = ..()
 	if(!defib)
 		to_chat(user, span_warning("There's no defibrillator unit loaded!"))
 		return

--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -36,6 +36,7 @@
 		. += span_notice("Alt-click it to beam its contents to any nearby disposal bins.")
 
 /obj/machinery/dish_drive/attack_hand(mob/living/user, list/modifiers)
+	. = ..()
 	if(!LAZYLEN(dish_drive_contents))
 		to_chat(user, span_warning("There's nothing in [src]!"))
 		return

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -177,7 +177,8 @@
 
 /obj/machinery/firealarm/attack_hand(mob/user, list/modifiers)
 	if(buildstage != 2)
-		return ..()
+		return
+	. = ..()
 	add_fingerprint(user)
 	var/area/area = get_area(src)
 	if(area.fire)

--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -50,12 +50,16 @@
 	harvesting = FALSE
 
 /obj/machinery/harvester/attack_hand(mob/user, list/modifiers)
+	. = ..()
 	if(state_open)
 		close_machine()
 	else if(!harvesting)
 		open_machine()
 
 /obj/machinery/harvester/AltClick(mob/user)
+	. = ..()
+	if(!can_interact(user))
+		return
 	if(harvesting || !user || !isliving(user) || state_open)
 		return
 	if(can_harvest())

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -38,6 +38,9 @@
 		last_stasis_sound = _running
 
 /obj/machinery/stasis/AltClick(mob/user)
+	. = ..()
+	if(!can_interact(user))
+		return
 	if(world.time >= stasis_can_toggle && user.canUseTopic(src, !issilicon(user)))
 		stasis_enabled = !stasis_enabled
 		stasis_can_toggle = world.time + STASIS_TOGGLE_COOLDOWN

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -100,6 +100,10 @@
 			. = TRUE
 		if("wireless")
 			AI.control_disabled = !AI.control_disabled
+			if(!AI.control_disabled)
+				AI.interaction_range = null
+			else
+				AI.interaction_range = 0
 			to_chat(AI, span_warning("[src]'s wireless port has been [AI.control_disabled ? "disabled" : "enabled"]!"))
 			. = TRUE
 		if("radio")

--- a/code/game/objects/structures/training_machine.dm
+++ b/code/game/objects/structures/training_machine.dm
@@ -396,6 +396,8 @@
 
 /obj/item/training_toolbox/AltClick(mob/user)
 	. = ..()
+	if(!can_interact(user))
+		return
 	to_chat(user, span_notice("You push the 'Lap' button on the toolbox's display."))
 	lap_hits = initial(lap_hits)
 

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -853,7 +853,9 @@
 	return FALSE
 
 /obj/machinery/airalarm/AltClick(mob/user)
-	..()
+	. = ..()
+	if(!can_interact(user))
+		return
 	if(!user.canUseTopic(src, !issilicon(user)) || !isturf(loc))
 		return
 	else

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -103,6 +103,7 @@
 	var/datum/robot_control/robot_control
 	///remember AI's last location
 	var/atom/lastloc
+	interaction_range = null
 
 /mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
 	. = ..()
@@ -821,6 +822,7 @@
 		new_core.circuit.battery = battery
 		ai_restore_power()//So the AI initially has power.
 		control_disabled = TRUE //Can't control things remotely if you're stuck in a card!
+		interaction_range = 0
 		radio_enabled = FALSE //No talking on the built-in radio for you either!
 		forceMove(card)
 		card.AI = src

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -16,6 +16,7 @@
 	var/static_visibility_range = 16
 	var/ai_detector_visible = TRUE
 	var/ai_detector_color = COLOR_RED
+	interaction_range = null
 
 /mob/camera/ai_eye/Initialize()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -322,11 +322,7 @@
 		return TRUE //bypass for borg tablets
 	if (low_power_mode)
 		return FALSE
-	var/turf/T0 = get_turf(src)
-	var/turf/T1 = get_turf(A)
-	if (!T0 || ! T1)
-		return FALSE
-	return ISINRANGE(T1.x, T0.x - interaction_range, T0.x + interaction_range) && ISINRANGE(T1.y, T0.y - interaction_range, T0.y + interaction_range)
+	return ..()
 
 /mob/living/silicon/robot/proc/allowed(mob/M)
 	//check if it doesn't require any access at all

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -43,7 +43,7 @@
 	var/updating = FALSE //portable camera camerachunk update
 
 	var/hack_software = FALSE //Will be able to use hacking actions
-	var/interaction_range = 7 //wireless control range
+	interaction_range = 7 //wireless control range
 	var/obj/item/pda/ai/aiPDA
 
 /mob/living/silicon/Initialize()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -308,6 +308,9 @@
 	show_controls(user)
 
 /mob/living/simple_animal/bot/AltClick(mob/user)
+	. = ..()
+	if(!can_interact(user))
+		return
 	if(!user.canUseTopic(src, !issilicon(user)))
 		return
 	unlock_with_id(user)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1000,20 +1000,18 @@
 /mob/proc/can_interact_with(atom/A)
 	if(isAdminGhostAI(src) || Adjacent(A))
 		return TRUE
-	if(!isliving(src))
-		return FALSE //no ghosts allowed, sorry
 	var/datum/dna/mob_dna = has_dna()
 	if(mob_dna?.check_mutation(TK) && tkMaxRangeCheck(src, A))
 		return TRUE
 
 	//range check
-	var/turf/T0 = get_turf(src)
-	var/turf/T1 = get_turf(A)
-	if (!T0 || ! T1)
-		return FALSE
 	if(!interaction_range)
 		return TRUE
-	return ISINRANGE(T1.x, T0.x - interaction_range, T0.x + interaction_range) && ISINRANGE(T1.y, T0.y - interaction_range, T0.y + interaction_range)
+	var/turf/our_turf = get_turf(src)
+	var/turf/their_turf = get_turf(A)
+	if (!our_turf || !their_turf)
+		return FALSE
+	return ISINRANGE(their_turf.x, our_turf.x - interaction_range, our_turf.x + interaction_range) && ISINRANGE(their_turf.y, our_turf.y - interaction_range, our_turf.y + interaction_range)
 
 ///Can the mob use Topic to interact with machines
 /mob/proc/canUseTopic(atom/movable/M, be_close=FALSE, no_dexterity=FALSE, no_tk=FALSE, need_hands = FALSE, floor_okay=FALSE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1000,9 +1000,20 @@
 /mob/proc/can_interact_with(atom/A)
 	if(isAdminGhostAI(src) || Adjacent(A))
 		return TRUE
+	if(!isliving(src))
+		return FALSE //no ghosts allowed, sorry
 	var/datum/dna/mob_dna = has_dna()
 	if(mob_dna?.check_mutation(TK) && tkMaxRangeCheck(src, A))
 		return TRUE
+
+	//range check
+	var/turf/T0 = get_turf(src)
+	var/turf/T1 = get_turf(A)
+	if (!T0 || ! T1)
+		return FALSE
+	if(!interaction_range)
+		return TRUE
+	return ISINRANGE(T1.x, T0.x - interaction_range, T0.x + interaction_range) && ISINRANGE(T1.y, T0.y - interaction_range, T0.y + interaction_range)
 
 ///Can the mob use Topic to interact with machines
 /mob/proc/canUseTopic(atom/movable/M, be_close=FALSE, no_dexterity=FALSE, no_tk=FALSE, need_hands = FALSE, floor_okay=FALSE)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -227,3 +227,5 @@
 
 	/// A mock client, provided by tests and friends
 	var/datum/client_interface/mock_client
+
+	var/interaction_range = 1 //how far a mob has to be to interact with something, defaulted to 1 tile

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -93,6 +93,9 @@
 
 
 /obj/item/modular_computer/laptop/AltClick(mob/user)
+	. = ..()
+	if(!can_interact(user))
+		return
 	if(screen_on) // Close it.
 		try_toggle_open(user)
 	else

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -92,6 +92,9 @@
 	return update_icon(updates)
 
 /obj/machinery/modular_computer/AltClick(mob/user)
+	. = ..()
+	if(!can_interact(user))
+		return
 	if(cpu)
 		cpu.AltClick(user)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -777,7 +777,9 @@
 	return FALSE
 
 /obj/machinery/power/apc/AltClick(mob/user)
-	..()
+	. = ..()
+	if(!can_interact(user))
+		return
 	if(!user.canUseTopic(src, !issilicon(user)) || !isturf(loc))
 		return
 	else


### PR DESCRIPTION
so heres the deal, this is the most complicated thing ive ever done here, so if would be of help if people who notice something that can be changed or fixed further etc... to please let me know

that said: ive done EXTENSIVE testing as human, AI, borg, pai, simplemobs and this has no changes playerfacing aside from the fact borgs now have their intentional 7 tile range respected

(I will admit, half my time coding this was literally just spent trying to get the apc AltClick to respect borg range lmao, im dumb)

this was just a straight up better way of fixing the issue than what i did in #60679, so im closing that PR, it can be reopened if this PR wont work out and you wanna do the other i guess

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Its a relatively small refactor that changes the previous machinery "can_interact()" proc that literally did a full override despite half of their checks already existing in not one, but TWO parent procs, so i removed the redundant checks, added callbacks to its parents and then added the cyborg range check on the can_interact_with() itself. in doing so i also moved the interaction range var from silicons only, to mobs as a whole and defaulted it to a single tile, silicons override it to 7 (so pAIs and borgs like before) but then set AI and AI.eye to "null", because i have a check in can_interact that if there is no range set, then the range is effectively unlimited. and i even added code for when AI is carded and their wireless transmission is disabled it sets their range to "0" aka, it has no range to do anything even if it could


this was really complicated for me so despite my extensive testing it probably would be a bad thing if any of you want to test my code yourself to ensure there isnt a bug with this (theres no runtimes ive come across)

note: i did a lot of searching and going through machinery to ensure i caught all the little snowflake overrides and added can_interact() checks to them, but i may have missed one or two things, especially maybe a altclick or ctrlclick somewhere, however i believe i caught most of them

one nice side effect of this refactor is that you can actually set another mobs range to something other than 1 tile and they can interact at range, rather than only silicons getting this ability, an admin could VV a human to have a 3 tile arm reach as a meme if they want

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes #60643
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: Nanotrasen expert roboticists have found an error in cyborg programming which allows them to interact with things farther than they are supposed to. some of those errors have been squashed.
refactor: can_interact() now has a few less unnesscary overrides and now properly checks for range such. and hotkeys are also now respected with can_interact()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
