### PR TITLE
 Greentexting as a traitor hardcore random now gives you hardcore random points

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -189,10 +189,8 @@
 
 	if(human_mob.mind && (human_mob.mind.special_role || length(human_mob.mind.antag_datums) > 0))
 		var/didthegamerwin = TRUE
-		for(var/a in human_mob.mind.antag_datums)
-			var/datum/antagonist/antag_datum = a
-			for(var/i in antag_datum.objectives)
-				var/datum/objective/objective_datum = i
+		for(var/datum/antagonist/antag_datums in human_mob.mind.antag_datums)
+			for(var/datum/objective/objective_datum in antag_datums.objectives)
 				if(!objective_datum.check_completion())
 					didthegamerwin = FALSE
 		if(!didthegamerwin)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -189,8 +189,8 @@
 
 	if(human_mob.mind && (human_mob.mind.special_role || length(human_mob.mind.antag_datums) > 0))
 		var/didthegamerwin = TRUE
-		for(var/datum/antagonist/antag_datums in human_mob.mind.antag_datums)
-			for(var/datum/objective/objective_datum in antag_datums.objectives)
+		for(var/datum/antagonist/antag_datums as anything in human_mob.mind.antag_datums)
+			for(var/datum/objective/objective_datum as anything in antag_datums.objectives)
 				if(!objective_datum.check_completion())
 					didthegamerwin = FALSE
 		if(!didthegamerwin)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -189,8 +189,10 @@
 
 	if(human_mob.mind && (human_mob.mind.special_role || length(human_mob.mind.antag_datums) > 0))
 		var/didthegamerwin = TRUE
-		for(var/datum/antagonist/antag_datums in human_mob.mind.antag_datums)
-			for(var/datum/objective/objective_datum in antag_datums.objectives)
+		for(var/a in human_mob.mind.antag_datums)
+			var/datum/antagonist/antag_datum = a
+			for(var/i in antag_datum.objectives)
+				var/datum/objective/objective_datum = i
 				if(!objective_datum.check_completion())
 					didthegamerwin = FALSE
 		if(!didthegamerwin)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -107,7 +107,7 @@
 	// for(in...to) loops iterate inclusively, so to reach objective_limit we need to loop to objective_limit - 1
 	// This does not give them 1 fewer objectives than intended.
 	for(var/i in objective_count to objective_limit - 1)
-		objectives += forge_single_generic_objective()
+		forge_single_generic_objective()
 
 
 /**


### PR DESCRIPTION
## About The Pull Request

every time a traitor greentexts with hardcore random, it runtimes and returns. I think it's because of the escape alive objective.

I've tested this before and after several times just to be completely sure this fixes it.

https://user-images.githubusercontent.com/53777086/130304179-92172977-b24a-414d-ad82-8349d6021b9c.mp4

## Why It's Good For The Game

Hardcore random antags put the work in, they should get the points for greentexting.

## Changelog
:cl:
fix: Hardcore random traitors now get their hardcore random points for greentexting.
/:cl: