### PR TITLE
HFR frontend rework

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
@@ -88,6 +88,10 @@
 	var/efficiency = 0
 	///Hotter air is easier to heat up and cool down
 	var/heat_limiter_modifier = 0
+	///How much the reaction can cool itself
+	var/heat_output_max = 0
+	///How much the reaction can heat itself
+	var/heat_output_min = 0
 	///The amount of heat that is finally emitted, based on the power output. Min and max are variables that depends of the modifier
 	var/heat_output = 0
 
@@ -144,10 +148,16 @@
 	var/last_accent_sound = 0
 
 	///These vars store the temperatures to be used in the GUI
+	var/fusion_temperature_archived = 0
 	var/fusion_temperature = 0
+	var/moderator_temperature_archived = 0
 	var/moderator_temperature = 0
+	var/coolant_temperature_archived = 0
 	var/coolant_temperature = 0
+	var/output_temperature_archived = 0
 	var/output_temperature = 0
+	///Time between current and _archived temperatures
+	var/temperature_period = 1
 	///Var used in the meltdown phase
 	var/final_countdown = FALSE
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -57,7 +57,7 @@
 		waste_remove = FALSE
 		iron_content += 0.02 * power_level * delta_time
 
-	update_temperature_status()
+	update_temperature_status(delta_time)
 
 	//Store the temperature of the gases after one cicle of the fusion reaction
 	var/archived_heat = internal_fusion.temperature
@@ -204,9 +204,9 @@
 	//Hotter air is easier to heat up and cool down
 	heat_limiter_modifier = 10 * (10 ** power_level) * (heating_conductor / 100)
 	//The amount of heat that is finally emitted, based on the power output. Min and max are variables that depends of the modifier
-	heat_output = clamp(internal_instability * power_output * heat_modifier / 100, \
-					- heat_limiter_modifier * 0.01 * negative_temperature_multiplier, \
-					heat_limiter_modifier * positive_temperature_multiplier)
+	heat_output_min = - heat_limiter_modifier * 0.01 * negative_temperature_multiplier
+	heat_output_max = heat_limiter_modifier * positive_temperature_multiplier
+	heat_output = clamp(internal_instability * power_output * heat_modifier / 100, heat_output_min, heat_output_max)
 
 	// Is the fusion process actually going to run?
 	// Note we have to always perform the above calculations to keep the UI updated, so we can't use this to early return.

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -274,8 +274,10 @@
 
 	data["energy_level"] = connected_core.energy
 	data["heat_limiter_modifier"] = connected_core.heat_limiter_modifier
-	data["heat_output"] = abs(connected_core.heat_output)
-	data["heat_output_bool"] = connected_core.heat_output >= 0 ? "" : "-"
+	data["heat_output_min"] = connected_core.heat_output_min
+	data["heat_output_max"] = connected_core.heat_output_max
+	data["heat_output"] = connected_core.heat_output
+	data["instability"] = connected_core.instability
 
 	data["heating_conductor"] = connected_core.heating_conductor
 	data["magnetic_constrictor"] = connected_core.magnetic_constrictor
@@ -296,6 +298,12 @@
 	data["moderator_internal_temperature"] = connected_core.moderator_temperature
 	data["internal_output_temperature"] = connected_core.output_temperature
 	data["internal_coolant_temperature"] = connected_core.coolant_temperature
+
+	data["internal_fusion_temperature_archived"] = connected_core.fusion_temperature_archived
+	data["moderator_internal_temperature_archived"] = connected_core.moderator_temperature_archived
+	data["internal_output_temperature_archived"] = connected_core.output_temperature_archived
+	data["internal_coolant_temperature_archived"] = connected_core.coolant_temperature_archived
+	data["temperature_period"] = connected_core.temperature_period
 
 	data["waste_remove"] = connected_core.waste_remove
 	data["filter_types"] = list()

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -286,6 +286,7 @@
 	data["current_damper"] = connected_core.current_damper
 
 	data["power_level"] = connected_core.power_level
+	data["apc_energy"] = connected_core.get_area_cell_percent()
 	data["iron_content"] = connected_core.iron_content
 	data["integrity"] = connected_core.get_integrity_percent()
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -239,29 +239,33 @@
 	//Internal Fusion gases
 	var/list/fusion_gasdata = list()
 	if(connected_core.internal_fusion.total_moles())
-		for(var/gasid in connected_core.internal_fusion.gases)
+		for(var/gas_type in connected_core.internal_fusion.gases)
+			var/datum/gas/gas = gas_type
 			fusion_gasdata.Add(list(list(
-			"name"= connected_core.internal_fusion.gases[gasid][GAS_META][META_GAS_NAME],
-			"amount" = round(connected_core.internal_fusion.gases[gasid][MOLES], 0.01),
+			"id"= initial(gas.id),
+			"amount" = round(connected_core.internal_fusion.gases[gas][MOLES], 0.01),
 			)))
 	else
-		for(var/gasid in connected_core.internal_fusion.gases)
+		for(var/gas_type in connected_core.internal_fusion.gases)
+			var/datum/gas/gas = gas_type
 			fusion_gasdata.Add(list(list(
-				"name"= connected_core.internal_fusion.gases[gasid][GAS_META][META_GAS_NAME],
+				"id"= initial(gas.id),
 				"amount" = 0,
 				)))
 	//Moderator gases
 	var/list/moderator_gasdata = list()
 	if(connected_core.moderator_internal.total_moles())
-		for(var/gasid in connected_core.moderator_internal.gases)
+		for(var/gas_type in connected_core.moderator_internal.gases)
+			var/datum/gas/gas = gas_type
 			moderator_gasdata.Add(list(list(
-			"name"= connected_core.moderator_internal.gases[gasid][GAS_META][META_GAS_NAME],
-			"amount" = round(connected_core.moderator_internal.gases[gasid][MOLES], 0.01),
+			"id"= initial(gas.id),
+			"amount" = round(connected_core.moderator_internal.gases[gas][MOLES], 0.01),
 			)))
 	else
-		for(var/gasid in connected_core.moderator_internal.gases)
+		for(var/gas_type in connected_core.moderator_internal.gases)
+			var/datum/gas/gas = gas_type
 			moderator_gasdata.Add(list(list(
-				"name"= connected_core.moderator_internal.gases[gasid][GAS_META][META_GAS_NAME],
+				"id"= initial(gas.id),
 				"amount" = 0,
 				)))
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -197,6 +197,15 @@
 	else
 		to_chat(user, span_notice("Activate the machine first by using a multitool on the interface."))
 
+/obj/machinery/hypertorus/interface/proc/gas_list_to_gasid_list(list/gas_list)
+	var/list/gasid_list = list()
+	for(var/gas_type in gas_list)
+		var/datum/gas/gas = gas_type
+		gasid_list += initial(gas.id)
+	return gasid_list
+
+
+
 /obj/machinery/hypertorus/interface/ui_static_data()
 	var/data = list()
 	data["base_max_temperature"] = FUSION_MAXIMUM_TEMPERATURE
@@ -204,21 +213,18 @@
 	for(var/path in GLOB.hfr_fuels_list)
 		var/datum/hfr_fuel/recipe = GLOB.hfr_fuels_list[path]
 
-		var/list/product_gases = list()
-		for(var/gas_type in recipe.secondary_products)
-			var/datum/gas/gas_produced = gas_type
-			product_gases += initial(gas_produced.id)
-
 		data["selectable_fuel"] += list(list(
 			"name" = recipe.name,
 			"id" = recipe.id,
+			"requirements" = gas_list_to_gasid_list(recipe.requirements),
+			"fusion_byproducts" = gas_list_to_gasid_list(recipe.primary_products),
+			"product_gases" = gas_list_to_gasid_list(recipe.secondary_products),
 			"recipe_cooling_multiplier" = recipe.negative_temperature_multiplier,
 			"recipe_heating_multiplier" = recipe.positive_temperature_multiplier,
 			"energy_loss_multiplier" = recipe.energy_concentration_multiplier,
 			"fuel_consumption_multiplier" = recipe.fuel_consumption_multiplier,
 			"gas_production_multiplier" = recipe.gas_production_multiplier,
 			"temperature_multiplier" = recipe.temperature_change_multiplier,
-			"product_gases" = product_gases,
 		))
 	return data
 

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -319,6 +319,23 @@
 	return integrity
 
 /**
+ * Get how charged the area's APC is
+ */
+/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/get_area_cell_percent()
+	// Make sure to get APC levels from the same area the core draws from
+	// Just in case people build an HFR across boundaries
+	var/area/area = get_area(src)
+	if (!area)
+		return 0
+	var/obj/machinery/power/apc/apc = area.get_apc()
+	if (!apc)
+		return 0
+	var/obj/item/stock_parts/cell/cell = apc.cell
+	if (!cell)
+		return 0
+	return cell.percent()
+
+/**
  * Called by process_atmos() in hfr_main_processes.dm
  * Called after checking the damage of the machine, calls alarm() and countdown()
  * Broadcast messages into engi and common radio

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -183,11 +183,16 @@
 	linked_output.update_parents()
 	linked_moderator.update_parents()
 
-/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/update_temperature_status()
+/obj/machinery/atmospherics/components/unary/hypertorus/core/proc/update_temperature_status(delta_time)
+	fusion_temperature_archived = fusion_temperature
 	fusion_temperature = internal_fusion.temperature
+	moderator_temperature_archived = moderator_temperature
 	moderator_temperature = moderator_internal.temperature
+	coolant_temperature_archived = coolant_temperature
 	coolant_temperature = airs[1].temperature
+	output_temperature_archived = output_temperature
 	output_temperature = linked_output.airs[1].temperature
+	temperature_period = delta_time
 
 	//Set the power level of the fusion process
 	switch(fusion_temperature)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -327,7 +327,7 @@
 	var/area/area = get_area(src)
 	if (!area)
 		return 0
-	var/obj/machinery/power/apc/apc = area.get_apc()
+	var/obj/machinery/power/apc/apc = area.apc
 	if (!apc)
 		return 0
 	var/obj/item/stock_parts/cell/cell = apc.cell

--- a/tgui/docs/component-reference.md
+++ b/tgui/docs/component-reference.md
@@ -662,7 +662,7 @@ to perform some sort of action), there is a way to do that:
 
 **Props:**
 
-- `label: string` - Item label.
+- `label: string|InfernoNode` - Item label.
 - `color: string` - Sets the color of the text.
 - `buttons: any` - Buttons to render aside the content.
 - `children: any` - Content of this labeled item.

--- a/tgui/docs/component-reference.md
+++ b/tgui/docs/component-reference.md
@@ -814,7 +814,8 @@ The alert on the gauge is optional, and will only be shown if the `alertAfter` p
 - `minValue: number` (default: 0) - The lower bound of the guage.
 - `maxValue: number` (default: 1) - The upper bound of the guage.
 - `ranges: { color: [from, to] }` (default: `{ "good": [0, 1] }`) - Provide regions of the guage to color between two specified values of the metric.
-- `alertAfter: number` (optional) - When provided, will cause an alert symbol on the gauge to begin flashing in the color upon which the needle currently rest, as defined in `ranges`.
+- `alertAfter: number` (optional) - When provided, will cause an alert symbol on the gauge to begin flashing in the color upon which the needle currently rests, as defined in `ranges`.
+- `alertBefore: number` (optional) - As with alertAfter, but alerts below a value. If both are set, and alertAfter comes earlier, the alert will only flash when the needle is between both values. Otherwise, the alert will flash when on the active side of either threshold.
 - `format: function(value) => string` (optional) - When provided, will be used to format the value of the metric for display.
 - `size: number` (default: 1) - When provided scales the gauge.
 

--- a/tgui/packages/tgui/components/LabeledList.tsx
+++ b/tgui/packages/tgui/components/LabeledList.tsx
@@ -26,7 +26,7 @@ LabeledList.defaultHooks = pureComponentHooks;
 
 type LabeledListItemProps = {
   className?: string | BooleanLike;
-  label?: string | BooleanLike;
+  label?: string | InfernoNode | BooleanLike;
   labelColor?: string | BooleanLike;
   color?: string | BooleanLike;
   textAlign?: string | BooleanLike;
@@ -63,7 +63,7 @@ const LabeledListItem = (props: LabeledListItemProps) => {
           'LabeledList__label',
         ])}
         verticalAlign={verticalAlign}>
-        {label ? label + ':' : null}
+        {label ? typeof(label) === "string" ? label + ':' : label : null}
       </Box>
       <Box
         as="td"

--- a/tgui/packages/tgui/components/RoundGauge.js
+++ b/tgui/packages/tgui/components/RoundGauge.js
@@ -62,10 +62,10 @@ export const RoundGauge = props => {
       return true;
     }
     return false;
-  }
+  };
 
-  const alertColor = shouldShowAlert() &&
-    keyOfMatchingRange(clampedValue, scaledRanges);
+  const alertColor = shouldShowAlert()
+    && keyOfMatchingRange(clampedValue, scaledRanges);
 
   return (
     <Box inline>

--- a/tgui/packages/tgui/components/RoundGauge.js
+++ b/tgui/packages/tgui/components/RoundGauge.js
@@ -23,6 +23,7 @@ export const RoundGauge = props => {
     maxValue = 1,
     ranges,
     alertAfter,
+    alertBefore,
     format,
     size = 1,
     className,
@@ -46,10 +47,25 @@ export const RoundGauge = props => {
     });
   }
 
-  let alertColor = null;
-  if (alertAfter < value) {
-    alertColor = keyOfMatchingRange(clampedValue, scaledRanges);
+  const shouldShowAlert = () => {
+    // If both after and before alert props are set, attempt to interpret both
+    // in a helpful way.
+    if (alertAfter && alertBefore && alertAfter < alertBefore) {
+      // If alertAfter is before alertBefore, only display an alert if
+      // we're between them.
+      if (alertAfter < value && alertBefore > value) {
+        return true;
+      }
+    } else if (alertAfter < value || alertBefore > value) {
+      // Otherwise, we have distint ranges, or only one or neither are set.
+      // Either way, being on the active side of either is sufficient.
+      return true;
+    }
+    return false;
   }
+
+  const alertColor = shouldShowAlert() &&
+    keyOfMatchingRange(clampedValue, scaledRanges);
 
   return (
     <Box inline>
@@ -68,7 +84,7 @@ export const RoundGauge = props => {
         })}>
         <svg
           viewBox="0 0 100 50">
-          {alertAfter && (
+          {(alertAfter || alertBefore) && (
             <g className={classes([
               'RoundGauge__alert',
               alertColor ? `active RoundGauge__alert--${alertColor}` : '',

--- a/tgui/packages/tgui/interfaces/Hypertorus.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus.js
@@ -1,190 +1,22 @@
-import { filter, sortBy } from 'common/collections';
-import { flow } from 'common/fp';
-import { toFixed } from 'common/math';
-import { useBackend, useLocalState } from '../backend';
-import { Box, Button, Collapsible, Icon, Knob, LabeledControls, LabeledList, NumberInput, ProgressBar, RoundGauge, Section, Stack, Table, Tabs, Tooltip } from '../components';
-import { Color } from '../../common/color';
-import { getGasColor, getGasLabel } from '../constants';
-import { recallWindowGeometry } from '../drag';
-import { formatSiBaseTenUnit, formatSiUnit } from '../format';
+
+import { useBackend } from '../backend';
+import { Button, Collapsible, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
-/**
- * The list of recipe effects to list, in order.
- * Parameters:
- *  - param: The name of the parameter passed in the data object.
- *  - label: The human readable label for this effect.
- *  - scale: The point at which a directional arrow become a
- *           double directional arrow.
- *  - icon:  A string or array of strings describing a pictographic
- *           icon for use with this effect.
- *  - override_base: Optional. Sets the base value for scale calculations
- *                   to something other than 1.
- *  - tooltip: Optional.
- *             If specified, this is passed the value and full data
- *             array and should return the tooltip string.
- *             If omitted, the default of "x{value}" is used.
- *
- */
-const recipe_effect_structure = [
-  {
-    param: "recipe_cooling_multiplier",
-    label: "Cooling",
-    icon: "snowflake-o",
-    scale: 3,
-  },
-  {
-    param: "recipe_heating_multiplier",
-    label: "Heating",
-    icon: "fire",
-    scale: 3,
-  },
-  {
-    param: "energy_loss_multiplier",
-    label: "Energy loss",
-    icon: "sun-o",
-    scale: 3,
-  },
-  {
-    param: "fuel_consumption_multiplier",
-    label: "Fuel use",
-    icon: ["window-minimize", "arrow-down"],
-    scale: 1.5,
-  },
-  {
-    param: "gas_production_multiplier",
-    label: "Production",
-    icon: ["window-minimize", "arrow-up"],
-    scale: 1.5,
-  },
-  {
-    param: "temperature_multiplier",
-    label: "Max temperature",
-    icon: "thermometer-full",
-    override_base: 0.85,
-    scale: 1.15,
-    tooltip: (v, d) => "Maximum: " + (d.base_max_temperature * v).toExponential() + " K",
-  },
-];
+import { HypertorusGases } from './Hypertorus/Gases';
+import { HypertorusParameters } from './Hypertorus/Parameters';
+import { HypertorusTemperatures } from './Hypertorus/Temperatures';
+import { HypertorusRecipes } from './Hypertorus/Recipes';
 
-const effect_to_icon = (effect_value, effect_scale, base) => {
-  if (effect_value === base) {
-    return "minus";
-  }
-  if (effect_value > base) {
-    if (effect_value > base * effect_scale) {
-      return "angle-double-up";
-    }
-    return "angle-up";
-  }
-  if (effect_value < base / effect_scale) {
-    return "angle-double-down";
-  }
-  return "angle-down";
-};
-
-const bgChange = {
-  onComponentShouldUpdate: (lastProps, nextProps) => {
-    return lastProps.backgroundColor !== nextProps.backgroundColor;
-  },
-};
-
-const MemoRow = props => {
-  const {
-    backgroundColor,
-    children,
-    key,
-    ...rest
-  } = props;
-  return <Table.Row backgroundColor={backgroundColor} {...rest}>{children}</Table.Row>
-};
-
-MemoRow.defaultHooks = bgChange;
-
-const GasCellItem = props => {
-  const {
-    gasid,
-    ...rest
-  } = props;
-  return (
-    <Table.Cell
-      key={gasid}
-      label={getGasLabel(gasid)} {...rest}>
-      <Box color={getGasColor(gasid)}>{getGasLabel(gasid)}</Box>
-    </Table.Cell>
-  );
-};
-
-// Quick wrapper to globally toggle use of tooltips on or off.
-// Remove once tooltip performance is fixed for good.
-const MaybeTooltip = props => {
-  const {
-    children,
-    ...rest
-  } = props;
-  const noTooltips = true;
-  if (noTooltips) {
-    return (<Box>{children}</Box>);
-  }
-  return (<Tooltip {...rest}>{children}</Tooltip>);
-};
-
-const ActParam = (key,value) => {
-  const ret = {};
-  ret[key] = value;
-  return ret;
-};
-
-const TweakControl = props => {
-  const {
-    act,
-    minValue,
-    maxValue,
-    parameter,
-    step=5,
-    unit,
-    value,
-    ...rest
-  } = props;
-  return (<Box
-    position="relative"
-    left="-8px">
-    <Knob
-      size={2}
-      color={false}
-      value={value}
-      unit={unit}
-      minValue={minValue}
-      maxValue={maxValue}
-      step={step}
-      stepPixelSize={1}
-      onDrag={(e, value) => act(parameter, ActParam(parameter, value))}
-    />
-    <Button
-      fluid
-      position="absolute"
-      top="-2px"
-      right="-20px"
-      color="transparent"
-      icon="fast-forward"
-      onClick={() => act(parameter, ActParam(parameter, maxValue))}
-    />
-    <Button
-      fluid
-      position="absolute"
-      top="16px"
-      right="-20px"
-      color="transparent"
-      icon="fast-backward"
-      onClick={() => act(parameter, ActParam(parameter, minValue))}
-    />
-  </Box>);
-}
+import { HypertorusSecondaryControls, HypertorusIO, HypertorusWasteRemove } from './Hypertorus/Controls';
 
 const HypertorusMainControls = (props, context) => {
   const { act, data } = useBackend(context);
-  const selectableFuels = data.selectable_fuel || [];
-  const selectedFuel = selectableFuels.filter(d => d.id === data.selected)[0];
+  const {
+    selectableFuels,
+    selectedFuelID,
+  } = props;
+
   return (
     <Section title="Startup">
       <Stack>
@@ -195,7 +27,7 @@ const HypertorusMainControls = (props, context) => {
             icon={data.start_power ? 'power-off' : 'times'}
             content={data.start_power ? 'On' : 'Off'}
             selected={data.start_power}
-            onClick={() => act('start_power')} />
+            onClick={act.bind(null, 'start_power')} />
         </Stack.Item>
         <Stack.Item color="label">
           {'Start cooling: '}
@@ -207,7 +39,7 @@ const HypertorusMainControls = (props, context) => {
             icon={data.start_cooling ? 'power-off' : 'times'}
             content={data.start_cooling ? 'On' : 'Off'}
             selected={data.start_cooling}
-            onClick={() => act('start_cooling')} />
+            onClick={act.bind(null, 'start_cooling')} />
         </Stack.Item>
         <Stack.Item color="label">
           {'Start fuel injection: '}
@@ -217,7 +49,7 @@ const HypertorusMainControls = (props, context) => {
             icon={data.start_fuel ? 'power-off' : 'times'}
             content={data.start_fuel ? 'On' : 'Off'}
             selected={data.start_fuel}
-            onClick={() => act('start_fuel')} />
+            onClick={act.bind(null, 'start_fuel')} />
         </Stack.Item>
         <Stack.Item color="label">
           {'Start moderator injection: '}
@@ -227,436 +59,114 @@ const HypertorusMainControls = (props, context) => {
             icon={data.start_moderator ? 'power-off' : 'times'}
             content={data.start_moderator ? 'On' : 'Off'}
             selected={data.start_moderator}
-            onClick={() => act('start_moderator')} />
+            onClick={act.bind(null, 'start_moderator')} />
         </Stack.Item>
       </Stack>
       <Collapsible title="Recipe selection">
-        <Table>
-          <MemoRow color="label" header>
-            <Table.Cell />
-            <Table.Cell textAlign="center" colspan="2">
-              Fuel
-            </Table.Cell>
-            <Table.Cell textAlign="center" colspan="2">
-              Fusion Byproducts
-            </Table.Cell>
-            <Table.Cell textAlign="center" colspan="6">
-              Produced gases
-            </Table.Cell>
-            <Table.Cell textAlign="center" colspan="6">
-              Effects
-            </Table.Cell>
-            <Table.Cell grow="1" />
-          </MemoRow>
-          <MemoRow color="label" header>
-            <Table.Cell />
-            <Table.Cell textAlign="center">
-              Primary
-            </Table.Cell>
-            <Table.Cell textAlign="center">
-              Secondary
-            </Table.Cell>
-            <Table.Cell colspan="2"/>
-            <Table.Cell textAlign="center">
-              Tier 1
-            </Table.Cell>
-            <Table.Cell textAlign="center">
-              Tier 2
-            </Table.Cell>
-            <Table.Cell textAlign="center">
-              Tier 3
-            </Table.Cell>
-            <Table.Cell textAlign="center">
-              Tier 4
-            </Table.Cell>
-            <Table.Cell textAlign="center">
-              Tier 5
-            </Table.Cell>
-            <Table.Cell textAlign="center">
-              Tier 6
-            </Table.Cell>
-            {
-              // Lay out our pictographic headers for effects.
-              recipe_effect_structure.map(item => (
-                <Table.Cell key={item.param} color="label">
-                <MaybeTooltip content={item.label}>
-                  {typeof(item.icon) === "string" ? (
-                    <Icon position="relative" width="10px" name={item.icon} />
-                  ) : (
-                    <Icon.Stack positition="relative" width="10px" textAlign="center">
-                      {item.icon.map(icon => (
-                        <Icon name={typeof(icon) === "string" ? icon : "shit's fucked"} />
-                      ))}
-                    </Icon.Stack>
-                  )}
-                </MaybeTooltip>
-                </Table.Cell>
-              ))
-            }
-          </MemoRow>
-          {selectableFuels.filter(d=>d.id).map((recipe,index) => {
-            const active = recipe.id === data.selected;
-            const odd = 1 - 2 * (index % 2);
-            const secondary = 50 - odd * 50;
-            const primary = active ? secondary + 80 : secondary;
-            const alpha = (active ? .13 : .07);
-            return (
-              <MemoRow backgroundColor={new Color(secondary, primary, secondary, alpha)}>
-                <Table.Cell>
-                  <Button
-                    icon={recipe.id === data.selected ? "times" : "power-off"}
-                    disabled={data.power_level > 0}
-                    key={recipe.id}
-                    selected={recipe.id === data.selected}
-                    onClick={() => act('fuel', {mode: recipe.id})}
-                  />
-                </Table.Cell>
-                <GasCellItem gasid={recipe.requirements[0]} />
-                <GasCellItem gasid={recipe.requirements[1]} />
-                <GasCellItem gasid={recipe.fusion_byproducts[0]} />
-                <GasCellItem gasid={recipe.fusion_byproducts[1]} />
-                {recipe.product_gases.map(gasid => (
-                  <GasCellItem gasid={gasid} />
-                ))}
-                {
-                  recipe_effect_structure.map(item => {
-                    const value = recipe[item.param];
-                    // Note that the minus icon is wider than the arrow icons,
-                    // so we set the width to work with both without jumping.
-                    return (
-                      <Table.Cell>
-                        <MaybeTooltip content={(item.tooltip || (v => "x"+v))(value, data)}>
-                          <Icon position="relative" color="rgb(230,30,40)" width="10px" name={effect_to_icon(value, item.scale, item.override_base || 1)} />
-                        </MaybeTooltip>
-                      </Table.Cell>
-                    );
-                  })
-                }
-              </MemoRow>
-            );
-          })}
-        </Table>
+        <HypertorusRecipes
+          baseMaximumTemperature={data.base_max_temperature}
+          enableRecipeSelection={data.power_level === 0}
+          onRecipe={id => act('fuel', { mode: id })}
+          selectableFuels={selectableFuels}
+          selectedFuelID={selectedFuelID}
+        />
       </Collapsible>
     </Section>
   );
 };
 
-const HypertorusSecondaryControls = (props, context) => {
-  const { act, data } = useBackend(context);
-  const filterTypes = data.filter_types || [];
-  return (
-    <>
-      <Section title="Tweakable Inputs">
-        <LabeledControls>
-          <LabeledControls.Item label="Heating Conductor">
-            <TweakControl
-              act={act}
-              value={parseFloat(data.heating_conductor)}
-              unit="J/cm"
-              minValue={50}
-              maxValue={500}
-              parameter='heating_conductor'
-            />
-          </LabeledControls.Item>
-          <LabeledControls.Item label="Cooling Volume">
-            <TweakControl
-              act={act}
-              value={parseFloat(data.cooling_volume)}
-              unit="L"
-              minValue={50}
-              maxValue={2000}
-              parameter='cooling_volume'
-              step={25}
-            />
-          </LabeledControls.Item>
-          <LabeledControls.Item label="Magnetic Constrictor">
-            <TweakControl
-              act={act}
-              value={parseFloat(data.magnetic_constrictor)}
-              unit="m³/T"
-              minValue={50}
-              maxValue={1000}
-              parameter='magnetic_constrictor'
-            />
-          </LabeledControls.Item>
-          <LabeledControls.Item label="Current Damper">
-            <TweakControl
-              act={act}
-              value={parseFloat(data.current_damper)}
-              unit="W"
-              minValue={0}
-              maxValue={1000}
-              onDrag={(e, value) => act('current_damper', {
-                current_damper: value,
-              })} />
-          </LabeledControls.Item>
-        </LabeledControls>
-      </Section>
-      <Section>
-        <LabeledControls>
-          <LabeledControls.Item label="Fuel Injection Rate">
-            <NumberInput
-              animated
-              value={parseFloat(data.fuel_injection_rate)}
-              unit="mol/s"
-              minValue={.5}
-              maxValue={150}
-              onDrag={(e, value) => act('fuel_injection_rate', {
-                fuel_injection_rate: value,
-              })} />
-          </LabeledControls.Item>
-          <LabeledControls.Item label="Moderator Injection Rate">
-            <NumberInput
-              animated
-              value={parseFloat(data.moderator_injection_rate)}
-              unit="mol/s"
-              minValue={.5}
-              maxValue={150}
-              onDrag={(e, value) => act('moderator_injection_rate', {
-                moderator_injection_rate: value,
-              })} />
-          </LabeledControls.Item>
-          <LabeledControls.Item label="Moderator filtering rate">
-            <NumberInput
-              animated
-              value={parseFloat(data.mod_filtering_rate)}
-              unit="mol/s"
-              minValue={5}
-              maxValue={200}
-              onDrag={(e, value) => act('mod_filtering_rate', {
-                mod_filtering_rate: value,
-              })} />
-          </LabeledControls.Item>
-        </LabeledControls>
-      </Section>
-      <Section title="Waste control and filtering">
-        <LabeledList>
-          <LabeledList.Item label="Waste remove">
-            <Button
-              icon={data.waste_remove ? 'power-off' : 'times'}
-              content={data.waste_remove ? 'On' : 'Off'}
-              selected={data.waste_remove}
-              onClick={() => act('waste_remove')} />
-          </LabeledList.Item>
-          <LabeledList.Item label="Filter from moderator mix">
-            {filterTypes.map(filter => (
-              <Button
-                key={filter.gas_id}
-                icon={filter.enabled ? 'check-square-o' : 'square-o'}
-                selected={filter.enabled}
-                content={getGasLabel(filter.gas_id, filter.gas_name)}
-                onClick={() => act('filter', {
-                  mode: filter.gas_id,
-                })} />
-            ))}
-          </LabeledList.Item>
-        </LabeledList>
-      </Section>
-    </>
-  );
-};
-
-const HypertorusGases = (props, context) => {
-  const { act, data } = useBackend(context);
-  const fusion_gases = flow([
-    filter(gas => gas.amount >= 0.01),
-    sortBy(gas => -gas.amount),
-  ])(data.fusion_gases || []);
-  const moderator_gases = flow([
-    filter(gas => gas.amount >= 0.01),
-    sortBy(gas => -gas.amount),
-  ])(data.moderator_gases || []);
-  const fusionMax = Math.max(1, ...fusion_gases.map(gas => gas.amount));
-  const moderatorMax = Math.max(1, ...moderator_gases.map(gas => gas.amount));
-  return (
-    <>
-      <Section title="Internal Fusion Gases">
-        <LabeledList>
-          {fusion_gases.map(gas => (
-            <LabeledList.Item
-              key={gas.name}
-              label={getGasLabel(gas.name)}>
-              <ProgressBar
-                color={getGasColor(gas.name)}
-                value={gas.amount}
-                minValue={0}
-                maxValue={fusionMax}>
-                {toFixed(gas.amount, 2) + ' moles'}
-              </ProgressBar>
-            </LabeledList.Item>
-          ))}
-        </LabeledList>
-      </Section>
-      <Section title="Moderator Gases">
-        <LabeledList>
-          {moderator_gases.map(gas => (
-            <LabeledList.Item
-              key={gas.name}
-              label={getGasLabel(gas.name)}>
-              <ProgressBar
-                color={getGasColor(gas.name)}
-                value={gas.amount}
-                minValue={0}
-                maxValue={moderatorMax}>
-                {toFixed(gas.amount, 2) + ' moles'}
-              </ProgressBar>
-            </LabeledList.Item>
-          ))}
-        </LabeledList>
-      </Section>
-    </>
-  );
-};
-
-const HypertorusParameters = (props, context) => {
-  const { act, data } = useBackend(context);
+const HypertorusLayout = (props, context) => {
+  const { data } = useBackend(context);
   const {
+    base_max_temperature,
     energy_level,
+    fusion_gases,
     heat_limiter_modifier,
     heat_output,
     heat_output_bool,
-    power_level,
     iron_content,
     integrity,
     internal_fusion_temperature,
-    moderator_internal_temperature,
     internal_output_temperature,
     internal_coolant_temperature,
+    moderator_gases,
+    moderator_internal_temperature,
+    power_level,
+    selectable_fuel,
+    selected,
   } = data;
+
+  const selectable_fuels = selectable_fuel || [];
+  const selected_fuel = selectable_fuels.filter(d => d.id === selected)[0];
+
+  // heat_output_bool is set to '-' if heat_output is negative.
+  // heat_output is always the absolute value of heat output.
+  // Why? aaaaaaaaaaaaaaaaaaaa
+  const real_heat_output = heat_output_bool === '-' ? -heat_output : heat_output;
+  const real_heat_limiter_modifier = heat_output_bool === '-' ? -heat_limiter_modifier / 100 : heat_limiter_modifier;
+
+  // Note this adds bottom margin to non-Section elements for consistent
+  // spacing. This is a good candidate to be moved to css > properties to
+  // avoid low level presentation detail being exposed here.
+
   return (
     <>
-      <Section title="Reactor Parameters">
-        <LabeledControls>
-          <LabeledControls.Item label="Fusion Level">
-            <RoundGauge
-              size={1.75}
-              minValue={0}
-              maxValue={6}
-              value={power_level}
-              alertAfter={5}
-              ranges={{
-                good: [0, 2],
-                average: [2, 4],
-                bad: [4, 6],
-              }} />
-          </LabeledControls.Item>
-          <LabeledControls.Item label="Integrity">
-            <ProgressBar
-              value={integrity / 100}
-              ranges={{
-                good: [0.90, Infinity],
-                average: [0.5, 0.90],
-                bad: [-Infinity, 0.5],
-              }} />
-          </LabeledControls.Item>
-          <LabeledControls.Item label="Iron Content">
-            <ProgressBar
-              value={iron_content}
-              ranges={{
-                good: [-Infinity, .1],
-                average: [.1, .36],
-                bad: [.36, Infinity],
-              }} />
-          </LabeledControls.Item>
-          <LabeledControls.Item label="Energy Levels">
-            <ProgressBar
-              color={'yellow'}
-              value={energy_level}
-              minValue={0}
-              maxValue={1e35}>
-              {formatSiUnit(energy_level, 1, 'J')}
-            </ProgressBar>
-          </LabeledControls.Item>
-          <LabeledControls.Item label="Heat Limiter Modifier">
-            <ProgressBar
-              color={'blue'}
-              value={heat_limiter_modifier}
-              minValue={-1e40}
-              maxValue={1e30}>
-              {formatSiBaseTenUnit(heat_limiter_modifier * 1000, 1, 'K')}
-            </ProgressBar>
-          </LabeledControls.Item>
-          <LabeledControls.Item label="Heat Output">
-            <ProgressBar
-              color={'grey'}
-              value={heat_output}
-              minValue={-1e40}
-              maxValue={1e30}>
-              {heat_output_bool + formatSiBaseTenUnit(heat_output * 1000, 1, 'K')}
-            </ProgressBar>
-          </LabeledControls.Item>
-        </LabeledControls>
-      </Section>
-      <Section title="Temperatures">
-        <LabeledList>
-          <LabeledList.Item label="Fusion gas temperature">
-            <ProgressBar
-              color={'yellow'}
-              value={internal_fusion_temperature}
-              minValue={0}
-              maxValue={1e30}>
-              {formatSiBaseTenUnit(internal_fusion_temperature * 1000, 1, 'K')}
-            </ProgressBar>
-          </LabeledList.Item>
-          <LabeledList.Item label="Moderator gas temperature">
-            <ProgressBar
-              color={'red'}
-              value={moderator_internal_temperature}
-              minValue={0}
-              maxValue={1e30}>
-              {formatSiBaseTenUnit(moderator_internal_temperature * 1000, 1, 'K')}
-            </ProgressBar>
-          </LabeledList.Item>
-          <LabeledList.Item label="Output gas temperature">
-            <ProgressBar
-              color={'pink'}
-              value={internal_output_temperature}
-              minValue={0}
-              maxValue={1e30}>
-              {formatSiBaseTenUnit(internal_output_temperature * 1000, 1, 'K')}
-            </ProgressBar>
-          </LabeledList.Item>
-          <LabeledList.Item label="Coolant output temperature">
-            <ProgressBar
-              color={'green'}
-              value={internal_coolant_temperature}
-              minValue={0}
-              maxValue={1e30}>
-              {formatSiBaseTenUnit(internal_coolant_temperature * 1000, 1, 'K')}
-            </ProgressBar>
-          </LabeledList.Item>
-        </LabeledList>
-      </Section>
+      <HypertorusMainControls
+        selectableFuels={selectable_fuels}
+        selectedFuelID={selected}
+       />
+      <Stack mb="0.5em">
+        <Stack.Item grow>
+          <HypertorusGases
+            selectedFuel={selected_fuel}
+            fusionGases={fusion_gases}
+            moderatorGases={moderator_gases}
+            />
+        </Stack.Item>
+        <Stack.Item>
+          <HypertorusTemperatures
+            powerLevel={power_level}
+            heatOutput={heat_output}
+            baseMaxTemperature={base_max_temperature}
+            heatLimiterModifier={heat_limiter_modifier}
+            internalFusionTemperature={internal_fusion_temperature}
+            moderatorInternalTemperature={moderator_internal_temperature}
+            internalOutputTemperature={internal_output_temperature}
+            internalCoolantTemperature={internal_coolant_temperature}
+            selectedFuel={selected_fuel}
+          />
+        </Stack.Item>
+      </Stack>
+      <Stack mb="0.5em">
+        <Stack.Item>
+          <HypertorusParameters
+            energyLevel={energy_level}
+            rawHeatLimiterModifier={heat_limiter_modifier}
+            realHeatOutput={real_heat_output}
+            realHeatLimiterModifier={real_heat_limiter_modifier}
+            heatOutput={heat_output}
+            powerLevel={power_level}
+            ironContent={iron_content}
+            integrity={integrity}/>
+          <HypertorusSecondaryControls />
+        </Stack.Item>
+        <Stack.Item grow>
+          <HypertorusIO />
+        </Stack.Item>
+      </Stack>
+      <HypertorusWasteRemove />
     </>
   );
 };
-
-const HypertorusTabs = (props, context) => {
-  const { act, data } = useBackend(context);
-  const [
-    tabIndex,
-    setTabIndex,
-  ] = useLocalState(context, 'tab-index', 1);
-  return (
-    <>
-      <HypertorusMainControls />
-      <HypertorusGases />
-      <HypertorusParameters />
-      <HypertorusSecondaryControls />
-    </>
-  );
-};
-
 
 export const Hypertorus = (props, context) => {
-  const { act, data } = useBackend(context);
   return (
     <Window
       title="Hypertorus Fusion Reactor control panel"
       width={950}
-      height={600}>
+      height={740}>
       <Window.Content scrollable>
-        <HypertorusTabs />
+        <HypertorusLayout />
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/Hypertorus.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus.js
@@ -138,7 +138,7 @@ const HypertorusLayout = (props, context) => {
         </Stack.Item>
       </Stack>
       <Stack mb="0.5em">
-        <Stack.Item>
+        <Stack.Item minWidth="600px" grow>
           <HypertorusParameters
             energyLevel={energy_level}
             rawHeatLimiterModifier={heat_limiter_modifier}
@@ -150,7 +150,7 @@ const HypertorusLayout = (props, context) => {
             integrity={integrity}/>
           <HypertorusSecondaryControls />
         </Stack.Item>
-        <Stack.Item grow>
+        <Stack.Item>
           <HypertorusIO />
         </Stack.Item>
       </Stack>

--- a/tgui/packages/tgui/interfaces/Hypertorus.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus.js
@@ -78,6 +78,7 @@ const HypertorusMainControls = (props, context) => {
 const HypertorusLayout = (props, context) => {
   const { data } = useBackend(context);
   const {
+    apc_energy,
     base_max_temperature,
     energy_level,
     fusion_gases,
@@ -145,13 +146,14 @@ const HypertorusLayout = (props, context) => {
         </Stack.Item>
       </Stack>
       <Stack mb="0.5em">
-        <Stack.Item minWidth="600px" grow>
+        <Stack.Item minWidth="660px" grow>
           <HypertorusParameters
             energyLevel={energy_level}
             heatLimiterModifier={heat_limiter_modifier}
             heatOutputMin={heat_output_min}
             heatOutputMax={heat_output_max}
             heatOutput={heat_output}
+            apcEnergy={apc_energy}
             heatLimiterModifier={heat_limiter_modifier}
             instability={instability}
             powerLevel={power_level}
@@ -172,7 +174,7 @@ export const Hypertorus = (props, context) => {
   return (
     <Window
       title="Hypertorus Fusion Reactor control panel"
-      width={950}
+      width={960}
       height={740}>
       <Window.Content scrollable>
         <HypertorusLayout />

--- a/tgui/packages/tgui/interfaces/Hypertorus.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus.js
@@ -103,10 +103,14 @@ const HypertorusLayout = (props, context) => {
     selected,
   } = data;
 
-  const internal_fusion_temperature_delta = internal_fusion_temperature - internal_fusion_temperature_archived;
-  const internal_output_temperature_delta = internal_output_temperature - internal_output_temperature_archived;
-  const internal_coolant_temperature_delta = internal_coolant_temperature - internal_coolant_temperature_archived;
-  const moderator_internal_temperature_delta = moderator_internal_temperature - moderator_internal_temperature_archived;
+  const internal_fusion_temperature_delta = internal_fusion_temperature
+    - internal_fusion_temperature_archived;
+  const internal_output_temperature_delta = internal_output_temperature
+    - internal_output_temperature_archived;
+  const internal_coolant_temperature_delta = internal_coolant_temperature
+    - internal_coolant_temperature_archived;
+  const moderator_internal_delta = moderator_internal_temperature
+    - moderator_internal_temperature_archived;
 
   const selectable_fuels = selectable_fuel || [];
   const selected_fuel = selectable_fuels.filter(d => d.id === selected)[0];
@@ -120,14 +124,14 @@ const HypertorusLayout = (props, context) => {
       <HypertorusMainControls
         selectableFuels={selectable_fuels}
         selectedFuelID={selected}
-       />
+      />
       <Stack mb="0.5em">
         <Stack.Item grow>
           <HypertorusGases
             selectedFuel={selected_fuel}
             fusionGases={fusion_gases}
             moderatorGases={moderator_gases}
-            />
+          />
         </Stack.Item>
         <Stack.Item>
           <HypertorusTemperatures
@@ -136,7 +140,7 @@ const HypertorusLayout = (props, context) => {
             internalFusionTemperature={internal_fusion_temperature}
             internalFusionTemperatureDelta={internal_fusion_temperature_delta}
             moderatorInternalTemperature={moderator_internal_temperature}
-            moderatorInternalTemperatureDelta={moderator_internal_temperature_delta}
+            moderatorInternalTemperatureDelta={moderator_internal_delta}
             internalOutputTemperature={internal_output_temperature}
             internalOutputTemperatureDelta={internal_output_temperature_delta}
             internalCoolantTemperature={internal_coolant_temperature}
@@ -154,11 +158,10 @@ const HypertorusLayout = (props, context) => {
             heatOutputMax={heat_output_max}
             heatOutput={heat_output}
             apcEnergy={apc_energy}
-            heatLimiterModifier={heat_limiter_modifier}
             instability={instability}
             powerLevel={power_level}
             ironContent={iron_content}
-            integrity={integrity}/>
+            integrity={integrity} />
           <HypertorusSecondaryControls />
         </Stack.Item>
         <Stack.Item>

--- a/tgui/packages/tgui/interfaces/Hypertorus.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus.js
@@ -82,28 +82,33 @@ const HypertorusLayout = (props, context) => {
     energy_level,
     fusion_gases,
     heat_limiter_modifier,
+    heat_output_min,
+    heat_output_max,
     heat_output,
-    heat_output_bool,
     iron_content,
+    instability,
     integrity,
     internal_fusion_temperature,
+    internal_fusion_temperature_archived,
     internal_output_temperature,
+    internal_output_temperature_archived,
     internal_coolant_temperature,
+    internal_coolant_temperature_archived,
     moderator_gases,
     moderator_internal_temperature,
+    moderator_internal_temperature_archived,
     power_level,
     selectable_fuel,
     selected,
   } = data;
 
+  const internal_fusion_temperature_delta = internal_fusion_temperature - internal_fusion_temperature_archived;
+  const internal_output_temperature_delta = internal_output_temperature - internal_output_temperature_archived;
+  const internal_coolant_temperature_delta = internal_coolant_temperature - internal_coolant_temperature_archived;
+  const moderator_internal_temperature_delta = moderator_internal_temperature - moderator_internal_temperature_archived;
+
   const selectable_fuels = selectable_fuel || [];
   const selected_fuel = selectable_fuels.filter(d => d.id === selected)[0];
-
-  // heat_output_bool is set to '-' if heat_output is negative.
-  // heat_output is always the absolute value of heat output.
-  // Why? aaaaaaaaaaaaaaaaaaaa
-  const real_heat_output = heat_output_bool === '-' ? -heat_output : heat_output;
-  const real_heat_limiter_modifier = heat_output_bool === '-' ? -heat_limiter_modifier / 100 : heat_limiter_modifier;
 
   // Note this adds bottom margin to non-Section elements for consistent
   // spacing. This is a good candidate to be moved to css > properties to
@@ -126,13 +131,15 @@ const HypertorusLayout = (props, context) => {
         <Stack.Item>
           <HypertorusTemperatures
             powerLevel={power_level}
-            heatOutput={heat_output}
             baseMaxTemperature={base_max_temperature}
-            heatLimiterModifier={heat_limiter_modifier}
             internalFusionTemperature={internal_fusion_temperature}
+            internalFusionTemperatureDelta={internal_fusion_temperature_delta}
             moderatorInternalTemperature={moderator_internal_temperature}
+            moderatorInternalTemperatureDelta={moderator_internal_temperature_delta}
             internalOutputTemperature={internal_output_temperature}
+            internalOutputTemperatureDelta={internal_output_temperature_delta}
             internalCoolantTemperature={internal_coolant_temperature}
+            internalCoolantTemperatureDelta={internal_coolant_temperature_delta}
             selectedFuel={selected_fuel}
           />
         </Stack.Item>
@@ -141,10 +148,12 @@ const HypertorusLayout = (props, context) => {
         <Stack.Item minWidth="600px" grow>
           <HypertorusParameters
             energyLevel={energy_level}
-            rawHeatLimiterModifier={heat_limiter_modifier}
-            realHeatOutput={real_heat_output}
-            realHeatLimiterModifier={real_heat_limiter_modifier}
+            heatLimiterModifier={heat_limiter_modifier}
+            heatOutputMin={heat_output_min}
+            heatOutputMax={heat_output_max}
             heatOutput={heat_output}
+            heatLimiterModifier={heat_limiter_modifier}
+            instability={instability}
             powerLevel={power_level}
             ironContent={iron_content}
             integrity={integrity}/>

--- a/tgui/packages/tgui/interfaces/Hypertorus.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus.js
@@ -1,6 +1,6 @@
 
 import { useBackend } from '../backend';
-import { Button, Collapsible, Section, Stack } from '../components';
+import { Button, Collapsible, Flex, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 import { HypertorusGases } from './Hypertorus/Gases';
@@ -40,26 +40,6 @@ const HypertorusMainControls = (props, context) => {
             content={data.start_cooling ? 'On' : 'Off'}
             selected={data.start_cooling}
             onClick={act.bind(null, 'start_cooling')} />
-        </Stack.Item>
-        <Stack.Item color="label">
-          {'Start fuel injection: '}
-          <Button
-            disabled={data.start_power === 0
-                || data.start_cooling === 0}
-            icon={data.start_fuel ? 'power-off' : 'times'}
-            content={data.start_fuel ? 'On' : 'Off'}
-            selected={data.start_fuel}
-            onClick={act.bind(null, 'start_fuel')} />
-        </Stack.Item>
-        <Stack.Item color="label">
-          {'Start moderator injection: '}
-          <Button
-            disabled={data.start_power === 0
-                || data.start_cooling === 0}
-            icon={data.start_moderator ? 'power-off' : 'times'}
-            content={data.start_moderator ? 'On' : 'Off'}
-            selected={data.start_moderator}
-            onClick={act.bind(null, 'start_moderator')} />
         </Stack.Item>
       </Stack>
       <Collapsible title="Recipe selection">
@@ -149,25 +129,18 @@ const HypertorusLayout = (props, context) => {
           />
         </Stack.Item>
       </Stack>
-      <Stack mb="0.5em">
-        <Stack.Item minWidth="660px" grow>
-          <HypertorusParameters
-            energyLevel={energy_level}
-            heatLimiterModifier={heat_limiter_modifier}
-            heatOutputMin={heat_output_min}
-            heatOutputMax={heat_output_max}
-            heatOutput={heat_output}
-            apcEnergy={apc_energy}
-            instability={instability}
-            powerLevel={power_level}
-            ironContent={iron_content}
-            integrity={integrity} />
-          <HypertorusSecondaryControls />
-        </Stack.Item>
-        <Stack.Item>
-          <HypertorusIO />
-        </Stack.Item>
-      </Stack>
+      <HypertorusParameters
+        energyLevel={energy_level}
+        heatLimiterModifier={heat_limiter_modifier}
+        heatOutputMin={heat_output_min}
+        heatOutputMax={heat_output_max}
+        heatOutput={heat_output}
+        apcEnergy={apc_energy}
+        instability={instability}
+        powerLevel={power_level}
+        ironContent={iron_content}
+        integrity={integrity} />
+      <HypertorusSecondaryControls />
       <HypertorusWasteRemove />
     </>
   );
@@ -177,8 +150,8 @@ export const Hypertorus = (props, context) => {
   return (
     <Window
       title="Hypertorus Fusion Reactor control panel"
-      width={960}
-      height={740}>
+      width={850}
+      height={980}>
       <Window.Content scrollable>
         <HypertorusLayout />
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -159,7 +159,7 @@ export const HypertorusSecondaryControls = (props, context) => {
 export const HypertorusIO = (props, context) => {
   const { act, data } = useBackend(context);
   return (
-    <Section title="I/O Flow Control" height="100%" width="280px">
+    <Section title="I/O Flow Control" height="100%" width="260px">
       <LabeledList >
         <LabeledList.Item label="Fuel Injection Rate">
           <NumberInput

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -94,7 +94,7 @@ export const HypertorusSecondaryControls = (props, context) => {
   const { act, data } = useBackend(context);
   return (
     <Section title="Tweakable Inputs">
-      <LabeledControls justify="flex-start">
+      <LabeledControls justify="space-around">
         <LabeledControls.Item label="Heating Conductor">
           <ComboKnob
             act={act}
@@ -157,8 +157,8 @@ export const HypertorusSecondaryControls = (props, context) => {
 export const HypertorusIO = (props, context) => {
   const { act, data } = useBackend(context);
   return (
-    <Section title="I/O Flow Control" height="100%">
-      <LabeledList width="200px">
+    <Section title="I/O Flow Control" height="100%" width="280px">
+      <LabeledList >
         <LabeledList.Item label="Fuel Injection Rate">
           <NumberInput
             animated

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -1,0 +1,228 @@
+
+import { useBackend } from '../../backend';
+import { Box, Button, Icon, Knob, LabeledControls, LabeledList, NumberInput, Section, Tooltip } from '../../components';
+import { getGasLabel } from '../../constants';
+
+/*
+ * This module holds user interactable controls. Some may be good candidates
+ * for generalizing and refactoring.
+ */
+
+const ActParam = (key,value) => {
+  const ret = {};
+  ret[key] = value;
+  return ret;
+};
+
+const ComboKnob = props => {
+  const {
+    act,
+    defaultValue,
+    icon,
+    flipIcon,
+    help,
+    minValue,
+    maxValue,
+    parameter,
+    step=5,
+    unit,
+    value,
+    ...rest
+  } = props;
+  const iconProps = {};
+  if (flipIcon) {
+    iconProps.rotation = 180;
+  }
+  const icon_element = icon && (<Icon
+    position="absolute"
+    top="16px"
+    left="-27px"
+    color='label'
+    fontSize='200%'
+    name={icon}
+    {...iconProps}
+  />);
+  return (<Box
+    position="relative"
+    left="2px">
+    {help ?
+      (<Tooltip content={help}>{icon_element}</Tooltip>) :
+      icon_element
+    }
+    <Knob
+      size={2}
+      color={false}
+      value={value}
+      unit={unit}
+      minValue={minValue}
+      maxValue={maxValue}
+      step={step}
+      stepPixelSize={1}
+      onDrag={(e, value) => act(parameter, ActParam(parameter, value))}
+    />
+    <Button
+      fluid
+      position="absolute"
+      top="-2px"
+      right="-20px"
+      color="transparent"
+      icon="fast-forward"
+      onClick={act.bind(null, parameter, ActParam(parameter, maxValue))}
+    />
+    <Button
+      fluid
+      position="absolute"
+      top="16px"
+      right="-20px"
+      color="transparent"
+      icon="undo"
+      onClick={act.bind(null, parameter, ActParam(parameter, defaultValue))}
+    />
+    <Button
+      fluid
+      position="absolute"
+      top="34px"
+      right="-20px"
+      color="transparent"
+      icon="fast-backward"
+      onClick={act.bind(null, parameter, ActParam(parameter, minValue))}
+    />
+  </Box>);
+}
+
+export const HypertorusSecondaryControls = (props, context) => {
+  const { act, data } = useBackend(context);
+  return (
+    <Section title="Tweakable Inputs">
+      <LabeledControls justify="flex-start">
+        <LabeledControls.Item label="Heating Conductor">
+          <ComboKnob
+            act={act}
+            value={parseFloat(data.heating_conductor)}
+            unit="J/cm"
+            minValue={50}
+            defaultValue={100}
+            maxValue={500}
+            parameter='heating_conductor'
+            icon='fire'
+            help='Adjusts the rate the fusion reaction heats or cools. Higher heating values improve production at the risk of a runaway reaction.'
+          />
+        </LabeledControls.Item>
+        <LabeledControls.Item label="Cooling Volume">
+          <ComboKnob
+            act={act}
+            value={parseFloat(data.cooling_volume)}
+            unit="L"
+            minValue={50}
+            defaultValue={100}
+            maxValue={2000}
+            parameter='cooling_volume'
+            step={25}
+            icon='snowflake-o'
+            help="Adjusts the HFR core's internal cooling space. A smaller space will provide less cooling internally, but will move most of the coolant outside of the HFR core, where it can be rapidly cooled when not needed."
+          />
+        </LabeledControls.Item>
+        <LabeledControls.Item label="Magnetic Constrictor">
+          <ComboKnob
+            act={act}
+            value={parseFloat(data.magnetic_constrictor)}
+            unit="m³/T"
+            minValue={50}
+            defaultValue={100}
+            maxValue={1000}
+            parameter='magnetic_constrictor'
+            icon='magnet'
+            flipIcon={true}
+            help='Adjusts the density of the fusion reaction. Denser reactions expose more energy, but may destabilize the reaction if too much mass is involved.'
+          />
+        </LabeledControls.Item>
+        <LabeledControls.Item label="Current Damper">
+          <ComboKnob
+            act={act}
+            value={parseFloat(data.current_damper)}
+            unit="W"
+            minValue={0}
+            defaultValue={0}
+            maxValue={1000}
+            parameter='current_damper'
+            icon='sun-o'
+            help='Destabilizes the reaction. A sufficiently destabilized reaction will halt production and become endothermic, cooling the Fusion Mix instead of heating it. Reactions with more iron are harder to destabilize.'
+          />
+        </LabeledControls.Item>
+      </LabeledControls>
+    </Section>
+  );
+};
+
+export const HypertorusIO = (props, context) => {
+  const { act, data } = useBackend(context);
+  return (
+    <Section title="I/O Flow Control" height="100%">
+      <LabeledList width="200px">
+        <LabeledList.Item label="Fuel Injection Rate">
+          <NumberInput
+            animated
+            value={parseFloat(data.fuel_injection_rate)}
+            unit="mol/s"
+            minValue={.5}
+            maxValue={150}
+            onDrag={(e, value) => act('fuel_injection_rate', {
+              fuel_injection_rate: value,
+            })} />
+        </LabeledList.Item>
+        <LabeledList.Item label="Moderator Injection Rate">
+          <NumberInput
+            animated
+            value={parseFloat(data.moderator_injection_rate)}
+            unit="mol/s"
+            minValue={.5}
+            maxValue={150}
+            onDrag={(e, value) => act('moderator_injection_rate', {
+              moderator_injection_rate: value,
+            })} />
+        </LabeledList.Item>
+        <LabeledList.Item label="Moderator filtering rate">
+          <NumberInput
+            animated
+            value={parseFloat(data.mod_filtering_rate)}
+            unit="mol/s"
+            minValue={5}
+            maxValue={200}
+            onDrag={(e, value) => act('mod_filtering_rate', {
+              mod_filtering_rate: value,
+            })} />
+        </LabeledList.Item>
+      </LabeledList>
+    </Section>
+  );
+};
+
+export const HypertorusWasteRemove = (props, context) => {
+  const { act, data } = useBackend(context);
+  const filterTypes = data.filter_types || [];
+  return (
+    <Section title="Waste control and filtering">
+      <LabeledList>
+        <LabeledList.Item label="Waste remove">
+          <Button
+            icon={data.waste_remove ? 'power-off' : 'times'}
+            content={data.waste_remove ? 'On' : 'Off'}
+            selected={data.waste_remove}
+            onClick={() => act('waste_remove')} />
+        </LabeledList.Item>
+        <LabeledList.Item label="Filter from moderator mix">
+          {filterTypes.map(filter => (
+            <Button
+              key={filter.gas_id}
+              icon={filter.enabled ? 'check-square-o' : 'square-o'}
+              selected={filter.enabled}
+              content={getGasLabel(filter.gas_id, filter.gas_name)}
+              onClick={() => act('filter', {
+                mode: filter.gas_id,
+              })} />
+          ))}
+        </LabeledList.Item>
+      </LabeledList>
+    </Section>
+  );
+};

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -2,7 +2,7 @@
 import { useBackend } from '../../backend';
 import { Box, Button, Icon, Knob, LabeledControls, LabeledList, NumberInput, Section, Tooltip } from '../../components';
 import { getGasLabel } from '../../constants';
-import { ActFixed, ActSet } from './helpers';
+import { ActFixed, ActSet, HelpDummy, HoverHelp } from './helpers';
 
 /*
  * This module holds user interactable controls. Some may be good candidates
@@ -168,14 +168,26 @@ export const HypertorusWasteRemove = (props, context) => {
   return (
     <Section title="Output control">
       <LabeledList>
-        <LabeledList.Item label="Waste remove">
+        <LabeledList.Item
+          label={
+            <>
+              <HoverHelp
+                content={"Remove waste gases from Fusion,"
+                +" and any selected gases from the Moderator."}
+              />
+              Waste remove:
+            </>
+          }
+        >
           <Button
             icon={data.waste_remove ? 'power-off' : 'times'}
             content={data.waste_remove ? 'On' : 'Off'}
             selected={data.waste_remove}
             onClick={() => act('waste_remove')} />
         </LabeledList.Item>
-        <LabeledList.Item label="Moderator filtering rate">
+        <LabeledList.Item
+          label={<><HelpDummy />Moderator filtering rate:</>}
+        >
           <NumberInput
             animated
             value={parseFloat(data.mod_filtering_rate)}
@@ -186,7 +198,9 @@ export const HypertorusWasteRemove = (props, context) => {
               mod_filtering_rate: value,
             })} />
         </LabeledList.Item>
-        <LabeledList.Item label="Filter from moderator mix">
+        <LabeledList.Item
+          label={<><HelpDummy />Filter from moderator mix:</>}
+        >
           {filterTypes.map(filter => (
             <Button
               key={filter.gas_id}

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -93,7 +93,7 @@ export const HypertorusSecondaryControls = (props, context) => {
   const { act, data } = useBackend(context);
   return (
     <Section title="Reactor Control">
-      <LabeledControls justify="space-around">
+      <LabeledControls justify="space-around" wrap>
         <LabeledControls.Item label="Heating Conductor">
           <ComboKnob
             color={data.heating_conductor > 50 && data.heat_output > 0 && "yellow"}

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -152,16 +152,6 @@ export const HypertorusSecondaryControls = (props, context) => {
   );
 };
 
-export const HypertorusIO = (props, context) => {
-  const { act, data } = useBackend(context);
-  return (
-    <Section title="I/O Flow Control" height="100%" width="260px">
-      <LabeledList >
-      </LabeledList>
-    </Section>
-  );
-};
-
 export const HypertorusWasteRemove = (props, context) => {
   const { act, data } = useBackend(context);
   const filterTypes = data.filter_types || [];

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -8,9 +8,8 @@ import { HelpDummy, HoverHelp } from './helpers';
  * for generalizing and refactoring.
  */
 
-const ComboKnob = props => {
+const ComboKnob = (props, context) => {
   const {
-    act,
     color=false,
     defaultValue,
     icon,
@@ -23,10 +22,14 @@ const ComboKnob = props => {
     value,
     ...rest
   } = props;
+
+  const { act, data } = useBackend(context);
+
   const iconProps = {};
   if (flipIcon) {
     iconProps.rotation = 180;
   }
+
   const icon_element = icon && (<Icon
     position="absolute"
     top="16px"
@@ -36,6 +39,7 @@ const ComboKnob = props => {
     name={icon}
     {...iconProps}
   />);
+
   return (
     <Box
       position="relative"
@@ -92,7 +96,6 @@ export const HypertorusSecondaryControls = (props, context) => {
       <LabeledControls justify="space-around">
         <LabeledControls.Item label="Heating Conductor">
           <ComboKnob
-            act={act}
             color={data.heating_conductor > 50 && data.heat_output > 0 && "yellow"}
             value={parseFloat(data.heating_conductor)}
             unit="J/cm"
@@ -106,7 +109,6 @@ export const HypertorusSecondaryControls = (props, context) => {
         </LabeledControls.Item>
         <LabeledControls.Item label="Cooling Volume">
           <ComboKnob
-            act={act}
             value={parseFloat(data.cooling_volume)}
             unit="L"
             minValue={50}
@@ -120,7 +122,6 @@ export const HypertorusSecondaryControls = (props, context) => {
         </LabeledControls.Item>
         <LabeledControls.Item label="Magnetic Constrictor">
           <ComboKnob
-            act={act}
             value={parseFloat(data.magnetic_constrictor)}
             unit="m³/T"
             minValue={50}
@@ -134,7 +135,6 @@ export const HypertorusSecondaryControls = (props, context) => {
         </LabeledControls.Item>
         <LabeledControls.Item label="Current Damper">
           <ComboKnob
-            act={act}
             color={data.current_damper && "yellow"}
             value={parseFloat(data.current_damper)}
             unit="W"

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -1,7 +1,7 @@
 import { useBackend } from '../../backend';
 import { Box, Button, Icon, Knob, LabeledControls, LabeledList, NumberInput, Section, Tooltip } from '../../components';
 import { getGasLabel } from '../../constants';
-import { ActFixed, ActSet, HelpDummy, HoverHelp } from './helpers';
+import { HelpDummy, HoverHelp } from './helpers';
 
 /*
  * This module holds user interactable controls. Some may be good candidates
@@ -51,7 +51,7 @@ const ComboKnob = props => {
         maxValue={maxValue}
         step={step}
         stepPixelSize={1}
-        onDrag={ActSet(act, parameter)}
+        onDrag={(_, v) => act(parameter, { [parameter]: v })}
         {...rest}
       />
       <Button
@@ -61,7 +61,7 @@ const ComboKnob = props => {
         right="-20px"
         color="transparent"
         icon="fast-forward"
-        onClick={ActFixed(act, parameter, maxValue)}
+        onClick={() => act(parameter, { [parameter]: maxValue })}
       />
       <Button
         fluid
@@ -70,7 +70,7 @@ const ComboKnob = props => {
         right="-20px"
         color="transparent"
         icon="undo"
-        onClick={ActFixed(act, parameter, defaultValue)}
+        onClick={() => act(parameter, { [parameter]: defaultValue })}
       />
       <Button
         fluid
@@ -79,7 +79,7 @@ const ComboKnob = props => {
         right="-20px"
         color="transparent"
         icon="fast-backward"
-        onClick={ActFixed(act, parameter, minValue)}
+        onClick={() => act(parameter, { [parameter]: minValue })}
       />
     </Box>
   );

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -8,7 +8,7 @@ import { getGasLabel } from '../../constants';
  * for generalizing and refactoring.
  */
 
-const ActParam = (key,value) => {
+const ActParam = (key, value) => {
   const ret = {};
   ret[key] = value;
   return ret;
@@ -37,58 +37,59 @@ const ComboKnob = props => {
     position="absolute"
     top="16px"
     left="-27px"
-    color='label'
-    fontSize='200%'
+    color="label"
+    fontSize="200%"
     name={icon}
     {...iconProps}
   />);
-  return (<Box
-    position="relative"
-    left="2px">
-    {help ?
-      (<Tooltip content={help}>{icon_element}</Tooltip>) :
-      icon_element
-    }
-    <Knob
-      color={color}
-      size={2}
-      value={value}
-      minValue={minValue}
-      maxValue={maxValue}
-      step={step}
-      stepPixelSize={1}
-      onDrag={(e, value) => act(parameter, ActParam(parameter, value))}
-      {...rest}
-    />
-    <Button
-      fluid
-      position="absolute"
-      top="-2px"
-      right="-20px"
-      color="transparent"
-      icon="fast-forward"
-      onClick={act.bind(null, parameter, ActParam(parameter, maxValue))}
-    />
-    <Button
-      fluid
-      position="absolute"
-      top="16px"
-      right="-20px"
-      color="transparent"
-      icon="undo"
-      onClick={act.bind(null, parameter, ActParam(parameter, defaultValue))}
-    />
-    <Button
-      fluid
-      position="absolute"
-      top="34px"
-      right="-20px"
-      color="transparent"
-      icon="fast-backward"
-      onClick={act.bind(null, parameter, ActParam(parameter, minValue))}
-    />
-  </Box>);
-}
+  return (
+    <Box
+      position="relative"
+      left="2px">
+      {help
+        ? (<Tooltip content={help}>{icon_element}</Tooltip>)
+        : icon_element}
+      <Knob
+        color={color}
+        size={2}
+        value={value}
+        minValue={minValue}
+        maxValue={maxValue}
+        step={step}
+        stepPixelSize={1}
+        onDrag={(e, value) => act(parameter, ActParam(parameter, value))}
+        {...rest}
+      />
+      <Button
+        fluid
+        position="absolute"
+        top="-2px"
+        right="-20px"
+        color="transparent"
+        icon="fast-forward"
+        onClick={act.bind(null, parameter, ActParam(parameter, maxValue))}
+      />
+      <Button
+        fluid
+        position="absolute"
+        top="16px"
+        right="-20px"
+        color="transparent"
+        icon="undo"
+        onClick={act.bind(null, parameter, ActParam(parameter, defaultValue))}
+      />
+      <Button
+        fluid
+        position="absolute"
+        top="34px"
+        right="-20px"
+        color="transparent"
+        icon="fast-backward"
+        onClick={act.bind(null, parameter, ActParam(parameter, minValue))}
+      />
+    </Box>
+  );
+};
 
 export const HypertorusSecondaryControls = (props, context) => {
   const { act, data } = useBackend(context);
@@ -104,9 +105,9 @@ export const HypertorusSecondaryControls = (props, context) => {
             minValue={50}
             defaultValue={100}
             maxValue={500}
-            parameter='heating_conductor'
-            icon='fire'
-            help='Adjusts the rate the fusion reaction heats or cools. Higher heating values improve production at the risk of a runaway reaction.'
+            parameter="heating_conductor"
+            icon="fire"
+            help="Adjusts the rate the fusion reaction heats or cools. Higher heating values improve production at the risk of a runaway reaction."
           />
         </LabeledControls.Item>
         <LabeledControls.Item label="Cooling Volume">
@@ -117,9 +118,9 @@ export const HypertorusSecondaryControls = (props, context) => {
             minValue={50}
             defaultValue={100}
             maxValue={2000}
-            parameter='cooling_volume'
+            parameter="cooling_volume"
             step={25}
-            icon='snowflake-o'
+            icon="snowflake-o"
             help="Adjusts the HFR core's internal cooling space. A smaller space will provide less cooling internally, but will move most of the coolant outside of the HFR core, where it can be rapidly cooled when not needed."
           />
         </LabeledControls.Item>
@@ -131,10 +132,10 @@ export const HypertorusSecondaryControls = (props, context) => {
             minValue={50}
             defaultValue={100}
             maxValue={1000}
-            parameter='magnetic_constrictor'
-            icon='magnet'
-            flipIcon={true}
-            help='Adjusts the density of the fusion reaction. Denser reactions expose more energy, but may destabilize the reaction if too much mass is involved.'
+            parameter="magnetic_constrictor"
+            icon="magnet"
+            flipIcon
+            help="Adjusts the density of the fusion reaction. Denser reactions expose more energy, but may destabilize the reaction if too much mass is involved."
           />
         </LabeledControls.Item>
         <LabeledControls.Item label="Current Damper">
@@ -146,9 +147,9 @@ export const HypertorusSecondaryControls = (props, context) => {
             minValue={0}
             defaultValue={0}
             maxValue={1000}
-            parameter='current_damper'
-            icon='sun-o'
-            help='Destabilizes the reaction. A sufficiently destabilized reaction will halt production and become endothermic, cooling the Fusion Mix instead of heating it. Reactions with more iron are harder to destabilize.'
+            parameter="current_damper"
+            icon="sun-o"
+            help="Destabilizes the reaction. A sufficiently destabilized reaction will halt production and become endothermic, cooling the Fusion Mix instead of heating it. Reactions with more iron are harder to destabilize."
           />
         </LabeledControls.Item>
       </LabeledControls>

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -17,6 +17,7 @@ const ActParam = (key,value) => {
 const ComboKnob = props => {
   const {
     act,
+    color=false,
     defaultValue,
     icon,
     flipIcon,
@@ -25,7 +26,6 @@ const ComboKnob = props => {
     maxValue,
     parameter,
     step=5,
-    unit,
     value,
     ...rest
   } = props;
@@ -50,15 +50,15 @@ const ComboKnob = props => {
       icon_element
     }
     <Knob
+      color={color}
       size={2}
-      color={false}
       value={value}
-      unit={unit}
       minValue={minValue}
       maxValue={maxValue}
       step={step}
       stepPixelSize={1}
       onDrag={(e, value) => act(parameter, ActParam(parameter, value))}
+      {...rest}
     />
     <Button
       fluid
@@ -98,6 +98,7 @@ export const HypertorusSecondaryControls = (props, context) => {
         <LabeledControls.Item label="Heating Conductor">
           <ComboKnob
             act={act}
+            color={data.heating_conductor > 50 && data.heat_output > 0 && "yellow"}
             value={parseFloat(data.heating_conductor)}
             unit="J/cm"
             minValue={50}
@@ -139,6 +140,7 @@ export const HypertorusSecondaryControls = (props, context) => {
         <LabeledControls.Item label="Current Damper">
           <ComboKnob
             act={act}
+            color={data.current_damper && "yellow"}
             value={parseFloat(data.current_damper)}
             unit="W"
             minValue={0}

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -89,7 +89,7 @@ const ComboKnob = props => {
 export const HypertorusSecondaryControls = (props, context) => {
   const { act, data } = useBackend(context);
   return (
-    <Section title="Tweakable Inputs">
+    <Section title="Reactor Control">
       <LabeledControls justify="space-around">
         <LabeledControls.Item label="Heating Conductor">
           <ComboKnob
@@ -166,7 +166,7 @@ export const HypertorusWasteRemove = (props, context) => {
   const { act, data } = useBackend(context);
   const filterTypes = data.filter_types || [];
   return (
-    <Section title="Output control">
+    <Section title="Output Control">
       <LabeledList>
         <LabeledList.Item
           label={

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -2,17 +2,12 @@
 import { useBackend } from '../../backend';
 import { Box, Button, Icon, Knob, LabeledControls, LabeledList, NumberInput, Section, Tooltip } from '../../components';
 import { getGasLabel } from '../../constants';
+import { ActFixed, ActSet } from './helpers';
 
 /*
  * This module holds user interactable controls. Some may be good candidates
  * for generalizing and refactoring.
  */
-
-const ActParam = (key, value) => {
-  const ret = {};
-  ret[key] = value;
-  return ret;
-};
 
 const ComboKnob = props => {
   const {
@@ -57,7 +52,7 @@ const ComboKnob = props => {
         maxValue={maxValue}
         step={step}
         stepPixelSize={1}
-        onDrag={(e, value) => act(parameter, ActParam(parameter, value))}
+        onDrag={ActSet(act, parameter)}
         {...rest}
       />
       <Button
@@ -67,7 +62,7 @@ const ComboKnob = props => {
         right="-20px"
         color="transparent"
         icon="fast-forward"
-        onClick={act.bind(null, parameter, ActParam(parameter, maxValue))}
+        onClick={ActFixed(act, parameter, maxValue)}
       />
       <Button
         fluid
@@ -76,7 +71,7 @@ const ComboKnob = props => {
         right="-20px"
         color="transparent"
         icon="undo"
-        onClick={act.bind(null, parameter, ActParam(parameter, defaultValue))}
+        onClick={ActFixed(act, parameter, defaultValue)}
       />
       <Button
         fluid
@@ -85,7 +80,7 @@ const ComboKnob = props => {
         right="-20px"
         color="transparent"
         icon="fast-backward"
-        onClick={act.bind(null, parameter, ActParam(parameter, minValue))}
+        onClick={ActFixed(act, parameter, minValue)}
       />
     </Box>
   );
@@ -162,27 +157,23 @@ export const HypertorusIO = (props, context) => {
   return (
     <Section title="I/O Flow Control" height="100%" width="260px">
       <LabeledList >
-        <LabeledList.Item label="Fuel Injection Rate">
-          <NumberInput
-            animated
-            value={parseFloat(data.fuel_injection_rate)}
-            unit="mol/s"
-            minValue={.5}
-            maxValue={150}
-            onDrag={(e, value) => act('fuel_injection_rate', {
-              fuel_injection_rate: value,
-            })} />
-        </LabeledList.Item>
-        <LabeledList.Item label="Moderator Injection Rate">
-          <NumberInput
-            animated
-            value={parseFloat(data.moderator_injection_rate)}
-            unit="mol/s"
-            minValue={.5}
-            maxValue={150}
-            onDrag={(e, value) => act('moderator_injection_rate', {
-              moderator_injection_rate: value,
-            })} />
+      </LabeledList>
+    </Section>
+  );
+};
+
+export const HypertorusWasteRemove = (props, context) => {
+  const { act, data } = useBackend(context);
+  const filterTypes = data.filter_types || [];
+  return (
+    <Section title="Output control">
+      <LabeledList>
+        <LabeledList.Item label="Waste remove">
+          <Button
+            icon={data.waste_remove ? 'power-off' : 'times'}
+            content={data.waste_remove ? 'On' : 'Off'}
+            selected={data.waste_remove}
+            onClick={() => act('waste_remove')} />
         </LabeledList.Item>
         <LabeledList.Item label="Moderator filtering rate">
           <NumberInput
@@ -194,24 +185,6 @@ export const HypertorusIO = (props, context) => {
             onDrag={(e, value) => act('mod_filtering_rate', {
               mod_filtering_rate: value,
             })} />
-        </LabeledList.Item>
-      </LabeledList>
-    </Section>
-  );
-};
-
-export const HypertorusWasteRemove = (props, context) => {
-  const { act, data } = useBackend(context);
-  const filterTypes = data.filter_types || [];
-  return (
-    <Section title="Waste control and filtering">
-      <LabeledList>
-        <LabeledList.Item label="Waste remove">
-          <Button
-            icon={data.waste_remove ? 'power-off' : 'times'}
-            content={data.waste_remove ? 'On' : 'Off'}
-            selected={data.waste_remove}
-            onClick={() => act('waste_remove')} />
         </LabeledList.Item>
         <LabeledList.Item label="Filter from moderator mix">
           {filterTypes.map(filter => (

--- a/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Controls.js
@@ -1,4 +1,3 @@
-
 import { useBackend } from '../../backend';
 import { Box, Button, Icon, Knob, LabeledControls, LabeledList, NumberInput, Section, Tooltip } from '../../components';
 import { getGasLabel } from '../../constants';

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
@@ -12,7 +12,7 @@ const moderator_gases_help = {
   o2: "When added in high quantities, rapidly purges iron content. Does not purge iron content fast enough to keep up with damage at high Fusion Levels.",
   healium: "Directly heals a heavily damaged HFR core at high Fusion Levels, but is rapidly consumed in the process.",
   antinoblium: "Provides huge amounts of energy and radiation. Can cause dangerous electrical storms even from a healthy HFR core when present in more than trace amounts. Wear appropriate electrical protection when handling.",
-  freon: "Saps most forms of energy expression. Slows the rate of temperature change."
+  freon: "Saps most forms of energy expression. Slows the rate of temperature change.",
 };
 
 const moderator_gases_sticky_order = [
@@ -23,14 +23,14 @@ const moderator_gases_sticky_order = [
 
 const ensure_gases = (gas_array, gasids) => {
   const gases_by_id = {};
-  gas_array.forEach(gas => gases_by_id[gas.id] = true);
+  gas_array.forEach(gas => { gases_by_id[gas.id] = true; });
 
   for (let gasid of gasids) {
     if (!gases_by_id[gasid]) {
-      gas_array.push({id: gasid, amount: 0});
+      gas_array.push({ id: gasid, amount: 0 });
     }
   }
-}
+};
 
 export const HypertorusGases = props => {
   const {
@@ -54,7 +54,8 @@ export const HypertorusGases = props => {
     sortBy(gas => -gas.amount),
   ])(raw_moderator_gases || []);
 
-  // Make sure the "sticky" production gases are always visible. We want to display help for these.
+  // Make sure the "sticky" production gases are always visible.
+  // We want to display help for these.
   ensure_gases(moderator_gases, moderator_gases_sticky_order);
 
   const fusionMax = Math.max(500, ...fusion_gases.map(gas => gas.amount));
@@ -63,23 +64,28 @@ export const HypertorusGases = props => {
   return (
     <>
       <Section title="Internal Fusion Gases">
-        {selectedFuel ? (<LabeledList>
-          {fusion_gases.map(gas => (
-            <LabeledList.Item
-              key={gas.id}
-              label={getGasLabel(gas.id)}>
-              <ProgressBar
-                color={getGasColor(gas.id)}
-                value={gas.amount}
-                minValue={0}
-                maxValue={fusionMax}>
-                {toFixed(gas.amount, 2) + ' moles'}
-              </ProgressBar>
-            </LabeledList.Item>
-          ))}
-        </LabeledList>) :
-        (<Box align="center" color="red">{"No recipe selected"}</Box>)
-        }
+        {selectedFuel 
+          ? (
+            <LabeledList>
+              {fusion_gases.map(gas => (
+                <LabeledList.Item
+                  key={gas.id}
+                  label={getGasLabel(gas.id)}>
+                  <ProgressBar
+                    color={getGasColor(gas.id)}
+                    value={gas.amount}
+                    minValue={0}
+                    maxValue={fusionMax}>
+                    {toFixed(gas.amount, 2) + ' moles'}
+                  </ProgressBar>
+                </LabeledList.Item>
+              ))}
+            </LabeledList>)
+          : (
+            <Box align="center" color="red">
+              {"No recipe selected"}
+            </Box>
+          )}
       </Section>
       <Section title="Moderator Gases">
         <LabeledList>
@@ -89,23 +95,23 @@ export const HypertorusGases = props => {
             if (moderator_gases_help[gas.id]) {
               labelPrefix = (
                 <Tooltip content={moderator_gases_help[gas.id]}>
-                  <Icon name="question-circle" width="12px" mr="6px"/>
+                  <Icon name="question-circle" width="12px" mr="6px" />
                 </Tooltip>
               );
             } else {
               // Empty icon for spacing purposes
               labelPrefix = (
                 <Icon name="" width="12px" mr="6px" />
-              )
+              );
             }
             return (
               <LabeledList.Item
                 key={gas.id}
                 label={
-                <>
-                  {labelPrefix}
-                  {getGasLabel(gas.id)}:
-                </>
+                  <>
+                    {labelPrefix}
+                    {getGasLabel(gas.id)}:
+                  </>
                 }>
                 <ProgressBar
                   color={getGasColor(gas.id)}

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
@@ -1,12 +1,10 @@
-import { useBackend } from '../../backend';
 import { filter, sortBy } from 'common/collections';
 import { flow } from 'common/fp';
 import { toFixed } from 'common/math';
-import { ActSet, HoverHelp, HelpDummy } from './helpers';
-
+import { useBackend } from '../../backend';
 import { Box, Button, LabeledList, NumberInput, ProgressBar, Section } from '../../components';
 import { getGasColor, getGasLabel } from '../../constants';
-import { ActFixed } from './helpers';
+import { ActFixed, ActSet, HelpDummy, HoverHelp } from './helpers';
 
 /*
  * Displays contents of gas mixtures, along with help text for gases with

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
@@ -63,7 +63,7 @@ const GasList = (props, context) => {
         label={
           <>
             <HoverHelp content={rateHelp} />
-            Injection Rate:
+            Injection control:
           </>
         }
       >
@@ -129,8 +129,10 @@ export const HypertorusGases = props => {
               gases={fusion_gases}
               minimumScale={500}
               prepend={()=>(<HelpDummy />)}
-              rateHelp={"The rate at which new fuel is added from the fuel input port. "
-               + "Affects the rate of production, even when not active."}
+              rateHelp={
+                "The rate at which new fuel is added from the fuel input port."
+                + " This rate affects the rate of production,"
+                + " even when input is not active."}
               stickyGases={selectedFuel.requirements}
             />
           )

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
@@ -2,9 +2,9 @@ import { useBackend } from '../../backend';
 import { filter, sortBy } from 'common/collections';
 import { flow } from 'common/fp';
 import { toFixed } from 'common/math';
-import { ActNone, ActSet } from './helpers';
+import { ActNone, ActSet, HoverHelp, HelpDummy } from './helpers';
 
-import { Box, Button, Icon, LabeledList, NumberInput, ProgressBar, Section, Tooltip } from '../../components';
+import { Box, Button, LabeledList, NumberInput, ProgressBar, Section, Tooltip } from '../../components';
 import { getGasColor, getGasLabel } from '../../constants';
 
 const moderator_gases_help = {
@@ -33,12 +33,6 @@ const ensure_gases = (gas_array, gasids) => {
     }
   }
 };
-
-const HoverHelp = props => (
-  <Tooltip content={props.content}>
-    <Icon name="question-circle" width="12px" mr="6px" />
-  </Tooltip>
-);
 
 const GasList = (props, context) => {
   const { act, data } = useBackend(context);
@@ -134,6 +128,7 @@ export const HypertorusGases = props => {
               input_min={.5}
               gases={fusion_gases}
               minimumScale={500}
+              prepend={()=>(<HelpDummy />)}
               rateHelp={"The rate at which new fuel is added from the fuel input port. "
                + "Affects the rate of production, even when not active."}
               stickyGases={selectedFuel.requirements}
@@ -158,7 +153,7 @@ export const HypertorusGases = props => {
           prepend={gas=>
             moderator_gases_help[gas.id]
             ? (<HoverHelp content={moderator_gases_help[gas.id]} />)
-            : (<Icon name="" width="12px" mr="6px" />)
+            : (<HelpDummy />)
           }
         />
       </Section>

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
@@ -4,7 +4,7 @@ import { flow } from 'common/fp';
 import { toFixed } from 'common/math';
 import { ActSet, HoverHelp, HelpDummy } from './helpers';
 
-import { Box, Button, LabeledList, NumberInput, ProgressBar, Section, Tooltip } from '../../components';
+import { Box, Button, LabeledList, NumberInput, ProgressBar, Section } from '../../components';
 import { getGasColor, getGasLabel } from '../../constants';
 import { ActFixed } from './helpers';
 
@@ -90,30 +90,31 @@ const GasList = (props, context) => {
           onDrag={ActSet(act, input_rate)}
         />
       </LabeledList.Item>
-    {gases.map(gas => {
-      let labelPrefix;
-      if (prepend) {
-        labelPrefix = prepend(gas)
-      }
-      return (
-      <LabeledList.Item
-        key={gas.id}
-        label={
-          <>
-            (labelPrefix)
-            {getGasLabel(gas.id)}:
-          </>}
-        >
-        <ProgressBar
-          color={getGasColor(gas.id)}
-          value={gas.amount}
-          minValue={0}
-          maxValue={minimumScale}>
-          {toFixed(gas.amount, 2) + ' moles'}
-        </ProgressBar>
-      </LabeledList.Item>);
-    })}
-  </LabeledList>);
+      {gases.map(gas => {
+        let labelPrefix;
+        if (prepend) {
+          labelPrefix = prepend(gas);
+        }
+        return (
+          <LabeledList.Item
+            key={gas.id}
+            label={
+              <>
+                {labelPrefix}
+                {getGasLabel(gas.id)}:
+              </>
+            }
+          >
+            <ProgressBar
+              color={getGasColor(gas.id)}
+              value={gas.amount}
+              minValue={0}
+              maxValue={minimumScale}>
+              {toFixed(gas.amount, 2) + ' moles'}
+            </ProgressBar>
+          </LabeledList.Item>);
+      })}
+    </LabeledList>);
 };
 
 export const HypertorusGases = (props, context) => {
@@ -121,7 +122,7 @@ export const HypertorusGases = (props, context) => {
 
   const {
     fusion_gases,
-    moderator_gases
+    moderator_gases,
   } = data;
 
   const selected_fuel = (data.selectable_fuel || []).filter(
@@ -140,11 +141,12 @@ export const HypertorusGases = (props, context) => {
               input_min={.5}
               gases={fusion_gases}
               minimumScale={500}
-              prepend={()=>(<HelpDummy />)}
+              prepend={() => (<HelpDummy />)}
               rateHelp={
                 "The rate at which new fuel is added from the fuel input port."
                 + " This rate affects the rate of production,"
-                + " even when input is not active."}
+                + " even when input is not active."
+              }
               stickyGases={selected_fuel.requirements}
             />
           )
@@ -164,11 +166,10 @@ export const HypertorusGases = (props, context) => {
           minimumScale={500}
           rateHelp={"The rate at which new moderator gas is added from the moderator port."}
           stickyGases={moderator_gases_sticky_order}
-          prepend={gas=>
+          prepend={gas =>
             moderator_gases_help[gas.id]
-            ? (<HoverHelp content={moderator_gases_help[gas.id]} />)
-            : (<HelpDummy />)
-          }
+              ? (<HoverHelp content={moderator_gases_help[gas.id]} />)
+              : (<HelpDummy />)}
         />
       </Section>
     </>

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
@@ -6,6 +6,7 @@ import { ActSet, HoverHelp, HelpDummy } from './helpers';
 
 import { Box, Button, LabeledList, NumberInput, ProgressBar, Section, Tooltip } from '../../components';
 import { getGasColor, getGasLabel } from '../../constants';
+import { ActFixed } from './helpers';
 
 const moderator_gases_help = {
   plasma: "Produces basic gases. Has a modest heat bonus to help kick start the early fusion process. When added in large quantities, its high heat capacity can help to slow down temperature changes to manageable speeds.",
@@ -109,17 +110,22 @@ const GasList = (props, context) => {
   </LabeledList>);
 };
 
-export const HypertorusGases = props => {
+export const HypertorusGases = (props, context) => {
+  const { data } = useBackend(context);
+
   const {
-    fusionGases: fusion_gases,
-    moderatorGases: moderator_gases,
-    selectedFuel,
-  } = props;
+    fusion_gases,
+    moderator_gases
+  } = data;
+
+  const selected_fuel = (data.selectable_fuel || []).filter(
+    d => d.id === data.selected
+  )[0];
 
   return (
     <>
       <Section title="Internal Fusion Gases">
-        {selectedFuel 
+        {selected_fuel
           ? (
             <GasList
               input_rate="fuel_injection_rate"
@@ -133,7 +139,7 @@ export const HypertorusGases = props => {
                 "The rate at which new fuel is added from the fuel input port."
                 + " This rate affects the rate of production,"
                 + " even when input is not active."}
-              stickyGases={selectedFuel.requirements}
+              stickyGases={selected_fuel.requirements}
             />
           )
           : (

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
@@ -57,8 +57,8 @@ export const HypertorusGases = props => {
   // Make sure the "sticky" production gases are always visible. We want to display help for these.
   ensure_gases(moderator_gases, moderator_gases_sticky_order);
 
-  const fusionMax = Math.max(1, ...fusion_gases.map(gas => gas.amount));
-  const moderatorMax = Math.max(1, ...moderator_gases.map(gas => gas.amount));
+  const fusionMax = Math.max(500, ...fusion_gases.map(gas => gas.amount));
+  const moderatorMax = Math.max(500, ...moderator_gases.map(gas => gas.amount));
 
   return (
     <>

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
@@ -2,7 +2,7 @@ import { useBackend } from '../../backend';
 import { filter, sortBy } from 'common/collections';
 import { flow } from 'common/fp';
 import { toFixed } from 'common/math';
-import { ActNone, ActSet, HoverHelp, HelpDummy } from './helpers';
+import { ActSet, HoverHelp, HelpDummy } from './helpers';
 
 import { Box, Button, LabeledList, NumberInput, ProgressBar, Section, Tooltip } from '../../components';
 import { getGasColor, getGasLabel } from '../../constants';
@@ -73,7 +73,7 @@ const GasList = (props, context) => {
           icon={data[input_switch] ? 'power-off' : 'times'}
           content={data[input_switch] ? 'On' : 'Off'}
           selected={data[input_switch]}
-          onClick={ActNone(act, input_switch)} />
+          onClick={ActFixed(act, input_switch)} />
         <NumberInput
           animated
           value={parseFloat(data[input_rate])}

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
@@ -8,6 +8,12 @@ import { Box, Button, LabeledList, NumberInput, ProgressBar, Section, Tooltip } 
 import { getGasColor, getGasLabel } from '../../constants';
 import { ActFixed } from './helpers';
 
+/*
+ * Displays contents of gas mixtures, along with help text for gases with
+ * special text when present. Some gas bars are always visible, even when
+ * absent, to hint at what can be added and their effects.
+ */
+
 const moderator_gases_help = {
   plasma: "Produces basic gases. Has a modest heat bonus to help kick start the early fusion process. When added in large quantities, its high heat capacity can help to slow down temperature changes to manageable speeds.",
   bz: "Produces intermediate gases at Fusion Level 3 or higher. Massively increases radiation, and induces hallucinations in bystanders.",

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
@@ -1,0 +1,124 @@
+import { filter, sortBy } from 'common/collections';
+import { flow } from 'common/fp';
+import { toFixed } from 'common/math';
+
+import { Box, Icon, LabeledList, ProgressBar, Section, Tooltip } from '../../components';
+import { getGasColor, getGasLabel } from '../../constants';
+
+const moderator_gases_help = {
+  plasma: "Produces basic gases. Has a modest heat bonus to help kick start the early fusion process. When added in large quantities, its high heat capacity can help to slow down temperature changes to manageable speeds.",
+  bz: "Produces intermediate gases at Fusion Level 3 or higher. Massively increases radiation, and induces hallucinations in bystanders.",
+  proto_nitrate: "Produces advanced gases. Massively increases radiation, and accelerates the rate of temperature change. Make sure you have enough cooling.",
+  o2: "When added in high quantities, rapidly purges iron content. Does not purge iron content fast enough to keep up with damage at high Fusion Levels.",
+  healium: "Directly heals a heavily damaged HFR core at high Fusion Levels, but is rapidly consumed in the process.",
+  antinoblium: "Provides huge amounts of energy and radiation. Can cause dangerous electrical storms even from a healthy HFR core when present in more than trace amounts. Wear appropriate electrical protection when handling.",
+  freon: "Saps most forms of energy expression. Slows the rate of temperature change."
+};
+
+const moderator_gases_sticky_order = [
+  "plasma",
+  "bz",
+  "proto_nitrate",
+];
+
+const ensure_gases = (gas_array, gasids) => {
+  const gases_by_id = {};
+  gas_array.forEach(gas => gases_by_id[gas.id] = true);
+
+  for (let gasid of gasids) {
+    if (!gases_by_id[gasid]) {
+      gas_array.push({id: gasid, amount: 0});
+    }
+  }
+}
+
+export const HypertorusGases = props => {
+  const {
+    fusionGases: raw_fusion_gases,
+    moderatorGases: raw_moderator_gases,
+    selectedFuel,
+  } = props;
+
+  const fusion_gases = flow([
+    filter(gas => gas.amount >= 0.01),
+    sortBy(gas => -gas.amount),
+  ])(raw_fusion_gases || []);
+
+  if (selectedFuel) {
+    // Always display the requirement gases of the selected recipe.
+    ensure_gases(fusion_gases, selectedFuel.requirements);
+  }
+
+  const moderator_gases = flow([
+    filter(gas => gas.amount >= 0.01),
+    sortBy(gas => -gas.amount),
+  ])(raw_moderator_gases || []);
+
+  // Make sure the "sticky" production gases are always visible. We want to display help for these.
+  ensure_gases(moderator_gases, moderator_gases_sticky_order);
+
+  const fusionMax = Math.max(1, ...fusion_gases.map(gas => gas.amount));
+  const moderatorMax = Math.max(1, ...moderator_gases.map(gas => gas.amount));
+
+  return (
+    <>
+      <Section title="Internal Fusion Gases">
+        {selectedFuel ? (<LabeledList>
+          {fusion_gases.map(gas => (
+            <LabeledList.Item
+              key={gas.id}
+              label={getGasLabel(gas.id)}>
+              <ProgressBar
+                color={getGasColor(gas.id)}
+                value={gas.amount}
+                minValue={0}
+                maxValue={fusionMax}>
+                {toFixed(gas.amount, 2) + ' moles'}
+              </ProgressBar>
+            </LabeledList.Item>
+          ))}
+        </LabeledList>) :
+        (<Box align="center" color="red">{"No recipe selected"}</Box>)
+        }
+      </Section>
+      <Section title="Moderator Gases">
+        <LabeledList>
+          {moderator_gases.map(gas => {
+            // Add in an icon to display tooltip help for interesting gases.
+            let labelPrefix;
+            if (moderator_gases_help[gas.id]) {
+              labelPrefix = (
+                <Tooltip content={moderator_gases_help[gas.id]}>
+                  <Icon name="question-circle" width="12px" mr="6px"/>
+                </Tooltip>
+              );
+            } else {
+              // Empty icon for spacing purposes
+              labelPrefix = (
+                <Icon name="" width="12px" mr="6px" />
+              )
+            }
+            return (
+              <LabeledList.Item
+                key={gas.id}
+                label={
+                <>
+                  {labelPrefix}
+                  {getGasLabel(gas.id)}:
+                </>
+                }>
+                <ProgressBar
+                  color={getGasColor(gas.id)}
+                  value={gas.amount}
+                  minValue={0}
+                  maxValue={moderatorMax}>
+                  {toFixed(gas.amount, 2) + ' moles'}
+                </ProgressBar>
+              </LabeledList.Item>
+            );
+          })}
+        </LabeledList>
+      </Section>
+    </>
+  );
+};

--- a/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Gases.js
@@ -4,7 +4,7 @@ import { toFixed } from 'common/math';
 import { useBackend } from '../../backend';
 import { Box, Button, LabeledList, NumberInput, ProgressBar, Section } from '../../components';
 import { getGasColor, getGasLabel } from '../../constants';
-import { ActFixed, ActSet, HelpDummy, HoverHelp } from './helpers';
+import { HelpDummy, HoverHelp } from './helpers';
 
 /*
  * Displays contents of gas mixtures, along with help text for gases with
@@ -78,14 +78,14 @@ const GasList = (props, context) => {
           icon={data[input_switch] ? 'power-off' : 'times'}
           content={data[input_switch] ? 'On' : 'Off'}
           selected={data[input_switch]}
-          onClick={ActFixed(act, input_switch)} />
+          onClick={() => act(input_switch)} />
         <NumberInput
           animated
           value={parseFloat(data[input_rate])}
           unit="mol/s"
           minValue={input_min}
           maxValue={input_max}
-          onDrag={ActSet(act, input_rate)}
+          onDrag={(_, v) => act(input_rate, { [input_rate]: v })}
         />
       </LabeledList.Item>
       {gases.map(gas => {

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -1,7 +1,7 @@
+import { toFixed } from 'common/math';
 import { useBackend } from '../../backend';
 import { LabeledControls, RoundGauge, Section } from '../../components';
 import { formatSiUnit } from '../../format';
-import { toFixed } from 'common/math';
 
 /*
  * Parameter display

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -105,7 +105,7 @@ export const HypertorusParameters = props => {
             minValue={0}
             maxValue={6}
             value={power_level}
-            alertAfter={5}
+            alertAfter={4.5}
             ranges={{
               grey: [0, 1],
               good: [1, 3.5],

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -5,6 +5,7 @@ import { toFixed } from 'common/math';
 
 export const HypertorusParameters = props => {
   const {
+    apcEnergy: apc_energy,
     energyLevel: energy_level,
     heatOutputMin: heat_output_min,
     heatOutputMax: heat_output_max,
@@ -55,6 +56,21 @@ export const HypertorusParameters = props => {
               bad: [.36, 1],
             }} />
         </LabeledControls.Item>
+        <LabeledControls.Item label="Area Power">
+          <RoundGauge
+            size={1.75}
+            value={apc_energy}
+            minValue={0}
+            maxValue={100}
+            alertBefore={30}
+            format={v=>`${Math.round(v)}%`}
+            ranges={{
+              // Keep these in line with the auto-off thresholds in apc.dm
+              bad: [0, 15],
+              average: [15, 30],
+              good: [30, 100],
+            }} />
+        </LabeledControls.Item>
         <LabeledControls.Item label="Fusion Level">
           <RoundGauge
             size={3}
@@ -88,7 +104,7 @@ export const HypertorusParameters = props => {
             size={1.75}
             value={activity * 100}
             minValue={0}
-            maxValue={130}
+            maxValue={130} // Proto-nitrate lets us exceed 100%
             format={v=>`${toFixed(activity * 100, 1)}%`}
             ranges={{
               grey: [0, 70],

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -101,7 +101,7 @@ export const HypertorusParameters = props => {
         <LabeledControls.Item label="Energy">
           <RoundGauge
             size={1.75}
-            value={Math.log10(energy_level)}
+            value={Math.max(0,Math.log10(energy_level))}
             minValue={12}
             maxValue={30}
             format={v=>formatSiUnit(10**v, 1, 'J')}

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -19,7 +19,7 @@ export const HypertorusParameters = (props, context) => {
   const {
     heat_output,
     heat_output_min,
-    heat_output_max
+    heat_output_max,
   } = data;
 
   const energy_minimum_exponent = 12;

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -104,7 +104,7 @@ export const HypertorusParameters = props => {
             value={Math.max(0,Math.log10(energy_level))}
             minValue={12}
             maxValue={30}
-            format={v=>formatSiUnit(10**v, 1, 'J')}
+            format={v=>formatSiUnit(10**v, 4, 'J')}
             ranges={{
               grey: [15, 18], // Anything under 1EJ is pretty mediocre
               yellow: [18, 24],

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -1,8 +1,9 @@
+import { useBackend } from '../../backend';
 import { LabeledControls, RoundGauge, Section } from '../../components';
 import { formatSiUnit } from '../../format';
 import { toFixed } from 'common/math';
 
-export const HypertorusParameters = props => {
+export const HypertorusParameters = (props, context) => {
   const {
     apcEnergy: apc_energy,
     energyLevel: energy_level,
@@ -15,6 +16,7 @@ export const HypertorusParameters = props => {
     ironContent: iron_content,
     integrity,
   } = props;
+  const { act, data } = useBackend(context);
 
   const energy_minimum_exponent = 12;
   const energy_minimum_suffix = energy_minimum_exponent / 3;
@@ -106,7 +108,7 @@ export const HypertorusParameters = props => {
             value={activity * 100}
             minValue={0}
             maxValue={130} // Proto-nitrate lets us exceed 100%
-            format={v => `${toFixed(activity * 100, 1)}%`}
+            format={v => `${data.start_power ? toFixed(activity * 100, 1) : 0}%`}
             ranges={{
               grey: [0, 70],
               blue: [70, 100],
@@ -119,7 +121,7 @@ export const HypertorusParameters = props => {
             value={Math.max(instability, 0)}
             minValue={0}
             maxValue={10}
-            format={v => `${toFixed(Math.max(instability, 0)/8 * 100, 1)}%`}
+            format={v => `${data.start_power ? toFixed(Math.max(instability, 0)/8 * 100, 1) : 0}%`}
             ranges={{
               orange: [0, 8], // exothermic
               blue: [8, 10], // endothermic

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -1,6 +1,6 @@
 import { toFixed } from 'common/math';
 import { useBackend } from '../../backend';
-import { LabeledControls, RoundGauge, Section } from '../../components';
+import { Flex, LabeledControls, RoundGauge, Section } from '../../components';
 import { formatSiUnit } from '../../format';
 
 /*
@@ -34,104 +34,116 @@ export const HypertorusParameters = (props, context) => {
 
   return (
     <Section title="Reactor Status">
-      <LabeledControls justify="space-around">
-        <LabeledControls.Item label="Reactor Integrity">
-          <RoundGauge
-            size={1.75}
-            value={data.integrity}
-            minValue={0}
-            maxValue={100}
-            alertBefore={95}
-            format={v => `${Math.round(v)}%`}
-            ranges={{
-              good: [90, 100],
-              average: [50, 90],
-              bad: [0, 50],
-            }} />
-        </LabeledControls.Item>
-        <LabeledControls.Item label="Iron Content">
-          <RoundGauge
-            size={1.75}
-            value={data.iron_content}
-            minValue={0}
-            maxValue={1}
-            alertAfter={.25}
-            format={v => `${Math.round(v*100)}%`}
-            ranges={{
-              good: [0, .1],
-              average: [.1, .36],
-              bad: [.36, 1],
-            }} />
-        </LabeledControls.Item>
-        <LabeledControls.Item label="Area Power">
-          <RoundGauge
-            size={1.75}
-            value={data.apc_energy}
-            minValue={0}
-            maxValue={100}
-            alertBefore={30}
-            format={v => `${Math.round(v)}%`}
-            ranges={{
-              // Keep these in line with the auto-off thresholds in apc.dm
-              bad: [0, 15],
-              average: [15, 30],
-              good: [30, 100],
-            }} />
-        </LabeledControls.Item>
-        <LabeledControls.Item label="Fusion Level">
-          <RoundGauge
-            size={3}
-            minValue={0}
-            maxValue={6}
-            value={data.power_level}
-            alertAfter={4.5}
-            ranges={{
-              grey: [0, 1],
-              good: [1, 3.5],
-              average: [3.5, 4.5],
-              bad: [4.5, 6],
-            }} />
-        </LabeledControls.Item>
-        <LabeledControls.Item label="Energy">
-          <RoundGauge
-            size={1.75}
-            value={Math.max(0, Math.log10(data.energy_level))}
-            minValue={energy_minimum_exponent}
-            maxValue={30}
-            format={v => formatSiUnit(10**v, energy_minimum_suffix, 'J')}
-            ranges={{
-              black: [energy_minimum_exponent, 15],
-              grey: [15, 18], // Anything under 1EJ is pretty mediocre
-              yellow: [18, 24],
-              orange: [24, 30],
-            }} />
-        </LabeledControls.Item>
-        <LabeledControls.Item label="Reaction activity">
-          <RoundGauge
-            size={1.75}
-            value={activity * 100}
-            minValue={0}
-            maxValue={130} // Proto-nitrate lets us exceed 100%
-            format={v => `${data.start_power ? toFixed(v, 1) : 0}%`}
-            ranges={{
-              grey: [0, 70],
-              blue: [70, 100],
-              orange: [100, 130],
-            }} />
-        </LabeledControls.Item>
-        <LabeledControls.Item label="Instability">
-          <RoundGauge
-            size={1.75}
-            value={Math.max(data.instability, 0)}
-            minValue={0}
-            maxValue={10}
-            format={v => `${data.start_power ? toFixed(v/8 * 100, 1) : 0}%`}
-            ranges={{
-              orange: [0, 8], // exothermic
-              blue: [8, 10], // endothermic
-            }} />
-        </LabeledControls.Item>
-      </LabeledControls>
+      <Flex className="hypertorus-parameters" justify="space-between" wrap>
+        <Flex.Item grow="360" minWidth="120px">
+          <LabeledControls justify="space-around" wrap>
+            <LabeledControls.Item label="Reactor Integrity">
+              <RoundGauge
+                size={1.75}
+                value={data.integrity}
+                minValue={0}
+                maxValue={100}
+                alertBefore={95}
+                format={v => `${Math.round(v)}%`}
+                ranges={{
+                  good: [90, 100],
+                  average: [50, 90],
+                  bad: [0, 50],
+                }} />
+            </LabeledControls.Item>
+            <LabeledControls.Item label="Iron Content">
+              <RoundGauge
+                size={1.75}
+                value={data.iron_content}
+                minValue={0}
+                maxValue={1}
+                alertAfter={.25}
+                format={v => `${Math.round(v*100)}%`}
+                ranges={{
+                  good: [0, .1],
+                  average: [.1, .36],
+                  bad: [.36, 1],
+                }} />
+            </LabeledControls.Item>
+            <LabeledControls.Item label="Area Power">
+              <RoundGauge
+                size={1.75}
+                value={data.apc_energy}
+                minValue={0}
+                maxValue={100}
+                alertBefore={30}
+                format={v => `${Math.round(v)}%`}
+                ranges={{
+                  // Keep these in line with the auto-off thresholds in apc.dm
+                  bad: [0, 15],
+                  average: [15, 30],
+                  good: [30, 100],
+                }} />
+            </LabeledControls.Item>
+          </LabeledControls>
+        </Flex.Item>
+        <Flex.Item grow="140" minWidth="140px" align="center">
+          <LabeledControls justify="space-around">
+            <LabeledControls.Item label="Fusion Level">
+              <RoundGauge
+                size={3}
+                minValue={0}
+                maxValue={6}
+                value={data.power_level}
+                alertAfter={4.5}
+                ranges={{
+                  grey: [0, 1],
+                  good: [1, 3.5],
+                  average: [3.5, 4.5],
+                  bad: [4.5, 6],
+                }} />
+            </LabeledControls.Item>
+          </LabeledControls>
+        </Flex.Item>
+        <Flex.Item grow="360" minWidth="120px">
+          <LabeledControls justify="space-around" wrap>
+            <LabeledControls.Item label="Energy">
+              <RoundGauge
+                size={1.75}
+                value={Math.max(0, Math.log10(data.energy_level))}
+                minValue={energy_minimum_exponent}
+                maxValue={30}
+                format={v => formatSiUnit(10**v, energy_minimum_suffix, 'J')}
+                ranges={{
+                  black: [energy_minimum_exponent, 15],
+                  grey: [15, 18], // Anything under 1EJ is pretty mediocre
+                  yellow: [18, 24],
+                  orange: [24, 30],
+                }} />
+            </LabeledControls.Item>
+            <LabeledControls.Item label="Reaction activity">
+              <RoundGauge
+                size={1.75}
+                value={activity * 100}
+                minValue={0}
+                maxValue={130} // Proto-nitrate lets us exceed 100%
+                format={v => `${data.start_power ? toFixed(v, 1) : 0}%`}
+                ranges={{
+                  grey: [0, 70],
+                  blue: [70, 100],
+                  orange: [100, 130],
+                }} />
+            </LabeledControls.Item>
+            <LabeledControls.Item label="Instability">
+              <RoundGauge
+                size={1.75}
+                value={Math.max(data.instability, 0)}
+                minValue={0}
+                maxValue={10}
+                format={v => `${data.start_power ? toFixed(v/8 * 100, 1) : 0}%`}
+                ranges={{
+                  orange: [0, 8], // exothermic
+                  blue: [8, 10], // endothermic
+                }} />
+            </LabeledControls.Item>
+          </LabeledControls>
+        </Flex.Item>
+      </Flex>
     </Section>
   );
 };

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -1,0 +1,130 @@
+import { LabeledControls, RoundGauge, Section } from '../../components';
+import { formatSiUnit } from '../../format';
+import { to_exponential_if_big }from './helpers';
+
+export const HypertorusParameters = props => {
+  const {
+    energyLevel: energy_level,
+    realHeatOutput: heat_output,
+    realHeatLimiterModifier: heat_limiter_modifier,
+    rawHeatLimiterModifier: raw_heat_limiter_modifier,
+    powerLevel: power_level,
+    ironContent: iron_content,
+    integrity,
+  } = props;
+
+  // Heat change is an interesting control, and there's a lot we're trying
+  // to indicate in a fairly small space.
+
+  // The scale must be logarithmic, simply due to the units involved.
+  const log10scale = value => {
+    const scale = Math.max(0,Math.log10(Math.abs(value)));
+    return (value < 0 ? -1 : 1) * scale;
+  };
+
+  // First, we want to indicate the potential range from the power level.
+  // This forms the scale that our gauge uses.
+  //
+  // max is 10 * 10**power_level * heating_conductor / 100
+  // min is 1/100th of max, but expressly leave this 2 off the real min to show asymmetry
+  const max_power_level_heat_change = 10 * 10 ** power_level * 5;
+  const min_power_level_heat_change = -max_power_level_heat_change;
+
+  // Next, we want to indicate how much of this range is available, based
+  // on our heat limiter modifier.
+  // This forms the markers on the gauge.
+  const max_capped_heat_change = raw_heat_limiter_modifier;
+  const min_capped_heat_change = -raw_heat_limiter_modifier / 100;
+
+  const log_max_capped_heat_change = log10scale(max_capped_heat_change);
+  const log_min_capped_heat_change = log10scale(min_capped_heat_change);
+
+  const log_cool_midpoint = Math.min(-0.5, log_min_capped_heat_change + 1);
+  const log_heat_midpoint = Math.max( 0.5, log_max_capped_heat_change - 1);
+
+  // Finally, we want to indicate how much of the potential heat change is
+  // being achieved.
+  // This will form the needle on the gauge. We pass this in to the
+  // heat RoundGauge directly.
+
+
+  // Visually, we place a large Fusion Level Gauge in the center.
+  // Immediately adjacent are Gauges that track an important intermediate
+  // parameter, and on the sides are Gauges that track the result that people
+  // are most likely to ultimately care about relating to each value.
+
+  return (
+    <Section title="Reactor Parameters">
+      <LabeledControls justify="space-around">
+        <LabeledControls.Item label="Reactor Integrity">
+          <RoundGauge
+            size={1.75}
+            value={integrity}
+            minValue={0}
+            maxValue={100}
+            alertBefore={95}
+            format={v=>`${Math.round(v)}%`}
+            ranges={{
+              good: [90, 100],
+              average: [50, 90],
+              bad: [0, 50],
+            }} />
+        </LabeledControls.Item>
+        <LabeledControls.Item label="Iron Content">
+          <RoundGauge
+            size={1.75}
+            value={iron_content}
+            minValue={0}
+            maxValue={1}
+            alertAfter={.25}
+            format={v=>`${Math.round(v*100)}%`}
+            ranges={{
+              good: [0, .1],
+              average: [.1, .36],
+              bad: [.36, 1],
+            }} />
+        </LabeledControls.Item>
+        <LabeledControls.Item label="Fusion Level">
+          <RoundGauge
+            size={2.5}
+            minValue={0}
+            maxValue={6}
+            value={power_level}
+            alertAfter={5}
+            ranges={{
+              grey: [0, 1],
+              good: [1, 3],
+              average: [3, 4],
+              bad: [4, 6],
+            }} />
+        </LabeledControls.Item>
+        <LabeledControls.Item label="Energy">
+          <RoundGauge
+            size={1.75}
+            value={Math.log10(energy_level)}
+            minValue={12}
+            maxValue={30}
+            format={v=>formatSiUnit(10**v, 1, 'J')}
+            ranges={{
+              grey: [15, 18], // Anything under 1EJ is pretty mediocre
+              yellow: [18, 24],
+              orange: [24, 30],
+            }} />
+        </LabeledControls.Item>
+        <LabeledControls.Item label="Heat Change/Cap">
+          <RoundGauge
+            size={1.75}
+            value={log10scale(heat_output)}
+            minValue={log10scale(min_power_level_heat_change)}
+            maxValue={log10scale(max_power_level_heat_change)}
+            format={()=>`${to_exponential_if_big(heat_output)} K/${to_exponential_if_big(heat_limiter_modifier)} K`}
+            ranges={{
+              cyan: [log_min_capped_heat_change, log_cool_midpoint],
+              grey: [log_cool_midpoint, log_heat_midpoint],
+              orange: [log_heat_midpoint, log_max_capped_heat_change],
+            }} />
+        </LabeledControls.Item>
+      </LabeledControls>
+    </Section>
+  );
+};

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -3,6 +3,16 @@ import { LabeledControls, RoundGauge, Section } from '../../components';
 import { formatSiUnit } from '../../format';
 import { toFixed } from 'common/math';
 
+/*
+ * Parameter display
+ *
+ * Displays a set of gauges displaying key information about the
+ * HFR.
+ * 
+ * Parameters with dangerous thresholds also display warnings at the
+ * relevant levels.
+ */
+
 export const HypertorusParameters = (props, context) => {
   const { data } = useBackend(context);
 
@@ -23,7 +33,7 @@ export const HypertorusParameters = (props, context) => {
   }
 
   return (
-    <Section title="Reactor Parameters">
+    <Section title="Reactor Status">
       <LabeledControls justify="space-around">
         <LabeledControls.Item label="Reactor Integrity">
           <RoundGauge

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -4,19 +4,13 @@ import { formatSiUnit } from '../../format';
 import { toFixed } from 'common/math';
 
 export const HypertorusParameters = (props, context) => {
+  const { data } = useBackend(context);
+
   const {
-    apcEnergy: apc_energy,
-    energyLevel: energy_level,
-    heatOutputMin: heat_output_min,
-    heatOutputMax: heat_output_max,
-    heatOutput: heat_output,
-    heatLimiterModifier: heat_limiter_modifier,
-    instability,
-    powerLevel: power_level,
-    ironContent: iron_content,
-    integrity,
-  } = props;
-  const { act, data } = useBackend(context);
+    heat_output,
+    heat_output_min,
+    heat_output_max
+  } = data;
 
   const energy_minimum_exponent = 12;
   const energy_minimum_suffix = energy_minimum_exponent / 3;
@@ -34,7 +28,7 @@ export const HypertorusParameters = (props, context) => {
         <LabeledControls.Item label="Reactor Integrity">
           <RoundGauge
             size={1.75}
-            value={integrity}
+            value={data.integrity}
             minValue={0}
             maxValue={100}
             alertBefore={95}
@@ -48,7 +42,7 @@ export const HypertorusParameters = (props, context) => {
         <LabeledControls.Item label="Iron Content">
           <RoundGauge
             size={1.75}
-            value={iron_content}
+            value={data.iron_content}
             minValue={0}
             maxValue={1}
             alertAfter={.25}
@@ -62,7 +56,7 @@ export const HypertorusParameters = (props, context) => {
         <LabeledControls.Item label="Area Power">
           <RoundGauge
             size={1.75}
-            value={apc_energy}
+            value={data.apc_energy}
             minValue={0}
             maxValue={100}
             alertBefore={30}
@@ -79,7 +73,7 @@ export const HypertorusParameters = (props, context) => {
             size={3}
             minValue={0}
             maxValue={6}
-            value={power_level}
+            value={data.power_level}
             alertAfter={4.5}
             ranges={{
               grey: [0, 1],
@@ -91,7 +85,7 @@ export const HypertorusParameters = (props, context) => {
         <LabeledControls.Item label="Energy">
           <RoundGauge
             size={1.75}
-            value={Math.max(0, Math.log10(energy_level))}
+            value={Math.max(0, Math.log10(data.energy_level))}
             minValue={energy_minimum_exponent}
             maxValue={30}
             format={v => formatSiUnit(10**v, energy_minimum_suffix, 'J')}
@@ -108,7 +102,7 @@ export const HypertorusParameters = (props, context) => {
             value={activity * 100}
             minValue={0}
             maxValue={130} // Proto-nitrate lets us exceed 100%
-            format={v => `${data.start_power ? toFixed(activity * 100, 1) : 0}%`}
+            format={v => `${data.start_power ? toFixed(v, 1) : 0}%`}
             ranges={{
               grey: [0, 70],
               blue: [70, 100],
@@ -118,10 +112,10 @@ export const HypertorusParameters = (props, context) => {
         <LabeledControls.Item label="Instability">
           <RoundGauge
             size={1.75}
-            value={Math.max(instability, 0)}
+            value={Math.max(data.instability, 0)}
             minValue={0}
             maxValue={10}
-            format={v => `${data.start_power ? toFixed(Math.max(instability, 0)/8 * 100, 1) : 0}%`}
+            format={v => `${data.start_power ? toFixed(v/8 * 100, 1) : 0}%`}
             ranges={{
               orange: [0, 8], // exothermic
               blue: [8, 10], // endothermic

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -1,72 +1,28 @@
 import { LabeledControls, RoundGauge, Section } from '../../components';
 import { formatSiUnit } from '../../format';
 import { to_exponential_if_big }from './helpers';
+import { toFixed } from 'common/math';
 
 export const HypertorusParameters = props => {
   const {
     energyLevel: energy_level,
-    realHeatOutput: heat_output,
-    realHeatLimiterModifier: heat_limiter_modifier,
-    rawHeatLimiterModifier: raw_heat_limiter_modifier,
+    heatOutputMin: heat_output_min,
+    heatOutputMax: heat_output_max,
+    heatOutput: heat_output,
+    heatLimiterModifier: heat_limiter_modifier,
+    instability,
     powerLevel: power_level,
     ironContent: iron_content,
     integrity,
   } = props;
 
-  // Heat change is an interesting control, and there's a lot we're trying
-  // to indicate in a fairly small space.
-
-  // The scale must be logarithmic, simply due to the units involved.
-  const log10scale = value => {
-    const scale = Math.max(0,Math.log10(Math.abs(value)));
-    return (value < 0 ? -1 : 1) * scale;
-  };
-
-  // First, we want to indicate the potential range from the power level.
-  // This forms the scale that our gauge uses.
-  //
-  // max is 10 * 10**power_level * heating_conductor / 100
-  // min is 1/100th of max, but expressly leave this 2 off the real min to show asymmetry
-  const max_power_level_heat_change = 10 * 10 ** power_level * 5;
-  const min_power_level_heat_change = -max_power_level_heat_change;
-
-  // Next, we want to indicate how much of this range is available, based
-  // on our heat limiter modifier.
-  // This forms the markers on the gauge.
-  const max_capped_heat_change = raw_heat_limiter_modifier;
-  const min_capped_heat_change = -raw_heat_limiter_modifier / 100;
-
-  // Force each band to be of minimum size for visibility
-  const visible_epsilon = 0.2;
-
-  const log_max_capped_heat_change = Math.max( 2 * visible_epsilon, log10scale(max_capped_heat_change));
-  const log_min_capped_heat_change = Math.min(-2 * visible_epsilon, log10scale(min_capped_heat_change));
-
-  const log_heat_midpoint = Math.max( visible_epsilon, log_max_capped_heat_change - 1);
-  const log_cool_midpoint = Math.min(-visible_epsilon, log_min_capped_heat_change + 1);
-
-  const heat_change_gauge_ranges = {
-    //pink: [log10scale(-max_power_level_heat_change), log_min_capped_heat_change],
-    blue: [log_min_capped_heat_change, log_cool_midpoint],
-    grey: [log_cool_midpoint, log_heat_midpoint],
-    orange: [log_heat_midpoint, log_max_capped_heat_change],
-    //red: [log_max_capped_heat_change, log10scale(max_power_level_heat_change)]
-  };
-
-  // Finally, we want to indicate how much of the potential heat change is
-  // being achieved.
-  // This will form the needle on the gauge. We pass this in to the
-  // heat RoundGauge directly.
-
-  const heat_change_value = log10scale(heat_output);
-
-  // Visually, we place a large Fusion Level Gauge in the center.
-  // Immediately adjacent are Gauges that track an important intermediate
-  // parameter, and on the sides are Gauges that track the result that people
-  // are most likely to ultimately care about relating to each value.
-
   const energy_minimum_exponent = 12;
   const energy_minimum_suffix = energy_minimum_exponent / 3;
+
+  let activity = heat_output / (heat_output < 0 ? heat_output_min : heat_output_max);
+  if (isNaN(activity) || !isFinite(activity)) {
+    activity = 0;
+  }
 
   return (
     <Section title="Reactor Parameters">
@@ -101,7 +57,7 @@ export const HypertorusParameters = props => {
         </LabeledControls.Item>
         <LabeledControls.Item label="Fusion Level">
           <RoundGauge
-            size={2.5}
+            size={3}
             minValue={0}
             maxValue={6}
             value={power_level}
@@ -127,14 +83,30 @@ export const HypertorusParameters = props => {
               orange: [24, 30],
             }} />
         </LabeledControls.Item>
-        <LabeledControls.Item label="Heat Change/Cap">
+        <LabeledControls.Item label="Reaction activity">
           <RoundGauge
             size={1.75}
-            value={heat_change_value}
-            minValue={log10scale(min_power_level_heat_change)}
-            maxValue={log10scale(max_power_level_heat_change)}
-            format={()=>`${to_exponential_if_big(heat_output)} K/${to_exponential_if_big(heat_limiter_modifier)} K`}
-            ranges={heat_change_gauge_ranges} />
+            value={activity * 100}
+            minValue={0}
+            maxValue={130}
+            format={v=>`${toFixed(activity * 100, 1)}%`}
+            ranges={{
+              grey: [0, 70],
+              blue: [70, 100],
+              orange: [100, 130],
+            }} />
+        </LabeledControls.Item>
+        <LabeledControls.Item label="Instability">
+          <RoundGauge
+            size={1.75}
+            value={Math.max(instability,0)}
+            minValue={0}
+            maxValue={10}
+            format={v=>`${toFixed(Math.max(instability,0)/8 * 100, 1)}%`}
+            ranges={{
+              orange: [0, 8], // exothermic
+              blue: [8,10] // endothermic
+            }} />
         </LabeledControls.Item>
       </LabeledControls>
     </Section>

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -1,6 +1,5 @@
 import { LabeledControls, RoundGauge, Section } from '../../components';
 import { formatSiUnit } from '../../format';
-import { to_exponential_if_big }from './helpers';
 import { toFixed } from 'common/math';
 
 export const HypertorusParameters = props => {
@@ -20,7 +19,9 @@ export const HypertorusParameters = props => {
   const energy_minimum_exponent = 12;
   const energy_minimum_suffix = energy_minimum_exponent / 3;
 
-  let activity = heat_output / (heat_output < 0 ? heat_output_min : heat_output_max);
+  let activity = heat_output / (heat_output < 0
+    ? heat_output_min
+    : heat_output_max);
   if (isNaN(activity) || !isFinite(activity)) {
     activity = 0;
   }
@@ -35,7 +36,7 @@ export const HypertorusParameters = props => {
             minValue={0}
             maxValue={100}
             alertBefore={95}
-            format={v=>`${Math.round(v)}%`}
+            format={v => `${Math.round(v)}%`}
             ranges={{
               good: [90, 100],
               average: [50, 90],
@@ -49,7 +50,7 @@ export const HypertorusParameters = props => {
             minValue={0}
             maxValue={1}
             alertAfter={.25}
-            format={v=>`${Math.round(v*100)}%`}
+            format={v => `${Math.round(v*100)}%`}
             ranges={{
               good: [0, .1],
               average: [.1, .36],
@@ -63,7 +64,7 @@ export const HypertorusParameters = props => {
             minValue={0}
             maxValue={100}
             alertBefore={30}
-            format={v=>`${Math.round(v)}%`}
+            format={v => `${Math.round(v)}%`}
             ranges={{
               // Keep these in line with the auto-off thresholds in apc.dm
               bad: [0, 15],
@@ -88,10 +89,10 @@ export const HypertorusParameters = props => {
         <LabeledControls.Item label="Energy">
           <RoundGauge
             size={1.75}
-            value={Math.max(0,Math.log10(energy_level))}
+            value={Math.max(0, Math.log10(energy_level))}
             minValue={energy_minimum_exponent}
             maxValue={30}
-            format={v=>formatSiUnit(10**v, energy_minimum_suffix, 'J')}
+            format={v => formatSiUnit(10**v, energy_minimum_suffix, 'J')}
             ranges={{
               black: [energy_minimum_exponent, 15],
               grey: [15, 18], // Anything under 1EJ is pretty mediocre
@@ -105,7 +106,7 @@ export const HypertorusParameters = props => {
             value={activity * 100}
             minValue={0}
             maxValue={130} // Proto-nitrate lets us exceed 100%
-            format={v=>`${toFixed(activity * 100, 1)}%`}
+            format={v => `${toFixed(activity * 100, 1)}%`}
             ranges={{
               grey: [0, 70],
               blue: [70, 100],
@@ -115,13 +116,13 @@ export const HypertorusParameters = props => {
         <LabeledControls.Item label="Instability">
           <RoundGauge
             size={1.75}
-            value={Math.max(instability,0)}
+            value={Math.max(instability, 0)}
             minValue={0}
             maxValue={10}
-            format={v=>`${toFixed(Math.max(instability,0)/8 * 100, 1)}%`}
+            format={v => `${toFixed(Math.max(instability, 0)/8 * 100, 1)}%`}
             ranges={{
               orange: [0, 8], // exothermic
-              blue: [8,10] // endothermic
+              blue: [8, 10], // endothermic
             }} />
         </LabeledControls.Item>
       </LabeledControls>

--- a/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Parameters.js
@@ -108,9 +108,9 @@ export const HypertorusParameters = props => {
             alertAfter={5}
             ranges={{
               grey: [0, 1],
-              good: [1, 3],
-              average: [3, 4],
-              bad: [4, 6],
+              good: [1, 3.5],
+              average: [3.5, 4.5],
+              bad: [4.5, 6],
             }} />
         </LabeledControls.Item>
         <LabeledControls.Item label="Energy">

--- a/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
@@ -87,13 +87,13 @@ const effect_to_icon = (effect_value, effect_scale, base) => {
 
 const recipeChange = {
   onComponentShouldUpdate: (lastProps, nextProps) =>
-    lastProps.selectedFuelID != nextProps.selectedFuelID
-    || lastProps.enableRecipeSelection != nextProps.enableRecipeSelection
+    lastProps.selectedFuelID !== nextProps.selectedFuelID
+    || lastProps.enableRecipeSelection !== nextProps.enableRecipeSelection,
 };
 
 const activeChange = {
   onComponentShouldUpdate: (lastProps, nextProps) =>
-    lastProps.active !== nextProps.active
+    lastProps.active !== nextProps.active,
 };
 
 const MemoRow = props => {
@@ -218,7 +218,7 @@ export const HypertorusRecipes = props => {
                 return (
                   <Table.Cell key={item.param}>
                     <MaybeTooltip content={(item.tooltip || (v => "x"+v))(value, rest)}>
-                      <Icon className='hypertorus-recipes__icon' name={effect_to_icon(value, item.scale, item.override_base || 1)} />
+                      <Icon className="hypertorus-recipes__icon" name={effect_to_icon(value, item.scale, item.override_base || 1)} />
                     </MaybeTooltip>
                   </Table.Cell>
                 );

--- a/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
@@ -2,6 +2,16 @@ import { Box, Button, Icon, Table, Tooltip } from '../../components';
 import { Color } from '../../../common/color';
 import { getGasColor, getGasLabel } from '../../constants';
 
+/*
+ * Recipe selection interface
+ *
+ * Displays a table of recipes with their outputs and effects, along
+ * with buttons to select the active recipe and highlights on the current
+ * recipe.
+ * 
+ * Frankly, rather ugly and a good candidate for future improvements.
+ */
+
 /**
  * The list of recipe effects to list, in order.
  * Parameters:

--- a/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
@@ -138,82 +138,84 @@ export const HypertorusRecipes = props => {
     ...rest
   } = props;
   return (
-    <Table>
-      <MemoRow header>
-        <Table.Cell />
-        <Table.Cell colspan="2">Fuel</Table.Cell>
-        <Table.Cell colspan="2">Fusion Byproducts</Table.Cell>
-        <Table.Cell colspan="6">Produced gases</Table.Cell>
-        <Table.Cell colspan="6">Effects</Table.Cell>
-      </MemoRow>
-      <MemoRow header>
-        <Table.Cell />
-        <Table.Cell>Primary</Table.Cell>
-        <Table.Cell>Secondary</Table.Cell>
-        <Table.Cell colspan="2" />
-        <Table.Cell>Tier 1</Table.Cell>
-        <Table.Cell>Tier 2</Table.Cell>
-        <Table.Cell>Tier 3</Table.Cell>
-        <Table.Cell>Tier 4</Table.Cell>
-        <Table.Cell>Tier 5</Table.Cell>
-        <Table.Cell>Tier 6</Table.Cell>
-        {
-          // Lay out our pictographic headers for effects.
-          recipe_effect_structure.map(item => (
-            <Table.Cell key={item.param} color="label">
-              <Tooltip content={item.label}>
-                {typeof(item.icon) === "string" ? (
-                  <Icon className="hypertorus-recipes__icon" name={item.icon} />
-                ) : (
-                  <Icon.Stack className="hypertorus-recipes__icon">
-                    {item.icon.map(icon => (
-                      <Icon key={icon} name={icon} />
-                    ))}
-                  </Icon.Stack>
-                )}
-              </Tooltip>
-            </Table.Cell>
-          ))
-        }
-      </MemoRow>
-      {selectable_fuels.filter(d => d.id).map((recipe, index) => {
-        const active = recipe.id === selected_fuel_id;
-        return (
-          <MemoRow key={recipe.id} active={active}>
-            <Table.Cell>
-              <Button
-                icon={recipe.id === selected_fuel_id ? "times" : "power-off"}
-                disabled={!enable_recipe_selection}
-                key={recipe.id}
-                selected={recipe.id === selected_fuel_id}
-                onClick={onRecipe.bind(null, recipe.id)}
-              />
-            </Table.Cell>
-            <GasCellItem gasid={recipe.requirements[0]} />
-            <GasCellItem gasid={recipe.requirements[1]} />
-            <GasCellItem gasid={recipe.fusion_byproducts[0]} />
-            <GasCellItem gasid={recipe.fusion_byproducts[1]} />
-            {recipe.product_gases.map(gasid => (
-              <GasCellItem key={gasid} gasid={gasid} />
-            ))}
-            {
-              recipe_effect_structure.map(item => {
-                const value = recipe[item.param];
-                // Note that the minus icon is wider than the arrow icons,
-                // so we set the width to work with both without jumping.
-                return (
-                  <Table.Cell key={item.param}>
-                    <Tooltip content={(item.tooltip || (v => "x"+v))(value, rest)}>
-                      <Icon className="hypertorus-recipes__icon" name={effect_to_icon(value, item.scale, item.override_base || 1)} />
-                    </Tooltip>
-                  </Table.Cell>
-                );
-              })
-            }
-          </MemoRow>
-        );
-      })}
-    </Table>
+    <Box overflowX="auto">
+      <Table>
+        <MemoRow header>
+          <Table.Cell />
+          <Table.Cell colspan="2">Fuel</Table.Cell>
+          <Table.Cell colspan="2">Fusion Byproducts</Table.Cell>
+          <Table.Cell colspan="6">Produced gases</Table.Cell>
+          <Table.Cell colspan="6">Effects</Table.Cell>
+        </MemoRow>
+        <MemoRow header>
+          <Table.Cell />
+          <Table.Cell>Primary</Table.Cell>
+          <Table.Cell>Secondary</Table.Cell>
+          <Table.Cell colspan="2" />
+          <Table.Cell>Tier 1</Table.Cell>
+          <Table.Cell>Tier 2</Table.Cell>
+          <Table.Cell>Tier 3</Table.Cell>
+          <Table.Cell>Tier 4</Table.Cell>
+          <Table.Cell>Tier 5</Table.Cell>
+          <Table.Cell>Tier 6</Table.Cell>
+          {
+            // Lay out our pictographic headers for effects.
+            recipe_effect_structure.map(item => (
+              <Table.Cell key={item.param} color="label">
+                <Tooltip content={item.label}>
+                  {typeof(item.icon) === "string" ? (
+                    <Icon className="hypertorus-recipes__icon" name={item.icon} />
+                  ) : (
+                    <Icon.Stack className="hypertorus-recipes__icon">
+                      {item.icon.map(icon => (
+                        <Icon key={icon} name={icon} />
+                      ))}
+                    </Icon.Stack>
+                  )}
+                </Tooltip>
+              </Table.Cell>
+            ))
+          }
+        </MemoRow>
+        {selectable_fuels.filter(d => d.id).map((recipe, index) => {
+          const active = recipe.id === selected_fuel_id;
+          return (
+            <MemoRow key={recipe.id} active={active}>
+              <Table.Cell>
+                <Button
+                  icon={recipe.id === selected_fuel_id ? "times" : "power-off"}
+                  disabled={!enable_recipe_selection}
+                  key={recipe.id}
+                  selected={recipe.id === selected_fuel_id}
+                  onClick={onRecipe.bind(null, recipe.id)}
+                />
+              </Table.Cell>
+              <GasCellItem gasid={recipe.requirements[0]} />
+              <GasCellItem gasid={recipe.requirements[1]} />
+              <GasCellItem gasid={recipe.fusion_byproducts[0]} />
+              <GasCellItem gasid={recipe.fusion_byproducts[1]} />
+              {recipe.product_gases.map(gasid => (
+                <GasCellItem key={gasid} gasid={gasid} />
+              ))}
+              {
+                recipe_effect_structure.map(item => {
+                  const value = recipe[item.param];
+                  // Note that the minus icon is wider than the arrow icons,
+                  // so we set the width to work with both without jumping.
+                  return (
+                    <Table.Cell key={item.param}>
+                      <Tooltip content={(item.tooltip || (v => "x"+v))(value, rest)}>
+                        <Icon className="hypertorus-recipes__icon" name={effect_to_icon(value, item.scale, item.override_base || 1)} />
+                      </Tooltip>
+                    </Table.Cell>
+                  );
+                })
+              }
+            </MemoRow>
+          );
+        })}
+      </Table>
+    </Box>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
@@ -76,10 +76,15 @@ const effect_to_icon = (effect_value, effect_scale, base) => {
   return "angle-down";
 };
 
+const recipeChange = {
+  onComponentShouldUpdate: (lastProps, nextProps) =>
+    lastProps.selectedFuelID != nextProps.selectedFuelID
+    || lastProps.enableRecipeSelection != nextProps.enableRecipeSelection
+};
+
 const bgChange = {
-  onComponentShouldUpdate: (lastProps, nextProps) => {
-    return lastProps.backgroundColor !== nextProps.backgroundColor;
-  },
+  onComponentShouldUpdate: (lastProps, nextProps) =>
+    lastProps.backgroundColor !== nextProps.backgroundColor
 };
 
 const MemoRow = props => {
@@ -247,3 +252,5 @@ export const HypertorusRecipes = props => {
     </Table>
   );
 };
+
+HypertorusRecipes.defaultHooks = recipeChange;

--- a/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
@@ -1,5 +1,4 @@
 import { Box, Button, Icon, Table, Tooltip } from '../../components';
-import { Color } from '../../../common/color';
 import { getGasColor, getGasLabel } from '../../constants';
 
 /*
@@ -92,21 +91,21 @@ const recipeChange = {
     || lastProps.enableRecipeSelection != nextProps.enableRecipeSelection
 };
 
-const bgChange = {
+const activeChange = {
   onComponentShouldUpdate: (lastProps, nextProps) =>
-    lastProps.backgroundColor !== nextProps.backgroundColor
+    lastProps.active !== nextProps.active
 };
 
 const MemoRow = props => {
   const {
-    backgroundColor,
+    active,
     children,
     key,
     ...rest
   } = props;
   return (
     <Table.Row
-      backgroundColor={backgroundColor}
+      className={`hypertorus-recipes__row${active ? ' hypertorus-recipes__activerow' : ''}`}
       {...rest}
     >
       {children}
@@ -114,7 +113,7 @@ const MemoRow = props => {
   );
 };
 
-MemoRow.defaultHooks = bgChange;
+MemoRow.defaultHooks = activeChange;
 
 const GasCellItem = props => {
   const {
@@ -154,58 +153,33 @@ export const HypertorusRecipes = props => {
   } = props;
   return (
     <Table>
-      <MemoRow color="label" header>
+      <MemoRow header>
         <Table.Cell />
-        <Table.Cell textAlign="center" colspan="2">
-          Fuel
-        </Table.Cell>
-        <Table.Cell textAlign="center" colspan="2">
-          Fusion Byproducts
-        </Table.Cell>
-        <Table.Cell textAlign="center" colspan="6">
-          Produced gases
-        </Table.Cell>
-        <Table.Cell textAlign="center" colspan="6">
-          Effects
-        </Table.Cell>
-        <Table.Cell grow="1" />
+        <Table.Cell colspan="2">Fuel</Table.Cell>
+        <Table.Cell colspan="2">Fusion Byproducts</Table.Cell>
+        <Table.Cell colspan="6">Produced gases</Table.Cell>
+        <Table.Cell colspan="6">Effects</Table.Cell>
       </MemoRow>
-      <MemoRow color="label" header>
+      <MemoRow header>
         <Table.Cell />
-        <Table.Cell textAlign="center">
-          Primary
-        </Table.Cell>
-        <Table.Cell textAlign="center">
-          Secondary
-        </Table.Cell>
+        <Table.Cell>Primary</Table.Cell>
+        <Table.Cell>Secondary</Table.Cell>
         <Table.Cell colspan="2" />
-        <Table.Cell textAlign="center">
-          Tier 1
-        </Table.Cell>
-        <Table.Cell textAlign="center">
-          Tier 2
-        </Table.Cell>
-        <Table.Cell textAlign="center">
-          Tier 3
-        </Table.Cell>
-        <Table.Cell textAlign="center">
-          Tier 4
-        </Table.Cell>
-        <Table.Cell textAlign="center">
-          Tier 5
-        </Table.Cell>
-        <Table.Cell textAlign="center">
-          Tier 6
-        </Table.Cell>
+        <Table.Cell>Tier 1</Table.Cell>
+        <Table.Cell>Tier 2</Table.Cell>
+        <Table.Cell>Tier 3</Table.Cell>
+        <Table.Cell>Tier 4</Table.Cell>
+        <Table.Cell>Tier 5</Table.Cell>
+        <Table.Cell>Tier 6</Table.Cell>
         {
           // Lay out our pictographic headers for effects.
           recipe_effect_structure.map(item => (
             <Table.Cell key={item.param} color="label">
               <MaybeTooltip content={item.label}>
                 {typeof(item.icon) === "string" ? (
-                  <Icon position="relative" width="10px" name={item.icon} />
+                  <Icon className="hypertorus-recipes__icon" name={item.icon} />
                 ) : (
-                  <Icon.Stack positition="relative" width="10px" textAlign="center">
+                  <Icon.Stack className="hypertorus-recipes__icon">
                     {item.icon.map(icon => (
                       <Icon key={icon} name={icon} />
                     ))}
@@ -218,14 +192,8 @@ export const HypertorusRecipes = props => {
       </MemoRow>
       {selectable_fuels.filter(d => d.id).map((recipe, index) => {
         const active = recipe.id === selected_fuel_id;
-        const odd = 1 - 2 * (index % 2);
-        const secondary = 50 - odd * 50;
-        const primary = active ? secondary + 80 : secondary;
-        const alpha = (active ? .13 : .07);
         return (
-          <MemoRow key={recipe.id} backgroundColor={
-            String(new Color(secondary, primary, secondary, alpha))
-          }>
+          <MemoRow key={recipe.id} active={active}>
             <Table.Cell>
               <Button
                 icon={recipe.id === selected_fuel_id ? "times" : "power-off"}
@@ -250,7 +218,7 @@ export const HypertorusRecipes = props => {
                 return (
                   <Table.Cell key={item.param}>
                     <MaybeTooltip content={(item.tooltip || (v => "x"+v))(value, rest)}>
-                      <Icon position="relative" color="rgb(230,30,40)" width="10px" name={effect_to_icon(value, item.scale, item.override_base || 1)} />
+                      <Icon className='hypertorus-recipes__icon' name={effect_to_icon(value, item.scale, item.override_base || 1)} />
                     </MaybeTooltip>
                   </Table.Cell>
                 );

--- a/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
@@ -201,7 +201,7 @@ export const HypertorusRecipes = props => {
         const primary = active ? secondary + 80 : secondary;
         const alpha = (active ? .13 : .07);
         return (
-          <MemoRow backgroundColor={new Color(secondary, primary, secondary, alpha)}>
+          <MemoRow backgroundColor={String(new Color(secondary, primary, secondary, alpha))}>
             <Table.Cell>
               <Button
                 icon={recipe.id === selected_fuel_id ? "times" : "power-off"}

--- a/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
@@ -19,7 +19,7 @@ import { getGasColor, getGasLabel } from '../../constants';
  *             If omitted, the default of "x{value}" is used.
  *
  */
- const recipe_effect_structure = [
+const recipe_effect_structure = [
   {
     param: "recipe_cooling_multiplier",
     label: "Cooling",
@@ -89,7 +89,14 @@ const MemoRow = props => {
     key,
     ...rest
   } = props;
-  return <Table.Row backgroundColor={backgroundColor} {...rest}>{children}</Table.Row>
+  return (
+    <Table.Row
+      backgroundColor={backgroundColor}
+      {...rest}
+    >
+      {children}
+    </Table.Row>
+  );
 };
 
 MemoRow.defaultHooks = bgChange;
@@ -156,7 +163,7 @@ export const HypertorusRecipes = props => {
         <Table.Cell textAlign="center">
           Secondary
         </Table.Cell>
-        <Table.Cell colspan="2"/>
+        <Table.Cell colspan="2" />
         <Table.Cell textAlign="center">
           Tier 1
         </Table.Cell>
@@ -179,29 +186,31 @@ export const HypertorusRecipes = props => {
           // Lay out our pictographic headers for effects.
           recipe_effect_structure.map(item => (
             <Table.Cell key={item.param} color="label">
-            <MaybeTooltip content={item.label}>
-              {typeof(item.icon) === "string" ? (
-                <Icon position="relative" width="10px" name={item.icon} />
-              ) : (
-                <Icon.Stack positition="relative" width="10px" textAlign="center">
-                  {item.icon.map(icon => (
-                    <Icon name={icon} />
-                  ))}
-                </Icon.Stack>
-              )}
-            </MaybeTooltip>
+              <MaybeTooltip content={item.label}>
+                {typeof(item.icon) === "string" ? (
+                  <Icon position="relative" width="10px" name={item.icon} />
+                ) : (
+                  <Icon.Stack positition="relative" width="10px" textAlign="center">
+                    {item.icon.map(icon => (
+                      <Icon key={icon} name={icon} />
+                    ))}
+                  </Icon.Stack>
+                )}
+              </MaybeTooltip>
             </Table.Cell>
           ))
         }
       </MemoRow>
-      {selectable_fuels.filter(d=>d.id).map((recipe,index) => {
+      {selectable_fuels.filter(d => d.id).map((recipe, index) => {
         const active = recipe.id === selected_fuel_id;
         const odd = 1 - 2 * (index % 2);
         const secondary = 50 - odd * 50;
         const primary = active ? secondary + 80 : secondary;
         const alpha = (active ? .13 : .07);
         return (
-          <MemoRow backgroundColor={String(new Color(secondary, primary, secondary, alpha))}>
+          <MemoRow key={recipe.id} backgroundColor={
+            String(new Color(secondary, primary, secondary, alpha))
+          }>
             <Table.Cell>
               <Button
                 icon={recipe.id === selected_fuel_id ? "times" : "power-off"}
@@ -216,7 +225,7 @@ export const HypertorusRecipes = props => {
             <GasCellItem gasid={recipe.fusion_byproducts[0]} />
             <GasCellItem gasid={recipe.fusion_byproducts[1]} />
             {recipe.product_gases.map(gasid => (
-              <GasCellItem gasid={gasid} />
+              <GasCellItem key={gasid} gasid={gasid} />
             ))}
             {
               recipe_effect_structure.map(item => {
@@ -224,7 +233,7 @@ export const HypertorusRecipes = props => {
                 // Note that the minus icon is wider than the arrow icons,
                 // so we set the width to work with both without jumping.
                 return (
-                  <Table.Cell>
+                  <Table.Cell key={item.param}>
                     <MaybeTooltip content={(item.tooltip || (v => "x"+v))(value, rest)}>
                       <Icon position="relative" color="rgb(230,30,40)" width="10px" name={effect_to_icon(value, item.scale, item.override_base || 1)} />
                     </MaybeTooltip>

--- a/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
@@ -1,0 +1,240 @@
+import { Box, Button, Icon, Table, Tooltip } from '../../components';
+import { Color } from '../../../common/color';
+import { getGasColor, getGasLabel } from '../../constants';
+
+/**
+ * The list of recipe effects to list, in order.
+ * Parameters:
+ *  - param: The name of the parameter passed in the data object.
+ *  - label: The human readable label for this effect.
+ *  - scale: The point at which a directional arrow become a
+ *           double directional arrow.
+ *  - icon:  A string or array of strings describing a pictographic
+ *           icon for use with this effect.
+ *  - override_base: Optional. Sets the base value for scale calculations
+ *                   to something other than 1.
+ *  - tooltip: Optional.
+ *             If specified, this is passed the value and full data
+ *             array and should return the tooltip string.
+ *             If omitted, the default of "x{value}" is used.
+ *
+ */
+ const recipe_effect_structure = [
+  {
+    param: "recipe_cooling_multiplier",
+    label: "Cooling",
+    icon: "snowflake-o",
+    scale: 3,
+  },
+  {
+    param: "recipe_heating_multiplier",
+    label: "Heating",
+    icon: "fire",
+    scale: 3,
+  },
+  {
+    param: "energy_loss_multiplier",
+    label: "Energy loss",
+    icon: "sun-o",
+    scale: 3,
+  },
+  {
+    param: "fuel_consumption_multiplier",
+    label: "Fuel use",
+    icon: ["window-minimize", "arrow-down"],
+    scale: 1.5,
+  },
+  {
+    param: "gas_production_multiplier",
+    label: "Production",
+    icon: ["window-minimize", "arrow-up"],
+    scale: 1.5,
+  },
+  {
+    param: "temperature_multiplier",
+    label: "Max temperature",
+    icon: "thermometer-full",
+    override_base: 0.85,
+    scale: 1.15,
+    tooltip: (v, d) => "Maximum: " + (d.baseMaximumTemperature * v).toExponential() + " K",
+  },
+];
+
+const effect_to_icon = (effect_value, effect_scale, base) => {
+  if (effect_value === base) {
+    return "minus";
+  }
+  if (effect_value > base) {
+    if (effect_value > base * effect_scale) {
+      return "angle-double-up";
+    }
+    return "angle-up";
+  }
+  if (effect_value < base / effect_scale) {
+    return "angle-double-down";
+  }
+  return "angle-down";
+};
+
+const bgChange = {
+  onComponentShouldUpdate: (lastProps, nextProps) => {
+    return lastProps.backgroundColor !== nextProps.backgroundColor;
+  },
+};
+
+const MemoRow = props => {
+  const {
+    backgroundColor,
+    children,
+    key,
+    ...rest
+  } = props;
+  return <Table.Row backgroundColor={backgroundColor} {...rest}>{children}</Table.Row>
+};
+
+MemoRow.defaultHooks = bgChange;
+
+const GasCellItem = props => {
+  const {
+    gasid,
+    ...rest
+  } = props;
+  return (
+    <Table.Cell
+      key={gasid}
+      label={getGasLabel(gasid)} {...rest}>
+      <Box color={getGasColor(gasid)}>{getGasLabel(gasid)}</Box>
+    </Table.Cell>
+  );
+};
+
+// Quick wrapper to globally toggle use of tooltips on or off.
+// Remove once tooltip performance is fixed for good.
+const MaybeTooltip = props => {
+  const {
+    children,
+    ...rest
+  } = props;
+  const noTooltips = false;
+  if (noTooltips) {
+    return (<Box>{children}</Box>);
+  }
+  return (<Tooltip {...rest}>{children}</Tooltip>);
+};
+
+export const HypertorusRecipes = props => {
+  const {
+    enableRecipeSelection: enable_recipe_selection,
+    onRecipe,
+    selectableFuels: selectable_fuels,
+    selectedFuelID: selected_fuel_id,
+    ...rest
+  } = props;
+  return (
+    <Table>
+      <MemoRow color="label" header>
+        <Table.Cell />
+        <Table.Cell textAlign="center" colspan="2">
+          Fuel
+        </Table.Cell>
+        <Table.Cell textAlign="center" colspan="2">
+          Fusion Byproducts
+        </Table.Cell>
+        <Table.Cell textAlign="center" colspan="6">
+          Produced gases
+        </Table.Cell>
+        <Table.Cell textAlign="center" colspan="6">
+          Effects
+        </Table.Cell>
+        <Table.Cell grow="1" />
+      </MemoRow>
+      <MemoRow color="label" header>
+        <Table.Cell />
+        <Table.Cell textAlign="center">
+          Primary
+        </Table.Cell>
+        <Table.Cell textAlign="center">
+          Secondary
+        </Table.Cell>
+        <Table.Cell colspan="2"/>
+        <Table.Cell textAlign="center">
+          Tier 1
+        </Table.Cell>
+        <Table.Cell textAlign="center">
+          Tier 2
+        </Table.Cell>
+        <Table.Cell textAlign="center">
+          Tier 3
+        </Table.Cell>
+        <Table.Cell textAlign="center">
+          Tier 4
+        </Table.Cell>
+        <Table.Cell textAlign="center">
+          Tier 5
+        </Table.Cell>
+        <Table.Cell textAlign="center">
+          Tier 6
+        </Table.Cell>
+        {
+          // Lay out our pictographic headers for effects.
+          recipe_effect_structure.map(item => (
+            <Table.Cell key={item.param} color="label">
+            <MaybeTooltip content={item.label}>
+              {typeof(item.icon) === "string" ? (
+                <Icon position="relative" width="10px" name={item.icon} />
+              ) : (
+                <Icon.Stack positition="relative" width="10px" textAlign="center">
+                  {item.icon.map(icon => (
+                    <Icon name={icon} />
+                  ))}
+                </Icon.Stack>
+              )}
+            </MaybeTooltip>
+            </Table.Cell>
+          ))
+        }
+      </MemoRow>
+      {selectable_fuels.filter(d=>d.id).map((recipe,index) => {
+        const active = recipe.id === selected_fuel_id;
+        const odd = 1 - 2 * (index % 2);
+        const secondary = 50 - odd * 50;
+        const primary = active ? secondary + 80 : secondary;
+        const alpha = (active ? .13 : .07);
+        return (
+          <MemoRow backgroundColor={new Color(secondary, primary, secondary, alpha)}>
+            <Table.Cell>
+              <Button
+                icon={recipe.id === selected_fuel_id ? "times" : "power-off"}
+                disabled={!enable_recipe_selection}
+                key={recipe.id}
+                selected={recipe.id === selected_fuel_id}
+                onClick={onRecipe.bind(null, recipe.id)}
+              />
+            </Table.Cell>
+            <GasCellItem gasid={recipe.requirements[0]} />
+            <GasCellItem gasid={recipe.requirements[1]} />
+            <GasCellItem gasid={recipe.fusion_byproducts[0]} />
+            <GasCellItem gasid={recipe.fusion_byproducts[1]} />
+            {recipe.product_gases.map(gasid => (
+              <GasCellItem gasid={gasid} />
+            ))}
+            {
+              recipe_effect_structure.map(item => {
+                const value = recipe[item.param];
+                // Note that the minus icon is wider than the arrow icons,
+                // so we set the width to work with both without jumping.
+                return (
+                  <Table.Cell>
+                    <MaybeTooltip content={(item.tooltip || (v => "x"+v))(value, rest)}>
+                      <Icon position="relative" color="rgb(230,30,40)" width="10px" name={effect_to_icon(value, item.scale, item.override_base || 1)} />
+                    </MaybeTooltip>
+                  </Table.Cell>
+                );
+              })
+            }
+          </MemoRow>
+        );
+      })}
+    </Table>
+  );
+};

--- a/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Recipes.js
@@ -129,20 +129,6 @@ const GasCellItem = props => {
   );
 };
 
-// Quick wrapper to globally toggle use of tooltips on or off.
-// Remove once tooltip performance is fixed for good.
-const MaybeTooltip = props => {
-  const {
-    children,
-    ...rest
-  } = props;
-  const noTooltips = false;
-  if (noTooltips) {
-    return (<Box>{children}</Box>);
-  }
-  return (<Tooltip {...rest}>{children}</Tooltip>);
-};
-
 export const HypertorusRecipes = props => {
   const {
     enableRecipeSelection: enable_recipe_selection,
@@ -175,7 +161,7 @@ export const HypertorusRecipes = props => {
           // Lay out our pictographic headers for effects.
           recipe_effect_structure.map(item => (
             <Table.Cell key={item.param} color="label">
-              <MaybeTooltip content={item.label}>
+              <Tooltip content={item.label}>
                 {typeof(item.icon) === "string" ? (
                   <Icon className="hypertorus-recipes__icon" name={item.icon} />
                 ) : (
@@ -185,7 +171,7 @@ export const HypertorusRecipes = props => {
                     ))}
                   </Icon.Stack>
                 )}
-              </MaybeTooltip>
+              </Tooltip>
             </Table.Cell>
           ))
         }
@@ -217,9 +203,9 @@ export const HypertorusRecipes = props => {
                 // so we set the width to work with both without jumping.
                 return (
                   <Table.Cell key={item.param}>
-                    <MaybeTooltip content={(item.tooltip || (v => "x"+v))(value, rest)}>
+                    <Tooltip content={(item.tooltip || (v => "x"+v))(value, rest)}>
                       <Icon className="hypertorus-recipes__icon" name={effect_to_icon(value, item.scale, item.override_base || 1)} />
-                    </MaybeTooltip>
+                    </Tooltip>
                   </Table.Cell>
                 );
               })

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -243,7 +243,9 @@ export const HypertorusTemperatures = props => {
             <VerticalProgressBar height={height} progressHeight={y} value={value} {...rest}>{children}</VerticalProgressBar>
           </Stack.Item>
           <Stack.Item color="label">
-            {label}
+            <Tooltip position="bottom" content={to_exponential_if_big(value) + " K"}>
+              <Box position="relative">{label}</Box>
+            </Tooltip>
           </Stack.Item>
         </Stack>
       </Flex.Item>

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -1,6 +1,5 @@
 import { useBackend } from '../../backend';
-import { Box, Icon, Flex, Section, Stack, Tooltip } from '../../components';
-
+import { Box, Flex, Icon, Section, Stack, Tooltip } from '../../components';
 import { to_exponential_if_big } from './helpers';
 
 /*

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -81,21 +81,30 @@ const VerticalProgressBar = props => {
 };
 
 export const HypertorusTemperatures = (props, context) => {
-  const {
-    powerLevel: power_level,
-    baseMaxTemperature: base_max_temperature,
-    internalFusionTemperature: internal_fusion_temperature,
-    internalFusionTemperatureDelta: internal_fusion_temperature_delta,
-    moderatorInternalTemperature: moderator_internal_temperature,
-    moderatorInternalTemperatureDelta: moderator_internal_temperature_delta,
-    internalOutputTemperature: internal_output_temperature,
-    internalOutputTemperatureDelta: internal_output_temperature_delta,
-    internalCoolantTemperature: internal_coolant_temperature,
-    internalCoolantTemperatureDelta: internal_coolant_temperature_delta,
-    selectedFuel: selected_fuel,
-  } = props;
+  const { data } = useBackend(context);
 
-  const { act, data } = useBackend(context);
+  const {
+    power_level,
+    base_max_temperature,
+    internal_fusion_temperature,
+    moderator_internal_temperature,
+    internal_output_temperature,
+    internal_coolant_temperature,
+    temperature_period,
+  } = data;
+
+  const internal_fusion_temperature_delta = (internal_fusion_temperature
+    - data.internal_fusion_temperature_archived) / temperature_period;
+  const internal_output_temperature_delta = (internal_output_temperature
+    - data.internal_output_temperature_archived) / temperature_period;
+  const internal_coolant_temperature_delta = (internal_coolant_temperature
+    - data.internal_coolant_temperature_archived) / temperature_period;
+  const moderator_internal_temperature_delta = (moderator_internal_temperature
+    - data.moderator_internal_temperature_archived) / temperature_period;
+
+  const selected_fuel = (data.selectable_fuel || []).filter(
+    d => d.id === data.selected
+  )[0];
 
   let prev_power_level_temperature = 10 ** (1+power_level);
   let next_power_level_temperature = 10 ** (2+power_level);
@@ -107,7 +116,7 @@ export const HypertorusTemperatures = (props, context) => {
     prev_power_level_temperature = 500;
   } else if (power_level === 6) {
     next_power_level_temperature = base_max_temperature
-      * selected_fuel.temperature_multiplier;
+      * (selected_fuel ? selected_fuel.temperature_multiplier : 1);
   }
 
   const temperatures = [
@@ -294,4 +303,4 @@ export const HypertorusTemperatures = (props, context) => {
     </Section>
   );
 };
-HypertorusTemperatures.defaultHooks = pureComponentHooks;
+//HypertorusTemperatures.defaultHooks = pureComponentHooks;

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -12,14 +12,16 @@ import { to_exponential_if_big } from './helpers';
  * maybe extending ProgressBar.
  */
 
-/// Note: This must be kept in sync with Hypertorus.scss
+/**
+ * Note: This must be kept in sync with Hypertorus.scss
+ */
 const height = 200;
 
 const VerticalBar = props => {
   const {
     color,
     value,
-    progressHeight
+    progressHeight,
   } = props;
   let y = height - progressHeight;
   return (
@@ -32,33 +34,34 @@ const BarLabel = (props) => {
   const {
     label,
     delta,
-    value
+    value,
   } = props;
 
-  return (<>
-    <Box align="center">{label}</Box>
-    {value > 0
-    ? (
-      <>
-        <Box align="center">{to_exponential_if_big(value) + " K"}</Box>
-        <Box align="center">{(delta == 0
-          ? '-'
-          : `${delta < 0 ? '' : '+'}${to_exponential_if_big(delta)} K/s`
-        )}
-        </Box>
-      </>)
-    : (
-      <>
-        <Box align="center" color="red">Empty</Box>
-        <Box class="hypertorus__unselectable"
-          {...(Byond.IS_LTE_IE8 ? {style:{unselectable:true}} : {})}
-        >
+  return (
+    <>
+      <Box align="center">{label}</Box>
+      {value > 0
+        ? (
+          <>
+            <Box align="center">{to_exponential_if_big(value) + " K"}</Box>
+            <Box align="center">{(delta === 0
+              ? '-'
+              : `${delta < 0 ? '' : '+'}${to_exponential_if_big(delta)} K/s`
+            )}
+            </Box>
+          </>)
+        : (
+          <>
+            <Box align="center" color="red">Empty</Box>
+            <Box class="hypertorus__unselectable"
+              {...(Byond.IS_LTE_IE8 ? { style: { unselectable: true } } : {})}
+            >
           &nbsp;
-        </Box>
-      </>
-    )}
-  </>);
-}
+            </Box>
+          </>
+        )}
+    </>);
+};
 
 export const HypertorusTemperatures = (props, context) => {
   const { data } = useBackend(context);
@@ -111,14 +114,18 @@ export const HypertorusTemperatures = (props, context) => {
   ].map(d => parseFloat(d));
 
   const maxTemperature = Math.max(...temperatures);
-  const minTemperature = Math.max(2.73, Math.min(20, ...temperatures.filter(d=>d>0)));
+  const minTemperature = Math.max(
+    2.73,
+    Math.min(20, ...temperatures.filter(d => d>0))
+  );
 
   if (power_level === 6) {
     next_power_level_temperature = 0;
   }
 
   const value_to_y = (value, baseTemp = minTemperature, fromBottom=false) => {
-    const ratio = (Math.log10(value) - Math.log10(baseTemp)) / (Math.log10(maxTemperature) - Math.log10(minTemperature));
+    const ratio = (Math.log10(value) - Math.log10(baseTemp))
+      / (Math.log10(maxTemperature) - Math.log10(minTemperature));
     return height * (fromBottom ? (1 - ratio) : ratio);
   };
 
@@ -127,22 +134,22 @@ export const HypertorusTemperatures = (props, context) => {
       icon,
       force,
       tooltip,
-      value
+      value,
     } = props;
     const y = value_to_y(value);
     const label = (
-      <Box className='hypertorus-temperatures__y-axis-label'>
+      <Box className="hypertorus-temperatures__y-axis-label">
         {icon && (
-        <Icon
-          className="hypertorus-temperatures__y-axis-label-icon"
-          name={icon}
-        />)}
+          <Icon
+            className="hypertorus-temperatures__y-axis-label-icon"
+            name={icon}
+          />)}
         {to_exponential_if_big(value) + " K"}
       </Box>
     );
     return (!!value || force) && (
       <Box class="hypertorus-temperatures__y-axis-tick-anchor" top={`${height - y}px`}>
-        <Box className="hypertorus-temperatures__y-axis-tick"/>
+        <Box className="hypertorus-temperatures__y-axis-tick" />
         {tooltip
           ? (<Tooltip content={tooltip}>{label}</Tooltip>)
           : label}

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -1,0 +1,271 @@
+
+import { Box, Icon, Flex, Section, Stack, Tooltip } from '../../components';
+
+import { to_exponential_if_big } from './helpers';
+
+/*
+ * Shows a set of temperatures on a unified temperature scale.
+ *
+ * Axis labels draw attention to points of interest.
+ *
+ * This module is largely a proof of concept, partly reusing the guts of
+ * ProgressBar css, and implementing a lot of use-specific logic.
+ *
+ * This is a good candidate for refactoring into something reusable, or
+ * extending ProgressBar.
+ */
+
+const VerticalProgressBar = props => {
+  const {
+    borderRadius = "0.16em",
+    color,
+    falling=false,
+    height,
+    value,
+    progressHeight,
+    children
+  } = props;
+  const fill_dims = {}, anchor_dims = {}, container_dims = {};
+  let y = height - progressHeight;
+  if (falling) {
+    fill_dims.top = '0px';
+    fill_dims.bottom = `${y}px`;
+    container_dims.top = '0px';
+    anchor_dims.top = `${progressHeight}px`;
+    anchor_dims.bottom = `${y}px`;
+  } else {
+    fill_dims.top = `${y}px`,
+    fill_dims.bottom = '0px';
+    container_dims.bottom = '0px';
+    anchor_dims.top = `${y}px`;
+    anchor_dims.bottom = `${progressHeight}px`;
+  }
+  return (<div className={`ProgressBar--color--${color}`} style={{
+    display: 'absolute',
+    position: 'relative',
+    height: `${height}px`,
+    width: '17px',
+    padding: '0',
+    "border-radius": borderRadius,
+    ...container_dims
+  }}>
+    {
+      !!value && (
+        <>
+          <div className="ProgressBar__fill ProgressBar__fill--animated" style={{
+            position: 'absolute',
+            left: '-0.5px',
+            right: '-0.5px',
+            "border-radius": borderRadius,
+            ...fill_dims
+          }} />
+          {children && (
+            <div style={{
+              position: 'relative',
+              height: '1px',
+              ...anchor_dims,
+              'background-color': 'magenta',
+            }}>{children}</div>
+          )}
+        </>
+      )
+    }
+  </div>);
+};
+
+export const HypertorusTemperatures = props => {
+  const {
+    powerLevel: power_level,
+    heatOutput: heat_output,
+    baseMaxTemperature: base_max_temperature,
+    heatLimiterModifier: heat_limiter_modifier,
+    internalFusionTemperature: internal_fusion_temperature,
+    moderatorInternalTemperature: moderator_internal_temperature,
+    internalOutputTemperature: internal_output_temperature,
+    internalCoolantTemperature: internal_coolant_temperature,
+    selectedFuel: selected_fuel,
+  } = props;
+
+  let prev_power_level_temperature = 10 ** (1+power_level), next_power_level_temperature = 10 ** (2+power_level);
+
+  if (power_level == 0) {
+    prev_power_level_temperature = 0;
+    next_power_level_temperature = 500;
+  } else if (power_level == 1) {
+    prev_power_level_temperature = 500;
+  } else if (power_level == 6) {
+    next_power_level_temperature = base_max_temperature * selected_fuel.temperature_multiplier;
+  }
+
+  const temperatures = [
+    prev_power_level_temperature,
+    next_power_level_temperature,
+    ...[
+      internal_fusion_temperature,
+      moderator_internal_temperature,
+      internal_output_temperature,
+      internal_coolant_temperature,
+    ].filter(d=>d),
+  ].map(d=>parseFloat(d));
+
+  const maxTemperature = Math.max(...temperatures);
+  const minTemperature = Math.min(...temperatures);
+
+  if (power_level == 6) {
+    next_power_level_temperature = 0;
+  }
+
+  const height = 200;
+
+  const yAxisLabelWidth = 60;
+  const yAxisIconPadding = 2;
+  const yAxisIconWidth = 14;
+  const yAxisMargin = yAxisLabelWidth + yAxisIconWidth + yAxisIconPadding * 2;
+
+  const value_to_y = (value, baseTemp = minTemperature, fromBottom=false) => {
+    const ratio = (value - baseTemp) / (maxTemperature - minTemperature);
+    const ret = height * (fromBottom ? (1 - ratio) : ratio);
+    return ret;
+  }
+
+  /*
+   * Display temperature change delta right of the temperature change bar.
+   */
+
+  const heat_delta_height = Math.max(1,value_to_y(Math.abs(heat_output), 0, false));
+  let heat_modifier_height = Math.max(1,value_to_y(Math.abs(heat_limiter_modifier), 0, false));
+  let heat_delta_indicator;
+  if (heat_output > 1) {
+    heat_delta_indicator = (
+      <div style={{
+        position: "absolute",
+        left: '17px',
+        top: `-${heat_modifier_height}px`,
+      }}>
+        <VerticalProgressBar
+          color="maroon"
+          height={heat_modifier_height}
+          progressHeight={heat_delta_height}
+          value={heat_output}
+          borderRadius="2px 9px 0 0"
+        />
+      </div>
+    );
+  } else if (heat_output < -1) {
+    heat_delta_indicator = (
+      <div style={{
+        position: "absolute",
+        left: '17px',
+        height: `${heat_modifier_height}px`,
+        bottom: `0px`,
+        'background-color': 'magenta',
+      }}>
+        <VerticalProgressBar
+          color="aliceblue"
+          height={heat_modifier_height}
+          progressHeight={heat_delta_height}
+          value={heat_output}
+          borderRadius="0 0 9px 2px"
+          falling
+        />
+      </div>
+    );
+  } else {
+    heat_delta_indicator = false;
+  }
+
+  const TemperatureLabel = (props, context) => {
+    const {
+      icon,
+      force,
+      tooltip,
+      value,
+      ...rest
+    } = props;
+    const y = value_to_y(value);
+    const label = (
+      <Box
+        fluid
+        align="right"
+        color="label"
+        position="absolute"
+        top="0"
+        left="0"
+        width={`${yAxisMargin}px`}
+        >
+          {icon && (<Icon
+            display="inline-block"
+            mr={`${yAxisIconPadding}px`}
+            name={icon}
+          />)}
+          {to_exponential_if_big(value) + " K"}
+      </Box>
+    );
+    return (!!value || force) && (
+      <Box fluid style={{
+        position: 'absolute',
+        top: `${height - y}px`,
+        left: '0px',
+        right: '20px',
+      }}>
+        <Box
+          backgroundColor="label"
+           style={{
+            position: "absolute",
+            left: `${yAxisMargin}px`,
+            right: '0',
+            top: '0.5em',
+            height: '1px',
+          }}
+        />
+        {tooltip ?
+          (<Tooltip content={tooltip}>
+            {label}
+          </Tooltip>) :
+          label
+        }
+      </Box>
+    );
+  };
+
+  const TemperatureBar = (props, context) => {
+    const {
+      label,
+      value,
+      children,
+      ...rest
+    } = props;
+    const y = value_to_y(value);
+    return (
+      <Flex.Item mx={1}>
+        <Stack vertical align="center">
+          <Stack.Item>
+            <VerticalProgressBar height={height} progressHeight={y} value={value} {...rest}>{children}</VerticalProgressBar>
+          </Stack.Item>
+          <Stack.Item color="label">
+            {label}
+          </Stack.Item>
+        </Stack>
+      </Flex.Item>
+    );
+  };
+
+  return (
+    <Section title="Temperatures">
+      <Flex overflowY="hidden">
+        <Flex.Item mx={1} width={`${yAxisMargin}px`}>
+          {(power_level == 0 || value_to_y(Math.abs(prev_power_level_temperature - minTemperature), 0) > 20) && (<TemperatureLabel value={minTemperature} force={true} />)}
+          <TemperatureLabel icon="chevron-down" tooltip="Previous Fusion Level" value={prev_power_level_temperature} />
+          <TemperatureLabel icon="chevron-up" tooltip="Next Fusion Level" value={next_power_level_temperature} />
+          {value_to_y(Math.abs(next_power_level_temperature - maxTemperature), 0) > 20 && (<TemperatureLabel value={maxTemperature} />)}
+        </Flex.Item>
+        <TemperatureBar label="Fusion" value={internal_fusion_temperature} color="orange">
+          {heat_delta_indicator}
+        </TemperatureBar>
+        <TemperatureBar label="Moderator" value={moderator_internal_temperature} color="pink" />
+        <TemperatureBar label="Coolant" value={internal_coolant_temperature} color="aliceblue" />
+        <TemperatureBar label="Output" value={internal_output_temperature} color="green" />
+      </Flex>
+    </Section>
+  );
+};

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -196,8 +196,8 @@ export const HypertorusTemperatures = (props, context) => {
   const show_max = label_legible(next_power_level_temperature, maxTemperature);
 
   return (
-    <Section title="Gas Monitoring" minWidth="400px">
-      <Box overflowY="hidden" className="hypertorus-temperatures__container">
+    <Section title="Gas Monitoring">
+      <Box className="hypertorus-temperatures__container">
         <Box className="hypertorus-temperatures__y-axis-marks">
           {show_min && (
             <TemperatureLabel key="min_temp"

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -254,10 +254,10 @@ export const HypertorusTemperatures = props => {
     <Section title="Temperatures">
       <Flex overflowY="hidden">
         <Flex.Item mx={1} width={`${yAxisMargin}px`}>
-          {(power_level == 0 || value_to_y(Math.abs(prev_power_level_temperature - minTemperature), 0) > 20) && (<TemperatureLabel value={minTemperature} force={true} />)}
-          <TemperatureLabel icon="chevron-down" tooltip="Previous Fusion Level" value={prev_power_level_temperature} />
-          <TemperatureLabel icon="chevron-up" tooltip="Next Fusion Level" value={next_power_level_temperature} />
-          {value_to_y(Math.abs(next_power_level_temperature - maxTemperature), 0) > 20 && (<TemperatureLabel value={maxTemperature} />)}
+          {(power_level == 0 || value_to_y(Math.abs(prev_power_level_temperature - minTemperature), 0) > 20) && (<TemperatureLabel key="min_temp" value={minTemperature} force={true} />)}
+          <TemperatureLabel key="prev_fusion_temp" icon="chevron-down" tooltip="Previous Fusion Level" value={prev_power_level_temperature} />
+          <TemperatureLabel key="next_fusion_temp" icon="chevron-up" tooltip="Next Fusion Level" value={next_power_level_temperature} />
+          {value_to_y(Math.abs(next_power_level_temperature - maxTemperature), 0) > 20 && (<TemperatureLabel key="max_temp" value={maxTemperature} />)}
         </Flex.Item>
         <TemperatureBar label="Fusion" value={internal_fusion_temperature} color="orange">
           {heat_delta_indicator}

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -23,7 +23,7 @@ const VerticalProgressBar = props => {
     height,
     value,
     progressHeight,
-    children
+    children,
   } = props;
   const fill_dims = {}, anchor_dims = {}, container_dims = {};
   let y = height - progressHeight;
@@ -34,43 +34,48 @@ const VerticalProgressBar = props => {
     anchor_dims.top = `${progressHeight}px`;
     anchor_dims.bottom = `${y}px`;
   } else {
-    fill_dims.top = `${y}px`,
+    fill_dims.top = `${y}px`;
     fill_dims.bottom = '0px';
     container_dims.bottom = '0px';
     anchor_dims.top = `${y}px`;
     anchor_dims.bottom = `${progressHeight}px`;
   }
-  return (<div className={`ProgressBar--color--${color}`} style={{
-    display: 'absolute',
-    position: 'relative',
-    height: `${height}px`,
-    width: '17px',
-    padding: '0',
-    "border-radius": borderRadius,
-    ...container_dims
-  }}>
-    {
-      !!value && (
-        <>
-          <div className="ProgressBar__fill ProgressBar__fill--animated" style={{
-            position: 'absolute',
-            left: '-0.5px',
-            right: '-0.5px',
-            "border-radius": borderRadius,
-            ...fill_dims
-          }} />
-          {children && (
-            <div style={{
-              position: 'relative',
-              height: '1px',
-              ...anchor_dims,
-              'background-color': 'magenta',
-            }}>{children}</div>
-          )}
-        </>
-      )
-    }
-  </div>);
+  return (
+    <div
+      className={`ProgressBar--color--${color}`}
+      style={{
+        display: 'absolute',
+        position: 'relative',
+        height: `${height}px`,
+        width: '17px',
+        padding: '0',
+        "border-radius": borderRadius,
+        ...container_dims,
+      }}
+    >
+      {
+        !!value && (
+          <>
+            <div className="ProgressBar__fill ProgressBar__fill--animated" style={{
+              position: 'absolute',
+              left: '-0.5px',
+              right: '-0.5px',
+              "border-radius": borderRadius,
+              ...fill_dims,
+            }} />
+            {children && (
+              <div style={{
+                position: 'relative',
+                height: '1px',
+                ...anchor_dims,
+                'background-color': 'magenta',
+              }}>{children}
+              </div>
+            )}
+          </>
+        )
+      }
+    </div>);
 };
 
 export const HypertorusTemperatures = props => {
@@ -88,15 +93,17 @@ export const HypertorusTemperatures = props => {
     selectedFuel: selected_fuel,
   } = props;
 
-  let prev_power_level_temperature = 10 ** (1+power_level), next_power_level_temperature = 10 ** (2+power_level);
+  let prev_power_level_temperature = 10 ** (1+power_level);
+  let next_power_level_temperature = 10 ** (2+power_level);
 
-  if (power_level == 0) {
+  if (power_level === 0) {
     prev_power_level_temperature = 0;
     next_power_level_temperature = 500;
-  } else if (power_level == 1) {
+  } else if (power_level === 1) {
     prev_power_level_temperature = 500;
-  } else if (power_level == 6) {
-    next_power_level_temperature = base_max_temperature * selected_fuel.temperature_multiplier;
+  } else if (power_level === 6) {
+    next_power_level_temperature = base_max_temperature
+      * selected_fuel.temperature_multiplier;
   }
 
   const temperatures = [
@@ -107,13 +114,13 @@ export const HypertorusTemperatures = props => {
       moderator_internal_temperature,
       internal_output_temperature,
       internal_coolant_temperature,
-    ].filter(d=>d),
-  ].map(d=>parseFloat(d));
+    ].filter(d => d),
+  ].map(d => parseFloat(d));
 
   const maxTemperature = Math.max(...temperatures);
   const minTemperature = Math.min(...temperatures);
 
-  if (power_level == 6) {
+  if (power_level === 6) {
     next_power_level_temperature = 0;
   }
 
@@ -128,7 +135,7 @@ export const HypertorusTemperatures = props => {
     const ratio = (value - baseTemp) / (maxTemperature - minTemperature);
     const ret = height * (fromBottom ? (1 - ratio) : ratio);
     return ret;
-  }
+  };
 
   const TemperatureLabel = (props, context) => {
     const {
@@ -148,13 +155,13 @@ export const HypertorusTemperatures = props => {
         top="0"
         left="0"
         width={`${yAxisMargin}px`}
-        >
-          {icon && (<Icon
-            display="inline-block"
-            mr={`${yAxisIconPadding}px`}
-            name={icon}
-          />)}
-          {to_exponential_if_big(value) + " K"}
+      >
+        {icon && (<Icon
+          display="inline-block"
+          mr={`${yAxisIconPadding}px`}
+          name={icon}
+        />)}
+        {to_exponential_if_big(value) + " K"}
       </Box>
     );
     return (!!value || force) && (
@@ -166,7 +173,7 @@ export const HypertorusTemperatures = props => {
       }}>
         <Box
           backgroundColor="label"
-           style={{
+          style={{
             position: "absolute",
             left: `${yAxisMargin}px`,
             right: '0',
@@ -174,12 +181,13 @@ export const HypertorusTemperatures = props => {
             height: '1px',
           }}
         />
-        {tooltip ?
-          (<Tooltip content={tooltip}>
-            {label}
-          </Tooltip>) :
-          label
-        }
+        {tooltip
+          ? (
+            <Tooltip content={tooltip}>
+              {label}
+            </Tooltip>
+          )
+          : label}
       </Box>
     );
   };
@@ -198,26 +206,50 @@ export const HypertorusTemperatures = props => {
       <Flex.Item mx={1}>
         <Stack vertical align="center">
           <Stack.Item>
-            <VerticalProgressBar height={height} progressHeight={y} value={value} {...rest}>{children}</VerticalProgressBar>
+            <VerticalProgressBar
+              height={height}
+              progressHeight={y}
+              value={value}
+              {...rest}
+            >
+              {children}
+            </VerticalProgressBar>
           </Stack.Item>
           <Stack.Item color="label">
             <Box align="center">{label}</Box>
-            {value > 0 ? ([<Box align="center">
-              {to_exponential_if_big(value) + " K"}
-            </Box>,<Box align="center">{(delta > 0 ?
-              `+${delta_str}` :
-              delta < 0 ?
-                `${delta_str}` :
-                "-"
-            )}</Box>]) : ([<Box align="center" color="red">
-              Empty
-            </Box>,<Box style={{
-              "user-select": "none",
-              "-ms-user-select": "none",
-              unselectable: Byond.IS_LTE_IE8
-            }}>
-              &nbsp; {/* Placeholder. Geocities did nothing wrong :o) */}
-            </Box>])}
+            {value > 0
+              ? (
+                <>
+                  <Box align="center">
+                    {to_exponential_if_big(value) + " K"}
+                  </Box>
+                  <Box align="center">{(delta > 0
+                    ? `+${delta_str}`
+                    : delta < 0
+                      ? `${delta_str}`
+                      : "-"
+                  )}
+                  </Box>
+                </>)
+              : (
+                <>
+                  <Box
+                    align="center"
+                    color="red"
+                  >
+                    Empty
+                  </Box>
+                  <Box
+                    style={{
+                      "user-select": "none",
+                      "-ms-user-select": "none",
+                      unselectable: Byond.IS_LTE_IE8,
+                    }}
+                  >
+                &nbsp; {/* Placeholder. Geocities did nothing wrong :o) */}
+                  </Box>
+                </>
+              )}
           </Stack.Item>
         </Stack>
       </Flex.Item>
@@ -228,7 +260,7 @@ export const HypertorusTemperatures = props => {
     <Section title="Temperatures">
       <Flex overflowY="hidden">
         <Flex.Item mx={1} width={`${yAxisMargin}px`}>
-          {(power_level == 0 || value_to_y(Math.abs(prev_power_level_temperature - minTemperature), 0) > 20) && (<TemperatureLabel key="min_temp" value={minTemperature} force={true} />)}
+          {(power_level === 0 || value_to_y(Math.abs(prev_power_level_temperature - minTemperature), 0) > 20) && (<TemperatureLabel key="min_temp" value={minTemperature} force />)}
           <TemperatureLabel key="prev_fusion_temp" icon="chevron-down" tooltip="Previous Fusion Level" value={prev_power_level_temperature} />
           <TemperatureLabel key="next_fusion_temp" icon="chevron-up" tooltip="Next Fusion Level" value={next_power_level_temperature} />
           {value_to_y(Math.abs(next_power_level_temperature - maxTemperature), 0) > 20 && (<TemperatureLabel key="max_temp" value={maxTemperature} />)}

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -185,14 +185,41 @@ export const HypertorusTemperatures = (props, context) => {
     );
   };
 
+  // Make sure that our labels are legible before displaying them.
+  // If two axis labels are too close to one another, don't show them.
+  const clutter_threshold = 20;
+  const label_legible = (l, r) =>
+    Math.abs(value_to_y(l) - value_to_y(r)) > clutter_threshold;
+
+  const show_min = label_legible(prev_power_level_temperature, minTemperature)
+    || power_level === 0;
+  const show_max = label_legible(next_power_level_temperature, maxTemperature);
+
   return (
     <Section title="Gas Monitoring" minWidth="400px">
       <Box overflowY="hidden" className="hypertorus-temperatures__container">
         <Box className="hypertorus-temperatures__y-axis-marks">
-          {(power_level === 0 || Math.abs(value_to_y(prev_power_level_temperature) - value_to_y(minTemperature)) > 20) && (<TemperatureLabel key="min_temp" value={minTemperature} force />)}
-          <TemperatureLabel key="prev_fusion_temp" icon="chevron-down" tooltip="Previous Fusion Level" value={prev_power_level_temperature} />
-          <TemperatureLabel key="next_fusion_temp" icon="chevron-up" tooltip="Next Fusion Level" value={next_power_level_temperature} />
-          {Math.abs(value_to_y(next_power_level_temperature) - value_to_y(maxTemperature)) > 20 && (<TemperatureLabel key="max_temp" value={maxTemperature} />)}
+          {show_min && (
+            <TemperatureLabel key="min_temp"
+              value={minTemperature}
+              force
+            />
+          )}
+          <TemperatureLabel key="prev_fusion_temp"
+            icon="chevron-down"
+            tooltip="Previous Fusion Level"
+            value={prev_power_level_temperature}
+          />
+          <TemperatureLabel key="next_fusion_temp"
+            icon="chevron-up"
+            tooltip="Next Fusion Level"
+            value={next_power_level_temperature}
+          />
+          {show_max && (
+            <TemperatureLabel key="max_temp"
+              value={maxTemperature}
+            />
+          )}
         </Box>
         <Box className="hypertorus-temperatures__y-axis">
           <Box className="hypertorus-temperatures__x-axis" />

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -209,9 +209,15 @@ export const HypertorusTemperatures = props => {
               delta < 0 ?
                 `${delta_str}` :
                 "-"
-            )}</Box>]) : (<Box align="center" color="red">
+            )}</Box>]) : ([<Box align="center" color="red">
               Empty
-            </Box>)}
+            </Box>,<Box style={{
+              "user-select": "none",
+              "-ms-user-select": "none",
+              unselectable: Byond.IS_LTE_IE8
+            }}>
+              &nbsp; {/* Placeholder. Geocities did nothing wrong :o) */}
+            </Box>])}
           </Stack.Item>
         </Stack>
       </Flex.Item>

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -1,7 +1,5 @@
 import { useBackend } from '../../backend';
-import { pureComponentHooks } from 'common/react';
 import { Box, Icon, Flex, Section, Stack, Tooltip } from '../../components';
-import { logger } from '../../logging';
 
 import { to_exponential_if_big } from './helpers';
 
@@ -10,71 +8,40 @@ import { to_exponential_if_big } from './helpers';
  *
  * Axis labels draw attention to points of interest.
  *
- * This module is largely a proof of concept, partly reusing the guts of
- * ProgressBar css, and implementing a lot of use-specific logic.
- *
  * This is a good candidate for refactoring into something reusable, or
- * extending ProgressBar.
+ * maybe extending ProgressBar.
  */
 
-const VerticalProgressBar = props => {
+const VerticalBar = props => {
   const {
     borderRadius = "0.16em",
     color,
-    falling=false,
     height,
     value,
-    progressHeight,
-    children,
+    progressHeight
   } = props;
-  const fill_dims = {}, anchor_dims = {}, container_dims = {};
   let y = height - progressHeight;
-  if (falling) {
-    fill_dims.top = '0px';
-    fill_dims.bottom = `${y}px`;
-    container_dims.top = '0px';
-    anchor_dims.top = `${progressHeight}px`;
-    anchor_dims.bottom = `${y}px`;
-  } else {
-    fill_dims.top = `${y}px`;
-    fill_dims.bottom = '0px';
-    container_dims.bottom = '0px';
-    anchor_dims.top = `${y}px`;
-    anchor_dims.bottom = `${progressHeight}px`;
-  }
   return (
     <div
-      className={`ProgressBar--color--${color}`}
       style={{
         display: 'absolute',
         position: 'relative',
         height: `${height}px`,
         width: '17px',
-        padding: '0',
-        "border-radius": borderRadius,
-        ...container_dims,
+        bottom: '0',
       }}
     >
       {
         !!value && (
-          <>
-            <div className="ProgressBar__fill ProgressBar__fill--animated" style={{
-              position: 'absolute',
-              left: '-0.5px',
-              right: '-0.5px',
-              "border-radius": borderRadius,
-              ...fill_dims,
-            }} />
-            {children && (
-              <div style={{
-                position: 'relative',
-                height: '1px',
-                ...anchor_dims,
-                'background-color': 'magenta',
-              }}>{children}
-              </div>
-            )}
-          </>
+          <div style={{
+            'background-color': color,
+            position: 'absolute',
+            left: '-0.5px',
+            right: '-0.5px',
+            bottom: '0px',
+            top: `${y}px`,
+            "border-radius": borderRadius,
+          }} />
         )
       }
     </div>);
@@ -131,7 +98,7 @@ export const HypertorusTemperatures = (props, context) => {
   ].map(d => parseFloat(d));
 
   const maxTemperature = Math.max(...temperatures);
-  const minTemperature = Math.max(2.73, Math.min(20, ...temperatures.filter(d=>d>0))); // Math.min(1, ...temperatures);
+  const minTemperature = Math.max(2.73, Math.min(20, ...temperatures.filter(d=>d>0)));
 
   if (power_level === 6) {
     next_power_level_temperature = 0;
@@ -146,9 +113,7 @@ export const HypertorusTemperatures = (props, context) => {
 
   const value_to_y = (value, baseTemp = minTemperature, fromBottom=false) => {
     const ratio = (Math.log10(value) - Math.log10(baseTemp)) / (Math.log10(maxTemperature) - Math.log10(minTemperature));
-    const ret = height * (fromBottom ? (1 - ratio) : ratio);
-    logger.log('value map:',value,baseTemp,maxTemperature,minTemperature,'(',ratio,')', height,'=>',ret);
-    return ret;
+    return height * (fromBottom ? (1 - ratio) : ratio);
   };
 
   const TemperatureLabel = (props, context) => {
@@ -220,14 +185,14 @@ export const HypertorusTemperatures = (props, context) => {
       <Flex.Item mx={1}>
         <Stack vertical align="center">
           <Stack.Item>
-            <VerticalProgressBar
+            <VerticalBar
               height={height}
               progressHeight={y}
               value={value}
               {...rest}
             >
               {children}
-            </VerticalProgressBar>
+            </VerticalBar>
           </Stack.Item>
           <Stack.Item color="label">
             <Box align="center">{label}</Box>
@@ -260,7 +225,7 @@ export const HypertorusTemperatures = (props, context) => {
                       unselectable: Byond.IS_LTE_IE8,
                     }}
                   >
-                &nbsp; {/* Placeholder. Geocities did nothing wrong :o) */}
+                &nbsp;
                   </Box>
                 </>
               )}
@@ -279,16 +244,26 @@ export const HypertorusTemperatures = (props, context) => {
           <TemperatureLabel key="next_fusion_temp" icon="chevron-up" tooltip="Next Fusion Level" value={next_power_level_temperature} />
           {Math.abs(value_to_y(next_power_level_temperature) - value_to_y(maxTemperature)) > 20 && (<TemperatureLabel key="max_temp" value={maxTemperature} />)}
         </Flex.Item>
+        <Box
+          backgroundColor="label"
+          style={{
+            position: "absolute",
+            left: `${yAxisMargin}px`,
+            height: `${height}px`,
+            top: '0.5em',
+            width: '1px',
+          }}
+        />
         <TemperatureBar
           label="Fusion"
           value={internal_fusion_temperature}
           delta={internal_fusion_temperature_delta}
-          color="orange" />
+          color="#f2711c" />
         <TemperatureBar
           label="Moderator"
           value={moderator_internal_temperature}
           delta={moderator_internal_temperature_delta}
-          color="pink" />
+          color="#e03997" />
         <TemperatureBar
           label="Coolant"
           value={internal_coolant_temperature}
@@ -298,9 +273,8 @@ export const HypertorusTemperatures = (props, context) => {
           label="Output"
           value={internal_output_temperature}
           delta={internal_output_temperature_delta}
-          color="green" />
+          color="#20b142" />
       </Flex>
     </Section>
   );
 };
-//HypertorusTemperatures.defaultHooks = pureComponentHooks;

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -257,7 +257,7 @@ export const HypertorusTemperatures = props => {
   };
 
   return (
-    <Section title="Temperatures">
+    <Section title="Gas Monitoring">
       <Flex overflowY="hidden">
         <Flex.Item mx={1} width={`${yAxisMargin}px`}>
           {(power_level === 0 || value_to_y(Math.abs(prev_power_level_temperature - minTemperature), 0) > 20) && (<TemperatureLabel key="min_temp" value={minTemperature} force />)}

--- a/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/Temperatures.js
@@ -1,4 +1,4 @@
-
+import { pureComponentHooks } from 'common/react';
 import { Box, Icon, Flex, Section, Stack, Tooltip } from '../../components';
 
 import { to_exponential_if_big } from './helpers';
@@ -271,3 +271,4 @@ export const HypertorusTemperatures = props => {
     </Section>
   );
 };
+HypertorusTemperatures.defaultHooks = pureComponentHooks;

--- a/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
@@ -5,3 +5,15 @@ export const to_exponential_if_big = (value) => {
   }
   return Math.round(value);
 };
+
+const ActParam = (key, value) => {
+  const ret = {};
+  ret[key] = value;
+  return ret;
+};
+
+export const ActNone = (act, key) => () => act(key);
+
+export const ActFixed = (act, key, val) => () => act(key, ActParam(key, val));
+
+export const ActSet = (act, key) => (e, val) => act(key, ActParam(key, val));

--- a/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
@@ -1,0 +1,7 @@
+
+export const to_exponential_if_big = (value) => {
+  if (value > 5000) {
+    return value.toExponential(1);
+  }
+  return Math.round(value);
+}

--- a/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
@@ -1,6 +1,6 @@
 
 export const to_exponential_if_big = (value) => {
-  if (value > 5000) {
+  if (Math.abs(value) > 5000) {
     return value.toExponential(1);
   }
   return Math.round(value);

--- a/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
@@ -2,6 +2,9 @@
 
 import { Icon, Tooltip } from '../../components';
 
+// Exponential rendering specifically for HFR values.
+// Note that we don't want to use unicode exponents as anything over ^3
+// is more or less unreadable.
 export const to_exponential_if_big = (value) => {
   if (Math.abs(value) > 5000) {
     return value.toExponential(1);
@@ -15,6 +18,7 @@ const ActParam = (key, value) => {
   return ret;
 };
 
+// Helpers to wrap act() for simple behavior
 export const ActFixed = (act, key, ...vals) => () => act(key, ActParam(key, ...vals));
 
 export const ActSet = (act, key) => (e, val) => act(key, ActParam(key, val));
@@ -25,6 +29,7 @@ export const HoverHelp = props => (
   </Tooltip>
 );
 
+// When no hover help is available, but we want a placeholder for spacing
 export const HelpDummy = props => (
   <Icon name="" width="12px" mr="6px" />
 );

--- a/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
@@ -19,7 +19,8 @@ const ActParam = (key, value) => {
 };
 
 // Helpers to wrap act() for simple behavior
-export const ActFixed = (act, key, ...vals) => () => act(key, ActParam(key, ...vals));
+export const ActFixed = (act, key, ...vals) =>
+  () => act(key, ActParam(key, ...vals));
 
 export const ActSet = (act, key) => (e, val) => act(key, ActParam(key, val));
 

--- a/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
@@ -10,18 +10,7 @@ export const to_exponential_if_big = (value) => {
   return Math.round(value);
 };
 
-const ActParam = (key, value) => {
-  const ret = {};
-  ret[key] = value;
-  return ret;
-};
-
-// Helpers to wrap act() for simple behavior
-export const ActFixed = (act, key, ...vals) =>
-  () => act(key, ActParam(key, ...vals));
-
-export const ActSet = (act, key) => (e, val) => act(key, ActParam(key, val));
-
+// Simple question mark icon with a hover tooltip
 export const HoverHelp = props => (
   <Tooltip content={props.content}>
     <Icon name="question-circle" width="12px" mr="6px" />

--- a/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
@@ -1,4 +1,7 @@
 
+
+import { Icon, Tooltip } from '../../components';
+
 export const to_exponential_if_big = (value) => {
   if (Math.abs(value) > 5000) {
     return value.toExponential(1);
@@ -17,3 +20,13 @@ export const ActNone = (act, key) => () => act(key);
 export const ActFixed = (act, key, val) => () => act(key, ActParam(key, val));
 
 export const ActSet = (act, key) => (e, val) => act(key, ActParam(key, val));
+
+export const HoverHelp = props => (
+  <Tooltip content={props.content}>
+    <Icon name="question-circle" width="12px" mr="6px" />
+  </Tooltip>
+);
+
+export const HelpDummy = props => (
+  <Icon name="" width="12px" mr="6px" />
+);

--- a/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
@@ -1,5 +1,3 @@
-
-
 import { Icon, Tooltip } from '../../components';
 
 // Exponential rendering specifically for HFR values.

--- a/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
@@ -15,9 +15,7 @@ const ActParam = (key, value) => {
   return ret;
 };
 
-export const ActNone = (act, key) => () => act(key);
-
-export const ActFixed = (act, key, val) => () => act(key, ActParam(key, val));
+export const ActFixed = (act, key, ...vals) => () => act(key, ActParam(key, ...vals));
 
 export const ActSet = (act, key) => (e, val) => act(key, ActParam(key, val));
 

--- a/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/helpers.js
@@ -4,4 +4,4 @@ export const to_exponential_if_big = (value) => {
     return value.toExponential(1);
   }
   return Math.round(value);
-}
+};

--- a/tgui/packages/tgui/interfaces/Hypertorus/index.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/index.js
@@ -50,7 +50,7 @@ const HypertorusMainControls = (props, context) => {
 
 const HypertorusLayout = () => {
   return (
-    <span class="hypertorus-layout">
+    <div className="hypertorus-layout">
       <HypertorusMainControls />
       <Stack>
         <Stack.Item grow>
@@ -63,7 +63,7 @@ const HypertorusLayout = () => {
       <HypertorusParameters />
       <HypertorusSecondaryControls />
       <HypertorusWasteRemove />
-    </span>
+    </div>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/Hypertorus/index.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/index.js
@@ -83,8 +83,8 @@ export const Hypertorus = (props, context) => {
   const idealWidth = 850, idealHeight = 980;
 
   // ...but we should check for small screens, to play nicely with eg laptops.
-  const winWidth  = window.screen.availWidth,
-        winHeight = window.screen.availHeight;
+  const winWidth  = window.screen.availWidth;
+  const winHeight = window.screen.availHeight;
 
   // Make sure we don't start larger than 50%/80% of screen width/height.
   const width = Math.min(idealWidth, winWidth * 0.5);

--- a/tgui/packages/tgui/interfaces/Hypertorus/index.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/index.js
@@ -1,14 +1,15 @@
 
-import { useBackend } from '../backend';
-import { Button, Collapsible, Flex, Section, Stack } from '../components';
-import { Window } from '../layouts';
+import { useBackend } from 'tgui/backend';
+import { Button, Collapsible, Section, Stack } from 'tgui/components';
+import { Window } from 'tgui/layouts';
 
-import { HypertorusGases } from './Hypertorus/Gases';
-import { HypertorusParameters } from './Hypertorus/Parameters';
-import { HypertorusTemperatures } from './Hypertorus/Temperatures';
-import { HypertorusRecipes } from './Hypertorus/Recipes';
+import { HypertorusGases } from './Gases';
+import { HypertorusParameters } from './Parameters';
+import { HypertorusTemperatures } from './Temperatures';
+import { HypertorusRecipes } from './Recipes';
 
-import { HypertorusSecondaryControls, HypertorusIO, HypertorusWasteRemove } from './Hypertorus/Controls';
+import { ActFixed } from './helpers';
+import { HypertorusSecondaryControls, HypertorusWasteRemove } from './Controls';
 
 const HypertorusMainControls = (props, context) => {
   const { act, data } = useBackend(context);

--- a/tgui/packages/tgui/interfaces/Hypertorus/index.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/index.js
@@ -13,10 +13,6 @@ import { HypertorusSecondaryControls, HypertorusWasteRemove } from './Controls';
 
 const HypertorusMainControls = (props, context) => {
   const { act, data } = useBackend(context);
-  const {
-    selectableFuels,
-    selectedFuelID,
-  } = props;
 
   return (
     <Section title="Startup">
@@ -28,7 +24,7 @@ const HypertorusMainControls = (props, context) => {
             icon={data.start_power ? 'power-off' : 'times'}
             content={data.start_power ? 'On' : 'Off'}
             selected={data.start_power}
-            onClick={act.bind(null, 'start_power')} />
+            onClick={ActFixed(act, 'start_power')} />
         </Stack.Item>
         <Stack.Item color="label">
           {'Start cooling: '}
@@ -40,7 +36,7 @@ const HypertorusMainControls = (props, context) => {
             icon={data.start_cooling ? 'power-off' : 'times'}
             content={data.start_cooling ? 'On' : 'Off'}
             selected={data.start_cooling}
-            onClick={act.bind(null, 'start_cooling')} />
+            onClick={ActFixed(act, 'start_cooling')} />
         </Stack.Item>
       </Stack>
       <Collapsible title="Recipe selection">
@@ -48,99 +44,31 @@ const HypertorusMainControls = (props, context) => {
           baseMaximumTemperature={data.base_max_temperature}
           enableRecipeSelection={data.power_level === 0}
           onRecipe={id => act('fuel', { mode: id })}
-          selectableFuels={selectableFuels}
-          selectedFuelID={selectedFuelID}
+          selectableFuels={data.selectable_fuel}
+          selectedFuelID={data.selected}
         />
       </Collapsible>
     </Section>
   );
 };
 
-const HypertorusLayout = (props, context) => {
-  const { data } = useBackend(context);
-  const {
-    apc_energy,
-    base_max_temperature,
-    energy_level,
-    fusion_gases,
-    heat_limiter_modifier,
-    heat_output_min,
-    heat_output_max,
-    heat_output,
-    iron_content,
-    instability,
-    integrity,
-    internal_fusion_temperature,
-    internal_fusion_temperature_archived,
-    internal_output_temperature,
-    internal_output_temperature_archived,
-    internal_coolant_temperature,
-    internal_coolant_temperature_archived,
-    moderator_gases,
-    moderator_internal_temperature,
-    moderator_internal_temperature_archived,
-    power_level,
-    selectable_fuel,
-    selected,
-  } = data;
-
-  const internal_fusion_temperature_delta = internal_fusion_temperature
-    - internal_fusion_temperature_archived;
-  const internal_output_temperature_delta = internal_output_temperature
-    - internal_output_temperature_archived;
-  const internal_coolant_temperature_delta = internal_coolant_temperature
-    - internal_coolant_temperature_archived;
-  const moderator_internal_delta = moderator_internal_temperature
-    - moderator_internal_temperature_archived;
-
-  const selectable_fuels = selectable_fuel || [];
-  const selected_fuel = selectable_fuels.filter(d => d.id === selected)[0];
-
+const HypertorusLayout = () => {
   // Note this adds bottom margin to non-Section elements for consistent
   // spacing. This is a good candidate to be moved to css > properties to
   // avoid low level presentation detail being exposed here.
 
   return (
     <>
-      <HypertorusMainControls
-        selectableFuels={selectable_fuels}
-        selectedFuelID={selected}
-      />
+      <HypertorusMainControls />
       <Stack mb="0.5em">
         <Stack.Item grow>
-          <HypertorusGases
-            selectedFuel={selected_fuel}
-            fusionGases={fusion_gases}
-            moderatorGases={moderator_gases}
-          />
+          <HypertorusGases />
         </Stack.Item>
         <Stack.Item>
-          <HypertorusTemperatures
-            powerLevel={power_level}
-            baseMaxTemperature={base_max_temperature}
-            internalFusionTemperature={internal_fusion_temperature}
-            internalFusionTemperatureDelta={internal_fusion_temperature_delta}
-            moderatorInternalTemperature={moderator_internal_temperature}
-            moderatorInternalTemperatureDelta={moderator_internal_delta}
-            internalOutputTemperature={internal_output_temperature}
-            internalOutputTemperatureDelta={internal_output_temperature_delta}
-            internalCoolantTemperature={internal_coolant_temperature}
-            internalCoolantTemperatureDelta={internal_coolant_temperature_delta}
-            selectedFuel={selected_fuel}
-          />
+          <HypertorusTemperatures />
         </Stack.Item>
       </Stack>
-      <HypertorusParameters
-        energyLevel={energy_level}
-        heatLimiterModifier={heat_limiter_modifier}
-        heatOutputMin={heat_output_min}
-        heatOutputMax={heat_output_max}
-        heatOutput={heat_output}
-        apcEnergy={apc_energy}
-        instability={instability}
-        powerLevel={power_level}
-        ironContent={iron_content}
-        integrity={integrity} />
+      <HypertorusParameters />
       <HypertorusSecondaryControls />
       <HypertorusWasteRemove />
     </>

--- a/tgui/packages/tgui/interfaces/Hypertorus/index.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/index.js
@@ -3,7 +3,6 @@ import { Button, Collapsible, Section, Stack } from 'tgui/components';
 import { Window } from 'tgui/layouts';
 import { HypertorusSecondaryControls, HypertorusWasteRemove } from './Controls';
 import { HypertorusGases } from './Gases';
-import { ActFixed } from './helpers';
 import { HypertorusParameters } from './Parameters';
 import { HypertorusRecipes } from './Recipes';
 import { HypertorusTemperatures } from './Temperatures';
@@ -21,7 +20,7 @@ const HypertorusMainControls = (props, context) => {
             icon={data.start_power ? 'power-off' : 'times'}
             content={data.start_power ? 'On' : 'Off'}
             selected={data.start_power}
-            onClick={ActFixed(act, 'start_power')} />
+            onClick={() => act('start_power')} />
         </Stack.Item>
         <Stack.Item color="label">
           {'Start cooling: '}
@@ -33,7 +32,7 @@ const HypertorusMainControls = (props, context) => {
             icon={data.start_cooling ? 'power-off' : 'times'}
             content={data.start_cooling ? 'On' : 'Off'}
             selected={data.start_cooling}
-            onClick={ActFixed(act, 'start_cooling')} />
+            onClick={() => act('start_cooling')} />
         </Stack.Item>
       </Stack>
       <Collapsible title="Recipe selection">

--- a/tgui/packages/tgui/interfaces/Hypertorus/index.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/index.js
@@ -1,5 +1,5 @@
 import { useBackend } from 'tgui/backend';
-import { Button, Collapsible, Section, Stack } from 'tgui/components';
+import { Button, Collapsible, Flex, Section, Stack } from 'tgui/components';
 import { Window } from 'tgui/layouts';
 import { HypertorusSecondaryControls, HypertorusWasteRemove } from './Controls';
 import { HypertorusGases } from './Gases';
@@ -50,29 +50,51 @@ const HypertorusMainControls = (props, context) => {
 
 const HypertorusLayout = () => {
   return (
-    <div className="hypertorus-layout">
-      <HypertorusMainControls />
-      <Stack>
-        <Stack.Item grow>
-          <HypertorusGases />
-        </Stack.Item>
-        <Stack.Item>
-          <HypertorusTemperatures />
-        </Stack.Item>
-      </Stack>
-      <HypertorusParameters />
-      <HypertorusSecondaryControls />
-      <HypertorusWasteRemove />
-    </div>
+    <Flex className="hypertorus-layout" wrap>
+      <Flex.Item grow width="100%">
+        <HypertorusMainControls />
+      </Flex.Item>
+      <Flex.Item grow="20" width="350px" minWidth="280px">
+        <HypertorusGases />
+      </Flex.Item>
+      <Flex.Item grow width="420px" overflowX="auto">
+        <HypertorusTemperatures />
+      </Flex.Item>
+      <Flex.Item grow="4" width="580px">
+        <Flex className="hypertorus-layout" wrap>
+          <Flex.Item grow width="860px">
+            <HypertorusParameters />
+          </Flex.Item>
+          <Flex.Item grow width="580px">
+            <HypertorusSecondaryControls />
+          </Flex.Item>
+        </Flex>
+      </Flex.Item>
+      <Flex.Item grow width="100%">
+        <HypertorusWasteRemove />
+      </Flex.Item>
+    </Flex>
   );
 };
 
 export const Hypertorus = (props, context) => {
+  // The HFR has a ridiculous amount of knobs and information.
+  // Ideally we'd display a large window for it all...
+  const idealWidth = 850, idealHeight = 980;
+
+  // ...but we should check for small screens, to play nicely with eg laptops.
+  const winWidth  = window.screen.availWidth,
+        winHeight = window.screen.availHeight;
+
+  // Make sure we don't start larger than 50%/80% of screen width/height.
+  const width = Math.min(idealWidth, winWidth * 0.5);
+  const height = Math.min(idealHeight, winHeight * 0.8);
+
   return (
     <Window
       title="Hypertorus Fusion Reactor control panel"
-      width={850}
-      height={980}>
+      width={width}
+      height={height}>
       <Window.Content scrollable>
         <HypertorusLayout />
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/Hypertorus/index.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/index.js
@@ -1,15 +1,12 @@
-
 import { useBackend } from 'tgui/backend';
 import { Button, Collapsible, Section, Stack } from 'tgui/components';
 import { Window } from 'tgui/layouts';
-
-import { HypertorusGases } from './Gases';
-import { HypertorusParameters } from './Parameters';
-import { HypertorusTemperatures } from './Temperatures';
-import { HypertorusRecipes } from './Recipes';
-
-import { ActFixed } from './helpers';
 import { HypertorusSecondaryControls, HypertorusWasteRemove } from './Controls';
+import { HypertorusGases } from './Gases';
+import { ActFixed } from './helpers';
+import { HypertorusParameters } from './Parameters';
+import { HypertorusRecipes } from './Recipes';
+import { HypertorusTemperatures } from './Temperatures';
 
 const HypertorusMainControls = (props, context) => {
   const { act, data } = useBackend(context);

--- a/tgui/packages/tgui/interfaces/Hypertorus/index.js
+++ b/tgui/packages/tgui/interfaces/Hypertorus/index.js
@@ -53,14 +53,10 @@ const HypertorusMainControls = (props, context) => {
 };
 
 const HypertorusLayout = () => {
-  // Note this adds bottom margin to non-Section elements for consistent
-  // spacing. This is a good candidate to be moved to css > properties to
-  // avoid low level presentation detail being exposed here.
-
   return (
-    <>
+    <span class="hypertorus-layout">
       <HypertorusMainControls />
-      <Stack mb="0.5em">
+      <Stack>
         <Stack.Item grow>
           <HypertorusGases />
         </Stack.Item>
@@ -71,7 +67,7 @@ const HypertorusLayout = () => {
       <HypertorusParameters />
       <HypertorusSecondaryControls />
       <HypertorusWasteRemove />
-    </>
+    </span>
   );
 };
 

--- a/tgui/packages/tgui/styles/interfaces/Hypertorus.scss
+++ b/tgui/packages/tgui/styles/interfaces/Hypertorus.scss
@@ -2,8 +2,13 @@
 
 /// Index @{
 
+.hypertorus-layout {
+  margin-right: -0.5em;
+};
+
 .hypertorus-layout > * {
   margin-bottom: 0.5em;
+  margin-right: 0.5em;
 };
 
 /// @}
@@ -68,6 +73,7 @@ $yAxisMargin: $yAxisLabelWidth + $yAxisIconWidth + $yAxisIconPadding * 2;
 .hypertorus-temperatures__container {
   position: relative;
   margin-right: 10px;
+  overflow-y: hidden;
 }
 
 .hypertorus-temperatures__y-axis-marks {

--- a/tgui/packages/tgui/styles/interfaces/Hypertorus.scss
+++ b/tgui/packages/tgui/styles/interfaces/Hypertorus.scss
@@ -1,0 +1,152 @@
+@use '../colors.scss';
+
+/// Index @{
+
+.hypertorus-layout > * {
+  margin-bottom: 0.5em;
+};
+
+/// @}
+
+/// Recipes @{
+
+// Subtle horizontal stripes for the table
+.hypertorus-recipes__row:nth-child(odd) {
+  background-color: rgba(0, 0, 0, .37);
+};
+.hypertorus-recipes__row:nth-child(even) {
+  background-color: rgba(14, 14, 14, .37);
+};
+
+// Highlight an active row
+.hypertorus-recipes__activerow:nth-child(odd) {
+  background-color: rgba(20, 50, 81, .37);
+};
+.hypertorus-recipes__activerow:nth-child(even) {
+  background-color: rgba(29, 61, 98, .37);
+};
+
+// Headers shouldn't get stripes, but should take the label text color.
+// Headers get left borders as a separator, except if they're furtherest left.
+.hypertorus-recipes__row.Table__row--header {
+  color: colors.fg(colors.$label);
+  background-color: rgba(0,0,0,0);
+};
+.hypertorus-recipes__row.Table__row--header > td {
+  border-left: 1px solid colors.bg(colors.$label);
+  text-align: center;
+};
+.hypertorus-recipes__row.Table__row--header > td:first-child {
+  border-left: none;
+};
+
+// Recipe icons are red, unless they're in a header
+.hypertorus-recipes__icon {
+  text-align: center;
+  position: relative;
+  color: colors.fg(colors.$red);
+  width: 10px;
+};
+.hypertorus-recipes__row.Table__row--header * .hypertorus-recipes__icon {
+  color: colors.fg(colors.$label);
+};
+
+/// @}
+
+/// Temperatures @{
+
+// Note: Height must be kept in sync with Hypertorus/Temperatures.js
+$height: 200px;
+
+// Calculate the space needed for the labels to the left of the chart
+$yAxisLabelWidth: 60px;
+$yAxisIconPadding: 2px;
+$yAxisIconWidth: 14px;
+$yAxisMargin: $yAxisLabelWidth + $yAxisIconWidth + $yAxisIconPadding * 2;
+
+// Relative container respects the padding provided by Section
+.hypertorus-temperatures__container {
+  position: relative;
+  margin-right: 10px;
+}
+
+.hypertorus-temperatures__y-axis-marks {
+  margin-left: 1px;
+  margin-right: 1px;
+  width: $yAxisMargin;
+}
+
+.hypertorus-temperatures__x-axis {
+  background-color: colors.bg(colors.$label);
+  position: absolute;
+  top: $height;
+  height: 1px;
+  left: $yAxisMargin;
+  right: 0;
+};
+
+.hypertorus-temperatures__y-axis {
+  background-color: colors.bg(colors.$label);
+  position: absolute;
+  width: 1px;
+  left: $yAxisMargin;
+  height: $height;
+};
+
+// Note: top set in js
+.hypertorus-temperatures__y-axis-tick-anchor {
+  position: absolute;
+  left: 0px;
+  right: 0;
+};
+
+.hypertorus-temperatures__y-axis-tick {
+  background-color: colors.bg(colors.$label);
+  position: absolute;
+  left: $yAxisMargin;
+  right: 0;
+  height: 1px;
+};
+
+.hypertorus-temperatures__y-axis-label {
+  text-align: right;
+  color: colors.fg(colors.$label);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: $yAxisMargin;
+};
+
+.hypertorus-temperatures__y-axis-icon {
+  display: inline-block;
+  margin-right: $yAxisIconPadding;
+}
+
+.hypertorus-temperatures__chart {
+  left: 0;
+  right: 0;
+  margin-left: $yAxisMargin;
+};
+
+.hypertorus-temperatures__vertical-bar {
+  height: $height;
+  position: relative;
+  width: 17px;
+  bottom: 0;
+};
+
+// Note: top set in js
+.hypertorus-temperatures__vertical-bar > * {
+  position: absolute;
+  left: -0.5px;
+  right: -0.5px;
+  bottom: 0px;
+  border-radius: 0.16em;
+};
+
+.hypertorus__unselectable {
+  user-select: none;
+  -ms-user-select: none;
+};
+
+/// @}

--- a/tgui/packages/tgui/styles/main.scss
+++ b/tgui/packages/tgui/styles/main.scss
@@ -53,6 +53,7 @@
 @include meta.load-css('./interfaces/CrewManifest.scss');
 @include meta.load-css('./interfaces/ExperimentConfigure.scss');
 @include meta.load-css('./interfaces/HellishRunes.scss');
+@include meta.load-css('./interfaces/Hypertorus.scss');
 @include meta.load-css('./interfaces/NuclearBomb.scss');
 @include meta.load-css('./interfaces/Paper.scss');
 @include meta.load-css('./interfaces/PreferencesMenu.scss');


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Massive overhaul of the HFR frontend.

![hfr-ui-redux-8](https://user-images.githubusercontent.com/14355175/136348022-3dfe794c-0b17-4b95-834f-aa9333e1962b.png)

I'm still getting used to the tgui framework, so any guidance toward becoming mergeworthy would be appreciated.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This makes the interface much more usable, and tries to help introduce the concepts involved in a very complicated system. The current interface is a bit clunky to use, and does not offer much guidance as to what actions are possible, or what the implications of taking them might be. You can't see the readouts at the same time you're tweaking the controls. Many failure states are not warned about, or even made clear when they're actively happening. To this end, this PR provides many very helpful qol changes, listed in the changelog below.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
code: LabeledList.Item now supports arbitrary nodes as labels. String labels still work as previously.
code: RoundGauge now supports an alertBefore property, for when warnings need to happen below a threshold. This can combine sensibly to form ranges with alertAfter.
refactor: The HFR interface has been heavily rewritten and restructured, fixing many edge cases where data was empty, unset, or took extreme values. Major parts now have their own file. The structure of gas lists is now consistent. Static data is used for more values. Much presentation layer logic has been moved to tgui instead of dm. Some processing that should never have happened, in tgui or anywhere else, is now gone forever.
qol: The HFR UI now displays the recipe specific gases that each fuel will create in a large table inside an expandable area. This can be collapsed when not needed.
qol: The HFR UI now uses a minimum mass for the scale of its gas lists. This should provide a visual cue for when a gas mix is running out, or needs more fuel to start.
qol: The HFR UI now graphs its various gas mixtures on a unified logarithmic scale, and tells you how fast the temperatures are changing in real units after all effects.
qol: The HFR UI now displays reactor status through gauges, with scales set to indicate typical ranges involved, and warnings to indicate when something is going wrong.
qol: The HFR UI now directly displays reaction instability, reaction activity, and the cell charge of the local APC. Reaction activity is the amount of heat output relative to what is permitted by the heat output limiter. This is effectively making explicit the result of a calculation you would otherwise need to do anyway, and makes it easier to notice when a reaction has stalled.
qol; The HFR UI will now helpfully inform you in discerning red text if you have no recipe set, or if any one of the gas mixtures is empty. This should be particularly helpful for noticing when you didn't add any coolant. Please involve coolant when operating a nuclear reactor.
qol: The HFR UI now always lists Plasma, BZ, and Proto-Nitrate in the moderator gas list, and provides tooltips explaining their usage and purpose.
qol: The HFR UI now has many other tooltips, from explaining the function and purpose of the various reactor controls, to the fringe effects of uncommon moderator gases.
code: heat_output_bool is gone forever yes this deserves its own changelog entry
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
