### PR TITLE
Fixes the auxiliary base construction console.

### DIFF
--- a/code/game/objects/structures/construction_console/construction_console.dm
+++ b/code/game/objects/structures/construction_console/construction_console.dm
@@ -112,14 +112,14 @@
 	var/obj/machinery/computer/camera_advanced/base_construction/linked_console
 
 /mob/camera/ai_eye/remote/base_construction/Initialize(mapload, obj/machinery/computer/camera_advanced/console_link)
+	linked_console = console_link
 	if(!linked_console)
 		stack_trace("A base consturuction drone was created with no linked console")
 		return INITIALIZE_HINT_QDEL
-	linked_console = console_link
 	return ..()
 
-/mob/camera/ai_eye/remote/base_construction/setLoc(t)
-	var/area/curr_area = get_area(t)
+/mob/camera/ai_eye/remote/base_construction/setLoc(destination)
+	var/area/curr_area = get_area(destination)
 	//Only move if we're in the allowed area. If no allowed area is defined, then we're free to move wherever.
 	if(!linked_console.allowed_area || istype(curr_area, linked_console.allowed_area))
 		return ..()


### PR DESCRIPTION
Closes #61241 

## About The Pull Request

This PR fixes the auxiliary base construction console so it actually works. Base construction consoles in general work now, but thats the only one you can actually use ingame without admin shenanigans.

Turns out some doofus was qdeling the console for not being linked before it was getting linked. Also in the process of finding that blunder, i updated setloc to use the standardized destination tag.

## Why It's Good For The Game

![https://i.imgur.com/JHXGUuU.png](https://i.imgur.com/JHXGUuU.png)
You can actually use the feature now.

## Changelog

:cl:
fix: Auxiliary base construction consoles now work, instead of deleting the drone before it exists.
/:cl: