### PR TITLE
Gibber will now give 3 pieces of meat at tier 1

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -22,7 +22,7 @@
 
 /obj/machinery/gibber/RefreshParts()
 	gibtime = 40
-	meat_produced = 2
+	meat_produced = initial(meat_produced)
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		meat_produced += B.rating
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -22,7 +22,7 @@
 
 /obj/machinery/gibber/RefreshParts()
 	gibtime = 40
-	meat_produced = 3
+	meat_produced = 2
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		meat_produced += B.rating
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -12,7 +12,7 @@
 	var/operating = FALSE //Is it on?
 	var/dirty = FALSE // Does it need cleaning?
 	var/gibtime = 40 // Time from starting until meat appears
-	var/meat_produced = 0
+	var/meat_produced = 2
 	var/ignore_clothing = FALSE
 
 

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -22,7 +22,7 @@
 
 /obj/machinery/gibber/RefreshParts()
 	gibtime = 40
-	meat_produced = 0
+	meat_produced = 3
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		meat_produced += B.rating
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)


### PR DESCRIPTION
This been bugged for YEARS the gibber always gave 3 pieces of meat and then +2 on every tier ontop of that.
If you put a body in the gibber like a WHOLE human body and its gives 1 piece of meat its just said this fixes the issue thats been here for years

## Changelog
:cl: Improvedname
fix: Gibbers now produce 3 pieces of meat at tier 1 again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
