### PR TITLE
Cannons now accept all oxygen tanks, not just red ones

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -551,7 +551,7 @@
 	result = /obj/structure/cannon/trash
 	reqs = list(
 		/obj/item/melee/skateboard/improvised = 1,
-		/obj/item/tank/internals/oxygen/red = 1,
+		/obj/item/tank/internals/oxygen = 1,
 		/datum/reagent/drug/maint/tar = 15,
 		/obj/item/restraints/handcuffs/cable = 1,
 		/obj/item/storage/toolbox = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes #61011 

## Why It's Good For The Game

I didn't realize when I was making the trash cannon that the red and yellow tanks don't actually have unique names, which makes it very unfair to craft with

## Changelog
:cl:
fix: trash cannons now accept any oxygen tank, not just red ones
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
