### PR TITLE
Hostile mobs will always face their targets when shooting.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -425,6 +425,7 @@
 	if(QDELETED(targeted_atom) || targeted_atom == target_from.loc || targeted_atom == target_from )
 		return
 	var/turf/startloc = get_turf(target_from)
+	face_atom(targeted_atom)
 	if(casingtype)
 		var/obj/item/ammo_casing/casing = new casingtype(startloc)
 		playsound(src, projectilesound, 100, TRUE)


### PR DESCRIPTION
## About The Pull Request
Added a `face_atom` call with `targeted_atom` as arg.

## Why It's Good For The Game
This will fix #37296

## Changelog
:cl:
fix: Hostile mobs will always face their targets when shooting.
/:cl:
