### PR TITLE
Change preference cache from addtimer to spawn, ideally preventing the savefile bug from happening pre-init

### DIFF
--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -213,10 +213,8 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 			if (!character_savefile)
 				character_savefile = new /savefile(path)
 				character_savefile.cd = "/character[default_slot]"
-
 				spawn (1)
 					character_savefile = null
-
 			return character_savefile
 		if (PREFERENCE_PLAYER)
 			if (!game_savefile)

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -206,19 +206,24 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 
 	// Both of these will cache savefiles, but only for a tick.
 	// This is because storing a savefile will lock it, causing later issues down the line.
+	// Do not change them to addtimer, since the timer SS might not be running at this time.
 
 	switch (savefile_identifier)
 		if (PREFERENCE_CHARACTER)
 			if (!character_savefile)
 				character_savefile = new /savefile(path)
 				character_savefile.cd = "/character[default_slot]"
-				addtimer(VARSET_CALLBACK(src, character_savefile, null), 1)
+
+				spawn (1)
+					character_savefile = null
+
 			return character_savefile
 		if (PREFERENCE_PLAYER)
 			if (!game_savefile)
 				game_savefile = new /savefile(path)
 				game_savefile.cd = "/"
-				addtimer(VARSET_CALLBACK(src, game_savefile, null), 1)
+				spawn (1)
+					game_savefile = null
 			return game_savefile
 		else
 			CRASH("Unknown savefile identifier [savefile_identifier]")


### PR DESCRIPTION
The bug #61469 was trying to fix is *mostly* successful, except in rare cases of a lot of people opening preferences pre-timer SS init, where `addtimer` is delayed. This changes it to spawn, which is good to run pre-init, though in small amounts. If this doesn't work, then I'm going to make a savefile pass through every proc as an argument, but it's a very tedious and frustrating change to do, and I only really want to do it if necessary.