### PR TITLE
Use experimental modules flag for Node before 12.22.4

### DIFF
--- a/tools/build/build.bat
+++ b/tools/build/build.bat
@@ -1,2 +1,2 @@
 @echo off
-"%~dp0\..\bootstrap\node.bat" "%~dp0\build.js" %*
+"%~dp0\..\bootstrap\node.bat" --experimental-modules "%~dp0\build.js" %*


### PR DESCRIPTION
## About The Pull Request

Fixes errors for those who are still on an old version of Node. Old versions are still technically compatible, only issue is that ES modules are simply disabled behind an experimental flag on old versions.