### PR TITLE
Fix HFR Oxygen based iron content mitigation

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
@@ -34,6 +34,14 @@
 #define DAMAGE_CAP_MULTIPLIER 0.005
 ///Sets the range of the hallucinations
 #define HALLUCINATION_HFR(P) (min(7, round(abs(P) ** 0.25)))
+///Chance in percentage points per fusion level of iron accumulation when operating at unsafe levels
+#define IRON_CHANCE_PER_FUSION_LEVEL 17
+///Amount of iron accumulated per second whenever we fail our saving throw, using the chance above
+#define IRON_ACCUMULATED_PER_SECOND 0.005
+///Maximum amount of iron that can be healed per second. Calculated to mostly keep up with fusion level 5.
+#define IRON_OXYGEN_HEAL_PER_SECOND (IRON_ACCUMULATED_PER_SECOND * (100 - IRON_CHANCE_PER_FUSION_LEVEL) / 100)
+///Amount of oxygen in moles required to fully remove 100% iron content. Currently about 2409mol. Calculated to consume at most 10mol/s.
+#define OXYGEN_MOLES_CONSUMED_PER_IRON_HEAL (10 / IRON_OXYGEN_HEAL_PER_SECOND)
 
 //If integrity percent remaining is less than these values, the monitor sets off the relevant alarm.
 #define HYPERTORUS_MELTING_PERCENT 5

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -512,8 +512,8 @@
 	//High power fusion might create other matter other than helium, iron is dangerous inside the machine, damage can be seen
 	if(moderator_internal.total_moles() > 0)
 		moderator_internal.remove(moderator_internal.total_moles() * (1 - (1 - 0.0005 * power_level) ** delta_time))
-	if(power_level > 4 && prob(17 * power_level))//at power level 6 is 100%
-		iron_content += 0.005 * delta_time
+	if(power_level > 4 && prob(IRON_CHANCE_PER_FUSION_LEVEL * power_level))//at power level 6 is 100%
+		iron_content += IRON_ACCUMULATED_PER_SECOND * delta_time
 	if(iron_content > 0 && power_level <= 4 && prob(25 / (power_level + 1)))
 		iron_content = max(iron_content - 0.01 * delta_time, 0)
 	iron_content = clamp(iron_content, 0, 1)
@@ -548,10 +548,10 @@
 
 	if(moderator_list[/datum/gas/oxygen] > 150)
 		if(iron_content > 0)
-			var/max_iron_removable = 0.00415
+			var/max_iron_removable = IRON_OXYGEN_HEAL_PER_SECOND
 			var/iron_removed = min(max_iron_removable * delta_time, iron_content)
 			iron_content -= iron_removed
-			moderator_internal.gases[/datum/gas/oxygen] -= 10 * iron_removed / max_iron_removable
+			moderator_internal.gases[/datum/gas/oxygen] -= iron_removed * OXYGEN_MOLES_CONSUMED_PER_IRON_HEAL
 
 	if(prob(critical_threshold_proximity / 15))
 		var/grav_range = round(log(2.5, critical_threshold_proximity))

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -548,8 +548,10 @@
 
 	if(moderator_list[/datum/gas/oxygen] > 150)
 		if(iron_content > 0)
-			iron_content = max(iron_content - 0.5, 0)
-			moderator_internal.gases[/datum/gas/oxygen] -= 10
+			var/max_iron_removable = 0.00415
+			var/iron_removed = min(max_iron_removable * delta_time, iron_content)
+			iron_content -= iron_removed
+			moderator_internal.gases[/datum/gas/oxygen] -= 10 * iron_removed / max_iron_removable
 
 	if(prob(critical_threshold_proximity / 15))
 		var/grav_range = round(log(2.5, critical_threshold_proximity))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Oxygen as an ameliorator for iron content buildup was added in 874914528. However, the values used removed a breathtaking 50 percentage points of iron content per tick (!) (note iron content is capped at 100 percentage points!), at a cost of only 10 moles of Oxygen.

The overall effect is that non-debug HFR setups incidentally create enough Oxygen to offset any iron content, and rarely risk meltdown.

This changes the values so that Oxygen is exactly enough to prevent expected iron content buildup at fusion level 5, and slows buildup at fusion level 6 to a mere 17% of the usual rate.

Oxygen consumed is now exactly proportional to the amount used to remove iron, and `delta_time` is respected as well.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

10 moles of oxygen healing 50 percentage points is a blatant oversight

The new healing rate is probably still unreasonably high, but not quite obvious typo territory

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The HFR no longer yeets all iron content given scraps of Oxygen.
fix: The HFR now burns Oxygen proportionally to the amount of iron content removed when appropriate.
fix: The HFR using Oxygen to mitigate iron content buildup now properly respects delta time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
