### PR TITLE
Fix HFR iron content UI scale

### DIFF
--- a/tgui/packages/tgui/interfaces/Hypertorus.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus.js
@@ -295,9 +295,9 @@ const HypertorusParameters = (props, context) => {
             <ProgressBar
               value={iron_content}
               ranges={{
-                good: [-Infinity, 3],
-                average: [3, 6],
-                bad: [6, Infinity],
+                good: [-Infinity, .1],
+                average: [.1, .36],
+                bad: [.36, Infinity],
               }} />
           </LabeledList.Item>
           <LabeledList.Item label="Energy Levels">


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Iron content is now clamped between 0% and 100%, meaning values over 1 never appear. The HFR now starts taking damage from iron content at 36%, but will always display "good" status on the UI, even when integrity failure is imminent.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This adjusts the iron content scale to use warning colors when over 10%, and use danger colors over 36%, where the HFR begins to take damage.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The HFR will now once again use warning colors on the iron content indicator when dangerous levels of iron content are present.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
