### PR TITLE
Allows detective vests to hold detective (and nukies' agent) holsters like other vests do

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -192,6 +192,8 @@ GLOBAL_LIST_INIT(detective_vest_allowed, typecacheof(list(
 	/obj/item/taperecorder,
 	/obj/item/tank/internals/emergency_oxygen,
 	/obj/item/tank/internals/plasmaman,
+	/obj/item/storage/belt/holster/detective,
+	/obj/item/storage/belt/holster/nukie,
 	)))
 
 GLOBAL_LIST_INIT(security_vest_allowed, typecacheof(list(


### PR DESCRIPTION
## About The Pull Request
Detective's holster and nukeops agent holsters were allowed into suit storages of armor vests and sec winter coats back in #59976 but detective's vest have been overlooked. This PR fixes that.
Closes #60046
## Why It's Good For The Game
Consistency good, not allowing detectives to use their own detective vests for holsters bad.
## Changelog
:cl:
fix: Detective vests can store detective's (and nukeops agent) holsters.
/:cl:
