### PR TITLE
*bong rip sound* "ok, ok, bros, what if, like, we add this space ruin, where you can like, get a bunch of guns and syndicate gear, but like, you have to beat really easy crappy AI simplemobs with guns" "oh yeah thats a great idea bro this definitely wont get run into the ground every single round"

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -117,13 +117,6 @@
 	name = "Authorship"
 	description = "Just somewhere quiet, where I can focus on my work with no interruptions."
 
-/datum/map_template/ruin/space/caravanambush
-	id = "space/caravanambush"
-	suffix = "caravanambush.dmm"
-	name = "Syndicate Ambush"
-	description = "A caravan route used by passing cargo freights has been ambushed by a salvage team manned by the syndicate. \
-	The caravan managed to send off a distress message before being surrounded, their video feed cutting off as the sound of gunfire and a parrot was heard."
-
 /datum/map_template/ruin/space/originalcontent
 	id = "paperwizard"
 	suffix = "originalcontent.dmm"


### PR DESCRIPTION
## About The Pull Request

Removes the Syndicate Ambush ruin from the game.

## Why It's Good For The Game

See fucking title. This shit was run into the ground the day it went live and it's just an endless source of fuckin guns and explosions in otherwise normal rounds.

## Changelog

:cl:
del: The Syndicate will no longer ambush space trade routes due to increased Spinward Stellar Coalition police presence.
/:cl: