### PR TITLE
FIX: Delta Station Console Unable to Monitor Power Grid (Merge Conflict Resoltion Caveman Style)

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -28766,12 +28766,6 @@
 "dvf" = (
 /turf/open/floor/wood,
 /area/commons/dorms)
-"dvg" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/engineering/main)
 "dvF" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/tile/neutral{
@@ -49238,6 +49232,14 @@
 	},
 /turf/open/floor/iron,
 /area/medical/medbay/central)
+"hGR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/engineering/main)
 "hHe" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -51383,6 +51385,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/fire,
 /turf/open/floor/iron,
 /area/engineering/main)
 "iiE" = (
@@ -64502,9 +64506,6 @@
 	},
 /area/commons/fitness/recreation)
 "lIU" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -64512,6 +64513,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/noticeboard/directional/east,
 /turf/open/floor/iron,
 /area/engineering/main)
 "lJj" = (
@@ -69281,6 +69283,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science)
+"mXa" = (
+/obj/machinery/light_switch/directional/east,
+/turf/closed/wall/r_wall,
+/area/engineering/main)
 "mXc" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/fyellow,
@@ -77578,9 +77584,6 @@
 	pixel_y = -28
 	},
 /obj/structure/cable,
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -77591,7 +77594,16 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/bot,
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/five,
+/obj/item/stock_parts/capacitor,
+/obj/item/circuitboard/machine/smes,
+/obj/item/paper/fluff{
+	info = "The Modular Console that was here wasn't functioning, so I replaced it and added another nearby the lockers outside this room. I started working on a spare SMES but I couldn't find any batteries. Either way, we have an engine to set up. Finish this for me if I'm not here. <i>- Payton Parsley</i>";
+	name = "Note from Payton"
+	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "oVm" = (
@@ -83435,7 +83447,9 @@
 	charge = 2e+006
 	},
 /obj/structure/cable,
-/obj/machinery/light_switch/directional/east,
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
+	},
 /turf/open/floor/circuit/green,
 /area/engineering/main)
 "qyu" = (
@@ -99793,9 +99807,9 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "uFL" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/fire,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/modular_computer/console/preset/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "uGa" = (
@@ -100468,6 +100482,17 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"uQB" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/iron,
+/area/engineering/main)
 "uQK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -136716,7 +136741,7 @@ oXW
 iHq
 hVZ
 nGZ
-nKE
+hGR
 vBh
 tXV
 oFY
@@ -137485,7 +137510,7 @@ wfe
 vne
 oMh
 hlI
-iit
+uQB
 gzu
 oMh
 tvp
@@ -137738,7 +137763,7 @@ vSw
 uIx
 fdT
 vrt
-dvg
+uFL
 vne
 lAU
 eMt
@@ -140569,7 +140594,7 @@ bQg
 tXV
 tXV
 tXV
-tXV
+mXa
 tXV
 caE
 ign


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A console in Delta Station was not connected to the main grid. By adding two cables, this console should be able to properly watch the power grid.

![StrongDMM_dQMTuQaG5k](https://user-images.githubusercontent.com/65935938/129624735-fe94f126-0220-4284-b645-ddeaa176c57e.png)

![StrongDMM_RRl5o1Hwf3](https://user-images.githubusercontent.com/65935938/129624750-4079023c-d5ca-4ab8-bf67-4bb979d2cddc.png)

![StrongDMM_aVa8pmQeDy](https://user-images.githubusercontent.com/65935938/129624760-2610300e-8eeb-4199-8c2d-f22d6df6b845.png)

Adding two wires doesn't solve the problem. Check this GIF. I added the two wires during a live round. It seems that wire grid doesn't monitor the ACP grid properly. Compare that to the location I've moved the console to.

![X4mCHex94t](https://user-images.githubusercontent.com/65935938/129630295-f783f745-7e1a-4169-81b8-2b394b6a4b97.gif)

![njG8ZhIKk5](https://user-images.githubusercontent.com/65935938/129630828-2b289480-6440-4f13-810b-9e53f41458a9.gif)

I checked one last time on my own privately run server to see if the wires I placed would actually get this console to monitor the ACP grid. I've confirmed that it doesn't. I'm closing this PR until I can get a properly working fix done.

![JfVdtxDHfN](https://user-images.githubusercontent.com/65935938/129757221-b4a0939d-4812-445f-b259-ff752c8a33af.gif)


 **The Nuclear Option - Move the Console**

This removes the original modular console and replaces it with a half constructed SMES machine frame. Two new modular consoles are placed next to the norther wall lockers. The tables that were originally there were moved to the center of the room.

There was also a minor fix to a board name I made, but it is not part of this pull request so I undid my change.

![dreamseeker_zS2lKA2E2C](https://user-images.githubusercontent.com/65935938/129811424-9d19a586-106b-41dc-a8b4-c7f7f14d68fd.png)

![dreamseeker_CeUhqEnpsc](https://user-images.githubusercontent.com/65935938/129811444-ae4e605d-7e9b-46d1-9b68-fcea23203b12.png)


## Why It's Good For The Game

Fixes a previously non-functional console.

## Changelog
:cl:
fix: Moves a modular console in order to make it functional. Replaces it with half constructed machine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
