### PR TITLE
Liquid Electricity actually works again; renamed Liquid Electricity into 'Electrolytes' since it isn't actually lethal.

### DIFF
--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -338,7 +338,7 @@
 	name = "empowered burger"
 	desc = "It's shockingly good, if you live off of electricity that is."
 	icon_state = "empoweredburger"
-	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/protein = 5, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/consumable/liquidelectricity/enriched = 6)
+	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/protein = 5, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/consumable/electrolyte/enriched = 6)
 	tastes = list("bun" = 2, "pure electricity" = 4)
 	foodtypes = GRAIN | TOXIC
 	venue_value = FOOD_PRICE_CHEAP

--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -203,7 +203,7 @@
 	icon_state = "energycake"
 	force = 5
 	hitsound = 'sound/weapons/blade1.ogg'
-	food_reagents = list(/datum/reagent/consumable/nutriment = 10, /datum/reagent/consumable/sprinkles = 10, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/consumable/pwr_game = 10, /datum/reagent/consumable/liquidelectricity/enriched = 10)
+	food_reagents = list(/datum/reagent/consumable/nutriment = 10, /datum/reagent/consumable/sprinkles = 10, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/consumable/pwr_game = 10, /datum/reagent/consumable/electrolyte/enriched = 10)
 	tastes = list("cake" = 3, "a Vlad's Salad" = 1)
 
 /obj/item/food/cake/birthday/energy/MakeProcessable()
@@ -230,7 +230,7 @@
 	icon_state = "energycakeslice"
 	force = 2
 	hitsound = 'sound/weapons/blade1.ogg'
-	food_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/sprinkles = 2, /datum/reagent/consumable/nutriment/vitamin = 1,  /datum/reagent/consumable/pwr_game = 2, /datum/reagent/consumable/liquidelectricity/enriched = 2)
+	food_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/sprinkles = 2, /datum/reagent/consumable/nutriment/vitamin = 1,  /datum/reagent/consumable/pwr_game = 2, /datum/reagent/consumable/electrolyte/enriched = 2)
 	tastes = list("cake" = 3, "a Vlad's Salad" = 1)
 
 /obj/item/food/cakeslice/birthday/energy/proc/energy_bite(mob/living/user)

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -717,7 +717,7 @@
 /obj/item/food/meat/slab/human/mutant/ethereal
 	icon_state = "etherealmeat"
 	desc = "So shiny you feel like ingesting it might make you shine too"
-	food_reagents = list(/datum/reagent/consumable/liquidelectricity/enriched = 10)
+	food_reagents = list(/datum/reagent/consumable/electrolyte/enriched = 10)
 	tastes = list("pure electricity" = 2, "meat" = 1)
 	foodtypes = RAW | MEAT | TOXIC
 

--- a/code/game/objects/items/food/snacks.dm
+++ b/code/game/objects/items/food/snacks.dm
@@ -164,7 +164,7 @@
 	icon_state = "energybar"
 	desc = "An energy bar with a lot of punch, you probably shouldn't eat this if you're not an Ethereal."
 	trash_type = /obj/item/trash/energybar
-	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/liquidelectricity/enriched = 3)
+	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/electrolyte/enriched = 3)
 	tastes = list("pure electricity" = 3, "fitness" = 2)
 	foodtypes = TOXIC
 	food_flags = FOOD_FINGER_FOOD

--- a/code/game/objects/items/food/soup.dm
+++ b/code/game/objects/items/food/soup.dm
@@ -256,7 +256,7 @@
 	name = "electron soup"
 	desc = "A gastronomic curiosity of ethereal origin. It is famed for the minature weather system formed over a properly prepared soup."
 	icon_state = "electronsoup"
-	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/liquidelectricity/enriched = 12)
+	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/electrolyte/enriched = 12)
 	tastes = list("mushroom" = 1, "electrons" = 4)
 	foodtypes = VEGETABLES | TOXIC
 

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -205,7 +205,7 @@
 	endurance = 8
 	yield = 4
 	growthstages = 2
-	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/reagent/liquidelectricity, /datum/plant_gene/trait/carnivory)
+	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/reagent/electrolyte, /datum/plant_gene/trait/carnivory)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.1)
 	mutatelist = null

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -101,7 +101,7 @@
 	mutability_flags = PLANT_GENE_GRAFTABLE
 
 /datum/plant_gene/reagent/electrolyte
-	name = "Enriched Liquid Electricity"
+	name = "Enriched electrolytes"
 	reagent_id = /datum/reagent/consumable/electrolyte/enriched
 	rate = 0.1
 	mutability_flags = PLANT_GENE_GRAFTABLE

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -100,9 +100,9 @@
 	rate = 0.15
 	mutability_flags = PLANT_GENE_GRAFTABLE
 
-/datum/plant_gene/reagent/liquidelectricity
+/datum/plant_gene/reagent/electrolyte
 	name = "Enriched Liquid Electricity"
-	reagent_id = /datum/reagent/consumable/liquidelectricity/enriched
+	reagent_id = /datum/reagent/consumable/electrolyte/enriched
 	rate = 0.1
 	mutability_flags = PLANT_GENE_GRAFTABLE
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	///Does the species use skintones or not? As of now only used by humans.
 	var/use_skintones = FALSE
-	///If your race bleeds something other than bog standard blood, change this to reagent id. For example, ethereals bleed liquid electricity.
+	///If your race bleeds something other than bog standard blood, change this to reagent id. For example, ethereals bleed electrolytes.
 	var/exotic_blood = ""
 	///If your race uses a non standard bloodtype (A+, O-, AB-, etc). For example, lizards have L type blood.
 	var/exotic_bloodtype = ""

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -8,7 +8,7 @@
 	mutantstomach = /obj/item/organ/stomach/ethereal
 	mutanttongue = /obj/item/organ/tongue/ethereal
 	mutantheart = /obj/item/organ/heart/ethereal
-	exotic_blood = /datum/reagent/consumable/liquidelectricity //Liquid Electricity. fuck you think of something better gamer
+	exotic_blood = /datum/reagent/consumable/electrolyte //Liquid Electricity. fuck you think of something better gamer //yeah okay hows about a real substance then
 	siemens_coeff = 0.5 //They thrive on energy
 	brutemod = 1.25 //They're weak to punches
 	payday_modifier = 0.75

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -784,18 +784,27 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 
-/datum/reagent/consumable/liquidelectricity
-	name = "Liquid Electricity"
-	description = "The blood of Ethereals, and the stuff that keeps them going. Great for them, horrid for anyone else."
+/datum/reagent/consumable/electrolyte
+	name = "Electrolytes"
+	description = "The blood of Ethereals, and the stuff necessary to carry electrical charge through their body. For everyone else, it's somewhat medicinal."
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#97ee63"
-	taste_description = "pure electricity"
+	taste_description = "energy-boosting nutrients"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/liquidelectricity/enriched
-	name = "Enriched Liquid Electricity"
+//Despite what the clown will tell you, electrolytes are not what plants crave.
+/datum/reagent/consumable/electrolyte/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)
+	. = ..()
+	if(chems.has_reagent(src, 1))
+		mytray.adjustHealth(-round(chems.get_reagent_amount(src.type) * 1))
 
-/datum/reagent/consumable/liquidelectricity/enriched/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume) //can't be on life because of the way blood works.
+/datum/reagent/consumable/electrolyte/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	if(isethereal(M))
+		M.blood_volume += 1 * delta_time
+	M.adjust_disgust(-1) //If you're vomiting, this helps that. It's mostly fluff.
+	return ..()
+
+/datum/reagent/consumable/electrolyte/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume) //can't be on life because of the way blood works.
 	. = ..()
 	if(!(methods & (INGEST|INJECT|PATCH)) || !iscarbon(exposed_mob))
 		return
@@ -805,13 +814,18 @@
 	if(istype(stomach))
 		stomach.adjust_charge(reac_volume * 30)
 
-/datum/reagent/consumable/liquidelectricity/enriched/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	if(isethereal(M))
-		M.blood_volume += 1 * delta_time
-	else if(DT_PROB(10, delta_time)) //lmao at the newbs who eat energy bars
+/datum/reagent/consumable/electrolyte/enriched
+	name = "Enriched Electrolytes"
+	description = "Infused with plasma, these electrolytes destroy plants and other living matter with intense electrical shocks, but keep ethereals topped up and estatic."
+	nutriment_factor = 5 * REAGENTS_METABOLISM
+	color = "#97ee63"
+	taste_description = "pure energy"
+
+/datum/reagent/consumable/electrolyte/enriched/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	if(DT_PROB(10, delta_time) && !isethereal(M)) //lmao at the newbs who eat energy bars
 		M.electrocute_act(rand(5,10), "Liquid Electricity in their body", 1, SHOCK_NOGLOVES) //the shock is coming from inside the house
 		playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-	return ..()
+	..()
 
 /datum/reagent/consumable/astrotame
 	name = "Astrotame"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -823,7 +823,7 @@
 
 /datum/reagent/consumable/electrolyte/enriched/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	if(DT_PROB(10, delta_time) && !isethereal(M)) //lmao at the newbs who eat energy bars
-		M.electrocute_act(rand(5,10), "Liquid Electricity in their body", 1, SHOCK_NOGLOVES) //the shock is coming from inside the house
+		M.electrocute_act(rand(5,10), "Enriched Electrolytes in their body", 1, SHOCK_NOGLOVES) //the shock is coming from inside the house
 		playsound(M, "sparks", 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	..()
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -587,7 +587,7 @@
 //water electrolysis
 /datum/chemical_reaction/electrolysis
 	results = list(/datum/reagent/oxygen = 1.5, /datum/reagent/hydrogen = 3)
-	required_reagents = list(/datum/reagent/consumable/liquidelectricity = 1, /datum/reagent/water = 5)
+	required_reagents = list(/datum/reagent/consumable/electrolyte/enriched = 1, /datum/reagent/water = 5)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL
 
 //butterflium

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -45,7 +45,7 @@
 	modifier = 2
 
 /datum/chemical_reaction/reagent_explosion/rdx_explosion2 //makes rdx unique , on its own it is a good bomb, but when combined with liquid electricity it becomes truly destructive
-	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/consumable/liquidelectricity = 1)
+	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/consumable/electrolyte = 1)
 	strengthdiv = 3.5 //actually a decrease of 1 becaused of how explosions are calculated. This is due to the fact we require 2 reagents
 	modifier = 4
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -44,8 +44,8 @@
 	strengthdiv = 7
 	modifier = 2
 
-/datum/chemical_reaction/reagent_explosion/rdx_explosion2 //makes rdx unique , on its own it is a good bomb, but when combined with liquid electricity it becomes truly destructive
-	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/consumable/electrolyte = 1)
+/datum/chemical_reaction/reagent_explosion/rdx_explosion2 //makes rdx unique , on its own it is a good bomb, but when combined with enriched electrolytes it becomes truly destructive
+	required_reagents = list(/datum/reagent/rdx = 1 , /datum/reagent/consumable/electrolyte/enriched = 1)
 	strengthdiv = 3.5 //actually a decrease of 1 becaused of how explosions are calculated. This is due to the fact we require 2 reagents
 	modifier = 4
 

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -61,7 +61,7 @@
 
 /obj/item/reagent_containers/blood/ethereal
 	blood_type = "LE"
-	unique_blood = /datum/reagent/consumable/liquidelectricity
+	unique_blood = /datum/reagent/consumable/electrolyte
 
 /obj/item/reagent_containers/blood/universal
 	blood_type = "U"

--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -193,7 +193,7 @@
 	name = "Biological Battery"
 	id = "etherealstomach"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/consumable/liquidelectricity/enriched = 20)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/consumable/electrolyte/enriched = 20)
 	build_path = /obj/item/organ/stomach/ethereal
 	category = list(SPECIES_ETHEREAL)
 
@@ -201,7 +201,7 @@
 	name = "Electrical Discharger"
 	id = "etherealtongue"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/consumable/liquidelectricity/enriched = 20)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/consumable/electrolyte/enriched = 20)
 	build_path = /obj/item/organ/tongue/ethereal
 	category = list(SPECIES_ETHEREAL)
 
@@ -210,7 +210,7 @@
 	name = "Crystal Core"
 	id = "etherealheart"
 	build_type = LIMBGROWER
-	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/consumable/liquidelectricity/enriched = 20)
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10, /datum/reagent/consumable/electrolyte/enriched = 20)
 	build_path = /obj/item/organ/heart/ethereal
 	category = list(SPECIES_ETHEREAL)
 

--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -386,7 +386,7 @@
 						/datum/reagent/consumable/nutriment/protein,
 						/datum/reagent/consumable/nutriment/vitamin,
 						/datum/reagent/consumable/nutriment/peptides,
-						/datum/reagent/consumable/liquidelectricity/enriched,
+						/datum/reagent/consumable/electrolyte/enriched,
 						/datum/reagent/growthserum,
 						/datum/reagent/yuck)
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/ethereal.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/ethereal.ts
@@ -26,8 +26,8 @@ const Ethereal: Species = {
     }, createLanguagePerk("Voltaic")],
     neutral: [{
       icon: "tint",
-      name: "Liquid Electricity",
-      description: "Ethereals have liquid electricity instead of blood. \
+      name: "electrolytes",
+      description: "Ethereals have electrolytes instead of blood. \
         Great for them, horrid for anyone else. Can make receiving medical \
         treatment harder.",
     }, {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/60927

**Currently:** Liquid Electricity does absolutely nothing except act as a very delicious and nutritional beverage for those willing to exsanguinate an ethereal for their blood. In a twist of irony, it does actually nothing for ethereals themselves whatsoever, despite being necessary for them to survive, as all relevant code was scraped from liquid electricity, making enriched a pointless child of such.

If you take out an entire ethereal blood supply and reinsert it, they do not recover that blood whatsoever or gain charge due to sloppy copy-pasted code changes. This means there is absolutely no way for ethereals currently to recover their blood except for someone in botany making a lot of plants containing enriched liquid electricity, or buying up energy bars out of vendors for the miniscule amount of the relevant substance.

**After this PR:** I renamed their blood to 'electrolytes', a substance that resembles what their blood supposedly does and because it apparently is safe for human consumption. As a result, I added some mostly meaningless mechanical bit about reducing disgust (the value is so small to be useless) and also it kills plants because...you probably know the reference. It's just fluff.

All the actual code relevant for blood replenishment is in the parent of electrolytes, and the additional lethal code in the child, enriched electrolytes.

## Why It's Good For The Game

I feel 'ethereals cannot be recovered from complete exsanguination and acquiring their blood replacements also impossible' is a self evident problem. No where in [this pr](https://github.com/tgstation/tgstation/pull/58408) that changed it was there any mention that the base reagent was supposed to be useless. 

It's kind of hilarious that ethereals are currently walking bottles of gatorade, and it's all thanks to liquid electricity having nutritional value. The joke writes itself, ~~and creates a creepy lore implication about why ethereals are valuable to NT I guess.~~

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Makes Liquid Electricity actually function properly as ethereal blood/nutrients, while also changing it's name to the more thematically appropriate 'electrolytes'.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
