### PR TITLE
Fix HFR recipe cooling modifier description

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -227,7 +227,7 @@
 		var/fuel_consumption = connected_core.selected_fuel.fuel_consumption_multiplier < 1 ? "Decrease" : "Increase"
 		var/fuel_production = connected_core.selected_fuel.gas_production_multiplier < 1 ? "Decrease" : "Increase"
 		product_gases += "The fuel mix will"
-		product_gases += "-[minimum_temp] the minimum cooling by a factor of [connected_core.selected_fuel.negative_temperature_multiplier]"
+		product_gases += "-[minimum_temp] the maximum cooling by a factor of [connected_core.selected_fuel.negative_temperature_multiplier]"
 		product_gases += "-[maximum_temp] the maximum heating by a factor of [connected_core.selected_fuel.positive_temperature_multiplier]"
 		product_gases += "-[energy] the energy output consumption by a factor of [1 / connected_core.selected_fuel.energy_concentration_multiplier]"
 		product_gases += "-[fuel_consumption] the fuel consumption by a factor of [connected_core.selected_fuel.fuel_consumption_multiplier]"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

While the negative temperature modifier adjusts the minimum bound of heat_output, this adjusts the maximum bound of cooling, since the minimum bound for both heating and cooling is a heat_output of 0

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Doublethink lies at the very heart of Ingsoc

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: The HFR now correctly describes the recipe cooling modifier as adjusting the maximum cooling, rather than the minimum cooling.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
