### PR TITLE
The nuke disk is hard to steal

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -70,7 +70,7 @@
 /datum/objective_item/steal/nukedisc
 	name = "the nuclear authentication disk."
 	targetitem = /obj/item/disk/nuclear
-	difficulty = 5
+	difficulty = 20 //Entire elite syndicate strike teams have trouble with this one!
 	excludefromjob = list("Captain")
 
 /datum/objective_item/steal/nukedisc/check_special_completion(obj/item/disk/nuclear/N)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives the nuke disk a higher difficulty weight for steal objectives

## Why It's Good For The Game

-The nuke disk is an item made exceedingly important to be secured as soon as possible, in someone's (likely command/security) direct possession, and mobile at all times.
-Two station-side pinpointers (including one for the Head of Security) exist to track this at all times, meaning you will also have to steal them in addition (or kill their holders / fight all of security)
-We have an entire game mode centered around stealing this item, which might ALSO be in play and potentially trying to get you killed and further promoting how important it is for crew to secure it.

It's probably harder to steal than the hand tele

## Changelog
Exceedingly minor change unlikely to be player-facing