### PR TITLE
Fixes the mind's name for evolved aliens.

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -128,6 +128,7 @@ Des: Removes all infected images from the alien.
 		new_xeno.real_name = real_name
 	if(mind)
 		mind.transfer_to(new_xeno)
+		mind.name = new_xeno.name
 	qdel(src)
 
 /mob/living/carbon/alien/can_hold_items(obj/item/I)

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -128,7 +128,7 @@ Des: Removes all infected images from the alien.
 		new_xeno.real_name = real_name
 	if(mind)
 		mind.transfer_to(new_xeno)
-		mind.name = new_xeno.name
+		mind.name = new_xeno.real_name
 	qdel(src)
 
 /mob/living/carbon/alien/can_hold_items(obj/item/I)


### PR DESCRIPTION
## About The Pull Request
Fixes an issue with `alien_evolve` not updating mind.name.

## Why It's Good For The Game
Fixes deadchat broadcast displaying the old mind name:
![irking issue](https://user-images.githubusercontent.com/42542238/134020041-e8f0baff-ee2f-4800-99b8-c81548d2ee51.png)

## Changelog

:cl:
fix: Fixes evolved xenos deaths being broadcasted in dchat with the old larva name .
/:cl:

