### PR TITLE
PREFS MENU INDUCED CODE FREEZE, no merging beyond this point!!!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## /tg/station codebase
 
 [![Build Status](https://github.com/tgstation/tgstation/workflows/CI%20Suite/badge.svg)](https://github.com/tgstation/tgstation/actions?query=workflow%3A%22CI+Suite%22)
-[![Percentage of issues still open](https://isitmaintained.com/badge/open/tgstation/tgstation.svg)](https://isitmaintained.com/project/tgstation/tgstation "Percentage of issues still open")
+[![Percentage of issues still open](All of them)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/tgstation/tgstation.svg)](https://isitmaintained.com/project/tgstation/tgstation "Average time to resolve an issue")
 ![Coverage](https://img.shields.io/badge/coverage---3%25-red.svg)
 


### PR DESCRIPTION
# NO PRs other than those necessary for https://github.com/tgstation/tgstation/pull/61313 to function properly will be merged until that PR is merged

# You are allowed to make PRs, but they will not be merged until prefs menu is merged.

## ~~WANTED: A fix for https://github.com/tgstation/tgstation/issues/61347, needed to make prefs menu look correctly!~~ We're working on it...

### Allowed PRs:
- PURELY icon updates (changing one sprite in a dmi to another)
- PURELY map related updates

### Touching ANY DM code makes you subject to this freeze.

![image](https://user-images.githubusercontent.com/35135081/132941714-a8cfbe39-c7e8-4fef-b1ba-d24e5ce04e82.png)

Prefs menu touches 372 files, mostly code that either vaguely touches prefs (like anything that needs to read it), or tangentially related things in order to make it function (a recent example being traumas which needed to be moved out for the phobia preference to work, but a PR being merged that skewed it).

## Look how BIG my TEXT IS