### PR TITLE
holographic esword doesnt have blockchance

### DIFF
--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -12,6 +12,7 @@
 	desc = "May the force be with you. Sorta."
 	damtype = STAMINA
 	throw_speed = 2
+	block_chance = 0
 	throwforce = 0
 	embedding = null
 	sword_color_icon = null


### PR DESCRIPTION

## About The Pull Request

fixes the holosword having inherited block chance from its parent after the transforming weapons refactor.

## Why It's Good For The Game

no more rng

## Changelog


:cl: Pepsiman0
fix: holosword doesnt have blockchance 
/:cl: