### PR TITLE
corrects the armor values of leader hoodies to make them match those of the other armament beacon choices

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -119,11 +119,13 @@
 	icon_state = "chaplain_hoodie_leader"
 	inhand_icon_state = "chaplain_hoodie_leader"
 	hoodtype = /obj/item/clothing/head/hooded/chaplain_hood/leader
+	armor = list(MELEE = 50, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 80, ACID = 80, WOUND = 20) //the other chaplain armors also have this wound armor, as they inherit it from riot suits
 
 /obj/item/clothing/head/hooded/chaplain_hood/leader
 	name = "leader hood"
 	desc = "I mean, you don't /have/ to seek bling water. I just think you should."
 	icon_state = "chaplain_hood_leader"
+	armor = list(MELEE = 50, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 80, ACID = 80, WOUND = 10) //the other chaplain helmets also have this wound armor, as they inherit it from helmets (but NOT the increased wound armor of riot helmets, as they're not subtypes of those)
 
 
 // CHAPLAIN NULLROD AND CUSTOM WEAPONS //


### PR DESCRIPTION
## About The Pull Request

Leader hoodies now have the same armor values as the other armament beacon choices. Follower hoodies have not been touched, and still provide no protection from damage.

## Why It's Good For The Game

A few nights ago, I rolled roundstart O.S.I. agent (a type of gangster) chaplain in one of the families test rounds on Manuel. Since the O.S.I. gang's flavor text said that we should be subtle about the existence of our organization, I chose the leader hoodie set as my armament beacon choice so that we could pretend to be a harmless cult instead of spooks. I then immediately remembered that the leader hoodie set is absolute trash and promptly ditched it.

The leader hoodie set is currently a trap option. Every other armor set available from the armaments beacon provided riot gear-grade protection, including the adept set, which is meant to look like a hoodie. The leader hoodie, on the other hand, has NO ARMOR WHATSOEVER, and chaplains are given no indication of this. It is no better than the various pieces of normal religious clothing that you can buy from the DeusVend. It comes with follower hoodies, yes, but those hoodies are also near-worthless (and are mechanically exactly the same as clothing you can buy from the DeusVend, even with regards to the exosuit storage slot).

By making choosing the leader hoodie set not the equivalent of shooting yourself in the foot as a chaplain, we can hopefully see more chaplains select it and try to recruit crew members into kooky cults.

## Changelog
:cl: ATHATH
fix: Leader hoodies now have the same armor values as the other armament beacon choices. Follower hoodies have not been touched, and still provide no protection from damage.
/:cl: