### PR TITLE
Buffs dragon's explosive resistance towards devastating explosions. Light and heavy explosions unchanged vs dragon. 

### DIFF
--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -149,6 +149,7 @@
 		if (EXPLODE_LIGHT)
 			ex_act_light()
 
+/// Called when a devastating explosive acts on this mob
 /mob/living/simple_animal/proc/ex_act_devastate()
 	var/bomb_armor = getarmor(null, BOMB)
 	if(prob(bomb_armor))
@@ -156,6 +157,7 @@
 	else
 		gib()
 
+/// Called when a heavy explosive acts on this mob
 /mob/living/simple_animal/proc/ex_act_heavy()
 	var/bomb_armor = getarmor(null, BOMB)
 	var/bloss = 60
@@ -163,6 +165,7 @@
 		bloss = bloss / 1.5
 	adjustBruteLoss(bloss)
 
+/// Called when a light explosive acts on this mob
 /mob/living/simple_animal/proc/ex_act_light()
 	var/bomb_armor = getarmor(null, BOMB)
 	var/bloss = 30

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -141,25 +141,34 @@
 	. = ..()
 	if(QDELETED(src))
 		return
-	var/bomb_armor = getarmor(null, BOMB)
 	switch (severity)
 		if (EXPLODE_DEVASTATE)
-			if(prob(bomb_armor))
-				adjustBruteLoss(500)
-			else
-				gib()
-				return
+			ex_act_devastate()
 		if (EXPLODE_HEAVY)
-			var/bloss = 60
-			if(prob(bomb_armor))
-				bloss = bloss / 1.5
-			adjustBruteLoss(bloss)
-
+			ex_act_heavy()
 		if (EXPLODE_LIGHT)
-			var/bloss = 30
-			if(prob(bomb_armor))
-				bloss = bloss / 1.5
-			adjustBruteLoss(bloss)
+			ex_act_light()
+
+/mob/living/simple_animal/proc/ex_act_devastate()
+	var/bomb_armor = getarmor(null, BOMB)
+	if(prob(bomb_armor))
+		adjustBruteLoss(500)
+	else
+		gib()
+
+/mob/living/simple_animal/proc/ex_act_heavy()
+	var/bomb_armor = getarmor(null, BOMB)
+	var/bloss = 60
+	if(prob(bomb_armor))
+		bloss = bloss / 1.5
+	adjustBruteLoss(bloss)
+
+/mob/living/simple_animal/proc/ex_act_light()
+	var/bomb_armor = getarmor(null, BOMB)
+	var/bloss = 30
+	if(prob(bomb_armor))
+		bloss = bloss / 1.5
+	adjustBruteLoss(bloss)
 
 /mob/living/simple_animal/blob_act(obj/structure/blob/B)
 	adjustBruteLoss(20)

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -90,6 +90,8 @@
 	var/datum/action/innate/summon_rift/rift
 	/// The color of the space dragon.
 	var/chosen_color
+	/// Devastation damage dealt coefficient based on max health
+	var/devastation_damage_percentage = 0.75
 
 /mob/living/simple_animal/hostile/space_dragon/Initialize(mapload)
 	. = ..()
@@ -104,6 +106,9 @@
 	if(!chosen_color)
 		dragon_name()
 		color_selection()
+
+/mob/living/simple_animal/hostile/space_dragon/ex_act_devastate()
+	adjustBruteLoss(initial(maxHealth)*devastation_damage_percentage)
 
 /mob/living/simple_animal/hostile/space_dragon/Life(delta_time = SSMOBS_DT, times_fired)
 	. = ..()
@@ -561,6 +566,12 @@
 /obj/structure/carp_rift/Initialize(mapload)
 	. = ..()
 	START_PROCESSING(SSobj, src)
+
+// Carp rifts always take heavy explosion damage. Discourages the use of maxcaps
+// and favours more weaker explosives to destroy the portal
+// as they have the same effect on the portal.
+/obj/structure/carp_rift/ex_act(severity, target)
+	return ..(min(EXPLODE_HEAVY, severity))
 
 /obj/structure/carp_rift/examine(mob/user)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -90,8 +90,10 @@
 	var/datum/action/innate/summon_rift/rift
 	/// The color of the space dragon.
 	var/chosen_color
-	/// Devastation damage dealt coefficient based on max health
-	var/devastation_damage_percentage = 0.75
+	/// Minimum devastation damage dealt coefficient based on max health
+	var/devastation_damage_min_percentage = 0.4
+	/// Maximum devastation damage dealt coefficient based on max health
+	var/devastation_damage_max_percentage = 0.75
 
 /mob/living/simple_animal/hostile/space_dragon/Initialize(mapload)
 	. = ..()
@@ -108,7 +110,8 @@
 		color_selection()
 
 /mob/living/simple_animal/hostile/space_dragon/ex_act_devastate()
-	adjustBruteLoss(initial(maxHealth)*devastation_damage_percentage)
+	var/damage_coefficient = rand(devastation_damage_min_percentage, devastation_damage_max_percentage)
+	adjustBruteLoss(initial(maxHealth)*damage_coefficient)
 
 /mob/living/simple_animal/hostile/space_dragon/Life(delta_time = SSMOBS_DT, times_fired)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
High devastation explosions always take 40% to 75% of a dragon's health away. Carp rifts can only ever take heavy explosive damage, making them more resistant maxcaps (previously, maxcaps would just instantly destroy them).

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The #61531 PR raises a valid concern about dragon v maxcaps but their implementation is poor.

Dragons are countered hard by maxcaps. They have only two options when they see someone with a maxcap: Run or fight. If they run, the person with the maxcap will just destroy their portal and they are fucked either way. If they fight, they will die due to the fact that maxcaps will instantly kill a dragon. 
This change makes it so that a dragon will still take devastating damage from a maxcap but the two options stated above will be more viable. If they choose to fight, they will tank a large amount of damage and possibly die. If they run, the portal won't be immediately destroyed if the person with the maxcap blows up. The aim of this PR is to discourage usage of people suicide bombing the dragon by making it so that it doesn't instantly kill the dragon.

tl;dr discourages the use of maxcaps to fight dragons because maxcaps not fun, still makes them viable but not as easy.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Devastating explosions will now deal damage equivalent to 40% to 75% of a dragon's max health.
balance: Carp rifts will no longer be instantly destroyed to devastating explosions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
