### PR TITLE
HFR: Fix T3 gas production at Fusion Level 2

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -392,7 +392,7 @@
 					if(moderator_list[/datum/gas/plasma] > 50)
 						internal_output.assert_gases(/datum/gas/bz)
 						internal_output.gases[/datum/gas/bz][MOLES] += scaled_production * 1.8
-						moderator_internal.gases[selected_fuel.secondary_products[3]] += scaled_production * 1.15
+						moderator_internal.gases[selected_fuel.secondary_products[3]][MOLES] += scaled_production * 1.15
 						moderator_internal.gases[/datum/gas/plasma][MOLES] -= min(moderator_internal.gases[/datum/gas/plasma][MOLES], scaled_production * 1.75)
 					if(moderator_list[/datum/gas/proto_nitrate] > 20)
 						radiation *= 1.55


### PR DESCRIPTION
## About The Pull Request

I am once again asking you to observe the /tg/station13 codebase
MISSING ANOTHER [MOLES] AAAAAAAAAAA WHAT IS THIS JOKE OF A TYPE SYSTEM

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

AAAAAAAAA byond AAAAAA types AAAAAAAAA clown AAAAAAAAAAAA

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The HFR now actually produces T3 gas at Fusion Level 2, provided you have enough plasma in the moderator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
