### PR TITLE
Another fix for laggy tgui tooltips -- Turn off popper event listeners (+ give R&D console its tooltips again)

### DIFF
--- a/tgui/packages/tgui/components/Tooltip.tsx
+++ b/tgui/packages/tgui/components/Tooltip.tsx
@@ -53,6 +53,10 @@ export class Tooltip extends Component<TooltipProps, TooltipState> {
       <Popper
         options={{
           placement: this.props.position || "auto",
+          modifiers: [{
+            name: "eventListeners",
+            enabled: false,
+          }],
         }}
         popperContent={
           <div

--- a/tgui/packages/tgui/interfaces/Techweb.js
+++ b/tgui/packages/tgui/interfaces/Techweb.js
@@ -722,8 +722,8 @@ const TechNode = (props, context) => {
             className={`${design_cache[k].class} Techweb__DesignIcon`}
             // Uncomment these only when tooltip performance is improved.
             // Reason for removal: Causes massive performance decreases
-            // tooltip={design_cache[k].name}
-            // tooltipPosition={i % 15 < 7 ? "right" : "left"}
+            tooltip={design_cache[k].name}
+            tooltipPosition={i % 15 < 7 ? "right" : "left"}
           />
         ))}
       </Box>

--- a/tgui/packages/tgui/interfaces/Techweb.js
+++ b/tgui/packages/tgui/interfaces/Techweb.js
@@ -720,8 +720,6 @@ const TechNode = (props, context) => {
           <Button
             key={id}
             className={`${design_cache[k].class} Techweb__DesignIcon`}
-            // Uncomment these only when tooltip performance is improved.
-            // Reason for removal: Causes massive performance decreases
             tooltip={design_cache[k].name}
             tooltipPosition={i % 15 < 7 ? "right" : "left"}
           />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Every single popper registered TWO event listeners for scrolling and resizing. This does not appear to be necessary for our cases.


https://user-images.githubusercontent.com/35135081/132781895-d91ea538-6ff0-4327-860e-5ec53be6a6e6.mp4



## Changelog

:cl:
fix: The R&D console has been given back its tooltips
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
