### PR TITLE
Adds Frostbite (Burn Wounds, but for Cold)

### DIFF
--- a/code/__DEFINES/wounds.dm
+++ b/code/__DEFINES/wounds.dm
@@ -58,7 +58,8 @@ GLOBAL_LIST_INIT(global_wound_types, list(WOUND_BLUNT = list(/datum/wound/blunt/
 GLOBAL_LIST_INIT(global_all_wound_types, list(/datum/wound/blunt/critical, /datum/wound/blunt/severe, /datum/wound/blunt/moderate,
 	/datum/wound/slash/critical, /datum/wound/slash/severe, /datum/wound/slash/moderate,
 	/datum/wound/pierce/critical, /datum/wound/pierce/severe, /datum/wound/pierce/moderate,
-	/datum/wound/burn/critical, /datum/wound/burn/severe, /datum/wound/burn/moderate))
+	/datum/wound/burn/critical, /datum/wound/burn/severe, /datum/wound/burn/moderate,
+	/datum/wound/burn/critical/frostbite, /datum/wound/burn/severe/frostbite, /datum/wound/burn/moderate/frostbite))
 
 
 // ~burn wound infection defines

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -307,12 +307,6 @@
 	treat_text = "Recommended application of topical ointment or regenerative mesh to affected region."
 	examine_desc = "appears slightly blackened, with the skin blistering and peeling off"
 	occur_text = "blisters, with the skin blackened and peeling"
-	severity = WOUND_SEVERITY_MODERATE
-	damage_mulitplier_penalty = 1.1
-	threshold_minimum = 40
-	threshold_penalty = 30 // burns cause significant decrease in limb integrity compared to other wounds
-	status_effect_type = /datum/status_effect/wound/burn/moderate
-	flesh_damage = 5
 	scar_keyword = "frostbitemoderate"
 
 /datum/wound/burn/severe/frostbite
@@ -321,14 +315,6 @@
 	treat_text = "Recommended immediate disinfection and excision of any infected skin, followed by bandaging and ointment."
 	examine_desc = "is discolored with a blue-gray coloration, and is covered in blood blisters"
 	occur_text = "breaks out into blood blisters, and a bluish-grey color"
-	severity = WOUND_SEVERITY_SEVERE
-	damage_mulitplier_penalty = 1.2
-	threshold_minimum = 80
-	threshold_penalty = 40
-	status_effect_type = /datum/status_effect/wound/burn/severe
-	treatable_by = list(/obj/item/flashlight/pen/paramedic, /obj/item/stack/medical/ointment, /obj/item/stack/medical/mesh)
-	infestation_rate = 0.07 // appx 9 minutes to reach sepsis without any treatment
-	flesh_damage = 12.5
 	scar_keyword = "frostbitesevere"
 
 /datum/wound/burn/critical/frostbite
@@ -337,13 +323,4 @@
 	treat_text = "Immediate surgical debriding of any infected skin, followed by potent tissue regeneration formula and bandaging."
 	examine_desc = "is charcoal black, and starting to fall off."
 	occur_text = "becomes charcoal black and mummifies"
-	severity = WOUND_SEVERITY_CRITICAL
-	damage_mulitplier_penalty = 1.3
-	sound_effect = 'sound/effects/wounds/sizzle2.ogg'
-	threshold_minimum = 140
-	threshold_penalty = 80
-	status_effect_type = /datum/status_effect/wound/burn/critical
-	treatable_by = list(/obj/item/flashlight/pen/paramedic, /obj/item/stack/medical/ointment, /obj/item/stack/medical/mesh)
-	infestation_rate = 0.075 // appx 4.33 minutes to reach sepsis without any treatment
-	flesh_damage = 20
 	scar_keyword = "frostbitecritical"

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -299,3 +299,51 @@
 	infestation_rate = 0.075 // appx 4.33 minutes to reach sepsis without any treatment
 	flesh_damage = 20
 	scar_keyword = "burncritical"
+
+
+/datum/wound/burn/moderate/frostbite
+	name = "Second Degree Frostbite"
+	desc = "Patient is suffering from second degree frostbite, weakening limb integrity and increased sensitivity to the cold and numbness in the region."
+	treat_text = "Recommended application of topical ointment or regenerative mesh to affected region."
+	examine_desc = "appears slightly blackened, with the skin blistering and peeling off"
+	occur_text = "blisters, with the skin blackened and peeling"
+	severity = WOUND_SEVERITY_MODERATE
+	damage_mulitplier_penalty = 1.1
+	threshold_minimum = 40
+	threshold_penalty = 30 // burns cause significant decrease in limb integrity compared to other wounds
+	status_effect_type = /datum/status_effect/wound/burn/moderate
+	flesh_damage = 5
+	scar_keyword = "frostbitemoderate"
+
+/datum/wound/burn/severe/frostbite
+	name = "Third Degree Frostbite"
+	desc = "Patient is suffering from third degree frostbite, creating serious risk of infection and greatly reduced limb integrity."
+	treat_text = "Recommended immediate disinfection and excision of any infected skin, followed by bandaging and ointment."
+	examine_desc = "is discolored with a blue-gray coloration, and is covered in blood blisters"
+	occur_text = "breaks out into blood blisters, and a bluish-grey color"
+	severity = WOUND_SEVERITY_SEVERE
+	damage_mulitplier_penalty = 1.2
+	threshold_minimum = 80
+	threshold_penalty = 40
+	status_effect_type = /datum/status_effect/wound/burn/severe
+	treatable_by = list(/obj/item/flashlight/pen/paramedic, /obj/item/stack/medical/ointment, /obj/item/stack/medical/mesh)
+	infestation_rate = 0.07 // appx 9 minutes to reach sepsis without any treatment
+	flesh_damage = 12.5
+	scar_keyword = "frostbitesevere"
+
+/datum/wound/burn/critical/frostbite
+	name = "Fourth Degree Frostbite"
+	desc = "Patient is suffering from fourth degree frostbite, with complete mummification of the underlying tissue, tendon, muscle, and bone, creating life-threatening risk of infection and negligible limb integrity."
+	treat_text = "Immediate surgical debriding of any infected skin, followed by potent tissue regeneration formula and bandaging."
+	examine_desc = "is charcoal black, and starting to fall off."
+	occur_text = "becomes charcoal black and mummifies"
+	severity = WOUND_SEVERITY_CRITICAL
+	damage_mulitplier_penalty = 1.3
+	sound_effect = 'sound/effects/wounds/sizzle2.ogg'
+	threshold_minimum = 140
+	threshold_penalty = 80
+	status_effect_type = /datum/status_effect/wound/burn/critical
+	treatable_by = list(/obj/item/flashlight/pen/paramedic, /obj/item/stack/medical/ointment, /obj/item/stack/medical/mesh)
+	infestation_rate = 0.075 // appx 4.33 minutes to reach sepsis without any treatment
+	flesh_damage = 20
+	scar_keyword = "frostbitecritical"

--- a/strings/wounds/flesh_scar_desc.json
+++ b/strings/wounds/flesh_scar_desc.json
@@ -77,6 +77,22 @@
 		"unmistakeable splotches of dead tissue from serious burns"
 	],
 
+	"frostbitemoderate": [
+		"small amoeba-shaped skinmarks",
+		"a faded streak of depressed skin"
+	],
+
+	"frostbitesevere": [
+		"a large, jagged patch of faded skin",
+		"random spots of shiny, smooth skin",
+		"spots of taut, leathery skin"
+	],
+
+	"frostbitecritical": [
+		"massive, disfiguring keloid scars",
+		"several long streaks of badly discolored and malformed skin",
+		"unmistakeable splotches of dead tissue from serious burns"
+	],
 
 	"dismember": [
 		"is several skintone shades paler than the rest of the body",


### PR DESCRIPTION
## About The Pull Request

Exposure to the cold can now give you Frostbite variations of the burn wounds.

## Why It's Good For The Game

Adds more danger to space walking and cold environments, which was previously not threatening in the slightest.
Mechanically, they're reskinned burn wounds because it's the same damage vector, just reversed, and a lot of the end results of Frostbite IRL are similar to burns.

## Changelog
:cl:
expansion: Frostbite wounds can now occur from the cold.
/:cl:

todo: write scar descriptions

@Ryll-Ryll 
