### PR TITLE
Fixes defib mounts taking damage when unwrenched, moves unwrenching of defib mounts to right click.

### DIFF
--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -167,7 +167,7 @@
 	update_appearance()
 	return TRUE
 
-/obj/machinery/defibrillator_mount/wrench_act(mob/living/user, obj/item/wrench/W)
+/obj/machinery/defibrillator_mount/wrench_act_secondary(mob/living/user, obj/item/tool)
 	if(!wallframe_type)
 		return ..()
 	if(user.combat_mode)
@@ -178,9 +178,9 @@
 		return TRUE
 	new wallframe_type(get_turf(src))
 	qdel(src)
-	W.play_tool_sound(user)
+	tool.play_tool_sound(user)
 	to_chat(user, span_notice("You remove [src] from the wall."))
-
+	return TRUE
 
 /obj/machinery/defibrillator_mount/AltClick(mob/living/carbon/user)
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! --> When unwrenching a defibrillator mount you'll hit it and it causes an error because it's taking damage after it's removed. I also changed deconstruction to right click with a wrench while not on combat mode when previously it was just wrench while not on combat mode.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. --> errors are bad, deconstructions being on right click adds consistency 

## Changelog
:cl:

qol: Defib mounts are now removed from the wall by right clicking with a wrench while not on combat mode.
fix: You will no longer smack defib mounts when removing them from the wall.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
