### PR TITLE
Fixes crowbars hitting toilets when opening the cistern

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -103,6 +103,7 @@
 			user.visible_message(span_notice("[user] [cistern ? "replaces the lid on the cistern" : "lifts the lid off the cistern"]!"), span_notice("You [cistern ? "replace the lid on the cistern" : "lift the lid off the cistern"]!"), span_hear("You hear grinding porcelain."))
 			cistern = !cistern
 			update_appearance()
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 	else if(I.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1))
 		I.play_tool_sound(src)
 		deconstruct()


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/61125
It returns an attack chain cancel now

## Why It's Good For The Game
The audio cue of someone opening the toilet's cistern is plenty enough, we don't need to awkwardly bonk the toilet with the crowbar after the do_after or if it's interrupted.

## Changelog
:cl:
fix: Opening a toilet's cistern will no longer strike the toilet with the crowbar.
/:cl:
