### PR TITLE
Fixes dash ability null `owner` refs

### DIFF
--- a/code/datums/dash_weapon.dm
+++ b/code/datums/dash_weapon.dm
@@ -46,7 +46,10 @@
 
 /datum/action/innate/dash/proc/charge()
 	current_charges = clamp(current_charges + 1, 0, max_charges)
-	owner.update_action_buttons_icon()
 	if(recharge_sound)
 		playsound(dashing_item, recharge_sound, 50, TRUE)
+
+	if(!owner)
+		return
+	owner.update_action_buttons_icon()
 	dashing_item.balloon_alert(owner, "[current_charges]/[max_charges] dash charges")

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -39,10 +39,13 @@
 		club.update_appearance()
 
 	current_charges = clamp(current_charges + 1, 0, max_charges)
-	owner.update_action_buttons_icon()
 
 	if(recharge_sound)
 		playsound(dashing_item, recharge_sound, 50, TRUE)
+
+	if(!owner)
+		return
+	owner.update_action_buttons_icon()
 	to_chat(owner, span_notice("[src] now has [current_charges]/[max_charges] charges."))
 
 /obj/item/hierophant_club


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the references to `owner` after a null check early return.

Might also fix this issue #60885

## Why It's Good For The Game

Fix good.

## Changelog
:cl:
fix: Fixed dash abilities, like from Hiero Club, null owner refs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
