### PR TITLE
Corrects a possessive case in the fluff text of a paper note found in an ice planet ruin.

### DIFF
--- a/code/modules/ruins/icemoonruin_code/library.dm
+++ b/code/modules/ruins/icemoonruin_code/library.dm
@@ -13,7 +13,7 @@
 
 /obj/item/paper/crumpled/bloody/fluff/stations/lavaland/library/warning
 	name = "ancient note"
-	info = "<b>Here lies the vast collection of He Who Knows Ten Thousand Things. Damned be those who seek it's knowledge for power.</b>"
+	info = "<b>Here lies the vast collection of He Who Knows Ten Thousand Things. Damned be those who seek its knowledge for power.</b>"
 
 /obj/item/paper/crumpled/fluff/stations/lavaland/library/diary
 	name = "diary entry 13"


### PR DESCRIPTION
## About The Pull Request
`its` versus `it's`

## Why It's Good For The Game
This will fix #61064.

## Changelog
:cl:
spellcheck: Corrected a possessive case in the text of the ancient note found in the ice library ruin.
/:cl:
