### PR TITLE
Adds the "speaker name" port to the voice activator circuit component

### DIFF
--- a/code/modules/wiremod/components/atom/hear.dm
+++ b/code/modules/wiremod/components/atom/hear.dm
@@ -13,6 +13,8 @@
 	var/datum/port/output/language_port
 	/// The speaker
 	var/datum/port/output/speaker_port
+	/// The speaker name port. Not necessarily the person who is speaking.
+	var/datum/port/output/speaker_name
 	/// The trigger sent when this event occurs
 	var/datum/port/output/trigger_port
 
@@ -20,6 +22,7 @@
 	message_port = add_output_port("Message", PORT_TYPE_STRING)
 	language_port = add_output_port("Language", PORT_TYPE_STRING)
 	speaker_port = add_output_port("Speaker", PORT_TYPE_ATOM)
+	speaker_name = add_output_port("Speaker Name", PORT_TYPE_STRING)
 	trigger_port = add_output_port("Triggered", PORT_TYPE_SIGNAL)
 	become_hearing_sensitive(ROUNDSTART_TRAIT)
 
@@ -31,4 +34,5 @@
 	if(message_language)
 		language_port.set_output(initial(message_language.name))
 	speaker_port.set_output(speaker)
+	speaker_name.set_output(speaker.GetVoice())
 	trigger_port.set_output(COMPONENT_SIGNAL)

--- a/code/modules/wiremod/components/atom/hear.dm
+++ b/code/modules/wiremod/components/atom/hear.dm
@@ -11,10 +11,10 @@
 	var/datum/port/output/message_port
 	/// The language heard
 	var/datum/port/output/language_port
-	/// The speaker
-	var/datum/port/output/speaker_port
-	/// The speaker name port. Not necessarily the person who is speaking.
+	/// The speaker name port, usually the name of the person who spoke.
 	var/datum/port/output/speaker_name
+	/// The speaker entity that is currently speaking. Not necessarily the person who is speaking.
+	var/datum/port/output/speaker_port
 	/// The trigger sent when this event occurs
 	var/datum/port/output/trigger_port
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Adds the "speaker name" port to the voice activator circuit component, which gets the voice of the current speaker.
Fixes #60426


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes an oversight with the voice activator circuit component not working properly with radios as you weren't able to get the voice of the person speaking.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
expansion: Adds the "speaker name" port to the voice activator circuit component
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
