### PR TITLE
Remove knockdown from cultist bolas

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -290,7 +290,6 @@
 	icon_state = "bola_cult"
 	inhand_icon_state = "bola_cult"
 	breakouttime = 6 SECONDS
-	knockdown = 30
 
 #define CULT_BOLA_PICKUP_STUN 6 SECONDS
 /obj/item/restraints/legcuffs/bola/cult/attack_hand(mob/living/carbon/user, list/modifiers)


### PR DESCRIPTION
## About The Pull Request
Removes the 3 second knockdown from cult bolas, as its not fun to play against at all

## Why It's Good For The Game
Right now the bolas can't be caught, it passes trough your ally cultists, it knocks you down for 3 seconds which is the most braindead thing to follow up with a stunhand, removing the stun atleast allows them to fight back but still keeping the purpose of the bolas of slowing people down

## Changelog
:cl: Improvedname
balance: Cult bolas no longer stun
/:cl: