### PR TITLE
Fixes the new action's permissions

### DIFF
--- a/.github/workflows/pr_emoji.yml
+++ b/.github/workflows/pr_emoji.yml
@@ -1,6 +1,6 @@
 name: PR emoji stripper
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 permissions:

--- a/.github/workflows/pr_emoji.yml
+++ b/.github/workflows/pr_emoji.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, edited]
 
+permissions:
+  pull-requests: write
+
 jobs:
   title_and_changelog:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr_emoji.yml
+++ b/.github/workflows/pr_emoji.yml
@@ -10,7 +10,7 @@ jobs:
   title_and_changelog:
     runs-on: ubuntu-20.04
     steps:
-    - uses: Wayland-Smithy/emoji-stripper-action@866e68ed5f20498ada6e9cc2e0708c81fc72f6c4
+    - uses: Wayland-Smithy/emoji-stripper-action@8f4c2fe9748bb9b02f105be4e72a1a42b0f34d84
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         title: true


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It turns out there is another layer of fun when it comes to workflow actions. The more you know.

Adds the necessary YAML overrides for use in a restrictive default environment https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token

Fixes this with any luck
![image](https://user-images.githubusercontent.com/64715958/129455549-02c31447-6e79-41bd-afe8-6d725e57cf26.png)

## Changelog
🥇