### PR TITLE
Ghosts can view Admin Circuits

### DIFF
--- a/code/modules/wiremod/core/integrated_circuit.dm
+++ b/code/modules/wiremod/core/integrated_circuit.dm
@@ -339,7 +339,10 @@ GLOBAL_LIST_EMPTY_TYPED(integrated_circuits, /obj/item/integrated_circuit)
 	// as ui_state is only set during
 	if(admin_only)
 		if(!check_rights_for(user.client, R_VAREDIT))
-			return UI_CLOSE
+			if(isobserver(user))
+				return UI_UPDATE
+			else
+				return UI_CLOSE
 		else
 			return UI_INTERACTIVE
 


### PR DESCRIPTION
## About The Pull Request

Ghosts are now able to view admin circuits.

## Why It's Good For The Game

I don't see what harm there is in allowing ghosts to see how admins set up their funny meme circuits. Could also help them come up with circuits of their own.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Ghosts are now able to view admin circuits
/:cl:

