### PR TITLE
Re-add camera mobs as observable points of interest

### DIFF
--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -1,5 +1,4 @@
 // Camera mob, used by AI camera and blob.
-
 /mob/camera
 	name = "camera mob"
 	density = FALSE
@@ -11,6 +10,10 @@
 	invisibility = INVISIBILITY_ABSTRACT // No one can see us
 	sight = SEE_SELF
 	move_on_shuttle = FALSE
+
+/mob/camera/Initialize(mapload)
+	. = ..()
+	SSpoints_of_interest.make_point_of_interest(src)
 
 /mob/camera/experience_pressure_difference()
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The living can be points of interest.

The dead can be points of interest, except when they're on the lobby screen.

Nobody thought of the cameras. The poor cameras cannot be points of interest. This travesty cannot be allowed to stand.

Makes /mob/camera a point of interest, allowing them to appear on observe and orbit menus the same way /mob/living and certain /mob/dead can be.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Easily orbit AI eyes and blob eyes again.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Players can once again select AI eyes and blob eyes from the various orbit, observe and jump menus.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
