### PR TITLE
The Unlatchening (toolboxes can now sometimes spawn latchless)

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -20,10 +20,13 @@
 	material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR
 	var/latches = "single_latch"
 	var/has_latches = TRUE
+	var/latch_exempt = FALSE
 	wound_bonus = 5
 
 /obj/item/storage/toolbox/Initialize()
 	. = ..()
+	if(prob(5))
+		has_latches = FALSE
 	if(has_latches)
 		if(prob(10))
 			latches = "double_latch"
@@ -36,6 +39,27 @@
 	if(has_latches)
 		. += latches
 
+/obj/item/storage/toolbox/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	. = ..()
+	if(!has_latches && !latch_exempt)
+		var/list/obj/item/oldContents = contents.Copy()
+		SEND_SIGNAL(src, COMSIG_TRY_STORAGE_QUICK_EMPTY)
+		for(var/obj/item/scatter_item in oldContents)
+			INVOKE_ASYNC(src, .proc/do_scatter, scatter_item)
+
+/obj/item/storage/toolbox/dropped(mob/user)
+	. = ..()
+	if(!has_latches && !latch_exempt)
+		var/list/obj/item/oldContents = contents.Copy()
+		SEND_SIGNAL(src, COMSIG_TRY_STORAGE_QUICK_EMPTY)
+		for(var/obj/item/scatter_item in oldContents)
+			INVOKE_ASYNC(src, .proc/do_scatter, scatter_item)
+
+/obj/item/storage/toolbox/proc/do_scatter(obj/item/scatter_item)
+	for(var/i in 1 to rand(1,2))
+		if(scatter_item)
+			step(scatter_item, pick(NORTH,SOUTH,EAST,WEST))
+			sleep(1)
 
 /obj/item/storage/toolbox/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] robusts [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
@@ -64,6 +88,7 @@
 	name = "rusty red toolbox"
 	icon_state = "toolbox_red_old"
 	has_latches = FALSE
+	latch_exempt = TRUE
 	material_flags = NONE
 
 /obj/item/storage/toolbox/mechanical
@@ -86,6 +111,7 @@
 	name = "rusty blue toolbox"
 	icon_state = "toolbox_blue_old"
 	has_latches = FALSE
+	latch_exempt = TRUE
 	has_soul = TRUE
 
 /obj/item/storage/toolbox/mechanical/old/heirloom
@@ -103,6 +129,7 @@
 	icon_state = "oldtoolboxclean"
 	inhand_icon_state = "toolbox_blue"
 	has_latches = FALSE
+	latch_exempt = TRUE
 	force = 19
 	throwforce = 22
 
@@ -252,6 +279,7 @@
 	throwforce = 18
 	w_class = WEIGHT_CLASS_NORMAL
 	has_latches = FALSE
+	latch_exempt = TRUE
 
 /obj/item/storage/toolbox/infiltrator/ComponentInitialize()
 	. = ..()

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -34,6 +34,11 @@
 				latches = "triple_latch"
 	update_appearance()
 
+/obj/item/storage/toolbox/examine(mob/user)
+	. = ..()
+	if(!has_latches && !latch_exempt)
+		. += span_danger("\The [src] lacks a latch, be careful to not spill its contents.")
+
 /obj/item/storage/toolbox/update_overlays()
 	. = ..()
 	if(has_latches)
@@ -48,6 +53,14 @@
 			INVOKE_ASYNC(src, .proc/do_scatter, scatter_item)
 
 /obj/item/storage/toolbox/dropped(mob/user)
+	. = ..()
+	if(!has_latches && !latch_exempt)
+		var/list/obj/item/oldContents = contents.Copy()
+		SEND_SIGNAL(src, COMSIG_TRY_STORAGE_QUICK_EMPTY)
+		for(var/obj/item/scatter_item in oldContents)
+			INVOKE_ASYNC(src, .proc/do_scatter, scatter_item)
+
+/obj/item/storage/toolbox/attack(mob/living/M, mob/living/user)
 	. = ..()
 	if(!has_latches && !latch_exempt)
 		var/list/obj/item/oldContents = contents.Copy()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -214,7 +214,18 @@
 		return TRUE
 
 	if(!user.combat_mode && !(I.item_flags & ABSTRACT))
+		//prevents latchless toolboxes from spilling contents when "dropped" on a table
+		var/was_latched_toolbox
+		var/obj/item/storage/toolbox/placed_toolbox
+		if(istype(I, /obj/item/storage/toolbox))
+			placed_toolbox = I
+			if(!placed_toolbox.has_latches && !placed_toolbox.latch_exempt)
+				placed_toolbox.latch_exempt = TRUE
+				was_latched_toolbox = TRUE
+
 		if(user.transferItemToLoc(I, drop_location(), silent = FALSE))
+			if(was_latched_toolbox)
+				placed_toolbox.latch_exempt = FALSE
 			//Center the icon where the user clicked.
 			if(!LAZYACCESS(modifiers, ICON_X) || !LAZYACCESS(modifiers, ICON_Y))
 				return

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -207,6 +207,7 @@
 	target_toolbox.icon_state = "toolbox_blue_old"
 	target_toolbox.has_soul = TRUE
 	target_toolbox.has_latches = FALSE
+	target_toolbox.latch_exempt = TRUE
 
 ///////////////////////////Transferring to constructs/////////////////////////////////////////////////////
 /obj/structure/constructshell

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -100,8 +100,17 @@
 			return
 
 	if(!user.combat_mode)
+		var/was_latched_toolbox
+		var/obj/item/storage/toolbox/placed_toolbox
+		if(istype(I, /obj/item/storage/toolbox))
+			placed_toolbox = I
+			if(!placed_toolbox.has_latches && !placed_toolbox.latch_exempt)
+				placed_toolbox.latch_exempt = TRUE
+				was_latched_toolbox = TRUE
 		if((I.item_flags & ABSTRACT) || !user.temporarilyRemoveItemFromInventory(I))
 			return
+		if(was_latched_toolbox)
+			placed_toolbox.latch_exempt = FALSE
 		place_item_in_disposal(I, user)
 		update_appearance()
 		return 1 //no afterattack


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds a new possible latch combination for toolboxes, we had 1 latch, then 2 lactches, then 3 latches..... now get ready for no latches

currently latchless toolboxes only exist because they use old sprites that have a latch on the static sprite, those now get latch_exempt status so actual latchless toolboxes dont mess with them

there is a 5% chance for a toolbox to be latchless, if this happens it is unsecure and as such if you drop it or throw it, it will spill its contents, you can safely place it on tables and into disposal bins however, though when the toolbox is thrown out the disposal outlets and hits something/the floor, it will also spill its contents

also spills if you hit someone with it (not shown in this video)
also latchless toolboxes have an examine text telling you to be careful not to spill its contents. (not shown)

https://user-images.githubusercontent.com/40489693/133172775-2009f247-6054-48d7-b408-01aa1bef1525.mp4


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/40489693/133185087-8f4bbb64-5c36-403a-a5ec-c4c4788831a1.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Nari Harimoto
expansion: Toolboxes now have a 5% chance to spawn without a latch, making the contents unsecure and liable to spill, be careful!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
