### PR TITLE
Fix quirks list in preferences menu being empty before SSquirks

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -17,17 +17,19 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	///An assoc list of quirks that can be obtained as a hardcore character, and their hardcore value.
 	var/list/hardcore_quirks = list()
 
+	var/static/list/quirks_blacklist = list(
+		list("Blind","Nearsighted"),
+		list("Jolly","Depression","Apathetic","Hypersensitive"),
+		list("Ageusia","Vegetarian","Deviant Tastes"),
+		list("Ananas Affinity","Ananas Aversion"),
+		list("Alcohol Tolerance","Light Drinker"),
+		list("Clown Fan","Mime Fan"),
+		list("Bad Touch", "Friendly"),
+		list("Extrovert", "Introvert"),
+	)
+
 /datum/controller/subsystem/processing/quirks/Initialize(timeofday)
 	get_quirks()
-
-	quirk_blacklist = list(list("Blind","Nearsighted"), \
-							list("Jolly","Depression","Apathetic","Hypersensitive"), \
-							list("Ageusia","Vegetarian","Deviant Tastes"), \
-							list("Ananas Affinity","Ananas Aversion"), \
-							list("Alcohol Tolerance","Light Drinker"), \
-							list("Clown Fan","Mime Fan"), \
-							list("Bad Touch", "Friendly"), \
-							list("Extrovert", "Introvert"))
 	return ..()
 
 /// Returns the list of possible quirks

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -18,8 +18,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	var/list/hardcore_quirks = list()
 
 /datum/controller/subsystem/processing/quirks/Initialize(timeofday)
-	if(!quirks.len)
-		SetupQuirks()
+	get_quirks()
 
 	quirk_blacklist = list(list("Blind","Nearsighted"), \
 							list("Jolly","Depression","Apathetic","Hypersensitive"), \
@@ -30,6 +29,13 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 							list("Bad Touch", "Friendly"), \
 							list("Extrovert", "Introvert"))
 	return ..()
+
+/datum/controller/subsystem/processing/quirks/proc/get_quirks()
+	RETURN_TYPE(/list)
+	if (!quirks.len)
+		SetupQuirks()
+
+	return quirks
 
 /datum/controller/subsystem/processing/quirks/proc/SetupQuirks()
 	// Sort by Positive, Negative, Neutral; and then by name

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -30,6 +30,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 							list("Extrovert", "Introvert"))
 	return ..()
 
+/// Returns the list of possible quirks
 /datum/controller/subsystem/processing/quirks/proc/get_quirks()
 	RETURN_TYPE(/list)
 	if (!quirks.len)

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -29,8 +29,10 @@
 /datum/preference_middleware/quirks/get_constant_data()
 	var/list/quirk_info = list()
 
-	for (var/quirk_name in SSquirks.quirks)
-		var/datum/quirk/quirk = SSquirks.quirks[quirk_name]
+	var/list/quirks = SSquirks.get_quirks()
+
+	for (var/quirk_name in quirks)
+		var/datum/quirk/quirk = quirks[quirk_name]
 		quirk_info[sanitize_css_class_name(quirk_name)] = list(
 			"description" = initial(quirk.desc),
 			"icon" = initial(quirk.icon),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #61490

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed the quirks list in the preferences menu sometimes being empty.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
