### PR TITLE
kills 4 object definitions that are inside of proc arguments

### DIFF
--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -95,7 +95,7 @@ Simple datum which is instanced once per type and is used for every object of sa
 	source.mat_update_desc(src)
 
 ///This proc is called when a material updates an object's description
-/atom/proc/mat_update_desc(/datum/material/mat)
+/atom/proc/mat_update_desc(datum/material/mat)
 	return
 
 ///This proc is called when the material is added to an object specifically.

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -300,7 +300,7 @@
 	SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "nyctophobia")
 
 /// Called when the quirk holder moves. Updates the quirk holder's mood.
-/datum/quirk/nyctophobia/proc/on_holder_moved(/mob/living/source, atom/old_loc, dir, forced)
+/datum/quirk/nyctophobia/proc/on_holder_moved(mob/living/source, atom/old_loc, dir, forced)
 	SIGNAL_HANDLER
 
 	if(quirk_holder.stat == DEAD)

--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -308,7 +308,7 @@
 	if(!powered())
 		toggle_drying(TRUE)
 
-/obj/machinery/smartfridge/drying_rack/load(/obj/item/dried_object) //For updating the filled overlay
+/obj/machinery/smartfridge/drying_rack/load(obj/item/dried_object) //For updating the filled overlay
 	. = ..()
 	update_appearance()
 

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -591,7 +591,7 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 		update_appearance()
 		return TRUE
 
-/obj/item/gun/ballistic/proc/guncleaning(mob/user, /obj/item/A)
+/obj/item/gun/ballistic/proc/guncleaning(mob/user, obj/item/A)
 	if(misfire_probability == 0)
 		to_chat(user, span_notice("[src] seems to be already clean of fouling."))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
thanks to putnam for reporting this in coderbus
`/obj/machinery/smartfridge/drying_rack/load(/obj/item/dried_object)`
looks pretty harmless right? youd think that this would make a proc argument called dried_object of type /obj/item but no, this defines a new /obj/item class definition called dried_object with zero changes from /obj/item

you can use this to do weird things, like `/obj/machinery/smartfridge/drying_rack/load(/obj/item/var/dried_object = 3)`
creates a new var on /obj/item called dried_object and is very cursed
gets rid of 4 of these abominations, they dont seem to have caused any bugs except for maybe behavior that relies on typesof(/some/path)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
this is sin
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
