### PR TITLE
Fix ping_update errors when certain operations resolve to scientific notation.

### DIFF
--- a/code/controllers/subsystem/server_maint.dm
+++ b/code/controllers/subsystem/server_maint.dm
@@ -69,7 +69,7 @@ SUBSYSTEM_DEF(server_maint)
 				continue
 
 		if (!(!C || world.time - C.connection_time < PING_BUFFER_TIME || C.inactivity >= (wait-1)))
-			winset(C, null, "command=.update_ping+[world.time+world.tick_lag*TICK_USAGE_REAL/100]")
+			winset(C, null, "command=.update_ping+[num2text(world.time+world.tick_lag*TICK_USAGE_REAL/100, 32)]")
 
 		if (MC_TICK_CHECK) //one day, when ss13 has 1000 people per server, you guys are gonna be glad I added this tick check
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sometimes when logging on Campbell, fancy chat fails to load and my non-fancy chat is spammed with the following.

![image](https://user-images.githubusercontent.com/24975989/133170271-dd022fcc-449a-42dc-8415-6828e2562912.png)

In addition, ping fails to update correct on the status tab when this happens.

Hypothesis:
Sometimes world.time can report a number that displays as scientific notation when converted to text.

The following code leads to calling the update_ping verb.
`winset(C, null, "command=.update_ping+[world.time+world.tick_lag*TICK_USAGE_REAL/100]")`

I suspect what's happening is world.time is being converted to text and you're getting the following command:
`command=.update_ping+2.1313e`

And this is causing an error in update_ping since it can't resolve 2.1313e as a valid number.

Wrapping that in text2num with 32 significant figures (arbitrary number, heat death of the universe proof by several orders of magnitude) means the update_ping verb always gets a number that isn't in scientific notation.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better support for long shifts. Fixes an error/oversight.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed an issue with ping display that could cause display and chat errors on exceptionally long shifts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
