### PR TITLE
Issue #52938 fix: blind people can tell how full they feel when eating

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -275,20 +275,38 @@ Behavior that's still missing from this component that original food items had t
 		if(IsFoodGone(owner, feeder))
 			return
 		var/eatverb = pick(eatverbs)
+
+		var/message_to_nearby_audience = ""
+		var/message_to_consumer = ""
+		var/message_to_blind_consumer = ""
+
 		if(junkiness && eater.satiety < -150 && eater.nutrition > NUTRITION_LEVEL_STARVING + 50 && !HAS_TRAIT(eater, TRAIT_VORACIOUS))
 			to_chat(eater, span_warning("You don't feel like eating any more junk food at the moment!"))
 			return
-		else if(fullness <= 50)
-			eater.visible_message(span_notice("[eater] hungrily [eatverb]s \the [parent], gobbling it down!"), span_notice("You hungrily [eatverb] \the [parent], gobbling it down!"))
-		else if(fullness > 50 && fullness < 150)
-			eater.visible_message(span_notice("[eater] hungrily [eatverb]s \the [parent]."), span_notice("You hungrily [eatverb] \the [parent]."))
-		else if(fullness > 150 && fullness < 500)
-			eater.visible_message(span_notice("[eater] [eatverb]s \the [parent]."), span_notice("You [eatverb] \the [parent]."))
-		else if(fullness > 500 && fullness < 600)
-			eater.visible_message(span_notice("[eater] unwillingly [eatverb]s a bit of \the [parent]."), span_notice("You unwillingly [eatverb] a bit of \the [parent]."))
 		else if(fullness > (600 * (1 + eater.overeatduration / (4000 SECONDS)))) // The more you eat - the more you can eat
-			eater.visible_message(span_warning("[eater] cannot force any more of \the [parent] to go down [eater.p_their()] throat!"), span_warning("You cannot force any more of \the [parent] to go down your throat!"))
+			message_to_nearby_audience = span_warning("[eater] cannot force any more of \the [parent] to go down [eater.p_their()] throat!")
+			message_to_consumer = span_warning("You cannot force any more of \the [parent] to go down your throat!")
+			message_to_blind_consumer = message_to_consumer
+			eater.visible_message(message_to_nearby_audience, message_to_consumer, message_to_blind_consumer)
+			//if we're too full, return because we can't eat whatever it is we're trying to eat
 			return
+		else if(fullness > 500)
+			message_to_nearby_audience = span_notice("[eater] unwillingly [eatverb]s a bit of \the [parent].")
+			message_to_consumer = span_notice("You unwillingly [eatverb] a bit of \the [parent].")
+		else if(fullness > 150)
+			message_to_nearby_audience = span_notice("[eater] [eatverb]s \the [parent].")
+			message_to_consumer = span_notice("You [eatverb] \the [parent].")
+		else if(fullness > 50)
+			message_to_nearby_audience = span_notice("[eater] hungrily [eatverb]s \the [parent].")
+			message_to_consumer = span_notice("You hungrily [eatverb] \the [parent].")
+		else
+			message_to_nearby_audience = span_notice("[eater] hungrily [eatverb]s \the [parent], gobbling it down!")
+			message_to_consumer = span_notice("You hungrily [eatverb] \the [parent], gobbling it down!")
+
+		//if we're blind, we want to feel how hungrily we ate that food
+		message_to_blind_consumer = message_to_consumer
+		eater.visible_message(message_to_nearby_audience, message_to_consumer, message_to_blind_consumer)
+
 	else //If you're feeding it to someone else.
 		if(isbrain(eater))
 			to_chat(feeder, span_warning("[eater] doesn't seem to have a mouth!"))

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -288,7 +288,7 @@ Behavior that's still missing from this component that original food items had t
 			message_to_consumer = span_warning("You cannot force any more of \the [parent] to go down your throat!")
 			message_to_blind_consumer = message_to_consumer
 			eater.show_message(message_to_consumer, MSG_VISUAL, message_to_blind_consumer)
-			eater.visible_message(message_to_nearby_audience)
+			eater.visible_message(message_to_nearby_audience, ignored_mobs = eater)
 			//if we're too full, return because we can't eat whatever it is we're trying to eat
 			return
 		else if(fullness > 500)
@@ -307,7 +307,7 @@ Behavior that's still missing from this component that original food items had t
 		//if we're blind, we want to feel how hungrily we ate that food
 		message_to_blind_consumer = message_to_consumer
 		eater.show_message(message_to_consumer, MSG_VISUAL, message_to_blind_consumer)
-		eater.visible_message(message_to_nearby_audience)
+		eater.visible_message(message_to_nearby_audience, ignored_mobs = eater)
 
 	else //If you're feeding it to someone else.
 		if(isbrain(eater))

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -287,7 +287,8 @@ Behavior that's still missing from this component that original food items had t
 			message_to_nearby_audience = span_warning("[eater] cannot force any more of \the [parent] to go down [eater.p_their()] throat!")
 			message_to_consumer = span_warning("You cannot force any more of \the [parent] to go down your throat!")
 			message_to_blind_consumer = message_to_consumer
-			eater.visible_message(message_to_nearby_audience, message_to_consumer, message_to_blind_consumer)
+			eater.show_message(message_to_consumer, MSG_VISUAL, message_to_blind_consumer)
+			eater.visible_message(message_to_nearby_audience)
 			//if we're too full, return because we can't eat whatever it is we're trying to eat
 			return
 		else if(fullness > 500)
@@ -305,7 +306,8 @@ Behavior that's still missing from this component that original food items had t
 
 		//if we're blind, we want to feel how hungrily we ate that food
 		message_to_blind_consumer = message_to_consumer
-		eater.visible_message(message_to_nearby_audience, message_to_consumer, message_to_blind_consumer)
+		eater.show_message(message_to_consumer, MSG_VISUAL, message_to_blind_consumer)
+		eater.visible_message(message_to_nearby_audience)
 
 	else //If you're feeding it to someone else.
 		if(isbrain(eater))


### PR DESCRIPTION
First PR in a while, if there' something I'm missing just let me know.

## About The Pull Request

Fixes #52938

Now if you're blind you can tell how full you're getting.
Reformatted the else/if logic to remove some repetitive checks, and added some vars on the stack to make things a bit more transparent.

## Why It's Good For The Game

Blind characters should feel how full they feel while eating.

## Changelog
:cl:
fix: if a character is blind, they can feel how full they feel while eating
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
