### PR TITLE
Make delay circuit component behavior continuous in its input

### DIFF
--- a/code/modules/wiremod/components/utility/delay.dm
+++ b/code/modules/wiremod/components/utility/delay.dm
@@ -1,6 +1,3 @@
-/// The minimum delay value that the delay component can have.
-#define COMP_DELAY_MIN_VALUE 0.1
-
 /**
  * # Delay Component
  *
@@ -34,10 +31,5 @@
 		return
 
 	var/delay = delay_amount.input_value
-	if(delay > COMP_DELAY_MIN_VALUE)
-		// Convert delay into deciseconds
-		addtimer(CALLBACK(output, /datum/port/output.proc/set_output, trigger.input_value), delay*10)
-	else
-		output.set_output(trigger.input_value)
-
-#undef COMP_DELAY_MIN_VALUE
+	// Convert delay into deciseconds
+	addtimer(CALLBACK(output, /datum/port/output.proc/set_output, trigger.input_value), max(delay,0) * 1 SECONDS)


### PR DESCRIPTION
## About The Pull Request

Calling this component with 0.1 activated the next component after 1 decisecond, while calling it with 0.2 activated the next component after 3 deciseconds. This bumps the 1 to 2.

## Changelog
:cl:
fix: Nerfs the delay added with a 0/0.1/0.2 delay circuit component from 0.1/0.1/0.3 to 0.1/0.2/0.3.
/:cl:
