### PR TITLE
Upgrade rustg to 0.4.10

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -8,7 +8,7 @@ export BYOND_MAJOR=514
 export BYOND_MINOR=1556
 
 #rust_g git tag
-export RUST_G_VERSION=0.4.9
+export RUST_G_VERSION=0.4.10
 
 #node version
 export NODE_VERSION=12


### PR DESCRIPTION
Needed so I can make tgs compiles follow the repo version again. (this fixes an issue compiling on latest rust)