### PR TITLE
Adds a new type of Experiment Scans: Machinery Scanning

### DIFF
--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -154,29 +154,34 @@
 
 /datum/experiment/scanning/points/machinery_tiered_scan/tier2_lathes
 	name = "Advanced Stock Parts Benchmark"
-	description = "Our newly-designed advanced machinery components require practical application tests for hints at possible further advancements, as well as a general confirmation the we didn't actually design worse parts somehow."
+	description = "Our newly-designed advanced machinery components require practical application tests for hints at possible further advancements, as well as a general confirmation that we didn't actually design worse parts somehow."
 	required_points = 6
-	required_atoms = list(/obj/machinery/rnd/production/protolathe/department/science = 1,
+	required_atoms = list(
+		/obj/machinery/rnd/production/protolathe/department/science = 1,
 		/obj/machinery/rnd/production/protolathe/department/engineering = 1,
 		/obj/machinery/rnd/production/techfab/department/cargo = 1,
 		/obj/machinery/rnd/production/techfab/department/medical = 1,
 		/obj/machinery/rnd/production/techfab/department/security = 1,
-		/obj/machinery/rnd/production/techfab/department/service = 1)
+		/obj/machinery/rnd/production/techfab/department/service = 1
+	)
 	required_tier = 2
 
 /datum/experiment/scanning/points/machinery_tiered_scan/tier3_bluespacemachines
 	name = "Bluespace Machinery Attunement"
 	description = "Teleportation technology using bluespace capabilities is a high selling point for our company, but the threat of a critical malfunction in calibration procedures wasn't something we predicted to emerge. Since our RnD department has started a flyperson race riot, maybe your advancements in stock parts could help mitigate the buzzing problem."
 	required_points = 4
-	required_atoms = list(/obj/machinery/teleport/hub = 1,
-		/obj/machinery/teleport/station = 1)
+	required_atoms = list(
+		/obj/machinery/teleport/hub = 1,
+		/obj/machinery/teleport/station = 1
+	)
 	required_tier = 3
 
 /datum/experiment/scanning/points/machinery_tiered_scan/tier3_variety
 	name = "High Efficiency Parts Applications Test"
 	description = "We require further testing of the stock part designs to push their efficiency and market price even further."
 	required_points = 15
-	required_atoms = list(/obj/machinery/autolathe = 1,
+	required_atoms = list(
+		/obj/machinery/autolathe = 1,
 		/obj/machinery/rnd/production/circuit_imprinter/department/science = 1,
 		/obj/machinery/monkey_recycler = 1,
 		/obj/machinery/processor/slime = 1,
@@ -188,76 +193,89 @@
 		/obj/machinery/chem_master = 3,
 		/obj/machinery/atmospherics/components/unary/cryo_cell = 3,
 		/obj/machinery/harvester = 5,
-		/obj/machinery/quantumpad = 5)
+		/obj/machinery/quantumpad = 5
+	)
 	required_tier = 3
 
 /datum/experiment/scanning/points/machinery_tiered_scan/tier3_mechbay
 	name = "Military-grade Mech Bay Setup"
 	description = "Constructing combat-oriented exosuits is a pricy endeavour. Make sure you have an efficient setup for production, and we'll send over some of our design documents."
 	required_points = 6
-	required_atoms = list(/obj/machinery/mecha_part_fabricator = 1,
+	required_atoms = list(
+		/obj/machinery/mecha_part_fabricator = 1,
 		/obj/machinery/mech_bay_recharge_port = 1,
-		/obj/machinery/recharge_station = 1)
+		/obj/machinery/recharge_station = 1
+	)
 	required_tier = 3
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_microlaser
 	name = "High-power Micro-lasers Calibration"
 	description = "Our Nanotrasen High-Power Office-Ready Laser Pointer ™ isn't powerful enough to strike airborne Syndidrones out of the sky yet. Find us some diode applications for hints on how to improve them!"
 	required_points = 10
-	required_atoms = list(/obj/machinery/mecha_part_fabricator = 1,
+	required_atoms = list(
+		/obj/machinery/mecha_part_fabricator = 1,
 		/obj/machinery/rnd/experimentor = 1,
 		/obj/machinery/dna_scannernew = 1,
 		/obj/machinery/microwave = 2,
 		/obj/machinery/deepfryer = 2,
 		/obj/machinery/chem_heater = 3,
-		/obj/machinery/power/emitter = 3)
+		/obj/machinery/power/emitter = 3
+	)
 	required_stock_part = /obj/item/stock_parts/micro_laser/high
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_capacitors
 	name = "Advanced Capacitors Benchmark"
 	description = "Further improving the power capacity of devices station-wide is the next step towards the important project marked as CRITICAL: motorised wheelchairs that run on bluespace-contained nuclear power."
 	required_points = 12
-	required_atoms = list(/obj/machinery/recharge_station = 1,
+	required_atoms = list(
+		/obj/machinery/recharge_station = 1,
 		/obj/machinery/cell_charger = 1,
 		/obj/machinery/mech_bay_recharge_port = 1,
 		/obj/machinery/recharger = 2,
 		/obj/machinery/power/smes = 2,
 		/obj/machinery/chem_dispenser = 3,
-		/obj/machinery/chem_dispenser/drinks = 3,
-		/obj/machinery/chem_dispenser/drinks/beer = 3) //actually having only the chem dispenser works for scanning soda/booze dispensers but im not quite sure how would i go about actually pointing that out w/o these two lines
+		/obj/machinery/chem_dispenser/drinks = 3, /*actually having only the chem dispenser works for scanning soda/booze dispensers but im not quite sure how would i go about actually pointing that out w/o these two lines*/
+		/obj/machinery/chem_dispenser/drinks/beer = 3
+	)
 	required_stock_part = /obj/item/stock_parts/capacitor/adv
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_scanmodules
 	name = "Advanced Scanning Modules Calibration"
 	description = "Despite the apparent lack of use of the scanning modules on our stations, we still expect you to run performance tests on them, just in case we come up with a ground-breaking way to fit 6 scanning modules in an exosuit."
 	required_points = 6
-	required_atoms = list(/obj/machinery/dna_scannernew = 1,
+	required_atoms = list(
+		/obj/machinery/dna_scannernew = 1,
 		/obj/machinery/rnd/experimentor = 1,
 		/obj/machinery/medical_kiosk = 2,
 		/obj/machinery/piratepad/civilian = 2,
-		/obj/machinery/rnd/bepis = 3)
+		/obj/machinery/rnd/bepis = 3
+	)
 	required_stock_part = /obj/item/stock_parts/scanning_module/adv
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_cells
 	name = "Power Cells Capacity Test"
 	description = "Nanotrasen has two major problems with their new Hamster-powered Generator Array: excess of power produced and violent protests of Animal Rights Consortium activists over genetically modifying hamsters with the Hulk gene. We place dibs on dealing with the latter!"
 	required_points = 8
-	required_atoms = list(/obj/machinery/recharge_station = 1,
+	required_atoms = list(
+		/obj/machinery/recharge_station = 1,
 		/obj/machinery/chem_dispenser = 1,
 		/obj/machinery/chem_dispenser/drinks = 1,
 		/obj/machinery/chem_dispenser/drinks/beer = 1,
-		/obj/machinery/power/smes = 2)
+		/obj/machinery/power/smes = 2
+	)
 	required_stock_part = /obj/item/stock_parts/cell/hyper
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser
 	name = "Ultra-high-power Micro-lasers Calibration"
 	description = "We're very close to outperforming the surgeons of the past by inventing laser tools precise enough to perform surgeries on grapes. Help us fine-tune the diodes to perfection!"
 	required_points = 10
-	required_atoms = list(/obj/machinery/mecha_part_fabricator = 1,
+	required_atoms = list(
+		/obj/machinery/mecha_part_fabricator = 1,
 		/obj/machinery/microwave = 1,
 		/obj/machinery/rnd/experimentor = 1,
 		/obj/machinery/atmospherics/components/binary/thermomachine/freezer = 2,
 		/obj/machinery/power/emitter = 2,
 		/obj/machinery/chem_heater = 2,
-		/obj/machinery/chem_mass_spec = 3)
+		/obj/machinery/chem_mass_spec = 3
+	)
 	required_stock_part = /obj/item/stock_parts/micro_laser/ultra

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -152,7 +152,7 @@
 	total_requirement = 3
 	possible_plant_genes = list(/datum/plant_gene/trait/squash, /datum/plant_gene/trait/cell_charge, /datum/plant_gene/trait/glow/shadow, /datum/plant_gene/trait/teleport, /datum/plant_gene/trait/brewing, /datum/plant_gene/trait/juicing, /datum/plant_gene/trait/eyes, /datum/plant_gene/trait/sticky)
 
-/datum/experiment/scanning/points/machinery_tiered_scan/lathes_tier2
+/datum/experiment/scanning/points/machinery_tiered_scan/tier2_lathes
 	name = "Advanced Stock Parts Benchmark"
 	description = "TBD"
 	required_points = 6
@@ -164,18 +164,93 @@
 		/obj/machinery/rnd/production/techfab/department/service = 1)
 	required_tier = 2
 
-/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_micro_laser_calibration
+/datum/experiment/scanning/points/machinery_tiered_scan/tier3_bluespacemachines
+	name = "Bluespace Machinery Attunement"
+	description = "TBD"
+	required_points = 4
+	required_atoms = list(/obj/machinery/teleport/hub = 1,
+		/obj/machinery/teleport/station = 1)
+	required_tier = 3
+
+/datum/experiment/scanning/points/machinery_tiered_scan/tier3_variety
+	name = "High Efficiency Parts Applications Test"
+	description = "TBD"
+	required_points = 15
+	required_atoms = list(/obj/machinery/autolathe = 1,
+		/obj/machinery/rnd/production/circuit_imprinter/department/science = 1,
+		/obj/machinery/monkey_recycler = 1,
+		/obj/machinery/processor/slime = 1,
+		/obj/machinery/processor = 2,
+		/obj/machinery/reagentgrinder = 2,
+		/obj/machinery/atmospherics/components/unary/cryo_cell = 3,
+		/obj/machinery/chem_master = 3,
+		/obj/machinery/harvester = 3,
+		/obj/machinery/quantumpad = 5
+		)
+	required_tier = 3
+
+/datum/experiment/scanning/points/machinery_tiered_scan/tier3_mechbay
+	name = "Military-grade Mech Bay Specs"
+	description = "TBD"
+	required_points = 6
+	required_atoms = list(/obj/machinery/mecha_part_fabricator = 1,
+		/obj/machinery/mech_bay_recharge_port = 1,
+		/obj/machinery/recharge_station = 1)
+	required_tier = 4
+
+/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_microlaser
 	name = "High-power Micro-lasers Calibration"
 	description = "TBD"
-	required_points = 2
-	required_atoms = list(/obj/machinery/mecha_part_fabricator = 1)
+	required_points = 10
+	required_atoms = list(/obj/machinery/mecha_part_fabricator = 1,
+		/obj/machinery/rnd/experimentor = 1,
+		/obj/machinery/dna_scannernew = 1,
+		/obj/machinery/microwave = 2,
+		/obj/machinery/deepfryer = 2,
+		/obj/machinery/chem_heater = 3,
+		/obj/machinery/power/emitter = 3)
 	required_stock_part = /obj/item/stock_parts/micro_laser/high
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_capacitors
 	name = "Advanced Capacitors Benchmark"
 	description = "TBD"
-	required_points = 6
+	required_points = 12
 	required_atoms = list(/obj/machinery/recharge_station = 1,
 		/obj/machinery/cell_charger = 1,
+		/obj/machinery/mech_bay_recharge_port = 1,
 		/obj/machinery/chem_dispenser = 2)
+		/*/obj/machinery/chem_dispenser/drinks = 2,
+		/obj/machinery/chem_dispenser/drinks/beer = 2)*/
 	required_stock_part = /obj/item/stock_parts/capacitor/adv
+
+/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_scanmodules
+	name = "Advanced Scanning Modules Calibration"
+	description = "TBD"
+	required_points = 6
+	required_atoms = list(/obj/machinery/dna_scannernew = 1,
+		/obj/machinery/rnd/experimentor = 1,
+		/obj/machinery/medical_kiosk = 2,
+		/obj/machinery/piratepad/civilian = 2
+		)
+	required_stock_part = /obj/item/stock_parts/scanning_module/adv
+
+/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_cells
+	name = "Power Cells Capacity Test"
+	description = "TBD"
+	required_points = 8
+	required_atoms = list(/obj/machinery/recharge_station = 1,
+		/obj/machinery/chem_dispenser = 1,
+		/obj/machinery/power/smes = 2)
+	required_stock_part = /obj/item/stock_parts/cell/hyper
+
+/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser
+	name = "Ultra-high-power Micro-lasers Calibration"
+	description = "TBD"
+	required_points = 10
+	required_atoms = list(/obj/machinery/mecha_part_fabricator = 1,
+		/obj/machinery/microwave = 1,
+		/obj/machinery/rnd/experimentor = 1,
+		/obj/machinery/atmospherics/components/binary/thermomachine/freezer = 2,
+		/obj/machinery/power/emitter = 2,
+		/obj/machinery/chem_heater = 2)
+	required_stock_part = /obj/item/stock_parts/micro_laser/ultra

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -152,7 +152,7 @@
 	total_requirement = 3
 	possible_plant_genes = list(/datum/plant_gene/trait/squash, /datum/plant_gene/trait/cell_charge, /datum/plant_gene/trait/glow/shadow, /datum/plant_gene/trait/teleport, /datum/plant_gene/trait/brewing, /datum/plant_gene/trait/juicing, /datum/plant_gene/trait/eyes, /datum/plant_gene/trait/sticky)
 
-/datum/experiment/scanning/machinery/lathes_tier2
+/datum/experiment/scanning/machinery_tiered_scan/lathes_tier2
 	name = "Advanced Stock Parts Benchmark"
 	description = "TBD"
 	required_atoms = list(/obj/machinery/rnd/production/protolathe/department/science = 1,
@@ -163,3 +163,9 @@
 		/obj/machinery/rnd/production/techfab/department/service = 1
 		)
 	required_tier = 2
+
+/datum/experiment/scanning/machinery_pinpoint_scan/tier2_micro_laser_calibration
+	name = "High-power Micro-lasers Calibration"
+	description = "TBD"
+	required_atoms = list(/obj/machinery/mecha_part_fabricator = 2)
+	required_stock_part = /obj/item/stock_parts/micro_laser/high

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -154,7 +154,7 @@
 
 /datum/experiment/scanning/points/machinery_tiered_scan/tier2_lathes
 	name = "Advanced Stock Parts Benchmark"
-	description = "TBD"
+	description = "Our newly-designed advanced machinery components require practical application tests for hints at possible further advancements, as well as a general confirmation the we didn't actually design worse parts somehow."
 	required_points = 6
 	required_atoms = list(/obj/machinery/rnd/production/protolathe/department/science = 1,
 		/obj/machinery/rnd/production/protolathe/department/engineering = 1,
@@ -166,7 +166,7 @@
 
 /datum/experiment/scanning/points/machinery_tiered_scan/tier3_bluespacemachines
 	name = "Bluespace Machinery Attunement"
-	description = "TBD"
+	description = "Teleportation technology using bluespace capabilities is a high selling point for our company, but the threat of a critical malfunction in calibration procedures wasn't something we predicted to emerge. Since our RnD department has started a flyperson race riot, maybe your advancements in stock parts could help mitigate the buzzing problem."
 	required_points = 4
 	required_atoms = list(/obj/machinery/teleport/hub = 1,
 		/obj/machinery/teleport/station = 1)
@@ -174,7 +174,7 @@
 
 /datum/experiment/scanning/points/machinery_tiered_scan/tier3_variety
 	name = "High Efficiency Parts Applications Test"
-	description = "TBD"
+	description = "We require further testing of the stock part designs to push their efficiency and market price even further."
 	required_points = 15
 	required_atoms = list(/obj/machinery/autolathe = 1,
 		/obj/machinery/rnd/production/circuit_imprinter/department/science = 1,
@@ -182,25 +182,26 @@
 		/obj/machinery/processor/slime = 1,
 		/obj/machinery/processor = 2,
 		/obj/machinery/reagentgrinder = 2,
+		/obj/machinery/hydroponics = 2,
+		/obj/machinery/gibber = 3,
 		/obj/machinery/atmospherics/components/unary/cryo_cell = 3,
 		/obj/machinery/chem_master = 3,
 		/obj/machinery/harvester = 3,
-		/obj/machinery/quantumpad = 5
-		)
+		/obj/machinery/quantumpad = 5)
 	required_tier = 3
 
 /datum/experiment/scanning/points/machinery_tiered_scan/tier3_mechbay
-	name = "Military-grade Mech Bay Specs"
-	description = "TBD"
+	name = "Military-grade Mech Bay Setup"
+	description = "Constructing combat-oriented exosuits is a pricy endeavour. Make sure you have an efficient setup for production, and we'll send over some of our design documents."
 	required_points = 6
 	required_atoms = list(/obj/machinery/mecha_part_fabricator = 1,
 		/obj/machinery/mech_bay_recharge_port = 1,
 		/obj/machinery/recharge_station = 1)
-	required_tier = 4
+	required_tier = 3
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_microlaser
 	name = "High-power Micro-lasers Calibration"
-	description = "TBD"
+	description = "Our Nanotrasen High-Power Office-Ready Laser Pointer ™ isn't powerful enough to strike airborne Syndidrones out of the sky yet. Find us some diode applications for hints on how to improve them!"
 	required_points = 10
 	required_atoms = list(/obj/machinery/mecha_part_fabricator = 1,
 		/obj/machinery/rnd/experimentor = 1,
@@ -213,44 +214,49 @@
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_capacitors
 	name = "Advanced Capacitors Benchmark"
-	description = "TBD"
+	description = "Further improving the power capacity of devices station-wide is the next step towards the important project marked as CRITICAL: motorised wheelchairs that run on bluespace-contained nuclear power."
 	required_points = 12
 	required_atoms = list(/obj/machinery/recharge_station = 1,
 		/obj/machinery/cell_charger = 1,
 		/obj/machinery/mech_bay_recharge_port = 1,
-		/obj/machinery/chem_dispenser = 2)
-		/*/obj/machinery/chem_dispenser/drinks = 2,
-		/obj/machinery/chem_dispenser/drinks/beer = 2)*/
+		/obj/machinery/recharger = 2,
+		/obj/machinery/power/smes = 2,
+		/obj/machinery/chem_dispenser = 3,
+		/obj/machinery/chem_dispenser/drinks = 3,
+		/obj/machinery/chem_dispenser/drinks/beer = 3) //actually having only the chem dispenser works for scanning soda/booze dispensers but im not quite sure how would i go about actually pointing that out w/o these two lines
 	required_stock_part = /obj/item/stock_parts/capacitor/adv
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_scanmodules
 	name = "Advanced Scanning Modules Calibration"
-	description = "TBD"
+	description = "Despite the apparent lack of use of the scanning modules on our stations, we still expect you to run performance tests on them, just in case we come up with a ground-breaking way to fit 6 scanning modules in an exosuit."
 	required_points = 6
 	required_atoms = list(/obj/machinery/dna_scannernew = 1,
 		/obj/machinery/rnd/experimentor = 1,
 		/obj/machinery/medical_kiosk = 2,
-		/obj/machinery/piratepad/civilian = 2
-		)
+		/obj/machinery/piratepad/civilian = 2,
+		/obj/machinery/rnd/bepis = 3)
 	required_stock_part = /obj/item/stock_parts/scanning_module/adv
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_cells
 	name = "Power Cells Capacity Test"
-	description = "TBD"
+	description = "Nanotrasen has two major problems with their new Hamster-powered Generator Array: excess of power produced and violent protests of Animal Rights Consortium activists over genetically modifying hamsters with the Hulk gene. We place dibs on dealing with the latter!"
 	required_points = 8
 	required_atoms = list(/obj/machinery/recharge_station = 1,
 		/obj/machinery/chem_dispenser = 1,
+		/obj/machinery/chem_dispenser/drinks = 1,
+		/obj/machinery/chem_dispenser/drinks/beer = 1,
 		/obj/machinery/power/smes = 2)
 	required_stock_part = /obj/item/stock_parts/cell/hyper
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser
 	name = "Ultra-high-power Micro-lasers Calibration"
-	description = "TBD"
+	description = "We're very close to outperforming the surgeons of the past by inventing laser tools precise enough to perform surgeries on grapes. Help us fine-tune the diodes to perfection!"
 	required_points = 10
 	required_atoms = list(/obj/machinery/mecha_part_fabricator = 1,
 		/obj/machinery/microwave = 1,
 		/obj/machinery/rnd/experimentor = 1,
 		/obj/machinery/atmospherics/components/binary/thermomachine/freezer = 2,
 		/obj/machinery/power/emitter = 2,
-		/obj/machinery/chem_heater = 2)
+		/obj/machinery/chem_heater = 2,
+		/obj/machinery/chem_mass_spec = 3)
 	required_stock_part = /obj/item/stock_parts/micro_laser/ultra

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -152,20 +152,30 @@
 	total_requirement = 3
 	possible_plant_genes = list(/datum/plant_gene/trait/squash, /datum/plant_gene/trait/cell_charge, /datum/plant_gene/trait/glow/shadow, /datum/plant_gene/trait/teleport, /datum/plant_gene/trait/brewing, /datum/plant_gene/trait/juicing, /datum/plant_gene/trait/eyes, /datum/plant_gene/trait/sticky)
 
-/datum/experiment/scanning/machinery_tiered_scan/lathes_tier2
+/datum/experiment/scanning/points/machinery_tiered_scan/lathes_tier2
 	name = "Advanced Stock Parts Benchmark"
 	description = "TBD"
+	required_points = 6
 	required_atoms = list(/obj/machinery/rnd/production/protolathe/department/science = 1,
 		/obj/machinery/rnd/production/protolathe/department/engineering = 1,
 		/obj/machinery/rnd/production/techfab/department/cargo = 1,
 		/obj/machinery/rnd/production/techfab/department/medical = 1,
 		/obj/machinery/rnd/production/techfab/department/security = 1,
-		/obj/machinery/rnd/production/techfab/department/service = 1
-		)
+		/obj/machinery/rnd/production/techfab/department/service = 1)
 	required_tier = 2
 
-/datum/experiment/scanning/machinery_pinpoint_scan/tier2_micro_laser_calibration
+/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_micro_laser_calibration
 	name = "High-power Micro-lasers Calibration"
 	description = "TBD"
-	required_atoms = list(/obj/machinery/mecha_part_fabricator = 2)
+	required_points = 2
+	required_atoms = list(/obj/machinery/mecha_part_fabricator = 1)
 	required_stock_part = /obj/item/stock_parts/micro_laser/high
+
+/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_capacitors
+	name = "Advanced Capacitors Benchmark"
+	description = "TBD"
+	required_points = 6
+	required_atoms = list(/obj/machinery/recharge_station = 1,
+		/obj/machinery/cell_charger = 1,
+		/obj/machinery/chem_dispenser = 2)
+	required_stock_part = /obj/item/stock_parts/capacitor/adv

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -151,3 +151,15 @@
 	performance_hint = "The wide varities of plants on station each carry various traits, some unique to them. Look for plants that may mutate into what we're looking for."
 	total_requirement = 3
 	possible_plant_genes = list(/datum/plant_gene/trait/squash, /datum/plant_gene/trait/cell_charge, /datum/plant_gene/trait/glow/shadow, /datum/plant_gene/trait/teleport, /datum/plant_gene/trait/brewing, /datum/plant_gene/trait/juicing, /datum/plant_gene/trait/eyes, /datum/plant_gene/trait/sticky)
+
+/datum/experiment/scanning/machinery/lathes_tier2
+	name = "Advanced Stock Parts Benchmark"
+	description = "TBD"
+	required_atoms = list(/obj/machinery/rnd/production/protolathe/department/science = 1,
+		/obj/machinery/rnd/production/protolathe/department/engineering = 1,
+		/obj/machinery/rnd/production/techfab/department/cargo = 1,
+		/obj/machinery/rnd/production/techfab/department/medical = 1,
+		/obj/machinery/rnd/production/techfab/department/security = 1,
+		/obj/machinery/rnd/production/techfab/department/service = 1
+		)
+	required_tier = 2

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -183,10 +183,11 @@
 		/obj/machinery/processor = 2,
 		/obj/machinery/reagentgrinder = 2,
 		/obj/machinery/hydroponics = 2,
+		/obj/machinery/biogenerator = 3,
 		/obj/machinery/gibber = 3,
-		/obj/machinery/atmospherics/components/unary/cryo_cell = 3,
 		/obj/machinery/chem_master = 3,
-		/obj/machinery/harvester = 3,
+		/obj/machinery/atmospherics/components/unary/cryo_cell = 3,
+		/obj/machinery/harvester = 5,
 		/obj/machinery/quantumpad = 5)
 	required_tier = 3
 

--- a/code/modules/experisci/experiment/types/scanning_machinery.dm
+++ b/code/modules/experisci/experiment/types/scanning_machinery.dm
@@ -1,42 +1,42 @@
 ///This experiment type will turn up TRUE if at least one of the stock parts in the scanned machine is of the required_tier.
 ///Pretend to upgrade security's techfab but in reality apply only one better matter bin!
 
-/datum/experiment/scanning/machinery_tiered_scan
+/datum/experiment/scanning/points/machinery_tiered_scan
 	name = "Upgraded Machinery Scanning Experiment"
 	description = "Base experiment for scanning machinery with upgraded parts"
 	exp_tag = "Scan"
 	///What tier of parts is required for the experiment
 	var/required_tier = 1
 
-/datum/experiment/scanning/machinery_tiered_scan/serialize_progress_stage(atom/target, list/seen_instances)
-	return EXPERIMENT_PROG_INT("Scan a [initial(target.name)] built with tier [required_tier] parts.", \
-		traits & EXPERIMENT_TRAIT_DESTRUCTIVE ? scanned[target] : seen_instances.len, required_atoms[target])
+/datum/experiment/scanning/points/machinery_tiered_scan/check_progress()
+	. = ..()
+	.[1] = EXPERIMENT_PROG_INT("Scan samples of the following machines built with tier [required_tier] parts.", points, required_points)[1]
 
-/datum/experiment/scanning/machinery_tiered_scan/final_contributing_index_checks(atom/target, typepath)
+/datum/experiment/scanning/points/machinery_tiered_scan/final_contributing_index_checks(atom/target, typepath)
 	. = ..()
 	if(!.)
 		return FALSE
 
 	var/obj/machinery/machine = target
 	for(var/obj/item/stock_parts/stock_part in machine.component_parts)
-		if(stock_part.rating == required_tier)
+		if(stock_part.rating >= required_tier) //>= for backwards research cases when you want the discount done after you did the node
 			return TRUE
 	return FALSE
 
 //This experiment type will turn up TRUE if there is a specific part in the scanned machine
-/datum/experiment/scanning/machinery_pinpoint_scan
+/datum/experiment/scanning/points/machinery_pinpoint_scan
 	name = "Machinery Pinpoint Stock Parts Scanning Experiment"
 	description = "Base experiment for scanning machinery with specific parts"
 	exp_tag = "Scan"
 	///Which stock part are we looking for in the machine
-	var/required_stock_part = /obj/item/stock_parts
+	var/obj/item/stock_parts/required_stock_part = /obj/item/stock_parts
 
-/datum/experiment/scanning/machinery_pinpoint_scan/serialize_progress_stage(atom/target, list/seen_instances)
-	return EXPERIMENT_PROG_INT("Scan \a [initial(target.name)] built with \a [required_stock_part].", \
-		traits & EXPERIMENT_TRAIT_DESTRUCTIVE ? scanned[target] : seen_instances.len, required_atoms[target]) //make this show the actual name of the part goddamnit
+/datum/experiment/scanning/points/machinery_pinpoint_scan/check_progress()
+	. = ..()
+	.[1] = EXPERIMENT_PROG_INT("Scan samples of the following machines upgraded with \a [initial(required_stock_part.name)] to accumulate enough points to complete this experiment.", points, required_points)[1]
 
-/datum/experiment/scanning/machinery_pinpoint_scan/final_contributing_index_checks(atom/target, typepath)
-	.=..()
+/datum/experiment/scanning/points/machinery_pinpoint_scan/final_contributing_index_checks(atom/target, typepath)
+	. = ..()
 	if(!.)
 		return FALSE
 

--- a/code/modules/experisci/experiment/types/scanning_machinery.dm
+++ b/code/modules/experisci/experiment/types/scanning_machinery.dm
@@ -1,0 +1,20 @@
+/datum/experiment/scanning/machinery
+	name = "Machinery Scanning Experiment"
+	description = "Base experiment for scanning machinery with upgraded parts"
+	exp_tag = "Scan"
+	///What tier of parts is required for the experiment
+	var/required_tier = 1
+
+/datum/experiment/scanning/machinery/serialize_progress_stage(atom/target, list/seen_instances)
+	return EXPERIMENT_PROG_INT("Scan a [initial(target.name)] built with tier [required_tier] parts.", \
+		traits & EXPERIMENT_TRAIT_DESTRUCTIVE ? scanned[target] : seen_instances.len, required_atoms[target])
+
+/datum/experiment/scanning/machinery/final_contributing_index_checks(atom/target, typepath)
+	.=..()
+	if(!.)
+		return
+
+	var/obj/machinery/machine = target
+	for(var/obj/item/stock_parts/stock_part in machine.component_parts)
+		if((stock_part.rating == required_tier))
+			return ..() && TRUE

--- a/code/modules/experisci/experiment/types/scanning_machinery.dm
+++ b/code/modules/experisci/experiment/types/scanning_machinery.dm
@@ -27,8 +27,8 @@
 	var/required_stock_part = /obj/item/stock_parts
 
 /datum/experiment/scanning/machinery_pinpoint_scan/serialize_progress_stage(atom/target, list/seen_instances)
-	return EXPERIMENT_PROG_INT("Scan \a [initial(target.name)] built with \a [required_stock_part].", \ //make this show the actual name of the part goddamnit
-		traits & EXPERIMENT_TRAIT_DESTRUCTIVE ? scanned[target] : seen_instances.len, required_atoms[target])
+	return EXPERIMENT_PROG_INT("Scan \a [initial(target.name)] built with \a [required_stock_part].", \
+		traits & EXPERIMENT_TRAIT_DESTRUCTIVE ? scanned[target] : seen_instances.len, required_atoms[target]) //make this show the actual name of the part goddamnit
 
 /datum/experiment/scanning/machinery_pinpoint_scan/final_contributing_index_checks(atom/target, typepath)
 	var/obj/machinery/machine = target

--- a/code/modules/experisci/experiment/types/scanning_machinery.dm
+++ b/code/modules/experisci/experiment/types/scanning_machinery.dm
@@ -10,7 +10,7 @@
 
 /datum/experiment/scanning/points/machinery_tiered_scan/check_progress()
 	. = ..()
-	.[1] = EXPERIMENT_PROG_INT("Scan samples of the following machines built with tier [required_tier] parts.", points, required_points)[1]
+	.[1] = EXPERIMENT_PROG_INT("Scan samples of the following machines built with parts of tier [required_tier] or better.", points, required_points)[1]
 
 /datum/experiment/scanning/points/machinery_tiered_scan/final_contributing_index_checks(atom/target, typepath)
 	. = ..()

--- a/code/modules/experisci/experiment/types/scanning_machinery.dm
+++ b/code/modules/experisci/experiment/types/scanning_machinery.dm
@@ -1,20 +1,37 @@
-/datum/experiment/scanning/machinery
-	name = "Machinery Scanning Experiment"
+///This experiment type will turn up TRUE if at least one of the stock parts in the scanned machine is of the required_tier.
+///Pretend to upgrade security's techfab but in reality apply only one better matter bin!
+
+/datum/experiment/scanning/machinery_tiered_scan
+	name = "Upgraded Machinery Scanning Experiment"
 	description = "Base experiment for scanning machinery with upgraded parts"
 	exp_tag = "Scan"
 	///What tier of parts is required for the experiment
 	var/required_tier = 1
 
-/datum/experiment/scanning/machinery/serialize_progress_stage(atom/target, list/seen_instances)
+/datum/experiment/scanning/machinery_tiered_scan/serialize_progress_stage(atom/target, list/seen_instances)
 	return EXPERIMENT_PROG_INT("Scan a [initial(target.name)] built with tier [required_tier] parts.", \
 		traits & EXPERIMENT_TRAIT_DESTRUCTIVE ? scanned[target] : seen_instances.len, required_atoms[target])
 
-/datum/experiment/scanning/machinery/final_contributing_index_checks(atom/target, typepath)
-	.=..()
-	if(!.)
-		return
-
+/datum/experiment/scanning/machinery_tiered_scan/final_contributing_index_checks(atom/target, typepath)
 	var/obj/machinery/machine = target
 	for(var/obj/item/stock_parts/stock_part in machine.component_parts)
 		if((stock_part.rating == required_tier))
+			return ..() && TRUE
+
+//This experiment type will turn up TRUE if there is a specific part in the scanned machine
+/datum/experiment/scanning/machinery_pinpoint_scan
+	name = "Machinery Pinpoint Stock Parts Scanning Experiment"
+	description = "Base experiment for scanning machinery with specific parts"
+	exp_tag = "Scan"
+	///Which stock part are we looking for in the machine
+	var/required_stock_part = /obj/item/stock_parts
+
+/datum/experiment/scanning/machinery_pinpoint_scan/serialize_progress_stage(atom/target, list/seen_instances)
+	return EXPERIMENT_PROG_INT("Scan \a [initial(target.name)] built with \a [required_stock_part].", \ //make this show the actual name of the part goddamnit
+		traits & EXPERIMENT_TRAIT_DESTRUCTIVE ? scanned[target] : seen_instances.len, required_atoms[target])
+
+/datum/experiment/scanning/machinery_pinpoint_scan/final_contributing_index_checks(atom/target, typepath)
+	var/obj/machinery/machine = target
+	for(var/obj/stock_part in machine.component_parts)
+		if(istype(stock_part, required_stock_part))
 			return ..() && TRUE

--- a/code/modules/experisci/experiment/types/scanning_machinery.dm
+++ b/code/modules/experisci/experiment/types/scanning_machinery.dm
@@ -13,10 +13,15 @@
 		traits & EXPERIMENT_TRAIT_DESTRUCTIVE ? scanned[target] : seen_instances.len, required_atoms[target])
 
 /datum/experiment/scanning/machinery_tiered_scan/final_contributing_index_checks(atom/target, typepath)
+	. = ..()
+	if(!.)
+		return FALSE
+
 	var/obj/machinery/machine = target
 	for(var/obj/item/stock_parts/stock_part in machine.component_parts)
-		if((stock_part.rating == required_tier))
-			return ..() && TRUE
+		if(stock_part.rating == required_tier)
+			return TRUE
+	return FALSE
 
 //This experiment type will turn up TRUE if there is a specific part in the scanned machine
 /datum/experiment/scanning/machinery_pinpoint_scan
@@ -31,7 +36,12 @@
 		traits & EXPERIMENT_TRAIT_DESTRUCTIVE ? scanned[target] : seen_instances.len, required_atoms[target]) //make this show the actual name of the part goddamnit
 
 /datum/experiment/scanning/machinery_pinpoint_scan/final_contributing_index_checks(atom/target, typepath)
+	.=..()
+	if(!.)
+		return FALSE
+
 	var/obj/machinery/machine = target
 	for(var/obj/stock_part in machine.component_parts)
 		if(istype(stock_part, required_stock_part))
-			return ..() && TRUE
+			return TRUE
+	return FALSE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -509,7 +509,7 @@
 		"super_matter_bin",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
-	discount_experiments = list(/datum/experiment/scanning/points/machinery_tiered_scan/lathes_tier2 = 3500)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_tiered_scan/tier2_lathes = 5000)
 
 /datum/techweb_node/adv_power
 	id = "adv_power"
@@ -527,7 +527,7 @@
 		"superpacman",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3500)
-	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_capacitors = 2000)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_capacitors = 2500)
 
 /////////////////////////Bluespace tech/////////////////////////
 /datum/techweb_node/bluespace_basic //Bluespace-memery
@@ -558,6 +558,7 @@
 		"teleconsole",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_tiered_scan/tier3_bluespacemachines = 4000)
 
 /datum/techweb_node/micro_bluespace
 	id = "micro_bluespace"
@@ -574,7 +575,8 @@
 		"wormholeprojector",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
-	discount_experiments = list(/datum/experiment/exploration_scan/random/condition)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_tiered_scan/tier3_variety = 5000)
+		/* /datum/experiment/exploration_scan/random/condition) this should have a point cost but im not even sure the experiment works properly lmao*/
 
 /datum/techweb_node/advanced_bluespace
 	id = "bluespace_storage"
@@ -602,6 +604,7 @@
 		"roastingstick",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_scanmodules = 3500)
 
 /datum/techweb_node/bluespace_power
 	id = "bluespace_power"
@@ -612,7 +615,8 @@
 		"bluespace_cell",
 		"quadratic_capacitor",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 4000)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_cells = 3000)
 
 /datum/techweb_node/regulated_bluespace
 	id = "regulated_bluespace"
@@ -876,7 +880,7 @@
 		"ultra_micro_laser",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
-	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_micro_laser_calibration = 1500)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_microlaser = 1500)
 
 /datum/techweb_node/emp_super
 	id = "emp_super"
@@ -886,7 +890,8 @@
 	design_ids = list(
 		"quadultra_micro_laser",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_microlaser = 4000)
 
 /////////////////////////Clown tech/////////////////////////
 /datum/techweb_node/clown
@@ -1470,7 +1475,8 @@
 		"gygax_targ",
 		"gygax_torso",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_tiered_scan/tier3_mechbay = 5000)
 
 /datum/techweb_node/durand
 	id = "mech_durand"
@@ -1490,7 +1496,8 @@
 		"durand_targ",
 		"durand_torso",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_tiered_scan/tier3_mechbay = 3500)
 
 /datum/techweb_node/phazon
 	id = "mecha_phazon"
@@ -1510,7 +1517,8 @@
 		"phazon_targ",
 		"phazon_torso",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_tiered_scan/tier3_mechbay = 2500)
 
 /datum/techweb_node/savannah_ivanov
 	id = "mecha_savannah_ivanov"
@@ -1530,7 +1538,8 @@
 		"savannah_ivanov_targ",
 		"savannah_ivanov_torso",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_tiered_scan/tier3_mechbay = 3000)
 
 /datum/techweb_node/adv_mecha_tools
 	id = "adv_mecha_tools"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -509,7 +509,7 @@
 		"super_matter_bin",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
-	discount_experiments = list(/datum/experiment/scanning/machinery/lathes_tier2 = 3500)
+	discount_experiments = list(/datum/experiment/scanning/machinery_tiered_scan/lathes_tier2 = 3500)
 
 /datum/techweb_node/adv_power
 	id = "adv_power"
@@ -875,6 +875,7 @@
 		"ultra_micro_laser",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
+	discount_experiments = list(/datum/experiment/scanning/machinery_pinpoint_scan/tier2_micro_laser_calibration = 1500)
 
 /datum/techweb_node/emp_super
 	id = "emp_super"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -509,7 +509,7 @@
 		"super_matter_bin",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
-	discount_experiments = list(/datum/experiment/scanning/machinery_tiered_scan/lathes_tier2 = 3500)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_tiered_scan/lathes_tier2 = 3500)
 
 /datum/techweb_node/adv_power
 	id = "adv_power"
@@ -526,7 +526,8 @@
 		"super_cell",
 		"superpacman",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3500)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_capacitors = 2000)
 
 /////////////////////////Bluespace tech/////////////////////////
 /datum/techweb_node/bluespace_basic //Bluespace-memery
@@ -875,7 +876,7 @@
 		"ultra_micro_laser",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
-	discount_experiments = list(/datum/experiment/scanning/machinery_pinpoint_scan/tier2_micro_laser_calibration = 1500)
+	discount_experiments = list(/datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_micro_laser_calibration = 1500)
 
 /datum/techweb_node/emp_super
 	id = "emp_super"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -509,6 +509,7 @@
 		"super_matter_bin",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
+	discount_experiments = list(/datum/experiment/scanning/machinery/lathes_tier2 = 3500)
 
 /datum/techweb_node/adv_power
 	id = "adv_power"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2391,6 +2391,7 @@
 #include "code\modules\experisci\experiment\types\physical_experiment.dm"
 #include "code\modules\experisci\experiment\types\random_scanning.dm"
 #include "code\modules\experisci\experiment\types\scanning.dm"
+#include "code\modules\experisci\experiment\types\scanning_machinery.dm"
 #include "code\modules\experisci\experiment\types\scanning_material.dm"
 #include "code\modules\experisci\experiment\types\scanning_plants.dm"
 #include "code\modules\experisci\experiment\types\scanning_points.dm"


### PR DESCRIPTION
## About The Pull Request
This PR adds a type of experiment for scanning machinery built with different tiered stock parts. Simply scan a required machine with the specified tier of stock parts in it for it to count towards the experiment. The basic type of this scan will work even if only one part of the machine is of the required tier, which can help you trick others into believing that you _did_ upgrade it properly.
An alternative type of this scan will look for a specified stock part type in the machine, such as a micro laser of tier 3.
## To-do
- [x] proper implementation of this scan
- [x] ~~randomized contents? perhaps making some experiments ask for unspecified machines with certain parts?~~ base this experiment on scanning_points instead
- [x] spread out the new experiments across the techweb
- [x] balance it out and write proper desriptions/names

## Why It's Good For The Game
Promotes using the acquired T2-T4 parts outside of Engineering or Science departments, profiting the whole station in varying amounts. More excuses for you to scream at AI to open Brig or Medical. ~~Buffs~~ ~~Nerfs~~ _Burfs_ various tech tree speedruns. More work for scientists to do aside from scanning literal toilets.

## Changelog
:cl:
expansion: There is a new type of experiment provided by Nanotrasen: Machinery scanning!
/:cl: