### PR TITLE
Blast doors & shutters fixes & cleanup: toolspeed, sounds, player feedback

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -36,6 +36,11 @@
 #define AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS 1
 #define AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER 2
 
+//blast door (de)construction states
+#define BLASTDOOR_NEEDS_WIRES 0
+#define BLASTDOOR_NEEDS_ELECTRONICS 1
+#define BLASTDOOR_FINISHED 2
+
 //default_unfasten_wrench() return defines
 #define CANT_UNFASTEN 0
 #define FAILED_UNFASTEN 1

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -63,7 +63,7 @@
 				var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
 				var/amount = recipe.reqs[/obj/item/stack/sheet/plasteel]
 				new /obj/item/stack/sheet/plasteel(loc, amount)
-				balloon_alert(user, "torn apart")
+				user.balloon_alert(user, "torn apart")
 				qdel(src)
 			return TRUE
 

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -22,7 +22,7 @@
 
 	if(W.tool_behaviour == TOOL_SCREWDRIVER)
 		if(density)
-			to_chat(user, span_warning("You need to open [src] before opening its maintenance panel."))
+			balloon_alert(user, "open the door first!")
 			return
 		else if(default_deconstruction_screwdriver(user, icon_state, icon_state, W))
 			return TRUE
@@ -33,37 +33,38 @@
 			if(change_id)
 				id = clamp(round(change_id, 1), 1, 100)
 				to_chat(user, span_notice("You change the ID to [id]."))
+				balloon_alert(user, "ID changed")
 
 		else if(W.tool_behaviour == TOOL_CROWBAR && deconstruction == BLASTDOOR_FINISHED)
-			to_chat(user, span_notice("You start to remove the airlock electronics."))
+			balloon_alert(user, "removing airlock electronics...")
 			if(W.use_tool(src, user, 100, volume=50))
 				new /obj/item/electronics/airlock(loc)
 				id = null
 				deconstruction = BLASTDOOR_NEEDS_ELECTRONICS
-				to_chat(user, span_notice("You remove the airlock electronics."))
+				balloon_alert(user, "removed airlock electronics")
 			return TRUE
 
 		else if(W.tool_behaviour == TOOL_WIRECUTTER && deconstruction == BLASTDOOR_NEEDS_ELECTRONICS)
-			to_chat(user, span_notice("You start to remove the internal cables."))
+			balloon_alert(user, "removing internal cables...")
 			if(W.use_tool(src, user, 100, volume=50))
 				var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
 				var/amount = recipe.reqs[/obj/item/stack/cable_coil]
 				new /obj/item/stack/cable_coil(loc, amount)
 				deconstruction = BLASTDOOR_NEEDS_WIRES
-				to_chat(user, span_notice("You remove the internal cables."))
+				balloon_alert(user, "removed internal cables")
 			return TRUE
 
 		else if(W.tool_behaviour == TOOL_WELDER && deconstruction == BLASTDOOR_NEEDS_WIRES)
 			if(!W.tool_start_check(user, amount=0))
 				return
 
-			to_chat(user, span_notice("You start tearing apart the [src]."))
+			balloon_alert(user, "tearing apart...") //You're tearing me apart, Lisa!
 			if(W.use_tool(src, user, 150, volume=50))
 				var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
 				var/amount = recipe.reqs[/obj/item/stack/sheet/plasteel]
 				new /obj/item/stack/sheet/plasteel(loc, amount)
+				balloon_alert(user, "torn apart")
 				qdel(src)
-				to_chat(user, span_notice("You tear the [src] apart."))
 			return TRUE
 
 /obj/machinery/door/poddoor/examine(mob/user)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -25,7 +25,6 @@
 			to_chat(user, span_warning("You need to open [src] before opening its maintenance panel."))
 			return
 		else if(default_deconstruction_screwdriver(user, icon_state, icon_state, W))
-			to_chat(user, span_notice("You [panel_open ? "open" : "close"] the maintenance hatch of [src]."))
 			return TRUE
 
 	if(panel_open)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -1,9 +1,3 @@
-
-//blast door (de)construction states
-#define BLASTDOOR_NEEDS_WIRES 0
-#define BLASTDOOR_NEEDS_ELECTRONICS 1
-#define BLASTDOOR_FINISHED 2
-
 /obj/machinery/door/poddoor
 	name = "blast door"
 	desc = "A heavy duty blast door that opens mechanically."
@@ -43,30 +37,35 @@
 
 		else if(W.tool_behaviour == TOOL_CROWBAR && deconstruction == BLASTDOOR_FINISHED)
 			to_chat(user, span_notice("You start to remove the airlock electronics."))
-			if(do_after(user, 10 SECONDS, target = src))
+			if(W.use_tool(src, user, 100, volume=50))
 				new /obj/item/electronics/airlock(loc)
 				id = null
 				deconstruction = BLASTDOOR_NEEDS_ELECTRONICS
+				to_chat(user, span_notice("You remove the airlock electronics."))
+			return TRUE
 
 		else if(W.tool_behaviour == TOOL_WIRECUTTER && deconstruction == BLASTDOOR_NEEDS_ELECTRONICS)
 			to_chat(user, span_notice("You start to remove the internal cables."))
-			if(do_after(user, 10 SECONDS, target = src))
+			if(W.use_tool(src, user, 100, volume=50))
 				var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
 				var/amount = recipe.reqs[/obj/item/stack/cable_coil]
 				new /obj/item/stack/cable_coil(loc, amount)
 				deconstruction = BLASTDOOR_NEEDS_WIRES
+				to_chat(user, span_notice("You remove the internal cables."))
+			return TRUE
 
 		else if(W.tool_behaviour == TOOL_WELDER && deconstruction == BLASTDOOR_NEEDS_WIRES)
 			if(!W.tool_start_check(user, amount=0))
 				return
 
 			to_chat(user, span_notice("You start tearing apart the [src]."))
-			playsound(src.loc, 'sound/items/welder.ogg', 50, 1)
-			if(do_after(user, 15 SECONDS, target = src))
+			if(W.use_tool(src, user, 150, volume=50))
 				var/datum/crafting_recipe/recipe = locate(recipe_type) in GLOB.crafting_recipes
 				var/amount = recipe.reqs[/obj/item/stack/sheet/plasteel]
 				new /obj/item/stack/sheet/plasteel(loc, amount)
 				qdel(src)
+				to_chat(user, span_notice("You tear the [src] apart."))
+			return TRUE
 
 /obj/machinery/door/poddoor/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Blast doors & shutters were using do_after for their deconstruction steps without taking toolspeed into the account. This PR replaces this by use_tool, so better tools actually do the steps faster. It also brings back the sounds for each step.
Screwdrivering the panel open/closed no longer produces two messages.
Moved two defines to their rightful place.
Each step now also provides feedback to the player upon completion. It used to just give you the _You start ..._ but no _You finish ..._ Wack.

## Why It's Good For The Game
Better tools should actually do their job better. Also, sounds and more feedback good.

## Changelog
:cl:
fix: Better tools now deconstruct blast doors and shutters quicker like they actually should. Each deconstruction step now provides a message upon completion as well as uses the tool's sounds!
/:cl: