### PR TITLE
Fix disposal eject speed

### DIFF
--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -57,7 +57,7 @@
 	if(!H)
 		return
 
-	pipe_eject(H, dir, TRUE, target, eject_range, throw_range)
+	pipe_eject(H, dir, TRUE, target, eject_range, eject_speed)
 
 	H.vent_gas(loc)
 	qdel(H)


### PR DESCRIPTION
:cl: Ryll/Shaps
fix: Disposal outlets no longer constantly shoot you out at an incredibly dangerous speed, and no longer deal a base 35 damage + guaranteed dislocation/likely hairline fracture when you hit a wall or other person. Instead, they're back to the old 10 brute damage they were at last year, though you can still multitool/emag them to make them shoot out things faster....
/:cl:

@Ryll-Ryll
Atomizing this needed fix from #61196 which I'm personally not invested in merging