### PR TITLE
Fixes neglected fern cell ine amounts + reverts undocumented crate spawner change that removed my brand new fern from the game.

### DIFF
--- a/code/game/objects/effects/spawners/random/structure.dm
+++ b/code/game/objects/effects/spawners/random/structure.dm
@@ -6,14 +6,14 @@
 	name = "crate spawner"
 	icon_state = "crate"
 	loot = list(
-		/obj/effect/spawner/random/structure/crate_empty = 75,
-		/obj/structure/closet/crate/trashcart/filled = 7,
-		/obj/effect/spawner/random/trash/moisture_trap = 5,
-		/obj/effect/spawner/random/trash/hobo_squat = 3,
-		/obj/structure/closet/mini_fridge = 3,
-		/obj/item/kirbyplants/random = 3,
-		/obj/effect/spawner/random/trash/mess = 3,
-		/obj/structure/closet/crate/decorations = 1,
+		/obj/effect/spawner/random/structure/crate_loot = 745,
+		/obj/structure/closet/crate/trashcart/filled = 75,
+		/obj/effect/spawner/random/trash/moisture_trap = 50,
+		/obj/effect/spawner/random/trash/hobo_squat = 30,
+		/obj/structure/closet/mini_fridge = 35,
+		/obj/item/kirbyplants/fern = 20,
+		/obj/effect/spawner/random/trash/mess = 30,
+		/obj/structure/closet/crate/decorations = 15,
 	)
 
 /obj/effect/spawner/random/structure/crate_abandoned

--- a/code/game/objects/effects/spawners/random/structure.dm
+++ b/code/game/objects/effects/spawners/random/structure.dm
@@ -11,8 +11,8 @@
 		/obj/effect/spawner/random/trash/moisture_trap = 50,
 		/obj/effect/spawner/random/trash/hobo_squat = 30,
 		/obj/structure/closet/mini_fridge = 35,
-		/obj/item/kirbyplants/fern = 20,
 		/obj/effect/spawner/random/trash/mess = 30,
+		/obj/item/kirbyplants/fern = 20,
 		/obj/structure/closet/crate/decorations = 15,
 	)
 

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -400,7 +400,7 @@
 
 /obj/item/kirbyplants/fern/Initialize()
 	. = ..()
-	AddElement(/datum/element/swabable, CELL_LINE_TABLE_ALGAE, CELL_VIRUS_TABLE_GENERIC, 1, 5)
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_ALGAE, CELL_VIRUS_TABLE_GENERIC, rand(2,4), 5)
 
 //a rock is flora according to where the icon file is
 //and now these defines


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the amount of cell lines on the neglected fern sample to the intended 2 to 4 cell lines.

This is not a balance change since the neglected fern is currently unobtainable due to another contributor accidentally removing it from the loot table hours after my PR was merged.

This brings us to the second fix. 

This PR also reverts the undocumented changes to the crate spawner(formerly loot site spawner). 

This makes the fern spawn ingame again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People who were excited for new cytology content can finally enjoy it and also open maintenance crates  that actually have loot in them. 

The change to crate spawner should have been documented properly as it was big balance change rather than a faithful refactor.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The crate spawner spawns full crates rather than empty ones again.
fix:The neglected fern can actually spawn now
fix: The neglected fern now has the standard 2-4 cell ines per sample rather than 1. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
