### PR TITLE
You can no longer use chameleon IDs/clothes while in crit/have hands blocked

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -139,6 +139,7 @@
 
 /datum/action/item_action/chameleon/change
 	name = "Chameleon Change"
+	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED
 	var/list/chameleon_blacklist = list() //This is a typecache
 	var/list/chameleon_list = list()
 	var/chameleon_type = null


### PR DESCRIPTION
## About The Pull Request

I rolled https://issue-roulette.vercel.app/ and this is what I got.

## Why It's Good For The Game

Fixes #61180

## Changelog

:cl:
fix: Agent IDs and other similar Chameleon gear can no longer be used/forged while you have your hand blocked and/or are in critical condition.
/:cl:
