### PR TITLE
Observers can now read circuits from anywhere + fix obscure tgui bug

### DIFF
--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -58,7 +58,7 @@
 	src.interface = interface
 	if(title)
 		src.title = title
-	src.state = src_object.ui_state()
+	src.state = src_object.ui_state(user)
 	// Deprecated
 	if(ui_x && ui_y)
 		src.window_size = list(ui_x, ui_y)

--- a/code/modules/wiremod/integrated_circuit.dm
+++ b/code/modules/wiremod/integrated_circuit.dm
@@ -295,6 +295,10 @@ GLOBAL_LIST_EMPTY_TYPED(integrated_circuits, /obj/item/integrated_circuit)
 
 /obj/item/integrated_circuit/ui_status(mob/user)
 	. = ..()
+
+	if (isobserver(user))
+		. = max(., UI_UPDATE)
+
 	// Extra protection because ui_state will not close the UI if they already have the ui open,
 	// as ui_state is only set during
 	if(admin_only)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

This was necessary for admins to be able to open up circuits from anywhere. Technically freeze-breaking but the ultimate goal here is for admins to be able to open up circuits--the current circuit admin panel requires you to have AI interact or to be right next to it. The original incarnation of this was checking admin observers specifically, but this ends up being a lot easier.

Also fixes a bug where `ui_state` wasn't passing in user, despite it being in the proc definition. This doesn't end up being used here, I was planning on it.

## Changelog
:cl:
qol: Observers can now read circuits from anywhere.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
