### PR TITLE
Fixes solar stacking

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -239,6 +239,7 @@
 	randomise_offset(anchored ? 0 : random_offset)
 
 /obj/item/solar_assembly/attackby(obj/item/W, mob/user, params)
+	var/turf/solarturf = get_turf(src)
 	if(W.tool_behaviour == TOOL_WRENCH && isturf(loc))
 		if(isinspace())
 			to_chat(user, span_warning("You can't secure [src] here."))
@@ -252,6 +253,10 @@
 		if(!anchored)
 			to_chat(user, span_warning("You need to secure the assembly before you can add glass."))
 			return
+		for(var/obj/anchorcheck in solarturf.contents)
+			if(istype(anchorcheck, /obj/machinery/power/solar))
+				to_chat(user, span_warning("[anchorcheck] is already assembled here."))
+				return
 		var/obj/item/stack/sheet/S = W
 		if(S.use(2))
 			glass_type = W.type

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -239,7 +239,6 @@
 	randomise_offset(anchored ? 0 : random_offset)
 
 /obj/item/solar_assembly/attackby(obj/item/W, mob/user, params)
-	var/turf/solarturf = get_turf(src)
 	if(W.tool_behaviour == TOOL_WRENCH && isturf(loc))
 		if(isinspace())
 			to_chat(user, span_warning("You can't secure [src] here."))
@@ -253,10 +252,10 @@
 		if(!anchored)
 			to_chat(user, span_warning("You need to secure the assembly before you can add glass."))
 			return
-		for(var/obj/anchorcheck in solarturf.contents)
-			if(istype(anchorcheck, /obj/machinery/power/solar))
-				to_chat(user, span_warning("[anchorcheck] is already assembled here."))
-				return
+		var/turf/solarturf = get_turf(src)
+		if(locate(/obj/machinery/power/solar) in solarturf)
+			to_chat(user, span_warning("A solar panel is already assembled here."))
+			return
 		var/obj/item/stack/sheet/S = W
 		if(S.use(2))
 			glass_type = W.type


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a check when applying glass to solar assemblies to see if a solar panel already exists on that turf so you can't stack them anymore.

Fixes #60565
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Infinitely stackable solar sounds bad for the already poor power balance.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: MMMiracles
fix: Solar assemblies can no longer be built on top of existing solar panels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
