### PR TITLE
Fixes stun-harmbatonging

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -488,8 +488,8 @@
 	if(. != BATON_DO_NORMAL_ATTACK)
 		return
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
-		if(active && cooldown_check <= world.time && check_parried(target, user))
-			finalize_baton_attack(target, user, modifiers)
+		if(active && cooldown_check <= world.time && !check_parried(target, user))
+			finalize_baton_attack(target, user, modifiers, in_attack_chain = FALSE)
 	else if(!user.combat_mode)
 		target.visible_message(span_warning("[user] prods [target] with [src]. Luckily it was off."), \
 			span_warning("[user] prods you with [src]. Luckily it was off."))


### PR DESCRIPTION
## About The Pull Request
Title. I have been told the refactor broke stun'n'harm batoning for stunbatons so I'm fixing it.

## Why It's Good For The Game
Clearing an oversight caused by a recent PR. Please link here any possible report about this issue. fixes #61458

## Changelog
:cl:
fix: stun-harm-batoning for stunbatons has been fixed.
/:cl:
