### PR TITLE
Fixes a plasmaman autoignition oversight

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -52,8 +52,7 @@
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
 	var/atmos_sealed = CanIgniteMob(H) && (isclothing(H.wear_suit) && H.wear_suit.clothing_flags & STOPSPRESSUREDAMAGE) && (isclothing(H.head) && H.head.clothing_flags & STOPSPRESSUREDAMAGE)
 	var/flammable_limb = FALSE
-	for(var/any_bodypart as anything in H.bodyparts)//If any plasma based limb is found the plasmaman will attempt to autoignite
-		var/obj/item/bodypart/found_bodypart = any_bodypart
+	for(var/obj/item/bodypart/found_bodypart as anything in H.bodyparts)//If any plasma based limb is found the plasmaman will attempt to autoignite
 		if(found_bodypart.status == BODYPART_ORGANIC && (found_bodypart.species_id == SPECIES_PLASMAMAN || HAS_TRAIT(found_bodypart, TRAIT_PLASMABURNT))) //Allows for "donated" limbs and augmented limbs to prevent autoignition
 			flammable_limb = TRUE
 			break

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -51,7 +51,12 @@
 
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
 	var/atmos_sealed = CanIgniteMob(H) && (isclothing(H.wear_suit) && H.wear_suit.clothing_flags & STOPSPRESSUREDAMAGE) && (isclothing(H.head) && H.head.clothing_flags & STOPSPRESSUREDAMAGE)
-	if(!atmos_sealed && (!istype(H.w_uniform, /obj/item/clothing/under/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/plasmaman) || !istype(H.gloves, /obj/item/clothing/gloves)))
+	var/list/flammable_limbs = list() //If any limbs are found in this list the plasmaman will attempt to autoignite
+	for(var/any_bodypart in H.bodyparts)
+		var/obj/item/bodypart/found_bodypart = any_bodypart
+		if(found_bodypart.status == BODYPART_ORGANIC && (found_bodypart.species_id == SPECIES_PLASMAMAN || HAS_TRAIT(found_bodypart, TRAIT_PLASMABURNT))) //Allows for "donated" limbs and augmented limbs to prevent autoignition
+			flammable_limbs += found_bodypart
+	if(!atmos_sealed && flammable_limbs.len && (!istype(H.w_uniform, /obj/item/clothing/under/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/plasmaman) || !istype(H.gloves, /obj/item/clothing/gloves)))
 		var/datum/gas_mixture/environment = H.loc.return_air()
 		if(environment?.total_moles())
 			if(environment.gases[/datum/gas/hypernoblium] && (environment.gases[/datum/gas/hypernoblium][MOLES]) >= 5)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -51,12 +51,15 @@
 
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
 	var/atmos_sealed = CanIgniteMob(H) && (isclothing(H.wear_suit) && H.wear_suit.clothing_flags & STOPSPRESSUREDAMAGE) && (isclothing(H.head) && H.head.clothing_flags & STOPSPRESSUREDAMAGE)
-	var/list/flammable_limbs = list() //If any limbs are found in this list the plasmaman will attempt to autoignite
-	for(var/any_bodypart in H.bodyparts)
+	var/flammable_limb = FALSE
+	for(var/any_bodypart as anything in H.bodyparts)//If any plasma based limb is found the plasmaman will attempt to autoignite
 		var/obj/item/bodypart/found_bodypart = any_bodypart
 		if(found_bodypart.status == BODYPART_ORGANIC && (found_bodypart.species_id == SPECIES_PLASMAMAN || HAS_TRAIT(found_bodypart, TRAIT_PLASMABURNT))) //Allows for "donated" limbs and augmented limbs to prevent autoignition
-			flammable_limbs += found_bodypart
-	if(!atmos_sealed && flammable_limbs.len && (!istype(H.w_uniform, /obj/item/clothing/under/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/plasmaman) || !istype(H.gloves, /obj/item/clothing/gloves)))
+			flammable_limb = TRUE
+			break
+	if(!flammable_limb && !H.on_fire) //Allows their suit to attempt to autoextinguish if augged and on fire
+		return
+	if(!atmos_sealed && (!istype(H.w_uniform, /obj/item/clothing/under/plasmaman) || !istype(H.head, /obj/item/clothing/head/helmet/space/plasmaman) || !istype(H.gloves, /obj/item/clothing/gloves)))
 		var/datum/gas_mixture/environment = H.loc.return_air()
 		if(environment?.total_moles())
 			if(environment.gases[/datum/gas/hypernoblium] && (environment.gases[/datum/gas/hypernoblium][MOLES]) >= 5)


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/33716
Adds a check to see if there are any organic plasmaman limbs or any plasmaburnt limbs (which are obtained by exposure to plasma lava on icebox) before igniting plasmemes so that a plasmeme with fully replaced limbs can stop burning

## Why It's Good For The Game
It fixes an oversight from 2017
Rewards players that have invested the time and effort to completely change a plasmaman's body with a more immersive experience

![image](https://user-images.githubusercontent.com/51932756/131203605-1f819d22-88a2-4a7f-a972-bab3f5cd3d05.png)
Even one plasma limb remaining will cause them to burn, but other donors will work

## Changelog
:cl:
fix: Plasmamen that have all of their limbs replaced with non-plasma alternatives will not autoignite in flammable environments.
/:cl: