### PR TITLE
Pretty huge change to tramstation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -608,6 +608,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/tram/center)
+"adp" = (
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "adr" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -715,14 +721,6 @@
 "adS" = (
 /turf/closed/wall,
 /area/maintenance/starboard/central)
-"adT" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Ladder Access Hatch";
-	req_one_access_txt = null
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/center)
 "adU" = (
 /obj/structure/musician/piano{
 	icon_state = "piano"
@@ -4531,7 +4529,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "ask" = (
@@ -4541,7 +4538,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "asl" = (
@@ -4559,7 +4555,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "asq" = (
@@ -6671,10 +6666,12 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "azN" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
-/turf/open/floor/vault,
-/area/hallway/primary/tram/left)
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/right)
 "azO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -7382,7 +7379,8 @@
 /area/commons/storage/primary)
 "aCP" = (
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "aCR" = (
 /obj/structure/table/wood,
@@ -7448,7 +7446,10 @@
 "aDm" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/closet/firecloset,
+/obj/effect/landmark/start/hangover/closet,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aDn" = (
 /obj/structure/table/wood,
@@ -7945,17 +7946,6 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"aEW" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/center)
 "aEX" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -7972,19 +7962,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "aEY" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aEZ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aFa" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -8115,22 +8099,18 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aFp" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/center)
+/turf/open/openspace,
+/area/hallway/primary/tram/left)
 "aFr" = (
-/obj/structure/sign/warning/vacuum{
-	pixel_y = 32
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
+/turf/open/openspace,
 /area/hallway/primary/tram/center)
 "aFs" = (
 /obj/structure/disposalpipe/segment,
@@ -8184,16 +8164,12 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aFE" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/center)
+/turf/open/openspace,
+/area/hallway/primary/tram/right)
 "aFF" = (
 /turf/closed/wall,
 /area/security/courtroom)
@@ -8206,23 +8182,14 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aFH" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/right)
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "aFI" = (
-/obj/structure/sign/warning/vacuum{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/right)
+/obj/structure/ladder,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "aFJ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -8231,16 +8198,9 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aFK" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
-/area/hallway/primary/tram/right)
+/area/hallway/primary/tram/left)
 "aFL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -20277,17 +20237,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"eqw" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Ladder Access Hatch";
-	req_one_access_txt = null
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "eqx" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
@@ -21343,21 +21292,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
-"eNs" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "eNw" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -23252,6 +23186,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"fzV" = (
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "fAw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 5
@@ -23661,6 +23601,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"fHl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall,
+/area/hallway/primary/tram/left)
 "fHE" = (
 /turf/open/floor/iron,
 /area/cargo/office)
@@ -24216,13 +24161,11 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "fPW" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/machinery/camera{
 	c_tag = "Hallway - North-West Tram Bridge";
 	dir = 1
 	},
-/turf/open/floor/vault,
+/turf/closed/wall,
 /area/hallway/primary/tram/center)
 "fQb" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -24492,6 +24435,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"fVp" = (
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "fVA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
@@ -24956,6 +24903,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
+"gem" = (
+/obj/machinery/light/directional/east{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "ges" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -26072,13 +26025,10 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "gBD" = (
-/obj/structure/sign/warning/vacuum{
-	pixel_y = 32
-	},
-/obj/machinery/light/small/directional/west,
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/center)
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "gBH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -27697,7 +27647,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "hfk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -33021,6 +32971,10 @@
 /obj/item/shovel,
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
+"iZI" = (
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "iZN" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -41123,6 +41077,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/science/research)
+"lWT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "lXu" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -41566,7 +41527,7 @@
 /obj/structure/holosign/barrier/atmos/sturdy,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/vault,
-/area/hallway/primary/tram/left)
+/area/hallway/primary/tram/center)
 "mje" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -42137,6 +42098,9 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"mss" = (
+/turf/open/floor/plating,
+/area/hallway/primary/tram/right)
 "msI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 1
@@ -42990,6 +42954,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"mKi" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "mKk" = (
 /obj/item/grown/bananapeel{
 	name = "stealthy banana peel"
@@ -44131,6 +44099,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
+"nkP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "nlc" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -45034,6 +45006,10 @@
 /area/medical/pharmacy)
 "nBD" = (
 /obj/machinery/light/directional/south,
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/openspace,
 /area/hallway/primary/tram/right)
 "nBH" = (
@@ -45485,12 +45461,8 @@
 /turf/open/floor/plating,
 /area/cargo/office)
 "nLJ" = (
-/obj/structure/sign/warning/vacuum{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "nLK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -47330,20 +47302,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
-"osE" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "osQ" = (
 /obj/structure/bed,
 /obj/item/clothing/suit/straight_jacket,
@@ -50560,9 +50518,8 @@
 /obj/machinery/light/small/directional/north,
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "pAp" = (
 /obj/structure/grille,
@@ -51288,7 +51245,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "pNt" = (
@@ -54029,13 +53985,11 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "qQJ" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
 /obj/machinery/camera{
 	c_tag = "Hallway - North-East Tram Bridge";
 	dir = 1
 	},
-/turf/open/floor/vault,
+/turf/closed/wall,
 /area/hallway/primary/tram/right)
 "qQR" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -56550,6 +56504,10 @@
 /area/service/kitchen)
 "rQq" = (
 /obj/machinery/light/directional/south,
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
 "rQy" = (
@@ -57709,7 +57667,7 @@
 "snL" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "snR" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -58649,6 +58607,10 @@
 /area/command/heads_quarters/ce)
 "sCS" = (
 /obj/machinery/light/directional/south,
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/openspace,
 /area/hallway/primary/tram/left)
 "sDb" = (
@@ -61634,6 +61596,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"tIP" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/hallway/primary/tram/center)
 "tJg" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -65428,10 +65394,9 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "vdk" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/holosign/barrier/atmos/sturdy,
-/obj/structure/fluff/tram_rail/floor,
-/turf/open/floor/vault,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "vdC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -67995,6 +67960,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"wbg" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "wbl" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -69858,8 +69828,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "wIk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
@@ -71322,12 +71291,9 @@
 /turf/open/floor/carpet,
 /area/command/bridge)
 "xkT" = (
-/obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "xkY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -73622,6 +73588,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"xYp" = (
+/turf/open/floor/plating,
+/area/hallway/primary/tram/center)
 "xYt" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -163884,8 +163853,8 @@ ajY
 qbg
 axX
 anG
-anG
-eqw
+aFH
+hfg
 awF
 aAX
 aAX
@@ -164398,8 +164367,8 @@ azB
 wUT
 axX
 anG
-auN
-hfg
+aFI
+xkT
 awF
 aGC
 aHg
@@ -164655,8 +164624,8 @@ azB
 qbg
 axX
 anG
-anG
-osE
+aFK
+xkT
 awF
 awF
 awF
@@ -165169,8 +165138,8 @@ azB
 qbg
 axX
 anG
-anG
-eNs
+gBD
+xkT
 anG
 aae
 aae
@@ -165425,10 +165394,10 @@ vUA
 azB
 qbg
 axX
-axX
-eFB
-bak
-aae
+aFp
+nLJ
+xkT
+anG
 aae
 aae
 aae
@@ -165682,10 +165651,10 @@ fve
 azB
 wUT
 axX
-axX
-eFB
-bak
-aBM
+aFp
+nLJ
+xkT
+anG
 aae
 aae
 aae
@@ -165939,10 +165908,10 @@ vUA
 azB
 qbg
 axX
-axX
-eFB
-bak
-aBM
+aFp
+auX
+xkT
+anG
 aae
 lvw
 aBM
@@ -166197,9 +166166,9 @@ azB
 qbg
 axX
 sCS
-anG
-eAU
-nBz
+nLJ
+xkT
+fHl
 nBz
 nBz
 nBz
@@ -166454,9 +166423,9 @@ azC
 jaz
 mhj
 dAd
-eFB
-aRN
-aBM
+vdk
+nLJ
+anG
 aBM
 aae
 aae
@@ -166703,17 +166672,17 @@ aBM
 aBM
 aBM
 dOi
-anG
-azN
-azN
-vdk
+avn
+azP
+azP
+fsL
 mjd
 ohl
 azP
 fPW
+lWT
+xYp
 avn
-aRN
-aBM
 aae
 aae
 aae
@@ -166968,9 +166937,9 @@ jWZ
 cpF
 kvx
 kvx
-jpW
-aRN
-aBM
+aEY
+avK
+avn
 aae
 aae
 aae
@@ -167225,9 +167194,9 @@ azT
 bgI
 ayd
 rQq
+aEY
+aEY
 avn
-aRN
-aBM
 aBM
 aae
 aae
@@ -167481,10 +167450,10 @@ xds
 azT
 bgI
 ayd
-ayd
-jpW
-aRN
-aBM
+aFr
+aEY
+aEY
+avn
 aae
 aae
 aae
@@ -167738,10 +167707,10 @@ qyp
 azT
 pKf
 ayd
-ayd
-jpW
-aRN
-lbM
+aFr
+avK
+avK
+avn
 lbM
 lbM
 lbM
@@ -167995,10 +167964,10 @@ xds
 azT
 bgI
 ayd
-ayd
-jpW
-aRN
-lbM
+aFr
+xYp
+aEY
+avn
 lCH
 wWF
 wWF
@@ -168253,8 +168222,8 @@ azT
 bgI
 ayd
 avn
-avn
-aEW
+tIP
+aEY
 avn
 wWF
 lwN
@@ -168510,7 +168479,7 @@ azT
 bgI
 ayd
 avn
-gBD
+avK
 aEZ
 avn
 nsk
@@ -168767,7 +168736,7 @@ azT
 bgI
 ayd
 avn
-avn
+fVp
 aEY
 avn
 wWF
@@ -169024,8 +168993,8 @@ azT
 pKf
 ayd
 avn
-dRg
-aEZ
+adp
+avK
 jre
 jHG
 lwN
@@ -169282,7 +169251,7 @@ bgI
 ayd
 avn
 aDm
-aEZ
+aEY
 avn
 wWF
 lwN
@@ -169538,8 +169507,8 @@ sAO
 bgI
 ayd
 avn
-avn
-adT
+avK
+aEY
 avn
 wWF
 lwN
@@ -174164,8 +174133,8 @@ rHD
 bgI
 ayd
 avn
-avn
-adT
+avK
+avK
 avn
 wWF
 eVQ
@@ -174422,7 +174391,7 @@ bgI
 ayd
 avn
 wIj
-aEZ
+aEY
 avn
 wWF
 iVt
@@ -174678,7 +174647,7 @@ azT
 pKf
 ayd
 avn
-dRg
+adp
 snL
 avn
 naC
@@ -174935,8 +174904,8 @@ azT
 bgI
 ayd
 avn
-avn
-aFp
+fVp
+avK
 avn
 wWF
 eVQ
@@ -175191,9 +175160,9 @@ xds
 azT
 bgI
 ayd
-ayd
 avn
-aFr
+xYp
+avK
 avn
 wWF
 eVQ
@@ -175448,9 +175417,9 @@ xds
 azT
 bgI
 ayd
-ayd
 avn
-aFE
+wbg
+avK
 avn
 wWF
 eVQ
@@ -175705,10 +175674,10 @@ xds
 azT
 bgI
 ayd
-ayd
-jpW
-aRN
-lbM
+aFr
+aEY
+avK
+avn
 wWF
 eVQ
 eVQ
@@ -175962,10 +175931,10 @@ qyp
 azT
 pKf
 ayd
-ayd
-jpW
-aRN
-lbM
+aFr
+avK
+avK
+avn
 wWF
 wWF
 evF
@@ -176219,10 +176188,10 @@ xds
 azT
 bgI
 ayd
-ayd
-jpW
-aRN
-lbM
+aFr
+aEY
+aEY
+avn
 lbM
 lbM
 lbM
@@ -176477,9 +176446,9 @@ azT
 bgI
 ayd
 rQq
+aEY
+aEY
 avn
-aRN
-aBM
 aBM
 aae
 lbM
@@ -176734,9 +176703,9 @@ aAu
 hqc
 hWg
 hWg
-jpW
-aRN
-aBM
+aEY
+aEY
+avn
 aBM
 aBM
 lbM
@@ -176991,9 +176960,9 @@ bnl
 tZs
 aAJ
 qQJ
+gem
+aEb
 aod
-aRN
-aBM
 aBM
 aBM
 lbM
@@ -177246,11 +177215,11 @@ dlR
 xSI
 aAO
 lbq
+azN
 dlR
-dlR
-xMC
-aRN
-aBM
+aEb
+ryJ
+aod
 aBM
 aBM
 aBM
@@ -177505,9 +177474,9 @@ aAQ
 ujT
 ayt
 nBD
+nkP
+mss
 aod
-aRN
-aBM
 aBM
 aBM
 aBM
@@ -177761,10 +177730,10 @@ omi
 aAQ
 ujT
 ayt
-ayt
-xMC
-aRN
-aBM
+aFE
+nkP
+mss
+aod
 aBM
 aBM
 aBM
@@ -178018,10 +177987,10 @@ pCN
 aAQ
 gSR
 ayt
-ayt
-xMC
-aRN
-aBM
+aFE
+aEb
+mss
+aod
 aBM
 aBM
 aBM
@@ -178275,10 +178244,10 @@ omi
 aAQ
 ujT
 ayt
-ayt
-xMC
-aRN
-aBM
+aFE
+nkP
+nkP
+aod
 aBM
 aae
 aae
@@ -178532,10 +178501,10 @@ omi
 aAQ
 ujT
 ayt
-ayt
 aod
-aFH
-axR
+mKi
+aEb
+aod
 sEJ
 sEJ
 sEJ
@@ -178789,9 +178758,9 @@ omi
 aAQ
 ujT
 ayt
-ayt
 aod
-aFI
+mss
+aEb
 axR
 uZJ
 wla
@@ -179047,8 +179016,8 @@ aAQ
 ujT
 ayt
 aod
-aod
-aFK
+aEb
+aEb
 axR
 lEr
 tka
@@ -179304,8 +179273,8 @@ aAQ
 gSR
 ayt
 aod
-avY
-aux
+fzV
+nkP
 axR
 ssR
 tka
@@ -179562,7 +179531,7 @@ ujT
 ayt
 aod
 pzR
-aux
+nkP
 axR
 uHz
 mOF
@@ -179818,8 +179787,8 @@ gIO
 ujT
 ayt
 aod
-aod
-adu
+iZI
+aEb
 axR
 quT
 eoU


### PR DESCRIPTION
## About The Pull Request
This PR adds a walkway that connects arrivals to departures on tramstation. This doesnt devalue the tram at all, as its still faster going on side to the other. This prevents assistant deaths by the tram, and gives the anit-tram gang a place to go. 
![image](https://user-images.githubusercontent.com/61367602/132957832-d2d9cedc-3677-4264-80e0-3881096ef1be.png)

## Why It's Good For The Game
Makes Tramstation less awful.

## Changelog

:cl:
add: Adds a walkway to the upper south side of tramstation.
/:cl:

