### PR TITLE
Fixes the queen bee spawn on icebox botany.

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -8967,8 +8967,8 @@
 /obj/item/clothing/suit/hooded/bee_costume,
 /obj/item/clothing/head/beekeeper_head,
 /obj/item/clothing/head/hooded/bee_hood,
-/obj/item/queen_bee,
 /obj/item/melee/flyswatter,
+/obj/item/queen_bee/bought,
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "Wt" = (


### PR DESCRIPTION
## About The Pull Request
The queen bee on icebox at round start isn't the correct one! It doesn't take reagents, and it de-spawns when you place it in an apiary. This PR replaces it with a working queen bee.

## Why It's Good For The Game
Botany needs bees, stops two runtime errors:"cannot null.assign reagents" and " beebox.dm Cannot axecute null.foreceMove" from the faulty bee by outright replacing it.

## Changelog
:cl:
fix: fixed a broken bee in botany.
/:cl:
