### PR TITLE
Cayenne can now strip people

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -246,7 +246,6 @@
 	AddElement(/datum/element/pet_bonus, "bloops happily!")
 	colored_disk_mouth = mutable_appearance(SSgreyscale.GetColoredIconByType(/datum/greyscale_config/carp/disk_mouth, greyscale_colors), "disk_mouth")
 	ADD_TRAIT(src, TRAIT_DISK_VERIFIER, INNATE_TRAIT) //carp can verify disky
-	ADD_TRAIT(src, TRAIT_ADVANCEDTOOLUSER, INNATE_TRAIT) //carp SMART
 	ADD_TRAIT(src, TRAIT_CAN_STRIP, INNATE_TRAIT) //carp can take the disk off the captain
 
 /mob/living/simple_animal/hostile/carp/cayenne/death(gibbed)
@@ -279,7 +278,7 @@
 	if(disky)
 		if(isopenturf(attacked_target))
 			to_chat(src, span_notice("You place [disky] on [attacked_target]"))
-			disky.forceMove(attacked_target.drop_location())
+			disky.forceMove(attacked_target)
 			disky = null
 			update_icon()
 		else

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -247,6 +247,7 @@
 	colored_disk_mouth = mutable_appearance(SSgreyscale.GetColoredIconByType(/datum/greyscale_config/carp/disk_mouth, greyscale_colors), "disk_mouth")
 	ADD_TRAIT(src, TRAIT_DISK_VERIFIER, INNATE_TRAIT) //carp can verify disky
 	ADD_TRAIT(src, TRAIT_ADVANCEDTOOLUSER, INNATE_TRAIT) //carp SMART
+	ADD_TRAIT(src, TRAIT_CAN_STRIP, INNATE_TRAIT) //carp can take the disk off the captain
 
 /mob/living/simple_animal/hostile/carp/cayenne/death(gibbed)
 	if(disky)


### PR DESCRIPTION
## About The Pull Request

I was told to do this after the feature freeze so here I am now.

Cayenne was given the ability to pick up the disk in their mouth with #57395, which also gave them the trait advancedtooluser for them to strip.
A while later, the ability to strip people was moved to a separate trait, which removed Cayenne's ability to strip. 
This PR restores that functionality, and also makes Cayenne able to drop the nuke disk without deleting it.

Also cayenne putting the nuke disk down would runtime and just delete the disk entirely, so this fixes that also.

## Why It's Good For The Game

It makes cayenne getting the disk a little more manageable and gives them back something they used to be able to do.

## Changelog
:cl:
qol: Cayenne can once again strip people.
fix: Cayenne no longer deletes the nuke disk when putting it back down.
/:cl: