### PR TITLE
changed minor typo in ventcrawling.dm

### DIFF
--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -39,7 +39,7 @@
 			visible_message(span_notice("[src] begins climbing out from the ventilation system...") ,span_notice("You begin climbing out from the ventilation system..."))
 			if(!client)
 				return
-			visible_message(span_notice("[src] scrambles out from the ventilation ducts!"),span_notice("You out from the ventilation ducts."))
+			visible_message(span_notice("[src] scrambles out from the ventilation ducts!"),span_notice("You scramble out from the ventilation ducts."))
 			forceMove(ventcrawl_target.loc)
 			REMOVE_TRAIT(src, TRAIT_MOVE_VENTCRAWLING, VENTCRAWLING_TRAIT)
 			update_pipe_vision()


### PR DESCRIPTION
changed "You out from the ventilation ducts." to "You scramble out from the ventilation ducts." to match the visible_message.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes a typo in ventcrawling.dm

## Why It's Good For The Game

soothes eyes from the searing pain of missing words in notices.

## Changelog
:cl:
spellcheck: fixed a single typo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
