### PR TITLE
Second spawn warden/detective gets other uniform and also some additional items

### DIFF
--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -75,3 +75,18 @@
 
 	if(visualsOnly)
 		return
+		
+/datum/outfit/job/detective/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return ..()
+
+	var/static/use_noir_suit = FALSE //If there is one detective, they get the default hard-worn suit. If another detective joins the round, they start with a noir suit. Stolen from lawyer code.
+	if(use_noir_suit)
+		uniform = /obj/item/clothing/under/rank/security/detective/grey
+		suit = /obj/item/clothing/suit/det_suit/grey
+		shoes = /obj/item/clothing/shoes/laceup
+		head = /obj/item/clothing/head/fedora
+		suit_store = /obj/item/storage/belt/holster/detective/full
+	else
+		use_noir_suit = TRUE
+	..()

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -86,7 +86,7 @@
 		suit = /obj/item/clothing/suit/det_suit/grey
 		shoes = /obj/item/clothing/shoes/laceup
 		head = /obj/item/clothing/head/fedora
-		suit_store = /obj/item/storage/belt/holster/detective/full
+		suit_store = /obj/item/gun/energy/disabler
 	else
 		use_noir_suit = TRUE
 	..()

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -79,7 +79,8 @@
 		gloves = /obj/item/clothing/gloves/krav_maga/sec
 		belt = /obj/item/storage/belt/security/full
 		backpack_contents = list(/obj/item/melee/baton/security/loaded=1,\
-			/obj/item/pda/warden)
+			/obj/item/restraints/handcuffs)
+		l_pocket = /obj/item/pda/warden
 	else
 		use_blue_suit = TRUE
 	..()

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -71,12 +71,15 @@
 	if(visualsOnly)
 		return ..()
 
-	var/static/use_blue_suit = FALSE //If there is one warden, they get the default red armored suit. If another warden joins the round, they start with a blue suit.
+	var/static/use_blue_suit = FALSE //If there is one warden, they get the default red armored suit. If another warden joins the round, they start with a blue suit. And their unique items.
 	if(use_blue_suit)
 		uniform = /obj/item/clothing/under/rank/security/warden/formal 
 		suit = /obj/item/clothing/suit/armor/vest/warden
 		head = /obj/item/clothing/head/beret/sec/navywarden 
 		gloves = /obj/item/clothing/gloves/krav_maga/sec
+		belt = /obj/item/storage/belt/security/full
+		backpack_contents = list(/obj/item/melee/baton/security/loaded=1,\
+			/obj/item/pda/warden)
 	else
 		use_blue_suit = TRUE
 	..()

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -76,7 +76,7 @@
 		uniform = /obj/item/clothing/under/rank/security/warden/formal 
 		suit = /obj/item/clothing/suit/armor/vest/warden
 		head = /obj/item/clothing/head/beret/sec/navywarden 
-		gloves = /obj/item/clothing/gloves/krav_maga/sec
+		gloves = /obj/item/clothing/gloves/tackler
 		belt = /obj/item/storage/belt/security/full
 		backpack_contents = list(/obj/item/melee/baton/security/loaded=1,\
 			/obj/item/restraints/handcuffs)

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -66,3 +66,17 @@
 	implants = list(/obj/item/implant/mindshield)
 
 	id_trim = /datum/id_trim/job/warden
+
+/datum/outfit/job/warden/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return ..()
+
+	var/static/use_blue_suit = FALSE //If there is one warden, they get the default red armored suit. If another warden joins the round, they start with a blue suit.
+	if(use_blue_suit)
+		uniform = /obj/item/clothing/under/rank/security/warden/formal 
+		suit = /obj/item/clothing/suit/armor/vest/warden
+		head = /obj/item/clothing/head/beret/sec/navywarden 
+		gloves = /obj/item/clothing/gloves/krav_maga/sec
+	else
+		use_blue_suit = TRUE
+	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If there can be more then 1 detective or warden (Like if it in map configs or some global config change) second warden/detective will get some items and diffirent set of clothings, because of copy-pasted part of the lawyer job-type code.

- Second detective gets a noir suit with trenchcoat and grey fedora. **Also he gets disabler on spawn, this is to make sure detective have any kind of sidearm to protect himself.**
- Second warden gets a formal jumpsuit, warden's jacket and beret. **Also he gets full secbelt and gripper gloves as krav maga replacment.**

## Why It's Good For The Game

This will be good for: maps with several detectives/wardens, servers with changed job capacity configs. Also giving second warden/detective other uniform makes first and second one more distinct from each other, and decrease possible confusion. And also solution to the detective sidearm problem, now second detective will have a disabler which is not a revolver but at least something.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: DrDiasyl (DrTuxedo)
balance: Second detective now spawns in a noir suit and with a disabler.
balance: Second warden now spawns in a warden jacket and beret, and with a full secbelt and gripper gloves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
