### PR TITLE
Firelance Can No Longer Be Used When Out of Charge

### DIFF
--- a/code/modules/explorer_drone/loot.dm
+++ b/code/modules/explorer_drone/loot.dm
@@ -167,6 +167,7 @@ GLOBAL_LIST_INIT(adventure_loot_generator_index,generate_generator_index())
 		return
 	if(!cell.use(charge_per_use))
 		to_chat(user,span_warning("[src] battery ran dry!"))
+		return
 	ADD_TRAIT(user,TRAIT_IMMOBILIZED,src)
 	to_chat(user,span_notice("You begin to charge [src]"))
 	inhand_icon_state = "firelance_charging"


### PR DESCRIPTION
## About The Pull Request

The firelance's afterattack() proc now actually returns after notifying the user it ran out of battery

## Why It's Good For The Game

Fixes good

## Changelog
:cl:
fix: Firelance can no longer be used when out of battery
/:cl: