### PR TITLE
Harddeletes: Accident edition

### DIFF
--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -53,23 +53,18 @@
 		screen_maps[screen_obj.assigned_map] = list()
 	// NOTE: Possibly an expensive operation
 	var/list/screen_map = screen_maps[screen_obj.assigned_map]
-	if(!screen_map.Find(screen_obj))
-		screen_map += screen_obj
-	if(!screen.Find(screen_obj))
-		screen += screen_obj
+	screen_map |= screen_obj
+	screen |= screen_obj
 
 /**
  * Clears the map of registered screen objects.
- *
- * Not really needed most of the time, as the client's screen list gets reset
- * on relog. any of the buttons are going to get caught by garbage collection
- * anyway. they're effectively qdel'd.
  */
 /client/proc/clear_map(map_name)
-	if(!map_name || !(map_name in screen_maps))
+	if(!map_name || !screen_maps[map_name])
 		return FALSE
 	for(var/atom/movable/screen/screen_obj in screen_maps[map_name])
 		screen_maps[map_name] -= screen_obj
+		screen -= screen_obj
 		if(screen_obj.del_on_map_removal)
 			qdel(screen_obj)
 	screen_maps -= map_name

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -51,9 +51,9 @@
 	cam_background.del_on_map_removal = FALSE
 
 /obj/machinery/computer/security/Destroy()
-	qdel(cam_screen)
+	QDEL_NULL(cam_screen)
 	QDEL_LIST(cam_plane_masters)
-	qdel(cam_background)
+	QDEL_NULL(cam_background)
 	return ..()
 
 /obj/machinery/computer/security/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock)

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -11,7 +11,7 @@
 		return
 	if(!linked_bug)
 		user.audible_message(span_warning("[src] lets off a shrill beep!"))
-	if("spypopup_map" in user.client.screen_maps) //alright, the popup this object uses is already IN use, so the window is open. no point in doing any other work here, so we're good.
+	if(user.client.screen_maps["spypopup_map"]) //alright, the popup this object uses is already IN use, so the window is open. no point in doing any other work here, so we're good.
 		return
 	user.client.setup_popup("spypopup", 3, 3, 2)
 	user.client.register_map_obj(linked_bug.cam_screen)
@@ -78,9 +78,9 @@
 /obj/item/clothing/accessory/spy_bug/Destroy()
 	if(linked_glasses)
 		linked_glasses.linked_bug = null
-	qdel(cam_screen)
+	QDEL_NULL(cam_screen)
 	QDEL_LIST(cam_plane_masters)
-	qdel(tracker)
+	QDEL_NULL(tracker)
 	. = ..()
 
 /obj/item/clothing/accessory/spy_bug/proc/update_view()//this doesn't do anything too crazy, just updates the vis_contents of its screen obj

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -367,7 +367,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/character_preview_view)
 		qdel(plane_master)
 
 	client?.clear_map(assigned_map)
-	client?.screen -= src
 
 	preferences?.character_preview_view = null
 

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -54,9 +54,9 @@
 	cam_background.del_on_map_removal = FALSE
 
 /datum/computer_file/program/secureye/Destroy()
-	qdel(cam_screen)
+	QDEL_NULL(cam_screen)
 	QDEL_LIST(cam_plane_masters)
-	qdel(cam_background)
+	QDEL_NULL(cam_background)
 	return ..()
 
 /datum/computer_file/program/secureye/ui_interact(mob/user, datum/tgui/ui)

--- a/code/modules/projectiles/ammunition/caseless/_caseless.dm
+++ b/code/modules/projectiles/ammunition/caseless/_caseless.dm
@@ -4,12 +4,14 @@
 	heavy_metal = FALSE
 
 /obj/item/ammo_casing/caseless/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from)
-	if (..()) //successfully firing
-		moveToNullspace()
-		QDEL_NULL(src)
-		return TRUE
-	else
+	if (!..()) //failed firing
 		return FALSE
+	if(istype(fired_from, /obj/item/gun))
+		var/obj/item/gun/shot_from = fired_from
+		if(shot_from.chambered == src)
+			shot_from.chambered = null //Nuke it. Nuke it now.
+	qdel(src)
+	return TRUE
 
 /obj/item/ammo_casing/caseless/update_icon_state()
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -213,12 +213,15 @@
 /obj/item/gun/ballistic/handle_chamber(empty_chamber = TRUE, from_firing = TRUE, chamber_next_round = TRUE)
 	if(!semi_auto && from_firing)
 		return
-	var/obj/item/ammo_casing/AC = chambered //Find chambered round
-	if(istype(AC)) //there's a chambered round
-		if(casing_ejector || !from_firing)
-			AC.forceMove(drop_location()) //Eject casing onto ground.
-			AC.bounce_away(TRUE)
-			SEND_SIGNAL(AC, COMSIG_CASING_EJECTED)
+	var/obj/item/ammo_casing/casing = chambered //Find chambered round
+	if(istype(casing)) //there's a chambered round
+		if(QDELING(casing))
+			stack_trace("Trying to move a qdeleted casing of type [casing.type]!")
+			chambered = null
+		else if(casing_ejector || !from_firing)
+			casing.forceMove(drop_location()) //Eject casing onto ground.
+			casing.bounce_away(TRUE)
+			SEND_SIGNAL(casing, COMSIG_CASING_EJECTED)
 			chambered = null
 		else if(empty_chamber)
 			chambered = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So I started with fixing some timing stuff in #61540, decided to look into foam harddels since I've known about them for a while, got bored, tried to figure out the plane master failures I've seen, and well uh, did.

I'm sure there'll be more, but for now:
Fixes foam darts sticking around post qdel due to dumb guncode, adds a stack trace to handle it.
Makes map popups actually clear the screen they're effecting of their objects, preventing plane master harddels, most commonly sourced from admin pod memes. Not clearing from the screen WAS SOMEHOW AN INTENDED FEATURE!?!@ because "clients log out often anyway and that clears screen so it's fine" I am having a meltdown
Changes examine timers from a ref + signal to a ref(), the timer's 1 second, it's not gonna cause any collisions for the love of christ
## Why It's Good For The Game
Fuck you
