### PR TITLE
Getting hit by the tram will now smash people through lattice and unplated flooring

### DIFF
--- a/code/game/objects/structures/industrial_lift.dm
+++ b/code/game/objects/structures/industrial_lift.dm
@@ -286,7 +286,8 @@ GLOBAL_LIST_EMPTY(lifts)
 
 			collided.throw_at()
 			//if going EAST, will turn to the NORTHEAST or SOUTHEAST and throw the ran over guy away
-			collided.throw_at(throw_target, 200, 4)
+			var/datum/callback/land_slam = new(collided, /mob/living/.proc/tram_slam_land)
+			collided.throw_at(throw_target, 200, 4, callback = land_slam)
 	forceMove(destination)
 	for(var/atom/movable/thing as anything in things2move)
 		thing.forceMove(destination)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2155,11 +2155,11 @@
 	return exp_list
 
 /**
-  * A proc triggered by callback when someone gets slammed by the tram and lands somewhere.
-  *
-  * This proc is used to force people to fall through things like lattice and unplated flooring at the expense of some
-  * extra damage, so jokers can't use half a stack of iron rods to make getting hit by the tram immediately lethal.
-  */
+ * A proc triggered by callback when someone gets slammed by the tram and lands somewhere.
+ *
+ * This proc is used to force people to fall through things like lattice and unplated flooring at the expense of some
+ * extra damage, so jokers can't use half a stack of iron rods to make getting hit by the tram immediately lethal.
+ */
 /mob/living/proc/tram_slam_land()
 	if(!istype(loc, /turf/open/openspace) && !istype(loc, /turf/open/floor/plating))
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2153,3 +2153,28 @@
 		exp_list[mind.assigned_role.title] = minutes
 
 	return exp_list
+
+/**
+  * A proc triggered by callback when someone gets slammed by the tram and lands somewhere.
+  *
+  * This proc is used to force people to fall through things like lattice and unplated flooring at the expense of some
+  * extra damage, so jokers can't use half a stack of iron rods to make getting hit by the tram immediately lethal.
+  */
+/mob/living/proc/tram_slam_land()
+	if(!istype(loc, /turf/open/openspace) && !istype(loc, /turf/open/floor/plating))
+		return
+
+	if(istype(loc, /turf/open/floor/plating))
+		var/turf/open/floor/smashed_plating = loc
+		visible_message(span_danger("[src] is thrown violently into [smashed_plating], smashing through it and punching straight through!"),
+				span_userdanger("You're thrown violently into [smashed_plating], smashing through it and punching straight through!"))
+		apply_damage(rand(5,20), BRUTE, BODY_ZONE_CHEST)
+		smashed_plating.ScrapeAway(1, CHANGETURF_INHERIT_AIR)
+
+	for(var/atom/iter_atom as anything in loc)
+		if(istype(iter_atom, /obj/structure/lattice))
+			visible_message(span_danger("[src] is thrown violently into [iter_atom], smashing through it and punching straight through!"),
+				span_userdanger("You're thrown violently into [iter_atom], smashing through it and punching straight through!"))
+			apply_damage(rand(5,10), BRUTE, BODY_ZONE_CHEST)
+			var/obj/structure/bye_bye = iter_atom
+			bye_bye.deconstruct(FALSE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2171,10 +2171,8 @@
 		apply_damage(rand(5,20), BRUTE, BODY_ZONE_CHEST)
 		smashed_plating.ScrapeAway(1, CHANGETURF_INHERIT_AIR)
 
-	for(var/atom/iter_atom as anything in loc)
-		if(istype(iter_atom, /obj/structure/lattice))
-			visible_message(span_danger("[src] is thrown violently into [iter_atom], smashing through it and punching straight through!"),
-				span_userdanger("You're thrown violently into [iter_atom], smashing through it and punching straight through!"))
-			apply_damage(rand(5,10), BRUTE, BODY_ZONE_CHEST)
-			var/obj/structure/bye_bye = iter_atom
-			bye_bye.deconstruct(FALSE)
+	for(var/obj/structure/lattice/lattice in loc)
+		visible_message(span_danger("[src] is thrown violently into [lattice], smashing through it and punching straight through!"),
+			span_userdanger("You're thrown violently into [lattice], smashing through it and punching straight through!"))
+		apply_damage(rand(5,10), BRUTE, BODY_ZONE_CHEST)
+		lattice.deconstruct(FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A common administrative issue and general gripe about Tramstation is the practice of players using lattice or floor tiles to cover up the big open pits people fall down when they're hit by the tram, making it so they're doomed to get hit again and again and again, racking up massive damage and quickly becoming lethal. This PR changes the tram to cause people it hits to smash right through lattice or unplated flooring, suffering some additional damage along the way. 

[![2021-09-25_22-58-58.png](https://i.imgur.com/USQgQzTl.jpg)](https://i.imgur.com/USQgQzT.png)

If you still want to see people get memed to hell, you can simply take the extra time to add plating to the floor tiles, but at least then admins know that you're purposely trying to get people killed and not just a naïve person thinking that keeping people from falling to the z-level below improves safety rather than massively decreases it.

[![Discord_2021-09-25_23-22-00.png](https://i.imgur.com/3ZOXZDsl.jpg)](https://i.imgur.com/3ZOXZDs.png)
Support from the resident tram expert, @tralezab 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hopefully reigns in the tram's extreme lethality when players modify the environment in certain ways
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Ryll/Shaps
balance: Getting hit by the tram and landing on lattice or unplated flooring (on the upper z-level) will now cause you to smash through it and fall to the z-level below at the cost of taking some extra damage. Note that floors with plating will still hold steady, so you can still use flooring to make getting hit by the tram insanely lethal, it just takes a bit more effort.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
