### PR TITLE
makes the SEND_SIGNAL() define use the ?[] operator, my biggest microop ever?

### DIFF
--- a/code/__DEFINES/dcs/helpers.dm
+++ b/code/__DEFINES/dcs/helpers.dm
@@ -2,7 +2,7 @@
 /// The datum hosting the signal is automaticaly added as the first argument
 /// Returns a bitfield gathered from all registered procs
 /// Arguments given here are packaged in a list and given to _SendSignal
-#define SEND_SIGNAL(target, sigtype, arguments...) ( !target.comp_lookup || !target.comp_lookup[sigtype] ? NONE : target._SendSignal(sigtype, list(target, ##arguments)) )
+#define SEND_SIGNAL(target, sigtype, arguments...) ( !target.comp_lookup?[sigtype] ? NONE : target._SendSignal(sigtype, list(target, ##arguments)) )
 
 #define SEND_GLOBAL_SIGNAL(sigtype, arguments...) ( SEND_SIGNAL(SSdcs, sigtype, ##arguments) )
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
if(list?[index]) is very slightly faster than if(list && list[index]) and SEND_SIGNAL() while very cheap is fucking everywhere, so i benchmarked ?[] with
[benchmark.txt](https://github.com/tgstation/tgstation/files/7135227/benchmark.txt)

![Screenshot_1249](https://user-images.githubusercontent.com/15794172/132658374-8ae8a4c1-2da4-425d-b2dd-c8e744560aa7.png)
![Screenshot_1250](https://user-images.githubusercontent.com/15794172/132658379-f4e37323-34b0-4384-b78d-03210b31c026.png)
![Screenshot_1251](https://user-images.githubusercontent.com/15794172/132658381-e646cd78-d8ee-4825-9594-1f3003bb46d6.png)
comp_lookup is either null or associative so the top and bottom tests are more relevant
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
looking at the last two, 2835487/second -> one iteration every 352.67 nanoseconds for the if(list && list[index])
and 2931099/second -> one iteration every 341.17 nanoseconds, so we saved a grand total of 11 nanoseconds for each SEND_SIGNAL() define! thats the time light in a vacuum takes to travel 3.3 meters!

thats a lower one though, the third null list check saved 24 ns and theres probably a fair bit of overhead with the way im benchmarking this since each loop has to check world.timeofday but eh whatever
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
