### PR TITLE
The pinpointer once again tracks shunted AIs

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -266,7 +266,7 @@
 		area.power_change()
 	QDEL_NULL(alarm_manager)
 	if(occupier)
-		malfvacate(1)
+		malfvacate(TRUE)
 	if(wires)
 		QDEL_NULL(wires)
 	if(cell)
@@ -1147,10 +1147,12 @@
 		occupier.parent = malf.parent
 	else
 		occupier.parent = malf
-	malf.shunted = 1
+	malf.shunted = TRUE
 	occupier.eyeobj.name = "[occupier.name] (AI Eye)"
 	if(malf.parent)
 		qdel(malf)
+	for(var/obj/item/pinpointer/nuke/disk_pinpointers in GLOB.pinpointer_list)
+		disk_pinpointers.switch_mode_to(TRACK_MALF_AI) //Pinpointer will track the shunted AI
 	var/datum/action/innate/core_return/CR = new
 	CR.Grant(occupier)
 	occupier.cancel_camera()
@@ -1160,7 +1162,7 @@
 		return
 	if(occupier.parent && occupier.parent.stat != DEAD)
 		occupier.mind.transfer_to(occupier.parent)
-		occupier.parent.shunted = 0
+		occupier.parent.shunted = FALSE
 		occupier.parent.setOxyLoss(occupier.getOxyLoss())
 		occupier.parent.cancel_camera()
 		qdel(occupier)
@@ -1170,9 +1172,11 @@
 			occupier.forceMove(drop_location())
 			occupier.death()
 			occupier.gib()
-			for(var/obj/item/pinpointer/nuke/P in GLOB.pinpointer_list)
-				P.switch_mode_to(TRACK_NUKE_DISK) //Pinpointers go back to tracking the nuke disk
-				P.alert = FALSE
+
+	if(!occupier.nuking) //Pinpointers go back to tracking the nuke disk, as long as the AI (somehow) isn't mid-nuking.
+		for(var/obj/item/pinpointer/nuke/disk_pinpointers in GLOB.pinpointer_list)
+			disk_pinpointers.switch_mode_to(TRACK_NUKE_DISK)
+			disk_pinpointers.alert = FALSE
 
 /obj/machinery/power/apc/transfer_ai(interaction, mob/user, mob/living/silicon/ai/AI, obj/item/aicard/card)
 	if(card.AI)
@@ -1485,7 +1489,7 @@
 	operating = FALSE
 	atom_break()
 	if(occupier)
-		malfvacate(1)
+		malfvacate(TRUE)
 	update()
 
 // overload all the lights in this APC area


### PR DESCRIPTION
## About The Pull Request

Restores the functionality from #301 which allows AIs to be tracked by nuke pinpointers when they shunt to an APC. 

It currently only does so if they shunt while on Delta alert, to nuke the station, the change to that being #1812 - But thanks to #56833, this scenario will never occur, meaning that the shunted AI's tracking is never seen in game anymore.

## Why It's Good For The Game

Searching for a shunted AI is a long and tedious task, you have to go through every single individual APC on the station just to see if its emagged, and break it with the hopes that its the one that had the Malf AI in it.

The pinpointers were meant to track to a shunted AI but was patched out overtime, and it's a shame because an AI can just emag an APC in perma and sit there if their sat is being broken to.

## Changelog

:cl:
fix: Malf AI's who shunt onto an APC can once again be tracked by the nuke disk pinpointer.
/:cl: