### PR TITLE
Fixes a minor client disconnection runtime

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -6,15 +6,16 @@
 /proc/is_banned_from(player_ckey, list/roles)
 	if(!player_ckey)
 		return
-	var/client/C = GLOB.directory[player_ckey]
-	if(C)
-		if(!C.ban_cache)
-			build_ban_cache(C)
+	var/client/player_client = GLOB.directory[player_ckey]
+	if(player_client)
+		var/list/ban_cache = player_client.ban_cache || build_ban_cache(player_client)
+		if(!islist(ban_cache))
+			return // Disconnected while building the list.
 		if(islist(roles))
-			for(var/R in roles)
-				if(R in C.ban_cache)
+			for(var/role in roles)
+				if(role in ban_cache)
 					return TRUE //they're banned from at least one role, no need to keep checking
-		else if(roles in C.ban_cache)
+		else if(roles in ban_cache)
 			return TRUE
 	else
 		var/values = list(
@@ -82,26 +83,34 @@
 		. += list(list("id" = query_check_ban.item[1], "bantime" = query_check_ban.item[2], "round_id" = query_check_ban.item[3], "expiration_time" = query_check_ban.item[4], "duration" = query_check_ban.item[5], "applies_to_admins" = query_check_ban.item[6], "reason" = query_check_ban.item[7], "key" = query_check_ban.item[8], "ip" = query_check_ban.item[9], "computerid" = query_check_ban.item[10], "admin_key" = query_check_ban.item[11]))
 	qdel(query_check_ban)
 
-/proc/build_ban_cache(client/C)
+
+/proc/build_ban_cache(client/player_client)
 	if(!SSdbcore.Connect())
 		return
-	if(C && istype(C))
-		C.ban_cache = list()
-		var/is_admin = FALSE
-		if(GLOB.admin_datums[C.ckey] || GLOB.deadmins[C.ckey])
-			is_admin = TRUE
-		var/datum/db_query/query_build_ban_cache = SSdbcore.NewQuery(
-			"SELECT role, applies_to_admins FROM [format_table_name("ban")] WHERE ckey = :ckey AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())",
-			list("ckey" = C.ckey)
-		)
-		if(!query_build_ban_cache.warn_execute())
-			qdel(query_build_ban_cache)
-			return
-		while(query_build_ban_cache.NextRow())
-			if(is_admin && !text2num(query_build_ban_cache.item[2]))
-				continue
-			C.ban_cache[query_build_ban_cache.item[1]] = TRUE
+	if(QDELETED(player_client))
+		return
+	var/ckey = player_client.ckey
+	var/list/ban_cache = list()
+	var/is_admin = FALSE
+	if(GLOB.admin_datums[ckey] || GLOB.deadmins[ckey])
+		is_admin = TRUE
+	var/datum/db_query/query_build_ban_cache = SSdbcore.NewQuery(
+		"SELECT role, applies_to_admins FROM [format_table_name("ban")] WHERE ckey = :ckey AND unbanned_datetime IS NULL AND (expiration_time IS NULL OR expiration_time > NOW())",
+		list("ckey" = ckey)
+	)
+	if(!query_build_ban_cache.warn_execute())
 		qdel(query_build_ban_cache)
+		return
+	while(query_build_ban_cache.NextRow())
+		if(is_admin && !text2num(query_build_ban_cache.item[2]))
+			continue
+		ban_cache[query_build_ban_cache.item[1]] = TRUE
+	qdel(query_build_ban_cache)
+	if(QDELETED(player_client)) // Disconnected while working with the DB.
+		return
+	player_client.ban_cache = ban_cache
+	return ban_cache
+
 
 /datum/admins/proc/ban_panel(player_key, player_ip, player_cid, role, duration = 1440, applies_to_admins, reason, edit_id, page, admin_key)
 	var/panel_height = 620


### PR DESCRIPTION
Runtime:
```
[2021-08-12 22:45:19.743] runtime error: Cannot read null.ban_cache
 - proc name: is banned from (/proc/is_banned_from)
 -   source file: sql_ban_system.dm,15
 -   usr: (src)
 -   src: null
 -   call stack:
 - is banned from("alysiah", /list (/list))
 - Ticker (/datum/controller/subsystem/ticker): equip characters()
 - Ticker (/datum/controller/subsystem/ticker): setup()
 - Ticker (/datum/controller/subsystem/ticker): fire(0)
 - Ticker (/datum/controller/subsystem/ticker): ignite(0)
```

This happened because clients are incredibly fickle and may disappear at any time.
In this case searching for the DB took long enough to cause this.
Improved a little code around it, in the process.