### PR TITLE
Fix HFR interface units

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
@@ -104,9 +104,9 @@
 	///Stores the iron content produced by the fusion
 	var/iron_content = 0
 	///User controlled variable to control the flow of the fusion by changing the amount of fuel injected
-	var/fuel_injection_rate = 250
+	var/fuel_injection_rate = 25
 	///User controlled variable to control the flow of the fusion by changing the amount of moderators injected
-	var/moderator_injection_rate = 250
+	var/moderator_injection_rate = 25
 
 	///Integrity of the machine, if reaches 900 the machine will explode
 	var/critical_threshold_proximity = 0

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -150,7 +150,7 @@
 	var/datum/gas_mixture/fuel_port = linked_input.airs[1]
 	for(var/gas_type in selected_fuel.requirements)
 		internal_fusion.assert_gas(gas_type)
-		internal_fusion.merge(fuel_port.remove_specific(gas_type, fuel_port.gases[gas_type][MOLES] * fuel_injection_rate))
+		internal_fusion.merge(fuel_port.remove_specific(gas_type, fuel_injection_rate / length(selected_fuel.requirements)))
 		linked_input.update_parents()
 
 /obj/machinery/atmospherics/components/unary/hypertorus/core/process(delta_time)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -140,7 +140,7 @@
 	//Check and stores the gases from the moderator input in the moderator internal gasmix
 	var/datum/gas_mixture/moderator_port = linked_moderator.airs[1]
 	if(start_moderator && moderator_port.total_moles())
-		moderator_internal.merge(moderator_port.remove(moderator_injection_rate * 0.1))
+		moderator_internal.merge(moderator_port.remove(moderator_injection_rate))
 		linked_moderator.update_parents()
 
 	//Check if the fuels are present and move them inside the fuel internal gasmix
@@ -150,7 +150,7 @@
 	var/datum/gas_mixture/fuel_port = linked_input.airs[1]
 	for(var/gas_type in selected_fuel.requirements)
 		internal_fusion.assert_gas(gas_type)
-		internal_fusion.merge(fuel_port.remove_specific(gas_type, fuel_port.gases[gas_type][MOLES] * fuel_injection_rate * 0.1))
+		internal_fusion.merge(fuel_port.remove_specific(gas_type, fuel_port.gases[gas_type][MOLES] * fuel_injection_rate))
 		linked_input.update_parents()
 
 /obj/machinery/atmospherics/components/unary/hypertorus/core/process(delta_time)
@@ -204,8 +204,8 @@
 		magnetic_constrictor = 100
 		heating_conductor = 500
 		current_damper = 0
-		fuel_injection_rate = 200
-		moderator_injection_rate = 500
+		fuel_injection_rate = 20
+		moderator_injection_rate = 50
 		waste_remove = FALSE
 		iron_content += 0.1 * delta_time
 
@@ -363,7 +363,7 @@
 	var/datum/gas_mixture/internal_output = new
 	//gas consumption and production
 	if(check_fuel())
-		var/fuel_consumption_rate = clamp((fuel_injection_rate * 0.001) * 5 * power_level, 0.05, 30) * selected_fuel.gas_production_multiplier
+		var/fuel_consumption_rate = clamp(fuel_injection_rate * 0.01 * 5 * power_level, 0.05, 30) * selected_fuel.gas_production_multiplier
 		var/fuel_consumption = fuel_consumption_rate * delta_time
 
 		for(var/gas_id in selected_fuel.requirements)
@@ -466,7 +466,7 @@
 							moderator_internal.gases[/datum/gas/healium][MOLES] -= min(moderator_internal.gases[/datum/gas/healium][MOLES], scaled_production * 20)
 					if(moderator_internal.temperature < 1e7 || (moderator_list[/datum/gas/plasma] > 100 && moderator_list[/datum/gas/bz] > 50))
 						internal_output.assert_gases(/datum/gas/antinoblium)
-						internal_output.gases[/datum/gas/antinoblium][MOLES] += 0.9 * (scaled_fuel_list[scaled_fuel_list[3]] / (fuel_injection_rate * 0.0065)) * delta_time
+						internal_output.gases[/datum/gas/antinoblium][MOLES] += 0.9 * (scaled_fuel_list[scaled_fuel_list[3]] / (fuel_injection_rate * 0.065)) * delta_time
 				if(6)
 					var/scaled_production = clamp(heat_output * 1e-7, 0, fuel_consumption_rate) * delta_time
 					moderator_internal.gases[selected_fuel.secondary_products[5]][MOLES] += scaled_production * 0.35
@@ -487,12 +487,12 @@
 							var/distance_root = sqrt(1 / max(1, get_dist(human, src)))
 							human.hallucination += power_level * 150 * distance_root
 							human.hallucination = clamp(human.hallucination, 0, 200)
-						moderator_internal.gases[/datum/gas/antinoblium][MOLES] += clamp((scaled_fuel_list[scaled_fuel_list[3]] / (fuel_injection_rate * 0.0045)), 0, 10) * delta_time
+						moderator_internal.gases[/datum/gas/antinoblium][MOLES] += clamp((scaled_fuel_list[scaled_fuel_list[3]] / (fuel_injection_rate * 0.045)), 0, 10) * delta_time
 					if(moderator_list[/datum/gas/healium] > 100)
 						if(critical_threshold_proximity > 400)
 							critical_threshold_proximity = max(critical_threshold_proximity - (moderator_list[/datum/gas/healium] / 100 * delta_time ), 0)
 							moderator_internal.gases[/datum/gas/healium][MOLES] -= min(moderator_internal.gases[/datum/gas/healium][MOLES], scaled_production * 20)
-					internal_fusion.gases[/datum/gas/antinoblium][MOLES] += 0.01 * (scaled_fuel_list[scaled_fuel_list[3]] / (fuel_injection_rate * 0.0095)) * delta_time
+					internal_fusion.gases[/datum/gas/antinoblium][MOLES] += 0.01 * (scaled_fuel_list[scaled_fuel_list[3]] / (fuel_injection_rate * 0.095)) * delta_time
 
 	//Modifies the internal_fusion temperature with the amount of heat output
 	var/temperature_modifier = selected_fuel.temperature_change_multiplier

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -335,12 +335,12 @@
 		if("fuel_injection_rate")
 			var/fuel_injection_rate = text2num(params["fuel_injection_rate"])
 			if(fuel_injection_rate != null)
-				connected_core.fuel_injection_rate = clamp(fuel_injection_rate, 5, 1500)
+				connected_core.fuel_injection_rate = clamp(fuel_injection_rate, 0.5, 150)
 				. = TRUE
 		if("moderator_injection_rate")
 			var/moderator_injection_rate = text2num(params["moderator_injection_rate"])
 			if(moderator_injection_rate != null)
-				connected_core.moderator_injection_rate = clamp(moderator_injection_rate, 5, 1500)
+				connected_core.moderator_injection_rate = clamp(moderator_injection_rate, 0.5, 150)
 				. = TRUE
 		if("current_damper")
 			var/current_damper = text2num(params["current_damper"])

--- a/tgui/packages/tgui/interfaces/Hypertorus.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus.js
@@ -117,7 +117,7 @@ const HypertorusSecondaryControls = (props, context) => {
               animated
               value={parseFloat(data.magnetic_constrictor)}
               width="63px"
-              unit="m^3/B"
+              unit="m³/T"
               minValue={50}
               maxValue={1000}
               onDrag={(e, value) => act('magnetic_constrictor', {
@@ -129,9 +129,9 @@ const HypertorusSecondaryControls = (props, context) => {
               animated
               value={parseFloat(data.fuel_injection_rate)}
               width="63px"
-              unit="g/s"
-              minValue={5}
-              maxValue={1500}
+              unit="mol/s"
+              minValue={.5}
+              maxValue={150}
               onDrag={(e, value) => act('fuel_injection_rate', {
                 fuel_injection_rate: value,
               })} />
@@ -141,9 +141,9 @@ const HypertorusSecondaryControls = (props, context) => {
               animated
               value={parseFloat(data.moderator_injection_rate)}
               width="63px"
-              unit="g/s"
-              minValue={5}
-              maxValue={1500}
+              unit="mol/s"
+              minValue={.5}
+              maxValue={150}
               onDrag={(e, value) => act('moderator_injection_rate', {
                 moderator_injection_rate: value,
               })} />
@@ -189,7 +189,7 @@ const HypertorusSecondaryControls = (props, context) => {
               animated
               value={parseFloat(data.mod_filtering_rate)}
               width="63px"
-              unit="moles/tick"
+              unit="mol/s"
               minValue={5}
               maxValue={200}
               onDrag={(e, value) => act('mod_filtering_rate', {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Exposing units in terms of tickrate to users shouldn't really happen, but in this case the HFR also already respects `delta_time` for moderator filtering rate.

See `hfr_main_processes.dm`:

```
moderator_internal.remove_specific(gas, (moderator_filtering_rate / filtering_amount) * delta_time)
```

Also consistently use `mol` over `g` for other types, since flow is calculated in terms of moles, and while the typical equation symbol for Magnetic Flux Density is `B`, the SI unit is Tesla (`T`).

## Why It's Good For The Game

Consistency, and avoids player visible references to tickrate

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The HFR interface now uses correct units, and avoids references to tickrate.
fix: The HFR no longer rapidly absorbs all available fuel from the fuel port at rates far exceeding the fuel injection rate.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
