### PR TITLE
Improve variable naming guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -480,8 +480,6 @@ The `SHOULD_CALL_PARENT(TRUE)` lint should be added to ensure that overrides/chi
 ### Use descriptive and obvious names
 Optimize for readability, not writability. While it is certainly easier to write `M` than `victim`, it will cause issues down the line for other developers to figure out what exactly your code is doing, even if you think the variable's purpose is obvious.
 
-#### Don't use abbreviations
-Avoid variables like C, M, and H. Prefer names like "user", "victim", "weapon", etc.
 
 ```dm
 // What is M? The user? The target?
@@ -528,26 +526,8 @@ This prevents double-negatives (such as `if (!is_not_flying)` which can make com
 
 #### Exceptions to variable names
 
-Exceptions can be made in the case of inheriting existing procs, as it makes it so you can use named parameters, but *new* variable names must follow these standards. It is also welcome, and encouraged, to refactor existing procs to use clearer variable names.
+These are not hard and fast rules, but a way to encourge readability, use of single letter variable names can be allowed, for instence, when naming numeral iterator variables `i`, or where the variables meaning is still obvious because the scope its used in is only a few lines. 
 
-Naming numeral iterator variables `i` is also allowed, but do remember to [Avoid unnecessary type checks and obscuring nulls in lists](#avoid-unnecessary-type-checks-and-obscuring-nulls-in-lists), and making more descriptive variables is always encouraged.
-
-```dm
-// Bad
-for (var/datum/reagent/R as anything in reagents)
-
-// Good
-for (var/datum/reagent/deadly_reagent as anything in reagents)
-
-// Allowed, but still has the potential to not be clear. What does `i` refer to?
-for (var/i in 1 to 12)
-
-// Better
-for (var/month in 1 to 12)
-
-// Bad, only use `i` for numeral loops
-for (var/i in reagents)
-```
 
 ### Icons are for image manipulation and defining an obj's `.icon` var, appearances are for everything else.
 BYOND will allow you to use a raw icon file or even an icon datum for underlays, overlays, and what not (you can even use strings to refer to an icon state on the current icon). The issue is these get converted by BYOND to appearances on every overlay insert or removal involving them, and this process requires inserting the new appearance into the global list of appearances, and informing clients about them.


### PR DESCRIPTION
@Rohesie do you think its possible you allowed inappropriate uses to cloud and bias your mind from non-inappropriate uses?

Or to put it another way, wouldn't it make sense that the bad uses of something don't make the non-bad uses automatically bad?

It seemed like your biggest complaint was that it was used for proc arguments and whole-proc scoped variables but then you went after 3 line typecasting out of no where.

