### PR TITLE
Fixes GetComponents() returning a list with a null entry when there's no component of a given type

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -381,8 +381,8 @@
 	if(!dc)
 		return null
 	. = dc[c_type]
-	if(. && !length(.))
-		return list(.)
+	if(!length(.))
+		return . ? list(.) : list()
 
 /**
  * Creates an instance of `new_type` in the datum and attaches to it as parent

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -381,7 +381,7 @@
 	if(!dc)
 		return null
 	. = dc[c_type]
-	if(!length(.))
+	if(. && !length(.))
 		return list(.)
 
 /**
@@ -450,7 +450,7 @@
 		arguments[1] = new_comp
 		var/make_new_component = TRUE
 		for(var/datum/component/existing_component as anything in GetComponents(new_type))
-			if(existing_component?.CheckDupeComponent(arglist(arguments)))
+			if(existing_component.CheckDupeComponent(arglist(arguments)))
 				make_new_component = FALSE
 				QDEL_NULL(new_comp)
 				break

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -377,12 +377,10 @@
  * * c_type The component type path
  */
 /datum/proc/GetComponents(c_type)
-	var/list/dc = datum_components
-	if(!dc)
-		return null
-	. = dc[c_type]
-	if(!length(.))
-		return . ? list(.) : list()
+	var/list/components = datum_components?[c_type]
+	if(!components)
+		return list()
+	return islist(components) ? dc : list(components)
 
 /**
  * Creates an instance of `new_type` in the datum and attaches to it as parent

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -380,7 +380,7 @@
 	var/list/components = datum_components?[c_type]
 	if(!components)
 		return list()
-	return islist(components) ? dc : list(components)
+	return islist(components) ? components : list(components)
 
 /**
  * Creates an instance of `new_type` in the datum and attaches to it as parent

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -450,7 +450,7 @@
 		arguments[1] = new_comp
 		var/make_new_component = TRUE
 		for(var/datum/component/existing_component as anything in GetComponents(new_type))
-			if(existing_component.CheckDupeComponent(arglist(arguments)))
+			if(existing_component?.CheckDupeComponent(arglist(arguments)))
 				make_new_component = FALSE
 				QDEL_NULL(new_comp)
 				break

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -242,12 +242,9 @@
 					var/obj/machinery/duct/duct = A
 					duct.attempt_connect()
 				else
-					for(var/plumber in A.GetComponents(/datum/component/plumbing))
-						if(!plumber) //apparently yes it will be null hahahaasahsdvashufv
-							continue
-						var/datum/component/plumbing/plumb = plumber
-						if(plumb && plumb.ducting_layer == ducting_layer)
-							direct_connect(plumb, D)
+					for(var/datum/component/plumbing/plumber as anything in A.GetComponents(/datum/component/plumbing))
+						if(plumber.ducting_layer == ducting_layer)
+							direct_connect(plumber, D)
 
 /// Toggle our machinery on or off. This is called by a hook from default_unfasten_wrench with anchored as only param, so we dont have to copypaste this on every object that can move
 /datum/component/plumbing/proc/toggle_active(obj/O, new_state)

--- a/code/modules/plumbing/ducts.dm
+++ b/code/modules/plumbing/ducts.dm
@@ -70,11 +70,8 @@ All the important duct code:
 /obj/machinery/duct/proc/attempt_connect()
 
 	for(var/atom/movable/AM in loc)
-		for(var/plumber in AM.GetComponents(/datum/component/plumbing))
-			if(!plumber) //apparently yes it will be null hahahaasahsdvashufv
-				continue
-			var/datum/component/plumbing/plumb = plumber
-			if(plumb.active)
+		for(var/datum/component/plumbing/plumber as anything in AM.GetComponents(/datum/component/plumbing))
+			if(plumber.active)
 				disconnect_duct() //let's not built under plumbing machinery
 				return
 
@@ -91,9 +88,7 @@ All the important duct code:
 	if(istype(AM, /obj/machinery/duct))
 		return connect_duct(AM, direction, ignore_color)
 
-	for(var/plumber in AM.GetComponents(/datum/component/plumbing))
-		if(!plumber) //apparently yes it will be null hahahaasahsdvashufv
-			continue
+	for(var/datum/component/plumbing/plumber as anything in AM.GetComponents(/datum/component/plumbing))
 		. += connect_plumber(plumber, direction) //so that if one is true, all is true. beautiful.
 
 ///connect to a duct


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
This can cause runtimes. The lists should only contains instances of a specific component type.

## Changelog
N/A.