### PR TITLE
Hypertorus: Permit waste remove toggling at power level 6

### DIFF
--- a/tgui/packages/tgui/interfaces/Hypertorus.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus.js
@@ -166,7 +166,6 @@ const HypertorusSecondaryControls = (props, context) => {
         <LabeledList>
           <LabeledList.Item label="Waste remove">
             <Button
-              disabled={data.power_level > 5}
               icon={data.waste_remove ? 'power-off' : 'times'}
               content={data.waste_remove ? 'On' : 'Off'}
               selected={data.waste_remove}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#61177 removed the backend restriction on waste removal, but did not update the frontend. This lets people toggle waste removal at power level 6 ~~without bookmagic~~.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

oh god not the href logging I can't go back

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The HFR interface now lets you toggle waste removal at power level 6, rather than merely having it permitted in the backend.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
