### PR TITLE
Reorder the POPUP button to be behind closure links

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -252,10 +252,9 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		ref_src = "[REF(src)]"
 	. = ADMIN_FULLMONTY_NONAME(initiator.mob)
 	if(state == AHELP_ACTIVE)
-		. += ClosureLinks(ref_src)
-
 		if (CONFIG_GET(flag/popup_admin_pm))
 			. += " (<A HREF='?_src_=holder;[HrefToken(TRUE)];adminpopup=[REF(initiator)]'>POPUP</A>)"
+		. += ClosureLinks(ref_src)
 
 //private
 /datum/admin_help/proc/ClosureLinks(ref_src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
On my screen:

![image](https://user-images.githubusercontent.com/35135081/131731287-da595d72-73fc-4888-8260-f01281ce096c.png)

On NamelessFairy's screen:

![image](https://user-images.githubusercontent.com/35135081/131731323-3a914723-e824-4f23-a610-93e245c3aa5d.png)


Hurts muscle memory in a way I didn't anticipate. New version puts it behind the REJT button.