### PR TITLE
Exosuit directional lights and sound effects

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -29,9 +29,9 @@
 	move_force = MOVE_FORCE_VERY_STRONG
 	move_resist = MOVE_FORCE_EXTREMELY_STRONG
 	COOLDOWN_DECLARE(mecha_bump_smash)
-	light_system = MOVABLE_LIGHT
+	light_system = MOVABLE_LIGHT_DIRECTIONAL
 	light_on = FALSE
-	light_range = 4
+	light_range = 8
 	generic_canpass = FALSE
 	///What direction will the mech face when entered/powered on? Defaults to South.
 	var/dir_in = SOUTH

--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -56,12 +56,14 @@
 
 	if(available_equipment.len == 0)
 		chassis.balloon_alert(owner, "no equipment available")
+		playsound(chassis,'sound/machines/terminal_error.ogg', 40, FALSE)
 		return
 	if(!chassis.selected)
 		chassis.selected = available_equipment[1]
 		chassis.balloon_alert(owner, "[chassis.selected] selected")
 		send_byjax(chassis.occupants,"exosuit.browser","eq_list",chassis.get_equipment_list())
 		button_icon_state = "mech_cycle_equip_on"
+		playsound(chassis,'sound/machines/piston_raise.ogg', 40, TRUE)
 		UpdateButtonIcon()
 		return
 	var/number = 0
@@ -73,10 +75,12 @@
 			chassis.selected = null
 			chassis.balloon_alert(owner, "switched to no equipment")
 			button_icon_state = "mech_cycle_equip_off"
+			playsound(chassis,'sound/machines/piston_lower.ogg', 40, TRUE)
 		else
 			chassis.selected = available_equipment[number+1]
 			chassis.balloon_alert(owner, "switched to [chassis.selected]")
 			button_icon_state = "mech_cycle_equip_on"
+			playsound(chassis,'sound/machines/piston_raise.ogg', 40, TRUE)
 		send_byjax(chassis.occupants,"exosuit.browser","eq_list",chassis.get_equipment_list())
 		UpdateButtonIcon()
 		return
@@ -100,6 +104,7 @@
 		button_icon_state = "mech_lights_off"
 	chassis.set_light_on(chassis.mecha_flags & LIGHTS_ON)
 	chassis.balloon_alert(owner, "toggled lights [chassis.mecha_flags & LIGHTS_ON ? "on":"off"]")
+	playsound(chassis,'sound/machines/clockcult/brass_skewer.ogg', 40, TRUE)
 	chassis.log_message("Toggled lights [(chassis.mecha_flags & LIGHTS_ON)?"on":"off"].", LOG_MECHA)
 	UpdateButtonIcon()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
First, this PR increases the range of lights on mechs from 4 tiles to 8. It seemed pretty strange for a machine with what I assume are mounted floodlights to have such a small area illuminated.

![dreamseeker_2021-09-27_14-19-18](https://user-images.githubusercontent.com/51190031/135036296-7e2e49c0-c9b6-4fe1-a72c-99bb52365128.png)

Second, the light is made directional, like a floodlight.
![vlc_2021-09-28_01-45-04](https://user-images.githubusercontent.com/51190031/135036681-b9904890-b10e-4c4f-a682-82aa42a95817.png)

Finally, sound effects are added for toggling the lights on and off, and raising/lowering equipment.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

https://user-images.githubusercontent.com/51190031/135037069-52e803e5-99d0-4bc3-8c3b-e81553a2100c.mp4




## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Improves the experience of piloting a mech and helps with user feedback.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
expansion: directional floodlights for exosuits
expansion: sound effects for switching exosuit equipment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
