### PR TITLE
Emergency Ice Box service fixes

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -12657,12 +12657,12 @@
 /turf/closed/wall,
 /area/medical/medbay/aft)
 "bvC" = (
-/obj/structure/chair/greyscale{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red/full,
 /obj/effect/turf_decal/siding/white{
 	dir = 4
+	},
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
@@ -21072,7 +21072,7 @@
 /area/commons/dorms)
 "dfC" = (
 /obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/greyscale,
+/obj/structure/chair,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
 "dfM" = (
@@ -21588,7 +21588,6 @@
 /area/maintenance/starboard/aft)
 "dwV" = (
 /obj/effect/turf_decal/tile/red/full,
-/obj/structure/table/greyscale,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
@@ -21602,6 +21601,7 @@
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
+/obj/structure/table,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
 "dxt" = (
@@ -22145,14 +22145,14 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "dRa" = (
-/obj/structure/chair/greyscale{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
 /obj/structure/sign/poster/random{
 	pixel_y = 32
+	},
+/obj/structure/chair{
+	dir = 4
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
@@ -24509,8 +24509,8 @@
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "fqr" = (
-/obj/structure/table/greyscale,
 /obj/effect/landmark/start/hangover,
+/obj/structure/table,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "fqF" = (
@@ -26091,13 +26091,13 @@
 /turf/closed/wall,
 /area/cargo/sorting)
 "gjg" = (
-/obj/structure/chair/greyscale{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "gjj" = (
@@ -26243,13 +26243,13 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
 "gmp" = (
-/obj/structure/chair/greyscale{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 10
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "gmx" = (
@@ -28052,7 +28052,7 @@
 /area/maintenance/starboard/fore)
 "hsd" = (
 /obj/effect/turf_decal/tile/red/full,
-/obj/structure/table/greyscale,
+/obj/structure/table,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
 "hsh" = (
@@ -29260,15 +29260,15 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "ids" = (
-/obj/structure/chair/greyscale{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red/full,
 /obj/effect/turf_decal/siding/white{
 	dir = 9
 	},
 /obj/structure/sign/poster/random{
 	pixel_y = 32
+	},
+/obj/structure/chair{
+	dir = 4
 	},
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
@@ -31338,7 +31338,6 @@
 /turf/open/floor/iron,
 /area/commons/locker)
 "jnv" = (
-/obj/structure/table/greyscale,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
@@ -31348,6 +31347,7 @@
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
+/obj/structure/table,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "jnK" = (
@@ -35639,15 +35639,15 @@
 /area/cargo/office)
 "lIw" = (
 /obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/greyscale{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Service-Diner";
 	dir = 4
+	},
+/obj/structure/chair{
+	dir = 1
 	},
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
@@ -38238,7 +38238,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "nbH" = (
-/obj/structure/chair/greyscale,
+/obj/structure/chair,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "nbT" = (
@@ -39560,7 +39560,6 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "nPr" = (
-/obj/structure/table/greyscale,
 /obj/effect/turf_decal/tile/red/full,
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -39572,6 +39571,7 @@
 	pixel_x = 3
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/table,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
 "nPx" = (
@@ -39845,10 +39845,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "nXe" = (
-/obj/structure/chair/greyscale{
+/obj/effect/landmark/start/hangover,
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "nXm" = (
@@ -42350,7 +42350,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "psp" = (
-/obj/structure/chair/greyscale{
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_large,
@@ -43514,7 +43514,6 @@
 /area/commons/dorms)
 "pVj" = (
 /obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/greyscale,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
@@ -43522,6 +43521,7 @@
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
+/obj/structure/chair,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
 "pVJ" = (
@@ -44228,10 +44228,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qqX" = (
-/obj/structure/chair/greyscale{
+/obj/effect/turf_decal/tile/red/full,
+/obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red/full,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
 "qqY" = (
@@ -47991,15 +47991,15 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "stA" = (
-/obj/structure/chair/greyscale{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red/full,
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
 /obj/effect/landmark/start/hangover,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
 "stL" = (
@@ -49686,14 +49686,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "trH" = (
-/obj/structure/chair/greyscale{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/white{
 	dir = 5
 	},
 /obj/structure/sign/poster/random{
 	pixel_y = 32
+	},
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
@@ -52864,10 +52864,10 @@
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "vgc" = (
-/obj/structure/chair/greyscale,
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
+/obj/structure/chair,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "vgq" = (
@@ -52978,9 +52978,9 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "vjE" = (
-/obj/structure/table/greyscale,
 /obj/effect/turf_decal/tile/red/full,
 /obj/item/clothing/head/fedora,
+/obj/structure/table,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
 "vjI" = (
@@ -53727,9 +53727,9 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "vHs" = (
-/obj/machinery/door/airlock/sandstone/glass{
+/obj/machinery/door/airlock{
 	name = "Kitchen";
-	req_access_txt = "28"
+	req_one_access_txt = "25;28"
 	},
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
@@ -53791,10 +53791,10 @@
 /area/maintenance/starboard/aft)
 "vJD" = (
 /obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/greyscale{
+/obj/effect/turf_decal/siding/white,
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/large,
 /area/service/kitchen/diner)
 "vJF" = (
@@ -54782,7 +54782,6 @@
 /turf/open/floor/carpet,
 /area/command/meeting_room)
 "wks" = (
-/obj/structure/table/greyscale,
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
@@ -54793,6 +54792,7 @@
 	pixel_x = 3
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/table,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "wky" = (
@@ -56906,8 +56906,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "xwa" = (
-/obj/structure/table/greyscale,
 /obj/item/clothing/mask/cigarette/cigar,
+/obj/structure/table,
 /turf/open/floor/iron/white/smooth_large,
 /area/service/kitchen/diner)
 "xwi" = (

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -198,7 +198,6 @@
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "aN" = (
-/obj/structure/table/wood/bar,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -207,6 +206,7 @@
 	dir = 9
 	},
 /obj/item/paicard,
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
 "aS" = (
@@ -662,13 +662,13 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "cz" = (
-/obj/structure/table/wood/bar,
 /obj/effect/landmark/start/hangover,
 /obj/effect/spawner/lootdrop/gambling,
 /obj/machinery/camera{
 	c_tag = "Service-Bar 2";
 	dir = 6
 	},
+/obj/structure/table/wood,
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "cA" = (
@@ -1762,13 +1762,13 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/structure/table/wood/bar,
 /obj/item/book/manual/wiki/barman_recipes{
 	pixel_x = 5;
 	pixel_y = 6
 	},
 /obj/item/reagent_containers/glass/rag,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/wood,
 /turf/open/floor/stone,
 /area/service/bar)
 "gG" = (
@@ -1843,7 +1843,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "he" = (
-/obj/structure/table/wood/bar,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -1851,6 +1850,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
 "hj" = (
@@ -2467,10 +2467,10 @@
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "kM" = (
-/obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/gambling,
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/status_display/evac/directional/west,
+/obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
 /area/service/bar/atrium)
 "kO" = (
@@ -2562,7 +2562,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "lu" = (
-/obj/structure/table/wood/bar,
 /obj/item/instrument/saxophone,
 /obj/machinery/camera{
 	c_tag = "Service-Theater";
@@ -2571,6 +2570,7 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/item/instrument/piano_synth,
+/obj/structure/table/wood,
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "lA" = (
@@ -2704,9 +2704,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
-/obj/structure/table/wood/bar,
 /obj/item/vending_refill/cigarette,
 /obj/machinery/light/small/directional/east,
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
 "mC" = (
@@ -2720,12 +2720,12 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "mF" = (
-/obj/structure/table/wood/bar,
 /obj/item/clothing/mask/fakemoustache,
 /obj/item/clothing/mask/cigarette/pipe,
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
 	},
+/obj/structure/table/wood,
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "mG" = (
@@ -3144,7 +3144,6 @@
 /turf/closed/wall,
 /area/maintenance/fore)
 "pt" = (
-/obj/structure/table/wood/bar,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -3152,6 +3151,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
 "pu" = (
@@ -3476,7 +3476,6 @@
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "rh" = (
-/obj/structure/table/wood/bar,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -3487,6 +3486,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
 "ri" = (
@@ -3805,7 +3805,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "tb" = (
-/obj/structure/table/wood/bar,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -3815,6 +3814,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
 "td" = (
@@ -4826,12 +4826,12 @@
 	},
 /area/science/xenobiology)
 "zx" = (
-/obj/structure/table/wood/bar,
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
 /obj/item/soap/nanotrasen,
 /obj/item/clothing/head/sombrero,
+/obj/structure/table/wood,
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "zA" = (
@@ -5256,7 +5256,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
-/obj/structure/table/wood/bar,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
 /obj/machinery/camera{
 	c_tag = "Service-Back Bar";
@@ -5265,6 +5264,7 @@
 /obj/machinery/requests_console/directional/east{
 	name = "Bar Requests Console"
 	},
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
 "Cr" = (
@@ -5494,8 +5494,8 @@
 /turf/open/floor/iron/white,
 /area/mine/laborcamp)
 "Dv" = (
-/obj/structure/table/wood/bar,
 /obj/effect/spawner/lootdrop/gambling,
+/obj/structure/table/wood,
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "Dy" = (
@@ -6010,8 +6010,8 @@
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "Gw" = (
-/obj/structure/table/wood/bar,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/table/wood,
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "Gy" = (
@@ -6401,7 +6401,6 @@
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "Ju" = (
-/obj/structure/table/wood/bar,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -6412,6 +6411,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
 "Jv" = (
@@ -6785,7 +6785,6 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "Lk" = (
-/obj/structure/table/wood/bar,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -6794,6 +6793,7 @@
 	dir = 8
 	},
 /mob/living/carbon/human/species/monkey/punpun,
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
 "Ls" = (
@@ -7065,12 +7065,12 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "MU" = (
-/obj/structure/table/wood/bar,
 /obj/structure/mirror/directional/west,
 /obj/item/toy/mecha/honk{
 	pixel_y = 12
 	},
 /obj/machinery/light/small/directional/west,
+/obj/structure/table/wood,
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "MV" = (
@@ -7541,7 +7541,6 @@
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
 "PF" = (
-/obj/structure/table/wood/bar,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -7549,6 +7548,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
+/obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/bar)
 "PG" = (
@@ -7853,10 +7853,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/structure/table/wood/bar,
 /obj/item/holosign_creator/robot_seat/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/table/wood,
 /turf/open/floor/stone,
 /area/service/bar)
 "RJ" = (
@@ -8252,12 +8252,12 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "TM" = (
-/obj/structure/table/wood/bar,
 /obj/item/clothing/mask/animal/pig,
 /obj/item/bikehorn,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
+/obj/structure/table/wood,
 /turf/open/floor/wood/tile,
 /area/service/theater)
 "TN" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This replaces the shuttle bar tables in the bar with regular wooden ones, to fix people getting flung off of them when they try to hop on them.

This also replaces the greyscale chairs and tables in the kitchen with regular ones, and replaces the sandstone airlock to the kitchen with a regular one.

## Why It's Good For The Game

Do i really need to explain?

## Changelog
:cl:
fix: Fixes multiple mapping errors in Ice Box's service.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
