### PR TITLE
Fixes some unnecessary attack chain cancels

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -270,7 +270,7 @@
 			forced_open = crowbar.force_opens
 		try_to_crowbar_secondary(weapon, user, forced_open)
 
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return ..()
 
 /obj/machinery/door/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -481,13 +481,14 @@
 	open()
 
 /obj/structure/closet/attack_hand_secondary(mob/user, modifiers)
-	. = SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	. = ..()
 
 	if(!user.canUseTopic(src, BE_CLOSE) || !isturf(loc))
 		return
 
 	if(!opened && secure)
 		togglelock(user)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/structure/closet/proc/togglelock(mob/living/user, silent)
 	if(secure && !broken)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -460,7 +460,7 @@
 			else if (tool.tool_behaviour)
 				to_chat(user, span_warning("The bolts need to be loosened first!"))
 
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return ..()
 
 /obj/structure/window/proc/cool_bolts()
 	if(state == RWINDOW_BOLTS_HEATED)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -460,6 +460,10 @@
 			else if (tool.tool_behaviour)
 				to_chat(user, span_warning("The bolts need to be loosened first!"))
 
+
+	if (tool.tool_behaviour)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 	return ..()
 
 /obj/structure/window/proc/cool_bolts()

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -33,7 +33,8 @@
 			return FALSE
 		else
 			check = TRUE
-	if(user.combat_mode || check)
+	var/list/modifiers = params2list(click_parameters)
+	if(LAZYACCESS(modifiers, RIGHT_CLICK) || check)
 		target.rust_heretic_act()
 		return TRUE
 

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -33,8 +33,7 @@
 			return FALSE
 		else
 			check = TRUE
-	var/list/modifiers = params2list(click_parameters)
-	if(LAZYACCESS(modifiers, RIGHT_CLICK) || check)
+	if(user.combat_mode || check)
 		target.rust_heretic_act()
 		return TRUE
 

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -112,7 +112,6 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 		. = SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	update_appearance()
-	return
 
 /obj/machinery/chem_mass_spec/AltClick(mob/living/user)
 	. = ..()

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -93,6 +93,8 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 	..()
 
 /obj/machinery/chem_mass_spec/attackby_secondary(obj/item/item, mob/user, params)
+	. = ..()
+
 	if(processing_reagents)
 		to_chat(user, "<span class='notice'> The [src] is currently processing a batch!")
 		return
@@ -107,8 +109,10 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 		replace_beaker(user, BEAKER2, beaker)
 		to_chat(user, span_notice("You add [beaker] to [src]."))
 		updateUsrDialog()
+		. = SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 	update_appearance()
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return
 
 /obj/machinery/chem_mass_spec/AltClick(mob/living/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Replaced attack chain cancels on some objects with parent calls

## Why It's Good For The Game

Just because you didn't use a specific item doesn't mean it should cancel the attack chain.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Doors, reinforced windows, lockers, mass spectrometers and lockers can now be attacked with right click
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
