### PR TITLE
Metastation Merge Conflict marker cleanup

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -605,9 +605,6 @@
 /obj/item/melee/baton/security/cattleprod,
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/machinery/power/apc/unlocked{
 	dir = 8;
 	environ = 0;
@@ -617,7 +614,6 @@
 	},
 /obj/structure/rack,
 /obj/item/melee/baton/security/cattleprod,
-/obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -4303,9 +4303,9 @@
 	req_access_txt = "20"
 	},
 /obj/effect/spawner/random/aimodule/harmless{
-	spawn_loot_split = 1;
 	spawn_loot_count = 3;
-	spawn_loot_double = 0
+	spawn_loot_double = 0;
+	spawn_loot_split = 1
 	},
 /obj/structure/table,
 /obj/structure/window/reinforced,
@@ -37376,9 +37376,9 @@
 	req_access_txt = "20"
 	},
 /obj/effect/spawner/random/aimodule/harmful{
-	spawn_loot_split = 1;
 	spawn_loot_count = 2;
-	spawn_loot_double = 0
+	spawn_loot_double = 0;
+	spawn_loot_split = 1
 	},
 /obj/item/ai_module/supplied/oxygen{
 	pixel_x = -3;
@@ -46480,12 +46480,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/crate,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4775,10 +4775,6 @@
 	},
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/gambling,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/gambling,
 /turf/open/floor/wood,
 /area/service/bar)
@@ -8571,10 +8567,6 @@
 "bNp" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/spawner/random/maintenance,
 /obj/structure/closet,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -8669,10 +8661,6 @@
 "bOJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
-	},
-/obj/effect/spawner/random/structure/crate,
-/obj{
-	name = "---Merge conflict marker---"
 	},
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
@@ -13123,10 +13111,6 @@
 	dir = 4
 	},
 /obj/item/storage/box/lights/mixed,
-/obj/effect/spawner/random/maintenance,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -15453,11 +15437,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/machinery/airalarm/directional/west,
-/obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -17698,10 +17678,6 @@
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -28909,14 +28885,10 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/structure/crate,
 /obj/machinery/light/dim{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -29749,11 +29721,11 @@
 	pixel_y = -23
 	},
 /obj/machinery/door/window{
+	atom_integrity = 300;
 	base_state = "leftsecure";
 	dir = 8;
 	icon_state = "leftsecure";
 	name = "Primary AI Core Access";
-	atom_integrity = 300;
 	req_access_txt = "16"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -32914,10 +32886,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/closet/crate,
 /obj/item/storage/box/drinkingglasses,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/bar{
@@ -33293,10 +33261,6 @@
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -36471,12 +36435,8 @@
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/bot,
@@ -41399,11 +41359,11 @@
 /area/medical/chemistry)
 "mLk" = (
 /obj/machinery/door/window{
+	atom_integrity = 300;
 	base_state = "rightsecure";
 	dir = 4;
 	icon_state = "rightsecure";
 	name = "Primary AI Core Access";
-	atom_integrity = 300;
 	req_access_txt = "16"
 	},
 /obj/machinery/camera{
@@ -44952,11 +44912,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/table/glass,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -47399,10 +47355,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -51748,10 +51700,6 @@
 "qlY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/spawner/random/maintenance,
-/obj{
-	name = "---Merge conflict marker---"
 	},
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating{
@@ -57567,10 +57515,6 @@
 /area/medical/storage)
 "stH" = (
 /obj/effect/spawner/random/vending/colavend,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/spawner/random/vending/colavend,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -58516,12 +58460,12 @@
 	pixel_x = 8
 	},
 /obj/machinery/door/window{
+	atom_integrity = 300;
 	base_state = "leftsecure";
 	dir = 8;
 	icon_state = "leftsecure";
 	layer = 4.1;
 	name = "Tertiary AI Core Access";
-	atom_integrity = 300;
 	pixel_x = -3;
 	req_access_txt = "16"
 	},
@@ -59622,10 +59566,6 @@
 "tfJ" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/machinery/light/directional/east,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/spawner/random/vending/snackvend,
 /obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -60806,10 +60746,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -61257,12 +61193,7 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/north,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "tIr" = (
@@ -61503,10 +61434,6 @@
 "tLA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/spawner/random/maintenance,
-/obj{
-	name = "---Merge conflict marker---"
 	},
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -69575,10 +69502,6 @@
 /area/engineering/break_room)
 "wKi" = (
 /obj/effect/spawner/random/structure/crate,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -70973,12 +70896,12 @@
 	pixel_x = -8
 	},
 /obj/machinery/door/window{
+	atom_integrity = 300;
 	base_state = "rightsecure";
 	dir = 4;
 	icon_state = "rightsecure";
 	layer = 4.1;
 	name = "Secondary AI Core Access";
-	atom_integrity = 300;
 	pixel_x = 4;
 	req_access_txt = "16"
 	},

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -12922,18 +12922,6 @@
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"cwD" = (
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "cwJ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
@@ -19325,17 +19313,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"eQL" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "eQS" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -20388,13 +20365,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
-"fke" = (
-/obj/effect/spawner/random/structure/crate,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "fkL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22135,26 +22105,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"fQq" = (
-/obj/structure/bed,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/bedsheet/red,
-/obj/effect/spawner/random/contraband/prison,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "fQs" = (
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating/asteroid,
@@ -24186,15 +24136,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
-"gGw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/seven,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "gGM" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -33961,16 +33902,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"koH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/flashlight,
-/obj/effect/spawner/random/maintenance/three,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "koJ" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -40215,30 +40146,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"mYX" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/contraband/armory,
-/obj/effect/spawner/random/contraband/armory,
-/obj/effect/spawner/random/maintenance/three,
-/obj/machinery/button/door/directional/east{
-	id = "armory";
-	name = "Armory Shutters";
-	req_access_txt = "3"
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "mZd" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -40267,14 +40174,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/science/explab)
-"mZp" = (
-/obj/effect/spawner/random/vending/colavend,
-/obj/structure/cable,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "mZD" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -41522,21 +41421,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"nCD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/trash/sosjerky,
-/obj/item/trash/boritos,
-/obj/item/trash/can,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "nDr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -44324,15 +44208,6 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
-"oHN" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/clothing/costume,
-/obj/effect/decal/cleanable/dirt,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "oHS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -49686,16 +49561,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
-"qII" = (
-/obj/effect/spawner/random/entertainment/arcade,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "qIK" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/poster/ripped{
@@ -50966,23 +50831,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
-"rjE" = (
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access_txt = "63; 42"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-side-entrance"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "rjI" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -53473,14 +53321,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"snC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "snL" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
@@ -56187,16 +56027,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"toO" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/storage/box/donkpockets/donkpocketberry,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "toQ" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -59016,14 +58846,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"uux" = (
-/obj/effect/spawner/random/trash/food_packaging,
-/obj/effect/decal/cleanable/dirt,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "uuB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -88099,7 +87921,7 @@ ahI
 vyF
 ahI
 dhe
-koH
+dhe
 dhe
 aEc
 wcA
@@ -91172,7 +90994,7 @@ bJv
 dhe
 dhe
 dhe
-mZp
+dhe
 aaB
 xPs
 yiT
@@ -92983,7 +92805,7 @@ aCk
 aaB
 dhe
 dhe
-gGw
+dhe
 dhe
 dhe
 aEc
@@ -95547,7 +95369,7 @@ dhe
 dhe
 dhe
 dhe
-fke
+dhe
 aaB
 acg
 vzN
@@ -96838,7 +96660,7 @@ vLw
 aGF
 aBM
 aBM
-oHN
+dhe
 dhe
 dhe
 aHH
@@ -97337,7 +97159,7 @@ gOH
 wZm
 dhe
 dhe
-snC
+dhe
 aGF
 lPJ
 aac
@@ -100659,7 +100481,7 @@ dhe
 dhe
 dhe
 dhe
-fQq
+dhe
 dhe
 dhe
 amK
@@ -101431,7 +101253,7 @@ dhe
 dhe
 dhe
 dhe
-cwD
+dhe
 dhe
 amK
 ahC
@@ -102198,7 +102020,7 @@ dhe
 dhe
 dhe
 dhe
-nCD
+dhe
 dhe
 dhe
 dhe
@@ -103742,7 +103564,7 @@ dhe
 dhe
 dhe
 dhe
-eQL
+dhe
 dhe
 dhe
 dhe
@@ -103994,7 +103816,7 @@ aBM
 aBM
 dhe
 dhe
-qII
+dhe
 dhe
 dhe
 dhe
@@ -104264,7 +104086,7 @@ dhe
 dhe
 dhe
 dhe
-toO
+dhe
 dhe
 dhe
 dhe
@@ -105030,7 +104852,7 @@ dhe
 dhe
 dhe
 dhe
-uux
+dhe
 dhe
 dhe
 dhe
@@ -161316,7 +161138,7 @@ aBM
 dhe
 dhe
 dhe
-rjE
+dhe
 dhe
 dhe
 aFF
@@ -167224,7 +167046,7 @@ aYr
 aBM
 aBM
 dhe
-mYX
+dhe
 dhe
 amK
 mWs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

We merged a big PR and made a little mess on some of the maps.

Also does Kilo and Tram and a ruin because I found more.

This should be speed merged along with forthcoming PRs on Ice and Delta.
## Why It's Good For The Game

Having to deal with merge conflicts is bad enough. Making us look at them in game is going too far.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The merge conflict markers have been cleaned up on Metastation
fix: The merge conflict markers have been cleaned out of Tram's walls
fix: One lonely merge conflict marker cleaned out of Kilo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
