### PR TITLE
Cleans up mapmerge artifacts on Delta and Icebox

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -64083,15 +64083,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/three,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mZk" = (
@@ -65819,17 +65810,6 @@
 /turf/open/floor/iron/dark,
 /area/service/electronic_marketing_den)
 "nuS" = (
-/obj/structure/closet/crate,
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/obj/effect/spawner/random/contraband/prison,
-/obj/item/instrument/harmonica,
-/obj/item/storage/dice,
-/obj/item/toy/cards/deck/tarot,
-/obj/machinery/light/directional/south,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/closet/crate,
 /obj/item/toy/beach_ball/holoball/dodgeball,
 /obj/item/toy/beach_ball/holoball/dodgeball,
@@ -79623,12 +79603,6 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "rzw" = (
-/obj/structure/table/wood/poker,
-/obj/item/storage/dice,
-/obj/effect/spawner/random/entertainment/money_large,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/table/wood/poker,
 /obj/item/storage/dice,
 /obj/effect/spawner/random/entertainment/money_large,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -44170,16 +44170,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -54074,9 +54064,9 @@
 	req_access_txt = "20"
 	},
 /obj/effect/spawner/random/aimodule/harmful{
-	spawn_loot_split = 1;
 	spawn_loot_count = 2;
-	spawn_loot_double = 0
+	spawn_loot_double = 0;
+	spawn_loot_split = 1
 	},
 /obj/item/ai_module/supplied/oxygen{
 	pixel_x = -3;
@@ -54329,9 +54319,9 @@
 	req_access_txt = "20"
 	},
 /obj/effect/spawner/random/aimodule/harmless{
-	spawn_loot_split = 1;
 	spawn_loot_count = 3;
-	spawn_loot_double = 0
+	spawn_loot_double = 0;
+	spawn_loot_split = 1
 	},
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
@@ -56058,15 +56048,6 @@
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "kIl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/crate,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/crate,
@@ -93824,9 +93805,9 @@
 "vIl" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/aimodule/neutral{
-	spawn_loot_split = 1;
 	spawn_loot_count = 3;
-	spawn_loot_double = 0
+	spawn_loot_double = 0;
+	spawn_loot_split = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -16156,13 +16156,6 @@
 "dUj" = (
 /turf/open/floor/iron/grimy,
 /area/maintenance/aft)
-"dUY" = (
-/obj/effect/spawner/random/structure/crate,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/closed/wall,
-/area/maintenance/starboard/aft)
 "dVc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -18048,17 +18041,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"fct" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
-/obj/item/poster/random_contraband,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "fcy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -18761,16 +18743,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"fuE" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/three,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "fuL" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
@@ -19609,19 +19581,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/command/heads_quarters/rd)
-"fSc" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/spawner/random/entertainment/drugs,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "fSi" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/yellow,
@@ -28642,13 +28601,6 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "kRx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/spawner/random/maintenance,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/effect/spawner/random/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28785,11 +28737,6 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "kXI" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/two,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/two,
 /obj/structure/disposalpipe/segment{
@@ -34657,17 +34604,6 @@
 "ojz" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/machinery/light/small/directional/north,
-/obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35115,10 +35051,6 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "ovY" = (
-/obj/effect/spawner/random/maintenance,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/effect/spawner/random/maintenance,
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -37671,14 +37603,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/medbay/central)
-"pJc" = (
-/obj/effect/spawner/random/maintenance,
-/obj/structure/closet/cardboard,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "pJf" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
@@ -39677,12 +39601,6 @@
 "qNY" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/table/greyscale,
-/obj{
-	name = "---Merge conflict marker---"
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/spawner/random/maintenance,
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -40077,10 +39995,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "raC" = (
-/obj/effect/spawner/random/maintenance,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/effect/spawner/random/maintenance,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -42236,17 +42150,6 @@
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "sgt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/structure/table/greyscale,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/cable,
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43750,10 +43653,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "sVT" = (
-/obj/effect/spawner/random/structure/crate,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45337,10 +45236,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tRa" = (
-/obj/effect/spawner/random/trash/mess,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/effect/spawner/random/trash/mess,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -47227,12 +47122,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uLx" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random/maintenance/four,
-/obj/structure/closet/crate/maint,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/effect/spawner/random/maintenance/four,
 /obj/structure/closet/crate/maint,
 /turf/open/floor/plating,
@@ -48270,12 +48159,6 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "vyj" = (
-/obj/structure/rack,
-/obj/machinery/light/small/directional/north,
-/obj/effect/spawner/random/maintenance,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/structure/rack,
 /obj/machinery/light/small/directional/north,
 /obj/effect/spawner/random/maintenance,
@@ -50415,10 +50298,6 @@
 /turf/open/floor/iron,
 /area/maintenance/department/electrical)
 "wGW" = (
-/obj/effect/spawner/random/trash/mess,
-/obj{
-	name = "---Merge conflict marker---"
-	},
 /obj/effect/spawner/random/trash/mess,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -75365,7 +75244,7 @@ cfV
 boP
 boP
 bLv
-pJc
+bHE
 fGn
 wDC
 rDP
@@ -85894,7 +85773,7 @@ aXf
 lBV
 lBV
 sMQ
-fSc
+ltH
 mPS
 ltH
 aQp
@@ -86666,8 +86545,8 @@ bCA
 lBV
 rON
 qsk
-fuE
-fct
+biq
+biq
 aQp
 sSC
 eZu
@@ -99799,7 +99678,7 @@ cNW
 cNW
 cvO
 cNW
-dUY
+cNW
 isx
 oTL
 viq


### PR DESCRIPTION
## About The Pull Request

#60522 Gave us bad artifacts from a mapmerge. This resolves those on two of our stations.

## Why It's Good For The Game

AAAAAAAAAAAAA

## Changelog

:cl:
fix: Icebox and Deltastation should no longer contain Mapmerge Artifacts. Still, if you spot one that we somehow missed, make an issue report, and we'll do our best to get to it. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
