### PR TITLE
Station alert bugfixes

### DIFF
--- a/code/datums/alarm.dm
+++ b/code/datums/alarm.dm
@@ -175,6 +175,10 @@
 		return //Return if there's still sources left, no sense clearing the list or bothering anyone about it
 
 	alarms_of_our_type -= source_area.name
+
+	if(!length(alarms_of_our_type))
+		alarms -= alarm_type
+
 	SEND_SIGNAL(src, COMSIG_ALARM_CLEARED, alarm_type, source_area)
 
 ///Does what it says on the tin, exists for signal hooking

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -10,6 +10,7 @@
 
 /obj/machinery/computer/station_alert/Initialize()
 	alert_control = new(src, list(ALARM_ATMOS, ALARM_FIRE, ALARM_POWER), list(z), title = name)
+	RegisterSignal(alert_control.listener, list(COMSIG_ALARM_TRIGGERED, COMSIG_ALARM_CLEARED), .proc/update_alarm_display)
 	return ..()
 
 /obj/machinery/computer/station_alert/Destroy()
@@ -31,3 +32,13 @@
 		return
 	if(length(alert_control.listener.alarms))
 		. += "alert:2"
+
+/**
+ * Signal handler for calling an icon update in case an alarm is added or cleared
+ *
+ * Arguments:
+ * * source The datum source of the signal
+ */
+/obj/machinery/computer/station_alert/proc/update_alarm_display(datum/source)
+	SIGNAL_HANDLER
+	update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR fixes two bugs regarding station alerts:

- Station alert console did not update its sprite when an alert was added/cleared, so it remained mostly static. Fixed by adding signal handler for updating console's icon for when an alert is added/cleared. Canary application already had this, so it seems like a simple oversight.

- Station alert console and Canary application got stuck in an alert mode forever once they received atleast one alert of any type, because even if it got cleared, the type would remain, which in turn meant that `if(length(alert_control.listener.alarms))` would always return true. Fixed by clearing the type too if there are no alerts left in it.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugfixes.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Arkatos
fix: Station alert console will now always show a correct icon when an alert is added or cleared.
fix: Station alert console and Canary application icons will no longer get stuck in an alert mode forever.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
