### PR TITLE
Emergency Access Button Cooldown

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -377,8 +377,8 @@
 			minor_announce("Due to staff shortages, your station has been approved for delivery of access codes to secure the Captain's Spare ID. Delivery via drop pod at [get_area(pod_location)]. ETA 120 seconds.")
 
 /obj/machinery/computer/communications/proc/emergency_access_cooldown(mob/user)
-	if(toggle_uses == toggle_max_uses) //you have used up 3 free uses already, do it one more time and start a cooldown
-		to_chat(user, span_warning("This was your third free use without cooldown, you will not be able to use this again for [DisplayTimeText(EMERGENCY_ACCESS_COOLDOWN)]."))
+	if(toggle_uses == toggle_max_uses) //you have used up free uses already, do it one more time and start a cooldown
+		to_chat(user, span_warning("This was your last free use without cooldown, you will not be able to use this again for [DisplayTimeText(EMERGENCY_ACCESS_COOLDOWN)]."))
 		COOLDOWN_START(src, emergency_access_cooldown, EMERGENCY_ACCESS_COOLDOWN)
 		++toggle_uses //add a use so that this if() is false the next time you try this button
 		return FALSE

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -41,11 +41,16 @@
 	/// The last lines used for changing the status display
 	var/static/last_status_display
 
-	var/toggle_uses = 0 //how many uses the console has done of toggling the emergency access
-	var/toggle_cooldown = 3 //the minimum cooldown of toggling the emergency access IN SECONDS
-	var/toggle_max_uses = 6 //how many uses can you toggle emergency access with before cooldowns start occuring BOTH ENABLE/DISABLE
-	var/time_last_toggled //when emergency access was last toggled
-	var/time_toggle_reset = 30 //how long one must wait without toggling to reset toggle_uses IN SECONDS
+	///how many uses the console has done of toggling the emergency access
+	var/toggle_uses = 0
+	///the minimum cooldown of toggling the emergency access IN SECONDS
+	var/toggle_cooldown = 3
+	///how many uses can you toggle emergency access with before cooldowns start occuring BOTH ENABLE/DISABLE
+	var/toggle_max_uses = 6
+	///when emergency access was last toggled
+	var/time_last_toggled
+	///how long one must wait without toggling to reset toggle_uses IN SECONDS
+	var/time_toggle_reset = 30
 
 /obj/machinery/computer/communications/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
Cyberboss said I could add this
## About The Pull Request
recently on Terry some insufferable twat decided to spam emergency access (both AI and two others actually), which is not only text spam but SOUND spam too, it makes ears bleed
![image](https://user-images.githubusercontent.com/40489693/131564566-5c94dd46-d3ab-45a1-8090-4798bba8e0ed.png)


so now theres a cooldown
you have 3 uses to click the button without a cooldown, afterwhich you get a 30 second cooldown, after the 30 seconds are up, you can hit the button 3 more times without cooldown... alternatively every 30 seconds of not clicking the button resets to 3 clicks without a cooldown, so if you click once, wait 30 seconds, you can hit 3 times free still.

this cooldown shouldnt ever occur during a round unless someones spamming it


all tested, if you dont use up all 3 uses and wait 30 seconds you get your uses back as well, so you always have the ability to spam it a few times before the cooldown kicks in, and once CD ends you get all uses back as well
![image](https://user-images.githubusercontent.com/40489693/132009019-6b3e12d6-30ff-4d25-bdfc-b334768b1333.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because abusing things which spam chat with massive bold words as well as makes a loud sound shouldnt be allowed

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: Emergency Access can no longer be spammed to cause sound and text pain
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
