### PR TITLE
Fixes right click on circuit controller

### DIFF
--- a/code/modules/wiremod/shell/controller.dm
+++ b/code/modules/wiremod/shell/controller.dm
@@ -43,12 +43,12 @@
 /obj/item/circuit_component/controller/register_shell(atom/movable/shell)
 	RegisterSignal(shell, COMSIG_ITEM_ATTACK_SELF, .proc/send_trigger)
 	RegisterSignal(shell, COMSIG_CLICK_ALT, .proc/send_alternate_signal)
-	RegisterSignal(shell, COMSIG_ATOM_ATTACK_HAND_SECONDARY, .proc/send_right_signal)
+	RegisterSignal(shell, COMSIG_ITEM_ATTACK_SELF_SECONDARY, .proc/send_right_signal)
 
 /obj/item/circuit_component/controller/unregister_shell(atom/movable/shell)
 	UnregisterSignal(shell, list(
 		COMSIG_ITEM_ATTACK_SELF,
-		COMSIG_ATOM_ATTACK_HAND_SECONDARY,
+		COMSIG_ITEM_ATTACK_SELF_SECONDARY,
 		COMSIG_CLICK_ALT,
 	))
 

--- a/code/modules/wiremod/shell/controller.dm
+++ b/code/modules/wiremod/shell/controller.dm
@@ -53,7 +53,7 @@
 	))
 
 /**
- * Called when the shell item is used in hand, including right click.
+ * Called when the shell item is used in hand(Left click or Z by default)
  */
 /obj/item/circuit_component/controller/proc/send_trigger(atom/source, mob/user)
 	SIGNAL_HANDLER
@@ -76,6 +76,9 @@
 	entity.set_output(user)
 	alt.set_output(COMPONENT_SIGNAL)
 
+/**
+ * Called when the shell item is right-clicked in active hand
+ */
 /obj/item/circuit_component/controller/proc/send_right_signal(atom/source, mob/user)
 	SIGNAL_HANDLER
 	if(!user.Adjacent(source))

--- a/code/modules/wiremod/shell/controller.dm
+++ b/code/modules/wiremod/shell/controller.dm
@@ -53,7 +53,7 @@
 	))
 
 /**
- * Called when the shell item is used in hand(Left click or Z by default)
+ * Called when the shell item is used in hand
  */
 /obj/item/circuit_component/controller/proc/send_trigger(atom/source, mob/user)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now it properly using a right signal. Before it was using signal for right click when not in active hand. Also adds comment on proc. thanks to anturk for actual fix and gurkenglas for explanation
closes: https://github.com/tgstation/tgstation/issues/59844

## Why It's Good For The Game

fixes

## Changelog
:cl: Colovorat
fix: Controller shell extra button now works properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
