### PR TITLE
Always draws moth antennae like they were meant to

### DIFF
--- a/code/modules/surgery/organs/external/_external_organs.dm
+++ b/code/modules/surgery/organs/external/_external_organs.dm
@@ -226,9 +226,7 @@
 	return GLOB.moth_antennae_list
 
 /obj/item/organ/external/antennae/can_draw_on_bodypart(mob/living/carbon/human/human)
-	if(!(human.head?.flags_inv & HIDEHAIR) || (human.wear_mask?.flags_inv & HIDEHAIR))
-		return TRUE
-	return FALSE
+	return TRUE
 
 ///For moth antennae and wings we make an exception. If their features are burnt, we only update our original sprite
 /obj/item/organ/external/antennae/set_sprite(sprite)

--- a/code/modules/surgery/organs/external/wings.dm
+++ b/code/modules/surgery/organs/external/wings.dm
@@ -15,7 +15,7 @@
 		return TRUE
 	return FALSE
 
-///The true wings that you can use to fly and shit (you cant actually shit with them, but it does wing stuff)
+///The true wings that you can use to fly and shit (you cant actually shit with them)
 /obj/item/organ/external/wings/functional
 	///The flight action object
 	var/datum/action/innate/flight/fly


### PR DESCRIPTION
I forgot wings were always supposed to be drawn over clothing, and then again forgot that that also included moth antennae

:cl:
fix: draws moth antennae when you're wearing helmets again (oops)
/:cl:

Obviously no GBP