### PR TITLE
Removes Duplicate Disposals Pipe and Glass Table from MetaENG

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -44905,11 +44905,7 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "nRV" = (
-/obj/structure/table/glass,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/table/glass,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -44906,8 +44906,6 @@
 /area/science/xenobiology)
 "nRV" = (
 /obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,


### PR DESCRIPTION

## About The Pull Request

We missed a spot when doing Metastation Mapmerge Marker Cleanup

## Why It's Good For The Game

Duplicate Items aren't. Closes #61734

## Changelog



:cl:
fix: Removes a duplicate table and pipes and cable from the Metastation Eng Foyer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
