### PR TITLE
Ships can now land on openspace

### DIFF
--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -20,7 +20,7 @@
 	var/view_range = 0
 	var/x_offset = 0
 	var/y_offset = 0
-	var/list/whitelist_turfs = list(/turf/open/space, /turf/open/floor/plating, /turf/open/lava)
+	var/list/whitelist_turfs = list(/turf/open/space, /turf/open/floor/plating, /turf/open/lava, /turf/open/openspace)
 	var/see_hidden = FALSE
 	var/designate_time = 0
 	var/turf/designating_target_loc

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -66,7 +66,7 @@
 	view_range = 5.5
 	x_offset = -7
 	y_offset = -1
-	whitelist_turfs = list(/turf/open/space, /turf/open/floor/plating, /turf/open/lava, /turf/closed/mineral)
+	whitelist_turfs = list(/turf/open/space, /turf/open/floor/plating, /turf/open/lava, /turf/closed/mineral, /turf/open/openspace)
 	see_hidden = TRUE
 
 #undef SYNDICATE_CHALLENGE_TIMER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Navigation computers in the whiteship, pirate ship, et al all rely on a whitelist of turfs to determine where/if they can arbitrarily land somewhere and not just at a docking port. The openspace turfs were not part of this whitelist previously. This leads to things like - 
![image](https://user-images.githubusercontent.com/28007787/128752396-9107fa3b-7466-44cb-bb75-b57fc734ab86.png)
Where you've clearly got enough "space" but you don't have any `space`.


## Why It's Good For The Game

Lets ships land wherever there's free openspace turf. In theory this only impacts Tram currently, but this extends to any multi-z space based map.

## Changelog
:cl:
fix: Navigation computers can now arbitrarily land on top z-level openspace.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
