### PR TITLE
Hauntium is chill with the undead, buffs hauntium stats

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -69,6 +69,8 @@
 #define BB_HAUNT_TARGET "BB_haunt_target"
 ///Amount of successful hits in a row this item has had
 #define BB_HAUNTED_THROW_ATTEMPT_COUNT "BB_haunted_throw_attempt_count"
+///If true, tolerates the equipper holding/equipping the hauntium
+#define BB_LIKES_EQUIPPER "BB_likes_equipper"
 
 ///Cursed item controller defines
 

--- a/code/datums/ai/hauntium/haunted_controller.dm
+++ b/code/datums/ai/hauntium/haunted_controller.dm
@@ -1,9 +1,12 @@
 
 /datum/ai_controller/haunted
 	movement_delay = 0.4 SECONDS
-	blackboard = list(BB_TO_HAUNT_LIST = list(),
-	BB_HAUNT_TARGET,
-	BB_HAUNTED_THROW_ATTEMPT_COUNT)
+	blackboard = list(
+		BB_TO_HAUNT_LIST = list(),
+		BB_LIKES_EQUIPPER = FALSE,
+		BB_HAUNT_TARGET,
+		BB_HAUNTED_THROW_ATTEMPT_COUNT,
+	)
 	planning_subtrees = list(/datum/ai_planning_subtree/haunted)
 	idle_behavior = /datum/idle_behavior/idle_ghost_item
 
@@ -21,8 +24,16 @@
 /datum/ai_controller/haunted/proc/on_equip(datum/source, mob/equipper, slot)
 	SIGNAL_HANDLER
 	UnregisterSignal(pawn, COMSIG_ITEM_EQUIPPED)
-	var/list/hauntee_list = blackboard[BB_TO_HAUNT_LIST]
-	hauntee_list[equipper] = hauntee_list[equipper] + HAUNTED_ITEM_AGGRO_ADDITION //You have now become one of the victims of the HAAAAUNTTIIIINNGGG OOOOOO~~~
+	var/haunt_equipper = TRUE
+	if(isliving(equipper))
+		var/mob/living/possibly_cool = equipper
+		if(possibly_cool.mob_biotypes & MOB_UNDEAD)
+			haunt_equipper = FALSE
+	if(!haunt_equipper)
+		blackboard[BB_LIKES_EQUIPPER] = TRUE
+	else
+		var/list/hauntee_list = blackboard[BB_TO_HAUNT_LIST]
+		hauntee_list[equipper] = hauntee_list[equipper] + HAUNTED_ITEM_AGGRO_ADDITION //You have now become one of the victims of the HAAAAUNTTIIIINNGGG OOOOOO~~~
 	RegisterSignal(pawn, COMSIG_ITEM_DROPPED, .proc/on_dropped)
 	SIGNAL_HANDLER
 
@@ -30,4 +41,5 @@
 /datum/ai_controller/haunted/proc/on_dropped(datum/source, mob/user)
 	SIGNAL_HANDLER
 	RegisterSignal(pawn, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
+	blackboard[BB_LIKES_EQUIPPER] = FALSE
 	UnregisterSignal(pawn, COMSIG_ITEM_DROPPED)

--- a/code/datums/ai/hauntium/hauntium_subtrees.dm
+++ b/code/datums/ai/hauntium/hauntium_subtrees.dm
@@ -2,6 +2,8 @@
 	var/obj/item/item_pawn = controller.pawn
 
 	if(ismob(item_pawn.loc)) //We're being held, maybe escape?
+		if(controller.blackboard[BB_LIKES_EQUIPPER])//don't unequip from people it's okay with
+			return SUBTREE_RETURN_FINISH_PLANNING
 		if(DT_PROB(HAUNTED_ITEM_ESCAPE_GRASP_CHANCE, delta_time))
 			controller.queue_behavior(/datum/ai_behavior/item_escape_grasp)
 		return SUBTREE_RETURN_FINISH_PLANNING

--- a/code/datums/ai/hauntium/hauntium_subtrees.dm
+++ b/code/datums/ai/hauntium/hauntium_subtrees.dm
@@ -3,7 +3,7 @@
 
 	if(ismob(item_pawn.loc)) //We're being held, maybe escape?
 		if(controller.blackboard[BB_LIKES_EQUIPPER])//don't unequip from people it's okay with
-			return SUBTREE_RETURN_FINISH_PLANNING
+			return
 		if(DT_PROB(HAUNTED_ITEM_ESCAPE_GRASP_CHANCE, delta_time))
 			controller.queue_behavior(/datum/ai_behavior/item_escape_grasp)
 		return SUBTREE_RETURN_FINISH_PLANNING

--- a/code/datums/materials/hauntium.dm
+++ b/code/datums/materials/hauntium.dm
@@ -8,9 +8,9 @@
 	sheet_type = /obj/item/stack/sheet/hauntium
 	value_per_unit = 0.05
 	beauty_modifier = 0.25
-	strength_modifier = 1
-	armor_modifiers = list(MELEE = 1, BULLET = 1, LASER = 1, ENERGY = 1, BOMB = 1, BIO = 1, RAD = 1, FIRE = 1, ACID = 1)
-
+	//pretty good but only the undead can actually make use of these modifiers
+	strength_modifier = 1.2
+	armor_modifiers = list(MELEE = 1.1, BULLET = 1.1, LASER = 1.15, ENERGY = 1.15, BOMB = 1, BIO = 1, RAD = 1, FIRE = 1, ACID = 0.7)
 
 /datum/material/hauntium/on_applied_obj(obj/o, amount, material_flags)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Figured it'd be really cool if hauntium could be used by the undead

## Why It's Good For The Game

Right now it's pretty useless beyond some pretty good memes.

Should be pretty cool having weapons and armor that you can equip but will turn upon your foes if they use it!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Hauntium can now be worn by the undead!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
