### PR TITLE
FIX: Delta Station Console Unable to Monitor Power Grid

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -28679,12 +28679,6 @@
 "dvf" = (
 /turf/open/floor/wood,
 /area/commons/dorms)
-"dvg" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/engineering/main)
 "dvF" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/tile/neutral{
@@ -51374,6 +51368,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/fire,
 /turf/open/floor/iron,
 /area/engineering/main)
 "iiE" = (
@@ -61334,7 +61330,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/iron,
 /area/engineering/main)
 "kUH" = (
@@ -64480,9 +64475,6 @@
 	},
 /area/commons/fitness/recreation)
 "lIU" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -64490,6 +64482,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/noticeboard/directional/east,
 /turf/open/floor/iron,
 /area/engineering/main)
 "lJj" = (
@@ -77600,16 +77593,25 @@
 	pixel_y = -28
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/computer/apc_control{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/smes,
+/obj/item/stack/cable_coil/five,
+/obj/item/stock_parts/capacitor/adv,
+/obj/item/paper/fluff{
+	info = "The Modular Console that was here wasn't functioning, so I moved it and made another next to the lockers outside this room. I found this capacitor sitting around. Another SMES never hurt the station's power grid. <i>- Payton Parsley</i>";
+	name = "Note From Payton"
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
@@ -83475,6 +83477,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/east,
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
+	},
 /turf/open/floor/circuit/green,
 /area/engineering/main)
 "qyu" = (
@@ -99837,9 +99842,9 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "uFL" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/fire,
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/iron,
 /area/engineering/main)
 "uGa" = (
@@ -109652,6 +109657,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"xtK" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/iron,
+/area/engineering/main)
 "xub" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -137481,7 +137497,7 @@ wfe
 vne
 oMh
 hlI
-iit
+xtK
 gzu
 oMh
 tvp
@@ -137734,7 +137750,7 @@ vSw
 uIx
 fdT
 vrt
-dvg
+uFL
 vne
 lAU
 eMt

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -65681,6 +65681,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "lZn" = (
@@ -109170,6 +109171,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "xno" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -61334,6 +61334,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/iron,
 /area/engineering/main)
 "kUH" = (
@@ -77599,12 +77600,6 @@
 	pixel_y = -28
 	},
 /obj/structure/cable,
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -77613,6 +77608,9 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/computer/apc_control{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "oVm" = (

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1122,7 +1122,7 @@
 		return ..()
 
 /obj/item/circuitboard/machine/protolathe/department/service
-	name = "Departmental Protolathe - Service (Machine Board)"
+	name = "Departmental Protolathe (Machine Board) - Service"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/rnd/production/protolathe/department/service
 
@@ -1145,7 +1145,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/techfab/department/service
-	name = "\improper Departmental Techfab - Service (Machine Board)"
+	name = "\improper Departmental Techfab (Machine Board) - Service"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/rnd/production/techfab/department/service
 

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1122,7 +1122,7 @@
 		return ..()
 
 /obj/item/circuitboard/machine/protolathe/department/service
-	name = "Departmental Protolathe (Machine Board) - Service"
+	name = "Departmental Protolathe - Service (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/rnd/production/protolathe/department/service
 
@@ -1145,7 +1145,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/techfab/department/service
-	name = "\improper Departmental Techfab (Machine Board) - Service"
+	name = "\improper Departmental Techfab - Service (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/rnd/production/techfab/department/service
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A console in Delta Station was not connected to the main grid. By adding two cables, this console should be able to properly watch the power grid.

![StrongDMM_dQMTuQaG5k](https://user-images.githubusercontent.com/65935938/129624735-fe94f126-0220-4284-b645-ddeaa176c57e.png)

![StrongDMM_RRl5o1Hwf3](https://user-images.githubusercontent.com/65935938/129624750-4079023c-d5ca-4ab8-bf67-4bb979d2cddc.png)

![StrongDMM_aVa8pmQeDy](https://user-images.githubusercontent.com/65935938/129624760-2610300e-8eeb-4199-8c2d-f22d6df6b845.png)

## Why It's Good For The Game

Fixes a previously non-functional console.

## Changelog
:cl:
fix: Moves a modular console in order to make it functional. Replaces it with half constructed machine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
