### PR TITLE
Fixes cables merging

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -422,7 +422,7 @@
 /obj/item/stack/proc/can_merge(obj/item/stack/check)
 	if(!istype(check, merge_type))
 		return FALSE
-	if(mats_per_unit != check.mats_per_unit)
+	if((mats_per_unit != check.mats_per_unit) && is_cyborg)
 		return FALSE
 	if(is_cyborg) // No merging cyborg stacks into other stacks
 		return FALSE

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -422,7 +422,7 @@
 /obj/item/stack/proc/can_merge(obj/item/stack/check)
 	if(!istype(check, merge_type))
 		return FALSE
-	if((mats_per_unit != check.mats_per_unit) && is_cyborg)
+	if(mats_per_unit != check.mats_per_unit)
 		return FALSE
 	if(is_cyborg) // No merging cyborg stacks into other stacks
 		return FALSE

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -80,7 +80,6 @@
 		var/obj/item/I = new path(get_turf(src))
 		if(efficient_with(I.type))
 			I.material_flags |= MATERIAL_NO_EFFECTS //Find a better way to do this.
-			I.set_custom_materials(matlist)
 	SSblackbox.record_feedback("nested tally", "item_printed", amount, list("[type]", "[path]"))
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fix to cable merging between autolathe printed ones and protolathe ones
closes: https://github.com/tgstation/tgstation/issues/60825

## Why It's Good For The Game

fixes :)

## Changelog
:cl: Colovorat
fix: Cable coils from autolathe and protolathe should merge just fine now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
