### PR TITLE
Removes a source of nonexistent parent pipenets during update

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -339,10 +339,7 @@ SUBSYSTEM_DEF(air)
 			currentrun.len--
 			if (!remake)
 				continue
-			var/list/targets = remake.get_rebuild_targets()
-			remake.rebuilding = FALSE //It's allowed to renter the queue now
-			for(var/datum/pipeline/build_off as anything in targets)
-				build_off.build_pipeline(remake) //This'll add to the expansion queue
+			remake.rebuild_pipes()
 			if (MC_TICK_CHECK)
 				return
 

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -111,7 +111,7 @@
 	var/list/targets = get_rebuild_targets()
 	rebuilding = FALSE
 	for(var/datum/pipeline/build_off as anything in targets)
-		build_off.build_pipeline(remake)
+		build_off.build_pipeline(src)
 
 /**
  * Returns a list of new pipelines that need to be built up

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -105,6 +105,14 @@
 /obj/machinery/atmospherics/proc/destroy_network()
 	return
 
+/// This should only be called by SSair as part of the rebuild queue.
+/// Handles rebuilding pipelines after init or they've been changed.
+/obj/machinery/atmospherics/proc/rebuild_pipes()
+	var/list/targets = get_rebuild_targets()
+	rebuilding = FALSE
+	for(var/datum/pipeline/build_off as anything in targets)
+		build_off.build_pipeline(remake)
+
 /**
  * Returns a list of new pipelines that need to be built up
  */

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -111,7 +111,7 @@
 	var/list/targets = get_rebuild_targets()
 	rebuilding = FALSE
 	for(var/datum/pipeline/build_off as anything in targets)
-		build_off.build_pipeline(src)
+		build_off.build_pipeline(src) //This'll add to the expansion queue
 
 /**
  * Returns a list of new pipelines that need to be built up

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -11,6 +11,8 @@
 	var/shift_underlay_only = TRUE
 	///Stores the component pipeline
 	var/list/datum/pipeline/parents
+	///If this is queued for a rebuild this var signifies whether parents should be updated after it's done
+	var/update_parents_after_rebuild = FALSE
 	///Stores the component gas mixture
 	var/list/datum/gas_mixture/airs
 	///Handles whether the custom reconcilation handling should be used
@@ -97,6 +99,11 @@
 /obj/machinery/atmospherics/components/on_construction()
 	. = ..()
 	update_parents()
+
+/obj/machinery/atmospherics/components/rebuild_pipes()
+	. = ..()
+	if(update_parents_after_rebuild)
+		update_parents()
 
 /obj/machinery/atmospherics/components/get_rebuild_targets()
 	var/list/to_return = list()
@@ -191,6 +198,9 @@
  */
 /obj/machinery/atmospherics/components/proc/update_parents()
 	if(!SSair.initialized)
+		return
+	if(rebuilding)
+		update_parents_after_rebuild = TRUE
 		return
 	for(var/i in 1 to device_type)
 		var/datum/pipeline/parent = parents[i]


### PR DESCRIPTION
Shouldn't have any visible effects. Atmos machines would occasionally complain about parent pipenets not existing during an update and this should resolve a category of those kinds of warning.