### PR TITLE
Get your protein fix here (for monkey meat).

### DIFF
--- a/code/datums/materials/meat.dm
+++ b/code/datums/materials/meat.dm
@@ -17,6 +17,8 @@
 
 /datum/material/meat/on_removed(atom/source, amount, material_flags)
 	. = ..()
+	if(material_flags & MATERIAL_NO_EFFECTS)
+		return
 	qdel(source.GetComponent(/datum/component/edible))
 
 /datum/material/meat/on_applied_obj(obj/O, amount, material_flags)

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -9,6 +9,7 @@
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	obj_flags = UNIQUE_RENAME
+	material_flags = MATERIAL_NO_EFFECTS
 	grind_results = list()
 	///List of reagents this food gets on creation
 	var/list/food_reagents

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -618,6 +618,8 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 6, /datum/reagent/consumable/cooking_oil = 2) //Meat has fats that a food processor can process into cooking oil
 	tastes = list("meat" = 1)
 	foodtypes = MEAT | RAW
+	//As we don't want meat slabs (Which would otherwise gain reagents when obtaining their materials) to have their chemicals overwritten, we apply this material flag.
+	material_flags = MATERIAL_NO_EFFECTS
 	///Legacy code, handles the coloring of the overlay of the cutlets made from this.
 	var/slab_color = "#FF0000"
 

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -618,8 +618,6 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 6, /datum/reagent/consumable/cooking_oil = 2) //Meat has fats that a food processor can process into cooking oil
 	tastes = list("meat" = 1)
 	foodtypes = MEAT | RAW
-	//As we don't want meat slabs (Which would otherwise gain reagents when obtaining their materials) to have their chemicals overwritten, we apply this material flag.
-	material_flags = MATERIAL_NO_EFFECTS
 	///Legacy code, handles the coloring of the overlay of the cutlets made from this.
 	var/slab_color = "#FF0000"
 


### PR DESCRIPTION
## About The Pull Request

Meat steaks now have the material flag to un-link from from material effects, meaning that monkey meat will now have the proper nutrients and reagents it was intended to, primarily that monkey meat will have protein for cytology purposes.

## Why It's Good For The Game

Fixes #60148. 
Apparently does NOT do #60352, as I can now tell..

## Changelog
:cl:
fix: Meat steaks now have protein as expected.
/:cl:
