### PR TITLE
Fix the species list not scrolling, fix halloween species runtimes

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -910,6 +910,15 @@
 
 ///Add a spell to the mobs spell list
 /mob/proc/AddSpell(obj/effect/proc_holder/spell/S)
+	// HACK: Preferences menu creates one of every selectable species.
+	// Some species, like vampires, create spells when they're made.
+	// The "action" is created when those spells Initialize.
+	// Preferences menu can create these assets at *any* time, primarily before
+	// the atoms SS initializes.
+	// That means "action" won't exist.
+	if (isnull(S.action))
+		return
+
 	LAZYADD(mob_spell_list, S)
 	S.action.Grant(src)
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/SpeciesPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/SpeciesPage.tsx
@@ -259,33 +259,33 @@ const SpeciesPageInner = (props: {
       <Stack.Item grow>
         <Stack fill>
           <Stack.Item>
-            <Stack vertical fill>
+            <Box height="calc(100vh - 170px)" overflowY="auto" pr={3}>
               {species.map(([speciesKey, species]) => {
                 return (
-                  <Stack.Item key={speciesKey}>
-                    <Button
-                      onClick={() => setSpecies(speciesKey)}
-                      selected={
-                        data.character_preferences.misc.species === speciesKey
-                      }
-                      tooltip={species.name}
-                      style={{
-                        height: "64px",
-                        width: "64px",
-                      }}
-                    >
-                      <Box
-                        className={classes([
-                          "species64x64",
-                          species.icon,
-                        ])}
-                        ml={-1}
-                      />
-                    </Button>
-                  </Stack.Item>
+                  <Button
+                    key={speciesKey}
+                    onClick={() => setSpecies(speciesKey)}
+                    selected={
+                      data.character_preferences.misc.species === speciesKey
+                    }
+                    tooltip={species.name}
+                    style={{
+                      display: "block",
+                      height: "64px",
+                      width: "64px",
+                    }}
+                  >
+                    <Box
+                      className={classes([
+                        "species64x64",
+                        species.icon,
+                      ])}
+                      ml={-1}
+                    />
+                  </Button>
                 );
               })}
-            </Stack>
+            </Box>
           </Stack.Item>
 
           <Stack.Item grow>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/35135081/135176253-628823c3-2acd-4c88-8eb7-4069c61e0be4.png)

Before this point, it simply extended the page.

Fixes a new runtime with vampires being created pre-atom-init.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The species list will now scroll properly when there are too many. This has meant nothing up until this point, but will when Halloween races are enabled again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
