### PR TITLE
multiplies the chance to start dreaming each sleep tick by 5

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -183,11 +183,10 @@
 		owner.adjustStaminaLoss(healing)
 	if(human_owner?.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
-	if(prob(20))
-		if(carbon_owner)
-			carbon_owner.handle_dreams()
-		if(prob(10) && owner.health > owner.crit_threshold)
-			owner.emote("snore")
+	if(carbon_owner)
+		carbon_owner.handle_dreams()
+	if(prob(2) && owner.health > owner.crit_threshold)
+		owner.emote("snore")
 
 /atom/movable/screen/alert/status_effect/asleep
 	name = "Asleep"


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/61214.

The chance for snoring looks a bit low as well, but changing that wouldn't be a direct fix to an issue.

## Changelog

:cl: ATHATH
fix: Dreaming is now less rare.
/:cl: