### PR TITLE
AI lawset can't be asimov on unique-lawset station trait shifts

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -263,7 +263,12 @@
 /datum/ai_laws/proc/pick_weighted_lawset()
 	var/datum/ai_laws/lawtype
 	var/list/law_weights = CONFIG_GET(keyed_list/law_weight)
-	law_weights -= /datum/ai_laws/default/asimov
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_UNIQUE_AI))
+		var/list/blacklist = (
+			/datum/ai_laws/default/asimov
+		)
+		for(var/datum/ai_laws/lawset in blacklist)
+			law_weights -= initial(lawset.id)
 	while(!lawtype && law_weights.len)
 		var/possible_id = pickweightAllowZero(law_weights)
 		lawtype = lawid_to_type(possible_id)

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -264,11 +264,12 @@
 	var/datum/ai_laws/lawtype
 	var/list/law_weights = CONFIG_GET(keyed_list/law_weight)
 	while(!lawtype && law_weights.len)
-		var/possible_id = pickweightAllowZero(law_weights)
-		lawtype = lawid_to_type(possible_id)
-		if(!lawtype)
-			law_weights -= possible_id
-			WARNING("Bad lawid in game_options.txt: [possible_id]")
+		if(lawtype != /datum/ai_laws/default/asimov)
+			var/possible_id = pickweightAllowZero(law_weights)
+			lawtype = lawid_to_type(possible_id)
+			if(!lawtype)
+				law_weights -= possible_id
+				WARNING("Bad lawid in game_options.txt: [possible_id]")
 
 	if(!lawtype)
 		WARNING("No LAW_WEIGHT entries.")

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -469,3 +469,10 @@
 			data += "[show_numbers ? "[number]:" : ""] [render_html ? "<font color='#990099'>[law]</font>" : law]"
 			number++
 	return data
+
+#undef AI_LAWS_ASIMOV
+#undef LAW_ZEROTH
+#undef LAW_INHERENT
+#undef LAW_SUPPLIED
+#undef LAW_ION
+#undef LAW_HACKED

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -263,13 +263,13 @@
 /datum/ai_laws/proc/pick_weighted_lawset()
 	var/datum/ai_laws/lawtype
 	var/list/law_weights = CONFIG_GET(keyed_list/law_weight)
+	law_weights -= /datum/ai_laws/default/asimov
 	while(!lawtype && law_weights.len)
-		if(lawtype != /datum/ai_laws/default/asimov)
-			var/possible_id = pickweightAllowZero(law_weights)
-			lawtype = lawid_to_type(possible_id)
-			if(!lawtype)
-				law_weights -= possible_id
-				WARNING("Bad lawid in game_options.txt: [possible_id]")
+		var/possible_id = pickweightAllowZero(law_weights)
+		lawtype = lawid_to_type(possible_id)
+		if(!lawtype)
+			law_weights -= possible_id
+			WARNING("Bad lawid in game_options.txt: [possible_id]")
 
 	if(!lawtype)
 		WARNING("No LAW_WEIGHT entries.")

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -471,8 +471,3 @@
 	return data
 
 #undef AI_LAWS_ASIMOV
-#undef LAW_ZEROTH
-#undef LAW_INHERENT
-#undef LAW_SUPPLIED
-#undef LAW_ION
-#undef LAW_HACKED

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -3,7 +3,7 @@
 #define LAW_SUPPLIED "supplied"
 #define LAW_ION "ion"
 #define LAW_HACKED "hacked"
-
+#define AI_LAWS_ASIMOV "asimov"
 
 /datum/ai_laws
 	var/name = "Unknown Laws"
@@ -36,7 +36,7 @@
 
 /datum/ai_laws/default/asimov
 	name = "Three Laws of Robotics"
-	id = "asimov"
+	id = AI_LAWS_ASIMOV
 	inherent = list("You may not injure a human being or, through inaction, allow a human being to come to harm.",\
 					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
@@ -264,11 +264,7 @@
 	var/datum/ai_laws/lawtype
 	var/list/law_weights = CONFIG_GET(keyed_list/law_weight)
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_UNIQUE_AI))
-		var/list/blacklist = (
-			/datum/ai_laws/default/asimov
-		)
-		for(var/datum/ai_laws/lawset in blacklist)
-			law_weights -= initial(lawset.id)
+		law_weights -= AI_LAWS_ASIMOV
 	while(!lawtype && law_weights.len)
 		var/possible_id = pickweightAllowZero(law_weights)
 		lawtype = lawid_to_type(possible_id)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
-adds a test to the loop that picks a random lawset for the ai on unique lawset rounds that doesnt let it get asimov again
Fixes: #61705 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
-asimov boring, event with different laws fun
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
code: AIs will no longer get the asimov lawset on unique-lawset station trait rounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
