### PR TITLE
HFR backend rework

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
@@ -53,14 +53,14 @@
 
 // Currently, this is 2700 moles at 1 Kelvin, linearly scaling down to a maximum of 1800 safe moles at 1e8 degrees kelvin
 // Settings:
-// Start taking overfull damage at this power level
+/// Start taking overfull damage at this power level
 #define HYPERTORUS_OVERFULL_MIN_POWER_LEVEL 6
-// Take 0 damage beneath this much fusion mass at 1 degree Kelvin
+/// Take 0 damage beneath this much fusion mass at 1 degree Kelvin
 #define HYPERTORUS_OVERFULL_MAX_SAFE_COLD_FUSION_MOLES 2700
-// Take 0 damage beneath this much fusion mass at FUSION_TEMPERATURE_MAX degrees Kelvin
+/// Take 0 damage beneath this much fusion mass at FUSION_TEMPERATURE_MAX degrees Kelvin
 #define HYPERTORUS_OVERFULL_MAX_SAFE_HOT_FUSION_MOLES 1800
 // From there, how quickly should things get bad?
-// Every 200 moles, 1 point of damage per second
+/// Every 200 moles, 1 point of damage per second
 #define HYPERTORUS_OVERFULL_MOLAR_SLOPE (1/200)
 // Derived:
 // Given these settings, derive the rest of the equation.
@@ -78,9 +78,9 @@
 //
 
 // Settings:
-// Start healing when fusion mass is below this threshold
+/// Start healing when fusion mass is below this threshold
 #define HYPERTORUS_SUBCRITICAL_MOLES 1200
-// Heal one point per second per this many moles under the threshold
+/// Heal one point per second per this many moles under the threshold
 #define HYPERTORUS_SUBCRITICAL_SCALE 400
 
 //
@@ -88,9 +88,9 @@
 //
 
 // Settings:
-// Heal up to this many points of damage per second at 1 degree kelvin
+/// Heal up to this many points of damage per second at 1 degree kelvin
 #define HYPERTORUS_COLD_COOLANT_MAX_RESTORE 2.5
-// Start healing below this temperature
+/// Start healing below this temperature
 #define HYPERTORUS_COLD_COOLANT_THRESHOLD (10 ** 5)
 // Derived:
 #define HYPERTORUS_COLD_COOLANT_SCALE (HYPERTORUS_COLD_COOLANT_MAX_RESTORE / log(10, HYPERTORUS_COLD_COOLANT_THRESHOLD))
@@ -100,7 +100,7 @@
 //
 
 // Settings:
-// Start taking damage over this threshold, up to a maximum of (1 - HYPERTORUS_MAX_SAFE_IRON) per tick at 100% iron
+/// Start taking damage over this threshold, up to a maximum of (1 - HYPERTORUS_MAX_SAFE_IRON) per tick at 100% iron
 #define HYPERTORUS_MAX_SAFE_IRON 0.35
 
 //
@@ -109,11 +109,11 @@
 
 // Note: Ignores the damage cap!
 // Settings:
-// Start taking damage over this threshold
+/// Start taking damage over this threshold
 #define HYPERTORUS_HYPERCRITICAL_MOLES 10000
-// Take this much damage per mole over the threshold per second
+/// Take this much damage per mole over the threshold per second
 #define HYPERTORUS_HYPERCRITICAL_SCALE 0.002
-// Take at most this much damage per second
+/// Take at most this much damage per second
 #define HYPERTORUS_HYPERCRITICAL_MAX_DAMAGE 20
 
 // If the moderator goes hypercritical, it cracks and starts to spill
@@ -121,17 +121,17 @@
 // Even a small amount is still extremely hazardous with fusion temperatures
 #define HYPERTORUS_WEAK_SPILL_RATE 0.0005
 #define HYPERTORUS_WEAK_SPILL_CHANCE 1
-// Start spilling superhot moderator gas when over this pressure threshold
+/// Start spilling superhot moderator gas when over this pressure threshold
 #define HYPERTORUS_MEDIUM_SPILL_PRESSURE 10000
-// How much should we spill initially?
+/// How much we should spill initially
 #define HYPERTORUS_MEDIUM_SPILL_INITIAL 0.25
-// How much of the moderator mix should we spill per second until mended?
+/// How much of the moderator mix we should spill per second until mended
 #define HYPERTORUS_MEDIUM_SPILL_RATE 0.01
-// If the moderator gas goes over this threshold, REALLY spill it
+/// If the moderator gas goes over this threshold, REALLY spill it
 #define HYPERTORUS_STRONG_SPILL_PRESSURE 12000
-// How much should we spill initially?
+/// How much we should spill initially
 #define HYPERTORUS_STRONG_SPILL_INITIAL 0.75
-// How much of the moderator mix should we spill per second until mended?
+/// How much of the moderator mix we should spill per second until mended
 #define HYPERTORUS_STRONG_SPILL_RATE 0.05
 
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
@@ -17,9 +17,9 @@
 ///Constant used when calculating the chance of emitting a radioactive particle
 #define PARTICLE_CHANCE_CONSTANT (-20000000)
 ///Conduction of heat inside the fusion reactor
-#define METALLIC_VOID_CONDUCTIVITY 0.15
+#define METALLIC_VOID_CONDUCTIVITY 0.38
 ///Conduction of heat near the external cooling loop
-#define HIGH_EFFICIENCY_CONDUCTIVITY 0.95
+#define HIGH_EFFICIENCY_CONDUCTIVITY 0.975
 ///Sets the minimum amount of power the machine uses
 #define MIN_POWER_USAGE 50000
 ///Sets the multiplier for the damage
@@ -62,8 +62,8 @@
 // Take 0 damage beneath this much fusion mass at FUSION_TEMPERATURE_MAX degrees Kelvin
 #define HYPERTORUS_OVERFULL_MAX_SAFE_HOT_FUSION_MOLES 2589
 // From there, how quickly should things get bad?
-// Every 400 moles, 1 point of damage per tick
-#define HYPERTORUS_OVERFULL_MOLAR_SLOPE (1/400)
+// Every 200 moles, 1 point of damage per second
+#define HYPERTORUS_OVERFULL_MOLAR_SLOPE (1/200)
 // Derived:
 // Given these settings, derive the rest of the equation.
 // Damage is the dependent variable, fusion_moles and damage_source_temperature are the independent variables
@@ -82,18 +82,20 @@
 // Settings:
 // Start healing when fusion mass is below this threshold
 #define HYPERTORUS_SUBCRITICAL_MOLES 1200
-// Heal one point per tick per this many moles under the threshold
-#define HYPERTORUS_SUBCRITICAL_SCALE 200
+// Heal one point per second per this many moles under the threshold
+#define HYPERTORUS_SUBCRITICAL_SCALE 400
 
 //
 // Heal source: Cold enough coolant
 //
 
 // Settings:
-// Heal up to this many points of damage
-#define HYPERTORUS_COLD_COOLANT_MAX_RESTORE 5
+// Heal up to this many points of damage per second at 1 degree kelvin
+#define HYPERTORUS_COLD_COOLANT_MAX_RESTORE 2.5
+// Start healing below this temperature
+#define HYPERTORUS_COLD_COOLANT_THRESHOLD (10 ** 5)
 // Derived:
-#define HYPERTORUS_COLD_COOLANT_THRESHOLD (10 ** HYPERTORUS_COLD_COOLANT_MAX_RESTORE)
+#define HYPERTORUS_COLD_COOLANT_SCALE (HYPERTORUS_COLD_COOLANT_MAX_RESTORE / log(10, HYPERTORUS_COLD_COOLANT_THRESHOLD))
 
 //
 // Damage source: Iron content
@@ -111,10 +113,10 @@
 // Settings:
 // Start taking damage over this threshold
 #define HYPERTORUS_HYPERCRITICAL_MOLES 10000
-// Take this much damage per mole over the threshold per tick
-#define HYPERTORUS_HYPERCRITICAL_SCALE 0.001
-// Take at least this much damage per tick.
-#define HYPERTORUS_HYPERCRITICAL_MIN_DAMAGE 10
+// Take this much damage per mole over the threshold per second
+#define HYPERTORUS_HYPERCRITICAL_SCALE 0.002
+// Take at least this much damage per second
+#define HYPERTORUS_HYPERCRITICAL_MIN_DAMAGE 20
 
 
 //

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
@@ -118,6 +118,24 @@
 // Take at least this much damage per second
 #define HYPERTORUS_HYPERCRITICAL_MIN_DAMAGE 20
 
+// If the moderator goes hypercritical, it cracks and starts to spill
+// If our pressure is weak, it can still spill, just weakly and infrequently
+// Even a small amount is still extremely hazardous with fusion temperatures
+#define HYPERTORUS_WEAK_SPILL_RATE 0.0005
+#define HYPERTORUS_WEAK_SPILL_CHANCE 1
+// Start spilling superhot moderator gas when over this pressure threshold
+#define HYPERTORUS_MEDIUM_SPILL_PRESSURE 10000
+// How much should we spill initially?
+#define HYPERTORUS_MEDIUM_SPILL_INITIAL 0.25
+// How much of the moderator mix should we spill per second until mended?
+#define HYPERTORUS_MEDIUM_SPILL_RATE 0.01
+// If the moderator gas goes over this threshold, REALLY spill it
+#define HYPERTORUS_STRONG_SPILL_PRESSURE 12000
+// How much should we spill initially?
+#define HYPERTORUS_STRONG_SPILL_INITIAL 0.75
+// How much of the moderator mix should we spill per second until mended?
+#define HYPERTORUS_STRONG_SPILL_RATE 0.05
+
 
 //
 // Explosion flags for use in fuel recipes

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
@@ -8,14 +8,6 @@
 #define CALCULATED_TRITRADIUS 230e-3
 ///Power conduction in the void, used to calculate the efficiency of the reaction
 #define VOID_CONDUCTION 1e-2
-///Max reaction point per reaction cycle
-#define MAX_FUSION_RESEARCH 1000
-///Min amount of allowed heat change
-#define MIN_HEAT_VARIATION -1e5
-///Max amount of allowed heat change
-#define MAX_HEAT_VARIATION 1e5
-///Max mole consumption per reaction cycle
-#define MAX_FUEL_USAGE 36
 ///Mole count required (tritium/hydrogen) to start a fusion reaction
 #define FUSION_MOLE_THRESHOLD 25
 ///Used to reduce the gas_power to a more useful amount

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_defines.dm
@@ -51,16 +51,14 @@
 // Damage source: Too much mass in the fusion mix at high fusion levels
 //
 
-// In the original release, this was 2500 moles at 1 Kelvin, linearly scaling down to a maximum of 1500 safe moles at 1e8 degrees kelvin
-// Currently, this is 2700 moles at 1 Kelvin, linearly scaling down to a maximum of 2589 safe moles at 1e8 degrees kelvin
-// ...this possibly was not intentional, but lets not change implementation and behavior at the same time
+// Currently, this is 2700 moles at 1 Kelvin, linearly scaling down to a maximum of 1800 safe moles at 1e8 degrees kelvin
 // Settings:
 // Start taking overfull damage at this power level
 #define HYPERTORUS_OVERFULL_MIN_POWER_LEVEL 6
 // Take 0 damage beneath this much fusion mass at 1 degree Kelvin
 #define HYPERTORUS_OVERFULL_MAX_SAFE_COLD_FUSION_MOLES 2700
 // Take 0 damage beneath this much fusion mass at FUSION_TEMPERATURE_MAX degrees Kelvin
-#define HYPERTORUS_OVERFULL_MAX_SAFE_HOT_FUSION_MOLES 2589
+#define HYPERTORUS_OVERFULL_MAX_SAFE_HOT_FUSION_MOLES 1800
 // From there, how quickly should things get bad?
 // Every 200 moles, 1 point of damage per second
 #define HYPERTORUS_OVERFULL_MOLAR_SLOPE (1/200)
@@ -115,8 +113,8 @@
 #define HYPERTORUS_HYPERCRITICAL_MOLES 10000
 // Take this much damage per mole over the threshold per second
 #define HYPERTORUS_HYPERCRITICAL_SCALE 0.002
-// Take at least this much damage per second
-#define HYPERTORUS_HYPERCRITICAL_MIN_DAMAGE 20
+// Take at most this much damage per second
+#define HYPERTORUS_HYPERCRITICAL_MAX_DAMAGE 20
 
 // If the moderator goes hypercritical, it cracks and starts to spill
 // If our pressure is weak, it can still spill, just weakly and infrequently

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -249,8 +249,7 @@
 		internal_fusion.gases[gas_id][MOLES] -= min(fuel_list[gas_id], fuel_consumption)
 	for(var/gas_id in fuel.primary_products)
 		internal_fusion.gases[gas_id][MOLES] += fuel_consumption * 0.5
-	//The decay of the tritium and the reaction's energy produces waste gases, different ones depending on whether the reaction is endo or exothermic
-	//Also dependant on what is the power level and what moderator gases are present
+
 	switch(power_level)
 		if(1)
 			moderator_internal.gases[fuel.secondary_products[1]][MOLES] += scaled_production * 0.95

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -250,29 +250,32 @@
 	for(var/gas_id in fuel.primary_products)
 		internal_fusion.gases[gas_id][MOLES] += fuel_consumption * 0.5
 
+	// Each recipe provides a tier list of six output gases.
+	// Which gases are produced depend on what the fusion level is.
+	var/list/tier = fuel.secondary_products
 	switch(power_level)
 		if(1)
-			moderator_internal.gases[fuel.secondary_products[1]][MOLES] += scaled_production * 0.95
-			moderator_internal.gases[fuel.secondary_products[2]][MOLES] += scaled_production *0.75
+			moderator_internal.gases[tier[1]][MOLES] += scaled_production * 0.95
+			moderator_internal.gases[tier[2]][MOLES] += scaled_production * 0.75
 		if(2)
-			moderator_internal.gases[fuel.secondary_products[1]][MOLES] += scaled_production * 1.65
-			moderator_internal.gases[fuel.secondary_products[2]][MOLES] += scaled_production
+			moderator_internal.gases[tier[1]][MOLES] += scaled_production * 1.65
+			moderator_internal.gases[tier[2]][MOLES] += scaled_production
 			if(moderator_list[/datum/gas/plasma] > 50)
-				moderator_internal.gases[fuel.secondary_products[3]][MOLES] += scaled_production * 1.15
+				moderator_internal.gases[tier[3]][MOLES] += scaled_production * 1.15
 		if(3, 4)
 			if(power_level == 3)
-				moderator_internal.gases[fuel.secondary_products[2]][MOLES] += scaled_production * 0.5
-				moderator_internal.gases[fuel.secondary_products[3]][MOLES] += scaled_production * 0.45
+				moderator_internal.gases[tier[2]][MOLES] += scaled_production * 0.5
+				moderator_internal.gases[tier[3]][MOLES] += scaled_production * 0.45
 			if(power_level == 4)
-				moderator_internal.gases[fuel.secondary_products[3]][MOLES] += scaled_production * 1.65
-				moderator_internal.gases[fuel.secondary_products[4]][MOLES] += scaled_production * 1.25
+				moderator_internal.gases[tier[3]][MOLES] += scaled_production * 1.65
+				moderator_internal.gases[tier[4]][MOLES] += scaled_production * 1.25
 		if(5)
-			moderator_internal.gases[fuel.secondary_products[4]][MOLES] += scaled_production * 0.65
-			moderator_internal.gases[fuel.secondary_products[5]][MOLES] += scaled_production
-			moderator_internal.gases[fuel.secondary_products[6]][MOLES] += scaled_production * 0.75
+			moderator_internal.gases[tier[4]][MOLES] += scaled_production * 0.65
+			moderator_internal.gases[tier[5]][MOLES] += scaled_production
+			moderator_internal.gases[tier[6]][MOLES] += scaled_production * 0.75
 		if(6)
-			moderator_internal.gases[fuel.secondary_products[5]][MOLES] += scaled_production * 0.35
-			moderator_internal.gases[fuel.secondary_products[6]][MOLES] += scaled_production
+			moderator_internal.gases[tier[5]][MOLES] += scaled_production * 0.35
+			moderator_internal.gases[tier[6]][MOLES] += scaled_production
 
 /**
  * Perform common fusion actions:

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -54,6 +54,8 @@
 		waste_remove = FALSE
 		iron_content += 0.02 * power_level * delta_time
 
+	update_temperature_status()
+
 	//Store the temperature of the gases after one cicle of the fusion reaction
 	var/archived_heat = internal_fusion.temperature
 	//Store the volume of the fusion reaction multiplied by the force of the magnets that controls how big it will be
@@ -524,28 +526,6 @@
 			cooling_remove.temperature = max(cooling_remove.temperature - cooling_heat_amount / cooling_remove.heat_capacity(), TCMB)
 			internal_fusion.temperature = max(internal_fusion.temperature + cooling_heat_amount / internal_fusion.heat_capacity(), TCMB)
 		cooling_port.merge(cooling_remove)
-
-	fusion_temperature = internal_fusion.temperature
-	moderator_temperature = moderator_internal.temperature
-	coolant_temperature = airs[1].temperature
-	output_temperature = linked_output.airs[1].temperature
-
-	//Set the power level of the fusion process
-	switch(fusion_temperature)
-		if(-INFINITY to 500)
-			power_level = 0
-		if(500 to 1e3)
-			power_level = 1
-		if(1e3 to 1e4)
-			power_level = 2
-		if(1e4 to 1e5)
-			power_level = 3
-		if(1e5 to 1e6)
-			power_level = 4
-		if(1e6 to 1e7)
-			power_level = 5
-		else
-			power_level = 6
 
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/inject_from_side_components(delta_time)
 	update_pipenets()

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -25,7 +25,6 @@
 		// Running out of fuel won't save you if your moderator and coolant are exploding on their own.
 		check_spill()
 		process_damageheal(delta_time)
-		process_damageheal_2(delta_time)
 		check_alert()
 	remove_waste(delta_time)
 	update_pipenets()
@@ -437,9 +436,6 @@
 		var/hypercritical_damage_taken = max((internal_fusion.total_moles() - HYPERTORUS_HYPERCRITICAL_MOLES) * HYPERTORUS_HYPERCRITICAL_SCALE, 0)
 		critical_threshold_proximity += min(hypercritical_damage_taken, HYPERTORUS_HYPERCRITICAL_MIN_DAMAGE) * delta_time
 
-/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/process_damageheal_2(delta_time)
-	// The damage and healing system under SSmachine.
-	// Distinct proc while we change the implementation rather than behavior, these will be merged soon.
 	// High power fusion might create other matter other than helium, iron is dangerous inside the machine, damage can be seen
 	if(power_level > 4 && prob(IRON_CHANCE_PER_FUSION_LEVEL * power_level))//at power level 6 is 100%
 		iron_content += IRON_ACCUMULATED_PER_SECOND * delta_time
@@ -453,12 +449,6 @@
 		if(moderator_list[/datum/gas/bz] > (150 / power_level))
 			var/obj/machinery/hypertorus/corner/picked_corner = pick(corners)
 			picked_corner.loc.fire_nuclear_particle(turn(picked_corner.dir, 180))
-
-	// Classic nuclear particle emission system. XXX: Are we supposed to have both?
-	var/particle_chance = max(((PARTICLE_CHANCE_CONSTANT)/(power_output-PARTICLE_CHANCE_CONSTANT)) + 1, 0)//Asymptopically approaches 100% as the energy of the reaction goes up.
-	if(prob(PERCENT(particle_chance)))
-		var/obj/machinery/hypertorus/corner/picked_corner = pick(corners)
-		picked_corner.loc.fire_nuclear_particle()
 
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/check_lightning_arcs(moderator_list)
 	if(power_level >= 4)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -223,7 +223,7 @@
 		fuel_injection_rate = 20
 		moderator_injection_rate = 50
 		waste_remove = FALSE
-		iron_content += 0.1 * delta_time
+		iron_content += 0.02 * power_level * delta_time
 
 	//Store the temperature of the gases after one cicle of the fusion reaction
 	var/archived_heat = internal_fusion.temperature

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -17,6 +17,8 @@
 		deactivate()
 		return
 
+	assert_gases()
+
 	// Run the reaction if it is either live or being started
 	if (start_power || power_level)
 		play_ambience()
@@ -60,18 +62,6 @@
 	var/archived_heat = internal_fusion.temperature
 	//Store the volume of the fusion reaction multiplied by the force of the magnets that controls how big it will be
 	var/volume = internal_fusion.volume * (magnetic_constrictor * 0.01)
-
-	//Assert the gases that will be used/created during the process
-	for(var/gas_id in selected_fuel.requirements) //These are the fuels
-		internal_fusion.assert_gas(gas_id)
-
-	for(var/gas_id in selected_fuel.primary_products) //These are the gases that can be produced inside the internal_fusion mix
-		internal_fusion.assert_gas(gas_id)
-
-	internal_fusion.assert_gas(/datum/gas/antinoblium)
-
-	for(var/gas_id in GLOB.meta_gas_info)
-		moderator_internal.assert_gas(gas_id)
 
 	//Store the fuel gases and the product gas moles
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -262,13 +262,12 @@
 			moderator_internal.gases[tier[2]][MOLES] += scaled_production
 			if(moderator_list[/datum/gas/plasma] > 50)
 				moderator_internal.gases[tier[3]][MOLES] += scaled_production * 1.15
-		if(3, 4)
-			if(power_level == 3)
-				moderator_internal.gases[tier[2]][MOLES] += scaled_production * 0.5
-				moderator_internal.gases[tier[3]][MOLES] += scaled_production * 0.45
-			if(power_level == 4)
-				moderator_internal.gases[tier[3]][MOLES] += scaled_production * 1.65
-				moderator_internal.gases[tier[4]][MOLES] += scaled_production * 1.25
+		if(3)
+			moderator_internal.gases[tier[2]][MOLES] += scaled_production * 0.5
+			moderator_internal.gases[tier[3]][MOLES] += scaled_production * 0.45
+		if(4)
+			moderator_internal.gases[tier[3]][MOLES] += scaled_production * 1.65
+			moderator_internal.gases[tier[4]][MOLES] += scaled_production * 1.25
 		if(5)
 			moderator_internal.gases[tier[4]][MOLES] += scaled_production * 0.65
 			moderator_internal.gases[tier[5]][MOLES] += scaled_production

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -419,12 +419,12 @@
 		critical_threshold_proximity = max(critical_threshold_proximity + max(overfull_damage_taken * delta_time, 0), 0)
 
 	// If we're running on a thin fusion mix, heal up
-	if(internal_fusion.total_moles() < HYPERTORUS_SUBCRITICAL_MOLES || power_level <= 5)
+	if(internal_fusion.total_moles() < HYPERTORUS_SUBCRITICAL_MOLES && power_level <= 5)
 		var/subcritical_heal_restore = (internal_fusion.total_moles() - HYPERTORUS_SUBCRITICAL_MOLES) / HYPERTORUS_SUBCRITICAL_SCALE
 		critical_threshold_proximity = max(critical_threshold_proximity + min(subcritical_heal_restore * delta_time, 0), 0)
 
 	// If coolant is sufficiently cold, heal up
-	if(internal_fusion.total_moles() > 0 && (airs[1].total_moles() && coolant_temperature < HYPERTORUS_COLD_COOLANT_THRESHOLD) || power_level <= 4)
+	if(internal_fusion.total_moles() > 0 && (airs[1].total_moles() && coolant_temperature < HYPERTORUS_COLD_COOLANT_THRESHOLD) && power_level <= 4)
 		var/cold_coolant_heal_restore = log(10, max(coolant_temperature, 1) * HYPERTORUS_COLD_COOLANT_SCALE) - (HYPERTORUS_COLD_COOLANT_MAX_RESTORE * 2)
 		critical_threshold_proximity = max(critical_threshold_proximity + min(cold_coolant_heal_restore * delta_time, 0), 0)
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -194,8 +194,7 @@
 		internal_fusion.merge(fuel_port.remove_specific(gas_type, fuel_injection_rate * delta_time * 2 / length(selected_fuel.requirements)))
 		linked_input.update_parents()
 
-/obj/machinery/atmospherics/components/unary/hypertorus/core/process(delta_time)
-	fusion_process(delta_time)
+/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/check_deconstructable()
 	if(!active)
 		return
 	if(power_level > 0)
@@ -214,6 +213,10 @@
 		linked_interface.fusion_started = FALSE
 		for(var/obj/machinery/hypertorus/corner/corner in corners)
 			corner.fusion_started = FALSE
+
+/obj/machinery/atmospherics/components/unary/hypertorus/core/process(delta_time)
+	fusion_process(delta_time)
+	check_deconstructable()
 
 /**
  * Called by process()

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -434,7 +434,7 @@
 	// If we have a preposterous amount of mass in the fusion mix, things get bad extremely fast
 	if(internal_fusion.total_moles() >= HYPERTORUS_HYPERCRITICAL_MOLES)
 		var/hypercritical_damage_taken = max((internal_fusion.total_moles() - HYPERTORUS_HYPERCRITICAL_MOLES) * HYPERTORUS_HYPERCRITICAL_SCALE, 0)
-		critical_threshold_proximity += min(hypercritical_damage_taken, HYPERTORUS_HYPERCRITICAL_MIN_DAMAGE) * delta_time
+		critical_threshold_proximity = max(critical_threshold_proximity + min(hypercritical_damage_taken, HYPERTORUS_HYPERCRITICAL_MAX_DAMAGE), 0) * delta_time
 
 	// High power fusion might create other matter other than helium, iron is dangerous inside the machine, damage can be seen
 	if(power_level > 4 && prob(IRON_CHANCE_PER_FUSION_LEVEL * power_level))//at power level 6 is 100%
@@ -550,12 +550,10 @@
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/inject_from_side_components(delta_time)
 	update_pipenets()
 
-	// XXX: x2 because units are wrong
-
 	//Check and stores the gases from the moderator input in the moderator internal gasmix
 	var/datum/gas_mixture/moderator_port = linked_moderator.airs[1]
 	if(start_moderator && moderator_port.total_moles())
-		moderator_internal.merge(moderator_port.remove(moderator_injection_rate * delta_time * 2))
+		moderator_internal.merge(moderator_port.remove(moderator_injection_rate * delta_time))
 		linked_moderator.update_parents()
 
 	//Check if the fuels are present and move them inside the fuel internal gasmix
@@ -565,7 +563,7 @@
 	var/datum/gas_mixture/fuel_port = linked_input.airs[1]
 	for(var/gas_type in selected_fuel.requirements)
 		internal_fusion.assert_gas(gas_type)
-		internal_fusion.merge(fuel_port.remove_specific(gas_type, fuel_injection_rate * delta_time * 2 / length(selected_fuel.requirements)))
+		internal_fusion.merge(fuel_port.remove_specific(gas_type, fuel_injection_rate * delta_time / length(selected_fuel.requirements)))
 		linked_input.update_parents()
 
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/check_deconstructable()

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -503,11 +503,12 @@
 		if(removed)
 			linked_output.airs[1].merge(removed)
 
-	var/datum/gas_mixture/internal_remove
-	for(var/gas_id in selected_fuel.primary_products)
-		if(internal_fusion.gases[gas_id][MOLES] > 0)
-			internal_remove = internal_fusion.remove_specific(gas_id, internal_fusion.gases[gas_id][MOLES] * (1 - (1 - 0.25) ** delta_time))
-			linked_output.airs[1].merge(internal_remove)
+	if (selected_fuel)
+		var/datum/gas_mixture/internal_remove
+		for(var/gas_id in selected_fuel.primary_products)
+			if(internal_fusion.gases[gas_id][MOLES] > 0)
+				internal_remove = internal_fusion.remove_specific(gas_id, internal_fusion.gases[gas_id][MOLES] * (1 - (1 - 0.25) ** delta_time))
+				linked_output.airs[1].merge(internal_remove)
 	internal_fusion.garbage_collect()
 	moderator_internal.garbage_collect()
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -64,17 +64,16 @@
 	//Store the volume of the fusion reaction multiplied by the force of the magnets that controls how big it will be
 	var/volume = internal_fusion.volume * (magnetic_constrictor * 0.01)
 
-	//Store the fuel gases and the product gas moles
-
 	var/energy_concentration_multiplier = 1
 	var/positive_temperature_multiplier = 1
 	var/negative_temperature_multiplier = 1
-	var/list/fuel_list = list()
 
 	//We scale it down by volume/2 because for fusion conditions, moles roughly = 2*volume, but we want it to be based off something constant between reactions.
 	var/scale_factor = volume * 0.5
 
-	//Scaled down moles of gases, no less than 0
+	/// Store the fuel gases and the byproduct gas quantities
+	var/list/fuel_list = list()
+	/// Scaled down moles of gases, no less than 0
 	var/list/scaled_fuel_list = list()
 
 	if (selected_fuel)
@@ -82,26 +81,19 @@
 		positive_temperature_multiplier = selected_fuel.positive_temperature_multiplier
 		negative_temperature_multiplier = selected_fuel.negative_temperature_multiplier
 
-		for(var/gas_id in selected_fuel.requirements)
-			fuel_list[gas_id] = internal_fusion.gases[gas_id][MOLES]
+		for(var/gas_id in selected_fuel.requirements | selected_fuel.primary_products)
+			var/amount = internal_fusion.gases[gas_id][MOLES]
+			fuel_list[gas_id] = amount
+			scaled_fuel_list[gas_id] = max((amount - FUSION_MOLE_THRESHOLD) / scale_factor, 0)
 
-		for(var/gas_id in selected_fuel.primary_products)
-			fuel_list[gas_id] = internal_fusion.gases[gas_id][MOLES]
-
-		for(var/gas_id in selected_fuel.requirements)
-			scaled_fuel_list[gas_id] = max((fuel_list[gas_id] - FUSION_MOLE_THRESHOLD) / scale_factor, 0)
-
-		for(var/gas_id in selected_fuel.primary_products)
-			scaled_fuel_list[gas_id] = max((fuel_list[gas_id] - FUSION_MOLE_THRESHOLD) / scale_factor, 0)
-
-	//Store the moderators gases moles
+	/// Store the moderators gases quantities
 	var/list/moderator_list = list()
-	for(var/gas_id in moderator_internal.gases)
-		moderator_list[gas_id] = moderator_internal.gases[gas_id][MOLES]
-
+	/// Scaled down moles of gases, no less than 0
 	var/list/scaled_moderator_list = list()
 	for(var/gas_id in moderator_internal.gases)
-		scaled_moderator_list[gas_id] = max((moderator_list[gas_id] - FUSION_MOLE_THRESHOLD) / scale_factor, 0)
+		var/amount = moderator_internal.gases[gas_id][MOLES]
+		moderator_list[gas_id] = amount
+		scaled_moderator_list[gas_id] = max((amount - FUSION_MOLE_THRESHOLD) / scale_factor, 0)
 
 	/*
 	 *FUSION MAIN PROCESS

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -409,7 +409,7 @@
 			iron_content -= iron_removed
 			moderator_internal.gases[/datum/gas/oxygen][MOLES] -= iron_removed * OXYGEN_MOLES_CONSUMED_PER_IRON_HEAL
 
-	check_gravity_pulse()
+	check_gravity_pulse(delta_time)
 
 	emit_rads(radiation)
 
@@ -493,8 +493,8 @@
 	for(var/i in 1 to zap_number)
 		supermatter_zap(src, 5, power_level * 300, flags, zap_cutoff = cutoff, power_level = src.power_level * 1000, zap_icon = zaps_aspect)
 
-/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/check_gravity_pulse()
-	if(prob(100 - critical_threshold_proximity / 15))
+/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/check_gravity_pulse(delta_time)
+	if(DT_PROB(100 - critical_threshold_proximity / 15, delta_time))
 		return
 	var/grav_range = round(log(2.5, critical_threshold_proximity))
 	for(var/mob/alive_mob in GLOB.alive_mob_list)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -308,22 +308,22 @@
 	/*
 	 *Modifiers
 	 */
-	///Those are the scaled gases that gets consumed and releases energy or help increase that energy
-	var/positive_modifiers = scaled_fuel_list[scaled_fuel_list[1]] + \
+	///Those are the scaled gases that gets consumed and adjust energy
+	// Gases that increase the amount of energy
+	var/energy_modifiers = scaled_fuel_list[scaled_fuel_list[1]] + \
 								scaled_fuel_list[scaled_fuel_list[2]] + \
 								scaled_moderator_list[/datum/gas/nitrogen] * 0.35 + \
 								scaled_moderator_list[/datum/gas/carbon_dioxide] * 0.55 + \
 								scaled_moderator_list[/datum/gas/nitrous_oxide] * 0.95 + \
 								scaled_moderator_list[/datum/gas/zauker] * 1.55 + \
-								scaled_moderator_list[/datum/gas/antinoblium] * 10 - \
-								scaled_moderator_list[/datum/gas/hypernoblium] * 10 //Hypernob decreases the amount of energy
-	///Those are the scaled gases that gets produced and consumes energy or help decrease that energy
-	var/negative_modifiers = scaled_fuel_list[scaled_fuel_list[3]] + \
+								scaled_moderator_list[/datum/gas/antinoblium] * 20
+	// Gases that decrease the amount of energy
+	energy_modifiers -= scaled_fuel_list[scaled_fuel_list[3]] + \
+								scaled_moderator_list[/datum/gas/hypernoblium] * 10 + \
 								scaled_moderator_list[/datum/gas/water_vapor] * 0.75 + \
 								scaled_moderator_list[/datum/gas/nitryl] * 0.15 + \
 								scaled_moderator_list[/datum/gas/healium] * 0.45 + \
-								scaled_moderator_list[/datum/gas/freon] * 1.15 - \
-								scaled_moderator_list[/datum/gas/antinoblium] * 10
+								scaled_moderator_list[/datum/gas/freon] * 1.15
 	///Between 0.25 and 100, this value is used to modify the behaviour of the internal energy and the core temperature based on the gases present in the mix
 	var/power_modifier = clamp( scaled_fuel_list[scaled_fuel_list[2]] * 1.05 + \
 								scaled_moderator_list[/datum/gas/oxygen] * 0.55 + \
@@ -357,9 +357,9 @@
 	 *Main calculations (energy, internal power, core temperature, delta temperature,
 	 *conduction, radiation, efficiency, power output, heat limiter modifier and heat output)
 	 */
-	//Can go either positive or negative depending on the instability and the negative_modifiers
+	//Can go either positive or negative depending on the instability and the negative energy modifiers
 	//E=mc^2 with some changes for gameplay purposes
-	energy = ((positive_modifiers - negative_modifiers) * LIGHT_SPEED ** 2) * max(internal_fusion.temperature * heat_modifier / 100, 1)
+	energy = (energy_modifiers * LIGHT_SPEED ** 2) * max(internal_fusion.temperature * heat_modifier / 100, 1)
 	energy = energy / selected_fuel.energy_concentration_multiplier
 	energy = clamp(energy, 0, 1e35) //ugly way to prevent NaN error
 	//Power of the gas mixture

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -405,6 +405,9 @@
 	emit_rads(radiation)
 
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/evaporate_moderator(delta_time)
+	// Don't evaporate if the reaction is dead
+	if (!power_level)
+		return
 	// All gases in the moderator slowly burn away over time, whether used for production or not
 	if(moderator_internal.total_moles() > 0)
 		moderator_internal.remove(moderator_internal.total_moles() * (1 - (1 - 0.0005 * power_level) ** delta_time))

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -28,7 +28,8 @@
 		check_spill()
 		process_damageheal(delta_time)
 		check_alert()
-	remove_waste(delta_time)
+	if (start_power)
+		remove_waste(delta_time)
 	update_pipenets()
 
 	check_deconstructable()

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -233,7 +233,7 @@
 	// Run the common effects, committing changes where applicable
 
 	// This is repetition, but is here as a placeholder for what will need to be done to allow concurrently running multiple recipes
-	var/common_production_amount = production_amount * selected_fuel.fuel_consumption_multiplier * selected_fuel.gas_production_multiplier
+	var/common_production_amount = production_amount * selected_fuel.gas_production_multiplier
 	moderator_common_process(delta_time, common_production_amount, internal_output, moderator_list, dirty_production_rate, heat_output, radiation_modifier)
 
 /**
@@ -242,8 +242,7 @@
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/moderator_fuel_process(delta_time, production_amount, consumption_amount, datum/gas_mixture/internal_output, moderator_list, datum/hfr_fuel/fuel, fuel_list)
 	// Adjust fusion consumption/production based on this recipe's characteristics
 	var/fuel_consumption = consumption_amount * 0.85 * selected_fuel.fuel_consumption_multiplier
-	// Note production depends on *both* the fuel consumption and gas production multipliers. XXX: Was this intentional?
-	var/scaled_production = production_amount * selected_fuel.fuel_consumption_multiplier * selected_fuel.gas_production_multiplier
+	var/scaled_production = production_amount * selected_fuel.gas_production_multiplier
 
 	for(var/gas_id in fuel.requirements)
 		internal_fusion.gases[gas_id][MOLES] -= min(fuel_list[gas_id], fuel_consumption)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -510,10 +510,11 @@
  */
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/induce_hallucination(strength, delta_time, force=FALSE)
 	for(var/mob/living/carbon/human/human in view(src, HALLUCINATION_HFR(heat_output)))
-		if(force || !istype(human.glasses, /obj/item/clothing/glasses/meson))
-			var/distance_root = sqrt(1 / max(1, get_dist(human, src)))
-			human.hallucination += strength * distance_root * delta_time
-			human.hallucination = clamp(human.hallucination, 0, 200)
+		if(!force && istype(human.glasses, /obj/item/clothing/glasses/meson))
+			continue
+		var/distance_root = sqrt(1 / max(1, get_dist(human, src)))
+		human.hallucination += strength * distance_root * delta_time
+		human.hallucination = clamp(human.hallucination, 0, 200)
 
 /**
  * Emit radiation

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -449,8 +449,8 @@
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/check_cracked_parts()
 	for(var/obj/machinery/atmospherics/components/unary/hypertorus/part in machine_parts)
 		if(part.cracked)
-			return TRUE
-	return FALSE
+			return part
+	return null
 
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/create_crack()
 	var/obj/machinery/atmospherics/components/unary/hypertorus/part = pick(machine_parts)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -162,6 +162,19 @@
 		corners = list()
 	QDEL_NULL(soundloop)
 
+/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/assert_gases()
+	//Assert the gases that will be used/created during the process
+	for(var/gas_id in selected_fuel.requirements) //These are the fuels
+		internal_fusion.assert_gas(gas_id)
+
+	for(var/gas_id in selected_fuel.primary_products) //These are the gases that can be produced inside the internal_fusion mix
+		internal_fusion.assert_gas(gas_id)
+
+	internal_fusion.assert_gas(/datum/gas/antinoblium)
+
+	for(var/gas_id in GLOB.meta_gas_info)
+		moderator_internal.assert_gas(gas_id)
+
 /**
  * Updates all related pipenets from all connected components
  */

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -164,16 +164,20 @@
 
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/assert_gases()
 	//Assert the gases that will be used/created during the process
-	for(var/gas_id in selected_fuel.requirements) //These are the fuels
-		internal_fusion.assert_gas(gas_id)
-
-	for(var/gas_id in selected_fuel.primary_products) //These are the gases that can be produced inside the internal_fusion mix
-		internal_fusion.assert_gas(gas_id)
 
 	internal_fusion.assert_gas(/datum/gas/antinoblium)
 
 	for(var/gas_id in GLOB.meta_gas_info)
 		moderator_internal.assert_gas(gas_id)
+
+	if (!selected_fuel)
+		return
+
+	for(var/gas_id in selected_fuel.requirements) //These are the fuels
+		internal_fusion.assert_gas(gas_id)
+
+	for(var/gas_id in selected_fuel.primary_products) //These are the gases that can be produced inside the internal_fusion mix
+		internal_fusion.assert_gas(gas_id)
 
 /**
  * Updates all related pipenets from all connected components

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -520,7 +520,7 @@
  * Emit radiation
  */
 /obj/machinery/atmospherics/components/unary/hypertorus/core/proc/emit_rads(radiation)
-	rad_power = clamp((radiation / 1e5), 0, FUSION_RAD_MAX)
+	rad_power = clamp(radiation / 1e5, 0, FUSION_RAD_MAX)
 	radiation_pulse(loc, rad_power)
 
 /*

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -171,6 +171,29 @@
 	linked_output.update_parents()
 	linked_moderator.update_parents()
 
+/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/update_temperature_status()
+	fusion_temperature = internal_fusion.temperature
+	moderator_temperature = moderator_internal.temperature
+	coolant_temperature = airs[1].temperature
+	output_temperature = linked_output.airs[1].temperature
+
+	//Set the power level of the fusion process
+	switch(fusion_temperature)
+		if(-INFINITY to 500)
+			power_level = 0
+		if(500 to 1e3)
+			power_level = 1
+		if(1e3 to 1e4)
+			power_level = 2
+		if(1e4 to 1e5)
+			power_level = 3
+		if(1e5 to 1e6)
+			power_level = 4
+		if(1e6 to 1e7)
+			power_level = 5
+		else
+			power_level = 6
+
 /**
  * Infrequently plays accent sounds, and adjusts main loop parameters
  */

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -219,14 +219,11 @@
 		return FALSE
 	if(!internal_fusion.total_moles())
 		return FALSE
-	var/gas_check = 0
 	for(var/gas_type in selected_fuel.requirements)
 		internal_fusion.assert_gas(gas_type)
-		if(internal_fusion.gases[gas_type][MOLES] >= FUSION_MOLE_THRESHOLD)
-			gas_check++
-	if(gas_check == length(selected_fuel.requirements))
-		return TRUE
-	return FALSE
+		if(internal_fusion.gases[gas_type][MOLES] < FUSION_MOLE_THRESHOLD)
+			return FALSE
+	return TRUE
 
 /**
  * Called by the main fusion processes in hfr_main_processes.dm

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -167,17 +167,12 @@
 
 	internal_fusion.assert_gas(/datum/gas/antinoblium)
 
-	for(var/gas_id in GLOB.meta_gas_info)
-		moderator_internal.assert_gas(gas_id)
+	moderator_internal.assert_gases(arglist(GLOB.meta_gas_info))
 
 	if (!selected_fuel)
 		return
 
-	for(var/gas_id in selected_fuel.requirements) //These are the fuels
-		internal_fusion.assert_gas(gas_id)
-
-	for(var/gas_id in selected_fuel.primary_products) //These are the gases that can be produced inside the internal_fusion mix
-		internal_fusion.assert_gas(gas_id)
+	internal_fusion.assert_gases(arglist(selected_fuel.requirements | selected_fuel.primary_products))
 
 /**
  * Updates all related pipenets from all connected components


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Massive overhaul of the HFR backend

Ping @Ghilker @LemonInTheDark 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Issues caused by SSair/SSmachines tickrate drift are now reduced to happen over one clear boundary
- The code should now be much more usable.
- Fewer broken edge cases
- Old changes should now work as I believe they were meant to work

Longer explanations are provided on major commits, click the ellipses if you feel like reading war and peace. Functional changes are kept in distinct commits from nonfunctional changes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
refactor: Completely restructure HFR main processes, fixing many unusual edge cases when the HFR was unpowered, out of fuel, interacted with other subsystems poorly, etc.
refactor: HFR equations with cryptic parameters have all been rewritten to use mathematically equivalent normalized equations derived from human-parseable parameters.
code: The HFR now has fewer superfluous and misleading checks.
code: HFR configuration is now much more heavily documented and generally readable.
code: Many HFR defines and comments which are unused, misleading, and/or completely inapplicable to any public release of HFR code have been removed.
fix: The HFR now only interacts with the SSair subsystem via the side IO components.
fix: The HFR will no longer fail to cool if atmospherics is running slowly.
fix: The HFR's ambient sound loop will no longer fail to update to match the current fusion level under certain conditions.
fix: The HFR will no longer fail to update its UI under certain conditions.
fix: The HFR will no longer melt down at speeds largely determined by the wider atmospherics system.
fix: The HFR can no longer get stuck in states which heal without taking damage or vice versa.
fix: The HFR's healing/damage effects that depend on fusion power level now genuinely depend on fusion power level, rather than doing nothing but at any power level.
fix: The HFR no longer uses two distinct functions to fire nuclear particles, which effectively doubled the rate under some conditions.
fix: The HFR now treats Iron Content as having appropriate units - fractional rather than percentage points. Accumulating Iron Content will now makes it slightly harder to destabilize the reaction (turn it endothermic), beware.
fix: The HFR now respects delta_time in more places, again, again.
fix: The HFR now respects delta_time in another place, again, again, again.
code: Some HFR calculations have been greatly simplified (no mechanical change).
fix: The HFR will no longer accumulate iron if there is no live reaction.
fix: The HFR will no longer passively evaporate moderator gases if there is no live reaction.
fix: The HFR, after cracking under pressure, will no longer merely leave a pretty decal on the affected part while becoming immune to all future cracking conditions, as long as nobody repaired the crack. The initial spill if highly pressurized is still the most dangerous, but the HFR will continue to slowly leak its contents even under low pressure while cracked.
content: The HFR initially took damage at unsafe fusion levels with excess mass over 2500-1500 moles, depending on temperature. This was later changed to 2700-2589 moles, but in a way that looked like it was only meant make the thresholds a few hundred moles more tolerant. The range is now 2700-1800 moles.
fix: HFR production rate is no longer multiplied by both the fuel consumption modifier and the gas production modifier. This means the top tier Hypernoblium/Anti-noblium recipe is now worth using, providing a production bonus of 3x rather than a penalty of x0.03. This recipe is still just as hard to operate safely.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
