### PR TITLE
Autolathe fixes: screwdrivers are recyclable, no inserting mats with an open maint panel

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -282,7 +282,7 @@
 		balloon_alert(user, "close the panel first!")
 		return FALSE
 
-	return ..()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/autolathe/proc/AfterMaterialInsert(obj/item/item_inserted, id_inserted, amount_inserted)
 	if(istype(item_inserted, /obj/item/stack/ore/bluespace_crystal))

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -267,12 +267,12 @@
 
 	return ..()
 
-/obj/machinery/autolathe/attackby_secondary(obj/item/O, mob/living/user, params)
+/obj/machinery/autolathe/attackby_secondary(obj/item/weapon, mob/living/user, params)
 	if (busy)
 		to_chat(user, "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>")
 		return TRUE
 
-	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
+	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", weapon))
 		return FALSE //returning this as FALSE prevents the screwdriver from being immediately eaten by the autolathe after you screw the panel open/closed. why? don't ask me
 
 	if(machine_stat)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -177,7 +177,7 @@
 
 			var/multiplier = text2num(params["multiplier"])
 			if(!multiplier)
-				to_chat(usr, "<span class=\"alert\">[src] only accepts a numerical multiplier!</span>")
+				to_chat(usr, span_alert("[src] only accepts a numerical multiplier!"))
 				return
 			var/is_stack = ispath(being_built.build_path, /obj/item/stack)
 			multiplier = clamp(round(multiplier),1,50)
@@ -215,24 +215,24 @@
 
 			if(materials.has_materials(materials_used))
 				busy = TRUE
-				to_chat(usr, "<span class=\"notice\">You print [multiplier] item(s) from the [src]</span>")
+				to_chat(usr, span_notice("You print [multiplier] item(s) from the [src]"))
 				use_power(power)
 				icon_state = "autolathe_n"
 				var/time = is_stack ? 32 : (32 * coeff * multiplier) ** 0.8
 				addtimer(CALLBACK(src, .proc/make_item, power, materials_used, custom_materials, multiplier, coeff, is_stack, usr), time)
 				. = TRUE
 			else
-				to_chat(usr, "<span class=\"alert\">Not enough materials for this operation.</span>")
+				to_chat(usr, span_alert("Not enough materials for this operation."))
 		else
-			to_chat(usr, "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>")
+			to_chat(usr, span_alert("The autolathe is busy. Please wait for completion of previous operation."))
 
 /obj/machinery/autolathe/on_deconstruction()
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 	materials.retrieve_all()
 
 /obj/machinery/autolathe/attackby(obj/item/O, mob/living/user, params)
-	if (busy)
-		to_chat(user, "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>")
+	if(busy)
+		balloon_alert(user, "it's busy!")
 		return TRUE
 
 	if(default_deconstruction_crowbar(O))
@@ -250,7 +250,7 @@
 
 	if(istype(O, /obj/item/disk/design_disk))
 		user.visible_message(span_notice("[user] begins to load \the [O] in \the [src]..."),
-			span_notice("You begin to load a design from \the [O]..."),
+			balloon_alert(user, "uploading design..."),
 			span_hear("You hear the chatter of a floppy drive."))
 		busy = TRUE
 		var/obj/item/disk/design_disk/D = O
@@ -268,8 +268,8 @@
 	return ..()
 
 /obj/machinery/autolathe/attackby_secondary(obj/item/O, mob/living/user, params)
-	if (busy)
-		to_chat(user, "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>")
+	if(busy)
+		balloon_alert(user, "it's busy!")
 		return TRUE
 
 	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -262,7 +262,7 @@
 		return TRUE
 
 	if(panel_open)
-		balloon_alert(user, "panel is open!")
+		balloon_alert(user, "close the panel first!")
 		return FALSE
 
 	return ..()
@@ -273,13 +273,13 @@
 		return TRUE
 
 	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
-		return FALSE
+		return FALSE //returning this as FALSE prevents the screwdriver from being immediately eaten by the autolathe after you screw the panel open/closed. why? don't ask me
 
 	if(machine_stat)
 		return TRUE
 
 	if(panel_open)
-		balloon_alert(user, "panel is open!")
+		balloon_alert(user, "close the panel first!")
 		return FALSE
 
 	return ..()

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -239,9 +239,6 @@
 		to_chat(user, "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>")
 		return TRUE
 
-	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
-		return TRUE
-
 	if(default_deconstruction_crowbar(O))
 		return TRUE
 
@@ -268,8 +265,28 @@
 		busy = FALSE
 		return TRUE
 
+	if(panel_open)
+		balloon_alert(user, "panel is open!")
+		return FALSE
+
 	return ..()
 
+/obj/machinery/autolathe/attackby_secondary(obj/item/O, mob/living/user, params)
+	if (busy)
+		to_chat(user, "<span class=\"alert\">The autolathe is busy. Please wait for completion of previous operation.</span>")
+		return TRUE
+
+	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
+		return FALSE
+
+	if(machine_stat)
+		return TRUE
+
+	if(panel_open)
+		balloon_alert(user, "panel is open!")
+		return FALSE
+
+	return ..()
 
 /obj/machinery/autolathe/proc/AfterMaterialInsert(obj/item/item_inserted, id_inserted, amount_inserted)
 	if(istype(item_inserted, /obj/item/stack/ore/bluespace_crystal))

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -267,12 +267,12 @@
 
 	return ..()
 
-/obj/machinery/autolathe/attackby_secondary(obj/item/O, mob/living/user, params)
+/obj/machinery/autolathe/attackby_secondary(obj/item/weapon, mob/living/user, params)
 	if(busy)
 		balloon_alert(user, "it's busy!")
 		return TRUE
 
-	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
+	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", weapon))
 		return FALSE //returning this as FALSE prevents the screwdriver from being immediately eaten by the autolathe after you screw the panel open/closed. why? don't ask me
 
 	if(machine_stat)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -1,7 +1,3 @@
-#define AUTOLATHE_MAIN_MENU 1
-#define AUTOLATHE_CATEGORY_MENU 2
-#define AUTOLATHE_SEARCH_MENU 3
-
 /obj/machinery/autolathe
 	name = "autolathe"
 	desc = "It produces items using iron and glass."


### PR DESCRIPTION
## About The Pull Request
Screwdrivers are now recyclable in the autolathe. Moves screwdrivering the maintenance panel to right click instead.
Fixes being able to feed the autolathe while the maintenance panel is open. (if this is a feature (which i'm fairly certain it's not since i remember not being able to put things into the machine with the panel open) then we need sprites to support the feeding animation with the panel open). Trying to feed the machine with its panel open now produces a balloon message that points out the panel and its open state.
Kills off three defines made obsolete by the #60800.

## Why It's Good For The Game
Not being able to recycle all those surplus screwdrivers has been a thing for ages and it doesn't really make sense. 

## Changelog
:cl:
fix: Fixes screwdrivers not being recycle-friendly in the autolathe.
qol: Moves screwdrivering an autolathe's maintenance panel open to right click.
fix: Fixes being able to feed the autolathe when its maintenance panel is open.
/:cl:
