### PR TITLE
Uncomments holymelon "check liked" code, makes it work with the edible component

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -200,7 +200,7 @@
 
 /datum/mood_event/holy_consumption
 	description = "<span class='nicegreen'>Truly, that was the food of the Divine!</span>\n"
-	mood_change = 5
+	mood_change = 1 // 1 + 5 from it being liked food makes it as good as jolly
 	timeout = 3 MINUTES
 
 /datum/mood_event/high_five

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -79,7 +79,12 @@
 		junkiness = junkiness, \
 		check_liked = CALLBACK(src, .proc/check_holyness))
 
-/obj/item/food/grown/holymelon/proc/check_holyness(fraction, mob/mob_eating) // Chaplains love holymelons!
+/*
+ * Callback to be used with the edible component.
+ * Checks whether or not the person eating the holymelon
+ * is a holy_role (chaplain), as chaplains love holymelons.
+ */
+/obj/item/food/grown/holymelon/proc/check_holyness(fraction, mob/mob_eating)
 	if(!ishuman(mob_eating))
 		return
 	var/mob/living/carbon/human/holy_person = mob_eating

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -65,22 +65,29 @@
 /obj/item/food/grown/holymelon/make_dryable()
 	return //No drying
 
-/*
-/obj/item/food/grown/holymelon/checkLiked(fraction, mob/M)    //chaplains sure love holymelons
-	if(!ishuman(M))
+/obj/item/food/grown/holymelon/MakeEdible()
+	AddComponent(/datum/component/edible, \
+		initial_reagents = food_reagents, \
+		food_flags = food_flags, \
+		foodtypes = foodtypes, \
+		volume = max_volume, \
+		eat_time = eat_time, \
+		tastes = tastes, \
+		eatverbs = eatverbs,\
+		bite_consumption = bite_consumption, \
+		microwaved_type = microwaved_type, \
+		junkiness = junkiness, \
+		check_liked = CALLBACK(src, .proc/check_holyness))
+
+/obj/item/food/grown/holymelon/proc/check_holyness(fraction, mob/mob_eating) // Chaplains love holymelons!
+	if(!ishuman(mob_eating))
 		return
-	if(last_check_time + 5 SECONDS >= world.time)
-		return
-	var/mob/living/carbon/human/holy_person = M
+	var/mob/living/carbon/human/holy_person = mob_eating
 	if(!holy_person.mind?.holy_role || HAS_TRAIT(holy_person, TRAIT_AGEUSIA))
 		return
-	to_chat(holy_person,span_notice("Truly, a piece of heaven!"))
-	M.adjust_disgust(-5 + -2.5 * fraction)
+	to_chat(holy_person, span_notice("Truly, a piece of heaven!"))
 	SEND_SIGNAL(holy_person, COMSIG_ADD_MOOD_EVENT, "Divine_chew", /datum/mood_event/holy_consumption)
-	last_check_time = world.time
-
-
-*/
+	return FOOD_LIKED
 
 /// Barrel melon Seeds
 /obj/item/seeds/watermelon/barrel


### PR DESCRIPTION
## About The Pull Request

This PR uncomments the checkLiked code for the holymelons, allowing holy people to once again enjoy eating it. The proc was commented out during the food refactor and no one refactored it so it would work with the edible component.

Since this PR changes it into a `checkLiked` callback on the edible component, I reduced the amount the positive moodlet gives the eater, since the eater also gain the `I liked this food` +5 moodlet. With this change, there's a net +1 mood gain (+6 vs +5) compared to the prior implementation.

## Why It's Good For The Game

Cleaning up some forgotten, commented out code.

## Changelog
:cl: Melbert
code: Uncomments the code that makes chaplains enjoy holymelons. Chaplains will now gain positive moodlets from eating holy melons once again.
/:cl:
