### PR TITLE
Fix thermomachines always having "grey" name

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -63,7 +63,7 @@
 
 /obj/machinery/atmospherics/LateInitialize()
 	. = ..()
-	name = "[GLOB.pipe_color_name[pipe_color]] [name]"
+	update_name()
 
 /obj/machinery/atmospherics/examine(mob/user)
 	. = ..()
@@ -453,7 +453,7 @@
 	if(can_unwrench)
 		add_atom_colour(obj_color, FIXED_COLOUR_PRIORITY)
 		pipe_color = obj_color
-	name = "[GLOB.pipe_color_name[obj_color]] [initial(name)]"
+	update_name()
 	setPipingLayer(set_layer)
 	atmosinit()
 	var/list/nodes = pipeline_expansion()
@@ -461,6 +461,10 @@
 		A.atmosinit()
 		A.addMember(src)
 	SSair.add_to_rebuild_queue(src)
+
+/obj/machinery/atmospherics/update_name()
+	name = "[GLOB.pipe_color_name[pipe_color]] [initial(name)]"
+	return ..()
 
 /obj/machinery/atmospherics/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	if(istype(arrived, /mob/living))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Using a multitool on an open TCU changes its pipe color. However, the name was not being updated, leaving them to always appear to be grey TCUs.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

...and so many colors
I will have seen...
the menacing greys
and pine greens
the soft pink and purples
of spring
and summer blue
and so many others
without you.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Temperature Control Units now display their color when set or changed, rather than always displaying as grey.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
