### PR TITLE
Lowers the cost of the obsessed midround ruleset from 10 to 3.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -861,7 +861,7 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	weight = 4
-	cost = 10
+	cost = 3 // Doesn't have the same impact on rounds as revenants, dragons, sentient disease (10) or syndicate infiltrators (5). 
 	requirements = list(101,101,101,80,60,50,30,20,10,10)
 	repeatable = TRUE
 


### PR DESCRIPTION
## About The Pull Request
See the title.

## Why It's Good For The Game
Obsessed is a really weak antagonist whose objectives revolve around creeping on a single crewmember. He doesn't have any special ability whatsoever other than suffering from heavy butterflies in the stomach when his mood is great or above and his presence barely affects the round. They shouldn't have the same cost of other rulsets like swarmers, pirates, ninjas and nightmare, or even latejoin traitors.

## Changelog

:cl:
balance: Lowered the cost of the obsessed midround ruleset from 10 to 3.
/:cl:
