### PR TITLE
Fixes monkey being unable to access right click functions on many objects.

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -40,10 +40,7 @@
 		return
 	SEND_SIGNAL(src, COMSIG_HUMAN_MELEE_UNARMED_ATTACK, A, proximity_flag, modifiers)
 
-	if(dna?.species?.spec_unarmedattack(src, A, modifiers)) //Because species like monkeys dont use attack hand
-		return
-
-	if(!right_click_attack_chain(A, modifiers))
+	if(!right_click_attack_chain(A, modifiers) && !dna?.species?.spec_unarmedattack(src, A, modifiers)) //Because species like monkeys dont use attack hand
 		A.attack_hand(src, modifiers)
 
 


### PR DESCRIPTION
## About The Pull Request
Inverted the position of the right click attack hand chain and spec unarmed attack procs. Caused by #59656. I don't think there's any issue report about it yet.

## Why It's Good For The Game
I can't open storages with right click nor can't split stacks as a monkey.
Any right click feature that monkeys shouldn't normally be able to access already makes use of `canUseTopic` with the dexterity set TRUE so I hope you won't tell me to make `spec_unarmedattack` any hackier.

## Changelog
:cl:
fix: Fixes monkey being unable to access right click functions on several objects such as stacks and storages.
/:cl:
