### PR TITLE
tgui: Add new and disambiguate old gas colors

### DIFF
--- a/tgui/docs/component-reference.md
+++ b/tgui/docs/component-reference.md
@@ -779,7 +779,11 @@ percentage and how filled the bar is.
 - `maxValue: number` - Highest possible value.
 - `ranges: { color: [from, to] }` - Applies a `color` to the progress bar
 based on whether the value lands in the range between `from` and `to`.
-- `color: string` - Color of the progress bar.
+- `color: string` - Color of the progress bar. Can take any of the following formats:
+  - `#ffffff` - Hex format
+  - `rgb(r,g,b) / rgba(r,g,b,a)` - RGB format
+  - `<name>` - the name of a `color-<name>` CSS class. See `CSS_COLORS` in `constants.js`.
+  - `<name>` - the name of a base CSS color, if not overridden by the definitions above.
 - `children: any` - Content to render inside the progress bar.
 
 ### `RoundGauge`

--- a/tgui/packages/tgui/components/ProgressBar.js
+++ b/tgui/packages/tgui/components/ProgressBar.js
@@ -7,6 +7,7 @@
 import { clamp01, scale, keyOfMatchingRange, toFixed } from 'common/math';
 import { classes, pureComponentHooks } from 'common/react';
 import { computeBoxClassName, computeBoxProps } from './Box';
+import { CSS_COLORS } from '../constants';
 
 export const ProgressBar = props => {
   const {
@@ -24,20 +25,35 @@ export const ProgressBar = props => {
   const effectiveColor = color
     || keyOfMatchingRange(value, ranges)
     || 'default';
+
+  // We permit colors to be in hex format, rgb()/rgba() format,
+  // a name for a color-<name> class, or a base CSS class.
+  const outerProps = computeBoxProps(rest);
+  const outerClasses = [
+    'ProgressBar',
+    className,
+    computeBoxClassName(rest),
+  ];
+  const fillStyles = {
+    'width': clamp01(scaledValue) * 100 + '%',
+  };
+  if (CSS_COLORS.includes(effectiveColor)) {
+    // If the color is a color-<name> class, just use that.
+    outerClasses.push('ProgressBar--color--' + effectiveColor);
+  } else {
+    // Otherwise, set styles directly.
+    outerProps.style = (outerProps.style || "")
+      + `border-color: ${effectiveColor};`;
+    fillStyles['background-color'] = effectiveColor;
+  }
+
   return (
     <div
-      className={classes([
-        'ProgressBar',
-        'ProgressBar--color--' + effectiveColor,
-        className,
-        computeBoxClassName(rest),
-      ])}
-      {...computeBoxProps(rest)}>
+      className={classes(outerClasses)}
+      {...outerProps}>
       <div
         className="ProgressBar__fill ProgressBar__fill--animated"
-        style={{
-          width: clamp01(scaledValue) * 100 + '%',
-        }} />
+        style={fillStyles} />
       <div className="ProgressBar__content">
         {hasContent
           ? children

--- a/tgui/packages/tgui/constants.js
+++ b/tgui/packages/tgui/constants.js
@@ -167,7 +167,7 @@ const GASES = [
     'id': 'water_vapor',
     'name': 'Water Vapor',
     'label': 'H₂O',
-    'color': 'grey',
+    'color': 'lightsteelblue',
   },
   {
     'id': 'nob',
@@ -179,7 +179,7 @@ const GASES = [
     'id': 'n2o',
     'name': 'Nitrous Oxide',
     'label': 'N₂O',
-    'color': 'red',
+    'color': 'bisque',
   },
   {
     'id': 'no2',
@@ -191,25 +191,25 @@ const GASES = [
     'id': 'tritium',
     'name': 'Tritium',
     'label': 'Tritium',
-    'color': 'green',
+    'color': 'limegreen',
   },
   {
     'id': 'bz',
     'name': 'BZ',
     'label': 'BZ',
-    'color': 'purple',
+    'color': 'mediumpurple',
   },
   {
     'id': 'stim',
     'name': 'Stimulum',
     'label': 'Stimulum',
-    'color': 'purple',
+    'color': 'darkviolet',
   },
   {
     'id': 'pluox',
     'name': 'Pluoxium',
     'label': 'Pluoxium',
-    'color': 'blue',
+    'color': 'mediumslateblue',
   },
   {
     'id': 'miasma',
@@ -218,10 +218,52 @@ const GASES = [
     'color': 'olive',
   },
   {
+    'id': 'Freon',
+    'name': 'Freon',
+    'label': 'Freon',
+    'color': 'paleturquoise',
+  },
+  {
     'id': 'hydrogen',
     'name': 'Hydrogen',
     'label': 'H₂',
     'color': 'white',
+  },
+  {
+    'id': 'healium',
+    'name': 'Healium',
+    'label': 'Healium',
+    'color': 'salmon',
+  },
+  {
+    'id': 'proto_nitrate',
+    'name': 'Proto Nitrate',
+    'label': 'Proto-Nitrate',
+    'color': 'greenyellow',
+  },
+  {
+    'id': 'zauker',
+    'name': 'Zauker',
+    'label': 'Zauker',
+    'color': 'darkgreen',
+  },
+  {
+    'id': 'halon',
+    'name': 'Halon',
+    'label': 'Halon',
+    'color': 'purple',
+  },
+  {
+    'id': 'helium',
+    'name': 'Helium',
+    'label': 'He',
+    'color': 'aliceblue',
+  },
+  {
+    'id': 'antinoblium',
+    'name': 'Antinoblium',
+    'label': 'Anti-Noblium',
+    'color': 'maroon',
   },
 ];
 

--- a/tgui/packages/tgui/stories/ProgressBar.stories.js
+++ b/tgui/packages/tgui/stories/ProgressBar.stories.js
@@ -5,7 +5,7 @@
  */
 
 import { useLocalState } from '../backend';
-import { Box, Button, ProgressBar, Section } from '../components';
+import { Box, Button, Input, LabeledList, ProgressBar, Section } from '../components';
 
 export const meta = {
   title: 'ProgressBar',
@@ -17,26 +17,44 @@ const Story = (props, context) => {
     progress,
     setProgress,
   ] = useLocalState(context, 'progress', 0.5);
+  const [
+    color,
+    setColor,
+  ] = useLocalState(context, 'color', '');
+
+  const color_data = color
+    ? { color: color }
+    : { ranges: {
+      good: [0.5, Infinity],
+      bad: [-Infinity, 0.1],
+      average: [0, 0.5],
+    } };
+
   return (
     <Section>
       <ProgressBar
-        ranges={{
-          good: [0.5, Infinity],
-          bad: [-Infinity, 0.1],
-          average: [0, 0.5],
-        }}
+        {...color_data}
         minValue={-1}
         maxValue={1}
         value={progress}>
         Value: {Number(progress).toFixed(1)}
       </ProgressBar>
       <Box mt={1}>
-        <Button
-          content="-0.1"
-          onClick={() => setProgress(progress - 0.1)} />
-        <Button
-          content="+0.1"
-          onClick={() => setProgress(progress + 0.1)} />
+        <LabeledList mt="2em">
+          <LabeledList.Item label="Adjust value">
+            <Button
+              content="-0.1"
+              onClick={() => setProgress(progress - 0.1)} />
+            <Button
+              content="+0.1"
+              onClick={() => setProgress(progress + 0.1)} />
+          </LabeledList.Item>
+          <LabeledList.Item label="Override color">
+            <Input
+              value={color}
+              onChange={(e, value) => setColor(value)} />
+          </LabeledList.Item>
+        </LabeledList>
       </Box>
     </Section>
   );

--- a/tgui/packages/tgui/styles/components/ProgressBar.scss
+++ b/tgui/packages/tgui/styles/components/ProgressBar.scss
@@ -17,6 +17,8 @@ $bg-map: colors.$bg-map !default;
   position: relative;
   width: 100%;
   padding: 0 0.5em;
+  border-width: base.em(1px) !important;
+  border-style: solid !important;
   border-radius: $border-radius;
   background-color: $background-color;
   transition: border-color 900ms ease-out;
@@ -50,7 +52,7 @@ $bg-map: colors.$bg-map !default;
 
 @each $color-name, $color-value in $bg-map {
   .ProgressBar--color--#{$color-name} {
-    border: base.em(1px) solid $color-value !important;
+    border-color: $color-value !important;
 
     .ProgressBar__fill {
       background-color: $color-value;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds color mappings for new gases, and disambiguates color mappings for old gases where multiple gases used one color - many used `red`, or `purple`.

Most of these have been around for a while, but were missing color mappings in interfaces.

This mainly affects the HFR gas list interface.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No more falling back to `color={false}` in Hypertorus.js

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
code: The tgui ProgressBar can now accept color specifications in hexademical, rgb/rgba, color-\<name\> class, and base CSS named colors.
fix: Add missing gas color mappings to tgui, and disambiguate old mappings. Exotic (and mundane) gases in the SM monitor and HFR interfaces have never been more colorful!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
