### PR TITLE
Disable lobby music until sound preferences are re-added to the top bar menu.

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -199,6 +199,7 @@ distance_multiplier - Can be used to multiply the distance at which the sound is
 
 /client/proc/playtitlemusic(vol = 85)
 	set waitfor = FALSE
+	return
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 
 	if(prefs && (prefs.toggles & SOUND_LOBBY))


### PR DESCRIPTION
Disable lobby music until sound preferences are re-added to the top bar menu.

This topbar menu:

![image](https://user-images.githubusercontent.com/7069733/133376595-85f6aaae-4b8c-4b56-a84d-38769466654f.png)

test merge pr