### PR TITLE
Fixes can_interact()

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -387,7 +387,7 @@
 		remove_area_power_relationship()
 
 	static_power_usage = new_usage
-	
+
 	if(new_usage)
 		var/area/our_area = get_area(src)
 		our_area?.addStaticPower(new_usage, DYNAMIC_TO_STATIC_CHANNEL(power_channel))
@@ -501,6 +501,10 @@
 	if(SEND_SIGNAL(user, COMSIG_TRY_USE_MACHINE, src) & COMPONENT_CANT_USE_MACHINE_INTERACT)
 		return FALSE
 
+
+	if(isAdminGhostAI(user))
+		return TRUE //the Gods have unlimited power and do not care for things such as range or blindness
+
 	if(!isliving(user))
 		return FALSE //no ghosts allowed, sorry
 
@@ -523,6 +527,8 @@
 		return user.can_interact_with(src) //AIs don't care about petty mortal concerns like needing to be next to a machine to use it, but borgs do care somewhat
 
 	. = ..()
+	if(!.)
+		return FALSE
 
 	if((interaction_flags_machine & INTERACT_MACHINE_REQUIRES_SIGHT) && user.is_blind())
 		to_chat(user, span_warning("This machine requires sight to use."))

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -310,7 +310,6 @@
 /obj/machinery/rnd/production/Topic(raw, ls)
 	if(..())
 		return
-	add_fingerprint(usr)
 	usr.set_machine(src)
 	if(ls["switch_screen"])
 		screen = text2num(ls["switch_screen"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
when i refactored can_interact() I thought ". = ..()" meant it would return with whatever the return value of the parent is... turns out thats not true, and i didnt catch it because there was only TWO machines that had issues from this, namely operating computer had unlimited range to view its tgui, and protolathes let you build things from unlimited range, provided the html window was open (you couldnt click any buttons out of range, except build buttons, weird, but whatever)

i also broke admin AI checks on machines, i added an explicit check back in

I also removed a redundant fingerprint from protolathes, their parent call already adds a fingerprint, they dont need to add it again
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
oopsie
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Nari Harimoto
fix: you can no longer print from a protolathe at a distance, and the operating computer tgui will grey out if you walk away again
fix: Admins can now use their godly powers of AdminGhostAI to interact with every machine again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
