### PR TITLE
Refactors supermatter dusting procs into signal handlers

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -193,6 +193,10 @@
 #define COMSIG_ATOM_RELAYMOVE "atom_relaymove"
 	///prevents the "you cannot move while buckled! message"
 	#define COMSIG_BLOCK_RELAYMOVE (1<<0)
+///from base of datum/mutation/human/telekinesis/proc/on_ranged_attack(): (/mob/user)
+#define COMSIG_ATOM_ATTACK_TK "atom_attack_tk"
+///from base of atom/proc/attack_robot(): (/mob/user)
+#define COMSIG_ATOM_ATTACK_ROBOT "atom_attack_robot"
 
 ///from [/datum/controller/subsystem/explosions/proc/explode]: (/list(/atom, devastation_range, heavy_impact_range, light_impact_range, flame_range, flash_range, adminlog, ignorecap, silent, smoke))
 #define COMSIG_ATOM_EXPLODE "atom_explode"

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -174,8 +174,9 @@
 	A.attack_robot(src)
 
 /atom/proc/attack_robot(mob/user)
-	attack_ai(user)
-	return
+	if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_ROBOT, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
+		return TRUE
+	return attack_ai(user)
 
 /**
  * What happens when the cyborg without active module holds right-click on an item. Returns a SECONDARY_ATTACK_* value.

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -133,7 +133,9 @@
 	attack_target.attack_animal(src, modifiers)
 
 /atom/proc/attack_animal(mob/user, list/modifiers)
-	SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_ANIMAL, user)
+	if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_ANIMAL, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
+		return FALSE //Because the return behavior for attack_animal is inverted relative to other attack chains
+	return TRUE
 
 ///Attacked by monkey
 /atom/proc/attack_paw(mob/user, list/modifiers)

--- a/code/datums/mutations/telekinesis.dm
+++ b/code/datums/mutations/telekinesis.dm
@@ -31,4 +31,6 @@
 ///Triggers on COMSIG_MOB_ATTACK_RANGED. Usually handles stuff like picking up items at range.
 /datum/mutation/human/telekinesis/proc/on_ranged_attack(mob/source, atom/target)
 	SIGNAL_HANDLER
+	if(SEND_SIGNAL(target, COMSIG_ATOM_ATTACK_TK, source) & COMPONENT_CANCEL_ATTACK_CHAIN)
+		return
 	return target.attack_tk(source)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -469,6 +469,9 @@
 /obj/machinery/attack_robot(mob/user)
 	if(!(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON) && !isAdminGhostAI(user))
 		return FALSE
+	. = ..()
+	if(.)
+		return
 	if(Adjacent(user) && can_buckle && has_buckled_mobs()) //so that borgs (but not AIs, sadly (perhaps in a future PR?)) can unbuckle people from machines
 		if(buckled_mobs.len > 1)
 			var/unbuckled = input(user, "Who do you wish to unbuckle?","Unbuckle Who?") as null|mob in sortNames(buckled_mobs)

--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -153,6 +153,9 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 	add_fingerprint(usr)
 
 /obj/machinery/announcement_system/attack_robot(mob/living/silicon/user)
+	. = ..()
+	if(.)
+		return
 	. = attack_ai(user)
 
 /obj/machinery/announcement_system/attack_ai(mob/user)

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -120,6 +120,9 @@
 		return attack_hand(user)
 
 /obj/machinery/button/attack_robot(mob/user)
+	. = ..()
+	if(.)
+		return
 	return attack_ai(user)
 
 /obj/machinery/button/proc/setup_device()

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -163,6 +163,9 @@
 		eyeobj.setLoc(eyeobj.loc)
 
 /obj/machinery/computer/camera_advanced/attack_robot(mob/user)
+	. = ..()
+	if(.)
+		return
 	return attack_hand(user)
 
 /obj/machinery/computer/camera_advanced/attack_ai(mob/user)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -188,6 +188,9 @@
 	return TRUE
 
 /obj/machinery/door/firedoor/attack_robot(mob/user)
+	. = ..()
+	if(.)
+		return
 	return attack_ai(user)
 
 /obj/machinery/door/firedoor/attack_alien(mob/user, list/modifiers)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -189,6 +189,9 @@
 	return attack_hand(user)
 
 /obj/machinery/firealarm/attack_robot(mob/user)
+	. = ..()
+	if(.)
+		return
 	return attack_hand(user)
 
 /obj/machinery/firealarm/attackby(obj/item/tool, mob/living/user, params)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -68,6 +68,9 @@
 		teleport(user)
 
 /obj/effect/portal/attack_robot(mob/living/user)
+	. = ..()
+	if(.)
+		return
 	if(Adjacent(user))
 		teleport(user)
 

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -140,13 +140,19 @@
 	return take_damage(damage_amount, damage_type, damage_flag, sound_effect, get_dir(src, user), armor_penetration)
 
 /obj/attack_alien(mob/living/carbon/alien/humanoid/user, list/modifiers)
+	. = ..()
+	if(.)
+		return
 	if(attack_generic(user, 60, BRUTE, MELEE, 0))
 		playsound(src.loc, 'sound/weapons/slash.ogg', 100, TRUE)
 
 /obj/attack_animal(mob/living/simple_animal/user, list/modifiers)
+	. = ..()
+	if(.)
+		return
 	if(!user.melee_damage_upper && !user.obj_damage)
 		user.emote("custom", message = "[user.friendly_verb_continuous] [src].")
-		return FALSE
+		return TRUE
 	else
 		var/play_soundeffect = TRUE
 		if(user.environment_smash)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -407,6 +407,9 @@
 	return attack_hand(user, modifiers)
 
 /obj/structure/closet/attack_robot(mob/user)
+	. = ..()
+	if(.)
+		return
 	if(user.Adjacent(src))
 		return attack_hand(user)
 

--- a/code/game/objects/structures/industrial_lift.dm
+++ b/code/game/objects/structures/industrial_lift.dm
@@ -350,6 +350,9 @@ GLOBAL_LIST_EMPTY(lifts)
 	return use(user)
 
 /obj/structure/industrial_lift/attack_robot(mob/living/silicon/robot/R)
+	. = ..()
+	if(.)
+		return
 	if(R.Adjacent(src))
 		return use(R)
 

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -150,6 +150,9 @@
 	return use(user)
 
 /obj/structure/ladder/attack_robot(mob/living/silicon/robot/R)
+	. = ..()
+	if(.)
+		return
 	if(R.Adjacent(src))
 		return use(R)
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -74,6 +74,9 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	add_fingerprint(user)
 
 /obj/structure/bodycontainer/attack_robot(mob/user)
+	. = ..()
+	if(.)
+		return
 	if(!user.Adjacent(src))
 		return
 	return attack_hand(user)
@@ -224,6 +227,9 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	connected.connected = src
 
 /obj/structure/bodycontainer/crematorium/attack_robot(mob/user) //Borgs can't use crematoriums without help
+	. = ..()
+	if(.)
+		return
 	to_chat(user, span_warning("[src] is locked against you."))
 	return
 

--- a/code/modules/awaymissions/signpost.dm
+++ b/code/modules/awaymissions/signpost.dm
@@ -43,6 +43,9 @@
 	return interact(user)
 
 /obj/structure/signpost/attack_robot(mob/user)
+	. = ..()
+	if(.)
+		return
 	if (Adjacent(user))
 		return interact(user)
 

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -437,6 +437,9 @@
 	anti_spam_cd = 0
 
 /obj/structure/mining_shuttle_beacon/attack_robot(mob/user)
+	. = ..()
+	if(.)
+		return
 	return attack_hand(user) //So borgies can help
 
 #undef ZONE_SET

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -43,6 +43,9 @@
 		ui_interact(user)
 
 /obj/structure/ore_box/attack_robot(mob/user)
+	. = ..()
+	if(.)
+		return
 	if(Adjacent(user))
 		ui_interact(user)
 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -708,6 +708,9 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 GLOBAL_LIST(hub_radial_layer_list)
 
 /obj/structure/cable/multilayer/attack_robot(mob/user)
+	. = ..()
+	if(.)
+		return
 	attack_hand(user)
 
 /obj/structure/cable/multilayer/attack_hand(mob/living/user, list/modifiers)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -885,7 +885,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	SIGNAL_HANDLER
 	if(Adjacent(user))
 		dust_mob(user, cause = "cyborg attack")
-	return COMPONENT_CANCEL_ATTACK_CHAIN
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/power/supermatter_crystal/proc/on_attack_hand(datum/source, mob/living/user, list/modifiers)
 	SIGNAL_HANDLER

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -314,6 +314,9 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	promptExit(user)
 
 /turf/closed/indestructible/hoteldoor/attack_robot(mob/user)
+	. = ..()
+	if(.)
+		return
 	if(get_dist(get_turf(src), get_turf(user)) <= 1)
 		promptExit(user)
 


### PR DESCRIPTION
## About The Pull Request

Refactors the procs used by the supermatter to dust things into signal handlers. As part of implementing this, two new signals were added - `COMSIG_ATOM_ATTACK_TK` and `COMSIG_ATOM_ATTACK_ROBOT`. Additionally, most implementations of `attack_robot` now call their parents to ensure that the signal-based attack chain handling works correctly.

## Why It's Good For The Game

![SM Refactor Justification](https://user-images.githubusercontent.com/12720844/130551457-9ef78327-f072-4143-8b01-a3e306dce2de.png)

## Changelog
:cl:
refactor: The supermatter's atom dusting behavior has been moved to signal handlers.
/:cl:
