### PR TITLE
Fixes window opacity when repainting bug

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -305,9 +305,8 @@
 	air_update_turf(TRUE, FALSE)
 	add_fingerprint(user)
 
-/obj/structure/window/proc/on_painted(is_dark_color)
+/obj/structure/window/proc/on_painted(obj/structure/window, is_dark_color)
 	SIGNAL_HANDLER
-
 	if (is_dark_color && fulltile) //Opaque directional windows restrict vision even in directions they are not placed in, please don't do this
 		set_opacity(255)
 	else

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -305,7 +305,7 @@
 	air_update_turf(TRUE, FALSE)
 	add_fingerprint(user)
 
-/obj/structure/window/proc/on_painted(obj/structure/window, is_dark_color)
+/obj/structure/window/proc/on_painted(obj/structure/window/source, is_dark_color)
 	SIGNAL_HANDLER
 	if (is_dark_color && fulltile) //Opaque directional windows restrict vision even in directions they are not placed in, please don't do this
 		set_opacity(255)


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/61251

## Why It's Good For The Game
Repainting a black full tile window to a lighter color should remove its opacity

## Changelog
:cl:
fix: Full tile windows that have become opaque from being painted a dark color will now lose their opacity when repainted with a light enough color
/:cl: