### PR TITLE
Increase SSdiscord init order

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -115,6 +115,7 @@
 #define INIT_ORDER_INSTRUMENTS 82
 #define INIT_ORDER_GREYSCALE 81
 #define INIT_ORDER_VIS 80
+#define INIT_ORDER_DISCORD 78
 #define INIT_ORDER_ACHIEVEMENTS 77
 #define INIT_ORDER_RESEARCH 75
 #define INIT_ORDER_STATION 74 //This is high priority because it manipulates a lot of the subsystems that will initialize after it.
@@ -150,7 +151,6 @@
 #define INIT_ORDER_SHUTTLE -21
 #define INIT_ORDER_MINOR_MAPPING -40
 #define INIT_ORDER_PATH -50
-#define INIT_ORDER_DISCORD -60
 #define INIT_ORDER_EXPLOSIONS -69
 #define INIT_ORDER_STATPANELS -98
 #define INIT_ORDER_DEMO -99  // o avoid a bunch of changes related to initialization being written, do this last


### PR DESCRIPTION
## About The Pull Request

Increases SSdiscord init order to be just after essential subsystems.

## Why It's Good For The Game

It takes too long to init the server and by the time somebody gets this discord ping, sits thru the ad, and finally gets in, the round will have already started.

An issue for me trying to do things that can only be done pre-round.

## Changelog
:cl:
fix: Discord new round notifications will no longer come shortly before the round starts. You should now have enough time to actually ready up before round start.
/:cl:

