### PR TITLE
Reorder HFR fuel datums

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
@@ -79,7 +79,6 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	secondary_products = list(/datum/gas/helium, /datum/gas/plasma, /datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/bz, /datum/gas/hypernoblium)
 	meltdown_flags = HYPERTORUS_FLAG_BASE_EXPLOSION | HYPERTORUS_FLAG_RADIATION_PULSE | HYPERTORUS_FLAG_MEDIUM_SPREAD
 
-
 /datum/hfr_fuel/hydrogen_tritium_fuel
 	id = "h2_t2_fuel"
 	name = "Hydrogen + Tritium fuel"
@@ -93,7 +92,6 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	primary_products = list(/datum/gas/helium)
 	secondary_products = list(/datum/gas/helium, /datum/gas/plasma, /datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/bz, /datum/gas/hypernoblium)
 	meltdown_flags = HYPERTORUS_FLAG_MEDIUM_EXPLOSION | HYPERTORUS_FLAG_RADIATION_PULSE | HYPERTORUS_FLAG_EMP | HYPERTORUS_FLAG_MEDIUM_SPREAD
-
 
 /datum/hfr_fuel/hypernob_hydrogen_fuel
 	id = "hypernob_hydrogen_fuel"

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
@@ -37,19 +37,19 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	///Flags to decide what behaviour the meltdown will have depending on the fuel mix used
 	var/meltdown_flags = HYPERTORUS_FLAG_BASE_EXPLOSION
 
-/datum/hfr_fuel/hydrogen_tritium_fuel
-	id = "h2_t2_fuel"
-	name = "Hydrogen + Tritium fuel"
-	negative_temperature_multiplier = 1
-	positive_temperature_multiplier = 1
-	energy_concentration_multiplier = 1
-	fuel_consumption_multiplier = 1
-	gas_production_multiplier = 1
-	temperature_change_multiplier = 0.85
-	requirements = list(/datum/gas/hydrogen, /datum/gas/tritium)
-	primary_products = list(/datum/gas/helium)
-	secondary_products = list(/datum/gas/helium, /datum/gas/plasma, /datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/bz, /datum/gas/hypernoblium)
-	meltdown_flags = HYPERTORUS_FLAG_MEDIUM_EXPLOSION | HYPERTORUS_FLAG_RADIATION_PULSE | HYPERTORUS_FLAG_EMP | HYPERTORUS_FLAG_MEDIUM_SPREAD
+/datum/hfr_fuel/plasma_oxy_fuel
+	id = "plasma_o2_fuel"
+	name = "Plasma + Oxygen fuel"
+	negative_temperature_multiplier = 2.5
+	positive_temperature_multiplier = 0.1
+	energy_concentration_multiplier = 10
+	fuel_consumption_multiplier = 3.3
+	gas_production_multiplier = 1.4
+	temperature_change_multiplier = 0.6
+	requirements = list(/datum/gas/plasma, /datum/gas/oxygen)
+	primary_products = list(/datum/gas/carbon_dioxide, /datum/gas/water_vapor)
+	secondary_products = list(/datum/gas/carbon_dioxide, /datum/gas/water_vapor, /datum/gas/freon, /datum/gas/nitrous_oxide, /datum/gas/pluoxium, /datum/gas/halon)
+	meltdown_flags = HYPERTORUS_FLAG_BASE_EXPLOSION | HYPERTORUS_FLAG_MINIMUM_SPREAD
 
 /datum/hfr_fuel/hydrogen_oxy_fuel
 	id = "h2_o2_fuel"
@@ -79,19 +79,21 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	secondary_products = list(/datum/gas/helium, /datum/gas/plasma, /datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/bz, /datum/gas/hypernoblium)
 	meltdown_flags = HYPERTORUS_FLAG_BASE_EXPLOSION | HYPERTORUS_FLAG_RADIATION_PULSE | HYPERTORUS_FLAG_MEDIUM_SPREAD
 
-/datum/hfr_fuel/plasma_oxy_fuel
-	id = "plasma_o2_fuel"
-	name = "Plasma + Oxygen fuel"
-	negative_temperature_multiplier = 2.5
-	positive_temperature_multiplier = 0.1
-	energy_concentration_multiplier = 10
-	fuel_consumption_multiplier = 3.3
-	gas_production_multiplier = 1.4
-	temperature_change_multiplier = 0.6
-	requirements = list(/datum/gas/plasma, /datum/gas/oxygen)
-	primary_products = list(/datum/gas/carbon_dioxide, /datum/gas/water_vapor)
-	secondary_products = list(/datum/gas/carbon_dioxide, /datum/gas/water_vapor, /datum/gas/freon, /datum/gas/nitrous_oxide, /datum/gas/pluoxium, /datum/gas/halon)
-	meltdown_flags = HYPERTORUS_FLAG_BASE_EXPLOSION | HYPERTORUS_FLAG_MINIMUM_SPREAD
+
+/datum/hfr_fuel/hydrogen_tritium_fuel
+	id = "h2_t2_fuel"
+	name = "Hydrogen + Tritium fuel"
+	negative_temperature_multiplier = 1
+	positive_temperature_multiplier = 1
+	energy_concentration_multiplier = 1
+	fuel_consumption_multiplier = 1
+	gas_production_multiplier = 1
+	temperature_change_multiplier = 0.85
+	requirements = list(/datum/gas/hydrogen, /datum/gas/tritium)
+	primary_products = list(/datum/gas/helium)
+	secondary_products = list(/datum/gas/helium, /datum/gas/plasma, /datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/bz, /datum/gas/hypernoblium)
+	meltdown_flags = HYPERTORUS_FLAG_MEDIUM_EXPLOSION | HYPERTORUS_FLAG_RADIATION_PULSE | HYPERTORUS_FLAG_EMP | HYPERTORUS_FLAG_MEDIUM_SPREAD
+
 
 /datum/hfr_fuel/hypernob_hydrogen_fuel
 	id = "hypernob_hydrogen_fuel"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This reorders the HFR datums in order of maximum temperature. This is also a rough approximation of difficulty and desirability.

No functional changes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This mostly stops the plasma/oxygen recipe being an extremely annoying outlier in the middle of the interface, but also somewhat makes the recipes above make more sense too.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: The HFR interface now lists recipes in a more sensible order. This is sorted by maximum temperature, which also roughly approximates difficulty and desirability.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
