### PR TITLE
Meteor guns, the admin weapon, once again harms living mobs

### DIFF
--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -11,7 +11,7 @@
 
 /obj/projectile/meteor/on_hit(atom/target, blocked = FALSE)
 	. = ..()
-	if(isliving(target))
+	if(. == BULLET_ACT_HIT && isliving(target))
 		explosion(target, devastation_range = -1, light_impact_range = 2, flame_range = 0, flash_range = 1, adminlog = FALSE)
 		playsound(target.loc, 'sound/effects/meteorimpact.ogg', 40, TRUE)
 

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -2,21 +2,25 @@
 	name = "meteor"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "small1"
-	damage = 0
+	damage = 90
+	paralyze = 100
+	dismemberment = 90
+	armour_penetration = 100
 	damage_type = BRUTE
-	nodamage = TRUE
 	flag = BULLET
 
-/obj/projectile/meteor/Bump(atom/A)
-	if(A == firer)
-		forceMove(A.loc)
+/obj/projectile/meteor/Bump(atom/hit_target)
+	if(hit_target == firer)
+		forceMove(hit_target.loc)
 		return
-	if(isobj(A))
-		SSexplosions.med_mov_atom += A
-	else if(isturf(A))
-		SSexplosions.medturf += A
+	if(isobj(hit_target))
+		SSexplosions.med_mov_atom += hit_target
+	if(isliving(hit_target))
+		explosion(hit_target, devastation_range = -1, light_impact_range = 1, flame_range = 0, flash_range = 1, adminlog = FALSE)
+	if(isturf(hit_target))
+		SSexplosions.medturf += hit_target
 	playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, TRUE)
-	for(var/mob/M in urange(10, src))
-		if(!M.stat)
-			shake_camera(M, 3, 1)
+	for(var/mob/onlookers_in_range in urange(10, src))
+		if(!onlookers_in_range.stat)
+			shake_camera(onlookers_in_range, 3, 1)
 	qdel(src)

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -10,11 +10,10 @@
 	flag = BULLET
 
 /obj/projectile/meteor/on_hit(atom/target, blocked = FALSE)
-	..()
+	. = ..()
 	if(isliving(target))
 		explosion(target, devastation_range = -1, light_impact_range = 2, flame_range = 0, flash_range = 1, adminlog = FALSE)
 		playsound(target.loc, 'sound/effects/meteorimpact.ogg', 40, TRUE)
-	return BULLET_ACT_HIT
 
 /obj/projectile/meteor/Bump(atom/hit_target)
 	if(hit_target == firer)

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -9,14 +9,19 @@
 	damage_type = BRUTE
 	flag = BULLET
 
+/obj/projectile/meteor/on_hit(atom/target, blocked = FALSE)
+	..()
+	if(isliving(target))
+		explosion(target, devastation_range = -1, light_impact_range = 2, flame_range = 0, flash_range = 1, adminlog = FALSE)
+		playsound(target.loc, 'sound/effects/meteorimpact.ogg', 40, TRUE)
+	return BULLET_ACT_HIT
+
 /obj/projectile/meteor/Bump(atom/hit_target)
 	if(hit_target == firer)
 		forceMove(hit_target.loc)
 		return
 	if(isobj(hit_target))
 		SSexplosions.med_mov_atom += hit_target
-	if(isliving(hit_target))
-		explosion(hit_target, devastation_range = -1, light_impact_range = 1, flame_range = 0, flash_range = 1, adminlog = FALSE)
 	if(isturf(hit_target))
 		SSexplosions.medturf += hit_target
 	playsound(src.loc, 'sound/effects/meteorimpact.ogg', 40, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When explosions got refactored, this stopped harming mobs because it lacked a check. Goof must have missed this, but it's also probably not as simple to put everything back as it was. This mostly restores old behaviour by putting the relevant code into on_hit() and out of Bump() when handling living mobs, since it's a projectile and all. I don't know if the values I added are appropriate but given that the old behaviour was a high damage localized explosion, it almost certainly isn't far off.

fixes https://github.com/tgstation/tgstation/issues/61244

## Why It's Good For The Game

helpies admin aboose

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
admin: Meteor guns do damage once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->