### PR TITLE
Makes plasmaman envirosuits actually impermeable.

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -45,6 +45,7 @@
 	flash_protect = FLASH_PROTECTION_WELDER
 	tint = 2
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, RAD = 0, FIRE = 100, ACID = 75)
+	permeability_coefficient = 0.05
 	resistance_flags = FIRE_PROOF
 	light_system = MOVABLE_LIGHT_DIRECTIONAL
 	light_range = 4

--- a/code/modules/clothing/under/jobs/Plasmaman/civilian_service.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/civilian_service.dm
@@ -10,6 +10,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	can_adjust = FALSE
 	strip_delay = 80
+	permeability_coefficient = 0.05
 	var/next_extinguish = 0
 	var/extinguish_cooldown = 100
 	var/extinguishes_left = 5


### PR DESCRIPTION
Fixes #61423 

## About The Pull Request

Plasmaman envirosuits now have a permeability coefficient of 0.05, making them resistant to touch diseases.
This is to fix the fact that a fully impenetrable envirosuit with 100% airborne disease resistance somehow lets diseases pass right through if its via touch.

Also you can tell its a consistency fix when the gloves already have a 0.05 coefficient.

## Why It's Good For The Game

Envirosuits actually protect you from diseases now, even if in most cases this can be a negative as infecting plasmamen requires inorganic biology.

## Changelog

:cl:
fix: Plasmaman envirosuits now have impermeability on them.
/:cl:

this is like the weird middle point between a balance change and a fix because it changes balance a bit but its also a clearly intended thing that was missing