### PR TITLE
Clipboard improvements and fixes

### DIFF
--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -200,12 +200,3 @@
 /obj/item/clipboard/proc/on_top_paper_change()
 	SIGNAL_HANDLER
 	update_appearance()
-
-/obj/item/clipboard/integrated
-	name = "\improper Paperwork Master's clipboard"
-	desc = "Having a pen integrated into a clipboard really streamlines a paperwork expert's job, or so they say."
-	integrated_pen = TRUE
-
-/obj/item/clipboard/integrated/Initialize()
-	pen = new /obj/item/pen
-	. = ..()

--- a/code/modules/paperwork/clipboard.dm
+++ b/code/modules/paperwork/clipboard.dm
@@ -15,6 +15,8 @@
 	resistance_flags = FLAMMABLE
 	/// The stored pen
 	var/obj/item/pen/pen
+	/// Is the pen integrated?
+	var/integrated_pen = FALSE
 	/**
 	 * Weakref of the topmost piece of paper
 	 *
@@ -38,7 +40,7 @@
 
 /obj/item/clipboard/examine()
 	. = ..()
-	if(pen)
+	if(!integrated_pen && pen)
 		. += span_notice("Alt-click to remove [pen].")
 	var/obj/item/paper/toppaper = toppaper_ref?.resolve()
 	if(toppaper)
@@ -53,6 +55,7 @@
 	to_chat(user, span_notice("You remove [paper] from [src]."))
 	var/obj/item/paper/toppaper = toppaper_ref?.resolve()
 	if(paper == toppaper)
+		UnregisterSignal(toppaper, COMSIG_ATOM_UPDATED_ICON)
 		toppaper_ref = null
 		var/obj/item/paper/newtop = locate(/obj/item/paper) in src
 		if(newtop && (newtop != paper))
@@ -71,7 +74,10 @@
 /obj/item/clipboard/AltClick(mob/user)
 	..()
 	if(pen)
-		remove_pen(user)
+		if(integrated_pen)
+			to_chat(user, span_warning("You can't seem to find a way to remove [src]'s [pen]."))
+		else
+			remove_pen(user)
 
 /obj/item/clipboard/update_overlays()
 	. = ..()
@@ -96,6 +102,9 @@
 		//Add paper into the clipboard
 		if(!user.transferItemToLoc(weapon, src))
 			return
+		if(toppaper)
+			UnregisterSignal(toppaper, COMSIG_ATOM_UPDATED_ICON)
+		RegisterSignal(weapon, COMSIG_ATOM_UPDATED_ICON, .proc/on_top_paper_change)
 		toppaper_ref = WEAKREF(weapon)
 		to_chat(user, span_notice("You clip [weapon] onto [src]."))
 	else if(istype(weapon, /obj/item/pen) && !pen)
@@ -123,6 +132,7 @@
 	// prepare data for TGUI
 	var/list/data = list()
 	data["pen"] = "[pen]"
+	data["integrated_pen"] = integrated_pen
 
 	var/obj/item/paper/toppaper = toppaper_ref?.resolve()
 	data["top_paper"] = "[toppaper]"
@@ -150,7 +160,10 @@
 		// Take the pen out
 		if("remove_pen")
 			if(pen)
-				remove_pen(usr)
+				if(!integrated_pen)
+					remove_pen(usr)
+				else
+					to_chat(usr, span_warning("You can't seem to find a way to remove [src]'s [pen]."))
 				. = TRUE
 		// Take paper out
 		if("remove_paper")
@@ -180,3 +193,19 @@
 				paper.rename()
 				update_icon()
 				. = TRUE
+
+/**
+ * This is a simple proc to handle calling update_icon() upon receiving the top paper's `COMSIG_ATOM_UPDATE_APPEARANCE`.
+ */
+/obj/item/clipboard/proc/on_top_paper_change()
+	SIGNAL_HANDLER
+	update_appearance()
+
+/obj/item/clipboard/integrated
+	name = "\improper Paperwork Master's clipboard"
+	desc = "Having a pen integrated into a clipboard really streamlines a paperwork expert's job, or so they say."
+	integrated_pen = TRUE
+
+/obj/item/clipboard/integrated/Initialize()
+	pen = new /obj/item/pen
+	. = ..()

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -258,7 +258,9 @@
 	// Use a clipboard's pen, if applicable
 	if(istype(loc, /obj/item/clipboard))
 		var/obj/item/clipboard/clipboard = loc
-		if(clipboard.pen)
+		// This is just so you can still use a stamp if you're holding one. Otherwise, it'll
+		// use the clipboard's pen, if applicable.
+		if(!istype(holding, /obj/item/stamp) && clipboard.pen)
 			holding = clipboard.pen
 	if(istype(holding, /obj/item/toy/crayon))
 		var/obj/item/toy/crayon/PEN = holding
@@ -326,6 +328,7 @@
 					stampoverlay.pixel_y = rand(-3, 2)
 					add_overlay(stampoverlay)
 					LAZYADD(stamped, stamp_icon_state)
+					update_icon()
 
 				update_static_data(usr,ui)
 				var/obj/O = ui.user.get_active_held_item()

--- a/tgui/packages/tgui/interfaces/Clipboard.js
+++ b/tgui/packages/tgui/interfaces/Clipboard.js
@@ -11,7 +11,8 @@ import { Window } from "../layouts";
 
 export const Clipboard = (props, context) => {
   const { act, data } = useBackend(context);
-  const { pen, top_paper, top_paper_ref, paper, paper_ref } = data;
+  const { pen, integrated_pen, top_paper, top_paper_ref, paper, paper_ref }
+    = data;
   return (
     <Window title="Clipboard" width={400} height={500}>
       <Window.Content backgroundColor="#704D25" scrollable>
@@ -27,11 +28,15 @@ export const Clipboard = (props, context) => {
                 {pen}
               </LabeledList.Item>
             </LabeledList>
+          ) : (integrated_pen ? (
+            <Box color="white" align="center">
+              There is a pen integrated into the clipboard&apos;s clip.
+            </Box>
           ) : (
             <Box color="white" align="center">
               No pen attached!
             </Box>
-          )}
+          ))}
         </Section>
         <Divider />
         {top_paper ? (

--- a/tgui/packages/tgui/interfaces/Clipboard.js
+++ b/tgui/packages/tgui/interfaces/Clipboard.js
@@ -11,8 +11,14 @@ import { Window } from "../layouts";
 
 export const Clipboard = (props, context) => {
   const { act, data } = useBackend(context);
-  const { pen, integrated_pen, top_paper, top_paper_ref, paper, paper_ref }
-    = data;
+  const {
+    pen,
+    integrated_pen,
+    top_paper,
+    top_paper_ref,
+    paper,
+    paper_ref,
+  } = data;
   return (
     <Window title="Clipboard" width={400} height={500}>
       <Window.Content backgroundColor="#704D25" scrollable>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Clipboards will now update their appearance in real-time when the paper on it is edited, instead of waiting to be interacted with again first.
Paper that's on a clipboard can now be stamped when there's a pen on the clipboard and takes priority over the pen. If you drop the stamp or switch hands, it'll go back to using the pen.
Clipboards now have code to support having a pen that can't be removed from the clipboard, through the use of a simple boolean.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improvements to the code of clipboards, while also fixing a bug that would prevent you to use stamps on the paper that's on it, and it finally is on par with paper updating its appearance in real time.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: GoldenAlpharex
fix: Paper that's on a clipboard doesn't need to be poked to realise that its appearance has changed and to properly display it on a clipboard.
fix: You finally figured that using a stamp on a clipboard was more important than using the pen that's currently attached to it. Congratulations!
code: Added support for preventing a pen from being removed from a clipboard.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
