### PR TITLE
Fix crayon text input

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -267,8 +267,8 @@
 	return FALSE
 
 /obj/item/toy/crayon/proc/crayon_text_strip(text)
-	text = strip_html_simple(text)
-	var/static/regex/crayon_regex = new /regex(@"[^\w!?,.=%#&+/\-]", "ig")
+	text = copytext(text, 1, MAX_MESSAGE_LEN)
+	var/static/regex/crayon_regex = new /regex(@"[^\w!?,.=%#+/\-]", "ig")
 	return lowertext(crayon_regex.Replace(text, ""))
 
 /obj/item/toy/crayon/afterattack(atom/target, mob/user, proximity, params)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -250,8 +250,7 @@
 		if("select_colour")
 			. = can_change_colour && select_colour(usr)
 		if("enter_text")
-			var/txt = stripped_input(usr,"Choose what to write.",
-				"Scribbles",default = text_buffer)
+			var/txt = stripped_input(usr,"Choose what to write.", "Scribbles", default = text_buffer)
 			text_buffer = crayon_text_strip(txt)
 			. = TRUE
 			paint_mode = PAINT_NORMAL
@@ -266,8 +265,12 @@
 	return FALSE
 
 /obj/item/toy/crayon/proc/crayon_text_strip(text)
-	var/static/regex/crayon_r = new /regex(@"[^\w!?,.=%#&+\/\-]")
-	return replacetext(lowertext(text), crayon_r, "")
+	// these replacetexts are removing the < and > symbols after stripped_input()
+	text = replacetext(text, "&gt", "")
+	text = replacetext(text, "&lt", "")
+	text = replacetext(text, "&amp", "&") // we want to re-insert the & symbol
+	var/static/regex/crayon_regex = new /regex(@"[^\w\s!?,.=%#&+/-]", "ig")
+	return lowertext(crayon_regex.Replace(text, ""))
 
 /obj/item/toy/crayon/afterattack(atom/target, mob/user, proximity, params)
 	. = ..()

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -250,7 +250,7 @@
 		if("select_colour")
 			. = can_change_colour && select_colour(usr)
 		if("enter_text")
-			var/txt = stripped_input(usr,"Choose what to write.", "Scribbles", default = text_buffer)
+			var/txt = input(usr, "Choose what to write.", "Scribbles", "") as text|null
 			text_buffer = crayon_text_strip(txt)
 			. = TRUE
 			paint_mode = PAINT_NORMAL
@@ -265,11 +265,8 @@
 	return FALSE
 
 /obj/item/toy/crayon/proc/crayon_text_strip(text)
-	// these replacetexts are removing the < and > symbols after stripped_input()
-	text = replacetext(text, "&gt", "")
-	text = replacetext(text, "&lt", "")
-	text = replacetext(text, "&amp", "&") // we want to re-insert the & symbol
-	var/static/regex/crayon_regex = new /regex(@"[^\w\s!?,.=%#&+/-]", "ig")
+	text = strip_html_simple(text)
+	var/static/regex/crayon_regex = new /regex(@"[^\w!?,.=%#&+/\-]", "ig")
 	return lowertext(crayon_regex.Replace(text, ""))
 
 /obj/item/toy/crayon/afterattack(atom/target, mob/user, proximity, params)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -253,7 +253,11 @@
 			var/txt = input(usr, "Choose what to write.", "Scribbles", text_buffer) as text|null
 			if(isnull(txt))
 				return
-			text_buffer = crayon_text_strip(txt)
+			txt = crayon_text_strip(txt)
+			if(text_buffer == txt)
+				return // No valid changes.
+			text_buffer = txt
+
 			. = TRUE
 			paint_mode = PAINT_NORMAL
 			drawtype = "a"

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -268,7 +268,7 @@
 
 /obj/item/toy/crayon/proc/crayon_text_strip(text)
 	text = copytext(text, 1, MAX_MESSAGE_LEN)
-	var/static/regex/crayon_regex = new /regex(@"[^\w!?,.=%#+/\-]", "ig")
+	var/static/regex/crayon_regex = new /regex(@"[^\w!?,.=&%#+/\-]", "ig")
 	return lowertext(crayon_regex.Replace(text, ""))
 
 /obj/item/toy/crayon/afterattack(atom/target, mob/user, proximity, params)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -250,7 +250,9 @@
 		if("select_colour")
 			. = can_change_colour && select_colour(usr)
 		if("enter_text")
-			var/txt = input(usr, "Choose what to write.", "Scribbles", "") as text|null
+			var/txt = input(usr, "Choose what to write.", "Scribbles", text_buffer) as text|null
+			if(isnull(txt))
+				return
 			text_buffer = crayon_text_strip(txt)
 			. = TRUE
 			paint_mode = PAINT_NORMAL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This fixes #50239

![74JlrZRE8E](https://user-images.githubusercontent.com/5195984/130522658-4a56c08d-b9de-4539-8788-3e50a3d57824.png)


The regex expression being used missed some symbols and screwed up spacing.  

## Changelog
:cl:
fix: Fixed crayon and spraycan text input to behave properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
