### PR TITLE
Fixes improper calculation of days in round time

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -2,7 +2,7 @@
 #define MIDNIGHT_ROLLOVER 864000
 
 ///displays the current time into the round, with a lot of extra code just there for ensuring it looks okay after an entire day passes
-#define ROUND_TIME ( "[world.time - SSticker.round_start_time > MIDNIGHT_ROLLOVER ? "[round(world.time - SSticker.round_start_time/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]" )
+#define ROUND_TIME ( "[world.time - SSticker.round_start_time > MIDNIGHT_ROLLOVER ? "[round((world.time - SSticker.round_start_time)/MIDNIGHT_ROLLOVER)]:[worldtime2text()]" : worldtime2text()]" )
 
 
 #define JANUARY 1


### PR DESCRIPTION
Currently, after round time passes the 24 hour mark (as defined in MIDNIGHT_ROLLOVER), instead of properly displaying the amount of days it instead increases by 4 every tick. Adding parentheses to prioritize subtraction first over division fixes the issue.

:cl:
fix: added parentheses to properly calculate days in round time
/:cl: