### PR TITLE
Fixes joining the game with the wrong dir

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -664,15 +664,15 @@ SUBSYSTEM_DEF(job)
 	newjob.spawn_positions = J.spawn_positions
 	newjob.current_positions = J.current_positions
 
-/atom/proc/JoinPlayerHere(mob/M, buckle)
+/atom/proc/JoinPlayerHere(mob/joining_mob, buckle)
 	// By default, just place the mob on the same turf as the marker or whatever.
-	M.forceMove(get_turf(src))
+	joining_mob.forceMove(get_turf(src))
 
-/obj/structure/chair/JoinPlayerHere(mob/M, buckle)
+/obj/structure/chair/JoinPlayerHere(mob/joining_mob, buckle)
+	. = ..()
 	// Placing a mob in a chair will attempt to buckle it, or else fall back to default.
-	if (buckle && isliving(M) && buckle_mob(M, FALSE, FALSE))
-		return
-	..()
+	if(buckle && isliving(joining_mob))
+		buckle_mob(joining_mob, FALSE, FALSE)
 
 /datum/controller/subsystem/job/proc/SendToLateJoin(mob/M, buckle = TRUE)
 	var/atom/destination

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -111,12 +111,12 @@
 	if(!length(buckled_mobs))
 		RegisterSignal(src, COMSIG_MOVABLE_SET_ANCHORED, .proc/on_set_anchored)
 	M.set_buckled(src)
-	M.setDir(dir)
 	buckled_mobs |= M
 	M.throw_alert("buckled", /atom/movable/screen/alert/buckled)
 	M.set_glide_size(glide_size)
 
 	M.Move(loc)
+	M.setDir(dir)
 
 	post_buckle_mob(M)
 

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -490,19 +490,19 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	if(spawned_carbon.head)
 		return
 
-/obj/effect/landmark/start/hangover/JoinPlayerHere(mob/M, buckle)
+/obj/effect/landmark/start/hangover/JoinPlayerHere(mob/joining_mob, buckle)
 	. = ..()
-	make_hungover(M)
+	make_hungover(joining_mob)
 
 /obj/effect/landmark/start/hangover/closet
 	name = "hangover spawn closet"
 	icon_state = "hangover_spawn_closet"
 
-/obj/effect/landmark/start/hangover/closet/JoinPlayerHere(mob/M, buckle)
-	make_hungover(M)
+/obj/effect/landmark/start/hangover/closet/JoinPlayerHere(mob/joining_mob, buckle)
+	make_hungover(joining_mob)
 	for(var/obj/structure/closet/closet in contents)
 		if(closet.opened)
 			continue
-		M.forceMove(closet)
+		joining_mob.forceMove(closet)
 		return
-	..() //Call parent as fallback
+	return ..() //Call parent as fallback


### PR DESCRIPTION
* The issue was a precedence one in the chair buckling. When spawning on a (shuttle) chair, it would buckle the mob and move it to the turf, changing its direction to a diagonal one. The solution is to first move to the turf and then attempt buckling.
* Improved a variable name a little.
* Fixes the more general issue of buckling moving the buckling mob after setting the dir, instead of before (the dir will change on the move proc as well).

## Changelog
:cl:
fix: Buckling to nearby objects and roundstart shuttle buckling now result in the proper facing direction.
/:cl: