### PR TITLE
Disables wrenching on money bot and scanner gate shells when they are locked

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -1398,6 +1398,9 @@
 /// Called when the integrated circuit's shell is set.
 #define COMSIG_CIRCUIT_SET_SHELL "circuit_set_shell"
 
+/// Called when the integrated circuit's is locked.
+#define COMSIG_CIRCUIT_SET_LOCKED "circuit_set_locked"
+
 /// Sent to an atom when a [/obj/item/usb_cable] attempts to connect to something. (/obj/item/usb_cable/usb_cable, /mob/user)
 #define COMSIG_ATOM_USB_CABLE_TRY_ATTACH "usb_cable_try_attach"
 	/// Attaches the USB cable to the atom. If the USB cables moves away, it will disconnect.

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -185,7 +185,7 @@
 /// Sets whether the shell is locked or not
 /datum/component/shell/proc/set_locked(new_value)
 	locked = new_value
-	attached_circuit?.locked = locked
+	attached_circuit?.set_locked(new_value)
 
 
 /datum/component/shell/proc/on_multitool_act(atom/source, mob/user, obj/item/tool)
@@ -270,7 +270,7 @@
 	attached_circuit.set_shell(parent_atom)
 	if(attached_circuit.display_name != "")
 		parent_atom.name = "[initial(parent_atom.name)] ([attached_circuit.display_name])"
-	attached_circuit.locked = FALSE
+	attached_circuit.set_locked(FALSE)
 
 	if(shell_flags & SHELL_FLAG_REQUIRE_ANCHOR)
 		attached_circuit.on = parent_atom.anchored
@@ -296,7 +296,7 @@
 	for(var/obj/item/circuit_component/to_remove as anything in unremovable_circuit_components)
 		attached_circuit.remove_component(to_remove)
 		to_remove.moveToNullspace()
-	attached_circuit.locked = FALSE
+	attached_circuit.set_locked(FALSE)
 	attached_circuit = null
 
 /datum/component/shell/proc/on_atom_usb_cable_try_attach(atom/source, obj/item/usb_cable/usb_cable, mob/user)

--- a/code/modules/wiremod/core/integrated_circuit.dm
+++ b/code/modules/wiremod/core/integrated_circuit.dm
@@ -104,6 +104,10 @@ GLOBAL_LIST_EMPTY_TYPED(integrated_circuits, /obj/item/integrated_circuit)
 	SEND_SIGNAL(src, COMSIG_CIRCUIT_SET_CELL, cell_to_set)
 	cell = cell_to_set
 
+/obj/item/integrated_circuit/proc/set_locked(new_value)
+	SEND_SIGNAL(src, COMSIG_CIRCUIT_SET_LOCKED, new_value)
+	locked = new_value
+
 /obj/item/integrated_circuit/attackby(obj/item/I, mob/living/user, params)
 	. = ..()
 	if(istype(I, /obj/item/circuit_component))

--- a/code/modules/wiremod/core/integrated_circuit.dm
+++ b/code/modules/wiremod/core/integrated_circuit.dm
@@ -100,10 +100,22 @@ GLOBAL_LIST_EMPTY_TYPED(integrated_circuits, /obj/item/integrated_circuit)
 	else
 		. += span_notice("There is no power cell installed.")
 
+/**
+ * Sets the cell of the integrated circuit.
+ *
+ * Arguments:
+ * * cell_to_set - The new cell of the circuit. Can be null.
+ **/
 /obj/item/integrated_circuit/proc/set_cell(obj/item/stock_parts/cell_to_set)
 	SEND_SIGNAL(src, COMSIG_CIRCUIT_SET_CELL, cell_to_set)
 	cell = cell_to_set
 
+/**
+ * Sets the locked status of the integrated circuit.
+ *
+ * Arguments:
+ * * new_value - A boolean that determines if the circuit is locked or not.
+ **/
 /obj/item/integrated_circuit/proc/set_locked(new_value)
 	SEND_SIGNAL(src, COMSIG_CIRCUIT_SET_LOCKED, new_value)
 	locked = new_value
@@ -174,6 +186,12 @@ GLOBAL_LIST_EMPTY_TYPED(integrated_circuits, /obj/item/integrated_circuit)
 	set_on(FALSE)
 	SEND_SIGNAL(src, COMSIG_CIRCUIT_SHELL_REMOVED)
 
+/**
+ * Sets the on status of the integrated circuit.
+ *
+ * Arguments:
+ * * new_value - A boolean that determines if the circuit is on or not.
+ **/
 /obj/item/integrated_circuit/proc/set_on(new_value)
 	SEND_SIGNAL(src, COMSIG_CIRCUIT_SET_ON, new_value)
 	on = new_value

--- a/code/modules/wiremod/shell/moneybot.dm
+++ b/code/modules/wiremod/shell/moneybot.dm
@@ -13,6 +13,7 @@
 	light_on = FALSE
 
 	var/stored_money = 0
+	var/locked = FALSE
 
 /obj/structure/money_bot/deconstruct(disassembled)
 	new /obj/item/holochip(drop_location(), stored_money)
@@ -30,6 +31,8 @@
 	), SHELL_CAPACITY_LARGE)
 
 /obj/structure/money_bot/wrench_act(mob/living/user, obj/item/tool)
+	if(locked)
+		return
 	set_anchored(!anchored)
 	tool.play_tool_sound(src)
 	balloon_alert(user, "You [anchored?"secure":"unsecure"] [src].")
@@ -102,6 +105,8 @@
 		total_money.set_output(attached_bot.stored_money)
 		RegisterSignal(shell, COMSIG_PARENT_ATTACKBY, .proc/handle_money_insert)
 		RegisterSignal(shell, COMSIG_MONEYBOT_ADD_MONEY, .proc/handle_money_update)
+		RegisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED, .proc/on_set_locked)
+		attached_bot.locked = parent.locked
 
 /obj/item/circuit_component/money_bot/unregister_shell(atom/movable/shell)
 	UnregisterSignal(shell, list(
@@ -109,6 +114,9 @@
 		COMSIG_MONEYBOT_ADD_MONEY,
 	))
 	total_money.set_output(null)
+	if(attached_bot)
+		attached_bot.locked = FALSE
+		UnregisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED)
 	attached_bot = null
 	return ..()
 
@@ -133,3 +141,6 @@
 	SIGNAL_HANDLER
 	if(attached_bot)
 		total_money.set_output(attached_bot.stored_money)
+
+/obj/item/circuit_component/money_bot/proc/on_set_locked(datum/source, new_value)
+	attached_bot.locked = new_value

--- a/code/modules/wiremod/shell/moneybot.dm
+++ b/code/modules/wiremod/shell/moneybot.dm
@@ -142,5 +142,11 @@
 	if(attached_bot)
 		total_money.set_output(attached_bot.stored_money)
 
+/**
+ * Locks the attached bot when the circuit is locked.
+ *
+ * Arguments:
+ * * new_value - A boolean that determines if the circuit is locked or not.
+ **/
 /obj/item/circuit_component/money_bot/proc/on_set_locked(datum/source, new_value)
 	attached_bot.locked = new_value

--- a/code/modules/wiremod/shell/scanner_gate.dm
+++ b/code/modules/wiremod/shell/scanner_gate.dm
@@ -73,5 +73,11 @@
 	scanned.set_output(passed)
 	trigger_output.set_output(COMPONENT_SIGNAL)
 
+/**
+ * Locks the attached bot when the circuit is locked.
+ *
+ * Arguments:
+ * * new_value - A boolean that determines if the circuit is locked or not.
+ **/
 /obj/item/circuit_component/scanner_gate/proc/on_set_locked(datum/source, new_value)
 	attached_gate.locked = new_value

--- a/code/modules/wiremod/shell/scanner_gate.dm
+++ b/code/modules/wiremod/shell/scanner_gate.dm
@@ -5,6 +5,8 @@
 	icon_state = "scangate_black"
 	var/scanline_timer
 
+	var/locked = FALSE
+
 /obj/structure/scanner_gate_shell/Initialize()
 	. = ..()
 	set_scanline("passive")
@@ -18,6 +20,8 @@
 	), SHELL_CAPACITY_LARGE, SHELL_FLAG_REQUIRE_ANCHOR)
 
 /obj/structure/scanner_gate_shell/wrench_act(mob/living/user, obj/item/tool)
+	if(locked)
+		return
 	set_anchored(!anchored)
 	tool.play_tool_sound(src)
 	balloon_alert(user, "You [anchored?"secure":"unsecure"] [src].")
@@ -53,9 +57,14 @@
 	if(istype(shell, /obj/structure/scanner_gate_shell))
 		attached_gate = shell
 		RegisterSignal(attached_gate, COMSIG_SCANGATE_SHELL_PASS, .proc/on_trigger)
+		RegisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED, .proc/on_set_locked)
+		attached_gate.locked = parent.locked
 
 /obj/item/circuit_component/scanner_gate/unregister_shell(atom/movable/shell)
 	UnregisterSignal(attached_gate, COMSIG_SCANGATE_SHELL_PASS)
+	if(attached_gate)
+		attached_gate.locked = FALSE
+		UnregisterSignal(parent, COMSIG_CIRCUIT_SET_LOCKED)
 	attached_gate = null
 	return ..()
 
@@ -63,3 +72,6 @@
 	SIGNAL_HANDLER
 	scanned.set_output(passed)
 	trigger_output.set_output(COMPONENT_SIGNAL)
+
+/obj/item/circuit_component/scanner_gate/proc/on_set_locked(datum/source, new_value)
+	attached_gate.locked = new_value


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Disables wrenching on money bot and scanner gate shells when they are locked

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Prevents people from just unwrenching a moneybot or a scanner gate and running off with it when it is locked.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Disables wrenching on money bot and scannter gate shells when they are locked.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
