### PR TITLE
hopefully fixes buckshots only shooting one projectile

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -63,8 +63,9 @@
 	if(!direct_target)
 		var/modifiers = params2list(params)
 		loaded_projectile.preparePixelProjectile(target, user, modifiers, spread)
-	loaded_projectile.fire(null, direct_target)
+	var/obj/projectile/loaded_projectile_cache = loaded_projectile
 	loaded_projectile = null
+	loaded_projectile_cache.fire(null, direct_target)
 	return TRUE
 
 /obj/item/ammo_casing/proc/spread(turf/target, turf/current, distro)


### PR DESCRIPTION
## About The Pull Request

# this is for downstream for the most part, I don't actually know if it's an issue upstream

so, pellet clouds were only shooting one projectile, because of async, and it yielding to a stoplag further on in the fire proc, it never nulls the loaded_projectile, thus firing only one projectile, and runtiming a bunch, so with some help from a tg coder, this is a fix that shooould work to stop pellet clouds from doing that

## Why It's Good For The Game

bug fix

## Changelog

:cl:
fix: hopefully fixes pellet clouds only spawning one projectile
/:cl: