### PR TITLE
Moves the geneticist department to science

### DIFF
--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -13,7 +13,7 @@
 	outfit = /datum/outfit/job/geneticist
 	plasmaman_outfit = /datum/outfit/plasmaman/genetics
 	departments_list = list(
-		/datum/job_department/medical,
+		/datum/job_department/science,
 		)
 
 	paycheck = PAYCHECK_MEDIUM


### PR DESCRIPTION
Fixes #60769

I described on the issue the cause of this error.
Chiefly before the job refactor there were multiple lists and department references and when the change of department happened not every one of them was properly updated.
It's this kind of thing that the refactor tries to address.