### PR TITLE
Remove atoms from vis_contents in Destroy()

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -149,6 +149,7 @@
 	//DO it after moveToNullspace so memes can be had
 	LAZYCLEARLIST(important_recursive_contents)
 
+	vis_locs = null //clears this atom out of all viscontents
 	vis_contents.Cut()
 
 /atom/movable/proc/update_emissive_block()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -170,6 +170,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	requires_activation = FALSE
 	..()
 
+	vis_locs = null //clears this atom out of all viscontents
 	vis_contents.Cut()
 
 /// WARNING WARNING


### PR DESCRIPTION
setting vis locs can be used to remove or add it to other objects vis contents and we can use this to null out refs in vis contents in destroy