### PR TITLE
Fixes the telescopic riot shield's weight class when extended (+ shortens shield balloon alerts)

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -236,7 +236,7 @@
 
 	enabled = active
 
-	balloon_alert(user, "[name] [active ? "activated":"deactivated"]")
+	balloon_alert(user, "[active ? "activated":"deactivated"]")
 	playsound(user ? user : src, active ? 'sound/weapons/saberon.ogg' : 'sound/weapons/saberoff.ogg', 35, TRUE)
 	return COMPONENT_NO_DEFAULT_MESSAGE
 
@@ -264,7 +264,7 @@
 		throwforce_on = 5, \
 		throw_speed_on = 2, \
 		hitsound_on = hitsound, \
-		w_class_on = WEIGHT_CLASS_NORMAL, \
+		w_class_on = WEIGHT_CLASS_BULKY, \
 		attack_verb_continuous_on = list("smacks", "strikes", "cracks", "beats"), \
 		attack_verb_simple_on = list("smack", "strike", "crack", "beat"))
 	RegisterSignal(src, COMSIG_TRANSFORMING_ON_TRANSFORM, .proc/on_transform)
@@ -285,5 +285,5 @@
 	extended = active
 	slot_flags = active ? ITEM_SLOT_BACK : null
 	playsound(user ? user : src, 'sound/weapons/batonextend.ogg', 50, TRUE)
-	balloon_alert(user, "[active ? "extended" : "collapsed"] [src]")
+	balloon_alert(user, "[active ? "extended" : "collapsed"]")
 	return COMPONENT_NO_DEFAULT_MESSAGE


### PR DESCRIPTION
## About The Pull Request

Makes the telescopic riot shield bulky when active as it was prior to refactor. 
Also shortens the balloon alerts for the shields while i'm here on mothblock's request.

(no gbp here)

## Why It's Good For The Game

- Accidental behavior change is bad!!
- shorter balloon alerts to be less distracting

## Changelog

:cl: Melbert
fix: Telescopic shields are bulky again when extended, and the balloon alerts are shorter
/:cl:
