### PR TITLE
Fix lingering alpha issues when the Chameleon mutation is removed.

### DIFF
--- a/code/datums/mutations/chameleon.dm
+++ b/code/datums/mutations/chameleon.dm
@@ -35,4 +35,4 @@
 	if(..())
 		return
 	owner.alpha = 255
-	UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(owner, list(COMSIG_MOVABLE_MOVED, COMSIG_HUMAN_EARLY_UNARMED_ATTACK))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Chameleon mutation registers COMSIG_HUMAN_EARLY_UNARMED_ATTACK when it is gained, but never unregisters it when it is lost.

Mutation datums aren't necessarily deleted and can sit in the DNA dormant until activated, as a result there's no nice qdel() handler to clean up the mess.

An example of this is a changeling with Chameleon skin, that adds/activates/deactivates the Chameleon mutation as required.

Honestly, this could probably be refactored into a component since the behaviour is pretty generic and can mostly be applied to any atom. That is a bit more work for another day and a good first PR for someone to learn how to make components.

This at least fixes the underlying issue.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Attacking something after you've deactivated the Chameleon mutation or changeling Chameleon Skin power should no longer turn you partially transparent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
