### PR TITLE
repaths wood/bar table to wood/shuttle_bar, and small shuttle fix

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -7810,7 +7810,7 @@
 /turf/open/floor/grass,
 /area/wizard_station)
 "yM" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/structure/safe/floor,
 /obj/item/seeds/cherry/bomb,
 /turf/open/floor/wood,
@@ -14457,7 +14457,7 @@
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Tq" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/storage/toolbox/mechanical,
@@ -14497,7 +14497,7 @@
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
 "TK" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/structure/mirror/directional/north,
 /turf/open/floor/wood,
 /area/centcom/holding)

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -167,8 +167,7 @@
 /area/shuttle/escape)
 "aG" = (
 /obj/structure/chair/stool/directional/east{
-	can_buckle = 1;
-	
+	can_buckle = 1
 	},
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
@@ -224,7 +223,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "aO" = (
-/obj/structure/table/wood/bar{
+/obj/structure/table/wood/shuttle_bar{
 	boot_dir = 9
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -234,7 +233,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "aP" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -242,7 +241,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "aR" = (
-/obj/structure/table/wood/bar{
+/obj/structure/table/wood/shuttle_bar{
 	boot_dir = 8
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -307,7 +306,7 @@
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
 "ba" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/effect/spawner/lootdrop/gambling,
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
@@ -320,7 +319,7 @@
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
 "bd" = (
-/obj/structure/table/wood/bar{
+/obj/structure/table/wood/shuttle_bar{
 	boot_dir = 10
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -330,7 +329,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "be" = (
-/obj/structure/table/wood/bar{
+/obj/structure/table/wood/shuttle_bar{
 	boot_dir = 2
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -463,7 +462,7 @@
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
 "bI" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/item/instrument/guitar,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -472,7 +471,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bJ" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
@@ -483,7 +482,7 @@
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
 "bL" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
 "bM" = (
@@ -504,12 +503,12 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bO" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/item/folder/red,
 /turf/open/floor/iron/grimy,
 /area/shuttle/escape)
 "bP" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/item/toy/cards/deck/cas,
 /obj/item/toy/cards/deck/cas/black{
 	pixel_y = 6
@@ -559,7 +558,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "bV" = (
-/obj/structure/table/wood/bar{
+/obj/structure/table/wood/shuttle_bar{
 	boot_dir = 8
 	},
 /obj/effect/fun_balloon/sentience/emergency_shuttle{

--- a/_maps/shuttles/emergency_rollerdome.dmm
+++ b/_maps/shuttles/emergency_rollerdome.dmm
@@ -53,7 +53,7 @@
 /turf/open/floor/eighties,
 /area/shuttle/escape)
 "ns" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/effect/fun_balloon/sentience/emergency_shuttle{
 	group_name = "snack bar drone at Uncle Pete's Rollerdome"
 	},
@@ -111,7 +111,7 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "uN" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/item/storage/bag/tray,
 /turf/open/floor/wood,
 /area/shuttle/escape)
@@ -226,7 +226,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "Ox" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/item/pizzabox/meat,
 /obj/item/pizzabox/meat,
 /obj/item/pizzabox/meat,
@@ -285,7 +285,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "Wg" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/item/storage/bag/tray,
 /obj/item/food/cake/birthday,
 /obj/item/kitchen/knife,
@@ -299,7 +299,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "Zo" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "ZN" = (

--- a/_maps/templates/holodeck_lounge.dmm
+++ b/_maps/templates/holodeck_lounge.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/item/reagent_containers/glass/rag{
 	pixel_x = 10;
 	pixel_y = 1
@@ -30,7 +30,7 @@
 	},
 /area/template_noop)
 "d" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /turf/open/floor/holofloor{
 	dir = 9;
 	icon_state = "wood"
@@ -53,7 +53,7 @@
 /turf/open/floor/holofloor/carpet,
 /area/template_noop)
 "i" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/holofloor{
 	dir = 9;
@@ -114,7 +114,7 @@
 /turf/open/floor/holofloor/carpet,
 /area/template_noop)
 "t" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/item/book/manual/wiki/barman_recipes,
 /turf/open/floor/holofloor{
 	dir = 9;
@@ -181,7 +181,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/item/storage/box/cups,
 /turf/open/floor/holofloor{
 	dir = 9;
@@ -292,7 +292,7 @@
 	},
 /area/template_noop)
 "Y" = (
-/obj/structure/table/wood/bar,
+/obj/structure/table/wood/shuttle_bar,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -69,7 +69,7 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 			new_dpdir = new_dpdir | angle2dir(rotation+dir2angle(D))
 	dpdir = new_dpdir
 
-/obj/structure/table/wood/bar/shuttleRotate(rotation, params)
+/obj/structure/table/wood/shuttle_bar/shuttleRotate(rotation, params)
 	. = ..()
 	boot_dir = angle2dir(rotation + dir2angle(boot_dir))
 

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -189,20 +189,20 @@
 // barstaff (defined as someone who was a roundstart bartender or someone
 // with CENTCOM_BARSTAFF)
 
-/obj/structure/table/wood/bar
+/obj/structure/table/wood/shuttle_bar
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	flags_1 = NODECONSTRUCT_1
 	max_integrity = 1000
 	var/boot_dir = 1
 
-/obj/structure/table/wood/bar/Initialize(mapload, _buildstack)
+/obj/structure/table/wood/shuttle_bar/Initialize(mapload, _buildstack)
 	. = ..()
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = .proc/on_entered,
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
-/obj/structure/table/wood/bar/proc/on_entered(datum/source, atom/movable/AM)
+/obj/structure/table/wood/shuttle_bar/proc/on_entered(datum/source, atom/movable/AM)
 	SIGNAL_HANDLER
 	var/mob/living/M = AM
 	if(istype(M) && !M.incorporeal_move && !is_barstaff(M))
@@ -212,7 +212,7 @@
 		M.throw_at(throwtarget, 5, 1)
 		to_chat(M, span_notice("No climbing on the bar please."))
 
-/obj/structure/table/wood/bar/proc/is_barstaff(mob/living/user)
+/obj/structure/table/wood/shuttle_bar/proc/is_barstaff(mob/living/user)
 	. = FALSE
 	if(ishuman(user))
 		var/mob/living/carbon/human/human_user = user


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
we recently had an issue where the table/wood/bar table was used all over icebox service, because a mapper thought that was just a wood table meant for the bar, but in reality its a special indestructable, non-deconstructable table that you cant even climb on, its meant for centcom and shuttles so people cant harrass the barstaff. it was fixed already, however in order to remove future confusion it will now be pathed as shuttle_bar so you cannot mistake this as something to use outside of a shuttle (and if you do, then you should learn to read a little more critically)

also fixed an apparent error in the bar shuttle that existed somehow, namely that a chair put a ";" followed by a tab.... for no reason
![image](https://user-images.githubusercontent.com/40489693/128459052-44e3f7c1-d1f9-4a2a-924b-79d17e9dc90b.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
so mappers dont get confused about where this table is meant to be used
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
**no changelog, as this does not affect players in any way**

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
