### PR TITLE
Adds a second Detective slot.

### DIFF
--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -3,8 +3,8 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
 	department_head = list("Head of Security")
 	faction = FACTION_STATION
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7


### PR DESCRIPTION
## About The Pull Request
Increases the open Detective positions to 2.

## Why It's Good For The Game

As someone who's played a lot of detective on many different servers from LRP to MRP to HRP, the number one most boring thing as a detective is having nobody to bounce ideas and theories off of. This usually ends up being the Warden because he's the only person in Security who's not constantly busy.

Opening a second detective slot will play right into typical detective media, where the detective has a comrade or buddy or assistant that works with him to crack the case.

It'll drastically improve the feel of Detective, and will allow for more interesting Detective cases and stories and roleplaying to occur.
## Changelog
:cl:
expansion: There is now a second Detective slot available.
/:cl:
