### PR TITLE
Fixes the pitchfok nullrod inhands not appearing

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -684,7 +684,7 @@
 	name = "unholy pitchfork"
 	desc = "Holding this makes you look absolutely devilish."
 	icon_state = "pitchfork0"
-	worn_icon_state = "pitchfork0"
+	inhand_icon_state = "pitchfork0"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	worn_icon_state = "pitchfork0"


### PR DESCRIPTION
## About The Pull Request

Fixes #60828 
There was a one word typo. The inhands state was never defined.

## Why It's Good For The Game

Chaplains can now use the unholy pitchfork with working in-hand sprites.

## Changelog
:cl:
fix: Defined the in-hand state for the chaplains' unholy pitchfork. The in-hand sprites will now actually appear. 
/:cl: