### PR TITLE
Fixes shotgun meteorslugs not displacing airlocks

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -55,7 +55,7 @@
 	if(ismovable(target))
 		var/atom/movable/M = target
 		var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
-		M.safe_throw_at(throw_target, 3, 2)
+		M.safe_throw_at(throw_target, 3, 2, force = MOVE_FORCE_EXTREMELY_STRONG)
 
 /obj/projectile/bullet/shotgun_meteorslug/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives meteorslugs `MOVE_FORCE_EXTREMELY_STRONG` force.

Turns out `safe_throw_at` was created to fix "situations involving mechas and the clock cult, and meteor slugs moving grav gen" (rip clock clut) and then later some force checks were added that made some movables resist meteorslugs with default force like airlocks. 

Fixes: #45831 thanks to [issue roulette](https://issue-roulette.vercel.app/)

## Why It's Good For The Game

Fix good.

## Changelog
:cl:
fix: Fixed shotgun meteorslugs not displacing airlocks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
