### PR TITLE
Vents and scrubbers get unique name tags again

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -167,12 +167,17 @@
 	if(!GLOB.air_vent_names[id_tag])
 		// If we do not have a name, assign one.
 		// Produces names like "Port Quarter Solar vent pump hZ2l6".
-		name = "\proper [vent_area.name] vent pump [id_tag]"
+		update_name()
 		GLOB.air_vent_names[id_tag] = name
 
 	vent_area.air_vent_info[id_tag] = signal.data
 
 	radio_connection.post_signal(src, signal, radio_filter_out)
+
+/obj/machinery/atmospherics/components/unary/vent_pump/update_name()
+	..()
+	var/area/vent_area = get_area(src)
+	name = "\proper [vent_area.name] [name] [id_tag]"
 
 
 /obj/machinery/atmospherics/components/unary/vent_pump/atmosinit()

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -119,7 +119,7 @@
 	var/area/scrub_area = get_area(src)
 	if(!GLOB.air_scrub_names[id_tag])
 		// If we do not have a name, assign one
-		name = "\proper [scrub_area.name] air scrubber [id_tag]"
+		update_name()
 		GLOB.air_scrub_names[id_tag] = name
 
 	scrub_area.air_scrub_info[id_tag] = signal.data
@@ -127,6 +127,11 @@
 	radio_connection.post_signal(src, signal, radio_filter_out)
 
 	return TRUE
+
+/obj/machinery/atmospherics/components/unary/vent_scrubber/update_name()
+	..()
+	var/area/scrub_area = get_area(src)
+	name = "\proper [scrub_area.name] [name] [id_tag]"
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/atmosinit()
 	radio_filter_in = frequency==initial(frequency)?(RADIO_FROM_AIRALARM):null


### PR DESCRIPTION
## About The Pull Request

You used to be able to mouse over a vent or scrubber to see its ID tag, in order to match it to its entry in an air alarm panel. However, this id tag is currently missing from the name.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

FUCK

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Vent and scrubber names once again contain their unique ID tags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
