### PR TITLE
Fixes a regression about skeleton pirates not having milk bottles.

### DIFF
--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -116,8 +116,6 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/item/reagent_containers/food/condiment/milk,
-/obj/item/reagent_containers/food/condiment/milk,
 /turf/open/floor/iron,
 /area/shuttle/pirate)
 "al" = (

--- a/_maps/shuttles/pirate_dutchman.dmm
+++ b/_maps/shuttles/pirate_dutchman.dmm
@@ -154,7 +154,7 @@
 	dir = 5
 	},
 /obj/structure/closet/cabinet,
-/obj/item/storage/bag/money/vault,
+/obj/item/storage/bag/money/dutchmen,
 /obj/item/stack/sheet/mineral/gold{
 	amount = 3;
 	pixel_x = -2;
@@ -591,29 +591,11 @@
 	icon_state = "minibar";
 	name = "skeletal minibar"
 	},
-/obj/item/coin/silver{
-	name = "doubloon"
+/obj/item/reagent_containers/food/condiment/milk{
+	pixel_x = -5
 	},
-/obj/item/coin/silver{
-	name = "doubloon"
-	},
-/obj/item/coin/silver{
-	name = "doubloon"
-	},
-/obj/item/coin/silver{
-	name = "doubloon"
-	},
-/obj/item/coin/silver{
-	name = "doubloon"
-	},
-/obj/item/coin/gold{
-	name = "doubloon"
-	},
-/obj/item/coin/gold{
-	name = "doubloon"
-	},
-/obj/item/coin/gold{
-	name = "doubloon"
+/obj/item/reagent_containers/food/condiment/milk{
+	pixel_x = 5
 	},
 /turf/open/floor/wood/airless,
 /area/shuttle/pirate/flying_dutchman)

--- a/code/modules/mining/money_bag.dm
+++ b/code/modules/mining/money_bag.dm
@@ -28,3 +28,11 @@
 	new /obj/item/coin/gold(src)
 	new /obj/item/coin/gold(src)
 	new /obj/item/coin/adamantine(src)
+
+///Used in the dutchmen pirate shuttle.
+/obj/item/storage/bag/money/dutchmen/PopulateContents()
+	for(var/iteration in 1 to 9)
+		new /obj/item/coin/silver/doubloon(src)
+	for(var/iteration in 1 to 9)
+		new /obj/item/coin/gold/doubloon(src)
+	new /obj/item/coin/adamantine/doubloon(src)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -517,4 +517,15 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 		to_chat(user,"<span class='bounty'>[SSeconomy.inflation_value()] is the inflation value.</span>")
 	return TRUE//did the coin flip? useful for suicide_act
 
+
+///Coins used in the dutchmen money bag.
+/obj/item/coin/silver/doubloon
+	name = "doubloon"
+
+/obj/item/coin/gold/doubloon
+	name = "doubloon"
+
+/obj/item/coin/adamantine/doubloon
+	name = "doubloon"
+
 #undef ORESTACK_OVERLAYS_MAX


### PR DESCRIPTION
## About The Pull Request
I have moved the doubloons from the skellie rack in the dutchmen ship to a moneybag found four tiles away. Said moneybag is now its own type. Doubloons have have their own type and aren't just coins with mapedited names anymore.

Two cartons of milk are now found on the skellie bar rack of the dutchmen ship. Coincidentally, two cartons are now missing from the default pirate shuttle.

## Why It's Good For The Game
When armhullen/trelezab revamped pirates in #56264 back in february, he accidentally caused a regression by removing the access to milk from skeleton pirates I have added years ago in #43095 to ease the drawbacks of having no normal reagent metabolism and being pierce immune.

## Changelog
:cl:
fix: Fixed a regression that removed easy access to milk cartons from skeleton pirates.
/:cl:
