### PR TITLE
Tramstation stampening & additional departmental resupplies

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -806,6 +806,7 @@
 "aep" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
+/obj/item/stamp/law,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "aeq" = (
@@ -5083,6 +5084,7 @@
 /area/medical/virology)
 "atA" = (
 /obj/structure/rack,
+/obj/item/storage/box/beakers,
 /obj/item/wrench,
 /obj/item/kitchen/knife,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -9023,6 +9025,10 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/iron/white,
 /area/science/research)
 "aHY" = (
@@ -37553,6 +37559,7 @@
 /area/science/storage)
 "lGl" = (
 /obj/structure/rack,
+/obj/item/book/manual/wiki/robotics_cyborgs,
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -3;
 	pixel_y = 3
@@ -59800,6 +59807,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
+/obj/item/book/manual/wiki/surgery{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/medicine,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "uYT" = (
@@ -62991,7 +63003,7 @@
 	pixel_y = 2
 	},
 /obj/item/aicard,
-/obj/item/ai_module/core,
+/obj/item/circuitboard/aicore,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "wmS" = (
@@ -68237,6 +68249,13 @@
 	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
+	},
+/obj/item/experi_scanner{
+	pixel_x = 5
+	},
+/obj/item/experi_scanner,
+/obj/item/experi_scanner{
+	pixel_x = -5
 	},
 /turf/open/floor/iron/white,
 /area/science/research)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -5084,7 +5084,6 @@
 /area/medical/virology)
 "atA" = (
 /obj/structure/rack,
-/obj/item/storage/box/beakers,
 /obj/item/wrench,
 /obj/item/kitchen/knife,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -9025,10 +9024,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
 /turf/open/floor/iron/white,
 /area/science/research)
 "aHY" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -58580,7 +58580,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/button/door/directional/west,
+/obj/machinery/button/door/directional/west{
+	id = "left_tram_lower";
+	req_access_txt = "12"
+	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "uxR" = (


### PR DESCRIPTION
## About The Pull Request
This PR restores the missing lawyer stamp to Tramstation for all your lawyer-based stampening goodness. I also replaced the dud AI core module in RD's office with an actual AI Core ciruitboard because you can't build an AI out of a lawchanging module. Tram RnD didn't have Experisci scanners shift start either, so I fixed that. I've also added basic book guides to Robotics and Medbay Treatment Center.
EDIT: Fixed the top right shutters button in left side of tram underpass since it didn't have either the shutters id or access restrictions for it.

## Why It's Good For The Game
Making Tramstation a little less tedious to play on by restoring things that every map has shift start as basic equipment. Restoring the lost RP potential of lawyers' paperwork. Reduces the chance of some jerk skipping the toilet scan for Industrial Engineering because he couldn't find an Experi-scanner anywhere including the lathe. Restores the RD's capability for building an AI. Also book manuals are handy sometimes.

## Changelog
:cl:
fix: Tramstation: Restored the missing law office stamp. Hail bureaucracy!
fix: Tramstation: Replaced the Core AI module in RD's office with an AI Core circuitboard. You can actually build a new AI with this!
fix: Tramstation: RnD now comes with three Experi-scanners. You no longer have an excuse for not scanning those toilets.
fix: Tramstation: Fixed a non-functional shutters button in left-side tram underpass.
add: Tramstation: Book manuals have been shipped to Robotics and Medbay Treatment Center.
/:cl:

