### PR TITLE
Stop RCD attack chain after pre_attack

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -746,7 +746,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	. = ..()
 	mode = construction_mode
 	rcd_create(A, user)
-	return FALSE
+	return TRUE
 
 /obj/item/construction/rcd/pre_attack_secondary(atom/target, mob/living/user, params)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so that the RCD attack chain stops after pre_attack
This should prevent runtimes like these:
![image](https://user-images.githubusercontent.com/33846895/132598354-c245de46-9725-4077-8dce-a485cf4642f4.png)
where the RCD for example replaces an lattice in in pre_attack which then causes a runtime in the attackby code.
It seems like all of the RCD stuff is handled pre_attack so it should be fine to stop the chain here.
The RCD also has the NOBLUDGEON flag meaning you can't attack with it anyways.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should prevent runtimes / incorrect behavior when using RCDs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:Gamer025
fix: RCDs end their attack chain early now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
