### PR TITLE
Stringify objects passed to url_encode and decode

### DIFF
--- a/code/__DEFINES/rust_g_overrides.dm
+++ b/code/__DEFINES/rust_g_overrides.dm
@@ -1,3 +1,3 @@
 // RUSTG_OVERRIDE_BUILTINS is not used since the file APIs don't work well over Linux.
-#define url_encode(text) rustg_url_encode(text)
-#define url_decode(text) rustg_url_decode(text)
+#define url_encode(text) rustg_url_encode("[text]")
+#define url_decode(text) rustg_url_decode("[text]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Automatically stringify all objects (stuff like type paths) passed to url_encode and url_decode since rustg can only take strings.
Not doing this can/will result in bugs like #60801 where type paths are still passed
These cases should probably be fixed but its still a good idea to at least try to fix wrong uses
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Passing non strings to url_encode tries to automatically convert them to strings which might prevent some issues of old code passing stuff like type paths

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Gamer025
code: url_encode and decode now try to stringify inputs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
