### PR TITLE
Fixes mousetraps causing mice to become invisible when splatted

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -34,7 +34,9 @@
 
 /mob/living/simple_animal/mouse/Initialize()
 	. = ..()
-	AddElement(/datum/element/animal_variety, "mouse", pick("brown","gray","white"), FALSE)
+	if(body_color == null)
+		body_color = pick("brown","gray","white")
+	AddElement(/datum/element/animal_variety, "mouse", body_color, FALSE)
 	AddComponent(/datum/component/squeak, list('sound/effects/mousesqueek.ogg' = 1), 100, extrarange = SHORT_RANGE_SOUND_EXTRARANGE) //as quiet as a mouse or whatever
 	add_cell_sample()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> Fixes #61130

This PR makes mice have an icon when they're splatted by a mousetrap. It also makes the subtypes of mice that have a specific colour set actually be that colour when spawned. 

The issue mentioned above thought the issue was caused by the mold mechanic but from what I can tell it's caused because the way that mouse colour is picked. It leaves body_color blank and the code that sets the dead icon to the special splatted icon uses body_color. The code not using body_color when picking the mouse's colour also meant that the subtypes that were supposed to be a specific colour would come out as a random mouse colour.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> Makes mousetraps function as intended and makes the colour subtypes not be meaningless.

## Changelog
:cl:

fix: Mice no longer become invisible when splatted by a mousetrap.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
