### PR TITLE
The Cycling 2.0, Airlocks can now be built in game to cycle and named

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -599,7 +599,7 @@
 /obj/machinery/door/airlock/examine(mob/user)
 	. = ..()
 	if(closeOtherId)
-		. += span_warning("This airlock cycles on ID: [closeOtherId].")
+		. += span_warning("This airlock cycles on ID: [sanitize(closeOtherId)].")
 	else if(!closeOtherId)
 		. += span_warning("This airlock does not cycle.")
 	if(obj_flags & EMAGGED)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -214,7 +214,10 @@
 /obj/machinery/door/airlock/proc/update_other_id()
 	for(var/obj/machinery/door/airlock/Airlock in GLOB.airlocks)
 		if(Airlock.closeOtherId == closeOtherId && Airlock != src)
-			close_others += Airlock
+			if(!(Airlock in close_others))
+				close_others += Airlock
+			if(!(src in Airlock.close_others))
+				Airlock.close_others += src
 
 /obj/machinery/door/airlock/proc/cyclelinkairlock()
 	if (cyclelinkedairlock)
@@ -595,6 +598,10 @@
 
 /obj/machinery/door/airlock/examine(mob/user)
 	. = ..()
+	if(closeOtherId)
+		. += span_warning("This airlock cycles on ID: [closeOtherId].")
+	else if(!closeOtherId)
+		. += span_warning("This airlock does not cycle.")
 	if(obj_flags & EMAGGED)
 		. += span_warning("Its access panel is smoking slightly.")
 	if(note)

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -87,7 +87,7 @@
 			accesses -= SSid_access.get_region_access_list(list(region))
 			. = TRUE
 		if("passedName")
-			var/new_name = trim(params["passedName"], 30)
+			var/new_name = trim("[params["passedName"]]", 30)
 			passed_name = new_name
 			. = TRUE
 		if("passedCycleId")

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -87,10 +87,12 @@
 			accesses -= SSid_access.get_region_access_list(list(region))
 			. = TRUE
 		if("passedName")
-			passed_name = params["passedName"]
+			var/new_name = trim(params["passedName"], 30)
+			passed_name = new_name
 			. = TRUE
 		if("passedCycleId")
-			passed_cycle_id = params["passedCycleId"]
+			var/new_cycle_id = trim(params["passedCycleId"], 30)
+			passed_cycle_id = new_cycle_id
 			. = TRUE
 
 /obj/item/electronics/airlock/ui_host()

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -7,6 +7,10 @@
 	var/one_access = 0
 	/// Unrestricted sides, or sides of the airlock that will open regardless of access
 	var/unres_sides = 0
+	///what name are we passing to the finished airlock
+	var/passed_name
+	///what string are we passing to the finished airlock as the cycle ID
+	var/passed_cycle_id
 	/// A holder of the electronics, in case of them working as an integrated part
 	var/holder
 
@@ -39,6 +43,8 @@
 	data["accesses"] = accesses
 	data["oneAccess"] = one_access
 	data["unres_direction"] = unres_sides
+	data["passedName"] = passed_name
+	data["passedCycleId"] = passed_cycle_id
 	return data
 
 /obj/item/electronics/airlock/ui_act(action, params)
@@ -79,6 +85,12 @@
 			if(isnull(region))
 				return
 			accesses -= SSid_access.get_region_access_list(list(region))
+			. = TRUE
+		if("passedName")
+			passed_name = params["passedName"]
+			. = TRUE
+		if("passedCycleId")
+			passed_cycle_id = params["passedCycleId"]
 			. = TRUE
 
 /obj/item/electronics/airlock/ui_host()

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -260,7 +260,7 @@
 				if(created_name)
 					door.name = created_name
 				else if(electronics.passed_name)
-					door.name = electronics.passed_name
+					door.name = sanitize(electronics.passed_name)
 				else
 					door.name = base_name
 				if(electronics.passed_cycle_id)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -259,8 +259,13 @@
 					door.req_access = electronics.accesses
 				if(created_name)
 					door.name = created_name
+				else if(electronics.passed_name)
+					door.name = electronics.passed_name
 				else
 					door.name = base_name
+				if(electronics.passed_cycle_id)
+					door.closeOtherId = electronics.passed_cycle_id
+					door.update_other_id()
 				door.previous_airlock = previous_assembly
 				electronics.forceMove(door)
 				door.update_appearance()

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -307,7 +307,7 @@
 			if(new_airlock.electronics.unres_sides)
 				new_airlock.unres_sides = new_airlock.electronics.unres_sides
 			if(new_airlock.electronics.passed_name)
-				new_airlock.name = new_airlock.electronics.passed_name
+				new_airlock.name = sanitize(new_airlock.electronics.passed_name)
 			if(new_airlock.electronics.passed_cycle_id)
 				new_airlock.closeOtherId = new_airlock.electronics.passed_cycle_id
 				new_airlock.update_other_id()

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -298,12 +298,19 @@
 				new_airlock.electronics.accesses = the_rcd.airlock_electronics.accesses.Copy()
 				new_airlock.electronics.one_access = the_rcd.airlock_electronics.one_access
 				new_airlock.electronics.unres_sides = the_rcd.airlock_electronics.unres_sides
+				new_airlock.electronics.passed_name = the_rcd.airlock_electronics.passed_name
+				new_airlock.electronics.passed_cycle_id = the_rcd.airlock_electronics.passed_cycle_id
 			if(new_airlock.electronics.one_access)
 				new_airlock.req_one_access = new_airlock.electronics.accesses
 			else
 				new_airlock.req_access = new_airlock.electronics.accesses
 			if(new_airlock.electronics.unres_sides)
 				new_airlock.unres_sides = new_airlock.electronics.unres_sides
+			if(new_airlock.electronics.passed_name)
+				new_airlock.name = new_airlock.electronics.passed_name
+			if(new_airlock.electronics.passed_cycle_id)
+				new_airlock.closeOtherId = new_airlock.electronics.passed_cycle_id
+				new_airlock.update_other_id()
 			new_airlock.autoclose = TRUE
 			new_airlock.update_appearance()
 			return TRUE

--- a/tgui/packages/tgui/interfaces/AirlockElectronics.js
+++ b/tgui/packages/tgui/interfaces/AirlockElectronics.js
@@ -61,6 +61,7 @@ export const AirlockElectronics = (props, context) => {
             <LabeledList.Item
               label="Airlock Name">
               <Input fluid
+                maxLength={30}
                 value={passedName}
                 onChange={(e, value) => act('passedName', {
                   passedName: value,
@@ -69,6 +70,7 @@ export const AirlockElectronics = (props, context) => {
             <LabeledList.Item
               label="Cycling Id">
               <Input fluid
+                maxLength={30}
                 value={passedCycleId}
                 onChange={(e, value) => act('passedCycleId', {
                   passedCycleId: value,

--- a/tgui/packages/tgui/interfaces/AirlockElectronics.js
+++ b/tgui/packages/tgui/interfaces/AirlockElectronics.js
@@ -1,5 +1,5 @@
 import { useBackend, useLocalState } from '../backend';
-import { Button, Flex, Grid, LabeledList, Section, Tabs } from '../components';
+import { Button, Flex, Grid, Input, LabeledList, Section, Tabs } from '../components';
 import { Window } from '../layouts';
 import { sortBy } from 'common/collections';
 
@@ -8,6 +8,8 @@ export const AirlockElectronics = (props, context) => {
   const {
     oneAccess,
     unres_direction,
+    passedName,
+    passedCycleId,
   } = data;
   const regions = data.regions || [];
   const accesses = data.accesses || [];
@@ -54,6 +56,22 @@ export const AirlockElectronics = (props, context) => {
                 selected={unres_direction & 8}
                 onClick={() => act('direc_set', {
                   unres_direction: '8',
+                })} />
+            </LabeledList.Item>
+            <LabeledList.Item
+              label="Airlock Name">
+              <Input fluid
+                value={passedName}
+                onChange={(e, value) => act('passedName', {
+                  passedName: value,
+                })} />
+            </LabeledList.Item>
+            <LabeledList.Item
+              label="Cycling Id">
+              <Input fluid
+                value={passedCycleId}
+                onChange={(e, value) => act('passedCycleId', {
+                  passedCycleId: value,
                 })} />
             </LabeledList.Item>
           </LabeledList>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- You can now edit an airlock control board (both physically and through an RCD) to set the airlock name and what ID it cycles on
- Airlocks now say what ID it cycles on when examined
- when an airlock is made it takes its circuits set name and ID and updates the cycling
- i redid how the cycle_id is updated on creation, so now when an airlock is made and grabbing airlocks with an identical ID to cycle it checks if the other airlocks with that ID needs a reference to the new airlock, and if so, it adds it, so you can add doors back to a cycle system if it breaks

NOTE: unfortunately the way linear airlocks, like the small 2 door airlocks to space, set their links, you cannot repair their cycle this way, you will have to deconstruct the remaining door and rebuild both to cycle again

Setting the settings:
![hi1](https://user-images.githubusercontent.com/40489693/132058054-0703dec8-eeb6-428a-929f-2b7078c01938.PNG)
![hi2](https://user-images.githubusercontent.com/40489693/132058064-26670383-c63f-4662-8748-aebef08a7ecf.PNG)
![hi3](https://user-images.githubusercontent.com/40489693/132058069-3a66aed6-9108-4654-8436-65229647754a.PNG)
![hi4](https://user-images.githubusercontent.com/40489693/132058073-6781dcb6-ffd8-4a2b-964b-e066b824cb2d.PNG)



Examine:
![hi5](https://user-images.githubusercontent.com/40489693/132058117-38b80637-9d49-4b70-99fc-215782164c55.PNG)
![hi6](https://user-images.githubusercontent.com/40489693/132058123-3eb08fdb-d985-4dfd-9e08-7ff49f853c44.PNG)



Clip of Cycling:

https://user-images.githubusercontent.com/40489693/132058137-ecd7568d-a732-490a-b6e2-1f4a50708743.mp4



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: You can now set an Airlocks name and cycle ID in the RCD airlock settings menu, or by clicking on an airlock control board and making an airlock manually, this allows you to make airlocks that can cycle with each other. examine an airlock to see what, if any, ID they are set to cycle on (linear 1x3 airlocks to space currently do not use cycleIDs)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
