### PR TITLE
Eng/Atmos/CE tablet come with Canary (Alarm monitor) preinstalled

### DIFF
--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -76,6 +76,7 @@
 /obj/item/modular_computer/tablet/preset/advanced/command/engineering/Initialize()
 	. = ..()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
+	hard_drive.store_file(new /datum/computer_file/program/alarm_monitor)
 	hard_drive.store_file(new /datum/computer_file/program/supermatter_monitor)
 
 /// Given by the syndicate as part of the contract uplink bundle - loads in the Contractor Uplink.

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -54,11 +54,15 @@
 
 /obj/item/modular_computer/tablet/preset/advanced/atmos/Initialize() //This will be defunct and will be replaced when NtOS PDAs are done
 	. = ..()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
 	install_component(new /obj/item/computer_hardware/sensorpackage)
+	hard_drive.store_file(new /datum/computer_file/program/alarm_monitor)
+	hard_drive.store_file(new /datum/computer_file/program/atmosscan)
 
 /obj/item/modular_computer/tablet/preset/advanced/engineering/Initialize()
 	. = ..()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = find_hardware_by_name("solid state drive")
+	hard_drive.store_file(new /datum/computer_file/program/alarm_monitor)
 	hard_drive.store_file(new /datum/computer_file/program/supermatter_monitor)
 
 /obj/item/modular_computer/tablet/preset/advanced/command/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tablets are often found thrown around a corner of the foyer, and I'm tired of bullying people to use it at this point. It's IMO the most powerful tool engineering has to keep the station in good condition but only a few players ever download anything in a round.


So let's make their lives easier, engineering tablets come preinstalled with Canary and the Atmos with the Gas Scanner too. (Even if I never saw anyone use that, just because the tablet comes preinstalled with the sensor that enables it.)


Canary is a powerful tool to assist on station maintenance that is not well known to the player, maybe this will get people curious enough to open it and start to enjoy having all alarms green as much as I do.

## Why It's Good For The Game
Nothing hurts more than a small breach at science that goes unfixed for half an hour and slowly creep in turning the station into Firelock hell... and nothing is funnier than screaming "Atmos alarm at the HoS Office!" the second it pops up only for the AI to lock the shutters down and tell sec that a random lizard broke the window and is trying to Esword the HoS locker.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Guillaume Prata
qol: Engineering, Atmos and the CE's tablets come preinstalled with Canary (Alarm monitor) now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
