### PR TITLE
Changes paper bins to be easier to use

### DIFF
--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -58,11 +58,8 @@
 				return FALSE
 			/// Number of sheets we're adding
 			var/num_to_add = 0
-			/// Some goober put their manifesto in the paperbin, complain at the user if that's why nothing happened
-			var/rejected_sheets = FALSE
 			for(var/obj/item/paper/the_paper as anything in bin.papers) // Search for the first blank sheet of paper, then toss it in
 				if(the_paper.info != "") // Uh oh, paper has words! 
-					rejected_sheets = TRUE
 					continue
 				if(istype(the_paper, /obj/item/paper/carbon)) // Add both the carbon, and the copy
 					var/obj/item/paper/carbon/carbon_paper = the_paper
@@ -76,10 +73,7 @@
 				break // All full!
 			bin.update_appearance()
 			if(!num_to_add)
-				if(rejected_sheets)
-					balloon_alert(user, "everything is written on!")
-				else
-					to_chat(user, span_warning("The [src]'s paper recycler refuses \the [bin], flashing some cryptic message about a feed error!"))
+				balloon_alert(user, "everything is written on!")
 			else
 				balloon_alert(user, "pulled in [num_to_add] sheets\s of paper")
 			return TRUE

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -50,6 +50,42 @@
 		qdel(I)
 		stored_paper++
 		return TRUE
+	if(istype(I, /obj/item/paper_bin))
+		var/obj/item/paper_bin/bin = I
+		if(LAZYLEN(bin.papers))
+			if(stored_paper >= max_paper)
+				to_chat(user, span_warning("You try to feed \the [bin] into [src]'s paper recycler, but its paper bin is full!"))
+				return FALSE
+			/// Number of sheets we're adding
+			var/num_to_add = 0
+			/// Some goober put their manifesto in the paperbin, complain at the user if that's why nothing happened
+			var/rejected_sheets = FALSE
+			for(var/obj/item/paper/the_paper in bin.papers) // Search for the first blank sheet of paper, then toss it in
+				if(the_paper.info != "") // Uh oh, paper has words! 
+					rejected_sheets = TRUE
+					continue
+				if(istype(the_paper, /obj/item/paper/carbon)) // Add both the carbon, and the copy
+					var/obj/item/paper/carbon/carbon_paper = the_paper
+					if(!carbon_paper.copied && ((max_paper - stored_paper) >= 2)) // See if there's room for both
+						num_to_add = 2
+				else
+					num_to_add = 1
+				LAZYREMOVE(bin.papers, the_paper)
+				qdel(the_paper)
+				stored_paper += num_to_add
+				break // All full!
+			bin.update_appearance()
+			if(!num_to_add)
+				if(rejected_sheets)
+					to_chat(user, span_warning("The [src]'s paper recycler detects writing on everything in \the [bin], outright refusing to accept anything!"))
+				else
+					to_chat(user, span_warning("The [src]'s paper recycler refuses \the [bin], flashing some cryptic message about a feed error!"))
+			else
+				to_chat(user, span_notice("The [src]'s paper recycler pulls in [num_to_add] unit[num_to_add >= 2 ? "s" : ""] of paper from \the [bin]."))
+			return TRUE
+		else
+			to_chat(user, span_warning("\The [bin] is empty."))
+			return FALSE
 	return FALSE
 
 /obj/item/computer_hardware/printer/mini

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -54,7 +54,7 @@
 		var/obj/item/paper_bin/bin = I
 		if(LAZYLEN(bin.papers))
 			if(stored_paper >= max_paper)
-				balloon_alert(user, "its full!")
+				balloon_alert(user, "it's full!")
 				return FALSE
 			/// Number of sheets we're adding
 			var/num_to_add = 0

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -54,13 +54,13 @@
 		var/obj/item/paper_bin/bin = I
 		if(LAZYLEN(bin.papers))
 			if(stored_paper >= max_paper)
-				to_chat(user, span_warning("You try to feed \the [bin] into [src]'s paper recycler, but its paper bin is full!"))
+				balloon_alert(user, "its full!")
 				return FALSE
 			/// Number of sheets we're adding
 			var/num_to_add = 0
 			/// Some goober put their manifesto in the paperbin, complain at the user if that's why nothing happened
 			var/rejected_sheets = FALSE
-			for(var/obj/item/paper/the_paper in bin.papers) // Search for the first blank sheet of paper, then toss it in
+			for(var/obj/item/paper/the_paper as anything in bin.papers) // Search for the first blank sheet of paper, then toss it in
 				if(the_paper.info != "") // Uh oh, paper has words! 
 					rejected_sheets = TRUE
 					continue
@@ -81,10 +81,10 @@
 				else
 					to_chat(user, span_warning("The [src]'s paper recycler refuses \the [bin], flashing some cryptic message about a feed error!"))
 			else
-				to_chat(user, span_notice("The [src]'s paper recycler pulls in [num_to_add] unit[num_to_add >= 2 ? "s" : ""] of paper from \the [bin]."))
+				balloon_alert(user, "pulled in [num_to_add] sheets\s of paper")
 			return TRUE
 		else
-			to_chat(user, span_warning("\The [bin] is empty."))
+			balloon_alert(user, "the bin is empty!")
 			return FALSE
 	return FALSE
 

--- a/code/modules/modular_computers/hardware/printer.dm
+++ b/code/modules/modular_computers/hardware/printer.dm
@@ -77,7 +77,7 @@
 			bin.update_appearance()
 			if(!num_to_add)
 				if(rejected_sheets)
-					to_chat(user, span_warning("The [src]'s paper recycler detects writing on everything in \the [bin], outright refusing to accept anything!"))
+					balloon_alert(user, "everything is written on!")
 				else
 					to_chat(user, span_warning("The [src]'s paper recycler refuses \the [bin], flashing some cryptic message about a feed error!"))
 			else

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -202,7 +202,7 @@
 		return
 
 	// Enable picking paper up by clicking on it with the clipboard or folder
-	if(istype(P, /obj/item/clipboard) || istype(P, /obj/item/folder))
+	if(istype(P, /obj/item/clipboard) || istype(P, /obj/item/folder) || istype(P, /obj/item/paper_bin))
 		P.attackby(src, user)
 		return
 	else if(istype(P, /obj/item/pen) || istype(P, /obj/item/toy/crayon))

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -78,7 +78,7 @@
 		var/mob/living/living_mob = user
 		if(!(living_mob.mobility_flags & MOBILITY_PICKUP))
 			return
-	user.changeNext_move(CLICK_CD_MELEE)
+	user.changeNext_move(CLICK_CD_RAPID)
 	if(at_overlay_limit())
 		dump_contents(drop_location(), TRUE)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowered the click cooldown on paper bin usage from 0.8 seconds to 0.2 seconds. Felt like it took way too long to dump paper onto the floor.

Made paper bins insert a sheet of whatever paper is has into computers with printers. Carbon papers count for two, and any papers in the bin with writing on them won't be accepted. Rejected sheets can still be inserted one at a time by hand though!

Using a paper bin on a sheet of paper adds the sheet to the bin.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Reloading printers takes ages, paper messes are annoying to clean up (without a folder), and it just feels strange that paperbins use the full attack cooldown for something that's pretty much harmless (unless knowledge is power!).

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Paper bins now can directly insert their contents into computers.
qol: Greatly reduced click cooldown on paper bins.
qol: Paper bins can now pick up papers by clicking on them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
