### PR TITLE
Fixes the cross comms exemption of the current server.

### DIFF
--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -147,13 +147,15 @@
 	abstract_type = /datum/config_entry/str_list
 	default = list()
 	dupes_allowed = TRUE
+	/// whether the string elements will be lowercased on ValidateAndSet or not.
+	lowercase = FALSE
 
 /datum/config_entry/str_list/ValidateAndSet(str_val)
 	if (!VASProcCallGuard(str_val))
 		return FALSE
 	str_val = trim(str_val)
 	if (str_val != "")
-		config_entry_value += str_val
+		config_entry_value += lowercase ? lowertext(str_val) : str_val
 	return TRUE
 
 /datum/config_entry/number_list

--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -96,6 +96,8 @@
 	default = ""
 	abstract_type = /datum/config_entry/string
 	var/auto_trim = TRUE
+	/// whether the string will be lowercased on ValidateAndSet or not.
+	var/lowercase = FALSE
 
 /datum/config_entry/string/vv_edit_var(var_name, var_value)
 	return var_name != NAMEOF(src, auto_trim) && ..()
@@ -104,6 +106,8 @@
 	if(!VASProcCallGuard(str_val))
 		return FALSE
 	config_entry_value = auto_trim ? trim(str_val) : str_val
+	if(lowercase)
+		config_entry_value = lowertext(config_entry_value)
 	return TRUE
 
 /datum/config_entry/number
@@ -180,6 +184,7 @@
 	var/key_mode
 	var/value_mode
 	var/splitter = " "
+	/// whether the key names will be lowercased on ValidateAndSet or not.
 	var/lowercase = TRUE
 
 /datum/config_entry/keyed_list/New()

--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -187,7 +187,7 @@
 	var/value_mode
 	var/splitter = " "
 	/// whether the key names will be lowercased on ValidateAndSet or not.
-	var/lowercase = TRUE
+	var/lowercase_key = TRUE
 
 /datum/config_entry/keyed_list/New()
 	. = ..()
@@ -205,7 +205,7 @@
 
 	if(key_pos || value_mode == VALUE_MODE_FLAG)
 		key_name = copytext(str_val, 1, key_pos)
-		if(lowercase)
+		if(lowercase_key)
 			key_name = lowertext(key_name)
 		if(key_pos)
 			key_value = copytext(str_val, key_pos + length(str_val[key_pos]))

--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -148,7 +148,7 @@
 	default = list()
 	dupes_allowed = TRUE
 	/// whether the string elements will be lowercased on ValidateAndSet or not.
-	lowercase = FALSE
+	var/lowercase = FALSE
 
 /datum/config_entry/str_list/ValidateAndSet(str_val)
 	if (!VASProcCallGuard(str_val))

--- a/code/controllers/configuration/config_entry.dm
+++ b/code/controllers/configuration/config_entry.dm
@@ -180,6 +180,7 @@
 	var/key_mode
 	var/value_mode
 	var/splitter = " "
+	var/lowercase = TRUE
 
 /datum/config_entry/keyed_list/New()
 	. = ..()
@@ -196,7 +197,9 @@
 	var/key_value = null
 
 	if(key_pos || value_mode == VALUE_MODE_FLAG)
-		key_name = lowertext(copytext(str_val, 1, key_pos))
+		key_name = copytext(str_val, 1, key_pos)
+		if(lowercase)
+			key_name = lowertext(key_name)
 		if(key_pos)
 			key_value = copytext(str_val, key_pos + length(str_val[key_pos]))
 		var/new_key

--- a/code/controllers/configuration/entries/comms.dm
+++ b/code/controllers/configuration/entries/comms.dm
@@ -8,6 +8,7 @@
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_TEXT
 	protection = CONFIG_ENTRY_LOCKED
+	lowercase = FALSE // The names of the servers are proper nouns. Also required for the cross_comms_name config to work.
 
 /datum/config_entry/keyed_list/cross_server/ValidateAndSet(str_val)
 	. = ..()

--- a/code/controllers/configuration/entries/comms.dm
+++ b/code/controllers/configuration/entries/comms.dm
@@ -8,7 +8,7 @@
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_TEXT
 	protection = CONFIG_ENTRY_LOCKED
-	lowercase = FALSE // The names of the servers are proper nouns. Also required for the cross_comms_name config to work.
+	lowercase_key = FALSE // The names of the servers are proper nouns. Also required for the cross_comms_name config to work.
 
 /datum/config_entry/keyed_list/cross_server/ValidateAndSet(str_val)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Thanks to MSO for pointing out the source of this problem in the relative issue report. As he suggested, I added a `lowercase` variable to string, string lists and keyed list configs.
Currently `lowercase` is only TRUE for keyed lists because they have been working like that since 2018. It might be changed to be FALSE by default but it'll take a while looking at the parsed logs for the config entries.

## Why It's Good For The Game
This wil fix #60948. Server names are generally proper nouns, plus they are displayed on the comms console section for cross server messages so it's only fair for them to not be lowercased in the cross server keyed list.

## Changelog
:cl:
fix: Outgoing comms console messages to allied stations will not be shown again as incoming messages.
/:cl:
