### PR TITLE
The Chemistry Heater now shuts off when a beaker is added to it.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -153,6 +153,7 @@
 
 	if(istype(I, /obj/item/reagent_containers) && !(I.item_flags & ABSTRACT) && I.is_open_container())
 		. = TRUE //no afterattack
+		on = FALSE // reduces accidents by 100%
 		var/obj/item/reagent_containers/B = I
 		if(!user.transferItemToLoc(B, src))
 			return


### PR DESCRIPTION
I definitely didn't blow up my illicit chemistry laboratory making performance enhancing materials for the Chaplain's fight pit or anything. That would be absurd.

## About The Pull Request

The Chemistry Heater now shuts off when a beaker is added to it.

## Why It's Good For The Game

Prevents accidents because you left the heater on by accident.

## Changelog

:cl:
qol: The Chemistry Heater now shuts off when a beaker is added to it.
/:cl: