### PR TITLE
Makes Auxbase console a proper wallmount

### DIFF
--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -32,6 +32,8 @@
 	/// If blind drop option is available
 	var/blind_drop_ready = TRUE
 
+	density = FALSE //this is a wallmount
+
 /obj/machinery/computer/auxiliary_base/directional/north
 	dir = SOUTH
 	pixel_y = 32


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
the Auxbase console is a subtype of consoles, despite being a wallmount, therefore it inherits consoles density = TRUE, despite being on a wall

this means that you get THIS ..... its on the WALL and the tile is EMPTY, but you cant step onto it, because the consoles there technically and dense

(I feel i should clarify before its asked: when a console is deconstructed it spawns a new console frame and copies the circuit over, that new frame will be dense again. so it only lacks density once its finished and on the wall)
![image](https://user-images.githubusercontent.com/40489693/132572507-dc799d05-df0d-4e31-9ec7-5b1c8b3d7061.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
pain
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Nari Harimoto
fix: the aux base console now wont block an empty tile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
