### PR TITLE
Refactor rolling paper to use customizable reagent holder

### DIFF
--- a/code/__DEFINES/dcs/flags.dm
+++ b/code/__DEFINES/dcs/flags.dm
@@ -48,6 +48,7 @@
 
 //Ingredient type in datum/component/customizable_reagent_holder
 #define CUSTOM_INGREDIENT_TYPE_EDIBLE 1
+#define CUSTOM_INGREDIENT_TYPE_DRYABLE 2
 
 //Icon overlay type in datum/component/customizable_reagent_holder
 #define CUSTOM_INGREDIENT_ICON_NOCHANGE 0

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -33,7 +33,8 @@
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 	var/atom/atom_parent = parent
-	if (!atom_parent.reagents)
+	// assume replacement is OK
+	if (!atom_parent.reagents && !replacement)
 		return COMPONENT_INCOMPATIBLE
 
 	src.replacement = replacement
@@ -108,6 +109,8 @@
 	switch (ingredient_type)
 		if (CUSTOM_INGREDIENT_TYPE_EDIBLE)
 			valid_ingredient = IS_EDIBLE(ingredient)
+		if (CUSTOM_INGREDIENT_TYPE_DRYABLE)
+			valid_ingredient = HAS_TRAIT(ingredient, TRAIT_DRYABLE)
 
 	// only accept valid ingredients
 	if (!valid_ingredient || HAS_TRAIT(ingredient, TRAIT_CUSTOMIZABLE_REAGENT_HOLDER))

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -893,25 +893,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "cig_paper"
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/rollingpaper/afterattack(atom/target, mob/user, proximity)
+/obj/item/rollingpaper/Initialize()
 	. = ..()
-	if(!proximity)
-		return
-	if(!istype(target, /obj/item/food/grown))
-		return
+	AddComponent(/datum/component/customizable_reagent_holder, /obj/item/clothing/mask/cigarette/rollie, CUSTOM_INGREDIENT_ICON_NOCHANGE, ingredient_type=CUSTOM_INGREDIENT_TYPE_DRYABLE, max_ingredients=2)
 
-	if(!HAS_TRAIT(target, TRAIT_DRIED))
-		to_chat(user, span_warning("You need to dry [target] first!"))
-		return
-
-	var/obj/item/clothing/mask/cigarette/rollie/R = new /obj/item/clothing/mask/cigarette/rollie(user.loc)
-	R.chem_volume = target.reagents.maximum_volume
-	target.reagents.trans_to(R, R.chem_volume, transfered_by = user)
-	qdel(target)
-	qdel(src)
-	user.put_in_active_hand(R)
-	to_chat(user, span_notice("You roll the [target.name] into a rolling paper."))
-	R.desc = "Dried [target.name] rolled up in a thin piece of paper."
 
 ///////////////
 //VAPE NATION//

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -893,7 +893,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "cig_paper"
 	w_class = WEIGHT_CLASS_TINY
 
-/obj/item/rollingpaper/Initialize()
+/obj/item/rollingpaper/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/customizable_reagent_holder, /obj/item/clothing/mask/cigarette/rollie, CUSTOM_INGREDIENT_ICON_NOCHANGE, ingredient_type=CUSTOM_INGREDIENT_TYPE_DRYABLE, max_ingredients=2)
 


### PR DESCRIPTION
:cl: That REALLY Good Soda Flavor
refactor: Rolling paper will now use the customizable reagent holder component. This cleans up the code and expands the possibilities for using the component by adding support for dried items.
/:cl:

**Details:**
The component can accept dryable items and food items now. Any instance of the component can be set to use dryable items, just like normally food items are used. To add the dryable item, it's the same as with food. You attack with the item in hand. I am currently thinking about more uses for dryable items and also more ways the component can be used.

**Why it's good:**
Expands the potential for this component and reduces the amount of code on the rolling paper.