### PR TITLE
fixes sdql spell parsing

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_spells/spell_edit_menu.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_spells/spell_edit_menu.dm
@@ -567,9 +567,9 @@ GLOBAL_LIST_INIT_TYPED(sdql_spells, /obj/effect/proc_holder/spell, list())
 				if(!(temp_list_vars[V][W]["flags"] & LIST_VAR_FLAGS_NAMED))
 					parse_errors += "[V]/[W] did not have the LIST_VAR_FLAGS_NAMED flag set; it has been set"
 					temp_list_vars[V][W]["flags"] |= LIST_VAR_FLAGS_NAMED
-				if(temp_list_vars & ~(LIST_VAR_FLAGS_NAMED | LIST_VAR_FLAGS_NAMED))
+				if(temp_list_vars & ~(LIST_VAR_FLAGS_NAMED | LIST_VAR_FLAGS_TYPED))
 					parse_errors += "[V]/[W] has unused bit flags set; they have been unset"
-					temp_list_vars[V][W]["flags"] &= LIST_VAR_FLAGS_NAMED | LIST_VAR_FLAGS_NAMED
+					temp_list_vars[V][W]["flags"] &= LIST_VAR_FLAGS_NAMED | LIST_VAR_FLAGS_TYPED
 				if(!(temp_list_vars[V][W]["flags"] & LIST_VAR_FLAGS_TYPED))
 					if(isnull(sample.vars[W]))
 						continue


### PR DESCRIPTION
## About The Pull Request

During the refactor of SDQL spells, I messed up with the parser and used the same bitflag twice in a binary OR rather than using two separate bitflags. This caused parse errors to appear where they shouldn't. This PR fixes that.

## Why It's Good For The Game

Makes sure parse errors don't appear when they shouldn't.

## Changelog
:cl:
fix: Admins will no longer receive erroneous SDQL spell parse errors when loading a json file that contains projectile var overrides or touch attack var overrides
/:cl:
