### PR TITLE
Fixed ntnet components not being type safe

### DIFF
--- a/code/modules/wiremod/components/ntnet/ntnet_receive.dm
+++ b/code/modules/wiremod/components/ntnet/ntnet_receive.dm
@@ -3,7 +3,6 @@
  *
  * Receives data through NTNet.
  */
-
 /obj/item/circuit_component/ntnet_receive
 	display_name = "NTNet Receiver"
 	desc = "Receives data packages through NTNet. If Encryption Key is set then only signals with the same Encryption Key will be received."
@@ -12,40 +11,16 @@
 
 	network_id = __NETWORK_CIRCUITS
 
-	var/datum/port/input/push_hid
-	var/datum/port/output/hid
+	/// Data being received
 	var/datum/port/output/data_package
-	var/datum/port/output/secondary_package
+
+	/// Encryption key
 	var/datum/port/input/enc_key
-	var/datum/port/input/option/data_type_options
-	var/datum/port/input/option/secondary_data_type_options
 
 /obj/item/circuit_component/ntnet_receive/populate_ports()
 	data_package = add_output_port("Data Package", PORT_TYPE_ANY)
-	secondary_package = add_output_port("Secondary Package", PORT_TYPE_ANY)
 	enc_key = add_input_port("Encryption Key", PORT_TYPE_STRING)
 	RegisterSignal(src, COMSIG_COMPONENT_NTNET_RECEIVE, .proc/ntnet_receive)
-
-/obj/item/circuit_component/ntnet_receive/populate_options()
-	var/static/component_options = list(
-		PORT_TYPE_ANY,
-		PORT_TYPE_STRING,
-		PORT_TYPE_NUMBER,
-		PORT_TYPE_LIST,
-		PORT_TYPE_ATOM,
-	)
-	data_type_options = add_option_port("Data Type", component_options)
-	secondary_data_type_options = add_option_port("Secondary Data Type", component_options)
-
-/obj/item/circuit_component/ntnet_receive/input_received(datum/port/input/port)
-
-	if(COMPONENT_TRIGGERED_BY(data_type_options, port))
-		data_package.set_datatype(data_type_options.value)
-
-	if(COMPONENT_TRIGGERED_BY(secondary_data_type_options, port))
-		secondary_package.set_datatype(secondary_data_type_options.value)
-
-	return TRUE
 
 /obj/item/circuit_component/ntnet_receive/proc/ntnet_receive(datum/source, datum/netdata/data)
 	SIGNAL_HANDLER
@@ -54,5 +29,4 @@
 		return
 
 	data_package.set_output(data.data["data"])
-	secondary_package.set_output(data.data["data_secondary"])
 	trigger_output.set_output(COMPONENT_SIGNAL)

--- a/code/modules/wiremod/components/ntnet/ntnet_send.dm
+++ b/code/modules/wiremod/components/ntnet/ntnet_send.dm
@@ -12,14 +12,15 @@
 
 	network_id = __NETWORK_CIRCUITS
 
+	/// Data being sent
 	var/datum/port/input/data_package
-	var/datum/port/input/secondary_package
+
+	/// Encryption key
 	var/datum/port/input/enc_key
 
 /obj/item/circuit_component/ntnet_send/populate_ports()
 	data_package = add_input_port("Data Package", PORT_TYPE_ANY)
-	secondary_package = add_input_port("Secondary Package", PORT_TYPE_ANY)
 	enc_key = add_input_port("Encryption Key", PORT_TYPE_STRING)
 
 /obj/item/circuit_component/ntnet_send/input_received(datum/port/input/port)
-	ntnet_send(list("data" = data_package.value, "data_secondary" = secondary_package.value, "enc_key" = enc_key.value))
+	ntnet_send(list("data" = data_package.value, "enc_key" = enc_key.value))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
NTNET component can set their output datatype to whatever and it'll just blindly accept it when setting the output. This shouldn't happen at all.

Removes the options that lets you set whatever type for the output ports for the ntnet component.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes ntnet components typesafe.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Ntnets are now type safe again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
