### PR TITLE
Many smart pipe fixes

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -8,6 +8,15 @@
 #define SOUTH_SHORTPIPE (1<<5)
 #define EAST_SHORTPIPE (1<<6)
 #define WEST_SHORTPIPE (1<<7)
+// Helpers to convert cardinals to and from pipe bitfields
+// Assumes X_FULLPIPE = X, X_SHORTPIPE >> 4 = X as above
+#define FULLPIPE_TO_CARDINALS(bitfield) ((bitfield) & ALL_CARDINALS)
+#define SHORTPIPE_TO_CARDINALS(bitfield) (((bitfield) >> 4) & ALL_CARDINALS)
+#define CARDINAL_TO_FULLPIPES(cardinals) (cardinals)
+#define CARDINAL_TO_SHORTPIPES(cardinals) ((cardinals) << 4)
+// A pipe is a stub if it only has zero or one permitted direction. For a regular pipe this is nonsensical, and there are no pipe sprites for this, so it is not allowed.
+#define ISSTUB(bits) !((bits) & (bits - 1))
+#define ISNOTSTUB(bits) ((bits) & (bits - 1))
 //Atmos pipe limits
 /// (kPa) What pressure pumps and powered equipment max out at.
 #define MAX_OUTPUT_PRESSURE 4500

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -167,9 +167,9 @@ Buildable meters
 			to_chat(user, span_warning("Something is hogging the tile!"))
 			return TRUE
 
-		if(pipe_count == 1 && istype(machine, /obj/machinery/atmospherics/pipe/smart) && ispath(pipe_type, /obj/machinery/atmospherics/pipe/smart) && lowertext(machine.pipe_color) != lowertext(pipe_color) && machine.connection_num < 3)
+		if(pipe_count == 1 && istype(machine, /obj/machinery/atmospherics/pipe/smart) && ispath(pipe_type, /obj/machinery/atmospherics/pipe/smart) && lowertext(machine.pipe_color) != lowertext(pipe_color))
 			var/direction = machine.dir
-			if((direction & EAST|WEST || direction & SOUTH|NORTH) && !ISDIAGONALDIR(direction))
+			if(((direction & (EAST|WEST)) || (direction & (SOUTH|NORTH))) && !ISDIAGONALDIR(direction))
 				pipe_type = /obj/machinery/atmospherics/pipe/bridge_pipe
 				if(EWCOMPONENT(direction))
 					dir = NORTH

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -171,27 +171,17 @@ Buildable meters
 		if(machine.piping_layer != piping_layer && !((machine.pipe_flags | flags) & PIPING_ALL_LAYER))
 			continue
 
-		// If we're a smart pipe, and we're looking to share space with a potentially perpendicular kind of pipe, see if we can smartly go over it as a bridge
-		if(pipe_count == 1 && ispath(pipe_type, /obj/machinery/atmospherics/pipe/smart))
-			// If we're looking to go over another smart pipe, it must be of a different color.
-			if (!istype(machine, /obj/machinery/atmospherics/pipe/smart) || lowertext(machine.pipe_color) != lowertext(pipe_color))
-				var/other_direction = machine.dir
-				if(((other_direction & (EAST|WEST)) || (other_direction & (SOUTH|NORTH))) && !ISDIAGONALDIR(other_direction))
-					pipe_type = /obj/machinery/atmospherics/pipe/bridge_pipe
-					if(EWCOMPONENT(other_direction))
-						dir = NORTH
-					if(NSCOMPONENT(other_direction))
-						dir = EAST
-					continue
-
-		// skip checks if we are placing a bridge pipe over a non-bridge-pipe at 90 degrees (can't stack bridges)
-		if(flags & PIPING_BRIDGE && !(machine.pipe_flags & PIPING_BRIDGE) && check_ninety_degree_dir(machine))
-			continue
-
 		// if the pipes have any directions in common, we can't place it that way.
-		if(machine.GetInitDirections() & SSair.get_init_dirs(pipe_type, fixed_dir(), p_init_dir))
-			to_chat(user, span_warning("There is already a pipe at that location!"))
-			return TRUE
+		var/our_init_dirs = SSair.get_init_dirs(pipe_type, fixed_dir(), p_init_dir)
+		if(machine.GetInitDirections() & our_init_dirs)
+			// We have a conflict!
+			if (pipe_count != 1 || !try_smart_reconfiguration(machine, our_init_dirs, user))
+				// No solutions found
+				if (pipe_count != 1)
+					to_chat(user, span_warning("pipe_count is [pipe_count], not attempting smart reconfiguration!"))
+				var/other_init_directions = machine.GetInitDirections()
+				to_chat(user, span_warning("There is already a pipe at that location: [ADMIN_VV(machine)]:[other_init_directions] [ADMIN_VV(src)]:[our_init_dirs] CONFLICT at [other_init_directions & our_init_dirs]!"))
+				return TRUE
 	// no conflicts found
 
 	var/obj/machinery/atmospherics/built_machine = new pipe_type(loc, , , p_init_dir)
@@ -206,6 +196,99 @@ Buildable meters
 		span_hear("You hear ratcheting."))
 
 	qdel(src)
+
+/**
+ * Attempt to automatically resolve a pipe conflict by reconfiguring any smart pipes involved.
+ *
+ * Constraints:
+ *  - A smart pipe cannot have current connections reconfigured.
+ *  - A smart pipe cannot have fewer than two directions in which it will connect.
+ *  - A smart pipe, existing or new, will not automatically reconfigure itself to permit directions it was not previously permitting.
+ */
+/obj/item/pipe/proc/try_smart_reconfiguration(obj/machinery/atmospherics/machine, our_init_dirs, mob/living/user)
+	// If we're a smart pipe, we might be able to solve this by placing down a more constrained version of ourselves.
+	to_chat(user, span_notice("Attempting smart pipe reconfiguration..."))
+	var/obj/machinery/atmospherics/pipe/smart/other_smart_pipe = machine
+	if(ispath(pipe_type, /obj/machinery/atmospherics/pipe/smart/))
+		// If we're conflicting with another smart pipe, see if we can negotiate.
+		if(istype(other_smart_pipe))
+			// Two smart pipes. This is going to get complicated.
+			// Check to see whether the already placed pipe is bent or not.
+			if (ISDIAGONALDIR(other_smart_pipe.dir))
+				// The other pipe is bent, with at least two current connections. See if we can bounce off it as a bent pipe in the other direction.
+				var/opposing_dir = (other_smart_pipe.connections ^ ALL_CARDINALS) & our_init_dirs
+				if (opposing_dir & (opposing_dir - 1))
+					// We only get here if both smart pipes have two directions.
+					p_init_dir = opposing_dir
+					other_smart_pipe.SetInitDirections(other_smart_pipe.connections)
+					other_smart_pipe.update_pipe_icon()
+					to_chat(user, span_notice("Reconfiguring smart pipe (bent)!"))
+					return TRUE
+				to_chat(user, span_warning("Could not reconfigure smart pipe (bent branch) [src]:I[our_init_dirs] -> [opposing_dir] [other_smart_pipe]:C[other_smart_pipe.connections]!"))
+				// We're left with one or no available directions if we look at the complement of the other smart pipe's live connections.
+				// There's nothing further we can do.
+				return FALSE
+			else
+				// The other pipe is straight. See if we can go over it in a perpindicular direction.
+				// Note that the other pipe cannot be unconnected, since we have a conflict.
+				if(EWCOMPONENT(other_smart_pipe.dir))
+					if ((NORTH|SOUTH) & ~p_init_dir)
+						// Not allowed to connect this way
+						to_chat(user, span_warning("We're not allowed to connect vertically."))
+						return FALSE
+					if (~other_smart_pipe.GetInitDirections() & (EAST|WEST))
+						// Not allowed to reconfigure the other pipe this way
+						to_chat(user, span_warning("Other smart pipe not allowed to connect horizontally."))
+						return FALSE
+					p_init_dir = NORTH|SOUTH
+					other_smart_pipe.SetInitDirections(EAST|WEST)
+					other_smart_pipe.update_pipe_icon()
+					to_chat(user, span_notice("Reconfiguring smart pipe (to horizontal)!"))
+					return TRUE
+				if (NSCOMPONENT(other_smart_pipe.dir))
+					if ((EAST|WEST) & ~p_init_dir)
+						// Not allowed to connect this way
+						to_chat(user, span_warning("We're not allowed to connect horizontally."))
+						return FALSE
+					if (~other_smart_pipe.GetInitDirections() & (NORTH|SOUTH))
+						// Not allowed to reconfigure the other pipe this way
+						to_chat(user, span_warning("Other smart pipe not allowed to connect vertically."))
+						return FALSE
+					p_init_dir = EAST|WEST
+					other_smart_pipe.SetInitDirections(NORTH|SOUTH)
+					other_smart_pipe.update_pipe_icon()
+					to_chat(user, span_notice("Reconfiguring smart pipe (to vertical)!"))
+					return TRUE
+			to_chat(user, span_warning("Fallthrough (two smart pipes, no other case); this should never happen!"))
+			return FALSE
+		// We're not dealing with another smart pipe. See if we can become the complement of the conflicting machine.
+		var/opposing_dir = (machine.GetInitDirections() ^ ALL_CARDINALS) & our_init_dirs
+		if (opposing_dir & (opposing_dir - 1))
+			// We have at least two permitted directions in the complement. Use them.
+			p_init_dir = opposing_dir
+			to_chat(user, span_notice("Reconfiguring ourselves to complement of [machine.GetInitDirections()]:[opposing_dir]!"))
+			return TRUE
+		to_chat(user, span_warning("Could not reconfigure ourselves with [ADMIN_VV(src)]:[our_init_dirs] to complement of [ADMIN_VV(machine)]:I[machine.GetInitDirections()]"))
+		return FALSE
+
+	else if(istype(other_smart_pipe))
+		// We're not a smart pipe ourselves, but we are conflicting with a smart pipe. We might be able to solve this by constraining the smart pipe.
+		if (our_init_dirs & other_smart_pipe.connections)
+			// We needed to go where a smart pipe already had connections, nothing further we can do
+			to_chat(user, span_warning("We ([ADMIN_VV(src)]) would go where a smart pipe ([ADMIN_VV(other_smart_pipe)]:C[other_smart_pipe.connections]) would be!"));
+			return FALSE
+		var/opposing_dir = (our_init_dirs ^ ALL_CARDINALS) & other_smart_pipe.GetInitDirections()
+		if (opposing_dir & (opposing_dir - 1))
+			// At least two directions remain for that smart pipe, reconfigure it
+			to_chat(user, span_notice("Reconfiguring other smart pipe ([ADMIN_VV(other_smart_pipe)]:I[other_smart_pipe.GetInitDirections()]) to complement of [machine.GetInitDirections()]: [opposing_dir]!"))
+			other_smart_pipe.SetInitDirections(opposing_dir)
+			other_smart_pipe.update_pipe_icon()
+			return TRUE
+		to_chat(user, span_warning("Other smart pipe ([ADMIN_VV(other_smart_pipe)]) would be left with less than two directions ([opposing_dir])"))
+		return FALSE
+	// No smart pipes involved, the conflict can't be solved this way.
+	to_chat(user, span_warning("No smart pipes involved, cannot reconfigure"))
+	return FALSE
 
 /obj/item/pipe/proc/build_pipe(obj/machinery/atmospherics/A)
 	A.setDir(fixed_dir())

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -167,15 +167,16 @@ Buildable meters
 			to_chat(user, span_warning("Something is hogging the tile!"))
 			return TRUE
 
-		if(pipe_count == 1 && istype(machine, /obj/machinery/atmospherics/pipe/smart) && ispath(pipe_type, /obj/machinery/atmospherics/pipe/smart) && lowertext(machine.pipe_color) != lowertext(pipe_color))
-			var/direction = machine.dir
-			if(((direction & (EAST|WEST)) || (direction & (SOUTH|NORTH))) && !ISDIAGONALDIR(direction))
-				pipe_type = /obj/machinery/atmospherics/pipe/bridge_pipe
-				if(EWCOMPONENT(direction))
-					dir = NORTH
-				if(NSCOMPONENT(direction))
-					dir = EAST
-				continue
+		if(pipe_count == 1 && ispath(pipe_type, /obj/machinery/atmospherics/pipe/smart))
+			if (!istype(machine, /obj/machinery/atmospherics/pipe/smart) || lowertext(machine.pipe_color) != lowertext(pipe_color))
+				var/direction = machine.dir
+				if(((direction & (EAST|WEST)) || (direction & (SOUTH|NORTH))) && !ISDIAGONALDIR(direction))
+					pipe_type = /obj/machinery/atmospherics/pipe/bridge_pipe
+					if(EWCOMPONENT(direction))
+						dir = NORTH
+					if(NSCOMPONENT(direction))
+						dir = EAST
+					continue
 
 		if(flags & PIPING_BRIDGE && !(machine.pipe_flags & PIPING_BRIDGE) && check_ninety_degree_dir(machine)) //continue if we are placing a bridge pipe over a normal pipe only (prevent duplicates)
 			continue

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -168,7 +168,7 @@ Buildable meters
 			return TRUE
 
 		// skip checks if we don't overlap layers, either by being on the same layer or by something being on all layers
-		if((machine.piping_layer != piping_layer) && !((machine.pipe_flags | flags) & PIPING_ALL_LAYER))
+		if(machine.piping_layer != piping_layer && !((machine.pipe_flags | flags) & PIPING_ALL_LAYER))
 			continue
 
 		// If we're a smart pipe, and we're looking to share space with a potentially perpendicular kind of pipe, see if we can smartly go over it as a bridge

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -177,10 +177,7 @@ Buildable meters
 			// We have a conflict!
 			if (length(potentially_conflicting_machines) != 1 || !try_smart_reconfiguration(machine, our_init_dirs, user))
 				// No solutions found
-				if (length(potentially_conflicting_machines) != 1)
-					to_chat(user, span_warning("pipe_count is [length(potentially_conflicting_machines)], not attempting smart reconfiguration!"))
-				var/other_init_directions = machine.GetInitDirections()
-				to_chat(user, span_warning("There is already a pipe at that location: [ADMIN_VV(machine)]:[other_init_directions] [ADMIN_VV(src)]:[our_init_dirs] CONFLICT at [other_init_directions & our_init_dirs]!"))
+				to_chat(user, span_warning("There is already a pipe at that location!"))
 				return TRUE
 	// no conflicts found
 
@@ -207,7 +204,6 @@ Buildable meters
  */
 /obj/item/pipe/proc/try_smart_reconfiguration(obj/machinery/atmospherics/machine, our_init_dirs, mob/living/user)
 	// If we're a smart pipe, we might be able to solve this by placing down a more constrained version of ourselves.
-	to_chat(user, span_notice("Attempting smart pipe reconfiguration..."))
 	var/obj/machinery/atmospherics/pipe/smart/other_smart_pipe = machine
 	if(ispath(pipe_type, /obj/machinery/atmospherics/pipe/smart/))
 		// If we're conflicting with another smart pipe, see if we can negotiate.
@@ -222,9 +218,7 @@ Buildable meters
 					p_init_dir = opposing_dir
 					other_smart_pipe.SetInitDirections(other_smart_pipe.connections)
 					other_smart_pipe.update_pipe_icon()
-					to_chat(user, span_notice("Reconfiguring smart pipe (bent)!"))
 					return TRUE
-				to_chat(user, span_warning("Could not reconfigure smart pipe (bent branch) [src]:I[our_init_dirs] -> [opposing_dir] [other_smart_pipe]:C[other_smart_pipe.connections]!"))
 				// We're left with one or no available directions if we look at the complement of the other smart pipe's live connections.
 				// There's nothing further we can do.
 				return FALSE
@@ -234,60 +228,47 @@ Buildable meters
 				if(EWCOMPONENT(other_smart_pipe.dir))
 					if ((NORTH|SOUTH) & ~p_init_dir)
 						// Not allowed to connect this way
-						to_chat(user, span_warning("We're not allowed to connect vertically."))
 						return FALSE
 					if (~other_smart_pipe.GetInitDirections() & (EAST|WEST))
 						// Not allowed to reconfigure the other pipe this way
-						to_chat(user, span_warning("Other smart pipe not allowed to connect horizontally."))
 						return FALSE
 					p_init_dir = NORTH|SOUTH
 					other_smart_pipe.SetInitDirections(EAST|WEST)
 					other_smart_pipe.update_pipe_icon()
-					to_chat(user, span_notice("Reconfiguring smart pipe (to horizontal)!"))
 					return TRUE
 				if (NSCOMPONENT(other_smart_pipe.dir))
 					if ((EAST|WEST) & ~p_init_dir)
 						// Not allowed to connect this way
-						to_chat(user, span_warning("We're not allowed to connect horizontally."))
 						return FALSE
 					if (~other_smart_pipe.GetInitDirections() & (NORTH|SOUTH))
 						// Not allowed to reconfigure the other pipe this way
-						to_chat(user, span_warning("Other smart pipe not allowed to connect vertically."))
 						return FALSE
 					p_init_dir = EAST|WEST
 					other_smart_pipe.SetInitDirections(NORTH|SOUTH)
 					other_smart_pipe.update_pipe_icon()
-					to_chat(user, span_notice("Reconfiguring smart pipe (to vertical)!"))
 					return TRUE
-			to_chat(user, span_warning("Fallthrough (two smart pipes, no other case); this should never happen!"))
 			return FALSE
 		// We're not dealing with another smart pipe. See if we can become the complement of the conflicting machine.
 		var/opposing_dir = our_init_dirs & ~machine.GetInitDirections()
 		if (ISNOTSTUB(opposing_dir))
 			// We have at least two permitted directions in the complement. Use them.
 			p_init_dir = opposing_dir
-			to_chat(user, span_notice("Reconfiguring ourselves to complement of [machine.GetInitDirections()]:[opposing_dir]!"))
 			return TRUE
-		to_chat(user, span_warning("Could not reconfigure ourselves with [ADMIN_VV(src)]:[our_init_dirs] to complement of [ADMIN_VV(machine)]:I[machine.GetInitDirections()]"))
 		return FALSE
 
 	else if(istype(other_smart_pipe))
 		// We're not a smart pipe ourselves, but we are conflicting with a smart pipe. We might be able to solve this by constraining the smart pipe.
 		if (our_init_dirs & other_smart_pipe.connections)
 			// We needed to go where a smart pipe already had connections, nothing further we can do
-			to_chat(user, span_warning("We ([ADMIN_VV(src)]) would go where a smart pipe ([ADMIN_VV(other_smart_pipe)]:C[other_smart_pipe.connections]) would be!"));
 			return FALSE
 		var/opposing_dir = other_smart_pipe.GetInitDirections() & ~our_init_dirs
 		if (ISNOTSTUB(opposing_dir))
 			// At least two directions remain for that smart pipe, reconfigure it
-			to_chat(user, span_notice("Reconfiguring other smart pipe ([ADMIN_VV(other_smart_pipe)]:I[other_smart_pipe.GetInitDirections()]) to complement of [machine.GetInitDirections()]: [opposing_dir]!"))
 			other_smart_pipe.SetInitDirections(opposing_dir)
 			other_smart_pipe.update_pipe_icon()
 			return TRUE
-		to_chat(user, span_warning("Other smart pipe ([ADMIN_VV(other_smart_pipe)]) would be left with less than two directions ([opposing_dir])"))
 		return FALSE
 	// No smart pipes involved, the conflict can't be solved this way.
-	to_chat(user, span_warning("No smart pipes involved, cannot reconfigure"))
 	return FALSE
 
 /obj/item/pipe/proc/build_pipe(obj/machinery/atmospherics/A)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -167,24 +167,29 @@ Buildable meters
 			to_chat(user, span_warning("Something is hogging the tile!"))
 			return TRUE
 
+		// If we're a smart pipe, and we're looking to share space with a potentially perpendicular kind of pipe, see if we can smartly go over it as a bridge
 		if(pipe_count == 1 && ispath(pipe_type, /obj/machinery/atmospherics/pipe/smart))
+			// If we're looking to go over another smart pipe, it must be of a different color.
 			if (!istype(machine, /obj/machinery/atmospherics/pipe/smart) || lowertext(machine.pipe_color) != lowertext(pipe_color))
-				var/direction = machine.dir
-				if(((direction & (EAST|WEST)) || (direction & (SOUTH|NORTH))) && !ISDIAGONALDIR(direction))
+				var/other_direction = machine.dir
+				if(((other_direction & (EAST|WEST)) || (other_direction & (SOUTH|NORTH))) && !ISDIAGONALDIR(other_direction))
 					pipe_type = /obj/machinery/atmospherics/pipe/bridge_pipe
-					if(EWCOMPONENT(direction))
+					if(EWCOMPONENT(other_direction))
 						dir = NORTH
-					if(NSCOMPONENT(direction))
+					if(NSCOMPONENT(other_direction))
 						dir = EAST
 					continue
 
-		if(flags & PIPING_BRIDGE && !(machine.pipe_flags & PIPING_BRIDGE) && check_ninety_degree_dir(machine)) //continue if we are placing a bridge pipe over a normal pipe only (prevent duplicates)
+		// skip checks if we are placing a bridge pipe over a non-bridge-pipe at 90 degrees (can't stack bridges)
+		if(flags & PIPING_BRIDGE && !(machine.pipe_flags & PIPING_BRIDGE) && check_ninety_degree_dir(machine))
 			continue
 
-		if((machine.piping_layer != piping_layer) && !((machine.pipe_flags | flags) & PIPING_ALL_LAYER)) //don't continue if either pipe goes across all layers
+		// skip checks if we don't overlap layers, either by being on the same layer or by something being on all layers
+		if((machine.piping_layer != piping_layer) && !((machine.pipe_flags | flags) & PIPING_ALL_LAYER))
 			continue
 
-		if(machine.GetInitDirections() & SSair.get_init_dirs(pipe_type, fixed_dir(), p_init_dir)) // matches at least one direction on either type of pipe
+		// if the pipes have any directions in common, we can't place it that way.
+		if(machine.GetInitDirections() & SSair.get_init_dirs(pipe_type, fixed_dir(), p_init_dir))
 			to_chat(user, span_warning("There is already a pipe at that location!"))
 			return TRUE
 	// no conflicts found

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -159,7 +159,7 @@ Buildable meters
 	var/flags = initial(fakeA.pipe_flags)
 	var/pipe_count = 0
 	for(var/obj/machinery/atmospherics/machine in loc)
-		if(machine.piping_layer != piping_layer)
+		if(machine.piping_layer != piping_layer && !((machine.pipe_flags | flags) & PIPING_ALL_LAYER))
 			continue
 		pipe_count += 1
 	for(var/obj/machinery/atmospherics/machine in loc)
@@ -177,10 +177,7 @@ Buildable meters
 			// We have a conflict!
 			if (pipe_count != 1 || !try_smart_reconfiguration(machine, our_init_dirs, user))
 				// No solutions found
-				if (pipe_count != 1)
-					to_chat(user, span_warning("pipe_count is [pipe_count], not attempting smart reconfiguration!"))
-				var/other_init_directions = machine.GetInitDirections()
-				to_chat(user, span_warning("There is already a pipe at that location: [ADMIN_VV(machine)]:[other_init_directions] [ADMIN_VV(src)]:[our_init_dirs] CONFLICT at [other_init_directions & our_init_dirs]!"))
+				to_chat(user, span_warning("There is already a pipe at that location!"))
 				return TRUE
 	// no conflicts found
 
@@ -207,7 +204,6 @@ Buildable meters
  */
 /obj/item/pipe/proc/try_smart_reconfiguration(obj/machinery/atmospherics/machine, our_init_dirs, mob/living/user)
 	// If we're a smart pipe, we might be able to solve this by placing down a more constrained version of ourselves.
-	to_chat(user, span_notice("Attempting smart pipe reconfiguration..."))
 	var/obj/machinery/atmospherics/pipe/smart/other_smart_pipe = machine
 	if(ispath(pipe_type, /obj/machinery/atmospherics/pipe/smart/))
 		// If we're conflicting with another smart pipe, see if we can negotiate.
@@ -222,9 +218,7 @@ Buildable meters
 					p_init_dir = opposing_dir
 					other_smart_pipe.SetInitDirections(other_smart_pipe.connections)
 					other_smart_pipe.update_pipe_icon()
-					to_chat(user, span_notice("Reconfiguring smart pipe (bent)!"))
 					return TRUE
-				to_chat(user, span_warning("Could not reconfigure smart pipe (bent branch) [src]:I[our_init_dirs] -> [opposing_dir] [other_smart_pipe]:C[other_smart_pipe.connections]!"))
 				// We're left with one or no available directions if we look at the complement of the other smart pipe's live connections.
 				// There's nothing further we can do.
 				return FALSE
@@ -234,60 +228,47 @@ Buildable meters
 				if(EWCOMPONENT(other_smart_pipe.dir))
 					if ((NORTH|SOUTH) & ~p_init_dir)
 						// Not allowed to connect this way
-						to_chat(user, span_warning("We're not allowed to connect vertically."))
 						return FALSE
 					if (~other_smart_pipe.GetInitDirections() & (EAST|WEST))
 						// Not allowed to reconfigure the other pipe this way
-						to_chat(user, span_warning("Other smart pipe not allowed to connect horizontally."))
 						return FALSE
 					p_init_dir = NORTH|SOUTH
 					other_smart_pipe.SetInitDirections(EAST|WEST)
 					other_smart_pipe.update_pipe_icon()
-					to_chat(user, span_notice("Reconfiguring smart pipe (to horizontal)!"))
 					return TRUE
 				if (NSCOMPONENT(other_smart_pipe.dir))
 					if ((EAST|WEST) & ~p_init_dir)
 						// Not allowed to connect this way
-						to_chat(user, span_warning("We're not allowed to connect horizontally."))
 						return FALSE
 					if (~other_smart_pipe.GetInitDirections() & (NORTH|SOUTH))
 						// Not allowed to reconfigure the other pipe this way
-						to_chat(user, span_warning("Other smart pipe not allowed to connect vertically."))
 						return FALSE
 					p_init_dir = EAST|WEST
 					other_smart_pipe.SetInitDirections(NORTH|SOUTH)
 					other_smart_pipe.update_pipe_icon()
-					to_chat(user, span_notice("Reconfiguring smart pipe (to vertical)!"))
 					return TRUE
-			to_chat(user, span_warning("Fallthrough (two smart pipes, no other case); this should never happen!"))
 			return FALSE
 		// We're not dealing with another smart pipe. See if we can become the complement of the conflicting machine.
 		var/opposing_dir = (machine.GetInitDirections() ^ ALL_CARDINALS) & our_init_dirs
 		if (opposing_dir & (opposing_dir - 1))
 			// We have at least two permitted directions in the complement. Use them.
 			p_init_dir = opposing_dir
-			to_chat(user, span_notice("Reconfiguring ourselves to complement of [machine.GetInitDirections()]:[opposing_dir]!"))
 			return TRUE
-		to_chat(user, span_warning("Could not reconfigure ourselves with [ADMIN_VV(src)]:[our_init_dirs] to complement of [ADMIN_VV(machine)]:I[machine.GetInitDirections()]"))
 		return FALSE
 
 	else if(istype(other_smart_pipe))
 		// We're not a smart pipe ourselves, but we are conflicting with a smart pipe. We might be able to solve this by constraining the smart pipe.
 		if (our_init_dirs & other_smart_pipe.connections)
 			// We needed to go where a smart pipe already had connections, nothing further we can do
-			to_chat(user, span_warning("We ([ADMIN_VV(src)]) would go where a smart pipe ([ADMIN_VV(other_smart_pipe)]:C[other_smart_pipe.connections]) would be!"));
 			return FALSE
 		var/opposing_dir = (our_init_dirs ^ ALL_CARDINALS) & other_smart_pipe.GetInitDirections()
 		if (opposing_dir & (opposing_dir - 1))
 			// At least two directions remain for that smart pipe, reconfigure it
-			to_chat(user, span_notice("Reconfiguring other smart pipe ([ADMIN_VV(other_smart_pipe)]:I[other_smart_pipe.GetInitDirections()]) to complement of [machine.GetInitDirections()]: [opposing_dir]!"))
 			other_smart_pipe.SetInitDirections(opposing_dir)
 			other_smart_pipe.update_pipe_icon()
 			return TRUE
-		to_chat(user, span_warning("Other smart pipe ([ADMIN_VV(other_smart_pipe)]) would be left with less than two directions ([opposing_dir])"))
 		return FALSE
 	// No smart pipes involved, the conflict can't be solved this way.
-	to_chat(user, span_warning("No smart pipes involved, cannot reconfigure"))
 	return FALSE
 
 /obj/item/pipe/proc/build_pipe(obj/machinery/atmospherics/A)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -167,6 +167,10 @@ Buildable meters
 			to_chat(user, span_warning("Something is hogging the tile!"))
 			return TRUE
 
+		// skip checks if we don't overlap layers, either by being on the same layer or by something being on all layers
+		if((machine.piping_layer != piping_layer) && !((machine.pipe_flags | flags) & PIPING_ALL_LAYER))
+			continue
+
 		// If we're a smart pipe, and we're looking to share space with a potentially perpendicular kind of pipe, see if we can smartly go over it as a bridge
 		if(pipe_count == 1 && ispath(pipe_type, /obj/machinery/atmospherics/pipe/smart))
 			// If we're looking to go over another smart pipe, it must be of a different color.
@@ -182,10 +186,6 @@ Buildable meters
 
 		// skip checks if we are placing a bridge pipe over a non-bridge-pipe at 90 degrees (can't stack bridges)
 		if(flags & PIPING_BRIDGE && !(machine.pipe_flags & PIPING_BRIDGE) && check_ninety_degree_dir(machine))
-			continue
-
-		// skip checks if we don't overlap layers, either by being on the same layer or by something being on all layers
-		if((machine.piping_layer != piping_layer) && !((machine.pipe_flags | flags) & PIPING_ALL_LAYER))
 			continue
 
 		// if the pipes have any directions in common, we can't place it that way.

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -411,14 +411,11 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			playeffect = FALSE
 		if("mode")
 			var/n = text2num(params["mode"])
-			if(mode & n)
-				mode &= ~n
-			else
-				mode |= n
+			mode ^= n
 		if("init_dir_setting")
 			var/target_dir = p_init_dir ^ text2dir(params["dir_flag"])
 			// Refuse to create a smart pipe that can only connect in one direction (it would act weirdly and lack an icon)
-			if (target_dir & (target_dir - 1))
+			if (ISNOTSTUB(target_dir))
 				p_init_dir = target_dir
 		if("init_reset")
 			p_init_dir = ALL_CARDINALS
@@ -484,7 +481,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 						return
 					var/new_dir = (S.GetInitDirections() & ~target_differences) | target_differences
 					// Don't make a smart pipe with only one connection
-					if (!(new_dir & (new_dir - 1)))
+					if (ISSTUB(new_dir))
 						to_chat(user, span_warning("\The [src]'s screen flashes a warning: Can't configure a pipe to only connect in one direction."))
 						return
 					S.SetInitDirections(new_dir)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -10,7 +10,7 @@ RPD
 #define BUILD_MODE (1<<0)
 #define WRENCH_MODE (1<<1)
 #define DESTROY_MODE (1<<2)
-
+#define REPROGRAM_MODE (1<<3)
 
 GLOBAL_LIST_INIT(atmos_pipe_recipes, list(
 	"Pipes" = list(
@@ -216,6 +216,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/transit_build_speed = 0.5 SECONDS
 	///Speed of removal of unwrenched devices
 	var/destroy_speed = 0.5 SECONDS
+	///Speed of reprogramming connectable directions of smart pipes
+	var/reprogram_speed = 0.5 SECONDS
 	///Category currently active (Atmos, disposal, transit)
 	var/category = ATMOS_CATEGORY
 	///Piping layer we are going to spawn the atmos device in
@@ -231,7 +233,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	///Stores the first transit device
 	var/static/datum/pipe_info/first_transit
 	///The modes that are allowed for the RPD
-	var/mode = BUILD_MODE | DESTROY_MODE | WRENCH_MODE
+	var/mode = BUILD_MODE | DESTROY_MODE | WRENCH_MODE | REPROGRAM_MODE
 	/// Bitflags for upgrades
 	var/upgrade_flags
 
@@ -460,6 +462,42 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			qdel(attack_target)
 		return
 
+	if(mode & REPROGRAM_MODE)
+		var/obj/machinery/atmospherics/pipe/smart/S = attack_target
+		if(istype(S))
+			if (S.dir == ALL_CARDINALS)
+				to_chat(user, span_warning("\The [S] has no unconnected directions!"))
+				return
+			var/target_init_dir = S.GetInitDirections()
+			if (target_init_dir == p_init_dir)
+				to_chat(user, span_warning("\The [S] is already in this configuration!"))
+				return
+			// Check for differences in unconnected directions
+			var/target_differences = (p_init_dir ^ target_init_dir) & ~S.connections
+			if (target_differences)
+				to_chat(user, span_notice("You start reprogramming \the [S]..."))
+				playsound(get_turf(src), 'sound/machines/click.ogg', 50, TRUE)
+				if(do_after(user, reprogram_speed, target = S))
+					// Double check to make sure that nothing has changed. If anything we were about to change is now connected, abort
+					if (target_differences & S.connections)
+						to_chat(user, span_warning("\The [src]'s screen flashes a warning: Can't configure a pipe in a currently connected direction."))
+						return
+					var/new_dir = (S.GetInitDirections() & ~target_differences) | target_differences
+					// Don't make a smart pipe with only one connection
+					if (!(new_dir & (new_dir - 1)))
+						to_chat(user, span_warning("\The [src]'s screen flashes a warning: Can't configure a pipe to only connect in one direction."))
+						return
+					S.SetInitDirections(new_dir)
+					S.update_pipe_icon()
+					user.visible_message(span_notice("[user] reprograms the \the [S]."),span_notice("You reprogram \the [S]."))
+				return
+			to_chat(user, span_warning("\The [S] is already in this configuration for its unconnected directions!"))
+			return
+		var/obj/item/pipe/quaternary/I = attack_target
+		if(istype(I) && ispath(I.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+			I.p_init_dir = p_init_dir
+			I.update()
+
 	if(mode & BUILD_MODE)
 		switch(category) //if we've gotten this var, the target is valid
 			if(ATMOS_CATEGORY) //Making pipes
@@ -587,6 +625,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 #undef BUILD_MODE
 #undef DESTROY_MODE
 #undef WRENCH_MODE
+#undef REPROGRAM_MODE
 
 /obj/item/rpd_upgrade
 	name = "RPD advanced design disk"

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -414,7 +414,10 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			else
 				mode |= n
 		if("init_dir_setting")
-			p_init_dir ^= text2dir(params["dir_flag"])
+			var/target_dir = p_init_dir ^ text2dir(params["dir_flag"])
+			// Refuse to create a smart pipe that can only connect in one direction (it would act weirdly and lack an icon)
+			if (target_dir & (target_dir - 1))
+				p_init_dir = target_dir
 		if("init_reset")
 			p_init_dir = ALL_CARDINALS
 	if(playeffect)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -58,9 +58,6 @@
 	///The bitflag that's being checked on ventcrawling. Default is to allow ventcrawling and seeing pipes.
 	var/vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE
 
-	///Store the smart pipes connections, used for pipe construction
-	var/connection_num = 0
-
 /obj/machinery/atmospherics/LateInitialize()
 	. = ..()
 	update_name()

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -93,32 +93,16 @@
 
 /obj/machinery/atmospherics/pipe/proc/update_pipe_icon()
 	icon = 'icons/obj/atmospherics/pipes/pipes_bitmask.dmi'
+	var/connections = NONE
 	var/bitfield = NONE
 	for(var/i in 1 to device_type)
 		if(!nodes[i])
 			continue
 		var/obj/machinery/atmospherics/node = nodes[i]
 		var/connected_dir = get_dir(src, node)
-		switch(connected_dir)
-			if(NORTH)
-				bitfield |= NORTH_FULLPIPE
-			if(SOUTH)
-				bitfield |= SOUTH_FULLPIPE
-			if(EAST)
-				bitfield |= EAST_FULLPIPE
-			if(WEST)
-				bitfield |= WEST_FULLPIPE
-	for(var/cardinal in GLOB.cardinals)
-		if(initialize_directions & cardinal && !(bitfield & cardinal))
-			switch(cardinal)
-				if(NORTH)
-					bitfield |= NORTH_SHORTPIPE
-				if(SOUTH)
-					bitfield |= SOUTH_SHORTPIPE
-				if(EAST)
-					bitfield |= EAST_SHORTPIPE
-				if(WEST)
-					bitfield |= WEST_SHORTPIPE
+		connections |= connected_dir
+	bitfield = CARDINAL_TO_FULLPIPES(connections)
+	bitfield |= CARDINAL_TO_SHORTPIPES(initialize_directions & ~connections)
 	icon_state = "[bitfield]_[piping_layer]"
 
 /obj/machinery/atmospherics/pipe/update_icon()

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -10,32 +10,21 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 	device_type = QUATERNARY
 	construction_type = /obj/item/pipe/quaternary
 	pipe_state = "manifold4w"
-	connection_num = 0
-	var/connections
 
 /obj/machinery/atmospherics/pipe/smart/update_pipe_icon()
 	icon = 'icons/obj/atmospherics/pipes/pipes_bitmask.dmi'
 	var/bitfield = NONE
 	var/bits = 0
-	connections = NONE
-	connection_num = 0
+
 	for(var/i in 1 to device_type)
 		if(!nodes[i])
 			continue
 		var/obj/machinery/atmospherics/node = nodes[i]
 		var/connected_dir = get_dir(src, node)
-		connections |= connected_dir
-		connection_num += 1
 		bits++
-		switch(connected_dir)
-			if(NORTH)
-				bitfield |= NORTH_FULLPIPE
-			if(SOUTH)
-				bitfield |= SOUTH_FULLPIPE
-			if(EAST)
-				bitfield |= EAST_FULLPIPE
-			if(WEST)
-				bitfield |= WEST_FULLPIPE
+		// Note X_FULLPIPE == X as described in defines/atmospherics.dm
+		bitfield |= connected_dir
+	dir = check_binary_direction(bitfield)
 	//If we dont have enough bits to make a proper sprite, add some shortpipe bits
 	if(bits < 2)
 		var/list/bits_to_add = list()
@@ -61,17 +50,6 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 					bitfield |= WEST_SHORTPIPE
 
 	icon_state = "[bitfield]_[piping_layer]"
-	switch(connection_num)
-		if(0)
-			dir = SOUTH
-		if(1)
-			dir = connections
-		if(2)
-			dir = check_binary_direction(connections)
-		if(3)
-			dir = connections
-		if(4)
-			dir = NORTH | SOUTH | EAST | WEST
 
 /obj/machinery/atmospherics/pipe/smart/SetInitDirections(init_dir)
 	if(init_dir)

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -42,6 +42,8 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 		while (ISSTUB(connections | bits_to_add) && (candidates >> shift) != 0)
 			bits_to_add |= candidates & (1 << shift)
 			shift += 1
+		if (ISSTUB(connections))
+			log_admin("DEBUG: [ADMIN_VV(src)] would have stub setup and be invisible. dir [dir], long pipes [bitfield], short pipes [bits_to_add], p_init_dir [initialize_directions]")
 		bitfield |= CARDINAL_TO_SHORTPIPES(bits_to_add)
 
 	icon_state = "[bitfield]_[piping_layer]"

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -42,8 +42,6 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 		while (ISSTUB(connections | bits_to_add) && (candidates >> shift) != 0)
 			bits_to_add |= candidates & (1 << shift)
 			shift += 1
-		if (ISSTUB(connections))
-			log_admin("DEBUG: [ADMIN_VV(src)] would have stub setup and be invisible. dir [dir], long pipes [bitfield], short pipes [bits_to_add], p_init_dir [initialize_directions]")
 		bitfield |= CARDINAL_TO_SHORTPIPES(bits_to_add)
 
 	icon_state = "[bitfield]_[piping_layer]"

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -15,47 +15,40 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 /obj/machinery/atmospherics/pipe/smart/update_pipe_icon()
 	icon = 'icons/obj/atmospherics/pipes/pipes_bitmask.dmi'
 	var/bitfield = NONE
-	var/bits = 0
 
 	for(var/i in 1 to device_type)
 		if(!nodes[i])
 			continue
 		var/obj/machinery/atmospherics/node = nodes[i]
 		var/connected_dir = get_dir(src, node)
-		bits++
-		// Note X_FULLPIPE == X as described in defines/atmospherics.dm
-		bitfield |= connected_dir
-	connections = bitfield
-	dir = check_binary_direction(bitfield)
-	//If we dont have enough bits to make a proper sprite, add some shortpipe bits
-	if(bits < 2)
-		var/list/bits_to_add = list()
-		var/list/iterate_list = list()
-		if(bits == 1)
-			iterate_list += REVERSE_DIR(bitfield)
-		iterate_list += GLOB.cardinals
-		for(var/cardinal in iterate_list)
-			if(!(bitfield & cardinal) && !(cardinal in bits_to_add) && initialize_directions & cardinal)
-				bits_to_add += cardinal
-				bits++
-				if(bits >= 2)
-					break
-		for(var/direction in bits_to_add)
-			switch(direction)
-				if(NORTH)
-					bitfield |= NORTH_SHORTPIPE
-				if(SOUTH)
-					bitfield |= SOUTH_SHORTPIPE
-				if(EAST)
-					bitfield |= EAST_SHORTPIPE
-				if(WEST)
-					bitfield |= WEST_SHORTPIPE
+		connections |= connected_dir
+	bitfield = CARDINAL_TO_FULLPIPES(connections)
+	dir = check_binary_direction(connections)
+
+	// If we dont have enough bits to make a proper sprite, add some shortpipe bits
+
+	// Smart pipe icons differ from classic pipe icons in that we stop adding
+	// short pipe directions as soon as we find a valid sprite, rather than
+	// adding in all connectable directions.
+	// This prevents a lot of visual clutter, though it does make it harder to
+	// notice completely disconnected pipes.
+	if(ISSTUB(connections))
+		var/bits_to_add = NONE
+		if(connections != NONE)
+			bits_to_add |= REVERSE_DIR(connections) & initialize_directions
+		var/candidates = initialize_directions
+		var/shift = 0
+		// Note that candidates "should" never reach 0, as stub pipes are not allowed and break things
+		while (ISSTUB(connections | bits_to_add) && (candidates >> shift) != 0)
+			bits_to_add |= candidates & (1 << shift)
+			shift += 1
+		bitfield |= CARDINAL_TO_SHORTPIPES(bits_to_add)
 
 	icon_state = "[bitfield]_[piping_layer]"
 
 /obj/machinery/atmospherics/pipe/smart/SetInitDirections(init_dir)
 	if(init_dir)
-		initialize_directions =	init_dir
+		initialize_directions = init_dir
 	else
 		initialize_directions = ALL_CARDINALS
 

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -10,6 +10,7 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 	device_type = QUATERNARY
 	construction_type = /obj/item/pipe/quaternary
 	pipe_state = "manifold4w"
+	var/connections = NONE
 
 /obj/machinery/atmospherics/pipe/smart/update_pipe_icon()
 	icon = 'icons/obj/atmospherics/pipes/pipes_bitmask.dmi'
@@ -24,6 +25,7 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 		bits++
 		// Note X_FULLPIPE == X as described in defines/atmospherics.dm
 		bitfield |= connected_dir
+	connections = bitfield
 	dir = check_binary_direction(bitfield)
 	//If we dont have enough bits to make a proper sprite, add some shortpipe bits
 	if(bits < 2)

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
@@ -34,6 +34,10 @@ const TOOLS = [
     name: 'Destroy',
     bitmask: 4,
   },
+  {
+    name: 'Reprogram',
+    bitmask: 8,
+  }
 ];
 
 const SelectionSection = (props, context) => {

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
@@ -37,7 +37,7 @@ const TOOLS = [
   {
     name: 'Reprogram',
     bitmask: 8,
-  }
+  },
 ];
 
 const SelectionSection = (props, context) => {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Most bridging was not happening when it needed to, and some bridging was happening against pipes on completely different layers that construction logic shouldn't have been considering.
The direction was also not being set properly.

This fixes #60978 and obsoletes #60804.

~~Note that the smart logic could stand to become smarter too, and I suspect the bridge-specific check isn't needed with the other checks already in place, though it shouldn't hurt. Turning a pipe into a bridge might now happen in cases where it doesn't need to, though running through the basic examples and a few pet projects didn't turn up anything particularly egregious.~~

Smart pipe negotiation during construction has now been completely reworked, even functioning when you're placing down a non-smart pipe that conflicts with a smart pipe.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Almost none of the setups demonstrated in the first merged PR's [BASIC PIPING GIFs](https://imgur.com/a/BDueHKa) work anymore. This fixes it so that they all work again.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Smart pipes now calculate their direction properly, and construction code checks direction logic properly. This fixes many problems with atmospherics construction.
fix: Smart pipe construction now no longer tries to work around irrelevant pipes which are on completely different layers and do not interact with the new pipe in any way.
fix: Smart pipes with less than two allowed directions can no longer be built. The pipe would be invisible, but still interact in weird ways.
fix: One tile can no longer have more than one atmospheric component ready to connect in the same direction and layer. This prevents the scenario where a temperature pump is placed in a manner which looks like it's going to connect to a horizontal bridge pipe, but actually turns the vertical plasma input pipe behind it into a manifold, ruptures the connected plasma canister, and sets Toxins on fire.
qol: Smart pipes are now much, much smarter. During construction, if a smart pipe would block placement of a component, it will see if permitted connectivity can be reconfigured to make room for other components. This includes negotiation with other smart pipes, preferring to create pipe crossings where available, or create an opposing corner pipe if not. The RPD can now also reconfigure allowed connectivity for existing smart pipes manually. Smart pipes can never be reconfigured to have less than two allowed directions, and active connections cannot be reconfigured. Automatic reconfiguration will never cause a smart pipe to permit connectivity that was not previously permitted.
fix: Multi-layer pipe components can trigger smart pipe negotiation where relevant.
refactor: Rearranged some atmospherics pipe code. Fewer redundant loops, add and use documented and centralized helpers for bit manipulation where sensible. Make bitfield assumptions explicit.
code: made a small part of the documentation in the area less wrong dear god my eyes the goggles do nothing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
