### PR TITLE
Fix being shocked while laying cables having a 50% chance to give you two cables instead of one.

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -598,7 +598,6 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 
 	if(C.shock(user, 50))
 		if(prob(50)) //fail
-			new /obj/item/stack/cable_coil(get_turf(C), 1)
 			C.deconstruct()
 
 	return C


### PR DESCRIPTION
## About The Pull Request
Title

deconstruct already gives cable
https://github.com/tgstation/tgstation/blob/5590e28db833e6aae8ee0939c0cdbc57bd8f0ed5/code/modules/power/cable.dm#L124

## Why It's Good For The Game
Bugfix

## Changelog
:cl:
fix: NanoTrasen denies all allegations of unethically producing electrical cables by forcing ill-equipped employees to lay them and materializing new cables out of thin air. The reports were clearly exaggerated.
/:cl: