### PR TITLE
Fixes a money generation exploit, some ref cleanup and `?.` operator usage

### DIFF
--- a/code/game/machinery/roulette_machine.dm
+++ b/code/game/machinery/roulette_machine.dm
@@ -56,6 +56,7 @@
 
 /obj/machinery/roulette/Destroy()
 	QDEL_NULL(jackpot_loop)
+	my_card = null
 	. = ..()
 
 /obj/machinery/roulette/obj_break(damage_flag)
@@ -176,13 +177,24 @@
 				name = msg
 				desc = "Owned by [new_card.registered_account.account_holder], draws directly from [user.p_their()] account."
 				my_card = new_card
+				RegisterSignal(my_card, COMSIG_PARENT_QDELETING, .proc/on_my_card_deleted)
 				to_chat(user, span_notice("You link the wheel to your account."))
 				power_change()
 				return
 	return ..()
 
+///deletes the my_card ref to prevent harddels
+/obj/machinery/roulette/proc/on_my_card_deleted(datum/source)
+	SIGNAL_HANDLER
+	my_card = null
+
 ///Proc called when player is going to try and play
 /obj/machinery/roulette/proc/play(mob/user, obj/item/card/id/player_id, bet_type, bet_amount, potential_payout)
+	if(!my_card?.registered_account) // Something happened to my_card during the 0.4 seconds delay of the timed callback.
+		icon_state = "idle"
+		flick("flick_down", src)
+		playsound(src, 'sound/machines/piston_lower.ogg', 70)
+		return
 
 	var/payout = potential_payout
 
@@ -222,6 +234,10 @@
 		playsound(src, 'sound/machines/synth_no.ogg', 50)
 		return FALSE
 
+	// Prevents money generation exploits. Doesn't prevent the owner being a scrooge and running away with the money.
+	var/account_balance = my_card?.registered_account?.account_balance
+	potential_payout = (account_balance >= potential_payout) ? potential_payout : account_balance
+
 	audible_message(span_notice("You have won [potential_payout] credits! Congratulations!"))
 	playsound(src, 'sound/machines/synth_yes.ogg', 50)
 
@@ -229,6 +245,8 @@
 
 ///Fills a list of coins that should be dropped.
 /obj/machinery/roulette/proc/dispense_prize(payout)
+	if(!payout)
+		return
 
 	if(payout >= ROULETTE_JACKPOT_AMOUNT)
 		jackpot_loop.start()
@@ -277,7 +295,7 @@
 	if(locked)
 		return
 	locked = TRUE
-	var/stolen_cash = my_card.registered_account.account_balance * percentage
+	var/stolen_cash = my_card?.registered_account?.account_balance * percentage
 	dispense_prize(stolen_cash)
 
 


### PR DESCRIPTION
## About The Pull Request
Title. New money won't be printed when the roulette owner withdraws money from his account while the roulette is still spinning anymore. I have also replaced a few `.` operators with `?.` because of the extensive usage of callbacks in this object, and added a few lines to set `my_card` to null when one or the other is deleted.

## Why It's Good For The Game
This will fix #61127. .

## Changelog
:cl:
fix: Fixed a money generation exploit with the roulette machine.
/:cl:
