### PR TITLE
Exit on DreamMaker warnings in CI Windows build

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -36,9 +36,10 @@ export const PortParameter = new Juke.Parameter({
 
 export const CiParameter = new Juke.Parameter({ type: 'boolean' });
 
-export const ErrorParameter = new Juke.Parameter({
-  type: 'boolean',
-})
+export const WarningParameter = new Juke.Parameter({
+  type: 'string[]',
+  alias: 'W',
+});
 
 export const DmMapsIncludeTarget = new Juke.Target({
   executes: async () => {
@@ -75,8 +76,9 @@ export const DmTarget = new Juke.Target({
     `${DME_NAME}.rsc`,
   ],
   executes: async ({ get }) => {
-    await DreamMaker(`${DME_NAME}.dme`, get(ErrorParameter), {
+    await DreamMaker(`${DME_NAME}.dme`, {
       defines: ['CBT', ...get(DefineParameter)],
+      warningsAsErrors: get(WarningParameter).includes('error'),
     });
   },
 });
@@ -88,8 +90,9 @@ export const DmTestTarget = new Juke.Target({
   ],
   executes: async ({ get }) => {
     fs.copyFileSync(`${DME_NAME}.dme`, `${DME_NAME}.test.dme`);
-    await DreamMaker(`${DME_NAME}.test.dme`, get(ErrorParameter), {
+    await DreamMaker(`${DME_NAME}.test.dme`, {
       defines: ['CBT', 'CIBUILDING', ...get(DefineParameter)],
+      warningsAsErrors: get(WarningParameter).includes('error'),
     });
     Juke.rm('data/logs/ci', { recursive: true });
     await DreamDaemon(

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -36,6 +36,10 @@ export const PortParameter = new Juke.Parameter({
 
 export const CiParameter = new Juke.Parameter({ type: 'boolean' });
 
+export const ErrorParameter = new Juke.Parameter({
+  type: 'boolean',
+})
+
 export const DmMapsIncludeTarget = new Juke.Target({
   executes: async () => {
     const folders = [
@@ -71,7 +75,7 @@ export const DmTarget = new Juke.Target({
     `${DME_NAME}.rsc`,
   ],
   executes: async ({ get }) => {
-    await DreamMaker(`${DME_NAME}.dme`, {
+    await DreamMaker(`${DME_NAME}.dme`, get(ErrorParameter), {
       defines: ['CBT', ...get(DefineParameter)],
     });
   },
@@ -84,7 +88,7 @@ export const DmTestTarget = new Juke.Target({
   ],
   executes: async ({ get }) => {
     fs.copyFileSync(`${DME_NAME}.dme`, `${DME_NAME}.test.dme`);
-    await DreamMaker(`${DME_NAME}.test.dme`, {
+    await DreamMaker(`${DME_NAME}.test.dme`, get(ErrorParameter), {
       defines: ['CBT', 'CIBUILDING', ...get(DefineParameter)],
     });
     Juke.rm('data/logs/ci', { recursive: true });

--- a/tools/build/lib/byond.js
+++ b/tools/build/lib/byond.js
@@ -61,9 +61,9 @@ const getDmPath = async () => {
 /**
  * @param {string} dmeFile
  * @param {{
-   defines?: string[],
-   warningsAsErrors?: boolean,
-  }} options
+ *   defines?: string[];
+ *   warningsAsErrors?: boolean;
+ * }} options
  */
 export const DreamMaker = async (dmeFile, options = {}) => {
   const dmPath = await getDmPath();
@@ -88,7 +88,7 @@ export const DreamMaker = async (dmeFile, options = {}) => {
   };
   testOutputFile(`${dmeBaseName}.dmb`);
   testOutputFile(`${dmeBaseName}.rsc`);
-  const runWithWarningChecks = async (dmeFile, ...args) => {
+  const runWithWarningChecks = async (dmeFile, args) => {
     const execReturn = await Juke.exec(dmeFile, args);
     if (options.warningsAsErrors && execReturn.combined.match(/\d+:warning: /)) {
       Juke.logger.error(`Compile warnings treated as errors`);

--- a/tools/ci/build.ps1
+++ b/tools/ci/build.ps1
@@ -5,6 +5,6 @@ if(!(Test-Path -Path "C:/byond")){
 }
 
 bash tools/ci/install_node.sh
-bash tools/build/build --error
+bash tools/build/build -Werror
 
 exit $LASTEXITCODE

--- a/tools/ci/build.ps1
+++ b/tools/ci/build.ps1
@@ -5,6 +5,6 @@ if(!(Test-Path -Path "C:/byond")){
 }
 
 bash tools/ci/install_node.sh
-bash tools/build/build
+bash tools/build/build --error
 
 exit $LASTEXITCODE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added an option to tools/build/build to treat DreamMaker warnings as errors. Enabled this option only for Windows Build (tools/ci/build.ps1).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Solves #60895. Warnings are treated only as errors if --error is flag is used in build. This is because you don't want local builds to fail because of warnings, sometimes you just want to test. It also is not enabled for all CI jobs. This is because I think it's beneficial to differentiate between map errors, integration error and and "warnings treated as errors" errors. The example is here https://github.com/mokulus/tgstation/pull/3. Only Windows build fails. The exit code is 2 to differentiate from a real error. There is also error message logged "=> Compile warnings treated as errors" and it only shows if there are warnings.

If any change doesn't seem right (for example naming or 2 return code) I'll change it.

## Changelog
:cl:
code: Treat DreamMaker warnings as errors in CI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
