### PR TITLE
Fixes floored mobs (paraplegia, missing limbs) not being able to stand up in zero G for real.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -1199,9 +1199,9 @@
 // /datum/element/movetype_handler signals
 /// Called when the floating anim has to be temporarily stopped and restarted later: (timer)
 #define COMSIG_PAUSE_FLOATING_ANIM "pause_floating_anim"
-/// From base of datum/element/movetype_handler/on_movement_type_trait_gain: (flag)
+/// From base of datum/element/movetype_handler/on_movement_type_trait_gain: (flag, old_movement_type)
 #define COMSIG_MOVETYPE_FLAG_ENABLED "movetype_flag_enabled"
-/// From base of datum/element/movetype_handler/on_movement_type_trait_loss: (flag)
+/// From base of datum/element/movetype_handler/on_movement_type_trait_loss: (flag, old_movement_type)
 #define COMSIG_MOVETYPE_FLAG_DISABLED "movetype_flag_disabled"
 
 // /datum/action signals

--- a/code/datums/elements/movetype_handler.dm
+++ b/code/datums/elements/movetype_handler.dm
@@ -53,10 +53,11 @@
 	var/flag = GLOB.movement_type_trait_to_flag[trait]
 	if(source.movement_type & flag)
 		return
-	if(!(source.movement_type & (FLOATING|FLYING)) && (trait == TRAIT_MOVE_FLYING || trait == TRAIT_MOVE_FLOATING) && !paused_floating_anim_atoms[source] && !HAS_TRAIT(source, TRAIT_NO_FLOATING_ANIM))
-		DO_FLOATING_ANIM(source)
+	var/old_state = source.movement_type
 	source.movement_type |= flag
-	SEND_SIGNAL(source, COMSIG_MOVETYPE_FLAG_ENABLED, flag)
+	if(!(old_state & (FLOATING|FLYING)) && (source.movement_type & (FLOATING|FLYING)) && !paused_floating_anim_atoms[source] && !HAS_TRAIT(source, TRAIT_NO_FLOATING_ANIM))
+		DO_FLOATING_ANIM(source)
+	SEND_SIGNAL(source, COMSIG_MOVETYPE_FLAG_ENABLED, flag, old_state)
 
 /// Called when a movement type trait is removed from the movable. Disables the relative bitflag if it wasn't there in the compile-time bitfield.
 /datum/element/movetype_handler/proc/on_movement_type_trait_loss(atom/movable/source, trait)
@@ -64,10 +65,11 @@
 	var/flag = GLOB.movement_type_trait_to_flag[trait]
 	if(initial(source.movement_type) & flag)
 		return
+	var/old_state = source.movement_type
 	source.movement_type &= ~flag
-	if((trait == TRAIT_MOVE_FLYING || trait == TRAIT_MOVE_FLOATING) && !(source.movement_type & (FLOATING|FLYING)))
+	if((old_state & (FLOATING|FLYING)) && !(source.movement_type & (FLOATING|FLYING)))
 		stop_floating(source)
-	SEND_SIGNAL(source, COMSIG_MOVETYPE_FLAG_DISABLED, flag)
+	SEND_SIGNAL(source, COMSIG_MOVETYPE_FLAG_DISABLED, flag, old_state)
 
 /// Called when the TRAIT_NO_FLOATING_ANIM trait is added to the movable. Stops it from bobbing up and down.
 /datum/element/movetype_handler/proc/on_no_floating_anim_trait_gain(atom/movable/source, trait)

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -59,16 +59,16 @@
 		if(!usable_legs && !(movement_type & (FLYING | FLOATING)))
 			ADD_TRAIT(src, TRAIT_IMMOBILIZED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
 
-/mob/living/carbon/on_movement_type_flag_enabled(datum/source, flag)
+/mob/living/carbon/on_movement_type_flag_enabled(datum/source, flag, old_movement_type)
 	. = ..()
-	if(flag & (FLYING | FLOATING) && ((movement_type & (FLYING | FLOATING)) == flag)) // If the mob wasn't already flying/floating before.
+	if(movement_type & (FLYING | FLOATING) && !(old_movement_type & (FLYING | FLOATING)))
 		remove_movespeed_modifier(/datum/movespeed_modifier/limbless)
 		REMOVE_TRAIT(src, TRAIT_FLOORED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
 		REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
 
-/mob/living/carbon/on_movement_type_flag_disabled(datum/source, flag)
+/mob/living/carbon/on_movement_type_flag_disabled(datum/source, flag, old_movement_type)
 	. = ..()
-	if(flag & (FLYING | FLOATING) && !(movement_type & (FLYING | FLOATING)))
+	if(old_movement_type & (FLYING | FLOATING) && !(movement_type & (FLYING | FLOATING)))
 		var/limbless_slowdown = 0
 		if(usable_legs < default_num_legs)
 			limbless_slowdown += (default_num_legs - usable_legs) * 3

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -61,7 +61,7 @@
 
 /mob/living/carbon/on_movement_type_flag_enabled(datum/source, flag)
 	. = ..()
-	if(flag & (FLYING | FLOATING) && (movement_type & (FLYING | FLOATING) == flag))
+	if(flag & (FLYING | FLOATING) && ((movement_type & (FLYING | FLOATING)) == flag)) // If the mob wasn't already flying/floating before.
 		remove_movespeed_modifier(/datum/movespeed_modifier/limbless)
 		REMOVE_TRAIT(src, TRAIT_FLOORED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
 		REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)

--- a/code/modules/mob/living/init_signals.dm
+++ b/code/modules/mob/living/init_signals.dm
@@ -191,12 +191,12 @@
 		clear_alert("succumb")
 
 ///From [element/movetype_handler/on_movement_type_trait_gain()]
-/mob/living/proc/on_movement_type_flag_enabled(datum/source, trait)
+/mob/living/proc/on_movement_type_flag_enabled(datum/source, flag, old_movement_type)
 	SIGNAL_HANDLER
 	update_movespeed(FALSE)
 
 ///From [element/movetype_handler/on_movement_type_trait_loss()]
-/mob/living/proc/on_movement_type_flag_disabled(datum/source, trait)
+/mob/living/proc/on_movement_type_flag_disabled(datum/source, flag, old_movement_type)
 	SIGNAL_HANDLER
 	update_movespeed(FALSE)
 


### PR DESCRIPTION
## About The Pull Request
Added a `old_movement_type` argument to the `COMSIG_MOVETYPE_FLAG_ENABLED` and `COMSIG_MOVETYPE_FLAG_DISABLED` signal, fixed the check for zero g movespeed and locomotion traits removal and made some statements easier to understand.

## Why It's Good For The Game
This will fix #56118. no gbp update.

## Changelog
:cl:
Fixes floored mobs (paraplegia, missing limbs) not being able to stand up in zero G. For real this time.
/:cl:
