### PR TITLE
Adds a short note on where the loc arg is being overwritten by mapload for atoms

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -212,6 +212,11 @@
  * the Atom subsystem intialization, or if the atom is being loaded from the map template.
  * If the item is being created at runtime any time after the Atom subsystem is intialized then
  * it's false.
+ * 
+ * The mapload argument occupies the same position as loc when Initialize() is called by New(). 
+ * The loc argument that usually accompanies New() will no longer be needed after it has 
+ * been stored. loc being the first positional argument will then be overwritten
+ * with mapload at atom/New() before this proc (atom/Initialize()) is called.
  *
  * You must always call the parent of this proc, otherwise failures will occur as the item
  * will not be seen as initalized (this can lead to all sorts of strange behaviour, like

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -214,9 +214,8 @@
  * it's false.
  * 
  * The mapload argument occupies the same position as loc when Initialize() is called by New(). 
- * The loc argument that usually accompanies New() will no longer be needed after it has 
- * been stored. loc being the first positional argument will then be overwritten
- * with mapload at atom/New() before this proc (atom/Initialize()) is called.
+ * loc will no longer be needed after it passed New(), and thus it is being overwritten
+ * with mapload at the end of atom/New() before this proc (atom/Initialize()) is called.
  *
  * You must always call the parent of this proc, otherwise failures will occur as the item
  * will not be seen as initalized (this can lead to all sorts of strange behaviour, like


### PR DESCRIPTION
## About The Pull Request
atom/New() rewriting `loc` is a bit difficult to find if you don't know what you're trying to look for, I hope this doc-comment might help people looking into this for the first time.

## Why It's Good For The Game
Doesn't affect the game