### PR TITLE
Fix mulebot movement while controlled by a player

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -576,6 +576,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define LYING_DOWN_TRAIT "lying-down"
 /// Trait associated to lacking electrical power.
 #define POWER_LACK_TRAIT "power-lack"
+/// Trait associated to lacking motor movement
+#define MOTOR_LACK_TRAIT "motor-lack"
 /// Trait associated with mafia
 #define MAFIA_TRAIT "mafia"
 /// Trait associated with highlander

--- a/code/datums/wires/mulebot.dm
+++ b/code/datums/wires/mulebot.dm
@@ -19,42 +19,42 @@
 /datum/wires/mulebot/interactable(mob/user)
 	if(!..())
 		return FALSE
-	var/mob/living/simple_animal/bot/mulebot/M = holder
-	if(M.open)
+	var/mob/living/simple_animal/bot/mulebot/mule = holder
+	if(mule.open)
 		return TRUE
 
 /datum/wires/mulebot/on_cut(wire, mend)
-	var/mob/living/simple_animal/bot/mulebot/M = holder
+	var/mob/living/simple_animal/bot/mulebot/mule = holder
 	switch(wire)
 		if(WIRE_MOTOR1, WIRE_MOTOR2)
 			if(is_cut(WIRE_MOTOR1) && is_cut(WIRE_MOTOR2))
-				ADD_TRAIT(M, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT)
+				ADD_TRAIT(mule, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT)
 			else
-				REMOVE_TRAIT(M, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT)
+				REMOVE_TRAIT(mule, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT)
 
 			if(is_cut(WIRE_MOTOR1))
-				M.set_varspeed(FAST_MOTOR_SPEED)
+				mule.set_varspeed(FAST_MOTOR_SPEED)
 			else if(is_cut(WIRE_MOTOR2))
-				M.set_varspeed(AVERAGE_MOTOR_SPEED)
+				mule.set_varspeed(AVERAGE_MOTOR_SPEED)
 			else
-				M.set_varspeed(SLOW_MOTOR_SPEED)
+				mule.set_varspeed(SLOW_MOTOR_SPEED)
 
 /datum/wires/mulebot/on_pulse(wire)
-	var/mob/living/simple_animal/bot/mulebot/M = holder
-	if(!M.has_power(TRUE))
+	var/mob/living/simple_animal/bot/mulebot/mule = holder
+	if(!mule.has_power(TRUE))
 		return //logically mulebots can't flash and beep if they don't have power.
 	switch(wire)
 		if(WIRE_POWER1, WIRE_POWER2)
-			holder.visible_message(span_notice("[icon2html(M, viewers(holder))] The charge light flickers."))
+			holder.visible_message(span_notice("[icon2html(mule, viewers(holder))] The charge light flickers."))
 		if(WIRE_AVOIDANCE)
-			holder.visible_message(span_notice("[icon2html(M, viewers(holder))] The external warning lights flash briefly."))
-			flick("[M.base_icon]1", M)
+			holder.visible_message(span_notice("[icon2html(mule, viewers(holder))] The external warning lights flash briefly."))
+			flick("[mule.base_icon]1", mule)
 		if(WIRE_LOADCHECK)
-			holder.visible_message(span_notice("[icon2html(M, viewers(holder))] The load platform clunks."))
+			holder.visible_message(span_notice("[icon2html(mule, viewers(holder))] The load platform clunks."))
 		if(WIRE_MOTOR1, WIRE_MOTOR2)
-			holder.visible_message(span_notice("[icon2html(M, viewers(holder))] The drive motor whines briefly."))
+			holder.visible_message(span_notice("[icon2html(mule, viewers(holder))] The drive motor whines briefly."))
 		else
-			holder.visible_message(span_notice("[icon2html(M, viewers(holder))] You hear a radio crackle."))
+			holder.visible_message(span_notice("[icon2html(mule, viewers(holder))] You hear a radio crackle."))
 
 #undef FAST_MOTOR_SPEED
 #undef AVERAGE_MOTOR_SPEED

--- a/code/datums/wires/mulebot.dm
+++ b/code/datums/wires/mulebot.dm
@@ -27,18 +27,17 @@
 	var/mob/living/simple_animal/bot/mulebot/M = holder
 	switch(wire)
 		if(WIRE_MOTOR1, WIRE_MOTOR2)
-			if(wires.is_cut(WIRE_MOTOR1) && wires.is_cut(WIRE_MOTOR2))
+			if(is_cut(WIRE_MOTOR1) && is_cut(WIRE_MOTOR2))
 				ADD_TRAIT(M, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT)
 			else
 				REMOVE_TRAIT(M, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT)
 
-			if(wires.is_cut(WIRE_MOTOR1))
-				M.speed = FAST_MOTOR_SPEED
-			else if(wires.is_cut(WIRE_MOTOR2))
-				M.speed = AVERAGE_MOTOR_SPEED
+			if(is_cut(WIRE_MOTOR1))
+				M.set_varspeed(FAST_MOTOR_SPEED)
+			else if(is_cut(WIRE_MOTOR2))
+				M.set_varspeed(AVERAGE_MOTOR_SPEED)
 			else
-				M.speed = SLOW_MOTOR_SPEED
-			M.update_simplemob_varspeed()
+				M.set_varspeed(SLOW_MOTOR_SPEED)
 
 /datum/wires/mulebot/on_pulse(wire)
 	var/mob/living/simple_animal/bot/mulebot/M = holder

--- a/code/datums/wires/mulebot.dm
+++ b/code/datums/wires/mulebot.dm
@@ -1,3 +1,7 @@
+#define FAST_MOTOR_SPEED 1
+#define AVERAGE_MOTOR_SPEED 2
+#define SLOW_MOTOR_SPEED 3
+
 /datum/wires/mulebot
 	holder_type = /mob/living/simple_animal/bot/mulebot
 	proper_name = "Mulebot"
@@ -28,6 +32,14 @@
 			else
 				REMOVE_TRAIT(M, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT)
 
+			if(wires.is_cut(WIRE_MOTOR1))
+				M.speed = FAST_MOTOR_SPEED
+			else if(wires.is_cut(WIRE_MOTOR2))
+				M.speed = AVERAGE_MOTOR_SPEED
+			else
+				M.speed = SLOW_MOTOR_SPEED
+			M.update_simplemob_varspeed()
+
 /datum/wires/mulebot/on_pulse(wire)
 	var/mob/living/simple_animal/bot/mulebot/M = holder
 	if(!M.has_power(TRUE))
@@ -44,3 +56,7 @@
 			holder.visible_message(span_notice("[icon2html(M, viewers(holder))] The drive motor whines briefly."))
 		else
 			holder.visible_message(span_notice("[icon2html(M, viewers(holder))] You hear a radio crackle."))
+
+#undef FAST_MOTOR_SPEED
+#undef AVERAGE_MOTOR_SPEED
+#undef SLOW_MOTOR_SPEED

--- a/code/datums/wires/mulebot.dm
+++ b/code/datums/wires/mulebot.dm
@@ -19,6 +19,15 @@
 	if(M.open)
 		return TRUE
 
+/datum/wires/mulebot/on_cut(wire, mend)
+	var/mob/living/simple_animal/bot/mulebot/M = holder
+	switch(wire)
+		if(WIRE_MOTOR1, WIRE_MOTOR2)
+			if(wires.is_cut(WIRE_MOTOR1) && wires.is_cut(WIRE_MOTOR2))
+				ADD_TRAIT(M, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT)
+			else
+				REMOVE_TRAIT(M, TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT)
+
 /datum/wires/mulebot/on_pulse(wire)
 	var/mob/living/simple_animal/bot/mulebot/M = holder
 	if(!M.has_power(TRUE))

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -558,6 +558,8 @@
 		return
 	if(mode == BOT_IDLE)
 		return
+	if(HAS_TRAIT(TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT))
+		return
 
 	var/speed = (wires.is_cut(WIRE_MOTOR1) ? 0 : 1) + (wires.is_cut(WIRE_MOTOR2) ? 0 : 2)
 	if(!speed)//Devide by zero man bad

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -18,6 +18,7 @@
 	animate_movement = FORWARD_STEPS
 	health = 50
 	maxHealth = 50
+	speed = 3
 	damage_coeff = list(BRUTE = 0.5, BURN = 0.7, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	combat_mode = TRUE //No swapping
 	buckle_lying = 0
@@ -128,8 +129,8 @@
 	return ..()
 
 /// returns true if the bot is fully powered.
-/mob/living/simple_animal/bot/mulebot/proc/has_power(bypass_open_check)
-	return (!open || bypass_open_check) && cell && cell.charge > 0 && (!wires.is_cut(WIRE_POWER1) && !wires.is_cut(WIRE_POWER2))
+/mob/living/simple_animal/bot/mulebot/proc/has_power()
+	return cell && cell.charge > 0 && (!wires.is_cut(WIRE_POWER1) && !wires.is_cut(WIRE_POWER2))
 
 
 /mob/living/simple_animal/bot/mulebot/proc/set_id(new_id)
@@ -146,10 +147,7 @@
 /mob/living/simple_animal/bot/mulebot/attackby(obj/item/I, mob/living/user, params)
 	if(I.tool_behaviour == TOOL_SCREWDRIVER)
 		. = ..()
-		if(open)
-			turn_off()
-		else
-			update_appearance() //this is also handled by turn_off(), so no need to call this twice.
+		update_appearance()
 	else if(istype(I, /obj/item/stock_parts/cell) && open)
 		if(cell)
 			to_chat(user, span_warning("[src] already has a power cell!"))
@@ -558,7 +556,7 @@
 		return
 	if(mode == BOT_IDLE)
 		return
-	if(HAS_TRAIT(TRAIT_IMMOBILIZED, MOTOR_LACK_TRAIT))
+	if(HAS_TRAIT(src, TRAIT_IMMOBILIZED))
 		return
 
 	var/speed = (wires.is_cut(WIRE_MOTOR1) ? 0 : 1) + (wires.is_cut(WIRE_MOTOR2) ? 0 : 2)
@@ -838,7 +836,7 @@
 	if(!on)
 		return COMPONENT_MOB_BOT_BLOCK_PRE_STEP
 
-	if((cell && (cell.charge < cell_move_power_usage)) || !has_power((client || paicard)))
+	if((cell && (cell.charge < cell_move_power_usage)) || !has_power())
 		turn_off()
 		return COMPONENT_MOB_BOT_BLOCK_PRE_STEP
 
@@ -928,4 +926,3 @@
 
 /obj/machinery/bot_core/mulebot
 	req_access = list(ACCESS_CARGO)
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This fixes #52281

- Player controlled mulebots now have their speed set based on the status of the two motor wires.  
- Player controlled mulebots will be immobilized if both their motor wires are cut.
- Mulebots no longer turn off power when the panel is opened with a screwdriver.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This makes persistence consistent.  Wires that affect the mulebot should also affect the player and not be ignored.    

## Changelog
:cl:
qol: Mulebots no longer turn off power when the panel is opened with a screwdriver.
fix: Player controlled mulebot mobility is now affected by motor wires. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
