### PR TITLE
Your Biggest Fan

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -236,6 +236,7 @@
 	name = "Labor Camp Shuttle Security Airlock";
 	req_access_txt = "2"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "bc" = (
@@ -349,6 +350,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Prisoner Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "by" = (
@@ -530,6 +532,7 @@
 	opacity = 0;
 	req_access_txt = "54"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/eva)
 "bY" = (
@@ -1848,6 +1851,7 @@
 	req_access_txt = "2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "gT" = (
@@ -3883,6 +3887,7 @@
 	opacity = 0
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/production)
 "sM" = (
@@ -4100,6 +4105,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Public Mining Storage"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "ub" = (
@@ -4334,6 +4340,7 @@
 	name = "Labor Camp External Airlock";
 	opacity = 0
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "vx" = (
@@ -4905,6 +4912,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/production)
 "zq" = (
@@ -9009,6 +9017,7 @@
 	opacity = 0;
 	req_access_txt = "54"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/eva)
 "WG" = (
@@ -9379,6 +9388,7 @@
 	name = "Labor Camp Shuttle Prisoner Airlock"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "Zf" = (

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Below.dmm
@@ -57,6 +57,7 @@
 /area/mine/eva)
 "m" = (
 /obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/eva)
 "n" = (

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -258,6 +258,7 @@
 	name = "Labor Camp Shuttle Security Airlock";
 	req_access_txt = "2"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "aZ" = (
@@ -436,6 +437,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Prisoner Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "by" = (
@@ -616,6 +618,7 @@
 	opacity = 0;
 	req_access_txt = "54"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/eva)
 "bY" = (
@@ -685,6 +688,7 @@
 	name = "Mining Shuttle Airlock";
 	opacity = 0
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/production)
 "ck" = (
@@ -3380,6 +3384,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Lavaland Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "oO" = (
@@ -3586,6 +3591,7 @@
 	name = "Labor Camp External Airlock";
 	opacity = 0
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "ss" = (
@@ -3615,6 +3621,7 @@
 	opacity = 0
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/production)
 "sK" = (
@@ -3879,6 +3886,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/production)
 "zo" = (
@@ -4775,6 +4783,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Lavaland Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "UV" = (
@@ -4877,6 +4886,7 @@
 	req_access_txt = "2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "WC" = (
@@ -4887,6 +4897,7 @@
 	name = "Labor Camp Shuttle Prisoner Airlock"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "WD" = (
@@ -4899,6 +4910,7 @@
 	opacity = 0;
 	req_access_txt = "54"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/eva)
 "WE" = (
@@ -4910,6 +4922,7 @@
 	name = "Mining Shuttle Airlock";
 	opacity = 0
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/mine/production)
 "Xb" = (


### PR DESCRIPTION

## About The Pull Request
Adds fans to the airlocks on the mining maps. Because why shouldn't they be there? This effects Lavaland, Icebox above, Icebox below, and the gulags on those Zlevels. 

## Why It's Good For The Game
Miners can no longer accidentally vent out the entire mining base because they left the airlocks open, it also wont slowly happen as they enter and exit the base. By extension, items being dragged will not get sucked out of miner's hands, and miners can stand ON the external door without getting sucked out.

## Changelog
:cl:
add: Adds tiny fans to mining levels
/:cl:
