### PR TITLE
Fixes the Deltastation Engineering console being wired to the wrong powernet

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -16619,6 +16619,7 @@
 "chI" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "chK" = (
@@ -64482,7 +64483,6 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -100404,6 +100404,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"uOl" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/engineering/main)
 "uOw" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -140565,7 +140569,7 @@ bQg
 tXV
 tXV
 tXV
-tXV
+uOl
 tXV
 caE
 ign


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
On Deltastation, the Engineering Modular Console housed inside the SMES room wasn't actually hooked up to the right powernet (hooked to the SME output rather than the actual station grid) so none of the APCs were ever listed in the Ampcheck program. This PR rewires the console to the station grid similarly to other stations.

EDIT: For clarity, this PR runs the cable under the wall out to the station grid in maint just to the right of the SMES room. Meta does this in the exact same way, and (ice)Box has something similar going on.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes #60822
## Changelog
:cl:PotatoMasher
fix: Fixes the Deltastation Engineering console being wired to the wrong powernet, allowing the Ampcheck program to function as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
