### PR TITLE
obsessed code improvements + admins can select an obsession

### DIFF
--- a/code/datums/brain_damage/brain_trauma.dm
+++ b/code/datums/brain_damage/brain_trauma.dm
@@ -24,15 +24,15 @@
 	owner = null
 	return ..()
 
-//Called on life ticks
-/datum/brain_trauma/proc/on_life(delta_time, times_fired)
+///Called on life ticks
+/datum/brain_trauma/proc/on_life(delta_time = SSMOBS_DT, times_fired)
 	return
 
-//Called on death
+///Called on death
 /datum/brain_trauma/proc/on_death()
 	return
 
-//Called when given to a mob
+///Called when given to a mob
 /datum/brain_trauma/proc/on_gain()
 	if(gain_text)
 		to_chat(owner, gain_text)

--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -2,30 +2,39 @@
 	name = "Psychotic Schizophrenia"
 	desc = "Patient has a subtype of delusional disorder, becoming irrationally attached to someone."
 	scan_desc = "psychotic schizophrenic delusions"
-	gain_text = "If you see this message, make a github issue report. The trauma initialized wrong."
-	lose_text = "<span class='warning'>The voices in your head fall silent.</span>"
+	gain_text = span_warning("You hear a sickening, raspy voice in your head. It wants one small task of you...")
+	lose_text = span_warning("The voices in your head fall silent.")
 	can_gain = TRUE
 	random_gain = FALSE
 	resilience = TRAUMA_RESILIENCE_SURGERY
+	///victim of the creep
 	var/mob/living/obsession
+	///reference to the spending time objective so "total_time_creeping" can be checked
 	var/datum/objective/spendtime/attachedobsessedobj
+	///reference to the obsessed antag datum
 	var/datum/antagonist/obsessed/antagonist
-	var/viewing = FALSE //it's a lot better to store if the owner is watching the obsession than checking it twice between two procs
+	///it's a lot better to store if the owner is watching the obsession than checking it twice between two procs
+	var/viewing = FALSE
 
-	var/total_time_creeping = 0 //just for roundend fun
+	///time spent near the obsession
+	var/total_time_creeping = 0
+	///time spent away from the obsession
 	var/time_spent_away = 0
+	///times hugged the obsession
 	var/obsession_hug_count = 0
 
-/datum/brain_trauma/special/obsessed/on_gain()
+/datum/brain_trauma/special/obsessed/New(obsession)
+	. = ..()
+	src.obsession = obsession
 
+/datum/brain_trauma/special/obsessed/on_gain()
 	//setup, linking, etc//
 	if(!obsession)//admins didn't set one
-		obsession = find_obsession()
+		obsession = pick(return_obsession_candidates(owner))
 		if(!obsession)//we didn't find one
 			lose_text = ""
 			qdel(src)
 			return
-	gain_text = "<span class='warning'>You hear a sickening, raspy voice in your head. It wants one small task of you...</span>"
 	owner.mind.add_antag_datum(/datum/antagonist/obsessed)
 	antagonist = owner.mind.has_antag_datum(/datum/antagonist/obsessed)
 	antagonist.trauma = src
@@ -36,7 +45,7 @@
 	antagonist.greet()
 	RegisterSignal(owner, COMSIG_CARBON_HUG, .proc/on_hug)
 
-/datum/brain_trauma/special/obsessed/on_life(delta_time, times_fired)
+/datum/brain_trauma/special/obsessed/on_life(delta_time = SSMOBS_DT, times_fired)
 	if(!obsession || obsession.stat == DEAD)
 		viewing = FALSE//important, makes sure you no longer stutter when happy if you murdered them while viewing
 		return
@@ -44,22 +53,18 @@
 		viewing = FALSE //they are further than our viewrange they are not viewing us
 		out_of_view()
 		return//so we're not searching everything in view every tick
-	if(obsession in view(7, owner))
-		viewing = TRUE
-	else
-		viewing = FALSE
-	if(viewing)
-		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "creeping", /datum/mood_event/creeping, obsession.name)
-		total_time_creeping += delta_time SECONDS
-		time_spent_away = 0
-		if(attachedobsessedobj)//if an objective needs to tick down, we can do that since traumas coexist with the antagonist datum
-			attachedobsessedobj.timer -= delta_time SECONDS //mob subsystem ticks every 2 seconds(?), remove 20 deciseconds from the timer. sure, that makes sense.
-	else
+	viewing = (obsession in view(7, owner))
+	if(!viewing)
 		out_of_view()
+	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "creeping", /datum/mood_event/creeping, obsession.name)
+	total_time_creeping += delta_time SECONDS
+	time_spent_away = 0
+	if(attachedobsessedobj)//if an objective needs to tick down, we can do that since traumas coexist with the antagonist datum
+		attachedobsessedobj.timer -= delta_time
 
 /datum/brain_trauma/special/obsessed/proc/out_of_view()
-	time_spent_away += 20
-	if(time_spent_away > 1800) //3 minutes
+	time_spent_away += 2 SECONDS
+	if(time_spent_away > 3 MINUTES)
 		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "creeping", /datum/mood_event/notcreepingsevere, obsession.name)
 	else
 		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "creeping", /datum/mood_event/notcreeping, obsession.name)
@@ -115,12 +120,11 @@
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, obsession, span_warning("You catch [examining_mob] staring at you..."), 3))
 	return COMSIG_BLOCK_EYECONTACT
 
-/datum/brain_trauma/special/obsessed/proc/find_obsession()
+/proc/return_obsession_candidates(mob/living/carbon/human/owner)
 	var/list/viable_minds = list() //The first list, which excludes hijinks
 	var/list/possible_targets = list() //The second list, which filters out silicons and simplemobs
 	var/static/list/trait_obsessions = list("Mime" = TRAIT_FAN_MIME, "Clown" = TRAIT_FAN_CLOWN, "Chaplain" = TRAIT_SPIRITUAL) //Jobs and their corresponding quirks
 	var/list/special_pool = list() //The special list, for quirk-based
-	var/chosen_victim  //The obsession target
 
 	for(var/mob/player as anything in GLOB.player_list)//prevents crewmembers falling in love with nuke ops they never met, and other annoying hijinks
 		if(!player.client || !player.mind || isnewplayer(player) || player.stat == DEAD || isbrain(player) || player == owner)
@@ -137,10 +141,8 @@
 
 	//Do we have any special target?
 	if(length(special_pool))
-		chosen_victim = pick(special_pool)
-		return chosen_victim
+		return special_pool
 
 	//If not, pick any other ordinary target
-	if(possible_targets.len > 0)
-		chosen_victim = pick(possible_targets)
-	return chosen_victim
+	if(length(possible_targets))
+		return possible_targets

--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -53,7 +53,7 @@
 		viewing = FALSE //they are further than our viewrange they are not viewing us
 		out_of_view()
 		return//so we're not searching everything in view every tick
-	viewing = obsession in view(7, owner)
+	viewing = (obsession in view(7, owner))
 	if(!viewing)
 		out_of_view()
 	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "creeping", /datum/mood_event/creeping, obsession.name)

--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -53,7 +53,7 @@
 		viewing = FALSE //they are further than our viewrange they are not viewing us
 		out_of_view()
 		return//so we're not searching everything in view every tick
-	viewing = (obsession in view(7, owner))
+	viewing = obsession in view(7, owner)
 	if(!viewing)
 		out_of_view()
 	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "creeping", /datum/mood_event/creeping, obsession.name)

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -12,17 +12,23 @@
 	var/datum/brain_trauma/special/obsessed/trauma
 
 /datum/antagonist/obsessed/admin_add(datum/mind/new_owner,mob/admin)
-	var/mob/living/carbon/C = new_owner.current
-	if(!istype(C))
+	var/mob/living/carbon/creep = new_owner.current
+	if(!istype(creep))
 		to_chat(admin, "[roundend_category] come from a brain trauma, so they need to at least be a carbon!")
 		return
-	if(!C.getorgan(/obj/item/organ/brain)) // If only I had a brain
+	if(!creep.getorgan(/obj/item/organ/brain)) // If only I had a brain
 		to_chat(admin, "[roundend_category] come from a brain trauma, so they need to HAVE A BRAIN.")
 		return
 	message_admins("[key_name_admin(admin)] made [key_name_admin(new_owner)] into [name].")
 	log_admin("[key_name(admin)] made [key_name(new_owner)] into [name].")
+
+	var/response = tgui_alert(admin, "Pick their obsession? If none is selected, a random one will be chosen.", "Obsession Selection", list("Yes", "No"))
+	var/admin_picked_obsession
+	if(response == "Yes")
+		var/list/candidates = return_obsession_candidates(creep)
+		admin_picked_obsession = tgui_input_list(admin, "Pick a victim!", "Valid candidates", candidates)
 	//PRESTO FUCKIN MAJESTO
-	C.gain_trauma(/datum/brain_trauma/special/obsessed)//ZAP
+	creep.gain_trauma(/datum/brain_trauma/special/obsessed, TRAUMA_RESILIENCE_SURGERY, admin_picked_obsession)//ZAP
 
 /datum/antagonist/obsessed/greet()
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/creepalert.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
@@ -64,8 +70,7 @@
 		objectives_left += "jealous"
 
 	for(var/i in 1 to 3)
-		var/chosen_objective = pick(objectives_left)
-		objectives_left.Remove(chosen_objective)
+		var/chosen_objective = pick_n_take(objectives_left)
 		switch(chosen_objective)
 			if("spendtime")
 				var/datum/objective/spendtime/spendtime = new


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- cleans up admin adding of obsessed- it used to leave behind instances of the antag datum with no owner
- admins can now select an obsession target because of above improvements
- documents the brain trauma
- removes a lot of boilerplate, trailing elses, single letter vars, and other garbage from the code. different era yknow
- jealousy objective now gives free objective when it makes sense to do so

## Why It's Good For The Game

improvements, admins keep telling me to let them select an obsession target

## Changelog
:cl:
code: improves obsession code
admin: admins can select a target for obsessed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
