### PR TITLE
Fix HFR box edge directions

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -483,7 +483,7 @@
 			continue
 		if(box.box_type == "body")
 			if(direction in GLOB.cardinals)
-				box.dir = DIRFLIP(direction)
+				box.dir = direction
 				parts |= box
 			continue
 	if(parts.len == 8)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Using the multitool on the HFR boxes creates an HFR with all corners correctly oriented, but all edges oriented in the opposite direction. This PR changes it so that the edge components have the correct orientation relative to the core.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Danger donut becomes danger donut shaped

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: The HFR now places its side components in the correct orientation when constructed by using a Multitool on the rapid HFR boxes. The core still needs rotating if your design requires it, and is best done before you step away unless you want to disassemble and move a side component.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
