### PR TITLE
RPD default pipe color change

### DIFF
--- a/code/__HELPERS/piping_colors_lists.dm
+++ b/code/__HELPERS/piping_colors_lists.dm
@@ -1,9 +1,8 @@
 ///All colors available to pipes and atmos components
-GLOBAL_LIST_INIT(pipe_paint_colors, sortList(list(
-	"grey" = COLOR_VERY_LIGHT_GRAY,
+GLOBAL_LIST_INIT(pipe_paint_colors, list(
+	"green" = COLOR_VIBRANT_LIME,
 	"blue" = COLOR_BLUE,
 	"red" = COLOR_RED,
-	"green" = COLOR_VIBRANT_LIME,
 	"orange" = COLOR_TAN_ORANGE,
 	"cyan" = COLOR_CYAN,
 	"dark" = COLOR_DARK,
@@ -11,8 +10,9 @@ GLOBAL_LIST_INIT(pipe_paint_colors, sortList(list(
 	"brown" = COLOR_BROWN,
 	"pink" = COLOR_LIGHT_PINK,
 	"purple" = COLOR_PURPLE,
-	"violet" = COLOR_STRONG_VIOLET
-)))
+	"violet" = COLOR_STRONG_VIOLET,
+	"omni" = COLOR_VERY_LIGHT_GRAY
+))
 
 ///List that sorts the colors and is used for setting up the pipes layer so that they overlap correctly
 GLOBAL_LIST_INIT(pipe_colors_ordered, sortList(list(
@@ -32,7 +32,7 @@ GLOBAL_LIST_INIT(pipe_colors_ordered, sortList(list(
 
 ///Names shown in the examine for every colored atmos component
 GLOBAL_LIST_INIT(pipe_color_name, sortList(list(
-	COLOR_VERY_LIGHT_GRAY = "grey",
+	COLOR_VERY_LIGHT_GRAY = "omni",
 	COLOR_BLUE = "blue",
 	COLOR_RED = "red",
 	COLOR_VIBRANT_LIME = "green",

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -207,7 +207,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	///Is the device of the flipped type?
 	var/p_flipped = FALSE
 	///Color of the device we are going to spawn
-	var/paint_color = "grey"
+	var/paint_color = "green"
 	///Speed of building atmos devices
 	var/atmos_build_speed = 0.5 SECONDS
 	///Speed of building disposal devices


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
New default color is green, also grey has been renamed to omni to ease new players without code diving (or changelog reading)
Moved the colors so that green is the first and the omni is the last
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
qol for new and recurring atmos players that had issues with grey pipes connecting everywhere
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
qol: RPD defaul pipe color is now green, grey has been renamed to omni and the two colors are moved to the first and last places of the RPD ui
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
