### PR TITLE
Rectifies the name and description of the cryostylane inverse chem.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents.dm
@@ -85,8 +85,8 @@
 	desc = "You're frozen inside of a protective ice cube! While inside, you can't do anything, but are immune to harm! You will be free when the chem runs out."
 
 /datum/reagent/inverse/cryostylane
-	name = "Cyrogelidia"
-	description = "Freezes the live or dead patient in an incuded cyrostasis ice block."
+	name = "Cryogelidia"
+	description = "Freezes the live or dead patient in a cryostasis ice block."
 	reagent_state = LIQUID
 	color = "#03dbfc"
 	taste_description = "your tongue freezing, shortly followed by your thoughts. Brr!"


### PR DESCRIPTION
## About The Pull Request
Title. Grammar and formatting. The "_included_" word is unnecessary in this sentence.

## Why It's Good For The Game
This will fix #61044.

## Changelog
:cl:
spellcheck: Rectifies the name and description of the cryostylane inverse chem.
/:cl:
