### PR TITLE
removes a useless check from organs and fixes maint eyes permanent blindness

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -207,7 +207,7 @@
 	if(victim.flags_1 & IS_SPINNING_1)
 		return DEVIATION_NONE
 
-	if(HAS_TRAIT(victim, TRAIT_FLASH_SENSITIVE)) //Basically if you have Flypeople eyes
+	if(HAS_TRAIT(victim, TRAIT_FLASH_SENSITIVE)) //If your eyes are sensitive and can be flashed from any direction.
 		return DEVIATION_NONE
 
 	// Are they on the same tile? We'll return partial deviation. This may be someone flashing while lying down

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -37,9 +37,6 @@
 	if(HAS_TRAIT_NOT_FROM(owner, TRAIT_DEAF, EAR_DAMAGE))
 		return
 
-	if((damage < maxHealth) && (organ_flags & ORGAN_FAILING)) //ear damage can be repaired from the failing condition
-		organ_flags &= ~ORGAN_FAILING
-
 	if((organ_flags & ORGAN_FAILING))
 		deaf = max(deaf, 1) // if we're failing we always have at least 1 deaf stack (and thus deafness)
 	else // only clear deaf stacks if we're not failing

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -31,7 +31,8 @@
 	var/see_invisible = SEE_INVISIBLE_LIVING
 	var/lighting_alpha
 	var/no_glasses
-	var/damaged = FALSE //damaged indicates that our eyes are undergoing some level of negative effect
+	/// indication that the eyes are undergoing some negative effect
+	var/damaged = FALSE
 
 /obj/item/organ/eyes/Insert(mob/living/carbon/eye_owner, special = FALSE, drop_if_replaced = FALSE, initialising)
 	. = ..()

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -83,12 +83,8 @@
 
 
 /obj/item/organ/eyes/on_life(delta_time, times_fired)
-	..()
+	. = ..()
 	var/mob/living/carbon/eye_owner = owner
-	//since we can repair fully damaged eyes, check if healing has occurred
-	if((organ_flags & ORGAN_FAILING) && (damage < maxHealth))
-		organ_flags &= ~ORGAN_FAILING
-		eye_owner.cure_blind(EYE_DAMAGE)
 	//various degrees of "oh fuck my eyes", from "point a laser at your eye" to "staring at the Sun" intensities
 	if(damage > 20)
 		damaged = TRUE
@@ -102,6 +98,7 @@
 	else if(damaged)
 		damaged = FALSE
 		eye_owner.clear_fullscreen("eye_damage")
+		eye_owner.cure_blind(EYE_DAMAGE)
 	return
 
 /obj/item/organ/eyes/night_vision


### PR DESCRIPTION
## About The Pull Request

The check for the damage under maxhealth and organs failing, was something never called because it is already dealt with by /obj/item/organ/proc/check_damage_thresholds(mob/organ_owner)
This meant that in some cases of going blind (Like maintenance sect's adapted eyes), cure_blindness was never called, so it would never get fixed.
This is also apparently in ear code for some reason, same effect there, never called and dealt with alternatively.

This theoretically makes the cure_blindness call when under 20 damage instead of under 50, but in actuality it makes cure_blindness called when under 20 instead of never.

## Why It's Good For The Game

People can now see after fixing their eyes, and unused code will no longer confuse people more than they already have to be.

Closes #58525

## Changelog

:cl:
fix: Maintenance sect's adapted eyes will no longer render you permanently blind despite having them repaired via the darkness.
/:cl: