### PR TITLE
The Odysseus is no longer an artillery mech.

### DIFF
--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -38,5 +38,13 @@
 	name = "syringe"
 	icon_state = "syringeproj"
 
+/obj/projectile/bullet/dart/syringe/Initialize()
+	. = ..()
+
+	// This prevents the Ody from being used as a combat mech spamming RDX/Teslium syringes all over the place.
+	// Other syringe guns are loaded manually with pre-filled syringes which will react chems themselves.
+	// The traitor chem dartgun uses /obj/projectile/bullet/dart/piercing, so this does not impact it.
+	reagents.flags &= ~NO_REACT
+
 /obj/projectile/bullet/dart/piercing
 	piercing = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the ability for the Odysseus to fire syringes filled with dangerous chemical combos that only react on impact. Does this by removing the NO_REACT flag when syringe darts are created.

This doesn't change any behaviour of handheld syringe guns. You can't fire a Water/Potassium syringe out of a handheld syringe gun as doing so requires creating a syringe of Water/Potassium, which will instantly react. The same holds true for other chem reactions. The traitor reagent dartgun which synths its own syringes uses different projectiles that are not impacted by this change. It functions identically to how it did before and is unchanged and untouched.

This change specifically targets Ody behaviour.

![9OPOSjbeqi](https://user-images.githubusercontent.com/24975989/132925873-ea730c43-e451-496e-9c7d-befab6a05d31.gif)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The Ody is intended to be a medical support mech. Stop using the Ody as a cheap spammable artillery mech with RDX/Teslium combos.

Use the Odysseus the way God himself intended. Fire sleepy chems into your victim, abduct him in your vore chamber and keep him sedated with a slow infusion of sleepy chems for the rest of the shift.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: The Odysseus no longer fires magical syringes that only react their contents when the target is hit. It now fires syringes that react as soon as your fire your Ody's syringe gun. You have been warned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
