### PR TITLE
fixes translocation define to actually mean translocation

### DIFF
--- a/code/__DEFINES/magic.dm
+++ b/code/__DEFINES/magic.dm
@@ -12,7 +12,7 @@
 //NEUTRAL SPELLS (punished by honorbound gods if you get caught using it)
 #define SCHOOL_EVOCATION "evocation" //kill or destroy shit, usually out of thin air
 #define SCHOOL_TRANSMUTATION "transmutation" //transform shit
-#define SCHOOL_TRANSLOCATION "illusion" //movement based
+#define SCHOOL_TRANSLOCATION "translocation" //movement based
 #define SCHOOL_CONJURATION "conjuration" //summoning
 
 //EVIL SPELLS (instant smite + banishment)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I may have missed one define and I found it while just working on something completely different

## Why It's Good For The Game

Now god won't smite you for using magic from a school that does not exist

## Changelog
:cl:
fix: Any instance where you'd see "illusion" as a school of magic is now "translocation". the illusion school has been dead for awhile now!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
