### PR TITLE
Separates checking failing organs and checking damage thresholds on organs

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -218,9 +218,9 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
  * output: failing organ flags on a failing/no longer failing organ.
  */
 /obj/item/organ/proc/check_failing_thresholds(mob/organ_owner)
-	if(!(organ_flags & ORGAN_FAILING) && damage >= maxHealth)
+	if(damage >= maxHealth)
 		organ_flags |= ORGAN_FAILING
-	if((organ_flags & ORGAN_FAILING) && (damage < maxHealth))
+	if(damage < maxHealth)
 		organ_flags &= ~ORGAN_FAILING
 
 //Looking for brains?

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -121,6 +121,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	applyOrganDamage(decay_factor * maxHealth * delta_time)
 
 /obj/item/organ/proc/on_life(delta_time, times_fired) //repair organ damage if the organ is not failing
+	check_failing_thresholds(owner) // Check if an organ should/shouldnt be failing
 	if(organ_flags & ORGAN_FAILING)
 		handle_failing_organs(delta_time)
 		return
@@ -172,7 +173,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	return //so we don't grant the organ's action to mobs who pick up the organ.
 
 ///Adjusts an organ's damage by the amount "damage_amount", up to a maximum amount, which is by default max damage
-/obj/item/organ/proc/applyOrganDamage(damage_amount, maximum = maxHealth) //use for damaging effects
+/obj/item/organ/proc/applyOrganDamage(damage_amount, maximum = maxHealth, ddeaf) //use for damaging effects
 	if(!damage_amount) //Micro-optimization.
 		return
 	if(maximum < damage)
@@ -199,20 +200,28 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	var/delta = damage - prev_damage
 	if(delta > 0)
 		if(damage >= maxHealth)
-			organ_flags |= ORGAN_FAILING
 			return now_failing
 		if(damage > high_threshold && prev_damage <= high_threshold)
 			return high_threshold_passed
 		if(damage > low_threshold && prev_damage <= low_threshold)
 			return low_threshold_passed
 	else
-		organ_flags &= ~ORGAN_FAILING
 		if(prev_damage > low_threshold && damage <= low_threshold)
 			return low_threshold_cleared
 		if(prev_damage > high_threshold && damage <= high_threshold)
 			return high_threshold_cleared
 		if(prev_damage == maxHealth)
 			return now_fixed
+
+/**check_failing_thresholds
+ * input: mob/organ_owner (a mob, the owner of the organ we call the proc on)
+ * output: failing organ flags on a failing/no longer failing organ.
+ */
+/obj/item/organ/proc/check_failing_thresholds(mob/organ_owner)
+	if(!(organ_flags & ORGAN_FAILING) && damage >= maxHealth)
+		organ_flags |= ORGAN_FAILING
+	if((organ_flags & ORGAN_FAILING) && (damage < maxHealth))
+		organ_flags &= ~ORGAN_FAILING
 
 //Looking for brains?
 //Try code/modules/mob/living/carbon/brain/brain_item.dm

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -173,7 +173,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	return //so we don't grant the organ's action to mobs who pick up the organ.
 
 ///Adjusts an organ's damage by the amount "damage_amount", up to a maximum amount, which is by default max damage
-/obj/item/organ/proc/applyOrganDamage(damage_amount, maximum = maxHealth, ddeaf) //use for damaging effects
+/obj/item/organ/proc/applyOrganDamage(damage_amount, maximum = maxHealth) //use for damaging effects
 	if(!damage_amount) //Micro-optimization.
 		return
 	if(maximum < damage)


### PR DESCRIPTION
## About The Pull Request

So I fucked up in #61541 - I didn't test/know Inacusiate/Oculine to know thats what the code was for.
Snowflake code in their on_life specifically there in case inacusiate/oculine was drank.

I thought about trying to make it something all organs did, rather than reverting my change, though I can just revert it if thats preferable.

## Why It's Good For The Game

Eyes/Ears can now be repaired with Inacusiate and Oculine again.

## Changelog

:cl:
fix: Organ repairing chemicals now repair your organs again (but for real this time).
/:cl:


I caused this bug so I would appreciate a GBP no update tag.