### PR TITLE
Fixed Fried Eggs

### DIFF
--- a/code/game/objects/items/food/egg.dm
+++ b/code/game/objects/items/food/egg.dm
@@ -85,6 +85,9 @@
 /obj/item/food/egg/yellow
 	icon_state = "egg-yellow"
 
+/obj/item/food/egg/MakeGrillable()
+	AddComponent(/datum/component/grillable, /obj/item/food/friedegg, rand(10 SECONDS, 30 SECONDS), TRUE, TRUE)
+
 /obj/item/food/friedegg
 	name = "fried egg"
 	desc = "A fried egg, with a touch of salt and pepper."

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_egg.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_egg.dm
@@ -3,16 +3,6 @@
 
 ////////////////////////////////////////////////EGG RECIPE's////////////////////////////////////////////////
 
-/datum/crafting_recipe/food/friedegg
-	name = "Fried egg"
-	reqs = list(
-		/datum/reagent/consumable/salt = 1,
-		/datum/reagent/consumable/blackpepper = 1,
-		/obj/item/food/egg = 1
-	)
-	result = /obj/item/food/friedegg
-	subcategory = CAT_EGG
-
 /datum/crafting_recipe/food/omelette
 	name = "Omelette"
 	reqs = list(


### PR DESCRIPTION
## About The Pull Request

Added grillable to eggs in egg.dm (to make fried eggs on griddle). Removed crafting recipe for fried eggs.

## Why It's Good For The Game

Now fried eggs can be made on griddle instead of magically being crafted with salt and pepper.

## Changelog
:cl: Flux
add: Fry eggs on the griddle
del: Craft fried eggs no longer
/:cl:
