### PR TITLE
Removes the three built in BCI action components from the BCI integrated circuit shell

### DIFF
--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -378,7 +378,7 @@
 	desc = "An implant that can be placed in a user's head to control circuits using their brain."
 	id = "bci_shell"
 	materials = list(
-		/datum/material/glass = 2000,
+		/datum/material/glass = 1000,
 		/datum/material/iron = 8000,
 	)
 	build_path = /obj/item/shell/bci

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -10,8 +10,7 @@
 	. = ..()
 
 	AddComponent(/datum/component/shell, list(
-		new /obj/item/circuit_component/bci_core,
-		new /obj/item/circuit_component/bci_action(null, "Info"),
+		new /obj/item/circuit_component/bci_core
 	), SHELL_CAPACITY_SMALL)
 
 /obj/item/organ/cyberimp/bci/Insert(mob/living/carbon/reciever, special, drop_if_replaced)

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -11,9 +11,7 @@
 
 	AddComponent(/datum/component/shell, list(
 		new /obj/item/circuit_component/bci_core,
-		new /obj/item/circuit_component/bci_action(null, "One"),
-		new /obj/item/circuit_component/bci_action(null, "Two"),
-		new /obj/item/circuit_component/bci_action(null, "Three"),
+		new /obj/item/circuit_component/bci_action(null, "Info"),
 	), SHELL_CAPACITY_SMALL)
 
 /obj/item/organ/cyberimp/bci/Insert(mob/living/carbon/reciever, special, drop_if_replaced)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The BCI integrated circuit shell starts off with three unremovable BCI action components, and this pr removes all of them. To reflect this change, BCI shells now cost 1000 glass less, down to 1000 from 2000
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Often I struggle to find a use for all three BCI action components, and I'm sure others have the same issue. They are unremovable, so if you were to just opt to ignore them you'd have 1-2 unused hud buttons on screen, which can clutter the screen and look ugly. If I, or anyone else making BCI circuits, want hud buttons, it's easy to just print more for only 1k glass each, and slot them in.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
del: Removed the three unremovable BCI hud buttons. If you need more, you can print them at any local component printer.
qol: BCI shells now cost 1000 less glass, to reflect the removal of the three built in BCI hud buttons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
