### PR TITLE
Adds a loose syndicate brand MMi to robo/rd/doctor/cmo traitors only for 2 tc

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1821,7 +1821,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An MMI modified to give cyborgs laws to serve the Syndicate without having their interface damaged by Cryptographic Sequencers, this will not unlock their hidden modules."
 	item = /obj/item/device/mmi/syndie
 	cost = 2
-	restricted_roles = list("Roboticist", "Research Director")
+	restricted_roles = list("Roboticist", "Research Director", Scientist, Medical Doctor, "Chief Medical Officer")
 	surplus = 0
 
 /datum/uplink_item/role_restricted/haunted_magic_eightball

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1816,6 +1816,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 3
 	restricted_roles = list("Roboticist", "Research Director")
 
+/datum/uplink_item/role_restricted/syndimmi
+	name = "Syndicate Brand MMI"
+	desc = "An MMI modified to give cyborgs laws to serve the Syndicate without having their interface damaged by Cryptographic Sequencers, this will not unlock their hidden modules."
+	item = /obj/item/device/mmi/syndie
+	cost = 2
+	restricted_roles = list("Roboticist", "Research Director")
+	surplus = 0
+
 /datum/uplink_item/role_restricted/haunted_magic_eightball
 	name = "Haunted Magic Eightball"
 	desc = "Most magic eightballs are toys with dice inside. Although identical in appearance to the harmless toys, this occult device reaches into the spirit world to find its answers. \

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1819,7 +1819,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/role_restricted/syndimmi
 	name = "Syndicate Brand MMI"
 	desc = "An MMI modified to give cyborgs laws to serve the Syndicate without having their interface damaged by Cryptographic Sequencers, this will not unlock their hidden modules."
-	item = /obj/item/device/mmi/syndie
+	item = /obj/item/mmi/syndie
 	cost = 2
 	restricted_roles = list("Roboticist", "Research Director", Scientist, Medical Doctor, "Chief Medical Officer")
 	surplus = 0

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1821,7 +1821,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "An MMI modified to give cyborgs laws to serve the Syndicate without having their interface damaged by Cryptographic Sequencers, this will not unlock their hidden modules."
 	item = /obj/item/mmi/syndie
 	cost = 2
-	restricted_roles = list("Roboticist", "Research Director", Scientist, Medical Doctor, "Chief Medical Officer")
+	restricted_roles = list("Roboticist", "Research Director", "Scientist", "Medical Doctor", "Chief Medical Officer")
 	surplus = 0
 
 /datum/uplink_item/role_restricted/haunted_magic_eightball


### PR DESCRIPTION
Sometimes emagging a borg could leave serious damage to its interface being immediatly noticed when you tinker with the cyborg.
yes i know you can get this by buying a big ass black dufflebag which makes you scream out TRAITOR sometimes just having something loose apply better to jobs who already got the tools to tinker with people, while surgery bags apply more to people who don't have the tools.

## Changelog
:cl: Improvedname
add: RD/Roboticists/Cmo/Doctors can now buy a syndi brand MMi from their uplink for 2 tc
/:cl: