### PR TITLE
Fix GODMODE ears being able to be damaged

### DIFF
--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -54,6 +54,8 @@
 		REMOVE_TRAIT(owner, TRAIT_DEAF, EAR_DAMAGE)
 
 /obj/item/organ/ears/proc/adjustEarDamage(ddmg, ddeaf)
+	if(owner.status_flags & owner.GODMODE)
+  		return FALSE
 	damage = max(damage + (ddmg*damage_multiplier), 0)
 	deaf = max(deaf + (ddeaf*damage_multiplier), 0)
 

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -55,10 +55,9 @@
 
 /obj/item/organ/ears/proc/adjustEarDamage(ddmg, ddeaf)
 	if(owner.status_flags & GODMODE)
-		return FALSE
-	else
-		damage = max(damage + (ddmg*damage_multiplier), 0)
-		deaf = max(deaf + (ddeaf*damage_multiplier), 0)
+		return
+	damage = max(damage + (ddmg*damage_multiplier), 0)
+	deaf = max(deaf + (ddeaf*damage_multiplier), 0)
 
 /obj/item/organ/ears/invincible
 	damage_multiplier = 0

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -54,10 +54,11 @@
 		REMOVE_TRAIT(owner, TRAIT_DEAF, EAR_DAMAGE)
 
 /obj/item/organ/ears/proc/adjustEarDamage(ddmg, ddeaf)
-	if(owner.status_flags & owner.GODMODE)
+	if(owner.status_flags & GODMODE)
 		return FALSE
-	damage = max(damage + (ddmg*damage_multiplier), 0)
-	deaf = max(deaf + (ddeaf*damage_multiplier), 0)
+	else
+		damage = max(damage + (ddmg*damage_multiplier), 0)
+		deaf = max(deaf + (ddeaf*damage_multiplier), 0)
 
 /obj/item/organ/ears/invincible
 	damage_multiplier = 0

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -55,7 +55,7 @@
 
 /obj/item/organ/ears/proc/adjustEarDamage(ddmg, ddeaf)
 	if(owner.status_flags & owner.GODMODE)
-  		return FALSE
+		return FALSE
 	damage = max(damage + (ddmg*damage_multiplier), 0)
 	deaf = max(deaf + (ddeaf*damage_multiplier), 0)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
-adds test in adjust ear damage section to test for god mode (test provided by @timothymtorres )
This is to close: https://github.com/tgstation/tgstation/issues/25990
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
GODMODE flagged dummies can no longed be deafened by flashbangs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: GODMODE dummies can no longer be deafened by flashbangs
/:cl:

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
