### PR TITLE
Sets the mouse_opacity of  imaginary friend mobs to MOUSE_OPACITY_ICON

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -63,7 +63,7 @@
 	see_in_dark = 0
 	lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
 	sight = NONE
-	mouse_opacity = MOUSE_OPACITY_OPAQUE
+	mouse_opacity = MOUSE_OPACITY_ICON
 	see_invisible = SEE_INVISIBLE_LIVING
 	invisibility = INVISIBILITY_MAXIMUM
 	var/icon/human_image


### PR DESCRIPTION
## About The Pull Request
Camera mobs normally have a mouse opacity value of MOUSE_OPACITY_TRANSPARENT, which makes them unclickable/unhoverable by cursor, so they wouldn't steal clicks from ai, blob, sentient disease and ghosts.
Back in #39008, to restore the mouse opacity of imaginary friends (a subtype of camera mob) XTDM set it to MOUSE_OPACITY_OPAQUE instead of MOUSE_OPACITY_ICON, which means the mask of its job-outfitted human icon is also clickable if I'm not wrong.

## Why It's Good For The Game
Fixes an oversight.

## Changelog
:cl:
fix: The transparent area of the image used by imaginary friend mobs should no longer catch clicks.
/:cl:
