### PR TITLE
Uncouples the cultist red eye trait examine text from requiring cultist status or a certain eye colour.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -316,9 +316,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_PLASMABURNT "plasma_burnt"
 /// Addictions don't tick down, basically they're permanently addicted
 #define TRAIT_HOPELESSLY_ADDICTED "hopelessly_addicted"
-/// Special examine if eyes are visible
-#define TRAIT_CULT_EYES "cult_eyes"
-/// Special examine if eyes are visible
+/// Their eyes glow an unnatural red colour. Currently used to set special examine text on humans. Does not guarantee the mob's eyes are coloured red, nor that there is any visible glow on their character sprite.
+#define TRAIT_UNNATURAL_RED_GLOWY_EYES "unnatural_red_glowy_eyes"
+/// Their eyes are bloodshot. Currently used to set special examine text on humans. Examine text is overridden by TRAIT_UNNATURAL_RED_GLOWY_EYES.
 #define TRAIT_BLOODSHOT_EYES "bloodshot_eyes"
 /// This mob should never close UI even if it doesn't have a client
 #define TRAIT_PRESERVE_UI_WITHOUT_CLIENT "preserve_ui_without_client"

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -135,7 +135,7 @@
 		var/mob/living/carbon/human/H = current
 		H.eye_color = initial(H.eye_color)
 		H.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
-		REMOVE_TRAIT(H, TRAIT_CULT_EYES, CULT_TRAIT)
+		REMOVE_TRAIT(H, TRAIT_UNNATURAL_RED_GLOWY_EYES, CULT_TRAIT)
 		H.remove_overlay(HALO_LAYER)
 		H.update_body()
 
@@ -280,9 +280,9 @@
 /datum/team/cult/proc/rise(cultist)
 	if(ishuman(cultist))
 		var/mob/living/carbon/human/H = cultist
-		H.eye_color = "f00"
+		H.eye_color = BLOODCULT_EYE
 		H.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
-		ADD_TRAIT(H, TRAIT_CULT_EYES, CULT_TRAIT)
+		ADD_TRAIT(H, TRAIT_UNNATURAL_RED_GLOWY_EYES, CULT_TRAIT)
 		H.update_body()
 
 /datum/team/cult/proc/ascend(cultist)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -81,11 +81,10 @@
 	if(!(obscured & ITEM_SLOT_EYES) )
 		if(glasses  && !(glasses.item_flags & EXAMINE_SKIP))
 			. += "[t_He] [t_has] [glasses.get_examine_string(user)] covering [t_his] eyes."
-		else if(eye_color == BLOODCULT_EYE)
-			if(IS_CULTIST(src) && HAS_TRAIT(src, TRAIT_CULT_EYES))
-				. += "<span class='warning'><B>[t_His] eyes are glowing an unnatural red!</B></span>"
-			else if(HAS_TRAIT(src, TRAIT_BLOODSHOT_EYES))
-				. += "<span class='warning'><B>[t_His] eyes are bloodshot!</B></span>"
+		else if(HAS_TRAIT(src, TRAIT_UNNATURAL_RED_GLOWY_EYES))
+			. += "<span class='warning'><B>[t_His] eyes are glowing with an unnatural red aura!</B></span>"
+		else if(HAS_TRAIT(src, TRAIT_BLOODSHOT_EYES))
+			. += "<span class='warning'><B>[t_His] eyes are bloodshot!</B></span>"
 
 	//ears
 	if(ears && !(obscured & ITEM_SLOT_EARS) && !(ears.item_flags & EXAMINE_SKIP))

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -476,7 +476,7 @@
 	adapt_light.update_brightness(adapted)
 	//traits
 	ADD_TRAIT(adapted, TRAIT_FLASH_SENSITIVE, ORGAN_TRAIT)
-	ADD_TRAIT(adapted, TRAIT_CULT_EYES, ORGAN_TRAIT)
+	ADD_TRAIT(adapted, TRAIT_UNNATURAL_RED_GLOWY_EYES, ORGAN_TRAIT)
 
 /obj/item/organ/eyes/night_vision/maintenance_adapted/on_life(delta_time, times_fired)
 	var/turf/owner_turf = get_turf(owner)
@@ -496,5 +496,5 @@
 	adapt_light.forceMove(src)
 	//traits
 	REMOVE_TRAIT(unadapted, TRAIT_FLASH_SENSITIVE, ORGAN_TRAIT)
-	REMOVE_TRAIT(unadapted, TRAIT_CULT_EYES, ORGAN_TRAIT)
+	REMOVE_TRAIT(unadapted, TRAIT_UNNATURAL_RED_GLOWY_EYES, ORGAN_TRAIT)
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Renames TRAIT_CULT_EYES to TRAIT_UNNATURAL_RED_GLOWY_EYES.

This trait now always displays a (slightly modified) message about unnatural glowy red eyes regardless of if the person is a cultist and regardless of what their eye colour is.

The examine is decoupled from eye colour because as it turns out, players can select the bloodcult red eye colour as part of character prefs. Anything that gave this trait set the eye colour to red anyway. Because there's now no guarantee the eyes themselves are red with this trait, the examine has been reworded slightly to reinforce that the eyes are merely glowing red and not necessarily are red themselves.

The examine is also decoupled from being a cultist. The trait can be added from multiple sources. Removing the cultist check means other things that want to tread the line of cult paranoia can add it too. Like Chaplain maint sect eyes and admin shennanigans.

This now means that the Chaplain's maint sect night vision eyes actually add the examine flavour text, instead of what they did before which is only add the examine flavour text if the player was a cultist that had bloodcult red coloured eyes. In other words, if they were risen and already had glowy eyes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A little bit easier for admins to add that iconic cult unnatural glowy eyes examine text without forcing them to turn a player into a cultist and change their eye colour to red.

Makes adding the trait via maint sect night vision eyes actually work.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Maint sect night vision eyes trait now correctly make your eyes show as glowing an unnatural red when examined instead of doing nothing.
qol: Tweaks the logic for the cultist glowy red eye trait, allowing admins to add this to players to make them appear as if they were cultists when examined, without actually forcing them to make that person a full blown cultist. The cultist glowy red eye message has been modified as a result, and now examines as "... glowing with an unnatural red aura!"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
