### PR TITLE
Cache savefiles just for a tick, likely fixing savefile misses

### DIFF
--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -204,13 +204,21 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 	if (!parent)
 		return null
 
+	// Both of these will cache savefiles, but only for a tick.
+	// This is because storing a savefile will lock it, causing later issues down the line.
+
 	switch (savefile_identifier)
 		if (PREFERENCE_CHARACTER)
+			if (!character_savefile)
+				character_savefile = new /savefile(path)
+				character_savefile.cd = "/character[default_slot]"
+				addtimer(VARSET_CALLBACK(src, character_savefile, null), 1)
 			return character_savefile
 		if (PREFERENCE_PLAYER)
 			if (!game_savefile)
 				game_savefile = new /savefile(path)
 				game_savefile.cd = "/"
+				addtimer(VARSET_CALLBACK(src, game_savefile, null), 1)
 			return game_savefile
 		else
 			CRASH("Unknown savefile identifier [savefile_identifier]")

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -279,6 +279,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		return FALSE
 	if(!fexists(path))
 		return FALSE
+
+	character_savefile = null
+
 	var/savefile/S = new /savefile(path)
 	if(!S)
 		return FALSE
@@ -291,7 +294,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		WRITE_FILE(S["default_slot"] , slot)
 
 	S.cd = "/character[slot]"
-	character_savefile = S
 	var/needs_update = savefile_needs_update(S)
 	if(needs_update == -2) //fatal, can't load any data
 		return FALSE
@@ -376,7 +378,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["all_quirks"] , all_quirks)
 
 	return TRUE
-
 
 /proc/sanitize_keybindings(value)
 	var/list/base_bindings = sanitize_islist(value,list())


### PR DESCRIPTION
Savefiles were cached in vars in order to not have to inject savefiles everywhere while still getting really good I/O speed.

They are now only cached for a tick, as this was holding locks in ways that were potentially not being cleared properly.