### PR TITLE
Fixing an oversight with porta_turret/proc/assess_perp

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -553,7 +553,7 @@ DEFINE_BITFIELD(turret_flags, list(
 			return 0
 
 	if(turret_flags & TURRET_FLAG_AUTH_WEAPONS) //check for weapon authorization
-		if(isnull(perp.wear_id) || istype(perp.wear_id.GetID(), /obj/item/card/id/advanced/chameleon))
+		if(!istype(perp.wear_id?.GetID(), /obj/item/card/id/advanced/chameleon))
 
 			if(allowed(perp)) //if the perp has security access, return 0
 				return 0


### PR DESCRIPTION
## About The Pull Request
The weapons authorization setting for turrets will now check for weapons on targets without a chameleon identification card instead of those with either a chameleon ID or no ID at all.

## Why It's Good For The Game
I'm pretty sure this is some human error. The setting doesn't currently work on your average crewmember.

## Changelog
:cl:
fix: The weapons authorization setting for turrets will now check for weapons on targets without a chameleon identification card instead of those with either a chameleon ID or no ID at all.
/:cl:
