### PR TITLE
Fixes traits added by quirks not being removed on `remove_from_current_holder`

### DIFF
--- a/code/datums/quirks/_quirk.dm
+++ b/code/datums/quirks/_quirk.dm
@@ -89,7 +89,7 @@
 		to_chat(quirk_holder, lose_text)
 
 	if(mob_trait)
-		REMOVE_TRAIT(quirk_holder, mob_trait, ROUNDSTART_TRAIT)
+		REMOVE_TRAIT(quirk_holder, mob_trait, QUIRK_TRAIT)
 
 	if(processing_quirk)
 		STOP_PROCESSING(SSquirks, src)


### PR DESCRIPTION
## About The Pull Request
See title. It used the old trait source on the `REMOVE_TRAIT` macro call. Caused by #59618.

## Why It's Good For The Game
This will fix #60809.

## Changelog
:cl:
fix: Fixes traits added by quirks not being removed when those are deleted (like from eigenstasium).
/:cl:
