### PR TITLE
Fixes the missing length of cable in the tramstation kitchen + adds missing salt and pepper shakers

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -42617,6 +42617,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "mDg" = (
@@ -62709,6 +62710,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"ucr" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/diner)
 "ucs" = (
 /obj/machinery/door/airlock{
 	id_tag = "commissarydoor";
@@ -67877,6 +67888,26 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"vYt" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/turf/open/floor/iron,
+/area/service/kitchen)
 "vYP" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Turbine Access";
@@ -160527,7 +160558,7 @@ aGY
 uKU
 uMr
 nLg
-xzW
+ucr
 xlh
 uDS
 ahY
@@ -161547,7 +161578,7 @@ eKG
 mQU
 xoX
 lJi
-qiH
+vYt
 bHJ
 xkd
 axa
@@ -162583,7 +162614,7 @@ aGY
 eNi
 gSs
 cPk
-xzW
+ucr
 iVp
 rpR
 nMb


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds a missing length of cable to the kitchen as well as adds the absent salt and pepper shakers usually found in every kitchen.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes #60858
## Changelog
:cl:PotatoMasher
fix: Added a missing length of cable to the tramstation kitchen, as well as the absent salt/pepper shakers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
