### PR TITLE
Native languages for tongues

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -562,10 +562,10 @@
 	#define SPEECH_MESSAGE 1
 	// #define SPEECH_BUBBLE_TYPE 2
 	#define SPEECH_SPANS 3
-	/* #define SPEECH_SANITIZE 4
+	// #define SPEECH_SANITIZE 4
 	#define SPEECH_LANGUAGE 5
-	#define SPEECH_IGNORE_SPAM 6
-	#define SPEECH_FORCED 7 */
+	/* #define SPEECH_IGNORE_SPAM 6
+	 #define SPEECH_FORCED 7 */
 
 ///from /mob/say_dead(): (mob/speaker, message)
 #define COMSIG_MOB_DEADSAY "mob_deadsay"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -565,7 +565,7 @@
 	// #define SPEECH_SANITIZE 4
 	#define SPEECH_LANGUAGE 5
 	/* #define SPEECH_IGNORE_SPAM 6
-	 #define SPEECH_FORCED 7 */
+	#define SPEECH_FORCED 7 */
 
 ///from /mob/say_dead(): (mob/speaker, message)
 #define COMSIG_MOB_DEADSAY "mob_deadsay"

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -38,6 +38,12 @@
 
 /obj/item/organ/tongue/proc/handle_speech(datum/source, list/speech_args)
 	SIGNAL_HANDLER
+	if(speech_args[SPEECH_LANGUAGE] in languages_native)
+		return FALSE //no changes
+	modify_speech(source, speech_args)
+
+/obj/item/organ/tongue/proc/modify_speech(datum/source, list/speech_args)
+	return speech_args[SPEECH_MESSAGE]
 
 /obj/item/organ/tongue/Insert(mob/living/carbon/tongue_owner, special = 0)
 	..()
@@ -78,9 +84,7 @@
 	modifies_speech = TRUE
 	languages_native = list(/datum/language/draconic)
 
-/obj/item/organ/tongue/lizard/handle_speech(datum/source, list/speech_args)
-	if(owner.get_selected_language() in languages_native)
-		return //to keep using autohiss with a native language, a player can use prefixes without using the language as main one
+/obj/item/organ/tongue/lizard/modify_speech(datum/source, list/speech_args)
 	var/static/regex/lizard_hiss = new("s+", "g")
 	var/static/regex/lizard_hiSS = new("S+", "g")
 	var/static/regex/lizard_kss = new(@"(\w)x", "g")
@@ -202,7 +206,7 @@
 		/datum/language/buzzwords
 	))
 
-/obj/item/organ/tongue/fly/handle_speech(datum/source, list/speech_args)
+/obj/item/organ/tongue/fly/modify_speech(datum/source, list/speech_args)
 	var/static/regex/fly_buzz = new("z+", "g")
 	var/static/regex/fly_buZZ = new("Z+", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
@@ -251,7 +255,7 @@
 		else
 			. += span_notice("It is attuned to [mothership].")
 
-/obj/item/organ/tongue/abductor/handle_speech(datum/source, list/speech_args)
+/obj/item/organ/tongue/abductor/modify_speech(datum/source, list/speech_args)
 	//Hacks
 	var/message = speech_args[SPEECH_MESSAGE]
 	var/mob/living/carbon/human/user = source
@@ -278,7 +282,7 @@
 	modifies_speech = TRUE
 	taste_sensitivity = 32
 
-/obj/item/organ/tongue/zombie/handle_speech(datum/source, list/speech_args)
+/obj/item/organ/tongue/zombie/modify_speech(datum/source, list/speech_args)
 	var/list/message_list = splittext(speech_args[SPEECH_MESSAGE], " ")
 	var/maxchanges = max(round(message_list.len / 1.5), 2)
 
@@ -311,7 +315,7 @@
 	. = ..()
 	languages_possible = languages_possible_alien
 
-/obj/item/organ/tongue/alien/handle_speech(datum/source, list/speech_args)
+/obj/item/organ/tongue/alien/modify_speech(datum/source, list/speech_args)
 	playsound(owner, "hiss", 25, TRUE, TRUE)
 
 /obj/item/organ/tongue/bone
@@ -348,7 +352,7 @@
 	phomeme_type = pick(phomeme_types)
 	languages_possible = languages_possible_skeleton
 
-/obj/item/organ/tongue/bone/handle_speech(datum/source, list/speech_args)
+/obj/item/organ/tongue/bone/modify_speech(datum/source, list/speech_args)
 	if (chattering)
 		chatter(speech_args[SPEECH_MESSAGE], phomeme_type, source)
 	switch(phomeme_type)
@@ -378,7 +382,7 @@
 /obj/item/organ/tongue/robot/can_speak_language(language)
 	return TRUE // THE MAGIC OF ELECTRONICS
 
-/obj/item/organ/tongue/robot/handle_speech(datum/source, list/speech_args)
+/obj/item/organ/tongue/robot/modify_speech(datum/source, list/speech_args)
 	speech_args[SPEECH_SPANS] |= SPAN_ROBOT
 
 /obj/item/organ/tongue/snail
@@ -387,7 +391,7 @@
 	desc = "A minutely toothed, chitious ribbon, which as a side effect, makes all snails talk IINNCCRREEDDIIBBLLYY SSLLOOWWLLYY."
 	modifies_speech = TRUE
 
-/obj/item/organ/tongue/snail/handle_speech(datum/source, list/speech_args)
+/obj/item/organ/tongue/snail/modify_speech(datum/source, list/speech_args)
 	var/new_message
 	var/message = speech_args[SPEECH_MESSAGE]
 	for(var/i in 1 to length(message))
@@ -456,7 +460,7 @@
 
 //Thank you Jwapplephobia for helping me with the literal hellcode below
 
-/obj/item/organ/tongue/tied/handle_speech(datum/source, list/speech_args)
+/obj/item/organ/tongue/tied/modify_speech(datum/source, list/speech_args)
 	var/new_message
 	var/message = speech_args[SPEECH_MESSAGE]
 	var/exclamation_found = findtext(message, "!")

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -7,6 +7,7 @@
 	attack_verb_continuous = list("licks", "slobbers", "slaps", "frenches", "tongues")
 	attack_verb_simple = list("lick", "slobber", "slap", "french", "tongue")
 	var/list/languages_possible
+	var/list/languages_native //human mobs can speak with this languages without the accent (letters replaces)
 	var/say_mod = null
 
 	/// Whether the owner of this tongue can taste anything. Being set to FALSE will mean no taste feedback will be provided.
@@ -75,8 +76,11 @@
 	say_mod = "hisses"
 	taste_sensitivity = 10 // combined nose + tongue, extra sensitive
 	modifies_speech = TRUE
+	languages_native = list(/datum/language/draconic)
 
 /obj/item/organ/tongue/lizard/handle_speech(datum/source, list/speech_args)
+	if(owner.get_selected_language() in languages_native)
+		return //to keep using autohiss with a native language, a player can use prefixes without using the language as main one
 	var/static/regex/lizard_hiss = new("s+", "g")
 	var/static/regex/lizard_hiSS = new("S+", "g")
 	var/static/regex/lizard_kss = new(@"(\w)x", "g")
@@ -180,6 +184,7 @@
 	say_mod = "buzzes"
 	taste_sensitivity = 25 // you eat vomit, this is a mercy
 	modifies_speech = TRUE
+	languages_native = list(/datum/language/buzzwords)
 	var/static/list/languages_possible_fly = typecacheof(list(
 		/datum/language/common,
 		/datum/language/draconic,


### PR DESCRIPTION
Old:

<details>

## About The Pull Request

If a mob (human one) speaks with a language their tongue tracks as native (for their language's anatomy), the message's text will not be changed with default language's text replaces.
Basicly, if a lizard (or other human mob) with lizard tongue speaks with draconic, their speech _in most cases_ will be without accent changes.

How it looks:
<details>

![image](https://user-images.githubusercontent.com/78963858/132823775-07425a91-ec97-4b8c-99a7-0dd14e3c770a.png)

</details>

So yes, due the check's specifity (it checks selected language) human mobs can speak with other languages without accent if they select their native one and will use language prefixes. "That is a feature, not a bad code - I promise."

## Why It's Good For The Game

It looks a bit strange when races speak at their own language with difficult without real reasons for it. The changes removes that part and let players roleplay characters who can speak other languages at good level (with using prefixes at start of messages) without having a proper tongue's anatomy.

</details>

## About The Pull Request

If a mob (human one) speaks with a language their tongue tracks as native (for their language's anatomy), the message's text will not be changed with default language's text replaces.
Basicly, if a lizard (or other human mob) with lizard tongue speaks with draconic, their speech  will be without accent changes.

How it looks:
<details>

![dreamseeker_kULTKEYTwZ](https://user-images.githubusercontent.com/78963858/132995028-c06e5216-0065-4826-a4a2-e80bc4a80ffa.png)

</details>

## Why It's Good For The Game

It looks a bit strange when races speak at their own language with difficult without real reasons for it. The changes remove that part.

## Changelog

:cl: SishTis
add: If a human mob speaks with a language their tongue counts as native one (like draconic for forked tongue), their speech will sound normally.
/:cl:
