### PR TITLE
Fix maint loot spawners not deleting after roundstart/spawning their loot.

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -599,4 +599,4 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		CHECK_TICK
 
 		spawner.spawn_loot()
-		spawner.hide()
+		qdel(spawner)

--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -12,14 +12,19 @@
 /obj/effect/spawner/random/maintenance/Initialize(mapload)
 	loot = GLOB.maintenance_loot
 
-	// Late loaded templates like shuttles can have maintenance loot.
-	// Once the game state progresses to roundstart, new maint loot spawners should just instantly pop.
-	if(SSticker.current_state >= GAME_STATE_SETTING_UP)
-		spawn_on_init = TRUE
-
 	. = ..()
 
 	GLOB.maintenance_loot_spawners += src
+
+/obj/effect/spawner/random/maintenance/should_spawn_on_init()
+	. = ..()
+
+	if(.)
+		return
+
+	// Late loaded templates like shuttles can have maintenance loot.
+	// Once the game state progresses to roundstart, new maint loot spawners should just instantly pop.
+	return (SSticker.current_state >= GAME_STATE_SETTING_UP)
 
 /obj/effect/spawner/random/maintenance/Destroy()
 	GLOB.maintenance_loot_spawners -= src

--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -19,11 +19,6 @@
 
 	. = ..()
 
-	// If parent Initialize is calling for us to qdel, we can just return early.
-	if(. == INITIALIZE_HINT_QDEL || . == INITIALIZE_HINT_QDEL_FORCE)
-		return
-
-	// Otherwise we hang around until SSmapping spawns us in OnRoundstart and deletes us.
 	GLOB.maintenance_loot_spawners += src
 
 /obj/effect/spawner/random/maintenance/Destroy()

--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -10,6 +10,8 @@
 	. += span_info("This spawner has an effective loot count of [get_effective_lootcount()].")
 
 /obj/effect/spawner/random/maintenance/Initialize(mapload)
+	loot = GLOB.maintenance_loot
+
 	// Late loaded templates like shuttles can have maintenance loot.
 	// Once the game state progresses to roundstart, new maint loot spawners should just instantly pop.
 	if(SSticker.current_state >= GAME_STATE_SETTING_UP)
@@ -23,7 +25,6 @@
 
 	// Otherwise we hang around until SSmapping spawns us in OnRoundstart and deletes us.
 	GLOB.maintenance_loot_spawners += src
-	loot = GLOB.maintenance_loot
 
 /obj/effect/spawner/random/maintenance/Destroy()
 	GLOB.maintenance_loot_spawners -= src

--- a/code/game/objects/effects/spawners/random/maintenance.dm
+++ b/code/game/objects/effects/spawners/random/maintenance.dm
@@ -10,16 +10,20 @@
 	. += span_info("This spawner has an effective loot count of [get_effective_lootcount()].")
 
 /obj/effect/spawner/random/maintenance/Initialize(mapload)
+	// Late loaded templates like shuttles can have maintenance loot.
+	// Once the game state progresses to roundstart, new maint loot spawners should just instantly pop.
+	if(SSticker.current_state >= GAME_STATE_SETTING_UP)
+		spawn_on_init = TRUE
+
 	. = ..()
-	// There is a single callback in SSmapping to spawn all delayed maintenance loot
-	// so we don't just make one callback per loot spawner
+
+	// If parent Initialize is calling for us to qdel, we can just return early.
+	if(. == INITIALIZE_HINT_QDEL || . == INITIALIZE_HINT_QDEL_FORCE)
+		return
+
+	// Otherwise we hang around until SSmapping spawns us in OnRoundstart and deletes us.
 	GLOB.maintenance_loot_spawners += src
 	loot = GLOB.maintenance_loot
-
-	// Late loaded templates like shuttles can have maintenance loot
-	if(SSticker.current_state >= GAME_STATE_SETTING_UP)
-		spawn_loot()
-		hide()
 
 /obj/effect/spawner/random/maintenance/Destroy()
 	GLOB.maintenance_loot_spawners -= src

--- a/code/game/objects/effects/spawners/random/random.dm
+++ b/code/game/objects/effects/spawners/random/random.dm
@@ -33,9 +33,13 @@
 /obj/effect/spawner/random/Initialize(mapload)
 	. = ..()
 
-	if(spawn_on_init)
+	if(should_spawn_on_init())
 		spawn_loot()
 		return INITIALIZE_HINT_QDEL
+
+/// Helper proc that returns TRUE if the spawner should spawn loot in Initialise() and FALSE otherwise. Override this to change spawning behaviour.
+/obj/effect/spawner/random/proc/should_spawn_on_init()
+	return spawn_on_init
 
 ///If the spawner has any loot defined, randomly picks some and spawns it. Does not cleanup the spawner.
 /obj/effect/spawner/random/proc/spawn_loot(lootcount_override)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Maint loot spawners hang around and never get qdeleted after spawning their loot.

This does a little bit of simple code logic to limit copypasta and ensure that loot spawners never qdel late and that they qdel precisely when they intend to. Or when SSmapping intends for them to.

## Testing

Push button to start the round on Metastation.
![PiKMgGXCD1](https://user-images.githubusercontent.com/24975989/134788753-ed5c8cf0-f1a3-41c8-9963-77b136b5e28f.gif)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

These spawners only fire once and I don't believe they were ever intended to hang around after the shift started.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Observers will no longer see ghost icons representing Maintenance Loot Spawners of Roundstart Past once the round has actually started.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
