### PR TITLE
Fixes Stargazers not being able to properly form Slime links. 

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -755,7 +755,7 @@
 		return
 
 	var/mob/living/target = H.pulling
-	var/datum/species/jelly/stargazer/species = target
+	var/datum/species/jelly/stargazer/species = H.dna.species
 
 	to_chat(H, span_notice("You begin linking [target]'s mind to yours..."))
 	to_chat(target, span_warning("You feel a foreign presence within your mind..."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an issue with Stargazers where they were unable to form slime links.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the slime link function on stargazers behave as intended 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: stargazers can now form slime links again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
