### PR TITLE
Immediately connect on smart pipe reprogram

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -510,8 +510,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 					var/obj/machinery/atmospherics/node = S.nodes[i]
 					if (!node)
 						continue
-					if (S in node.nodes)
-						node.disconnect(S)
+					node.disconnect(S)
 					S.nodes[i] = null
 				// Get our new connections
 				S.atmosinit()

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -484,7 +484,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 				to_chat(user, span_warning("\The [src]'s screen flashes a warning: Can't configure a pipe in a currently connected direction."))
 				return
 			var/old_dir = S.GetInitDirections()
-			var/new_dir = (old_dir & ~target_differences) | target_differences
+			var/new_dir = (old_dir & ~target_differences) | (p_init_dir & target_differences)
 			// Don't make a smart pipe with only one connection
 			if (ISSTUB(new_dir))
 				to_chat(user, span_warning("\The [src]'s screen flashes a warning: Can't configure a pipe to only connect in one direction."))

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -466,32 +466,41 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			if (S.dir == ALL_CARDINALS)
 				to_chat(user, span_warning("\The [S] has no unconnected directions!"))
 				return
-			var/target_init_dir = S.GetInitDirections()
-			if (target_init_dir == p_init_dir)
+			var/old_init_dir = S.GetInitDirections()
+			if (old_init_dir == p_init_dir)
 				to_chat(user, span_warning("\The [S] is already in this configuration!"))
 				return
 			// Check for differences in unconnected directions
-			var/target_differences = (p_init_dir ^ target_init_dir) & ~S.connections
+			var/target_differences = (p_init_dir ^ old_init_dir) & ~S.connections
 			if (!target_differences)
 				to_chat(user, span_warning("\The [S] is already in this configuration for its unconnected directions!"))
 				return
+
 			to_chat(user, span_notice("You start reprogramming \the [S]..."))
 			playsound(get_turf(src), 'sound/machines/click.ogg', 50, TRUE)
 			if(!do_after(user, reprogram_speed, target = S))
 				return
-			// Double check to make sure that nothing has changed. If anything we were about to change is now connected, abort
+
+			// Something else could have changed the target's state while we were waiting in do_after
+			// Most of the edge cases don't matter, but atmos components being able to have live connections not described by initializable directions sounds like a headache at best and an exploit at worst
+
+			// Double check to make sure that nothing has changed. If anything we were about to change was connected during do_after, abort
 			if (target_differences & S.connections)
 				to_chat(user, span_warning("\The [src]'s screen flashes a warning: Can't configure a pipe in a currently connected direction."))
 				return
-			var/old_dir = S.GetInitDirections()
-			var/new_dir = (old_dir & ~target_differences) | (p_init_dir & target_differences)
+			// Grab the current initializable directions, which may differ from old_init_dir if someone else was working on the same pipe at the same time
+			var/current_init_dir = S.GetInitDirections()
+			// Access p_init_dir directly. The RPD can change target layer and initializable directions (though not pipe type or dir) while working to dispense and connect a component,
+			// and have it reflected in the final result. Reprogramming should be similarly consistent.
+			var/new_init_dir = (current_init_dir & ~target_differences) | (p_init_dir & target_differences)
 			// Don't make a smart pipe with only one connection
-			if (ISSTUB(new_dir))
+			if (ISSTUB(new_init_dir))
 				to_chat(user, span_warning("\The [src]'s screen flashes a warning: Can't configure a pipe to only connect in one direction."))
 				return
-			S.SetInitDirections(new_dir)
-			// We can never disconnect from existing connections, but we can connect to previously unconnected directions
-			var/newly_permitted_connections = new_dir & ~old_dir
+			S.SetInitDirections(new_init_dir)
+			// We're now reconfigured.
+			// We can never disconnect from existing connections, but we can connect to previously unconnected directions, and should immediately do so
+			var/newly_permitted_connections = new_init_dir & ~current_init_dir
 			if(newly_permitted_connections)
 				// We're allowed to connect in new directions. Recompute our nodes
 				// Disconnect from everything that is currently connected

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -505,7 +505,14 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 				// We're allowed to connect in new directions. Recompute our nodes
 				// Disconnect from everything that is currently connected
 				for (var/i in 1 to S.device_type)
-					S.nullifyNode(i)
+					// This is basically pipe.nullifyNode, but using it here would create a pitfall for others attempting to
+					// copy and paste disconnection code for other components. Welcome to the atmospherics subsystem
+					var/obj/machinery/atmospherics/node = S.nodes[i]
+					if (!node)
+						continue
+					if (S in node.nodes)
+						node.disconnect(S)
+					S.nodes[i] = null
 				// Get our new connections
 				S.atmosinit()
 				// Connect to our new connections


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously, a smart pipe reprogrammed to permit a new direction would connect to a device or pipe that was added later, but not to any existing device or pipe.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More smart more good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: When reprogramming a smart pipe to permit more directions, the smart pipe will now immediately connect in any newly allowed direction, rather than only connecting when a component is newly placed.
fix: The RPD now correctly reprograms smart pipes to more restrictive states.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
