### PR TITLE
Update byond CI to 1560

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@
 
 # byond version
 export BYOND_MAJOR=514
-export BYOND_MINOR=1556
+export BYOND_MINOR=1560
 
 #rust_g git tag
 export RUST_G_VERSION=0.4.10


### PR DESCRIPTION
Something odd happened when i updated the webserver byond version so this is a test to see if it happens on ci. 

Note: latest linux version is 1560 because 1561 only changed client code and has no linux release.