### PR TITLE
redpill junkmail sanity

### DIFF
--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -293,7 +293,7 @@
 	var/code = random_nukecode()
 	var/code_already_set = FALSE
 	for(var/obj/machinery/nuclearbomb/selfdestruct/self_destruct in GLOB.nuke_list)
-		if(self_destruct.r_code == "ADMIN")
+		if(self_destruct.r_code != "ADMIN")
 			code_already_set = TRUE
 			code = self_destruct.r_code
 			break
@@ -303,7 +303,9 @@
 	else
 		message_admins("Through junkmail, the self-destruct code was set to \"[code]\".")
 
-	info = "<i>You need to escape the simulation. Don't forget the numbers, they help you remember:</i> '[pick_n_take(code)][pick_n_take(code)]...'"
+	var/list/code_list = splittext(code, "")
+
+	info = "<i>You need to escape the simulation. Don't forget the numbers, they help you remember:</i> '[pick_n_take(code_list)][pick_n_take(code_list)]...'"
 
 ///admin letter enabling players to brute force their way through the nuke code if they're so inclined.
 /obj/item/paper/fluff/junkmail_redpill/true

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -291,12 +291,22 @@
 		info = "<i>You need to escape the simulation. Don't forget the numbers, they help you remember:</i> '[rand(0,9)][rand(0,9)][rand(0,9)]...'"
 		return
 	var/code = random_nukecode()
+	var/code_already_set = FALSE
 	for(var/obj/machinery/nuclearbomb/selfdestruct/self_destruct in GLOB.nuke_list)
+		if(self_destruct.r_code == "ADMIN")
+			code_already_set = TRUE
+			code = self_destruct.r_code
+			break
 		self_destruct.r_code = code
-	message_admins("Through junkmail, the self-destruct code was set to \"[code]\".")
-	info = "<i>You need to escape the simulation. Don't forget the numbers, they help you remember:</i> '[code[rand(1,5)]][code[rand(1,5)]]...'"
+	if(code_already_set)
+		message_admins("Through junkmail, the nuclear self-destruct code was partially revealed.")
+	else
+		message_admins("Through junkmail, the self-destruct code was set to \"[code]\".")
 
-/obj/item/paper/fluff/junkmail_redpill/true //admin letter enabling players to brute force their way through the nuke code if they're so inclined.
+	info = "<i>You need to escape the simulation. Don't forget the numbers, they help you remember:</i> '[pick_n_take(code)][pick_n_take(code)]...'"
+
+///admin letter enabling players to brute force their way through the nuke code if they're so inclined.
+/obj/item/paper/fluff/junkmail_redpill/true
 	nuclear_option_odds = 100
 
 /obj/item/paper/fluff/junkmail_generic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- junkmail no longer changes the nuke code if one is already set. this isn't really a bug per se but it can severely ruin a nuke op's round if one is set and a new one is randomly set via mail
- junkmail now has correct doc format on the /true subtype
- junkmail can no longer pick the same character to reveal twice, giving you an incorrect hint of the real nuclear auth code

## Why It's Good For The Game

bugfeexes

## Changelog
:cl:
fix: junkmail no longer changes the nuke code if one is already set.
fix: junkmail can no longer pick the same character to reveal twice, giving you an incorrect hint of the real nuclear auth code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
