### PR TITLE
balloon alerts now have the RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM appearance flags.

### DIFF
--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -45,6 +45,7 @@
 	var/image/balloon_alert = image(loc = get_atom_on_turf(src), layer = ABOVE_MOB_LAYER)
 	balloon_alert.plane = BALLOON_CHAT_PLANE
 	balloon_alert.alpha = 0
+	balloon_alert.appearance_flags = RESET_ALPHA|RESET_COLOR|RESET_TRANSFORM
 	balloon_alert.maptext = MAPTEXT("<span style='text-align: center; -dm-text-outline: 1px #0005'>[text]</span>")
 	balloon_alert.maptext_x = (BALLOON_TEXT_WIDTH - bound_width) * -0.5
 	balloon_alert.maptext_height = WXH_TO_HEIGHT(viewer_client?.MeasureText(text, null, BALLOON_TEXT_WIDTH))


### PR DESCRIPTION
## About The Pull Request
Remembers me of this #54870

## Why It's Good For The Game
This will fix #61027.

## Changelog
:cl:
fix: balloon alerts no longer become transparent, scale up/down or get colored alongside their holder.
/:cl:
