### PR TITLE
Restores the long lost CMO's stamp on Delta.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -89128,6 +89128,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/stamp/cmo,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "rWL" = (


### PR DESCRIPTION
_!!this is my first goddamn attempt at anything related to coding I tried following the wikiguide as best as i could please bear with me!!_

## About The Pull Request
Deltastation's CMO office did not have the CMO's rubber stamp for no good reason in months, if not longer. It is now sitting on top of a paperbin on their desk.

## Why It's Good For The Game
In my CMO days back in spring I've had a secoff come to me, asking for my approval of his psychological state so he could get a gun from the warden. Since I didn't have my stamp, I had to use a lame signature of %s and I was sad for the rest of the shift. This will leave such cases of sad CMOs in the past.

## Changelog
:cl:
fix: The long-presumed-missing CMO's rubber stamp has been returned to Delta station's CMO office. Hail bureaucracy!
/:cl:

