### PR TITLE
RPD: Feedback when configuration can't change

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -417,6 +417,9 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			// Refuse to create a smart pipe that can only connect in one direction (it would act weirdly and lack an icon)
 			if (ISNOTSTUB(target_dir))
 				p_init_dir = target_dir
+			else
+				to_chat(usr, span_warning("\The [src]'s screen flashes a warning: Can't configure a pipe to only connect in one direction."))
+				playeffect = FALSE
 		if("init_reset")
 			p_init_dir = ALL_CARDINALS
 	if(playeffect)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Preventing the creation of stub pipes involved adding a lot of checks to ensure a pipe could never be created with only one or no directions connectable. This PR adds feedback for when this happens, rather than appearing to silently fail - yet still generating the "I did something!" sparks.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Slightly better UX and feedback hopefully makes dealing with a fairly complicated system slightly easier

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: When configuring smart pipes, the RPD will now only spark if the configuration actually changed, and the RPD now provides feedback if configuration couldn't change.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
