### PR TITLE
Extends suspicious login logging to players with a banned account in their connection history.

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -115,13 +115,14 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
  * Writes to a special log file if the log_suspicious_login config flag is set,
  * which is intended to contain all logins that failed under suspicious circumstances.
  *
- * Mirrors this log entry to log_access as well, so this proc doesn't need to be used
- * alongside log_access and can replace it where appropriate.
+ * Mirrors this log entry to log_access when access_log_mirror is TRUE, so this proc
+ * doesn't need to be used alongside log_access and can replace it where appropriate.
  */
-/proc/log_suspicious_login(text)
+/proc/log_suspicious_login(text, access_log_mirror = TRUE)
 	if (CONFIG_GET(flag/log_suspicious_login))
 		WRITE_LOG(GLOB.world_suspicious_login_log, "SUSPICIOUS_ACCESS: [text]")
-	log_access(text)
+	if(access_log_mirror)
+		log_access(text)
 
 /proc/log_law(text)
 	if (CONFIG_GET(flag/log_law))

--- a/code/modules/tgui_panel/telemetry.dm
+++ b/code/modules/tgui_panel/telemetry.dm
@@ -78,3 +78,4 @@
 		var/msg = "[key_name(client)] has a banned account in connection history! (Matched: [found["ckey"]], [found["address"]], [found["computer_id"]])"
 		message_admins(msg)
 		log_admin_private(msg)
+		log_suspicious_login(msg, access_log_mirror = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new optional arg to `log_suspicious_login()` to allow it to log without mirroring to the game logs. This will allow it to work alongside things like `log_admin_private()` which ALSO send to game logs.

Mirrors logging of `banned account in connection history` instances to suspicious logins log file.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

QoL loog

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: Admins can now find "banned account in connection history" admin alerts mirrored to the suspicious logins log file.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
