### PR TITLE
Makes used dme explicit in sdmm config.

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,4 +1,5 @@
 environment = "tgstation.dme"
+
 [langserver]
 dreamchecker = true
 

--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,3 +1,4 @@
+environment = "tgstation.dme"
 [langserver]
 dreamchecker = true
 


### PR DESCRIPTION
To prevent the common issues stemming from the `tgstation.mdme` -> `tgstation.m.dme` change