### PR TITLE
Pirates now speak piratespeak.

### DIFF
--- a/code/__DEFINES/language.dm
+++ b/code/__DEFINES/language.dm
@@ -17,6 +17,7 @@
 #define LANGUAGE_HAT "hat"
 #define LANGUAGE_HIGH "high"
 #define LANGUAGE_MALF "malf"
+#define LANGUAGE_PIRATE "pirate"
 #define LANGUAGE_MASTER "master"
 #define LANGUAGE_SOFTWARE "software"
 #define LANGUAGE_STONER "stoner"

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -37,6 +37,18 @@
 		objectives |= crew.objectives
 	. = ..()
 
+/datum/antagonist/pirate/apply_innate_effects(mob/living/mob_override)
+	. = ..()
+	var/mob/living/owner_mob = mob_override || owner.current
+	var/datum/language_holder/holder = owner_mob.get_language_holder()
+	holder.grant_language(/datum/language/piratespeak, TRUE, TRUE, LANGUAGE_PIRATE)
+	holder.selected_language = /datum/language/piratespeak
+
+/datum/antagonist/pirate/remove_innate_effects(mob/living/mob_override)
+	. = ..()
+	var/mob/living/owner_mob = mob_override || owner.current
+	owner_mob.remove_language(/datum/language/piratespeak, TRUE, TRUE, LANGUAGE_PIRATE)
+
 /datum/team/pirate
 	name = "Pirate crew"
 

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -45,9 +45,9 @@
 	holder.selected_language = /datum/language/piratespeak
 
 /datum/antagonist/pirate/remove_innate_effects(mob/living/mob_override)
-	. = ..()
 	var/mob/living/owner_mob = mob_override || owner.current
 	owner_mob.remove_language(/datum/language/piratespeak, TRUE, TRUE, LANGUAGE_PIRATE)
+	return ..()
 
 /datum/team/pirate
 	name = "Pirate crew"


### PR DESCRIPTION
## About The Pull Request
Apparently we have had this thoughtless (like many other small features) language datum ever since late 2018 that only costume pirate hats use: Piratespeak . Space pirates don't even use it also because their hats aren't a subtype of the costume pirate hat for good reasons like armor and EVA. Yea, this is also an oversight since space pirates were added before the language.

## Why It's Good For The Game
Will enhance the space pirate gameplay experience a little and make the language more than just a jest. Fixes #50100.

## Changelog
:cl:
expansion: Space pirates now speak Piratespeak.
/:cl:
