### PR TITLE
fixes inconsistencies in which items can fit inside of a PDA's pen slot

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -94,7 +94,15 @@
 		/obj/item/toy/crayon,
 		/obj/item/lipstick,
 		/obj/item/flashlight/pen,
-		/obj/item/clothing/mask/cigarette)
+		/obj/item/clothing/mask/cigarette,
+		/obj/item/match,
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/hypospray/medipen
+		), //vapes, syringes, screwdrivers, etc. are intentionally not included in this list; they're a bit too long to comfortably fit
+		list(
+		/obj/item/clothing/mask/cigarette/pipe,
+		/obj/item/toy/crayon/spraycan
+		)
 		)
 
 /datum/component/storage/concrete/pockets/pocketprotector/real_location()

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -83,7 +83,10 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	var/datum/picture/picture //Scanned photo
 
-	var/list/contained_item = list(/obj/item/pen, /obj/item/toy/crayon, /obj/item/lipstick, /obj/item/flashlight/pen, /obj/item/clothing/mask/cigarette)
+	///a list of items that could reasonably fit in a PDA's pen slot
+	var/list/whitelisted_items = list(/obj/item/pen, /obj/item/toy/crayon, /obj/item/lipstick, /obj/item/flashlight/pen, /obj/item/clothing/mask/cigarette, /obj/item/match, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/hypospray/medipen)
+	///a list of items that are subtypes of the above items but couldn't reasonably fit inside of a PDA's pen slot
+	var/list/blacklisted_items = list(/obj/item/clothing/mask/cigarette/pipe, /obj/item/toy/crayon/spraycan)
 	var/obj/item/inserted_item //Used for pen, crayon, and lipstick insertion or removal. Same as above.
 	var/overlays_x_offset = 0 //x offset to use for certain overlays
 
@@ -1061,7 +1064,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		to_chat(user, span_notice("You slot \the [C] into [src]."))
 		update_appearance()
 		updateUsrDialog()
-	else if(is_type_in_list(C, contained_item)) //Checks if there is a pen
+	else if(is_type_in_list(C, whitelisted_items) && !is_type_in_list(C, blacklisted_items)) //Checks to see if the item you're using could reasonably fit in the PDA's pen slot
 		if(inserted_item)
 			to_chat(user, span_warning("There is already \a [inserted_item] in \the [src]!"))
 		else


### PR DESCRIPTION
## About The Pull Request

Matches, droppers, and medipens can now fit inside of pocket protectors and the pen slots of PDAs.

Smoking pipes and spray cans(!) can no longer fit inside of pocket protectors and the pen slots of PDAs.

## Why It's Good For The Game

Matches and droppers are thin, pen-like items. Medipens literally have "pen" in their names.

![image](https://user-images.githubusercontent.com/42606352/132672413-e2be06c7-f91c-4cf6-8c87-b88faf67c6ab.png)
I can maybe see jamming a rollie or a Havanan cigar into a PDA's pen slot, but a Garfield pipe is where I draw the line.

Spray cans are obviously too big to fit inside of a PDA's pen slot (or a pocket protector).

Vapes, screwdrivers, and syringes have not been added to the list of items that PDAs or pocket protectors can accept, as I feel that they're a bit too long to comfortably sit inside of a PDA's pen slot or a pocket protector.

## Changelog

:cl: ATHATH
fix: Matches, droppers, and medipens can now fit inside of pocket protectors and the pen slots of PDAs.
fix: Smoking pipes and spray cans(!) can no longer fit inside of pocket protectors and the pen slots of PDAs.
/:cl: