### PR TITLE
shock touch will no longer discharge itself if you accidentally click on a random floor decal

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -30,14 +30,14 @@
 /obj/item/melee/touch_attack/shock/afterattack(atom/target, mob/living/carbon/user, proximity)
 	if(!proximity || !isliving(target))
 		return
-	var/mob/living/L = target
-	if(L.electrocute_act(15, user, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN)) //Doesn't stun. Never let this stun.
-		if(iscarbon(target))
-			var/mob/living/carbon/C = target
-			C.dropItemToGround(C.get_active_held_item())
-			C.dropItemToGround(C.get_inactive_held_item())
-			C.add_confusion(15)
-		L.visible_message(span_danger("[user] electrocutes [target]!"),span_userdanger("[user] electrocutes you!"))
-	else
+	var/mob/living/living_target = target
+	if(!living_target.electrocute_act(15, user, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN)) //Doesn't stun. Never let this stun.
 		user.visible_message(span_warning("[user] fails to electrocute [target]!"))
+		return ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/carbon_target = target
+		carbon_target.dropItemToGround(carbon_target.get_active_held_item())
+		carbon_target.dropItemToGround(carbon_target.get_inactive_held_item())
+		carbon_target.add_confusion(15)
+	living_target.visible_message(span_danger("[user] electrocutes [target]!"),span_userdanger("[user] electrocutes you!"))
 	return ..()

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -30,19 +30,14 @@
 /obj/item/melee/touch_attack/shock/afterattack(atom/target, mob/living/carbon/user, proximity)
 	if(!proximity || !isliving(target))
 		return
-	if(iscarbon(target))
-		var/mob/living/carbon/C = target
-		if(C.electrocute_act(15, user, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN))//doesnt stun. never let this stun
+	var/mob/living/L = target
+	if(L.electrocute_act(15, user, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN)) //Doesn't stun. Never let this stun.
+		if(iscarbon(target))
+			var/mob/living/carbon/C = target
 			C.dropItemToGround(C.get_active_held_item())
 			C.dropItemToGround(C.get_inactive_held_item())
 			C.add_confusion(15)
-			C.visible_message(span_danger("[user] electrocutes [target]!"),span_userdanger("[user] electrocutes you!"))
-			return ..()
-		else
-			user.visible_message(span_warning("[user] fails to electrocute [target]!"))
-			return ..()
-	else
-		var/mob/living/L = target
-		L.electrocute_act(15, user, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN)
 		L.visible_message(span_danger("[user] electrocutes [target]!"),span_userdanger("[user] electrocutes you!"))
-		return ..()
+	else
+		user.visible_message(span_warning("[user] fails to electrocute [target]!"))
+	return ..()

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -28,7 +28,7 @@
 	inhand_icon_state = "zapper"
 
 /obj/item/melee/touch_attack/shock/afterattack(atom/target, mob/living/carbon/user, proximity)
-	if(!proximity)
+	if(!proximity || !isliving(target))
 		return
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
@@ -41,11 +41,8 @@
 		else
 			user.visible_message(span_warning("[user] fails to electrocute [target]!"))
 			return ..()
-	else if(isliving(target))
-		var/mob/living/L = target
-		L.electrocute_act(15, user, 1, SHOCK_NOSTUN)
-		L.visible_message(span_danger("[user] electrocutes [target]!"),span_userdanger("[user] electrocutes you!"))
-		return ..()
 	else
-		to_chat(user,span_warning("The electricity doesn't seem to affect [target]..."))
+		var/mob/living/L = target
+		L.electrocute_act(15, user, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN)
+		L.visible_message(span_danger("[user] electrocutes [target]!"),span_userdanger("[user] electrocutes you!"))
 		return ..()


### PR DESCRIPTION
## About The Pull Request

Prevents this from happening: https://youtu.be/r-Oe8karW0o?t=43.

Also fixes an oversight from https://github.com/tgstation/tgstation/pull/54906 - in that PR, I made Shock Touch's vs. carbon shock ignore insulated gloves, but forgot to make its vs. living non-carbon shock also ignore insulated gloves. This has been corrected.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/42606352/133234368-8c2fe1c0-e4a9-480b-9e86-d122f065674e.png)

## Changelog

:cl: ATHATH
qol: Shock touch will no longer discharge itself on non-living targets.
fix: The shock that shock touch gives to non-carbons is now identical to the shock that it gives to carbons.
/:cl: