### PR TITLE
fixes missing APC to the supermatter room #2 electric boogaloo

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -49779,6 +49779,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
+"ilL" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "ilU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -95419,6 +95424,7 @@
 /area/engineering/main)
 "vSm" = (
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "vSn" = (
@@ -124781,7 +124787,7 @@ uZA
 xCx
 oCQ
 xPF
-otP
+ilL
 otP
 vyR
 otP

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -21494,6 +21494,11 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"ges" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "gfO" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Lockers";
@@ -83024,7 +83029,7 @@ wfC
 fQX
 ifh
 fQX
-wfC
+ges
 eia
 boP
 bBM

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -57545,6 +57545,7 @@
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -24352,6 +24352,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/service/theater)
+"geN" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/plating,
+/area/engineering/supermatter/room)
 "geR" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cabin6";
@@ -119735,7 +119740,7 @@ oma
 bpc
 bpc
 czV
-bpc
+geN
 bpc
 uFM
 oma


### PR DESCRIPTION
i hate git, i hate git, re-make of #61018 because github has the actual weirdest bug when renaming branches that completely broke everything, so i had no choice but to redo this on a new branch

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
4 months ago someone added a new area for the area surrounding the SM (aka emitters and filters etc...) so that we arent just using the main engineering rooms area

but ....... they never added APCs to the new room they made CRINGE

also, areas that dont have APCs mapped in on initialization basically have infinate power, so thethermomachines and other equipment in there can draw power from thin air. the emitters i think draw from the rad collectors ot the SMES through the wire

Gitblame:
![image](https://user-images.githubusercontent.com/40489693/130727797-bd2752a0-dc22-4500-8a7e-6108628ce608.png)


Metastation:
![31](https://user-images.githubusercontent.com/40489693/130727854-9c849026-6a4d-4fec-96be-7dbb524b2813.PNG)


Deltastation:
![32](https://user-images.githubusercontent.com/40489693/130727877-d3337018-0213-48f9-994d-ec9551ccdfb3.PNG)


Kilostation:
![33](https://user-images.githubusercontent.com/40489693/130727898-b4f4f936-5c4e-4ab2-801f-4f829ccd0ff8.PNG)


Icebox:
![34](https://user-images.githubusercontent.com/40489693/130727914-de684de5-ec9f-465c-9799-b2d4f2131f81.PNG)


none on tram because tram mapper is chad and already had an APC there
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
*Adds a new area*
*doesnt add APCs for it*

Actual chad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: the emitter area around the SM chamber now has APCs, so no more infinate power for the thermomachines and other equipment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
