### PR TITLE
Cyborg emergency reboot module now is no longer dropped if revive is succesful

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -72,6 +72,7 @@
 	R.revive(full_heal = FALSE, admin_revive = FALSE)
 	R.logevent("WARN -- System recovered from unexpected shutdown.")
 	R.logevent("System brought online.")
+	return TRUE
 
 /obj/item/borg/upgrade/disablercooler
 	name = "cyborg rapid disabler cooling module"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

closes: https://github.com/tgstation/tgstation/issues/50198

## Why It's Good For The Game

sadly it's not a feature

## Changelog
:cl: Colovorat
fix: Cyborg emergency reboot module now is no longer dropped if revive is succesful
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
