### PR TITLE
Ridden creatures gets their ability back once the rider dismounts.

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -79,6 +79,7 @@
 		living_parent.log_message("is no longer being ridden by [former_rider]", LOG_ATTACK, color="pink")
 		former_rider.log_message("is no longer riding [living_parent]", LOG_ATTACK, color="pink")
 	remove_abilities(former_rider)
+
 	// We gotta reset those layers at some point, don't we?
 	former_rider.layer = MOB_LAYER
 	living_parent.layer = MOB_LAYER
@@ -146,6 +147,8 @@
 	for(var/i in ridden_creature.abilities)
 		var/obj/effect/proc_holder/proc_holder = i
 		M.RemoveAbility(proc_holder)
+		if(proc_holder.has_action)
+			proc_holder.action.Grant(ridden_creature)
 
 
 ///////Yes, I said humans. No, this won't end well...//////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes the maint part of  #55309

This PR fixes the issue where vat beasts would permanently lose their slap ability when ridden.  This was because granting the action to the rider automatically removes the action from the previous owner.

This PR makes it so they at least get their ability back once the owner dismounts.

Ideally, both the rider and mount would be able to use the ability, but this does not seem possible without refactoring the ability code to allow multiple owners of an action.

If you have a good way of implementing it that way instead, let me know.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Riding sentient mobs is really fun, but it sucks to lose your signature ability because someone tried to ride you.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix:  Vat beasts now get their slap ability back once the person riding them dismounts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
