### PR TITLE
Fixes contractor drop pods not being clickable due to suspected BYOND issue.

### DIFF
--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -612,8 +612,6 @@
 /obj/effect/pod_landingzone/proc/beginLaunch(effectCircle) //Begin the animation for the pod falling. The effectCircle param determines whether the pod gets to come in from any descent angle
 	pod.addGlow()
 	pod.update_appearance()
-	if (pod.style != STYLE_INVISIBLE)
-		pod.add_filter("motionblur",1,list("type"="motion_blur", "x"=0, "y"=3))
 	pod.forceMove(drop_location())
 	for (var/mob/living/M in pod) //Remember earlier (initialization) when we moved mobs into the pod_landingzone so they wouldnt get lost in nullspace? Time to get them out
 		M.reset_perspective(null)
@@ -625,8 +623,7 @@
 	pod.transform = matrix().Turn(rotation)
 	pod.layer = FLY_LAYER
 	if (pod.style != STYLE_INVISIBLE)
-		animate(pod.get_filter("motionblur"), y = 0, time = pod.delays[POD_FALLING], flags = ANIMATION_PARALLEL)
-		animate(pod, pixel_z = -1 * abs(sin(rotation))*4, pixel_x = SUPPLYPOD_X_OFFSET + (sin(rotation) * 20), time = pod.delays[POD_FALLING], easing = LINEAR_EASING, flags = ANIMATION_PARALLEL) //Make the pod fall! At an angle!
+		animate(pod, pixel_z = -1 * abs(sin(rotation))*4, pixel_x = SUPPLYPOD_X_OFFSET + (sin(rotation) * 20), time = pod.delays[POD_FALLING], easing = LINEAR_EASING) //Make the pod fall! At an angle!
 	addtimer(CALLBACK(src, .proc/endLaunch), pod.delays[POD_FALLING], TIMER_CLIENT_TIME) //Go onto the last step after a very short falling animation
 
 /obj/effect/pod_landingzone/proc/setupSmoke(rotation)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #61695

When breaking the entire problem down, I identified the point in time at which the pod stopped being clickable

![XXZj4daPPN](https://user-images.githubusercontent.com/24975989/134827518-058739f9-25e1-43bc-9b41-56439b6e19ca.gif)

Then set a line-by-line delay to find the exact line of code that caused it, which was this code resetting the pod's transformation matrix:
![image](https://user-images.githubusercontent.com/24975989/134826908-69b08d94-3604-4901-8a22-b6e7839bbebd.png)

The second `transform = matrix()` is called, the pod becomes unclickable.

I did some byond issue searching and found this:
http://www.byond.com/forum/post/2238889
![image](https://user-images.githubusercontent.com/24975989/134826947-2956689f-cc89-4295-abbd-307d4545ff88.png)

Modifying the pod's translation matrix (for example, apply a +1x, +1y translation matrix) made the pod clickable again. Undoing this (applying -1x, -1y translation matrix) so the pod's transformation matrix was effectively identity again made it unclickable again.

![1ZeiYgedmX](https://user-images.githubusercontent.com/24975989/134827588-ec5d7566-fd64-4b82-8b76-c639cde600fa.gif)

Spawning in pods manually and running their various procs couldn't replicate the issue. As a result, I eliminated pod code as the root cause and focused on the pod_landingzone that control them.

I considered the debris as a possible cause following:
https://github.com/tgstation/tgstation/issues/61695

However, removing the debris actually removed ALL clickable area for the pods. The debris overlap was the only part that let me click on the pods.

So then I set to hacking away at any animation code. At one point I removed both the animates
```
animate(pod.get_filter("motionblur"), y = 0, time = pod.delays[POD_FALLING], flags = ANIMATION_PARALLEL)
animate(pod, pixel_z = -1 * abs(sin(rotation))*4, pixel_x = SUPPLYPOD_X_OFFSET + (sin(rotation) * 20), time = pod.delays[POD_FALLING], easing = LINEAR_EASING, flags = ANIMATION_PARALLEL) //Make the pod fall! At an angle!
```
from `/obj/effect/pod_landingzone/proc/beginLaunch` and the problem still persisted.

When I removed `pod.add_filter("motionblur",1,list("type"="motion_blur", "x"=0, "y"=3))` after this (the effect was permanently on the pod which made it pretty obvious as a possible cause) the problem vanished entirely.

Without the motion blur filter applied, pods now function properly.

As a result, I believe this is a BYOND issue. Someone with more brains than me can probably work out a test case. Until someone with more brains than me comes along to fix it, removing the motion blur filter is my solution.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog


<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Contractor drop pods are now actually clickable and you can place your target into them without having to drag them to the tiny bit of pod where the rubble overlaps it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
