### PR TITLE
Slight refractor to borg reboot boards, allows them to be reusable

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -757,9 +757,10 @@
 		R.model.remove_module(BR, TRUE)
 
 ///This isn't an upgrade or part of the same path, but I'm gonna just stick it here because it's a tool used on cyborgs.
+//A reusable tool that can bring borgs back to life. They gotta be repaired first, though.
 /obj/item/borg_restart_board
 	name = "cyborg emergency reboot module"
-	desc = "Used to force a reboot of a disabled-but-repaired cyborg, bringing it back online."
+	desc = "A reusable firmware reset tool that can force a reboot of a disabled-but-repaired cyborg, bringing it back online."
 	w_class = WEIGHT_CLASS_SMALL
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cyborg_upgrade1"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -54,26 +54,6 @@
 			R.notify_ai(RENAME, oldname, R.real_name)
 		log_game("[key_name(user)] have used a cyborg reclassification board to rename [oldkeyname] to [key_name(R)] at [loc_name(user)]")
 
-/obj/item/borg/upgrade/restart
-	name = "cyborg emergency reboot module"
-	desc = "Used to force a reboot of a disabled-but-repaired cyborg, bringing it back online."
-	icon_state = "cyborg_upgrade1"
-	one_use = TRUE
-
-/obj/item/borg/upgrade/restart/action(mob/living/silicon/robot/R, user = usr)
-	if(R.health < 0)
-		to_chat(user, span_warning("You have to repair the cyborg before using this module!"))
-		return FALSE
-
-	if(R.mind)
-		R.mind.grab_ghost()
-		playsound(loc, 'sound/voice/liveagain.ogg', 75, TRUE)
-
-	R.revive(full_heal = FALSE, admin_revive = FALSE)
-	R.logevent("WARN -- System recovered from unexpected shutdown.")
-	R.logevent("System brought online.")
-	return TRUE
-
 /obj/item/borg/upgrade/disablercooler
 	name = "cyborg rapid disabler cooling module"
 	desc = "Used to cool a mounted disabler, increasing the potential current in it and thus its recharge rate."
@@ -775,3 +755,35 @@
 	var/obj/item/pushbroom/cyborg/BR = locate() in R.model.modules
 	if (BR)
 		R.model.remove_module(BR, TRUE)
+
+///This isn't an upgrade or part of the same path, but I'm gonna just stick it here because it's a tool used on cyborgs.
+/obj/item/borg_restart_board
+	name = "cyborg emergency reboot module"
+	desc = "Used to force a reboot of a disabled-but-repaired cyborg, bringing it back online."
+	w_class = WEIGHT_CLASS_SMALL
+	icon = 'icons/obj/module.dmi'
+	icon_state = "cyborg_upgrade1"
+
+/obj/item/borg_restart_board/pre_attack(mob/living/silicon/robot/borgo, mob/living/user, params)
+	if(!istype(borgo))
+		return ..()
+	if(!borgo.opened)
+		to_chat(user, span_warning("You must access the cyborg's internals!"))
+		return ..()
+	if(borgo.health < 0)
+		to_chat(user, span_warning("You have to repair the cyborg before using this module!"))
+		return ..()
+	if(!(borgo.stat & DEAD))
+		to_chat(user, span_warning("This cyborg is already operational!"))
+		return ..()
+
+	if(borgo.mind)
+		borgo.mind.grab_ghost()
+		playsound(loc, 'sound/voice/liveagain.ogg', 75, TRUE)
+	else
+		playsound(loc, 'sound/machines/ping.ogg', 75, TRUE)
+
+	borgo.revive(full_heal = FALSE, admin_revive = FALSE)
+	borgo.logevent("WARN -- System recovered from unexpected shutdown.")
+	borgo.logevent("System brought online.")
+	return ..()

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -737,7 +737,7 @@
 	name = "Cyborg Upgrade (Emergency Reboot Board)"
 	id = "borg_upgrade_restart"
 	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/restart
+	build_path = /obj/item/borg_restart_board
 	materials = list(/datum/material/iron = 20000 , /datum/material/glass = 5000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -142,6 +142,9 @@
 					sub_category += "Engineering"
 			else
 				sub_category += "All Cyborgs"
+		else if(built_item in typesof(/obj/item/borg_restart_board)) //This is shitty but it wasn't I who made this code this way
+			sub_category += "All Cyborgs" //Otherwise the restart board shows in the "parts" category, which seems dumb
+
 		// Else check if this design builds a piece of exosuit equipment.
 		else if(built_item in typesof(/obj/item/mecha_parts/mecha_equipment))
 			var/obj/item/mecha_parts/mecha_equipment/E = built_item

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -142,7 +142,7 @@
 					sub_category += "Engineering"
 			else
 				sub_category += "All Cyborgs"
-		else if(built_item in typesof(/obj/item/borg_restart_board)) //This is shitty but it wasn't I who made this code this way
+		else if(ispath(built_item, /obj/item/borg_restart_board))
 			sub_category += "All Cyborgs" //Otherwise the restart board shows in the "parts" category, which seems dumb
 
 		// Else check if this design builds a piece of exosuit equipment.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Refractors the cyborg reboot module to be an independent item rather than a subtype of cyborg upgrades. The new item is no longer consumed during use.

Rebooting now makes a different sound when rebooting an AI shell or ghostless borg, rather than no sound at all.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A recent PR fixed a longstanding apparent bug that allowed reboot boards to be resused. A bug it may have been, but the reboot board being a single-use item is kinda terrible, and doesn't make a lot of sense that the board is somehow destroyed when used. Mothblocks, who merged the bugfix PR, has given me permission to PR this change.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The cyborg emergency reboot module is now reusable.
sound: The cyborg emergency reboot module will now make a different sound when rebooting AI shells or borgs without a ghost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
