### PR TITLE
Fix xenos not taking damage while in crit

### DIFF
--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -11,7 +11,7 @@
 		return 0
 
 	if(health <= HEALTH_THRESHOLD_CRIT)
-		adjustBruteLoss(2)
+		adjustOxyLoss(2)
 
 	var/plasma_used = 0
 	var/plas_detect_threshold = 0.02

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -10,6 +10,10 @@
 		//Aliens breathe in vaccuum
 		return 0
 
+	if(health <= HEALTH_THRESHOLD_CRIT)
+		adjustBruteLoss(2)
+		updatehealth()
+
 	var/plasma_used = 0
 	var/plas_detect_threshold = 0.02
 	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*breath.temperature)/BREATH_VOLUME

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -12,7 +12,6 @@
 
 	if(health <= HEALTH_THRESHOLD_CRIT)
 		adjustBruteLoss(2)
-		updatehealth()
 
 	var/plasma_used = 0
 	var/plas_detect_threshold = 0.02


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #61022

Xenos will now slowly take damage while in crit state.

## Changelog
:cl:
fix: Fixed xenos will now take damage while in crit state
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
