### PR TITLE
Updates security rifle crate names

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -643,7 +643,7 @@
 	cost = CARGO_CRATE_VALUE * 7
 	contains = list(/obj/item/gun/ballistic/automatic/wt550,
 					/obj/item/gun/ballistic/automatic/wt550)
-	crate_name = "auto rifle crate"
+	crate_name = "wt-550 auto rifle crate"
 
 /datum/supply_pack/security/armory/wt550ammo
 	name = "WT-550 Auto Rifle Ammo Crate"
@@ -653,6 +653,7 @@
 					/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9)
+	crate_name = "wt-550 auto rifle ammo crate"
 
 
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -646,15 +646,14 @@
 	crate_name = "wt-550 auto rifle crate"
 
 /datum/supply_pack/security/armory/wt550ammo
-	name = "WT-550 Auto Rifle Ammo Crate"
+	name = "WT-550 Standard Ammo Crate"
 	desc = "Contains four 20-round magazine for the WT-550 Auto Rifle. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
 	cost = CARGO_CRATE_VALUE * 3.5
 	contains = list(/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9)
-	crate_name = "wt-550 auto rifle ammo crate"
-
+	crate_name = "wt-550 standard ammo crate"
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Engineering /////////////////////////////////////


### PR DESCRIPTION
They're no longer called security rifle crates they are now called by the brand WT-550 auto rifle crate
and fixes the issue where WT-550 ammo crates dont have names so they just appear as "crate"

## Changelog
:cl: Improvedname
fix: Auto rifle ammo crates have a name now
/:cl:
