### PR TITLE
Fixed hitting people accidentally with food if their mouth is covered.

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -261,6 +261,8 @@ Behavior that's still missing from this component that original food items had t
 	if(feeder.combat_mode)
 		return
 
+	. = COMPONENT_CANCEL_ATTACK_CHAIN
+
 	if(IsFoodGone(owner, feeder))
 		return
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -261,7 +261,7 @@ Behavior that's still missing from this component that original food items had t
 	if(feeder.combat_mode)
 		return
 
-	. = COMPONENT_CANCEL_ATTACK_CHAIN
+	. = COMPONENT_CANCEL_ATTACK_CHAIN //Point of no return I suppose
 
 	if(IsFoodGone(owner, feeder))
 		return
@@ -269,8 +269,6 @@ Behavior that's still missing from this component that original food items had t
 	if(!CanConsume(eater, feeder))
 		return
 	var/fullness = eater.get_fullness() + 10 //The theoretical fullness of the person eating if they were to eat this
-
-	. = COMPONENT_CANCEL_ATTACK_CHAIN //Point of no return I suppose
 
 	if(eater == feeder)//If you're eating it yourself.
 		if(eat_time && !do_mob(feeder, eater, eat_time, timed_action_flags = food_flags & FOOD_FINGER_FOOD ? IGNORE_USER_LOC_CHANGE | IGNORE_TARGET_LOC_CHANGE : NONE)) //Gotta pass the minimal eat time


### PR DESCRIPTION
## About The Pull Request
Title. That's a months old issue caused by the food refactor done by qustinnus/codemonkey.

## Why It's Good For The Game
Fixes a bothersome issue with food.

## Changelog
:cl:
fix: Fixed hitting people accidentally with food if their mouth is covered or if they can't  otherwise consume food.
/:cl:
