### PR TITLE
Lets admins cancel out of sending an announcement

### DIFF
--- a/code/modules/admin/verbs/admin.dm
+++ b/code/modules/admin/verbs/admin.dm
@@ -33,7 +33,7 @@
 	if(!check_rights(0))
 		return
 
-	var/message = input("Global message to send:", "Admin Announce", null, null)  as message
+	var/message = input("Global message to send:", "Admin Announce", null, null)  as message|null
 	if(message)
 		if(!check_rights(R_SERVER,0))
 			message = adminscrub(message,500)


### PR DESCRIPTION
## About The Pull Request

This has been a constant problem for as long as I can remember, admins who accidentally press the announce button cant cancel out of it, instead you just have to send it as an empty message to not have it sent.

## Why It's Good For The Game

It hurts my eyes to see this, it's bugged me every time I've accidentally clicked on it.

## Changelog

:cl:
admin: Admins can now cancel out of sending an announcement.
/:cl: