### PR TITLE
More thermomachine fixes

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
@@ -226,9 +226,8 @@
 		if (use_enviroment_heat)
 			efficiency *= clamp(log(1.55, exchange_target.total_moles()) * 0.15, 0.65, 1)
 
-		efficiency = max(efficiency, parts_efficiency)
-
 		efficiency *= mole_efficiency
+		efficiency = max(efficiency, parts_efficiency) 
 
 		if (exchange_target.temperature > THERMOMACHINE_SAFE_TEMPERATURE && safeties)
 			on = FALSE
@@ -247,8 +246,8 @@
 		exchange_target.temperature = max((THERMAL_ENERGY(exchange_target) - (heat_amount * efficiency) + motor_heat) / exchange_target.heat_capacity(), TCMB)
 
 	if(!cooling)
-		efficiency = max(efficiency, parts_efficiency)
 		efficiency *= mole_efficiency
+		efficiency = max(efficiency, parts_efficiency)
 
 	main_port.temperature = max((THERMAL_ENERGY(main_port) + (heat_amount * efficiency)) / main_port.heat_capacity(), TCMB)
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
@@ -1,4 +1,5 @@
 #define THERMOMACHINE_SAFE_TEMPERATURE 500000
+#define THERMOMACHINE_POWER_CONVERSION 0.01
 
 /obj/machinery/atmospherics/components/binary/thermomachine
 	icon = 'icons/obj/atmospherics/components/thermomachine.dmi'
@@ -251,7 +252,7 @@
 
 	main_port.temperature = max((THERMAL_ENERGY(main_port) + (heat_amount * efficiency)) / main_port.heat_capacity(), TCMB)
 
-	heat_amount = max(abs(heat_amount), 1e8)
+	heat_amount = min(abs(heat_amount), 1e8) * THERMOMACHINE_POWER_CONVERSION
 	var/power_usage = 0
 	var/power_efficiency = max(efficiency, 0.4)
 	if(abs(temperature_target_delta)  > 1)
@@ -511,3 +512,4 @@
 	icon_state = "thermo_base_1"
 
 #undef THERMOMACHINE_SAFE_TEMPERATURE
+#undef THERMOMACHINE_POWER_CONVERSION


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fix error when typing the mole efficiency (instead of 0.1 it was 0.001, didn't push the change)
fix infinite power consumption (capped)
fix efficiency not being tied to laser tiers (issue connected to infinite power consumption)
Also fix #61006 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
several fixes to thermomachine errors and shortcoming
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: error when typing the mole efficiency (instead of 0.1 it was 0.001, didn't push the change)
fix: infinite power consumption (capped)
fix: efficiency not being tied to laser tiers (issue connected to infinite power consumption)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
