### PR TITLE
Fixes a spurious unit test failure sourced from stack code

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -334,7 +334,7 @@
  * Initial is used to indicate whether or not this is the initial equipment (job datums etc) or just a player doing it
  */
 /mob/proc/equip_to_slot_if_possible(obj/item/W, slot, qdel_on_fail = FALSE, disable_warning = FALSE, redraw_mob = TRUE, bypass_equip_delay_self = FALSE, initial = FALSE)
-	if(!istype(W))
+	if(!istype(W) || QDELETED(W)) //This qdeleted is to prevent stupid behavior with things that qdel during init, like say stacks
 		return FALSE
 	if(!W.mob_can_equip(src, null, slot, disable_warning, bypass_equip_delay_self))
 		if(qdel_on_fail)


### PR DESCRIPTION
## About The Pull Request
Adds a qdeleted check to mob equipping. This fixes potential runtimes/harddeletes caused by attempting to add stacks to a slot, since stacks will commonly self delete, even if you add them to different slots. This is
because stack code does not respect slots, and I can't figure out a good way to fix that outside of this.

Also fixes like, a 2% chance unit test failure caused by a mob spawner that has a low percent chance to spawn a miner with cash in both pockets. I hate god.

Fixes runtimes/failures of this type https://github.com/tgstation/tgstation/runs/3339304654
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I suffer eternal 
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
