### PR TITLE
Fixes some text inaccuracies in the changeling antagonist ui

### DIFF
--- a/tgui/packages/tgui/interfaces/AntagInfoChangeling.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoChangeling.tsx
@@ -106,15 +106,15 @@ const AbilitiesSection = (props, context) => {
             <Stack.Item basis={0} textColor="label" grow>
               Your
               <span style={absorbstyle}>
-                &ensp;Absorb
+                &ensp;Absorb DNA
               </span> ability
-              allows you to steal the DNA and memories of a victim. The
+              allows you to steal the DNA and memories of a victim.
+              Your
               <span style={absorbstyle}>
-                &ensp;Transform Sting
+                &ensp;Extract DNA Sting
               </span> ability
-              does the same instantly and quietly, but doesn&apos;t
-              count for objectives, kill them, or
-              include their memories and speech patterns.
+              also steals the DNA of a victim, and is undetectable, but
+              does not grant you their memories or speech patterns.
             </Stack.Item>
             <Stack.Divider />
             <Stack.Item basis={0} textColor="label" grow>


### PR DESCRIPTION
## About The Pull Request

- The absorb ability is actually called `Absorb DNA`.
- `Transform Sting` is not the sting changelings use to extract DNA. `Extract DNA Sting` is the correct ability.
- DNA collected from Extract DNA string **do** contribute to objectives.

## Why It's Good For The Game

Less confusion / misinformation displayed. 

## Changelog

:cl: Melbert
spellcheck: Fixes some errors in the changeling antagonist UI
/:cl:

