### PR TITLE
Detomatix is now locked behind nukies.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -993,6 +993,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer."
 	item = /obj/item/cartridge/virus/syndicate
 	cost = 6
+	purchasable_from = UPLINK_NUKE_OPS
 	restricted = TRUE
 
 /datum/uplink_item/explosives/emp


### PR DESCRIPTION
with the current way exlposions work, a pda bomb is capable of nuggeting, killing, and is also unavoidable aside then metagaming and turning off pda messages roundstart(which most people do anyway)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Locks PDA Bombs behind nukies
## Why It's Good For The Game

A unavoidable round removal and instant death if you are unlucky and loosing limbs and lots of time if you aren't(with no counter other then metagaming i might add) is awful gameplay and creates massive metagaming as people(rightfully) turn off pda messaging to avoid the pain of pda bombs.
## Changelog
:cl:
del: The syndicate have cut funding to their cyberweapons team, only nukies can access pda bombs now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
