### PR TITLE
fixes missing APC to the supermatter room

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -38541,6 +38541,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"eDE" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "eDP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
@@ -104116,6 +104121,7 @@
 /area/cargo/storage)
 "vSm" = (
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "vSn" = (
@@ -134352,7 +134358,7 @@ uZA
 xCx
 oCQ
 xPF
-otP
+eDE
 otP
 vyR
 otP

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -21175,6 +21175,11 @@
 /obj/item/flashlight,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
+"dhA" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "dhK" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -88270,7 +88275,7 @@ wfC
 fQX
 ifh
 fQX
-wfC
+dhA
 eia
 boP
 bBM

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -66012,6 +66012,7 @@
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -52650,6 +52650,11 @@
 	},
 /turf/open/floor/iron,
 /area/science/research)
+"pgo" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "pgt" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -125877,7 +125882,7 @@ oma
 bpc
 bpc
 czV
-bpc
+pgo
 bpc
 uFM
 oma


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
4 months ago someone added a new area for the area surrounding the SM (aka emitters and filters etc...) so that we arent just using the main engineering rooms area

but ....... they never added APCs to the new room they made CRINGE

also, areas that dont have APCs mapped in on initialization basically have infinate power, so thethermomachines and other equipment in there can draw power from thin air. the emitters i think draw from the rad collectors ot the SMES through the wire

Gitblame:
![image](https://user-images.githubusercontent.com/40489693/130727797-bd2752a0-dc22-4500-8a7e-6108628ce608.png)


Metastation:
![31](https://user-images.githubusercontent.com/40489693/130727854-9c849026-6a4d-4fec-96be-7dbb524b2813.PNG)


Deltastation:
![32](https://user-images.githubusercontent.com/40489693/130727877-d3337018-0213-48f9-994d-ec9551ccdfb3.PNG)


Kilostation:
![33](https://user-images.githubusercontent.com/40489693/130727898-b4f4f936-5c4e-4ab2-801f-4f829ccd0ff8.PNG)


Icebox:
![34](https://user-images.githubusercontent.com/40489693/130727914-de684de5-ec9f-465c-9799-b2d4f2131f81.PNG)


none on tram because tram mapper is chad and already had an APC there
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
*Adds a new area*
*doesnt add APCs for it*

Actual chad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: the emitter area around the SM chamber now has APCs, so no more infinate power for the thermomachines and other equipment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
