### PR TITLE
Adds Custom Milj Option to Udders

### DIFF
--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -10,10 +10,10 @@
 	var/datum/callback/on_milk_callback
 
 //udder and custom_milk_reagent are typepaths, not reference
-/datum/component/udder/Initialize(udder_type = /obj/item/udder, custom_milk_reagent, on_milk_callback, on_generate_callback)
+/datum/component/udder/Initialize(udder_type = /obj/item/udder, reagent_produced_typepath = /datum/reagent/consumable/milk, on_milk_callback, on_generate_callback)
 	if(!isliving(parent)) //technically is possible to drop this on carbons... but you wouldn't do that to me, would you?
 		return COMPONENT_INCOMPATIBLE
-	udder = new udder_type(null, parent, on_generate_callback, custom_milk_reagent)
+	udder = new udder_type(null, parent, on_generate_callback, reagent_produced_typepath)
 	src.on_milk_callback = on_milk_callback
 
 /datum/component/udder/RegisterWithParent()
@@ -70,12 +70,11 @@
 	///optional proc to callback to when the udder generates milk
 	var/datum/callback/on_generate_callback
 
-/obj/item/udder/Initialize(mapload, udder_mob, on_generate_callback, custom_milk_reagent)
+/obj/item/udder/Initialize(mapload, udder_mob, on_generate_callback, reagent_produced_typepath)
 	src.udder_mob = udder_mob
 	src.on_generate_callback = on_generate_callback
 	create_reagents(size, REAGENT_HOLDER_ALIVE)
-	if(custom_milk_reagent)
-		reagent_produced_typepath = custom_milk_reagent
+	src.reagent_produced_typepath = reagent_produced_typepath ? reagent_produced_typepath : initial(src.reagent_produced_typepath)
 	initial_conditions()
 	. = ..()
 

--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -9,7 +9,7 @@
 	///optional proc to callback to when the udder is milked
 	var/datum/callback/on_milk_callback
 
-//udder and custom_milk_reagent are typepaths, not reference
+//udder_type and custom_milk_reagent are typepaths, not reference
 /datum/component/udder/Initialize(udder_type = /obj/item/udder, custom_milk_reagent, on_milk_callback, on_generate_callback)
 	if(!isliving(parent)) //technically is possible to drop this on carbons... but you wouldn't do that to me, would you?
 		return COMPONENT_INCOMPATIBLE

--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -10,6 +10,7 @@
 	var/datum/callback/on_milk_callback
 
 //udder_type and custom_milk_reagent are typepaths, not reference
+/datum/component/udder/Initialize(udder_type = /obj/item/udder, on_milk_callback, on_generate_callback, reagent_produced_typepath = /datum/reagent/consumable/milk)
 	if(!isliving(parent)) //technically is possible to drop this on carbons... but you wouldn't do that to me, would you?
 		return COMPONENT_INCOMPATIBLE
 	udder = new udder_type(null, parent, on_generate_callback, reagent_produced_typepath)

--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -9,10 +9,11 @@
 	///optional proc to callback to when the udder is milked
 	var/datum/callback/on_milk_callback
 
-/datum/component/udder/Initialize(udder_type = /obj/item/udder, on_milk_callback, on_generate_callback)
+//udder and custom_milk_reagent are typepaths, not reference
+/datum/component/udder/Initialize(udder_type = /obj/item/udder, custom_milk_reagent, on_milk_callback, on_generate_callback)
 	if(!isliving(parent)) //technically is possible to drop this on carbons... but you wouldn't do that to me, would you?
 		return COMPONENT_INCOMPATIBLE
-	udder = new udder_type(null, parent, on_generate_callback)
+	udder = new udder_type(null, parent, on_generate_callback, custom_milk_reagent)
 	src.on_milk_callback = on_milk_callback
 
 /datum/component/udder/RegisterWithParent()
@@ -69,10 +70,12 @@
 	///optional proc to callback to when the udder generates milk
 	var/datum/callback/on_generate_callback
 
-/obj/item/udder/Initialize(mapload, udder_mob, on_generate_callback)
+/obj/item/udder/Initialize(mapload, udder_mob, on_generate_callback, custom_milk_reagent)
 	src.udder_mob = udder_mob
 	src.on_generate_callback = on_generate_callback
 	create_reagents(size, REAGENT_HOLDER_ALIVE)
+	if(custom_milk_reagent)
+		reagent_produced_typepath = custom_milk_reagent
 	initial_conditions()
 	. = ..()
 

--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -60,6 +60,8 @@
  */
 /obj/item/udder
 	name = "udder"
+	///typepath of reagent produced by the udder
+	var/reagent_produced_typepath = /datum/reagent/consumable/milk
 	///how much the udder holds
 	var/size = 50
 	///mob that has the udder component
@@ -88,7 +90,7 @@
  * also useful for changing initial amounts in reagent holder (cows start with milk, gutlunches start empty)
  */
 /obj/item/udder/proc/initial_conditions()
-	reagents.add_reagent(/datum/reagent/consumable/milk, 20)
+	reagents.add_reagent(reagent_produced_typepath, 20)
 	START_PROCESSING(SSobj, src)
 
 /**
@@ -96,7 +98,7 @@
  */
 /obj/item/udder/proc/generate()
 	if(prob(5))
-		reagents.add_reagent(/datum/reagent/consumable/milk, rand(5, 10))
+		reagents.add_reagent(reagent_produced_typepath, rand(5, 10))
 		if(on_generate_callback)
 			on_generate_callback.Invoke(reagents.total_volume, reagents.maximum_volume)
 

--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -70,11 +70,11 @@
 	///optional proc to callback to when the udder generates milk
 	var/datum/callback/on_generate_callback
 
-/obj/item/udder/Initialize(mapload, udder_mob, on_generate_callback, reagent_produced_typepath)
+/obj/item/udder/Initialize(mapload, udder_mob, on_generate_callback, reagent_produced_typepath = /datum/reagent/consumable/milk)
 	src.udder_mob = udder_mob
 	src.on_generate_callback = on_generate_callback
 	create_reagents(size, REAGENT_HOLDER_ALIVE)
-	src.reagent_produced_typepath = reagent_produced_typepath ? reagent_produced_typepath : initial(src.reagent_produced_typepath)
+	src.reagent_produced_typepath = reagent_produced_typepath
 	initial_conditions()
 	. = ..()
 

--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -9,7 +9,7 @@
 	///optional proc to callback to when the udder is milked
 	var/datum/callback/on_milk_callback
 
-//udder_type and custom_milk_reagent are typepaths, not reference
+//udder_type and reagent_produced_typepath are typepaths, not reference
 	if(!isliving(parent)) //technically is possible to drop this on carbons... but you wouldn't do that to me, would you?
 		return COMPONENT_INCOMPATIBLE
 	udder = new udder_type(null, parent, on_generate_callback, reagent_produced_typepath)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows for malleability in the reagent an udder can produce.

Want to make a fuel-producing cow for your event? Well Now you can!

You **will** drink from the adminorazine cow.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It probably isnt but it's something I wanted to utilize until I realized milk was HARDCODED into the procs.

Can be used for events.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: you can now customize what udders produce using `reagent_produced_typepath` or by using the `custom_milk_reagent` argument when adding the component
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
