### PR TITLE
Fixes magmawing watcher projectile oversight

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -195,6 +195,7 @@
 	damage_type = BURN
 	nodamage = FALSE
 	temperature = 200 // Heats you up! per hit!
+	slowdown = FALSE
 
 /obj/projectile/temp/basilisk/magmawing/on_hit(atom/target, blocked = FALSE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
I forgot to put this var here too
fixes https://github.com/tgstation/tgstation/issues/61359

## Why It's Good For The Game
Magmawings aren't supposed to slow you down

## Changelog
:cl:
fix: Magmawing watchers do not apply a slowdown any more.
/:cl: