### PR TITLE
Fixes the lone operative event hardly ever rolling because of dynamic.

### DIFF
--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -1,9 +1,8 @@
 /datum/round_event_control/operative
 	name = "Lone Operative"
 	typepath = /datum/round_event/ghost_role/operative
-	weight = 0 //Admin only
+	weight = 0 //its weight is relative to how much stationary and neglected the nuke disk is. See nuclearbomb.dm. Shouldn't be dynamic hijackable.
 	max_occurrences = 1
-	dynamic_should_hijack = TRUE
 
 /datum/round_event/ghost_role/operative
 	minimum_required = 1


### PR DESCRIPTION
## About The Pull Request
See #58265. Unforeseen consequence of the dynamic changes. The event is already impossible to trigger unless the disk stays on the same turf for at least 9 minutes circa. It really shouldn't be denied by dynamic. It's an incentive for players to secure dat fukken disk.

I have contemplated making it into a dynamic ruleset but that's incompatible right now because of a multitude of factors such as dynamic weights being capped at 9, peaceful percentage, longer injection delays, threat level curves...

## Why It's Good For The Game
This will close #58265.

## Changelog
:cl:
fix: Fixes the lone operative event hardly ever rolling even if the disk is left on the same place for hours because of dynamic.
/:cl:
