### PR TITLE
Ditches the Spare Monkey-Operated Firealarm in Kilostaiton Genetics

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -83627,7 +83627,6 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "ylc" = (
-/obj/machinery/firealarm/directional/south,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -83636,6 +83635,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /mob/living/carbon/human/species/monkey,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/grass,
 /area/science/genetics)
 "yll" = (


### PR DESCRIPTION
Replaces it with a lightswitch.

## About The Pull Request

Closes #61047


## Why It's Good For The Game

I can see how that would be annoying, but in exchange, they get to play with a lightswitch now. 
They're your monkies, and shouldn't be mistreated.

## Changelog


:cl:
fix: Monkies no longer play with the firelock switch in Kilostation Genetics via the power of uninstallation. 
/:cl:
