### PR TITLE
Adds basic logging for pressing a sheet of paper to a camera

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -340,7 +340,7 @@
 				if(AI.control_disabled || (AI.stat == DEAD))
 					continue
 				if(paper_user.name == "Unknown")
-					to_chat(AI, "[span_name("[paper_user]")] holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ...")
+					to_chat(AI, "[span_name(paper_user)] holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ...")
 				else
 					to_chat(AI, "<b><a href='?src=[REF(AI)];track=[html_encode(paper_user.name)]'>[paper_user]</a></b> holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ...")
 				AI.log_talk(sanitized_name, LOG_VICTIM, tag="Pressed to camera from [key_name(paper_user)]", log_globally=FALSE)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -346,10 +346,8 @@
 				AI.log_talk(sanitized_name, LOG_VICTIM, tag="Pressed to camera from [key_name(paper_user)]", log_globally=FALSE)
 				AI.last_paper_seen = "<HTML><HEAD><TITLE>[itemname]</TITLE></HEAD><BODY><TT>[info]</TT></BODY></HTML>"
 			else if (potential_viewer.client.eye == src)
-				potential_viewer.log_talk(sanitized_name, LOG_VICTIM, tag="Pressed to camera from [key_name(paper_user)]", log_globally=FALSE)
 				to_chat(potential_viewer, "[span_name("[paper_user]")] holds \a [itemname] up to one of the cameras ...")
-
-
+				potential_viewer.log_talk(sanitized_name, LOG_VICTIM, tag="Pressed to camera from [key_name(paper_user)]", log_globally=FALSE)
 				potential_viewer << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", itemname, info), text("window=[]", itemname))
 		return
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -315,35 +315,42 @@
 
 	// OTHER
 	if((istype(I, /obj/item/paper) || istype(I, /obj/item/pda)) && isliving(user))
-		var/mob/living/U = user
-		var/obj/item/paper/X = null
-		var/obj/item/pda/P = null
+		var/mob/living/paper_user = user
 
 		var/itemname = ""
 		var/info = ""
 		if(istype(I, /obj/item/paper))
-			X = I
-			itemname = X.name
-			info = X.info
+			var/obj/item/paper/pressed_paper = I
+			itemname = pressed_paper.name
+			info = pressed_paper.info
 		else
-			P = I
-			itemname = P.name
-			info = P.notehtml
-		to_chat(U, span_notice("You hold \the [itemname] up to the camera..."))
-		U.changeNext_move(CLICK_CD_MELEE)
-		for(var/mob/O in GLOB.player_list)
-			if(isAI(O))
-				var/mob/living/silicon/ai/AI = O
+			var/obj/item/pda/pressed_pda = I
+			itemname = pressed_pda.name
+			info = pressed_pda.notehtml
+
+		var/sanitized_name = sanitize(itemname)
+
+		to_chat(paper_user, span_notice("You hold \the [itemname] up to the camera..."))
+		paper_user.log_talk(sanitized_name, LOG_GAME, log_globally=TRUE, tag="Pressed to camera")
+		paper_user.changeNext_move(CLICK_CD_MELEE)
+
+		for(var/mob/potential_viewer in GLOB.player_list)
+			if(isAI(potential_viewer))
+				var/mob/living/silicon/ai/AI = potential_viewer
 				if(AI.control_disabled || (AI.stat == DEAD))
 					continue
-				if(U.name == "Unknown")
-					to_chat(AI, "[span_name("[U]")] holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ...")
+				if(paper_user.name == "Unknown")
+					to_chat(AI, "[span_name("[paper_user]")] holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ...")
 				else
-					to_chat(AI, "<b><a href='?src=[REF(AI)];track=[html_encode(U.name)]'>[U]</a></b> holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ...")
+					to_chat(AI, "<b><a href='?src=[REF(AI)];track=[html_encode(paper_user.name)]'>[paper_user]</a></b> holds <a href='?_src_=usr;show_paper=1;'>\a [itemname]</a> up to one of your cameras ...")
+				AI.log_talk(sanitized_name, LOG_VICTIM, tag="Pressed to camera from [key_name(paper_user)]", log_globally=FALSE)
 				AI.last_paper_seen = "<HTML><HEAD><TITLE>[itemname]</TITLE></HEAD><BODY><TT>[info]</TT></BODY></HTML>"
-			else if (O.client.eye == src)
-				to_chat(O, "[span_name("[U]")] holds \a [itemname] up to one of the cameras ...")
-				O << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", itemname, info), text("window=[]", itemname))
+			else if (potential_viewer.client.eye == src)
+				potential_viewer.log_talk(sanitized_name, LOG_VICTIM, tag="Pressed to camera from [key_name(paper_user)]", log_globally=FALSE)
+				to_chat(potential_viewer, "[span_name("[paper_user]")] holds \a [itemname] up to one of the cameras ...")
+
+
+				potential_viewer << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", itemname, info), text("window=[]", itemname))
 		return
 
 	else if(istype(I, /obj/item/camera_bug))


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
We don't log the contents, just that it happen in the first place. Partially to avoid html injection or something, and partially so people can't put war and peace in the admin logs
## Why It's Good For The Game
Admins asked for it, and I was sufficiently bored/burned out on ui code

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
admin: Putting pdas/paper up against cameras is now logged. Not what is actually written, I'm too scared of people injecting war and peace into the game logs section of a log panel, but you'll be able to tell em off for spamming the poor ai with messages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
