### PR TITLE
Fixed holosigns not registering it's projector

### DIFF
--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -10,7 +10,7 @@
 	var/obj/item/holosign_creator/projector
 	var/use_vis_overlay = TRUE
 
-/obj/structure/holosign/Initialize(mapload, loc, source_projector)
+/obj/structure/holosign/Initialize(mapload, source_projector)
 	. = ..()
 	if(use_vis_overlay)
 		alpha = 0


### PR DESCRIPTION
## About The Pull Request
Before the mapload PR got merged, the mapload param got treated incorrectly as the loc param, allowing the proc to work without problems since source_projector is in the right place. But now that the mapload param is implemented here properly, the previous bad implementation turned into a working feature turned back into a bug. This took way longer than it should have.

## Why It's Good For The Game
you bet it is

## Changelog
:cl:
fix: fixed holosigns not counting towards the max limit and not being deleted when clicking the creator.
/:cl: