### PR TITLE
Traitors now get objectives again

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -108,7 +108,7 @@
 	// for(in...to) loops iterate inclusively, so to reach objective_limit we need to loop to objective_limit - 1
 	// This does not give them 1 fewer objectives than intended.
 	for(var/i in objective_count to objective_limit - 1)
-		forge_single_generic_objective()
+		objectives += forge_single_generic_objective()
 
 
 /**


### PR DESCRIPTION
## About The Pull Request

So I made #60957 to fix traitors getting hardcore random score.
Later, #60993 was made to fix traitor runtimes, which so happened to also fix hardcore random score

Problem is, we both used different ways to fix it, and I didn't notice they fixed it in their PR, which was made after my PR, but was merged days before, and I never updated my branch to notice it.
We both deleted 1 traitor objective assignement so it wouldn't double, and together ended up deleting both.

no GBP update tag please because I'm an idiot and broke it

## Why It's Good For The Game

Traitors can now get objectives again.
Closes #61128

## Changelog
:cl:
fix: traitors now get objectives again.
/:cl: