### PR TITLE
Delete AutoChangeLog-pr-60733.yml

### DIFF
--- a/html/changelogs/AutoChangeLog-pr-60733.yml
+++ b/html/changelogs/AutoChangeLog-pr-60733.yml
@@ -1,5 +1,0 @@
-author: "MrStonedOne"
-delete-after: True
-changes: 
-  - rscadd: "Added new mechanics or gameplay changes"
-  - expansion: "Expands content of an existing thing"


### PR DESCRIPTION
Deletes the file named `AutoChangeLog-pr-60733.yml` for being mis-generated