### PR TITLE
Juke Build 0.8.1 Hotfix 1

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -56,11 +56,6 @@ jobs:
         with:
           path: ~/BYOND
           key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}
-      - name: Restore Yarn Cache
-        uses: actions/cache@v2
-        with:
-          path: tgui/.yarn/cache
-          key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}
       - name: Compile All Maps
         run: |
           bash tools/ci/install_byond.sh

--- a/tools/bootstrap/node
+++ b/tools/bootstrap/node
@@ -65,6 +65,7 @@ fi
 
 # Invoke Node with all command-line arguments
 if [ "$is_vendored" = "1" ]; then
+	PATH="$(readlink -f "$NodeDir"):$PATH"
 	echo "Using vendored Node $("$NodeExe" --version)"
 else
 	echo "Using system-wide Node $("$NodeExe" --version)"

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -16,7 +16,7 @@ import { yarn } from './lib/yarn.js';
 import Juke from './juke/index.js';
 
 Juke.chdir('../..', import.meta.url);
-Juke.setup({ file: import.meta.url });
+Juke.setup({ file: import.meta.url }).then((code) => process.exit(code));
 
 const DME_NAME = 'tgstation';
 


### PR DESCRIPTION
## About The Pull Request

- Restored accidental removal of adding node to `PATH` in node bootstrap.
- Forcefully kill Juke Build, just like before, because it hangs on Windows for some reason after it's done.
- Do not restore Yarn cache during Compile All Maps step, because Yarn doesn't run.

Fixes docker builds by proxy.