### PR TITLE
Revert "Fix thermomachine temperature abuse"

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
@@ -160,7 +160,6 @@
 
 	// The gas we want to cool/heat
 	var/datum/gas_mixture/main_port = airs[1]
-	var/datum/gas_mixture/exchange_target = airs[2]
 
 	// The difference between target and what we need to heat/cool. Positive if heating, negative if cooling.
 	var/temperature_target_delta = target_temperature - main_port.temperature
@@ -188,29 +187,14 @@
 	// This is to reset the value when we are heating.
 	efficiency = 1
 
-	var/mole_efficiency = 1
-	var/mole_eff_main_port = 1
-	var/mole_eff_thermal_port = 1
 	if(cooling)
+		var/datum/gas_mixture/exchange_target
 		// Exchange target is the thing we are paired with, be it enviroment or the red port.
 		if(use_enviroment_heat)
 			exchange_target = local_turf.return_air()
 		else
 			exchange_target = airs[2]
 
-		if(exchange_target.total_moles() < 5)
-			mole_eff_thermal_port = 0.001
-		else
-			mole_eff_thermal_port = 1 - (1 / (exchange_target.total_moles() + 1)) * 5
-
-	if(main_port.total_moles() < 5)
-		mole_eff_main_port = 0.001
-	else
-		mole_eff_main_port = 1 - (1 / (main_port.total_moles() + 1)) * 5
-
-	mole_efficiency = min(mole_eff_main_port, mole_eff_thermal_port)
-
-	if(cooling)
 		if (exchange_target.total_moles() < 0.01)
 			skipping_work = TRUE
 			return
@@ -223,8 +207,6 @@
 		// Cases of log(0) will be caught by the early return above.
 		if (use_enviroment_heat)
 			efficiency *= clamp(log(1.55, exchange_target.total_moles()) * 0.15, 0.65, 1)
-
-		efficiency *= mole_efficiency
 
 		if (exchange_target.temperature > THERMOMACHINE_SAFE_TEMPERATURE && safeties)
 			on = FALSE
@@ -241,9 +223,6 @@
 					return PROCESS_KILL //We're dying anyway, so let's stop processing
 
 		exchange_target.temperature = max((THERMAL_ENERGY(exchange_target) - (heat_amount * efficiency) + motor_heat) / exchange_target.heat_capacity(), TCMB)
-
-	if(!cooling)
-		efficiency *= mole_efficiency
 
 	main_port.temperature = max((THERMAL_ENERGY(main_port) + (heat_amount * efficiency)) / main_port.heat_capacity(), TCMB)
 


### PR DESCRIPTION
## About the Pull Request
Reverts tgstation/tgstation#60841
Breaks #60580 again, unfortunately
## Why It's good for the game
#60841 completely broke thermomachines, they now fail to change the temperature of anything, even with 200 or more mols in the waste line, and drain exorbitant amounts of power, to the point where a t4 thermomachine will drain an APC in seconds.

KEEPING IN MIND: My issues come from downstream, but we have not touched thermomachines since this patch (or ever, really), and they were working fine until this patch. If I get verification that they're working fine up here, I'll go yell at our downstream maintainers who refused to allow us to revert this downstream.

ALSO, I'm happy to close this in exchange for a further patch to thermomachines.

## Changelog
:cl: FlamingLily
fix: Fixes thermomachines not working
/:cl: