### PR TITLE
Fixes moths infinitely eating most clothing

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -41,6 +41,8 @@
 #define MAGIC "magic"
 /// Involved in checking the likelyhood of applying a wound to a mob.
 #define WOUND "wound"
+/// Involves being consumed
+#define VORE "vore"
 
 // Weather immunities //
 #define WEATHER_STORM "storm"

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -41,8 +41,8 @@
 #define MAGIC "magic"
 /// Involved in checking the likelyhood of applying a wound to a mob.
 #define WOUND "wound"
-/// Involves being consumed
-#define VORE "vore"
+/// Involves being eaten
+#define CONSUME "consume"
 
 // Weather immunities //
 #define WEATHER_STORM "storm"

--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -18,6 +18,7 @@
 	var/acid
 	var/magic
 	var/wound
+	var/vore
 
 /datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)
 	src.melee = melee
@@ -31,6 +32,7 @@
 	src.acid = acid
 	src.magic = magic
 	src.wound = wound
+	src.vore = melee
 	tag = ARMORID
 
 /datum/armor/proc/modifyRating(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)

--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -18,7 +18,7 @@
 	var/acid
 	var/magic
 	var/wound
-	var/vore
+	var/consume
 
 /datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)
 	src.melee = melee
@@ -32,7 +32,7 @@
 	src.acid = acid
 	src.magic = magic
 	src.wound = wound
-	src.vore = melee
+	src.consume = melee
 	tag = ARMORID
 
 /datum/armor/proc/modifyRating(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -497,7 +497,7 @@ BLIND     // can't see anything
 		new /obj/effect/decal/cleanable/shreds(current_position, name)
 		if(isliving(loc))
 			var/mob/living/possessing_mob = loc
-			possessing_mob.visible_message(span_danger("[src] is consumed until naught but shreds remains!"), span_warning("<b>[src] falls apart into little bits!</b>"))
+			possessing_mob.visible_message(span_danger("[src] is consumed until naught but shreds remains!"), span_boldwarning("[src] falls apart into little bits!"))
 		deconstruct(FALSE)
 	else if(!(damage_flag in list(ACID, FIRE)))
 		body_parts_covered = NONE

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -118,7 +118,7 @@
 /obj/item/food/clothing/proc/after_eat(mob/eater)
 	var/obj/item/clothing/resolved_clothing = clothing.resolve()
 	if (resolved_clothing)
-		resolved_clothing.take_damage(MOTH_EATING_CLOTHING_DAMAGE, sound_effect = FALSE, damage_flag = BOMB) //The bomb damage flag allows mundane clothing items to be destroyed, leaving scraps
+		resolved_clothing.take_damage(MOTH_EATING_CLOTHING_DAMAGE, sound_effect = FALSE, damage_flag = VORE)
 	else
 		qdel(src)
 
@@ -492,13 +492,20 @@ BLIND     // can't see anything
 		//so the shred survives potential turf change from the explosion.
 		addtimer(CALLBACK_NEW(/obj/effect/decal/cleanable/shreds, list(T, name)), 1)
 		deconstruct(FALSE)
+	if(damage_flag == VORE) //This allows for moths to fully consume clothing, rather than damaging it like other sources like brute
+		var/turf/current_position = get_turf(src)
+		new /obj/effect/decal/cleanable/shreds(current_position, name)
+		if(isliving(loc))
+			var/mob/living/possessing_mob = loc
+			possessing_mob.visible_message(span_danger("[src] is consumed until naught but shreds remains!"), span_warning("<b>[src] falls apart into little bits!</b>"))
+		deconstruct(FALSE)
 	else if(!(damage_flag in list(ACID, FIRE)))
 		body_parts_covered = NONE
 		slot_flags = NONE
 		update_clothes_damaged_state(CLOTHING_SHREDDED)
 		if(isliving(loc))
 			var/mob/living/M = loc
-			if(src in M.get_equipped_items(FALSE)) //make sure they were wearing it and not attacking the item in their hands / eating it if they were a moth.
+			if(src in M.get_equipped_items(FALSE)) //make sure they were wearing it and not attacking the item in their hands
 				M.visible_message(span_danger("[M]'s [src.name] fall[p_s()] off, [p_theyre()] completely shredded!"), span_warning("<b>Your [src.name] fall[p_s()] off, [p_theyre()] completely shredded!</b>"), vision_distance = COMBAT_MESSAGE_RANGE)
 				M.dropItemToGround(src)
 			else

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -118,7 +118,7 @@
 /obj/item/food/clothing/proc/after_eat(mob/eater)
 	var/obj/item/clothing/resolved_clothing = clothing.resolve()
 	if (resolved_clothing)
-		resolved_clothing.take_damage(MOTH_EATING_CLOTHING_DAMAGE, sound_effect = FALSE, damage_flag = VORE)
+		resolved_clothing.take_damage(MOTH_EATING_CLOTHING_DAMAGE, sound_effect = FALSE, damage_flag = CONSUME)
 	else
 		qdel(src)
 
@@ -492,7 +492,7 @@ BLIND     // can't see anything
 		//so the shred survives potential turf change from the explosion.
 		addtimer(CALLBACK_NEW(/obj/effect/decal/cleanable/shreds, list(T, name)), 1)
 		deconstruct(FALSE)
-	if(damage_flag == VORE) //This allows for moths to fully consume clothing, rather than damaging it like other sources like brute
+	if(damage_flag == CONSUME) //This allows for moths to fully consume clothing, rather than damaging it like other sources like brute
 		var/turf/current_position = get_turf(src)
 		new /obj/effect/decal/cleanable/shreds(current_position, name)
 		if(isliving(loc))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -118,7 +118,7 @@
 /obj/item/food/clothing/proc/after_eat(mob/eater)
 	var/obj/item/clothing/resolved_clothing = clothing.resolve()
 	if (resolved_clothing)
-		resolved_clothing.take_damage(MOTH_EATING_CLOTHING_DAMAGE, sound_effect = FALSE)
+		resolved_clothing.take_damage(MOTH_EATING_CLOTHING_DAMAGE, sound_effect = FALSE, damage_flag = BOMB) //The bomb damage flag allows mundane clothing items to be destroyed, leaving scraps
 	else
 		qdel(src)
 


### PR DESCRIPTION
## About The Pull Request
Creates a new `damage_flag` for the proc call done by moths eating clothing items, so that articles of clothing can be fully consumed, which is checked against melee armor.
Traitor objectives like the advanced magboots do not take integrity damage from this, and remain unaffected by this change.

This has been bugged since June 2020 as this change made it so that an article of clothing needed a bomb, fire, or acid damage flag to be completely destroyed. https://github.com/tgstation/tgstation/pull/50558#discussion_r697777901

## Why It's Good For The Game
Infinite sources of food available everywhere on your person is bad
![Untitled](https://user-images.githubusercontent.com/51932756/131200749-de914f40-02ac-44cc-a949-5c77c2dccc9b.png)

Moths eating the entirety of a piece of clothing is innately comical, and this is a much funnier outcome that can fuel social interactions with others
![image](https://user-images.githubusercontent.com/51932756/131200771-2f06d780-a591-454c-9f45-15913ecf6370.png)

## Changelog
:cl:
fix: Moths have finally figured out how to finish eating clothes again, rather than infinitely eating a singular sock.
/:cl: