### PR TITLE
basic critters can now hop in da vim

### DIFF
--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -33,7 +33,7 @@
 	return ..()
 
 /obj/vehicle/sealed/car/vim/mob_try_enter(mob/entering)
-	if(!isanimal(entering))
+	if(!isanimal(entering) || !isbasicmob(entering))
 		return FALSE
 	var/mob/living/simple_animal/animal = entering
 	if(animal.mob_size != MOB_SIZE_TINY)

--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -35,8 +35,8 @@
 /obj/vehicle/sealed/car/vim/mob_try_enter(mob/entering)
 	if(!isanimal(entering) || !isbasicmob(entering))
 		return FALSE
-	var/mob/living/simple_animal/animal = entering
-	if(animal.mob_size != MOB_SIZE_TINY)
+	var/mob/living/animal_or_basic = entering
+	if(animal_or_basic.mob_size != MOB_SIZE_TINY)
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
:cl:
fix: some small critters that should have been able to fit in the vim but couldn't, now can
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
