### PR TITLE
HFR: Prevent moderator injection lockout

### DIFF
--- a/tgui/packages/tgui/interfaces/Hypertorus.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus.js
@@ -27,6 +27,7 @@ const HypertorusMainControls = (props, context) => {
             {'Start cooling: '}
             <Button
               disabled={data.start_fuel === 1
+                || data.start_moderator === 1
                 || data.start_power === 0
                 || (data.start_cooling && data.power_level > 0)}
               icon={data.start_cooling ? 'power-off' : 'times'}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Injection control was split into fuel injection and moderator injection, but in the controls the cooling phase still only checked against fuel injection.

This meant it was possible to start moderator injection, then disable cooling to leave moderator injection on, but uninteractable.

The main process already guards against this case, but the UI does not.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

aaaaaaaaaaaa why is everything broken aaaaaaaaaaaaaaaaaaa

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: You can no longer leave HFR moderator injection uninteractably on with cooling disabled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
