### PR TITLE
Fix picture metadata storing json strings inside json.

### DIFF
--- a/code/modules/photography/_pictures.dm
+++ b/code/modules/photography/_pictures.dm
@@ -155,7 +155,7 @@
 		fdel(jsonpath)
 	else
 		json = list()
-	json[id] = serialize_json()
+	json[id] = serialize_list()
 	WRITE_FILE(jsonpath, json_encode(json))
 
 /datum/picture/proc/Copy(greyscale = FALSE, cropx = 0, cropy = 0)


### PR DESCRIPTION
https://tgstation13.org/parsed-logs/sybil/data/picture_logs/2021/08/17/round-167978/metadata.json
```json
{
  "L_20210817_R_167978_1": "{\"id\":\"L_20210817_R_167978_1\",\"desc\":\"This is a photo of an area of 2 meters by 2 meters. You can also see Nia Caldwell on the photo. .. You can also see Dan Ross on the photo. He is holding a camera..\",\"name\":\"picture\",\"caption\":null,\"pixel_size_x\":96,\"pixel_size_y\":96,\"blueprints\":0,\"logpath\":\"data/picture_logs/2021/08/17/round-167978/1.png\"}",
  "L_20210817_R_167978_2": "{\"id\":\"L_20210817_R_167978_2\",\"desc\":\"B&amp;E - This is a photo of an area of 2 meters by 2 meters. You can also see Alejandro Snyder on the photo. He is holding a spear..\",\"name\":\"Alejandro Snyder\",\"caption\":\"Sly dog...\",\"pixel_size_x\":96,\"pixel_size_y\":96,\"blueprints\":0,\"logpath\":\"data/picture_logs/2021/08/17/round-167978/2.png\"}",
  "L_20210817_R_167978_3": "{\"id\":\"L_20210817_R_167978_3\",\"desc\":\"B&amp;E - This is a photo of an area of 2 meters by 2 meters. You can also see Nia Caldwell on the photo. .. a ... thing?\",\"name\":\"Nia Caldwell\",\"caption\":\"Yikes!\",\"pixel_size_x\":96,\"pixel_size_y\":96,\"blueprints\":0,\"logpath\":\"data/picture_logs/2021/08/17/round-167978/3.png\"}"
}
```

This is not at all what was likely intended.

Serializing it to a list is the proper way of doing this. 