### PR TITLE
Nuclear Operatives will now see the nuke codes in memories

### DIFF
--- a/code/__DEFINES/memory_defines.dm
+++ b/code/__DEFINES/memory_defines.dm
@@ -88,6 +88,8 @@
 #define MEMORY_VENDING_CRUSHED "vending_crushed"
 /// Dusted by SM
 #define MEMORY_SUPERMATTER_DUSTED "supermatter_dusted"
+/// Nuke ops nuke code memory
+#define MEMORY_NUKECODE "nuke_code"
 
 /**
  * These are also memories, but they're examples of what I kinda don't want to be memories. They're stuff that I had to port
@@ -141,5 +143,6 @@
 #define DETAIL_STATION_NAME "STATION_NAME"
 #define DETAIL_MEDAL_TYPE "MEDAL_TYPE"
 #define DETAIL_MEDAL_REASON "MEDAL_REASON"
+#define DETAIL_NUKE_CODE "NUKE_CODE"
 
 

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -87,6 +87,7 @@
 /datum/antagonist/nukeop/proc/memorize_code()
 	if(nuke_team && nuke_team.tracked_nuke && nuke_team.memorized_code)
 		antag_memory += "<B>[nuke_team.tracked_nuke] Code</B>: [nuke_team.memorized_code]<br>"
+		owner.add_memory(MEMORY_NUKECODE, list(DETAIL_NUKE_CODE = nuke_team.memorized_code, DETAIL_PROTAGONIST = owner.current), story_value = STORY_VALUE_SHIT, memory_flags = MEMORY_FLAG_NOLOCATION)
 		to_chat(owner, "The nuclear authorization code is: <B>[nuke_team.memorized_code]</B>")
 	else
 		to_chat(owner, "Unfortunately the syndicate was unable to provide you with nuclear authorization code.")

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -87,7 +87,7 @@
 /datum/antagonist/nukeop/proc/memorize_code()
 	if(nuke_team && nuke_team.tracked_nuke && nuke_team.memorized_code)
 		antag_memory += "<B>[nuke_team.tracked_nuke] Code</B>: [nuke_team.memorized_code]<br>"
-		owner.add_memory(MEMORY_NUKECODE, list(DETAIL_NUKE_CODE = nuke_team.memorized_code, DETAIL_PROTAGONIST = owner.current), story_value = STORY_VALUE_SHIT, memory_flags = MEMORY_FLAG_NOLOCATION)
+		owner.add_memory(MEMORY_NUKECODE, list(DETAIL_NUKE_CODE = nuke_team.memorized_code, DETAIL_PROTAGONIST = owner.current), story_value = STORY_VALUE_SHIT, memory_flags = MEMORY_FLAG_NOLOCATION | MEMORY_FLAG_NOMOOD) 
 		to_chat(owner, "The nuclear authorization code is: <B>[nuke_team.memorized_code]</B>")
 	else
 		to_chat(owner, "Unfortunately the syndicate was unable to provide you with nuclear authorization code.")

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -87,7 +87,7 @@
 /datum/antagonist/nukeop/proc/memorize_code()
 	if(nuke_team && nuke_team.tracked_nuke && nuke_team.memorized_code)
 		antag_memory += "<B>[nuke_team.tracked_nuke] Code</B>: [nuke_team.memorized_code]<br>"
-		owner.add_memory(MEMORY_NUKECODE, list(DETAIL_NUKE_CODE = nuke_team.memorized_code, DETAIL_PROTAGONIST = owner.current), story_value = STORY_VALUE_SHIT, memory_flags = MEMORY_FLAG_NOLOCATION | MEMORY_FLAG_NOMOOD) 
+		owner.add_memory(MEMORY_NUKECODE, list(DETAIL_NUKE_CODE = nuke_team.memorized_code, DETAIL_PROTAGONIST = owner.current), story_value = STORY_VALUE_AMAZING, memory_flags = MEMORY_FLAG_NOLOCATION | MEMORY_FLAG_NOMOOD | MEMORY_FLAG_NOPERSISTENCE) 
 		to_chat(owner, "The nuclear authorization code is: <B>[nuke_team.memorized_code]</B>")
 	else
 		to_chat(owner, "Unfortunately the syndicate was unable to provide you with nuclear authorization code.")

--- a/strings/memories.json
+++ b/strings/memories.json
@@ -415,7 +415,7 @@
 	"nuke_code_names":[
 		"%PROTAGONIST learns the detonation codes for a nuclear weapon, %NUKE_CODE."
 		],
-		"nuke_code_starts":[
+	"nuke_code_starts":[
 		"The number %NUKE_CODE written on a sticky note with the words \"FOR SYNDICATE EYES ONLY\" scrawled next to it.",
 		"A piece of paper with the number %NUKE_CODE being handed to %PROTAGONIST from a figure in a blood-red hardsuit."
 	]

--- a/strings/memories.json
+++ b/strings/memories.json
@@ -413,15 +413,10 @@
 		"%PROTAGONIST %MOOD as they are reduced to atoms."
 	],
 	"nuke_code_names":[
-		"%NUKE_CODE, The detonation code for the nuclear device" 
-	],
-	"nuke_code_starts":[
-		"%PROTAGONIST firing their neurons to remember the important detonation code",
-		"%PROTAGONIST rapidly combing through their thoughts so they can make the station light up like a christmas tree"
-	],
-	"nuke_code_moods":[
-		"%PROTAGONIST %MOOD as they look at the nuclear device",
-		"%PROTAGONIST %MOOD as they cry into they keypad of the nuclear device",
-		"%PROTAGONIST %MOOD as they punch in those magic numbers"
+		"%PROTAGONIST learns the detonation codes for a nuclear weapon, %NUKE_CODE."
+		],
+		"nuke_code_starts":[
+		"The number %NUKE_CODE written on a sticky note with the words \"FOR SYNDICATE EYES ONLY\" scrawled next to it.",
+		"A piece of paper with the number %NUKE_CODE being handed to %PROTAGONIST from a figure in a blood-red hardsuit."
 	]
 }

--- a/strings/memories.json
+++ b/strings/memories.json
@@ -413,12 +413,15 @@
 		"%PROTAGONIST %MOOD as they are reduced to atoms."
 	],
 	"nuke_code_names":[
-		"The detonation code for the %PROTAGONIST, %NUKE_CODE" 
+		"%NUKE_CODE, The detonation code for the nuclear device" 
 	],
 	"nuke_code_starts":[
-		"%PROTAGONIST starts grinning as they recall the code for detonating a nuclear device, %NUKE_CODE"
+		"%PROTAGONIST firing their neurons to remember the important detonation code",
+		"%PROTAGONIST rapidly combing through their thoughts so they can make the station light up like a christmas tree"
 	],
 	"nuke_code_moods":[
-		"%PROTAGONIST %MOOD as they recalled the codes for detonating a nuclear device, %NUKE_CODE"
+		"%PROTAGONIST %MOOD as they look at the nuclear device",
+		"%PROTAGONIST %MOOD as they cry into they keypad of the nuclear device",
+		"%PROTAGONIST %MOOD as they punch in those magic numbers"
 	]
 }

--- a/strings/memories.json
+++ b/strings/memories.json
@@ -411,5 +411,14 @@
 	"supermatter_dusted_moods":[
 		"%PROTAGONIST %MOOD as they faded way.",
 		"%PROTAGONIST %MOOD as they are reduced to atoms."
+	],
+	"nuke_code_names":[
+		"The nuke code for the %PROTAGONIST, %NUKE_CODE" 
+	],
+	"nuke_code_starts":[
+		"%PROTAGONIST starts grinning recalling the nuke code, %NUKE_CODE"
+	],
+	"nuke_code_moods":[
+		"%PROTAGONIST %MOOD as they recalled the nuke code, %NUKE_CODE"
 	]
 }

--- a/strings/memories.json
+++ b/strings/memories.json
@@ -413,12 +413,12 @@
 		"%PROTAGONIST %MOOD as they are reduced to atoms."
 	],
 	"nuke_code_names":[
-		"The nuke code for the %PROTAGONIST, %NUKE_CODE" 
+		"The detonation code for the %PROTAGONIST, %NUKE_CODE" 
 	],
 	"nuke_code_starts":[
-		"%PROTAGONIST starts grinning recalling the nuke code, %NUKE_CODE"
+		"%PROTAGONIST starts grinning as they recall the code for detonating a nuclear device, %NUKE_CODE"
 	],
 	"nuke_code_moods":[
-		"%PROTAGONIST %MOOD as they recalled the nuke code, %NUKE_CODE"
+		"%PROTAGONIST %MOOD as they recalled the codes for detonating a nuclear device, %NUKE_CODE"
 	]
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This adds the ability for the nuclear operatives to check their memories for the nuke code. Memories are the successor to notes, the latter being where the nuke code was stored before. Many thanks to tralezab for helping me make this change. Also shoutout MrDoomBringer for making the messages suck less

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
You no longer need to admin help or open a notepad for the nuke code because you forgot the bit of paper that everyone is used to throwing away!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Burgerman, tralezab
fix: You can now see the nuke code in your memories
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
