### PR TITLE
Fixes + unit tests botany plants mutating into themselves, and makes mutatelists proper lazylists 

### DIFF
--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -37,7 +37,7 @@
 	maturation = 10
 	production = 10
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/gold = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 40 // Alchemy!
 

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -85,7 +85,7 @@
 	plantname = "Mimana Tree"
 	product = /obj/item/food/grown/banana/mime
 	growthstages = 4
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/nothing = 0.1, /datum/reagent/toxin/mutetoxin = 0.1, /datum/reagent/consumable/nutriment = 0.02)
 	rarity = 15
 
@@ -114,7 +114,7 @@
 	plantname = "Bluespace Banana Tree"
 	instability = 40
 	product = /obj/item/food/grown/banana/bluespace
-	mutatelist = list()
+	mutatelist = null
 	genes = list(/datum/plant_gene/trait/slip, /datum/plant_gene/trait/teleport, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/bluespace = 0.2, /datum/reagent/consumable/banana = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.02)
 	rarity = 30

--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -37,7 +37,7 @@
 	plantname = "Koibean Plants"
 	product = /obj/item/food/grown/koibeans
 	potency = 10
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/toxin/carpotoxin = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.05)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -63,7 +63,7 @@
 	product = /obj/item/food/grown/berries/death
 	lifespan = 30
 	potency = 50
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/toxin/coniine = 0.08, /datum/reagent/toxin/staminatoxin = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 30
 
@@ -88,7 +88,7 @@
 	product = /obj/item/food/grown/berries/glow
 	lifespan = 30
 	endurance = 25
-	mutatelist = list()
+	mutatelist = null
 	genes = list(/datum/plant_gene/trait/glow/white, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/uranium = 0.25, /datum/reagent/iodine = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
@@ -149,6 +149,7 @@
 	plantname = "Green-Grape Vine"
 	product = /obj/item/food/grown/grapes/green
 	reagents_add = list( /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/sugar = 0.1, /datum/reagent/medicine/c2/aiuri = 0.2)
+	mutatelist = null
 
 /obj/item/food/grown/grapes/green
 	seed = /obj/item/seeds/grape/green

--- a/code/modules/hydroponics/grown/cannabis.dm
+++ b/code/modules/hydroponics/grown/cannabis.dm
@@ -28,7 +28,7 @@
 	species = "megacannabis"
 	plantname = "Rainbow Weed"
 	product = /obj/item/food/grown/cannabis/rainbow
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/colorful_reagent = 0.05, /datum/reagent/medicine/psicodine = 0.03, /datum/reagent/drug/happiness = 0.1, /datum/reagent/toxin/mindbreaker = 0.1, /datum/reagent/toxin/lipolicide = 0.15, /datum/reagent/drug/space_drugs = 0.15)
 	rarity = 40
 
@@ -39,7 +39,7 @@
 	species = "blackcannabis"
 	plantname = "Deathweed"
 	product = /obj/item/food/grown/cannabis/death
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/toxin/cyanide = 0.35, /datum/reagent/drug/cannabis = 0.15)
 	rarity = 40
 
@@ -51,7 +51,7 @@
 	plantname = "Lifeweed"
 	instability = 30
 	product = /obj/item/food/grown/cannabis/white
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/medicine/omnizine = 0.35, /datum/reagent/drug/cannabis = 0.15)
 	rarity = 40
 
@@ -64,7 +64,7 @@
 	plantname = "Omega Weed"
 	product = /obj/item/food/grown/cannabis/ultimate
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/glow/green, /datum/plant_gene/trait/modified_volume/omega_weed)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/drug/cannabis = 0.3,
 						/datum/reagent/toxin/mindbreaker = 0.3,
 						/datum/reagent/mercury = 0.15,

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -34,7 +34,7 @@
 	species = "oat"
 	plantname = "Oat Stalks"
 	product = /obj/item/food/grown/oat
-	mutatelist = list()
+	mutatelist = null
 
 /obj/item/food/grown/oat
 	seed = /obj/item/seeds/wheat/oat
@@ -57,7 +57,7 @@
 	plantname = "Rice Stalks"
 	instability = 1
 	product = /obj/item/food/grown/rice
-	mutatelist = list()
+	mutatelist = null
 	growthstages = 3
 
 /obj/item/food/grown/rice
@@ -80,7 +80,7 @@
 	species = "meatwheat"
 	plantname = "Meatwheat"
 	product = /obj/item/food/grown/meatwheat
-	mutatelist = list()
+	mutatelist = null
 
 /obj/item/food/grown/meatwheat
 	name = "meatwheat"

--- a/code/modules/hydroponics/grown/cherries.dm
+++ b/code/modules/hydroponics/grown/cherries.dm
@@ -40,7 +40,7 @@
 	species = "bluecherry"
 	plantname = "Blue Cherry Tree"
 	product = /obj/item/food/grown/bluecherries
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.07, /datum/reagent/consumable/sugar = 0.07, /datum/reagent/oxygen = 0.07)
 	rarity = 10
 
@@ -64,7 +64,7 @@
 	plantname = "Cherry Bulb Tree"
 	product = /obj/item/food/grown/cherrybulbs
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/glow/pink)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.07, /datum/reagent/consumable/sugar = 0.07)
 	rarity = 10
 	graft_gene = /datum/plant_gene/trait/glow/pink
@@ -88,7 +88,7 @@
 	species = "cherry_bomb"
 	plantname = "Cherry Bomb Tree"
 	product = /obj/item/food/grown/cherry_bomb
-	mutatelist = list()
+	mutatelist = null
 	genes = list(/datum/plant_gene/trait/bomb_plant, /datum/plant_gene/trait/modified_volume/cherry_bomb)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/sugar = 0.1, /datum/reagent/gunpowder = 0.7)
 	rarity = 60 //See above

--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -41,7 +41,7 @@
 	production = 4
 	rarity = 20
 	genes = list(/datum/plant_gene/trait/chem_cooling)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/frostoil = 0.25, /datum/reagent/consumable/nutriment/vitamin = 0.02, /datum/reagent/consumable/nutriment = 0.02)
 	graft_gene = /datum/plant_gene/trait/chem_cooling
 
@@ -68,7 +68,7 @@
 	yield = 3
 	rarity = 20
 	genes = list(/datum/plant_gene/trait/chem_heating, /datum/plant_gene/trait/backfire/chili_heat)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/condensedcapsaicin = 0.3, /datum/reagent/consumable/capsaicin = 0.55, /datum/reagent/consumable/nutriment = 0.04)
 	graft_gene = /datum/plant_gene/trait/chem_heating
 

--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -38,7 +38,7 @@
 	plantname = "Vanilla Tree"
 	product = /obj/item/food/grown/vanillapod
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/vanilla = 0.25, /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/food/grown/vanillapod
@@ -63,7 +63,7 @@
 	yield = 3
 	production = 7
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/enzyme = 0.1, /datum/reagent/consumable/nutriment = 0.1)
 	growthstages = 4
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'

--- a/code/modules/hydroponics/grown/corn.dm
+++ b/code/modules/hydroponics/grown/corn.dm
@@ -56,7 +56,7 @@
 	species = "snapcorn"
 	plantname = "Snapcorn Stalks"
 	product = /obj/item/grown/snapcorn
-	mutatelist = list()
+	mutatelist = null
 	rarity = 10
 
 /obj/item/grown/snapcorn

--- a/code/modules/hydroponics/grown/cotton.dm
+++ b/code/modules/hydroponics/grown/cotton.dm
@@ -65,6 +65,7 @@
 	growthstages = 3
 	growing_icon = 'icons/obj/hydroponics/growing.dmi'
 	icon_dead = "cotton-dead"
+	mutatelist = null
 
 /obj/item/grown/cotton/durathread
 	seed = /obj/item/seeds/cotton/durathread

--- a/code/modules/hydroponics/grown/eggplant.dm
+++ b/code/modules/hydroponics/grown/eggplant.dm
@@ -33,7 +33,7 @@
 	product = /obj/item/food/grown/shell/eggy
 	lifespan = 75
 	production = 12
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/food/grown/shell/eggy

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -68,7 +68,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	icon_grow = "spacemanstrumpet-grow"
 	icon_dead = "spacemanstrumpet-dead"
-	mutatelist = list()
+	mutatelist = null
 	genes = list(/datum/plant_gene/reagent/polypyr, /datum/plant_gene/trait/preserved)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05)
 	rarity = 30
@@ -106,7 +106,7 @@
 	species = "fraxinella"
 	plantname = "Fraxinella Plants"
 	product = /obj/item/food/grown/poppy/geranium/fraxinella
-	mutatelist = list()
+	mutatelist = null
 	rarity = 15
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05, /datum/reagent/fuel/oil = 0.05)
 
@@ -199,7 +199,7 @@
 	icon_dead = "sunflower-dead"
 	product = /obj/item/food/grown/moonflower
 	genes = list(/datum/plant_gene/trait/glow/purple, /datum/plant_gene/trait/preserved)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/ethanol/moonshine = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.02, /datum/reagent/consumable/nutriment = 0.02)
 	rarity = 15
 	graft_gene = /datum/plant_gene/trait/glow/purple
@@ -223,7 +223,7 @@
 	icon_dead = "sunflower-dead"
 	product = /obj/item/grown/novaflower
 	genes = list(/datum/plant_gene/trait/backfire/novaflower_heat, /datum/plant_gene/trait/attack/novaflower_attack, /datum/plant_gene/trait/preserved)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/condensedcapsaicin = 0.25, /datum/reagent/consumable/capsaicin = 0.3, /datum/reagent/consumable/nutriment = 0)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -53,6 +53,7 @@
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/glow/blue)
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.02, /datum/reagent/hydrogen = 0.05, /datum/reagent/drug/space_drugs = 0.15)
 	graft_gene = /datum/plant_gene/trait/glow/blue
+	mutatelist = null
 
 /obj/item/food/grown/grass/fairy
 	seed = /obj/item/seeds/grass/fairy
@@ -70,7 +71,7 @@
 	species = "carpet"
 	plantname = "Carpet"
 	product = /obj/item/food/grown/grass/carpet
-	mutatelist = list()
+	mutatelist = null
 	rarity = 10
 
 /obj/item/food/grown/grass/carpet

--- a/code/modules/hydroponics/grown/korta_nut.dm
+++ b/code/modules/hydroponics/grown/korta_nut.dm
@@ -37,7 +37,7 @@
 	product = /obj/item/food/grown/korta_nut/sweet
 	maturation = 10
 	production = 10
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/korta_nectar = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -48,7 +48,7 @@
 	plantname = "Holy Melon Vines"
 	product = /obj/item/food/grown/holymelon
 	genes = list(/datum/plant_gene/trait/glow/yellow, /datum/plant_gene/trait/anti_magic)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/water/holywater = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
 	graft_gene = /datum/plant_gene/trait/glow/yellow
@@ -103,7 +103,7 @@
 	plantname = "Barrel Melon Vines"
 	product = /obj/item/food/grown/barrelmelon
 	genes = list(/datum/plant_gene/trait/brewing)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/ethanol/ale = 0.2, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 10
 	graft_gene = /datum/plant_gene/trait/brewing

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -152,7 +152,7 @@
 	yield = 1
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/mob_transformation/shroom)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.05, /datum/reagent/consumable/nutriment = 0.15)
 	rarity = 30
 	graft_gene = /datum/plant_gene/trait/eyes
@@ -208,6 +208,7 @@
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/reagent/liquidelectricity, /datum/plant_gene/trait/carnivory)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1)
+	mutatelist = null
 	graft_gene = /datum/plant_gene/trait/carnivory
 
 /obj/item/seeds/chanter/jupitercup/Initialize(mapload,nogenes)
@@ -285,7 +286,7 @@
 	plantname = "Glowcaps"
 	product = /obj/item/food/grown/mushroom/glowshroom/glowcap
 	genes = list(/datum/plant_gene/trait/glow/red, /datum/plant_gene/trait/cell_charge, /datum/plant_gene/trait/plant_type/fungal_metabolism)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/teslium = 0.1, /datum/reagent/consumable/nutriment = 0.04)
 	rarity = 30
 	graft_gene = /datum/plant_gene/trait/cell_charge
@@ -310,7 +311,7 @@
 	plantname = "Shadowshrooms"
 	product = /obj/item/food/grown/mushroom/glowshroom/shadowshroom
 	genes = list(/datum/plant_gene/trait/glow/shadow, /datum/plant_gene/trait/plant_type/fungal_metabolism)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/uranium/radium = 0.2, /datum/reagent/consumable/nutriment = 0.04)
 	rarity = 30
 	graft_gene = /datum/plant_gene/trait/glow/shadow

--- a/code/modules/hydroponics/grown/onion.dm
+++ b/code/modules/hydroponics/grown/onion.dm
@@ -37,6 +37,7 @@
 	weed_chance = 1
 	product = /obj/item/food/grown/onion/red
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/consumable/tearjuice = 0.05)
+	mutatelist = null
 
 /obj/item/food/grown/onion/red
 	seed = /obj/item/seeds/onion/red

--- a/code/modules/hydroponics/grown/peas.dm
+++ b/code/modules/hydroponics/grown/peas.dm
@@ -79,6 +79,7 @@
 	reagents_add = list (/datum/reagent/pax = 0.1, /datum/reagent/drug/happiness = 0.1, /datum/reagent/consumable/nutriment = 0.15)
 	rarity = 50 // This absolutely will make even the most hardened Syndicate Operators relax.
 	graft_gene = /datum/plant_gene/trait/glow/blue
+	mutatelist = null
 
 /obj/item/food/grown/peace
 	seed = /obj/item/seeds/peas/laugh/peace

--- a/code/modules/hydroponics/grown/potato.dm
+++ b/code/modules/hydroponics/grown/potato.dm
@@ -53,7 +53,7 @@
 	species = "sweetpotato"
 	plantname = "Sweet Potato Plants"
 	product = /obj/item/food/grown/potato/sweet
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.1, /datum/reagent/consumable/sugar = 0.1, /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/food/grown/potato/sweet

--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -45,7 +45,7 @@
 	species = "blumpkin"
 	plantname = "Blumpkin Vines"
 	product = /obj/item/food/grown/pumpkin/blumpkin
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/ammonia = 0.2, /datum/reagent/chlorine = 0.1, /datum/reagent/consumable/nutriment = 0.2)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -44,7 +44,7 @@
 	plantname = "Parsnip"
 	product = /obj/item/food/grown/parsnip
 	icon_dead = "carrot-dead"
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.05, /datum/reagent/consumable/nutriment = 0.05, /datum/reagent/aluminium = 0.05)
 
 /obj/item/food/grown/parsnip

--- a/code/modules/hydroponics/grown/sugarcane.dm
+++ b/code/modules/hydroponics/grown/sugarcane.dm
@@ -44,6 +44,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing.dmi'
 	icon_dead = "bamboo-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
+	mutatelist = null
 
 /obj/item/grown/log/bamboo
 	seed = /obj/item/seeds/bamboo

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -32,7 +32,7 @@
 	species = "teaastra"
 	plantname = "Tea Astra Plant"
 	product = /obj/item/food/grown/tea/astra
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/medicine/synaptizine = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/toxin/teapowder = 0.1)
 	rarity = 20
 
@@ -81,7 +81,7 @@
 	species = "coffeer"
 	plantname = "Coffee Robusta Bush"
 	product = /obj/item/food/grown/coffee/robusta
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/medicine/ephedrine = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/toxin/coffeepowder = 0.1)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/tobacco.dm
+++ b/code/modules/hydroponics/grown/tobacco.dm
@@ -30,7 +30,7 @@
 	species = "stobacco"
 	plantname = "Space Tobacco Plant"
 	product = /obj/item/food/grown/tobacco/space
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/medicine/salbutamol = 0.05, /datum/reagent/drug/nicotine = 0.08, /datum/reagent/consumable/nutriment = 0.03)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -35,7 +35,7 @@
 	species = "bloodtomato"
 	plantname = "Blood-Tomato Plants"
 	product = /obj/item/food/grown/tomato/blood
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/blood = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
 
@@ -84,7 +84,7 @@
 	plantname = "Bluespace Tomato Plants"
 	product = /obj/item/food/grown/tomato/blue/bluespace
 	yield = 2
-	mutatelist = list()
+	mutatelist = null
 	genes = list(/datum/plant_gene/trait/squash, /datum/plant_gene/trait/slip, /datum/plant_gene/trait/teleport, /datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/backfire/bluespace)
 	reagents_add = list(/datum/reagent/lube = 0.2, /datum/reagent/bluespace = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 50
@@ -113,7 +113,7 @@
 	icon_grow = "killertomato-grow"
 	icon_harvest = "killertomato-harvest"
 	icon_dead = "killertomato-dead"
-	mutatelist = list()
+	mutatelist = null
 	rarity = 30
 
 /obj/item/food/grown/tomato/killer

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -26,7 +26,7 @@
 	species = "steelcap"
 	plantname = "Steel Caps"
 	product = /obj/item/grown/log/steel
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/cellulose = 0.05, /datum/reagent/iron = 0.05)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/weeds/nettle.dm
+++ b/code/modules/hydroponics/grown/weeds/nettle.dm
@@ -26,7 +26,7 @@
 	maturation = 8
 	yield = 2
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/plant_type/weed_hardy, /datum/plant_gene/trait/stinging, /datum/plant_gene/trait/attack/nettle_attack/death, /datum/plant_gene/trait/backfire/nettle_burn/death)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/toxin/acid/fluacid = 0.5, /datum/reagent/toxin/acid = 0.5)
 	rarity = 20
 	graft_gene = /datum/plant_gene/trait/stinging

--- a/code/modules/hydroponics/grown/weeds/starthistle.dm
+++ b/code/modules/hydroponics/grown/weeds/starthistle.dm
@@ -40,7 +40,7 @@
 	production = 2
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	genes = list(/datum/plant_gene/trait/gas_production)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/toxin/formaldehyde = 0.1)
 
 //Galaxy Thistle
@@ -61,7 +61,7 @@
 	growthstages = 3
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	genes = list(/datum/plant_gene/trait/plant_type/weed_hardy, /datum/plant_gene/trait/invasive)
-	mutatelist = list()
+	mutatelist = null
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05, /datum/reagent/medicine/silibinin = 0.1)
 	graft_gene = /datum/plant_gene/trait/invasive
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -120,7 +120,7 @@
 		return myseed.bullet_act(Proj)
 	else if(istype(Proj , /obj/projectile/energy/florarevolution))
 		if(myseed)
-			if(LAZYEN(myseed.mutatelist))
+			if(LAZYLEN(myseed.mutatelist))
 				myseed.set_instability(myseed.instability/2)
 		mutatespecie()
 	else

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -120,7 +120,7 @@
 		return myseed.bullet_act(Proj)
 	else if(istype(Proj , /obj/projectile/energy/florarevolution))
 		if(myseed)
-			if(myseed.mutatelist.len > 0)
+			if(LAZYEN(myseed.mutatelist))
 				myseed.set_instability(myseed.instability/2)
 		mutatespecie()
 	else
@@ -251,7 +251,7 @@
 				var/mutation_chance = myseed.instability - 75
 				mutate(0, 0, 0, 0, 0, 0, 0, mutation_chance, 0) //Scaling odds of a random trait or chemical
 			if(myseed.instability >= 60)
-				if(prob((myseed.instability)/2) && !self_sustaining && length(myseed.mutatelist)) //Minimum 30%, Maximum 50% chance of mutating every age tick when not on autogrow.
+				if(prob((myseed.instability)/2) && !self_sustaining && LAZYLEN(myseed.mutatelist)) //Minimum 30%, Maximum 50% chance of mutating every age tick when not on autogrow.
 					mutatespecie()
 					myseed.set_instability(myseed.instability/2)
 			if(myseed.instability >= 40)
@@ -425,7 +425,7 @@
 		return
 
 	var/oldPlantName = myseed.plantname
-	if(myseed.mutatelist.len > 0)
+	if(LAZYLEN(myseed.mutatelist))
 		var/mutantseed = pick(myseed.mutatelist)
 		qdel(myseed)
 		myseed = null
@@ -715,7 +715,7 @@
 		if(myseed.endurance <= 20)
 			to_chat(user, span_warning("[myseed.plantname] isn't hardy enough to sequence it's mutation!"))
 			return
-		if(!myseed.mutatelist)
+		if(!LAZYLEN(myseed.mutatelist))
 			to_chat(user, span_warning("[myseed.plantname] has nothing else to mutate into!"))
 			return
 		else

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -65,6 +65,7 @@
 #include "heretic_knowledge.dm"
 #include "holidays.dm"
 #include "hydroponics_harvest.dm"
+#include "hydroponics_self_mutations.dm"
 #include "keybinding_init.dm"
 #include "machine_disassembly.dm"
 #include "medical_wounds.dm"

--- a/code/modules/unit_tests/hydroponics_self_mutations.dm
+++ b/code/modules/unit_tests/hydroponics_self_mutations.dm
@@ -1,10 +1,9 @@
 /// Unit test to ensure plants can't self-mutate into themselves.
 /datum/unit_test/hydroponics_self_mutation/Run()
-	var/list/seeds/all_seeds = subtypesof(/obj/item/seeds)
+	var/list/all_seeds = subtypesof(/obj/item/seeds)
 
 	for(var/seed in all_seeds)
 		var/obj/item/seeds/instantiated_seed = new seed()
 		for(var/path in instantiated_seed.mutatelist)
-			if(istype(instantiated_seed, path))
-				Fail("[instantiated_seed] - [instantiated_seed.type] is able to mutate into itself! Its mutatelist is not set correctly.")
-		qdel(seed)
+			TEST_ASSERT(!istype(instantiated_seed, path), "[instantiated_seed] - [instantiated_seed.type] is able to mutate into itself! Its mutatelist is not set correctly.")
+		qdel(instantiated_seed)

--- a/code/modules/unit_tests/hydroponics_self_mutations.dm
+++ b/code/modules/unit_tests/hydroponics_self_mutations.dm
@@ -1,0 +1,10 @@
+/// Unit test to ensure plants can't self-mutate into themselves.
+/datum/unit_test/hydroponics_self_mutation/Run()
+	var/list/seeds/all_seeds = subtypesof(/obj/item/seeds)
+
+	for(var/seed in all_seeds)
+		var/obj/item/seeds/instantiated_seed = new seed()
+		for(var/path in instantiated_seed.mutatelist)
+			if(istype(instantiated_seed, path))
+				Fail("[instantiated_seed] - [instantiated_seed.type] is able to mutate into itself! Its mutatelist is not set correctly.")
+		qdel(seed)

--- a/code/modules/unit_tests/hydroponics_self_mutations.dm
+++ b/code/modules/unit_tests/hydroponics_self_mutations.dm
@@ -1,4 +1,6 @@
 /// Unit test to ensure plants can't self-mutate into themselves.
+/datum/unit_test/hydroponics_self_mutation
+
 /datum/unit_test/hydroponics_self_mutation/Run()
 	var/list/all_seeds = subtypesof(/obj/item/seeds)
 


### PR DESCRIPTION
## About The Pull Request

- This PR fixes a few botany plants mutating into themselves due to seeds inheriting the mutation list from its parent. Durathread, Jupiter Cups, Fairy Grass, Red Onions, Bamboo, Green Grapes, and World Peas (maybe some others I forgot). 
- This PR also unit tests to ensure plants don't mutate into themselves. 
- This PR also converts mutatelist into a proper lazylist. IT was already kinda a lazy list, in that it's null by default, but for some reason it was treated as a normal list in multiple places. 

## Why It's Good For The Game

Plants shouldn't be able to mutate into themselves.

## Changelog
:cl: Melbert
fix: Durathread, Jupiter Cups, Fairy Grass, and a few other plants can no longer hard species mutate into themselves.
/:cl:
