### PR TITLE
Spider Fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -151,6 +151,9 @@
 	if(hurt_spider.health >= hurt_spider.maxHealth)
 		to_chat(src, span_warning("You can't find any wounds to wrap up."))
 		return
+	if(hurt_spider.stat == DEAD)
+		to_chat(src, span_warning("You're a nurse, not a miracle worker."))
+		return
 	visible_message(span_notice("[src] begins wrapping the wounds of [hurt_spider]."),span_notice("You begin wrapping the wounds of [hurt_spider]."))
 	is_busy = TRUE
 	if(do_after(src, 20, target = hurt_spider))
@@ -545,12 +548,14 @@
 /datum/action/innate/spider/comm
 	name = "Command"
 	desc = "Send a command to all living spiders."
+	check_flags = AB_CHECK_CONSCIOUS
 	button_icon_state = "command"
 
 /datum/action/innate/spider/comm/IsAvailable()
-	if(!istype(owner, /mob/living/simple_animal/hostile/giant_spider/midwife))
-		return FALSE
-	return TRUE
+	if(..())
+		if(!istype(owner, /mob/living/simple_animal/hostile/giant_spider/midwife))
+			return FALSE
+		return TRUE
 
 /datum/action/innate/spider/comm/Trigger()
 	var/input = stripped_input(owner, "Input a command for your legions to follow.", "Command", "")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #60699
Makes it so midwives can no longer send commands while dead. Also makes it so nurses can't heal dead spiders, since they're dead.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dead spiders can't talk and bandaging the dead is a wasted effort.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: MMMiracles
fix: Spider midwives can no longer send commands while dead
fix: Nurse spiders can no longer heal dead spiders and get a message when trying to do so.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
