### PR TITLE
Add preference to disable deadmin preferences in CentCom

### DIFF
--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -304,6 +304,9 @@
 	D.deactivate() //after logs so the deadmined admin can see the message.
 
 /datum/admins/proc/auto_deadmin()
+	if (owner.prefs.read_preference(/datum/preference/toggle/bypass_deadmin_in_centcom) && is_centcom_level(owner.mob.z))
+		return FALSE
+
 	to_chat(owner, span_interface("You are now a normal player."), confidential = TRUE)
 	var/old_owner = owner
 	deactivate()

--- a/code/modules/client/preferences/admin.dm
+++ b/code/modules/client/preferences/admin.dm
@@ -39,3 +39,14 @@
 		return FALSE
 
 	return is_admin(preferences.parent)
+
+/datum/preference/toggle/bypass_deadmin_in_centcom
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "bypass_deadmin_in_centcom"
+	savefile_identifier = PREFERENCE_PLAYER
+
+/datum/preference/toggle/bypass_deadmin_in_centcom/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return is_admin(preferences.parent)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/admin.tsx
@@ -1,4 +1,4 @@
-import { FeatureColorInput, Feature, FeatureDropdownInput } from "../base";
+import { CheckboxInput, FeatureColorInput, Feature, FeatureDropdownInput, FeatureToggle } from "../base";
 
 export const asaycolor: Feature<string> = {
   name: "Admin chat color",
@@ -12,4 +12,11 @@ export const brief_outfit: Feature<string> = {
   category: "ADMIN",
   description: "The outfit to gain when spawning as the briefing officer.",
   component: FeatureDropdownInput,
+};
+
+export const bypass_deadmin_in_centcom: FeatureToggle = {
+  name: "Bypass deadmin options when in CentCom",
+  category: "ADMIN",
+  description: "Whether or not to always remain an admin when spawned in CentCom.",
+  component: CheckboxInput,
 };


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a "bypass deadmin options when in CentCom" preference, which will ignore your usual auto deadmin preferences (such as always deadmin) when you are spawned in CentCom, which is used by admins to test stuff. This makes auto-deadmin preferences frustrating since readminning reloads a bunch of verbs and is fairly laggy.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
admin: Added a preference to disable your usual deadmin preferences when you are spawned in CentCom. This is on by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
