### PR TITLE
Traitors who aren't meant to get codewords, will no longer get them.

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -213,7 +213,7 @@
 
 /datum/antagonist/traitor/ui_static_data(mob/user)
 	var/list/data = list()
-	data["has_codewords"] = should_give_codewords ? TRUE : FALSE
+	data["has_codewords"] = should_give_codewords
 	if(should_give_codewords)
 		data["phrases"] = jointext(GLOB.syndicate_code_phrase, ", ")
 		data["responses"] = jointext(GLOB.syndicate_code_response, ", ")

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -198,8 +198,9 @@
 
 	add_antag_hud(antag_hud_type, antag_hud_name, datum_owner)
 	handle_clown_mutation(datum_owner, mob_override ? null : "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
-	datum_owner.AddComponent(/datum/component/codeword_hearing, GLOB.syndicate_code_phrase_regex, "blue", src)
-	datum_owner.AddComponent(/datum/component/codeword_hearing, GLOB.syndicate_code_response_regex, "red", src)
+	if(should_give_codewords)
+		datum_owner.AddComponent(/datum/component/codeword_hearing, GLOB.syndicate_code_phrase_regex, "blue", src)
+		datum_owner.AddComponent(/datum/component/codeword_hearing, GLOB.syndicate_code_response_regex, "red", src)
 
 /datum/antagonist/traitor/remove_innate_effects(mob/living/mob_override)
 	. = ..()
@@ -212,8 +213,10 @@
 
 /datum/antagonist/traitor/ui_static_data(mob/user)
 	var/list/data = list()
-	data["phrases"] = jointext(GLOB.syndicate_code_phrase, ", ")
-	data["responses"] = jointext(GLOB.syndicate_code_response, ", ")
+	data["has_codewords"] = should_give_codewords ? TRUE : FALSE
+	if(should_give_codewords)
+		data["phrases"] = jointext(GLOB.syndicate_code_phrase, ", ")
+		data["responses"] = jointext(GLOB.syndicate_code_response, ", ")
 	data["theme"] = traitor_flavor["ui_theme"]
 	data["code"] = uplink?.unlock_code
 	data["failsafe_code"] = uplink?.failsafe_code
@@ -226,26 +229,6 @@
 		data["uplink_unlock_info"] = uplink.unlock_text
 	data["objectives"] = get_objectives()
 	return data
-
-/// Outputs this shift's codewords and responses to the antag's chat and copies them to their memory.
-/datum/antagonist/traitor/proc/give_codewords()
-	if(!owner.current)
-		return
-
-	var/mob/traitor_mob = owner.current
-
-	var/phrases = jointext(GLOB.syndicate_code_phrase, ", ")
-	var/responses = jointext(GLOB.syndicate_code_response, ", ")
-
-	to_chat(traitor_mob, "<U><B>The Syndicate have provided you with the following codewords to identify fellow agents:</B></U>")
-	to_chat(traitor_mob, "<B>Code Phrase</B>: [span_blue("[phrases]")]")
-	to_chat(traitor_mob, "<B>Code Response</B>: [span_red("[responses]")]")
-
-	antag_memory += "<b>Code Phrase</b>: [span_blue("[phrases]")]<br>"
-	antag_memory += "<b>Code Response</b>: [span_red("[responses]")]<br>"
-
-	to_chat(traitor_mob, "Use the codewords during regular conversation to identify other agents. Proceed with caution, however, as everyone is a potential foe.")
-	to_chat(traitor_mob, span_alertwarning("You memorize the codewords, allowing you to recognise them when heard."))
 
 /datum/antagonist/traitor/roundend_report()
 	var/list/result = list()

--- a/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
@@ -26,6 +26,7 @@ type Objective = {
 }
 
 type Info = {
+  has_codewords: string;
   phrases: string;
   responses: string;
   theme: string;
@@ -175,42 +176,55 @@ const UplinkSection = (props, context) => {
 const CodewordsSection = (props, context) => {
   const { data } = useBackend<Info>(context);
   const {
+    has_codewords,
     phrases,
     responses,
   } = data;
   return (
-    <Section title="Codewords">
+    <Section
+      title="Codewords"
+      mb={!has_codewords && -1}>
       <Stack fill>
-        <Stack.Item grow basis={0}>
+        {!has_codewords && (
           <BlockQuote>
-            The Syndicate have provided you with the following
-            codewords to identify fellow agents. Use the codewords
-            during regular conversation to identify other agents.
-            Proceed with caution, however, as everyone is a
-            potential foe.
-            <span style={badstyle}>
-              &ensp;You have memorized the codewords, allowing you
-              to recognise them when heard.
-            </span>
+            You have not been supplied the Syndicate codewords.
+            You will have to use alternative methods to find potential allies.
+            Proceed with caution, however, as everyone is a potential foe.
           </BlockQuote>
-        </Stack.Item>
-        <Stack.Divider mr={1} />
-        <Stack.Item grow basis={0}>
-          <Stack vertical>
-            <Stack.Item>
-              Code Phrases:
+        ) || (
+          <>
+            <Stack.Item grow basis={0}>
+              <BlockQuote>
+                The Syndicate have provided you with the following
+                codewords to identify fellow agents. Use the codewords
+                during regular conversation to identify other agents.
+                Proceed with caution, however, as everyone is a
+                potential foe.
+                <span style={badstyle}>
+                  &ensp;You have memorized the codewords, allowing you
+                  to recognise them when heard.
+                </span>
+              </BlockQuote>
             </Stack.Item>
-            <Stack.Item bold textColor="blue">
-              {phrases}
+            <Stack.Divider mr={1} />
+            <Stack.Item grow basis={0}>
+              <Stack vertical>
+                <Stack.Item>
+                  Code Phrases:
+                </Stack.Item>
+                <Stack.Item bold textColor="blue">
+                  {phrases}
+                </Stack.Item>
+                <Stack.Item>
+                  Code Responses:
+                </Stack.Item>
+                <Stack.Item bold textColor="red">
+                  {responses}
+                </Stack.Item>
+              </Stack>
             </Stack.Item>
-            <Stack.Item>
-              Code Responses:
-            </Stack.Item>
-            <Stack.Item bold textColor="red">
-              {responses}
-            </Stack.Item>
-          </Stack>
-        </Stack.Item>
+          </>
+        )}
       </Stack>
     </Section>
   );

--- a/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
@@ -26,7 +26,7 @@ type Objective = {
 }
 
 type Info = {
-  has_codewords: string;
+  has_codewords: BooleanLike;
   phrases: string;
   responses: string;
   theme: string;


### PR DESCRIPTION
## About The Pull Request

This has been a bug since before I knew how github worked, and I've been working on IAA recently, but thought this was a good change to do on its own.
This also possibly allows future PRs to have certain factions not get codewords, if that's something anyone is interested in.

This also removes give_codewords() - I think this was added specifically for Malf AI, but since that has been split into its own Antagonist, it was never used and was just sitting idle without reason to exist.

And finally, this is my first time genuinely working with TGUI, this PR my excuse to start learning it.

This is what the menu looks like when not given an uplink;
![image](https://user-images.githubusercontent.com/53777086/134788369-9f361493-7e9a-48b3-91b7-f6c2b4157348.png)

## Why It's Good For The Game

We have a var on whether to give codewords or not, but they get them regardless, which is dumb.

## Changelog

:cl:
fix: Traitors who aren't given codewords will no longer notice them when said or have them in their antag menu.
/:cl: