### PR TITLE
Adds a stack trace for objs with <=0 integ taking damage

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -4,9 +4,11 @@
 	if(QDELETED(src))
 		stack_trace("[src] taking damage after deletion")
 		return
+	if(obj_integrity <= 0)
+		stack_trace("[src] taking damage while having <= 0 integrity")
 	if(sound_effect)
 		play_attack_sound(damage_amount, damage_type, damage_flag)
-	if((resistance_flags & INDESTRUCTIBLE) || obj_integrity <= 0)
+	if(resistance_flags & INDESTRUCTIBLE)
 		return
 	damage_amount = run_obj_armor(damage_amount, damage_type, damage_flag, attack_dir, armour_penetration)
 	if(damage_amount < DAMAGE_PRECISION)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -6,6 +6,7 @@
 		return
 	if(obj_integrity <= 0)
 		stack_trace("[src] taking damage while having <= 0 integrity")
+		return
 	if(sound_effect)
 		play_attack_sound(damage_amount, damage_type, damage_flag)
 	if(resistance_flags & INDESTRUCTIBLE)


### PR DESCRIPTION
## About The Pull Request
Adds a stack_trace to <=0 integ objs taking damage so instances of people relying on this early return prior can be identified


## Why It's Good For The Game
Items with 0 integrity not breaking/destroyed is dumb
Completely damaged clothing items on a griddle should be destroyed, but wasn't getting caught
![image](https://user-images.githubusercontent.com/51932756/131189125-6f1f99d9-5788-4460-8309-39baba7bb422.png)