### PR TITLE
Fixes references to now dead gangs in Families objectives.

### DIFF
--- a/code/modules/antagonists/gang/themes.dm
+++ b/code/modules/antagonists/gang/themes.dm
@@ -180,14 +180,14 @@
 	gang_objectives = list(
 
 		/datum/antagonist/gang/saints = "Hey man, welcome to the Third Street Saints! Check out this sweet new pad! \
-		Well it WOULD be a sweet new pad, but we got some rivals to deal with. People don't love us as much as they love those Grove Street fools and those Tunnel Snake greasers. \
+		Well it WOULD be a sweet new pad, but we got some rivals to deal with. People don't love us as much as they love those Tunnel Snake greasers. \
 		We need to make the Third Street Saints the most popular group on the station! \
-		Get rid of those Grove Street and Tunnel Snake kids.",
+		Destroy the reputation of the Tunnel Snakes!",
 
 		/datum/antagonist/gang/tunnel_snakes = "TUNNEL SNAKES RULE!!! \
 		We're the Tunnel Snakes, and we rule! \
-		Make sure the station knows that the Tunnel Snakes RULE!!! And that the other two gangs are LAME and DO NOT RULE! \
-		Get rid of those Third Street Saint and Grove Street cowards."
+		Make sure the station knows that the Tunnel Snakes RULE!!! And that the Saints are LAME and DO NOT RULE! \
+		Destroy the reputation of the Third Street Saints!",
 	)
 
 /datum/gang_theme/steelport_shuffle


### PR DESCRIPTION
## About The Pull Request

Popularity Contest still referenced Grove Street like it's 1995.

## Why It's Good For The Game

Grove Street is no longer Home.

## Changelog

:cl:
spellcheck: Fixed the Popularity Contest theme having references to Grove Street Families, a long since removed Gang.
/:cl:
