### PR TITLE
Rebalances watchers, making them able to actually damage you

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1090,3 +1090,24 @@
 	if(ishostile(owner))
 		var/mob/living/simple_animal/hostile/simple_owner = owner
 		simple_owner.ranged_cooldown_time /= 2.5
+
+/datum/status_effect/freezing_blast
+	id = "freezing_blast"
+	alert_type = /atom/movable/screen/alert/status_effect/freezing_blast
+	duration = 5 SECONDS
+	status_type = STATUS_EFFECT_REPLACE
+
+/atom/movable/screen/alert/status_effect/freezing_blast
+	name = "Freezing Blast"
+	desc = "You've been struck by a freezing blast! Your body moves more slowly!"
+	icon_state = "frozen"
+
+/datum/status_effect/freezing_blast/on_apply()
+	owner.add_movespeed_modifier(/datum/movespeed_modifier/freezing_blast, update = TRUE)
+	return ..()
+
+/datum/status_effect/freezing_blast/on_remove()
+	owner.remove_movespeed_modifier(/datum/movespeed_modifier/freezing_blast, update = TRUE)
+
+/datum/movespeed_modifier/freezing_blast
+	multiplicative_slowdown = 1

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -40,11 +40,18 @@
 /obj/projectile/temp/basilisk
 	name = "freezing blast"
 	icon_state = "ice_2"
-	damage = 0
+	damage = 10
 	damage_type = BURN
-	nodamage = TRUE
+	nodamage = FALSE
 	flag = ENERGY
 	temperature = -50 // Cools you down! per hit!
+	var/slowdown = TRUE //Determines if the projectile applies a slowdown status effect on carbons or not
+
+/obj/projectile/temp/basilisk/on_hit(atom/target, blocked = 0)
+	. = ..()
+	if(iscarbon(target) && slowdown)
+		var/mob/living/carbon/carbon_target = target
+		carbon_target.apply_status_effect(/datum/status_effect/freezing_blast)
 
 /obj/projectile/temp/basilisk/heated
 	name = "energy blast"
@@ -53,6 +60,7 @@
 	damage_type = BRUTE
 	nodamage = FALSE
 	temperature = 0
+	slowdown = FALSE
 
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/GiveTarget(new_target)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice demon.dm
@@ -53,6 +53,7 @@
 	speed = 4
 	nodamage = FALSE
 	temperature = -75
+	slowdown = FALSE
 
 /mob/living/simple_animal/hostile/asteroid/ice_demon/OpenFire()
 	ranged_cooldown = world.time + ranged_cooldown_time


### PR DESCRIPTION
## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/49999
Gives them a bit of base damage that's burn for carbons and brute for borgs so they can still self-repair
Gives them a slowdown on par with hardsuits that lasts just long enough to wear off if you dodge one more shot while under its effects

## Why It's Good For The Game

Watchers were made a complete joke with body temperature regulation mechanics being changed, and the effects of those changes weren't thoroughly addressed. This is one of those lasting oversights.

Watcher tendrils have been a free source of diamonds with literally zero risk for a miner if they stay at a distance with a ranged weapon for over a year. Reintroducing soft crowd control for a single hit encourages players to practice their positioning and situational awareness, and the soft nature of the cc allows for players to continue to interact with the content even after making a mistake.

## Changelog
:cl:
balance: Projectiles fired by the watchers on lavaland will now deal damage and apply a short slowdown to carbons.
/:cl: