### PR TITLE
Lizard Firebreath is now a cone of fire instead of a fireball

### DIFF
--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -104,59 +104,59 @@
 	locked = TRUE
 	text_gain_indication = "<span class='notice'>Your throat is burning!</span>"
 	text_lose_indication = "<span class='notice'>Your throat is cooling down.</span>"
-	power = /obj/effect/proc_holder/spell/aimed/firebreath
+	power = /obj/effect/proc_holder/spell/cone/staggered/firebreath/
 	instability = 30
 	energy_coeff = 1
 	power_coeff = 1
 
 /datum/mutation/human/firebreath/modify()
-	if(power)
-		var/obj/effect/proc_holder/spell/aimed/firebreath/S = power
-		S.strength = GET_MUTATION_POWER(src)
+	// If we have a power chromosome, buff our spell
+	if(power && GET_MUTATION_POWER(src) > 1)
+		var/obj/effect/proc_holder/spell/cone/staggered/firebreath/our_spell = power
+		our_spell.cone_levels *= 2 //Power firebreath makes it fwoosh double distance.
 
-/obj/effect/proc_holder/spell/aimed/firebreath
+/obj/effect/proc_holder/spell/cone/staggered/firebreath
 	name = "Fire Breath"
-	desc = "You can breathe fire at a target."
+	desc = "You can breathe a cone of fire at a target."
 	school = SCHOOL_EVOCATION
+	invocation = ""
 	charge_max = 600
 	clothes_req = FALSE
 	range = 20
-	projectile_type = /obj/projectile/magic/aoe/fireball/firebreath
 	base_icon_state = "fireball"
 	action_icon_state = "fireball0"
+	still_recharging_msg = "<span class='warning'>You can't muster any flames!</span>"
 	sound = 'sound/magic/demon_dies.ogg' //horrifying lizard noises
-	active_msg = "You built up heat in your mouth."
-	deactive_msg = "You swallow the flame."
-	var/strength = 1
+	respect_density = TRUE
+	cone_levels = 2
 
-/obj/effect/proc_holder/spell/aimed/firebreath/before_cast(list/targets)
+/obj/effect/proc_holder/spell/cone/staggered/firebreath/before_cast(list/targets)
 	. = ..()
-	if(iscarbon(usr))
-		var/mob/living/carbon/C = usr
-		if(C.is_mouth_covered())
-			C.adjust_fire_stacks(2)
-			C.IgniteMob()
-			to_chat(C,span_warning("Something in front of your mouth caught fire!"))
-			return FALSE
-
-/obj/effect/proc_holder/spell/aimed/firebreath/ready_projectile(obj/projectile/P, atom/target, mob/user, iteration)
-	. = ..()
-	if(!istype(P, /obj/projectile/magic/aoe/fireball))
+	if(!iscarbon(usr))
 		return
-	var/obj/projectile/magic/aoe/fireball/F = P
-	switch(strength)
-		if(1 to 3)
-			F.exp_light = strength-1
-		if(4 to INFINITY)
-			F.exp_heavy = strength-3
-	F.exp_fire += strength
 
-/obj/projectile/magic/aoe/fireball/firebreath
-	name = "fire breath"
-	exp_heavy = 0
-	exp_light = 0
-	exp_flash = 0
-	exp_fire= 4
+	var/mob/living/carbon/our_lizard = usr
+	if(!our_lizard.is_mouth_covered())
+		return
+
+	our_lizard.adjust_fire_stacks(cone_levels)
+	our_lizard.IgniteMob()
+	to_chat(our_lizard, span_warning("Something in front of your mouth caught fire!"))
+
+/obj/effect/proc_holder/spell/cone/staggered/firebreath/do_turf_cone_effect(turf/target_turf, level)
+	// Further turfs experience less exposed_temperature and exposed_volume
+	new /obj/effect/hotspot(target_turf)
+	target_turf.hotspot_expose(max(500, 900 - (100 * level)), max(50, 200 - (50 * level)), 1)
+
+/obj/effect/proc_holder/spell/cone/staggered/firebreath/do_mob_cone_effect(mob/living/target_mob, level)
+	// Further out targets take less burn damage
+	target_mob.apply_damage(max(10, 30 - (5 * level)), BURN)
+	target_mob.adjust_fire_stacks(max(2, 5 - level))
+	target_mob.IgniteMob()
+
+/obj/effect/proc_holder/spell/cone/staggered/firebreath/do_obj_cone_effect(obj/target_obj, level)
+	// Further out objects are exposed to less heat
+	target_obj.fire_act(max(1000, 500 + (100 * level)), max(50, 200 - (50 * level)))
 
 /datum/mutation/human/void
 	name = "Void Magnet"

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -110,8 +110,11 @@
 	power_coeff = 1
 
 /datum/mutation/human/firebreath/modify()
-	var/obj/effect/proc_holder/spell/cone/staggered/firebreath/our_spell = power
-	our_spell.cone_levels = round(our_spell.cone_levels * GET_MUTATION_POWER(src) + 0.5) //Power firebreath makes it fwoosh more. Round up.
+	// If we have a power chromosome...
+	if(power && GET_MUTATION_POWER(src) > 1)
+		var/obj/effect/proc_holder/spell/cone/staggered/firebreath/our_spell = power
+		our_spell.cone_levels += 2 // Cone fwooshes further, and...
+		our_spell.self_throw_range += 1 // the breath throws the user back more
 
 /obj/effect/proc_holder/spell/cone/staggered/firebreath
 	name = "Fire Breath"
@@ -127,6 +130,8 @@
 	sound = 'sound/magic/demon_dies.ogg' //horrifying lizard noises
 	respect_density = TRUE
 	cone_levels = 3
+	/// The range our user is thrown backwards after casting the spell
+	var/self_throw_range = 1
 
 /obj/effect/proc_holder/spell/cone/staggered/firebreath/before_cast(list/targets)
 	. = ..()
@@ -140,6 +145,14 @@
 	our_lizard.adjust_fire_stacks(cone_levels)
 	our_lizard.IgniteMob()
 	to_chat(our_lizard, span_warning("Something in front of your mouth catches fire!"))
+
+/obj/effect/proc_holder/spell/cone/staggered/firebreath/cast(list/targets, mob/user)
+	. = ..()
+	// When casting, throw them backwards a few tiles.
+	var/original_dir = user.dir
+	user.throw_at(get_edge_target_turf(user, turn(user.dir, 180)), range = self_throw_range, speed = 2, gentle = TRUE)
+	//Try to set us to our original direction after, so we don't end up backwards.
+	user.setDir(original_dir)
 
 // Makes the cone shoot out into a 3 wide column of flames.
 /obj/effect/proc_holder/spell/cone/staggered/firebreath/calculate_cone_shape(current_level)

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -104,7 +104,7 @@
 	locked = TRUE
 	text_gain_indication = "<span class='notice'>Your throat is burning!</span>"
 	text_lose_indication = "<span class='notice'>Your throat is cooling down.</span>"
-	power = /obj/effect/proc_holder/spell/cone/staggered/firebreath/
+	power = /obj/effect/proc_holder/spell/cone/staggered/firebreath
 	instability = 30
 	energy_coeff = 1
 	power_coeff = 1

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -150,7 +150,7 @@
 
 /obj/effect/proc_holder/spell/cone/staggered/firebreath/do_mob_cone_effect(mob/living/target_mob, level)
 	// Further out targets take less burn damage
-	target_mob.apply_damage(max(10, 30 - (5 * level)), BURN)
+	target_mob.apply_damage(max(10, 30 - (5 * level)), BURN, spread_damage = TRUE)
 	target_mob.adjust_fire_stacks(max(2, 5 - level))
 	target_mob.IgniteMob()
 

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -111,7 +111,7 @@
 
 /datum/mutation/human/firebreath/modify()
 	var/obj/effect/proc_holder/spell/cone/staggered/firebreath/our_spell = power
-	our_spell.cone_levels = round(our_spell.cone_levels * GET_MUTATION_POWER(src) + 0.1) //Power firebreath makes it fwoosh more. Round up.
+	our_spell.cone_levels = round(our_spell.cone_levels * GET_MUTATION_POWER(src) + 0.5) //Power firebreath makes it fwoosh more. Round up.
 
 /obj/effect/proc_holder/spell/cone/staggered/firebreath
 	name = "Fire Breath"
@@ -153,7 +153,7 @@
 /obj/effect/proc_holder/spell/cone/staggered/firebreath/do_mob_cone_effect(mob/living/target_mob, level)
 	// Further out targets take less immediate burn damage and get less fire stacks.
 	// The actual burn damage application is not blocked by fireproofing, like space dragons.
-	target_mob.apply_damage(max(10, 30 - (5 * level)), BURN, spread_damage = TRUE)
+	target_mob.apply_damage(max(10, 40 - (5 * level)), BURN, spread_damage = TRUE)
 	target_mob.adjust_fire_stacks(max(2, 5 - level))
 	target_mob.IgniteMob()
 

--- a/code/modules/mob/living/silicon/damage_procs.dm
+++ b/code/modules/mob/living/silicon/damage_procs.dm
@@ -1,5 +1,5 @@
 
-/mob/living/silicon/apply_damage(damage = 0,damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE, wound_bonus = 0, bare_wound_bonus = 0, sharpness = NONE)
+/mob/living/silicon/apply_damage(damage = 0,damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE, spread_damage = FALSE, wound_bonus = 0, bare_wound_bonus = 0, sharpness = NONE)
 	var/hit_percent = (100-blocked)/100
 	if((!damage || (!forced && hit_percent <= 0)))
 		return 0


### PR DESCRIPTION
## About The Pull Request

https://user-images.githubusercontent.com/51863163/135035875-5246ca7c-388d-4cc9-9773-6a2076adf463.mp4

This PR reworks the firebreath mutation from being a wizard fireball that one hit crits with a power chromosome to a wave of fire.

The cone is 3 tiles, or 5 with the power chromosome, and travels in mostly a three wide column.

The closer you are to the caster, the more fire damage you take. 

- [x] 2 wide cones are super wide for some reason, need to check that out.

## Why It's Good For The Game

Non-antags can get wizard fireball and that's really dumb, this re-flavors it to be more like a dragon's breath, while removing the stupid aspect.

## Changelog

:cl: Melbert
balance: The firebreath Mutation is now a cone of fire, instead of a real fireball. 
/:cl:

