### PR TITLE
Fixes the protect objective

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -269,9 +269,9 @@ GLOBAL_LIST_EMPTY(objectives)
 /datum/objective/protect/check_completion()
 	var/obj/item/organ/brain/brain_target
 	if(human_check)
-		brain_target = target.current.getorganslot(ORGAN_SLOT_BRAIN)
+		brain_target = target.current?.getorganslot(ORGAN_SLOT_BRAIN)
 	//Protect will always suceed when someone suicides
-	return !target || considered_alive(target, enforce_human = human_check) || (human_check == TRUE && brain_target) ? brain_target.suicided : FALSE
+	return !target || considered_alive(target, enforce_human = human_check) || brain_target?.suicided
 
 /datum/objective/protect/update_explanation_text()
 	..()


### PR DESCRIPTION
## About The Pull Request
A ternary operator was screwing things up. I have also replaced some `.` path operators with `?.` to avoid runtime errors. And yes, I have tested it.

## Why It's Good For The Game
This will fix #61019 and fix #55183

## Changelog
:cl:
fix: Fixed the protect objective always failing.
/:cl:
