### PR TITLE
Trait macros now use the ?[] operator.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -29,7 +29,7 @@
 		} else { \
 			_S = sources\
 		}; \
-		if (_L && _L[trait]) { \
+		if (_L?[trait]) { \
 			for (var/_T in _L[trait]) { \
 				if ((!_S && (_T != ROUNDSTART_TRAIT)) || (_T in _S)) { \
 					_L[trait] -= _T \
@@ -53,7 +53,7 @@
 		} else { \
 			_sources_list = sources\
 		}; \
-		if (_traits_list && _traits_list[trait]) { \
+		if (_traits_list?[trait]) { \
 			for (var/_trait_source in _traits_list[trait]) { \
 				if (!(_trait_source in _sources_list)) { \
 					_traits_list[trait] -= _trait_source \
@@ -109,15 +109,11 @@
 		}\
 	} while (0)
 
-#define HAS_TRAIT(target, trait) (target.status_traits ? (target.status_traits[trait] ? TRUE : FALSE) : FALSE)
-#define HAS_TRAIT_FROM(target, trait, source) (target.status_traits ? (target.status_traits[trait] ? (source in target.status_traits[trait]) : FALSE) : FALSE)
-#define HAS_TRAIT_FROM_ONLY(target, trait, source) (\
-	target.status_traits ?\
-		(target.status_traits[trait] ?\
-			((source in target.status_traits[trait]) && (length(target.status_traits) == 1))\
-			: FALSE)\
-		: FALSE)
-#define HAS_TRAIT_NOT_FROM(target, trait, source) (target.status_traits ? (target.status_traits[trait] ? (length(target.status_traits[trait] - source) > 0) : FALSE) : FALSE)
+#define HAS_TRAIT(target, trait) (target.status_traits?[trait])
+#define OLD_HAS_TRAIT(target, trait) (target.status_traits ? (target.status_traits[trait] ? TRUE : FALSE) : FALSE)
+#define HAS_TRAIT_FROM(target, trait, source) (target.status_traits?[trait] && (source in target.status_traits[trait]))
+#define HAS_TRAIT_FROM_ONLY(target, trait, source) (target.status_traits?[trait] && (source in target.status_traits[trait]) && (length(target.status_traits) == 1))
+#define HAS_TRAIT_NOT_FROM(target, trait, source) (target.status_traits?[trait] && (length(target.status_traits[trait] - source) > 0))
 
 /*
 Remember to update _globalvars/traits.dm if you're adding/removing/renaming traits.

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -110,7 +110,6 @@
 	} while (0)
 
 #define HAS_TRAIT(target, trait) (target.status_traits?[trait])
-#define OLD_HAS_TRAIT(target, trait) (target.status_traits ? (target.status_traits[trait] ? TRUE : FALSE) : FALSE)
 #define HAS_TRAIT_FROM(target, trait, source) (target.status_traits?[trait] && (source in target.status_traits[trait]))
 #define HAS_TRAIT_FROM_ONLY(target, trait, source) (target.status_traits?[trait] && (source in target.status_traits[trait]) && (length(target.status_traits) == 1))
 #define HAS_TRAIT_NOT_FROM(target, trait, source) (target.status_traits?[trait] && (length(target.status_traits[trait] - source) > 0))

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -109,7 +109,7 @@
 		}\
 	} while (0)
 
-#define HAS_TRAIT(target, trait) (target.status_traits?[trait])
+#define HAS_TRAIT(target, trait) (target.status_traits?[trait] ? TRUE : FALSE)
 #define HAS_TRAIT_FROM(target, trait, source) (target.status_traits?[trait] && (source in target.status_traits[trait]))
 #define HAS_TRAIT_FROM_ONLY(target, trait, source) (target.status_traits?[trait] && (source in target.status_traits[trait]) && (length(target.status_traits) == 1))
 #define HAS_TRAIT_NOT_FROM(target, trait, source) (target.status_traits?[trait] && (length(target.status_traits[trait] - source) > 0))


### PR DESCRIPTION
## About The Pull Request
As shown in #61319, `list?[index]` is slightly faster than `list && list[index]`.
It's most probably also faster than a ternary operation like `list ? (list[index] ? TRUE : FALSE) : FALSE`.
I have tried benchmarking it but probably ended up with inaccurate results (though the new HAS_TRAIT had about 30-50k~ more iterations) since I'm unsure what's the best way to do it for a macro. I'll give it another shot when someone tells me how to do it.
EDIT: Changed the `HAS_TRAIT` macro to `list?[index] ? TRUE : FALSE` after Anturk pointed out the return value was a list.

## Why It's Good For The Game
Micro-optimization. Trait macros are even more present in the code than `SEND_SIGNAL`.

## Changelog
N/A.