### PR TITLE
You can now use backslashes as an escape character for text modification.

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -588,7 +588,7 @@
 			C.energy_fail(rand(duration_min,duration_max))
 
 /**
- * Sends a round tip to a target. If selected_tip is null, a random tip will be sent instaed (5% chance of it being silly).
+ * Sends a round tip to a target. If selected_tip is null, a random tip will be sent instead (5% chance of it being silly).
  * Tips that starts with the @ character won't be html encoded. That's necessary for any tip containing markup tags,
  * just make sure they don't also have html characters like <, > and ' which will be garbled.
  */

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -586,3 +586,28 @@
 				continue
 
 			C.energy_fail(rand(duration_min,duration_max))
+
+/**
+ * Sends a round tip to a target. If selected_tip is null, a random tip will be sent instaed (5% chance of it being silly).
+ * Tips that starts with the @ character won't be html encoded. That's necessary for any tip containing markup tags,
+ * just make sure they don't also have html characters like <, > and ' which will be garbled.
+ */
+/proc/send_tip_of_the_round(target, selected_tip)
+	var/message
+	if(selected_tip)
+		message = selected_tip
+	else
+		var/list/randomtips = world.file2list("strings/tips.txt")
+		var/list/memetips = world.file2list("strings/sillytips.txt")
+		if(randomtips.len && prob(95))
+			message = pick(randomtips)
+		else if(memetips.len)
+			message = pick(memetips)
+
+	if(!message)
+		return
+	if(message[1] != "@")
+		message = html_encode(message)
+	else
+		message = copytext(message, 2)
+	to_chat(target, span_purple("<span class='oocplain'><b>Tip of the round: </b>[message]</span>"))

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -171,7 +171,7 @@ SUBSYSTEM_DEF(ticker)
 			timeLeft -= wait
 
 			if(timeLeft <= 300 && !tipped)
-				send_tip_of_the_round()
+				send_tip_of_the_round(world, selected_tip)
 				tipped = TRUE
 
 			if(timeLeft <= 0)
@@ -458,21 +458,6 @@ SUBSYSTEM_DEF(ticker)
 	for(var/I in livings)
 		var/mob/living/L = I
 		L.notransform = FALSE
-
-/datum/controller/subsystem/ticker/proc/send_tip_of_the_round()
-	var/m
-	if(selected_tip)
-		m = selected_tip
-	else
-		var/list/randomtips = world.file2list("strings/tips.txt")
-		var/list/memetips = world.file2list("strings/sillytips.txt")
-		if(randomtips.len && prob(95))
-			m = pick(randomtips)
-		else if(memetips.len)
-			m = pick(memetips)
-
-	if(m)
-		to_chat(world, span_purple("<span class='oocplain'><b>Tip of the round: </b>[html_encode(m)]</span>"))
 
 /datum/controller/subsystem/ticker/proc/check_queue()
 	if(!queued_players.len)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -99,9 +99,9 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	var/spanned = attach_spans(input, spans)
 	return "[say_mod(input, message_mods)], \"[spanned]\""
 
-/// Transforms the speech emphasis mods from [/atom/movable/proc/say_emphasis] into the appropriate HTML tags
+/// Transforms the speech emphasis mods from [/atom/movable/proc/say_emphasis] into the appropriate HTML tags. Includes escaping.
 #define ENCODE_HTML_EMPHASIS(input, char, html, varname) \
-	var/static/regex/##varname = regex("[char](.+?)[char]", "g");\
+	var/static/regex/##varname = regex("(?<!\\\\)[char](.+?)(?<!\\\\)[char]", "g");\
 	input = varname.Replace_char(input, "<[html]>$1</[html]>")
 
 /// Scans the input sentence for speech emphasis modifiers, notably |italics|, +bold+, and _underline_ -mothblocks
@@ -109,6 +109,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	ENCODE_HTML_EMPHASIS(input, "\\|", "i", italics)
 	ENCODE_HTML_EMPHASIS(input, "\\+", "b", bold)
 	ENCODE_HTML_EMPHASIS(input, "_", "u", underline)
+	var/static/regex/remove_escape_backlashes = regex("\\\\(_|\\+|\\|)", "g") // Removes backslashes used to escape text modification.
+	input = remove_escape_backlashes.Replace_char(input, "$1")
 	return input
 
 #undef ENCODE_HTML_EMPHASIS

--- a/code/modules/admin/verbs/admin.dm
+++ b/code/modules/admin/verbs/admin.dm
@@ -16,11 +16,11 @@
 	if(!SSticker)
 		return
 
-	SSticker.selected_tip = input
-
 	// If we've already tipped, then send it straight away.
 	if(SSticker.tipped)
-		SSticker.send_tip_of_the_round()
+		send_tip_of_the_round(world, input)
+	else
+		SSticker.selected_tip = input
 
 	message_admins("[key_name_admin(usr)] sent a tip of the round.")
 	log_admin("[key_name(usr)] sent \"[input]\" as the Tip of the Round.")

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -890,7 +890,7 @@
 	. = ..()
 
 /datum/reagent/medicine/mannitol/overdose_start(mob/living/owner)
-	to_chat(owner, span_notice("You suddenly feel </span><span class='purple'>E N L I G H T E N E D!"))
+	to_chat(owner, span_notice("You suddenly feel <span class='purple'>E N L I G H T E N E D!</span>"))
 
 /datum/reagent/medicine/mannitol/overdose_process(mob/living/owner, delta_time, times_fired)
 	if(DT_PROB(65, delta_time))
@@ -903,8 +903,8 @@
 	else
 		tips = world.file2list("strings/chemistrytips.txt")
 	var/message = pick(tips)
-	to_chat(owner, span_purple("<b>Tip of the round: </b>[html_encode(message)]"))
-	..()
+	send_tip_of_the_round(owner, message)
+	return ..()
 
 /datum/reagent/medicine/neurine
 	name = "Neurine"

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -253,3 +253,5 @@ Standard epipens contain a potent coagulant that not only slow bloodloss, but al
 Anything you can light a cigarette with, you can use to cauterize a bleeding wound. Technically, that includes the supermatter.
 If you're bleeding, you can apply pressure to the limb by grabbing yourself while targeting the bleeding limb. This will slow you down and take up a hand, but it'll slow down how fast you lose blood. Note this won't help the bleeding clot any faster.
 Laying down will help slow down bloodloss. Death will halt it entirely.
+♪ Hey, have you ever tried appending the % character before your messages when speaking in-game? ♫
+@You can use the |, + and _ characters to emphasize parts of what you say in-game (e.g. say"my _ass_ |is| +heavy+." will be outputted as "my <u>ass</u> <i>is</i> <b>heavy</b>."). You can also escape these emphasizers by appending backslashes before them (e.g. say"1\+2\+3" will come out as "1+2+3" and not "1\<b>2\</b>3").


### PR DESCRIPTION
## About The Pull Request
When the feature was first coded back on citadelstation years ago I told kevinz to make the text emphasis macros and have them require the characters being inputted twice (`++text++` vs `+text+` to avoid stuff like a+b+c being outputted as a**b**c).
It turned out to be a terrible solution that made the feature more tedious to use, so it got reverted back to its original, unescapeable implementation last december. Afterward, it's ported to TGMC and then here a few days ago.

So here I am, making the underline, bold and italics text modification escapeable in a similar fashion of a markdown language, with backslashes.

## Why It's Good For The Game
Underscore, plus symbols and vertical bars are not often used in sentences (specially ICly), but there are still situations where you should be able to use these symbols more than once in a sentence without getting screwed over by these modifiers.

## Changelog
:cl:
qol: You can now use backslashes to escape say text modifiers (e.g. a\\+b\\+c = d will be outputted as a+b+c instead of abc with the middle letter b bolded).
qol: Two new tips of the round, both concerning say"" syntax.
/:cl:
