### PR TITLE
Adds a span_notice when emaging a PACMAN

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -220,6 +220,7 @@
 	if(obj_flags & EMAGGED)
 		return
 	obj_flags |= EMAGGED
+	to_chat(user, span_notice("You hear a clunk from inside the generator."))
 	emp_act(EMP_HEAVY)
 
 /obj/machinery/power/port_gen/pacman/attack_ai(mob/user)


### PR DESCRIPTION

## About The Pull Request
Adds a textual indication that a generator has been emaged.
## Why It's Good For The Game

Surprise!  PACMAN generators can be emaged!  It's not listed in the wiki, but I've used this to great effect as a traitor.

## Changelog
:cl:
add: PACMANs could previously be emaged, but now there's a text indicator when you do so successfully.
/:cl:
