### PR TITLE
Off-station (ruins) shield wall gens start unlocked

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "ab" = (
-/obj/machinery/power/shieldwallgen/anchored,
+/obj/machinery/power/shieldwallgen/unlocked/anchored,
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
@@ -99,7 +99,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/abandonedzoo)
 "aE" = (
-/obj/machinery/power/shieldwallgen/anchored,
+/obj/machinery/power/shieldwallgen/unlocked/anchored,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
@@ -298,12 +298,12 @@
 /area/ruin/space/has_grav/abandonedzoo)
 "bs" = (
 /obj/structure/cable,
-/obj/machinery/power/shieldwallgen/anchored,
+/obj/machinery/power/shieldwallgen/unlocked/anchored,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
 "bt" = (
 /obj/structure/cable,
-/obj/machinery/power/shieldwallgen/anchored,
+/obj/machinery/power/shieldwallgen/unlocked/anchored,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
 "bu" = (
@@ -429,7 +429,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/abandonedzoo)
 "bV" = (
-/obj/machinery/power/shieldwallgen,
+/obj/machinery/power/shieldwallgen/unlocked,
 /turf/template_noop,
 /area/template_noop)
 "bW" = (

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -914,7 +914,7 @@
 /turf/open/floor/carpet,
 /area/awaymission/bmpship/fore)
 "dL" = (
-/obj/machinery/power/shieldwallgen,
+/obj/machinery/power/shieldwallgen/unlocked,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/awaymission/bmpship/midship)

--- a/_maps/RandomZLevels/Academy.dmm
+++ b/_maps/RandomZLevels/Academy.dmm
@@ -1291,7 +1291,7 @@
 /turf/open/floor/carpet,
 /area/awaymission/academy/academyaft)
 "fH" = (
-/obj/machinery/power/shieldwallgen,
+/obj/machinery/power/shieldwallgen/unlocked,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -3173,10 +3173,7 @@
 	},
 /area/awaymission/moonoutpost19/research)
 "gZ" = (
-/obj/machinery/power/shieldwallgen{
-	locked = 0;
-	req_access = null
-	},
+/obj/machinery/power/shieldwallgen/unlocked
 /obj/structure/cable,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -3173,7 +3173,7 @@
 	},
 /area/awaymission/moonoutpost19/research)
 "gZ" = (
-/obj/machinery/power/shieldwallgen/unlocked
+/obj/machinery/power/shieldwallgen/unlocked,
 /obj/structure/cable,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -276,6 +276,13 @@
 /obj/machinery/power/shieldwallgen/anchored
 	anchored = TRUE
 
+/obj/machinery/power/shieldwallgen/unlocked //for use in ruins, etc
+	locked = FALSE
+	req_access = null
+
+/obj/machinery/power/shieldwallgen/unlocked/anchored
+	anchored = TRUE
+
 /obj/machinery/power/shieldwallgen/Initialize()
 	. = ..()
 	if(anchored)


### PR DESCRIPTION


## About The Pull Request

Adds a variant of shield wall generators (the kind in xenobio and the teleporter) without access restrictions, for use in ruins.

## Why It's Good For The Game
Consistency with most things in space not having access requirements. Given its use is limited to the RD, captain, or silicons, having a bunch of them in space and unusable is not really sensible. Unlocks the few in away missions as well (and in one case turns a varedited one into just the unlocked one)

## Changelog

:cl:
fix: shield wall generators in space now start unlocked, previously only usable by the odd RD or cyborg.
/:cl:

