### PR TITLE
Fixes Duplicate Icebox Theater Chair

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -2419,7 +2419,6 @@
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "mn" = (
-/obj/structure/chair/stool/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},


### PR DESCRIPTION
Duplicate Chair that nobody has done anything about yet.

## About The Pull Request

Gets rid of a random chair just taking up space in the theater. 

## Why It's Good For The Game

It doesn't look good. It's not supposed to be there.

## Changelog

:cl:
fix: Removes the spare stool from the Icebox Theater. 

/:cl:
