### PR TITLE
Make space dragons bomb proof. Rant included inside.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -96,6 +96,7 @@
 	AddElement(/datum/element/simple_flying)
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	ADD_TRAIT(src, TRAIT_NO_FLOATING_ANIM, INNATE_TRAIT)
+	ADD_TRAIT(src, TRAIT_BOMBIMMUNE, INNATE_TRAIT)
 	rift = new
 	rift.Grant(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the dragon bomb immune, or at least I think it does

## Why It's Good For The Game

Well. You see, maxcaps delete pretty much everything instantly (seriously, only rust heretics on rust have 'bomb-immune trait' And even a bomb suit won't save you if you are close to a bomb. You won't get gibbed sure, but you will die), and that's lame. Worse though, Space Dragon is not a very elusive antag. They don't have any abilities to remove themselves from harm's way besides what everyone can, the 'get out of the way move' BUT, space dragons also have rifts. They need to defend their rifts because if it's destroyed they get debuffs that make them practically unplayable. If someone has a bomb, you can't get near them, because they will delete you instantly. But if you don't get near them, they and their friends can just go and destroy your rift without being contested, which makes your survival worthless. You can poke them from a distance with fire breath, but you know, they can dodge. and take cover. and you cant push them because you will get deleted, so unless your rift is in some one-tile corridor, it's hard. and they can always just, ya know, run at you and blow up because suicide bombing WORKS (also did you know you can swap with dragon and carps? why is that a thing. why can't simple mobs not control it). Also, making bombs is common knowledge. Very common knowledge. So really, it can happen every time a dragon spawns. Now you say 'why not just storm toxins?' Well, dragons spawn randomly, and you have 5 minutes to place your rift, or else you despawn (and heavens help you if you spawned on icebox...) You don't want to place your rift just anywhere because that will make it piss easy for other, more skilled people to take it out. And 5 minutes isn't exactly a lot of time to trash toxins AND go to make your rift somewhere secure. Toxins is also a pretty frequented area, meaning if you start making noise there, someone will come in short order, yell on radio, and suddenly everyone comes to fight you. Also, atmos can make bombs too, which means you need to storm 2 places. You can only storm one place at a time, leaving the other completely uncontested, and once they have their bombs, well, good luck.
(Also is dragon stomp still a thing? I feel like the new antag UI thing broke it and the 'self small sprite', I couldn't see either of those things when I was playing dragon, just the spawn rift skill)
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: SaltyDragonMan
balance: Space Dragon is now bomb-immune, so you are going to actually need skill to beat them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
