### PR TITLE
Fix wormhole jaunter behavior with chasms and EMP

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -84,16 +84,16 @@
 		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM
 			if(istype(H.belt, /obj/item/wormhole_jaunter))
-				var/obj/item/wormhole_jaunter/Jaunter = H.belt
-				var/list/Destinations = Jaunter.get_destinations()
+				var/obj/item/wormhole_jaunter/jaunter = H.belt
+				var/list/destinations = jaunter.get_destinations()
 
-				if(Destinations.len)
-					to_chat(H, span_notice("Your [Jaunter.name] activates, saving you from the chasm!"))
+				if(destinations.len)
+					to_chat(H, span_notice("Your [jaunter.name] activates, saving you from the chasm!"))
 					H.visible_message(span_boldwarning("[H] falls into [parent]!")) //To freak out any bystanders
-					Jaunter.chasm_react(H)
+					jaunter.chasm_react(H)
 					return FALSE
-				else if(!Destinations.len)
-					to_chat(H, span_userdanger("The [Jaunter.name] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm.  RIP."))
+				else if(!destinations.len)
+					to_chat(H, span_userdanger("The [jaunter.name] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm.  RIP."))
 	return TRUE
 
 /datum/component/chasm/proc/drop(atom/movable/AM)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -85,10 +85,15 @@
 			var/mob/living/carbon/human/H = AM
 			if(istype(H.belt, /obj/item/wormhole_jaunter))
 				var/obj/item/wormhole_jaunter/J = H.belt
-				//To freak out any bystanders
-				H.visible_message(span_boldwarning("[H] falls into [parent]!"))
-				J.chasm_react(H)
-				return FALSE
+				var/list/D = J.get_destinations()
+
+				if(D.len)
+					to_chat(H, span_notice("Your [J.name] activates, saving you from the chasm!"))
+					H.visible_message(span_boldwarning("[H] falls into [parent]!")) //To freak out any bystanders
+					J.chasm_react(H)
+					return FALSE
+				else if(!D.len)
+					to_chat(user, span_userdanger("The [J.name] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm.  RIP."))
 	return TRUE
 
 /datum/component/chasm/proc/drop(atom/movable/AM)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -85,8 +85,10 @@
 			var/mob/living/carbon/human/H = AM
 			if(istype(H.belt, /obj/item/wormhole_jaunter))
 				var/obj/item/wormhole_jaunter/jaunter = H.belt
-				var/can_jaunter_teleport = jaunter.chasm_react(H)
-				return can_jaunter_teleport
+				var/fall_into_chasm = jaunter.chasm_react(H)
+				if(!fall_into_chasm)
+					visible_message(span_boldwarning("[H] falls into the chasm!")) //To freak out any bystanders
+				return fall_into_chasm
 	return TRUE
 
 /datum/component/chasm/proc/drop(atom/movable/AM)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -84,16 +84,16 @@
 		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM
 			if(istype(H.belt, /obj/item/wormhole_jaunter))
-				var/obj/item/wormhole_jaunter/J = H.belt
-				var/list/D = J.get_destinations()
+				var/obj/item/wormhole_jaunter/Jaunter = H.belt
+				var/list/Destinations = Jaunter.get_destinations()
 
-				if(D.len)
-					to_chat(H, span_notice("Your [J.name] activates, saving you from the chasm!"))
+				if(Destinations.len)
+					to_chat(H, span_notice("Your [Jaunter.name] activates, saving you from the chasm!"))
 					H.visible_message(span_boldwarning("[H] falls into [parent]!")) //To freak out any bystanders
-					J.chasm_react(H)
+					Jaunter.chasm_react(H)
 					return FALSE
-				else if(!D.len)
-					to_chat(H, span_userdanger("The [J.name] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm.  RIP."))
+				else if(!Destinations.len)
+					to_chat(H, span_userdanger("The [Jaunter.name] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm.  RIP."))
 	return TRUE
 
 /datum/component/chasm/proc/drop(atom/movable/AM)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -85,15 +85,8 @@
 			var/mob/living/carbon/human/H = AM
 			if(istype(H.belt, /obj/item/wormhole_jaunter))
 				var/obj/item/wormhole_jaunter/jaunter = H.belt
-				var/list/destinations = jaunter.get_destinations()
-
-				if(destinations.len)
-					to_chat(H, span_notice("Your [jaunter.name] activates, saving you from the chasm!"))
-					H.visible_message(span_boldwarning("[H] falls into [parent]!")) //To freak out any bystanders
-					jaunter.chasm_react(H)
-					return FALSE
-				else if(!destinations.len)
-					to_chat(H, span_userdanger("The [jaunter.name] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm.  RIP."))
+				var/can_jaunter_teleport = jaunter.chasm_react(H)
+				return can_jaunter_teleport
 	return TRUE
 
 /datum/component/chasm/proc/drop(atom/movable/AM)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -82,12 +82,13 @@
 			if((!ismob(M.buckled) || (buckled_to.buckled != M)) && !droppable(M.buckled))
 				return FALSE
 		if(ishuman(AM))
-			var/mob/living/carbon/human/H = AM
-			if(istype(H.belt, /obj/item/wormhole_jaunter))
-				var/obj/item/wormhole_jaunter/jaunter = H.belt
-				var/fall_into_chasm = jaunter.chasm_react(H)
+			var/mob/living/carbon/human/victim = AM
+			if(istype(victim.belt, /obj/item/wormhole_jaunter))
+				var/obj/item/wormhole_jaunter/jaunter = victim.belt
+				var/turf/chasm = get_turf(victim)
+				var/fall_into_chasm = jaunter.chasm_react(victim)
 				if(!fall_into_chasm)
-					visible_message(span_boldwarning("[H] falls into the chasm!")) //To freak out any bystanders
+					chasm.visible_message(span_boldwarning("[victim] falls into the [chasm]!")) //To freak out any bystanders
 				return fall_into_chasm
 	return TRUE
 

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -93,7 +93,7 @@
 					J.chasm_react(H)
 					return FALSE
 				else if(!D.len)
-					to_chat(user, span_userdanger("The [J.name] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm.  RIP."))
+					to_chat(H, span_userdanger("The [J.name] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm.  RIP."))
 	return TRUE
 
 /datum/component/chasm/proc/drop(atom/movable/AM)

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -20,13 +20,14 @@
 	activate(user, TRUE)
 
 /obj/item/wormhole_jaunter/proc/turf_check(mob/user)
-	var/turf/device_turf = get_turf(user)
+	var/turf/device_turf = get_turf(src)
 	if(!device_turf || is_centcom_level(device_turf.z) || is_reserved_level(device_turf.z))
-		to_chat(user, span_notice("You're having difficulties getting the [src.name] to work."))
+		if(user)
+			to_chat(user, span_notice("You're having difficulties getting the [src.name] to work."))
 		return FALSE
 	return TRUE
 
-/obj/item/wormhole_jaunter/proc/get_destinations(mob/user)
+/obj/item/wormhole_jaunter/proc/get_destinations()
 	var/list/destinations = list()
 
 	for(var/obj/item/beacon/B in GLOB.teleportbeacons)
@@ -36,18 +37,28 @@
 
 	return destinations
 
-/obj/item/wormhole_jaunter/proc/activate(mob/user, adjacent)
+/obj/item/wormhole_jaunter/proc/find_beacon(mob/user)
+
+
+/obj/item/wormhole_jaunter/proc/activate(mob/user, adjacent, teleport)
 	if(!turf_check(user))
 		return
 
-	var/list/L = get_destinations(user)
+	var/list/L = get_destinations()
 	if(!L.len)
-		to_chat(user, span_notice("The [src.name] found no beacons in the world to anchor a wormhole to."))
+		if(user)
+			to_chat(user, span_notice("The [src.name] found no beacons in the world to anchor a wormhole to."))
+		else
+			visible_message(span_notice("The [src.name] found no beacons in the world to anchor a wormhole to!"))
 		return
+
 	var/chosen_beacon = pick(L)
-	var/obj/effect/portal/jaunt_tunnel/J = new (get_turf(src), 100, null, FALSE, get_turf(chosen_beacon))
-	if(adjacent)
-		try_move_adjacent(J)
+	var/obj/effect/portal/jaunt_tunnel/Tunnel = new (get_turf(src), 100, null, FALSE, get_turf(chosen_beacon))
+	if(teleport)
+		Tunnel.teleport(user)
+	else if(adjacent)
+		try_move_adjacent(Tunnel)
+
 	playsound(src,'sound/effects/sparks4.ogg',50,TRUE)
 	qdel(src)
 
@@ -56,25 +67,30 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 
-	var/mob/M = loc
-	if(istype(M))
-		var/triggered = FALSE
-		if(M.get_item_by_slot(ITEM_SLOT_BELT) == src)
-			if(power == 1)
-				triggered = TRUE
-			else if(power == 2 && prob(50))
-				triggered = TRUE
+	var/triggered = FALSE
+	if(power == 1)
+		triggered = TRUE
+	else if(power == 2 && prob(50))
+		triggered = TRUE
 
-		if(triggered)
-			M.visible_message(span_warning("[src] overloads and activates!"))
-			SSblackbox.record_feedback("tally", "jaunter", 1, "EMP") // EMP accidental activation
-			activate(M)
+	var/mob/M = loc
+	if(istype(M) && triggered)
+		M.visible_message(span_warning("[src] overloads and activates!"))
+		SSblackbox.record_feedback("tally", "jaunter", 1, "EMP") // EMP accidental activation
+		activate(M, FALSE, TRUE)
+	else if(triggered)
+		visible_message(span_warning("The [src.name] overloads and activates!"))
+		activate()
 
 /obj/item/wormhole_jaunter/proc/chasm_react(mob/user)
-	if(user.get_item_by_slot(ITEM_SLOT_BELT) == src)
+	var/list/L = get_destinations()
+
+	if(user.get_item_by_slot(ITEM_SLOT_BELT) == src && L.len)
 		to_chat(user, span_notice("Your [name] activates, saving you from the chasm!"))
 		SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
-		activate(user, FALSE)
+		activate(user, FALSE, TRUE)
+	else if(!L.len)
+		to_chat(user, span_userdanger("The [src.name] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm.  RIP."))
 	else
 		to_chat(user, span_userdanger("[src] is not attached to your belt, preventing it from saving you from the chasm. RIP."))
 

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -45,15 +45,16 @@
 	if(!turf_check(user))
 		return
 
-	var/list/destinations = get_destinations()
-	if(!destinations.len)
+	if(!can_jaunter_teleport())
 		if(user)
-			to_chat(user, span_notice("The [src] found no beacons in the world to anchor a wormhole to."))
+			to_chat(user, span_notice("\The [src] found no beacons in the world to anchor a wormhole to."))
 		else
 			visible_message(span_notice("\The [src] found no beacons in the world to anchor a wormhole to!"))
 		return
 
+	var/list/destinations = get_destinations()
 	var/chosen_beacon = pick(destinations)
+
 	var/obj/effect/portal/jaunt_tunnel/tunnel = new (get_turf(src), 100, null, FALSE, get_turf(chosen_beacon))
 	if(teleport)
 		tunnel.teleport(user)
@@ -76,11 +77,11 @@
 
 	var/mob/M = loc
 	if(istype(M) && triggered)
-		M.visible_message(span_warning("[src] overloads and activates!"))
+		M.visible_message(span_warning("Your [src] overloads and activates!"))
 		SSblackbox.record_feedback("tally", "jaunter", 1, "EMP") // EMP accidental activation
 		activate(M, FALSE, TRUE)
 	else if(triggered)
-		visible_message(span_warning("The [src.name] overloads and activates!"))
+		visible_message(span_warning("\The [src] overloads and activates!"))
 		activate()
 
 /obj/item/wormhole_jaunter/proc/chasm_react(mob/user)

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -37,9 +37,6 @@
 
 	return destinations
 
-/obj/item/wormhole_jaunter/proc/find_beacon(mob/user)
-
-
 /obj/item/wormhole_jaunter/proc/activate(mob/user, adjacent, teleport)
 	if(!turf_check(user))
 		return

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -88,11 +88,8 @@
 /obj/item/wormhole_jaunter/proc/chasm_react(mob/user)
 	var/fall_into_chasm = activate(user, FALSE, TRUE)
 
-	if(fall_into_chasm)
-		to_chat(user, span_userdanger("\The [src] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm. RIP."))
-	else
+	if(!fall_into_chasm)
 		to_chat(user, span_notice("Your [src.name] activates, saving you from the chasm!"))
-		user.visible_message(span_boldwarning("[user] falls into the chasm!")) //To freak out any bystanders
 		SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
 	return fall_into_chasm
 

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -83,16 +83,8 @@
 		activate()
 
 /obj/item/wormhole_jaunter/proc/chasm_react(mob/user)
-	var/list/L = get_destinations()
-
-	if(user.get_item_by_slot(ITEM_SLOT_BELT) == src && L.len)
-		to_chat(user, span_notice("Your [name] activates, saving you from the chasm!"))
-		SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
-		activate(user, FALSE, TRUE)
-	else if(!L.len)
-		to_chat(user, span_userdanger("The [src.name] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm.  RIP."))
-	else
-		to_chat(user, span_userdanger("[src] is not attached to your belt, preventing it from saving you from the chasm. RIP."))
+	SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
+	activate(user, FALSE, TRUE)
 
 //jaunter tunnel
 /obj/effect/portal/jaunt_tunnel

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -43,7 +43,7 @@
 
 /obj/item/wormhole_jaunter/proc/activate(mob/user, adjacent, teleport)
 	if(!turf_check(user))
-		return
+		return FALSE
 
 	if(!can_jaunter_teleport())
 		if(user)

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -50,7 +50,7 @@
 			to_chat(user, span_notice("\The [src] found no beacons in the world to anchor a wormhole to."))
 		else
 			visible_message(span_notice("\The [src] found no beacons in the world to anchor a wormhole to!"))
-		return TRUE
+		return TRUE // used for chasm code
 
 	var/list/destinations = get_destinations()
 	var/chosen_beacon = pick(destinations)
@@ -63,7 +63,7 @@
 
 	playsound(src,'sound/effects/sparks4.ogg',50,TRUE)
 	qdel(src)
-	return FALSE
+	return FALSE // used for chasm code
 
 /obj/item/wormhole_jaunter/emp_act(power)
 	. = ..()
@@ -78,7 +78,7 @@
 
 	var/mob/M = loc
 	if(istype(M) && triggered)
-		M.visible_message(span_warning("Your [src] overloads and activates!"))
+		M.visible_message(span_warning("Your [src.name] overloads and activates!"))
 		SSblackbox.record_feedback("tally", "jaunter", 1, "EMP") // EMP accidental activation
 		activate(M, FALSE, TRUE)
 	else if(triggered)
@@ -86,14 +86,15 @@
 		activate()
 
 /obj/item/wormhole_jaunter/proc/chasm_react(mob/user)
-	var/can_jaunter_teleport = activate(user, FALSE, TRUE)
-	if(can_jaunter_teleport)
-		to_chat(user, span_notice("Your [src] activates, saving you from the chasm!"))
+	var/fall_into_chasm = activate(user, FALSE, TRUE)
+
+	if(fall_into_chasm)
+		to_chat(user, span_userdanger("\The [src] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm. RIP."))
+	else
+		to_chat(user, span_notice("Your [src.name] activates, saving you from the chasm!"))
 		user.visible_message(span_boldwarning("[user] falls into the chasm!")) //To freak out any bystanders
 		SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
-	else
-		to_chat(user, span_userdanger("\The [src] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm. RIP."))
-	return can_jaunter_teleport
+	return fall_into_chasm
 
 //jaunter tunnel
 /obj/effect/portal/jaunt_tunnel

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -41,20 +41,20 @@
 	if(!turf_check(user))
 		return
 
-	var/list/L = get_destinations()
-	if(!L.len)
+	var/list/destinations = get_destinations()
+	if(!destinations.len)
 		if(user)
 			to_chat(user, span_notice("The [src.name] found no beacons in the world to anchor a wormhole to."))
 		else
 			visible_message(span_notice("The [src.name] found no beacons in the world to anchor a wormhole to!"))
 		return
 
-	var/chosen_beacon = pick(L)
-	var/obj/effect/portal/jaunt_tunnel/Tunnel = new (get_turf(src), 100, null, FALSE, get_turf(chosen_beacon))
+	var/chosen_beacon = pick(destinations)
+	var/obj/effect/portal/jaunt_tunnel/tunnel = new (get_turf(src), 100, null, FALSE, get_turf(chosen_beacon))
 	if(teleport)
-		Tunnel.teleport(user)
+		tunnel.teleport(user)
 	else if(adjacent)
-		try_move_adjacent(Tunnel)
+		try_move_adjacent(tunnel)
 
 	playsound(src,'sound/effects/sparks4.ogg',50,TRUE)
 	qdel(src)

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -37,6 +37,10 @@
 
 	return destinations
 
+/obj/item/wormhole_jaunter/proc/can_jaunter_teleport()
+	var/list/destinations = get_destinations()
+	return destinations.len > 0
+
 /obj/item/wormhole_jaunter/proc/activate(mob/user, adjacent, teleport)
 	if(!turf_check(user))
 		return
@@ -44,9 +48,9 @@
 	var/list/destinations = get_destinations()
 	if(!destinations.len)
 		if(user)
-			to_chat(user, span_notice("The [src.name] found no beacons in the world to anchor a wormhole to."))
+			to_chat(user, span_notice("The [src] found no beacons in the world to anchor a wormhole to."))
 		else
-			visible_message(span_notice("The [src.name] found no beacons in the world to anchor a wormhole to!"))
+			visible_message(span_notice("\The [src] found no beacons in the world to anchor a wormhole to!"))
 		return
 
 	var/chosen_beacon = pick(destinations)
@@ -80,8 +84,15 @@
 		activate()
 
 /obj/item/wormhole_jaunter/proc/chasm_react(mob/user)
-	SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
-	activate(user, FALSE, TRUE)
+	if(can_jaunter_teleport())
+		to_chat(user, span_notice("Your [src] activates, saving you from the chasm!"))
+		user.visible_message(span_boldwarning("[user] falls into the chasm!")) //To freak out any bystanders
+		SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
+		activate(user, FALSE, TRUE)
+		return FALSE
+	else
+		to_chat(user, span_userdanger("\The [src] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm. RIP."))
+		return TRUE
 
 //jaunter tunnel
 /obj/effect/portal/jaunt_tunnel

--- a/code/modules/mining/equipment/wormhole_jaunter.dm
+++ b/code/modules/mining/equipment/wormhole_jaunter.dm
@@ -50,7 +50,7 @@
 			to_chat(user, span_notice("\The [src] found no beacons in the world to anchor a wormhole to."))
 		else
 			visible_message(span_notice("\The [src] found no beacons in the world to anchor a wormhole to!"))
-		return
+		return TRUE
 
 	var/list/destinations = get_destinations()
 	var/chosen_beacon = pick(destinations)
@@ -63,6 +63,7 @@
 
 	playsound(src,'sound/effects/sparks4.ogg',50,TRUE)
 	qdel(src)
+	return FALSE
 
 /obj/item/wormhole_jaunter/emp_act(power)
 	. = ..()
@@ -85,15 +86,14 @@
 		activate()
 
 /obj/item/wormhole_jaunter/proc/chasm_react(mob/user)
-	if(can_jaunter_teleport())
+	var/can_jaunter_teleport = activate(user, FALSE, TRUE)
+	if(can_jaunter_teleport)
 		to_chat(user, span_notice("Your [src] activates, saving you from the chasm!"))
 		user.visible_message(span_boldwarning("[user] falls into the chasm!")) //To freak out any bystanders
 		SSblackbox.record_feedback("tally", "jaunter", 1, "Chasm") // chasm automatic activation
-		activate(user, FALSE, TRUE)
-		return FALSE
 	else
 		to_chat(user, span_userdanger("\The [src] found no beacons in the world to anchor a wormhole to, preventing it from saving you from the chasm. RIP."))
-		return TRUE
+	return can_jaunter_teleport
 
 //jaunter tunnel
 /obj/effect/portal/jaunt_tunnel


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #60196

Wormhole jaunters will now save the user from a chasm if they fall in and **it's on their belt**.  Wormhole jaunters also are affected by EMP correctly.  Before it would only be affected by an EMP if it was in the belt storage area which made no sense. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugs are bad.

## Changelog
:cl:
fix: Fixed wormhole jaunter to trigger when falling into a chasm
fix: Fixed wormhole jaunter to be affected by EMP
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
