### PR TITLE
Folded gold wheelchairs are now actually made of gold like unfolded ones.

### DIFF
--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -110,6 +110,7 @@
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	force = 10
+	custom_materials = list(/datum/material/gold = 10000)
 	unfolded_type = /obj/vehicle/ridden/wheelchair/gold
 
 /obj/vehicle/ridden/wheelchair/MouseDrop(over_object, src_location, over_location)  //Lets you collapse wheelchair


### PR DESCRIPTION
## About The Pull Request
Title. They're currently made of iron while the vehicle is made of gold.

## Why It's Good For The Game
Fixes an oversight.

## Changelog
:cl:
fix: Folded gold wheelchairs are now actually made of gold.
/:cl:
