### PR TITLE
adds logging for all canisters opened, logs all gases in spooky gas cans too

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -182,6 +182,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	id = "freon"
 	specific_heat = 600
 	name = "Freon"
+	dangerous = TRUE
 	gas_overlay = "freon"
 	moles_visible = MOLES_GAS_VISIBLE *30
 	fusion_power = -5

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -72,6 +72,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	id = "co2"
 	specific_heat = 30
 	name = "Carbon Dioxide"
+	dangerous = TRUE
 	rarity = 700
 	purchaseable = TRUE
 	base_value = 0.2
@@ -171,6 +172,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 	id = "miasma"
 	specific_heat = 20
 	name = "Miasma"
+	dangerous = TRUE
 	gas_overlay = "miasma"
 	moles_visible = MOLES_GAS_VISIBLE * 60
 	rarity = 250

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -677,26 +677,24 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 				SSair.start_processing_machine(src)
 				logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into \the [holding || "air"].<br>"
 				if(!holding)
-					//list for logging all gases in canister
-					var/list/gaseslog = list()
+					var/list/gaseslog = list() //list for logging all gases in canister
 					for(var/id in air_contents.gases)
 						var/gas = air_contents.gases[id]
-						gaseslog[gas[GAS_META][META_GAS_NAME]] = gas[MOLES]
+						gaseslog[gas[GAS_META][META_GAS_NAME]] = gas[MOLES]	//adds gases to gaseslog
 						if(!gas[GAS_META][META_GAS_DANGER])
 							continue
 						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_GAS_VISIBLE)) //if moles_visible is undefined, default to default visibility
-							danger = TRUE //at least 1 danger gas in there
-					//logging messages + paths
+							danger = TRUE //at least 1 danger gas
 					logmsg = "[key_name(usr)] <b>opened</b> a canister that contains the following:"
 					admin_msg = "[key_name(usr)] <b>opened</b> a canister that contains the following at [ADMIN_VERBOSEJMP(src)]:"
 					for(var/name in gaseslog)
 						n = n + 1
-						logmsg+= "\n[name]: [gaseslog[name]] moles."
-						if(n <= 5)
-							admin_msg+= "\n[name]: [gaseslog[name]] moles."
-						if(n == 5 && gaseslog.len > 5)
-							admin_msg+= "\nToo many gases to log. Check investigate log."
-					if(danger)
+						logmsg += "\n[name]: [gaseslog[name]] moles."
+						if(n <= 5) //the first five gases added
+							admin_msg += "\n[name]: [gaseslog[name]] moles."
+						if(n == 5 && gaseslog.len > 5) //message added if more than 5 gases
+							admin_msg += "\nToo many gases to log. Check investigate log."
+					if(danger) //sent to admin's chat if contains dangerous gases
 						message_admins(admin_msg)
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into \the [holding || "air"].<br>"

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -686,6 +686,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 							continue
 						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_GAS_VISIBLE)) //if moles_visible is undefined, default to default visibility
 							danger = TRUE //at least 1 danger gas in there
+					//logging messages + paths
 					logmsg = "[key_name(usr)] <b>opened</b> a canister that contains the following:"
 					admin_msg = "[key_name(usr)] <b>opened</b> a canister that contains the following at [ADMIN_VERBOSEJMP(src)]:"
 					for(var/name in gaseslog)
@@ -693,11 +694,8 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 						logmsg+= "\n[name]: [gaseslog[name]] moles."
 						if(danger && n <= 5)
 							admin_msg+= "\n[name]: [gaseslog[name]] moles."
-
 						if(n == 5 && danger)
-							message_admins(admin_msg)
-							message_admins("Too many gases to log. Check investigate.")
-				if(danger && n <= 5)
+							admin_msg+= "\nToo many gases to log. Check investigate log."
 					message_admins(admin_msg)
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into \the [holding || "air"].<br>"

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -675,7 +675,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 				logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into \the [holding || "air"].<br>"
 				if(!holding)
 					var/list/danger = list()
-					///list for logging all gases in canister
+					//list for logging all gases in canister
 					var/list/gaseslog = list()		
 					for(var/id in air_contents.gases)
 						var/gas = air_contents.gases[id]
@@ -684,12 +684,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 							continue
 						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_GAS_VISIBLE)) //if moles_visible is undefined, default to default visibility
 							danger[gas[GAS_META][META_GAS_NAME]] = gas[MOLES] //ex. "plasma" = 20
-					/**
-					* just works better to use danger
-					* list as a test for admin alerts
-					*/
-					///alert + log path
-					///end of loop counter var
+					//end of loop counter var
 					var/n = 0
 					if(danger)
 						message_admins("[ADMIN_LOOKUPFLW(usr)] opened a canister that contains the following at [ADMIN_VERBOSEJMP(src)]:")

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -693,12 +693,12 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 					var/n = 0
 					if(danger)
 						message_admins("[ADMIN_LOOKUPFLW(usr)] opened a canister that contains the following at [ADMIN_VERBOSEJMP(src)]:")
-					msg = "[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
+					var/msg = "[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:"
 					investigate_log(msg, INVESTIGATE_ATMOS)
 					for(var/name in gaseslog)
 						if(!isnull(name))
 							n = n + 1
-							var/msg = "[name]: [gaseslog[name]] moles."
+							msg = "[name]: [gaseslog[name]] moles."
 							investigate_log(msg, INVESTIGATE_ATMOS)
 							if(danger)
 								message_admins(msg)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -689,19 +689,23 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 					* list as a test for admin alerts
 					*/
 					///alert + log path
-					if(danger.len)
+					///end of loop counter var
+					var/n = 0
+					if(danger)
 						message_admins("[ADMIN_LOOKUPFLW(usr)] opened a canister that contains the following at [ADMIN_VERBOSEJMP(src)]:")
-						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
-						for(var/name in gaseslog)
+					msg = "[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
+					investigate_log(msg, INVESTIGATE_ATMOS)
+					for(var/name in gaseslog)
+						if(!isnull(name))
+							n = n + 1
 							var/msg = "[name]: [gaseslog[name]] moles."
-							log_admin(msg)
-							message_admins(msg)
-					///just logging, no alert
-					else
-						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
-						for(var/name in gaseslog)
-							var/msg = "[name]: [gaseslog[name]] moles."
-							log_admin(msg)
+							investigate_log(msg, INVESTIGATE_ATMOS)
+							if(danger)
+								message_admins(msg)
+							if(n == 5)
+								break
+					if(gaseslog.len > 5)
+						message_admins("Too many gases to log.")
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into \the [holding || "air"].<br>"
 			investigate_log(logmsg, INVESTIGATE_ATMOS)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -694,7 +694,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 						logmsg+= "\n[name]: [gaseslog[name]] moles."
 						if(danger && n <= 5)
 							admin_msg+= "\n[name]: [gaseslog[name]] moles."
-						if(n == 5 && danger)
+						if(n == 5 && danger && gaseslog.len > 5)
 							admin_msg+= "\nToo many gases to log. Check investigate log."
 					message_admins(admin_msg)
 			else

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -692,11 +692,12 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 					for(var/name in gaseslog)
 						n = n + 1
 						logmsg+= "\n[name]: [gaseslog[name]] moles."
-						if(danger && n <= 5)
+						if(n <= 5)
 							admin_msg+= "\n[name]: [gaseslog[name]] moles."
-						if(n == 5 && danger && gaseslog.len > 5)
+						if(n == 5 && gaseslog.len > 5)
 							admin_msg+= "\nToo many gases to log. Check investigate log."
-					message_admins(admin_msg)
+					if(danger)
+						message_admins(admin_msg)
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into \the [holding || "air"].<br>"
 			investigate_log(logmsg, INVESTIGATE_ATMOS)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -678,7 +678,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 					var/list/gaseslog = list()
 					for(var/id in air_contents.gases)
 						var/gas = air_contents.gases[id]
-						gaseslog[gas[GAS_META][META_GAS_NAME]] = gas[moles] //this may be the logging mechanism
+						gaseslog[gas[GAS_META][META_GAS_NAME]] = gas[MOLES] //this may be the logging mechanism also i didnt capitalize right lol
 						if(!gas[GAS_META][META_GAS_DANGER])
 							continue
 						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_GAS_VISIBLE)) //if moles_visible is undefined, default to default visibility

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -695,8 +695,8 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 							message_admins(msg)
 					else
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
-						for(var/name in GLOBAL_LIST_INIT)
-							var/msg = "[name]: [gaseslog[name]] moles."
+						for(var/name in gaseslog)
+							var/msg = "[name]: [gaseslog[name]] moles." //owo shrug
 							log_admin(msg)
 							message_admins(msg)
 			else

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -684,17 +684,17 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_GAS_VISIBLE)) //if moles_visible is undefined, default to default visibility
 							danger[gas[GAS_META][META_GAS_NAME]] = gas[MOLES] //ex. "plasma" = 20
 							
-/*alerting + log*/ 	if(danger.len)		
+/**alert + log*/	if(danger.len)		
 						message_admins("[ADMIN_LOOKUPFLW(usr)] opened a canister that contains the following at [ADMIN_VERBOSEJMP(src)]:")
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
 						for(var/name in gaseslog)
-/*just works better	*/   	var/msg = "[name]: [gaseslog[name]] moles." 
-/*to use danger		*/ 		log_admin(msg)										
-/*list as a test	*/ 		message_admins(msg)			
-/*for admin alerts	*/ 			
-/*instead of 	*/ 	else	//just logging, no alert
-/*logging when we 	*/	log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
-/*log all gas		*/	for(var/name in gaseslog)
+/**just works better*/   	var/msg = "[name]: [gaseslog[name]] moles." 
+/**to use danger	*/ 		log_admin(msg)										
+/**list as a test	*/ 		message_admins(msg)			
+/**for admin alerts	*/ 			
+				 	else	//just logging, no alert
+						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
+						for(var/name in gaseslog)
 							var/msg = "[name]: [gaseslog[name]] moles." 
 							log_admin(msg)
 			else

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -675,12 +675,16 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 				logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into \the [holding || "air"].<br>"
 				if(!holding)
 					var/list/danger = list()
+					var/list/gaseslog = list()
 					for(var/id in air_contents.gases)
 						var/gas = air_contents.gases[id]
+						gaseslog[gas][GAS_META][META_GAS_NAME]] = gas[moles]//this may be the loggin mechanism
 						if(!gas[GAS_META][META_GAS_DANGER])
 							continue
 						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_GAS_VISIBLE)) //if moles_visible is undefined, default to default visibility
 							danger[gas[GAS_META][META_GAS_NAME]] = gas[MOLES] //ex. "plasma" = 20
+							
+						
 
 					if(danger.len)
 						message_admins("[ADMIN_LOOKUPFLW(usr)] opened a canister that contains the following at [ADMIN_VERBOSEJMP(src)]:")
@@ -692,7 +696,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 					else
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
 						for(var/name in GLOBAL_LIST_INIT)
-							var/msg = "[name]: [GLOBAL_LIST_INIT[name]] moles."
+							var/msg = "[name]: [gaseslog[name]] moles."
 							log_admin(msg)
 							message_admins(msg)
 			else

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -667,7 +667,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 			if(.)
 				release_pressure = clamp(round(pressure), can_min_release_pressure, can_max_release_pressure)
 				investigate_log("was set to [release_pressure] kPa by [key_name(usr)].", INVESTIGATE_ATMOS)
-		if("valve")
+		if("valve")		//logging for openning canisters
 			var/logmsg
 			valve_open = !valve_open
 			if(valve_open)
@@ -675,25 +675,24 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 				logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into \the [holding || "air"].<br>"
 				if(!holding)
 					var/list/danger = list()
-					var/list/gaseslog = list()
+					var/list/gaseslog = list()		//list for logging all gases in canister
 					for(var/id in air_contents.gases)
 						var/gas = air_contents.gases[id]
-						gaseslog[gas[GAS_META][META_GAS_NAME]] = gas[MOLES] //this may be the logging mechanism also i didnt capitalize right lol
+						gaseslog[gas[GAS_META][META_GAS_NAME]] = gas[MOLES] 
 						if(!gas[GAS_META][META_GAS_DANGER])
 							continue
 						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_GAS_VISIBLE)) //if moles_visible is undefined, default to default visibility
 							danger[gas[GAS_META][META_GAS_NAME]] = gas[MOLES] //ex. "plasma" = 20
 							
-						
-
-					if(danger.len)
+					if(danger.len)		//alerting and logging
 						message_admins("[ADMIN_LOOKUPFLW(usr)] opened a canister that contains the following at [ADMIN_VERBOSEJMP(src)]:")
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
-						for(var/name in danger)
-							var/msg = "[name]: [danger[name]] moles."
+						for(var/name in gaseslog)
+							var/msg = "[name]: [gaseslog[name]] moles." //just works better to use danger list as a test for admin alerts instead of logging
+																		//when we log everything
 							log_admin(msg)
 							message_admins(msg)
-					else
+					else				//just logging for admin path
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
 						for(var/name in gaseslog)
 							var/msg = "[name]: [gaseslog[name]] moles." //owo shrug

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -688,7 +688,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
  * just works better to use danger	
  * list as a test for admin alerts
  */ 
- 					///alert + log path
+					///alert + log path
 					if(danger.len)	
 						message_admins("[ADMIN_LOOKUPFLW(usr)] opened a canister that contains the following at [ADMIN_VERBOSEJMP(src)]:")
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
@@ -697,7 +697,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 							log_admin(msg)										 		
 							message_admins(msg)		
 					///just logging, no alert	
-				 	else	
+					else	
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
 						for(var/name in gaseslog)
 							var/msg = "[name]: [gaseslog[name]] moles." 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -675,7 +675,8 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 				logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting a transfer into \the [holding || "air"].<br>"
 				if(!holding)
 					var/list/danger = list()
-					var/list/gaseslog = list()		//list for logging all gases in canister
+					///list for logging all gases in canister
+					var/list/gaseslog = list()		
 					for(var/id in air_contents.gases)
 						var/gas = air_contents.gases[id]
 						gaseslog[gas[GAS_META][META_GAS_NAME]] = gas[MOLES] 
@@ -683,16 +684,20 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 							continue
 						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_GAS_VISIBLE)) //if moles_visible is undefined, default to default visibility
 							danger[gas[GAS_META][META_GAS_NAME]] = gas[MOLES] //ex. "plasma" = 20
-							
-/**alert + log*/	if(danger.len)		
+/**
+ * just works better to use danger	
+ * list as a test for admin alerts
+ */ 
+ 					///alert + log path
+					if(danger.len)	
 						message_admins("[ADMIN_LOOKUPFLW(usr)] opened a canister that contains the following at [ADMIN_VERBOSEJMP(src)]:")
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
-						for(var/name in gaseslog)
-/**just works better*/   	var/msg = "[name]: [gaseslog[name]] moles." 
-/**to use danger	*/ 		log_admin(msg)										
-/**list as a test	*/ 		message_admins(msg)			
-/**for admin alerts	*/ 			
-				 	else	//just logging, no alert
+						for(var/name in gaseslog)   	
+							var/msg = "[name]: [gaseslog[name]] moles."  		
+							log_admin(msg)										 		
+							message_admins(msg)		
+					///just logging, no alert	
+				 	else	
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
 						for(var/name in gaseslog)
 							var/msg = "[name]: [gaseslog[name]] moles." 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -691,6 +691,10 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 							message_admins(msg)
 					else
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
+						for(var/name in GLOBAL_LIST_INIT)
+							var/msg = "[name]: [GLOBAL_LIST_INIT[name]] moles."
+							log_admin(msg)
+							message_admins(msg)
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into \the [holding || "air"].<br>"
 			investigate_log(logmsg, INVESTIGATE_ATMOS)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -678,7 +678,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 					var/list/gaseslog = list()
 					for(var/id in air_contents.gases)
 						var/gas = air_contents.gases[id]
-						gaseslog[gas][GAS_META][META_GAS_NAME]] = gas[moles]//this may be the loggin mechanism
+						gaseslog[gas[GAS_META][META_GAS_NAME]] = gas[moles] //this may be the logging mechanism
 						if(!gas[GAS_META][META_GAS_DANGER])
 							continue
 						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_GAS_VISIBLE)) //if moles_visible is undefined, default to default visibility

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -684,23 +684,23 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 							continue
 						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_GAS_VISIBLE)) //if moles_visible is undefined, default to default visibility
 							danger[gas[GAS_META][META_GAS_NAME]] = gas[MOLES] //ex. "plasma" = 20
-/**
- * just works better to use danger	
- * list as a test for admin alerts
- */ 
+					/**
+					* just works better to use danger
+					* list as a test for admin alerts
+					*/
 					///alert + log path
-					if(danger.len)	
+					if(danger.len)
 						message_admins("[ADMIN_LOOKUPFLW(usr)] opened a canister that contains the following at [ADMIN_VERBOSEJMP(src)]:")
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
-						for(var/name in gaseslog)   	
-							var/msg = "[name]: [gaseslog[name]] moles."  		
-							log_admin(msg)										 		
-							message_admins(msg)		
-					///just logging, no alert	
-					else	
+						for(var/name in gaseslog)
+							var/msg = "[name]: [gaseslog[name]] moles."
+							log_admin(msg)
+							message_admins(msg)
+					///just logging, no alert
+					else
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
 						for(var/name in gaseslog)
-							var/msg = "[name]: [gaseslog[name]] moles." 
+							var/msg = "[name]: [gaseslog[name]] moles."
 							log_admin(msg)
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into \the [holding || "air"].<br>"

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -684,18 +684,18 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 						if(gas[MOLES] > (gas[GAS_META][META_GAS_MOLES_VISIBLE] || MOLES_GAS_VISIBLE)) //if moles_visible is undefined, default to default visibility
 							danger[gas[GAS_META][META_GAS_NAME]] = gas[MOLES] //ex. "plasma" = 20
 							
-					if(danger.len)		//alerting and logging
+/*alerting + log*/ 	if(danger.len)		
 						message_admins("[ADMIN_LOOKUPFLW(usr)] opened a canister that contains the following at [ADMIN_VERBOSEJMP(src)]:")
 						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
 						for(var/name in gaseslog)
-							var/msg = "[name]: [gaseslog[name]] moles." //just works better to use danger list as a test for admin alerts instead of logging
-																		//when we log everything
-							log_admin(msg)
-							message_admins(msg)
-					else				//just logging for admin path
-						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
-						for(var/name in gaseslog)
-							var/msg = "[name]: [gaseslog[name]] moles." //owo shrug
+/*just works better	*/   	var/msg = "[name]: [gaseslog[name]] moles." 
+/*to use danger		*/ 		log_admin(msg)										
+/*list as a test	*/ 		message_admins(msg)			
+/*for admin alerts	*/ 			
+/*instead of 	*/ 	else	//just logging, no alert
+/*logging when we 	*/	log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
+/*log all gas		*/	for(var/name in gaseslog)
+							var/msg = "[name]: [gaseslog[name]] moles." 
 							log_admin(msg)
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into \the [holding || "air"].<br>"

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -689,6 +689,8 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 							var/msg = "[name]: [danger[name]] moles."
 							log_admin(msg)
 							message_admins(msg)
+					else
+						log_admin("[key_name(usr)] opened a canister that contains the following at [AREACOORD(src)]:")
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into \the [holding || "air"].<br>"
 			investigate_log(logmsg, INVESTIGATE_ATMOS)

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -698,7 +698,6 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 						for(var/name in gaseslog)
 							var/msg = "[name]: [gaseslog[name]] moles." //owo shrug
 							log_admin(msg)
-							message_admins(msg)
 			else
 				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into \the [holding || "air"].<br>"
 			investigate_log(logmsg, INVESTIGATE_ATMOS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
-adds freon, CO2, and miasma dangerous var
-adds logging for opening canisters in general
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
-adds logging for all canisters being opened and contained gases

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
admin: admins are now alerted when miasma, freon, and co2 canisters are opened, and are informed of the contents of canisters containing dangerous gases in general, not just the spooky gas on its own.  
code: added overall logging for all canisters opened
/:cl:
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
