### PR TITLE
Set the event hall world topic

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -186,3 +186,5 @@
 		.["shuttle_timer"] = SSshuttle.emergency.timeLeft()
 		// Shuttle timer, in seconds
 
+	.["custom_event"] = "Testing New Prefs Menu"
+	.["event_colors"] = TRUE


### PR DESCRIPTION
I'm going to be using the event hall to test some new prefs stuff on a prod-like environment, doesn't appear to be possible with server_side_modifications. Just going to make this PR to test merge.