### PR TITLE
Fixes TP assigned_role change, adds safety check

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -239,6 +239,7 @@ GLOBAL_LIST_INIT(book_types, typecacheof(list(
 
 
 // Jobs
+#define is_job(job_type)  (istype(job_type, /datum/job))
 #define is_assistant_job(job_type) (istype(job_type, /datum/job/assistant))
 #define is_bartender_job(job_type) (istype(job_type, /datum/job/bartender))
 #define is_captain_job(job_type) (istype(job_type, /datum/job/captain))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -102,6 +102,18 @@
 	set_current(null)
 	return ..()
 
+
+/datum/mind/vv_edit_var(var_name, var_value)
+	switch(var_name)
+		if(NAMEOF(src, assigned_role))
+			set_assigned_role(var_value)
+			. = TRUE
+	if(!isnull(.))
+		datum_flags |= DF_VAR_EDITED
+		return
+	return ..()
+
+
 /datum/mind/proc/set_current(mob/new_current)
 	if(new_current && QDELETED(new_current))
 		CRASH("Tried to set a mind's current var to a qdeleted mob, what the fuck")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -513,7 +513,7 @@
 		if (!new_job)
 			to_chat(usr, span_warning("Job not found."))
 			return
-		set_assigned_role(new_role)
+		set_assigned_role(new_job)
 
 	else if (href_list["memory_edit"])
 		var/new_memo = stripped_multiline_input(usr, "Write new memory", "Memory", memory, MAX_MESSAGE_LEN)
@@ -826,6 +826,8 @@
 /datum/mind/proc/set_assigned_role(datum/job/new_role)
 	if(assigned_role == new_role)
 		return
+	if(!is_job(new_role))
+		CRASH("set_assigned_role called with invalid role: [isnull(new_role) ? "null" : new_role]")
 	. = assigned_role
 	assigned_role = new_role
 


### PR DESCRIPTION
* This error broke the Traitor Panel by generating a runtime, fixed here.
* Added a check in case something else tries to change the variable to use an invalid value, so we know about it.
* Added VV editing protection.