### PR TITLE
Adds plates to the autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -403,6 +403,14 @@
 	build_path = /obj/item/storage/bag/tray
 	category = list("initial","Dinnerware")
 
+/datum/design/plate
+	name = "Plate"
+	id = "plate"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 3500)
+	build_path = /obj/item/plate
+	category = list("initial","Dinnerware")
+
 /datum/design/cafeteria_tray
 	name = "Cafeteria Tray"
 	id = "foodtray"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds plates to the autolathe for printing. Also fixes #61431

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
You can now print plates to eat food with or throw in tense situations. This is good for the game because the mechanic of vendor restocks is barely ever seen or used, getting more plates can be annoying because most people will take the plate and not leave it back when you leave food out on them, additionally you can print basically every other piece of dinnerware in an autolathe even cleavers if they're hacked, so there is no reason why you shouldn't be able to print a plate as well.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
expansion: Adds plates to the autolathe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
