### PR TITLE
Makes copy_research_to slightly better, regarding revealing hidden techs

### DIFF
--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -147,7 +147,7 @@
 	if(unlock_hidden)
 		for(var/i in receiver.hidden_nodes)
 			CHECK_TICK
-			if(!hidden_nodes[i])
+			if(available_nodes[i] || researched_nodes[i] || visible_nodes[i])
 				receiver.hidden_nodes -= i //We can see it so let them see it too.
 	for(var/i in researched_nodes)
 		CHECK_TICK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alright so, the current way it sees if it should reveal hidden nodes is if it's not in the copied techweb's hidden nodes.
This relies upon every techweb having these same nodes hidden and requires quite some bloat in tech disks or simillar if you, e.g. want a tech disk to have a single technology to reveal (you have to have the entire base techweb, then add your technology onto that, then remove it from the hidden techs)
This inverts this check and makes it so a tech instead gets revealed provided the copied techweb has it accessible (reads: visible, currently reachable or already researched)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should make it easier to create techwebs with differing techs without having to copy the base techweb to avoid issues if the two techwebs meet thanks to e.g. data disks (or, if said techweb *is* for a data disk).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
None.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
