### PR TITLE
[s]block observing lobby mobs

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -876,7 +876,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/proc/do_observe(mob/mob_eye)
 	//Istype so we filter out points of interest that are not mobs
-	if(client && mob_eye && istype(mob_eye))
+	if(client && mob_eye && istype(mob_eye) && !isnewplayer(mob_eye))
 		client.eye = mob_eye
 		if(mob_eye.hud_used)
 			client.screen = list()


### PR DESCRIPTION
"""Fixes""" #61508

These mobs should be treated as abstract anyways, and we lose nothing by not supporting observing them.

Note/reminder, observing a mob is different from orbiting them, as observing sets your client eye to their eye, and gives you a """""read only""""" view of their hud.

i did want to keep ai_eye observing, or i would have just required it be a living mob.