### PR TITLE
Hit the Deck! Dropping to the ground to avoid shots.

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -144,6 +144,8 @@
 
 #define STATUS_EFFECT_STONED /datum/status_effect/stoned
 
+#define STATUS_EFFECT_CRAWLING /datum/status_effect/crawling
+
 /////////////
 //  SLIME  //
 /////////////

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -460,6 +460,17 @@
 		QDEL_NULL(alt_clone)
 	return ..()
 
+// A status effect that represents a character crawling
+/datum/status_effect/crawling
+	id = "crawling"
+	duration = 6 SECONDS
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = null
+
+/datum/status_effect/crawling/on_remove()
+	if(owner.body_position == LYING_DOWN)
+		to_chat(owner, "<span class='notice'>You assume a prone posistion.")
+
 #undef EIGENSTASIUM_MAX_BUFFER
 #undef EIGENSTASIUM_STABILISATION_RATE
 #undef EIGENSTASIUM_PHASE_1_END

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -469,7 +469,7 @@
 
 /datum/status_effect/crawling/on_remove()
 	if(owner.body_position == LYING_DOWN)
-		owner.balloon_alert(owner, "You assume a prone position.")
+		owner.balloon_alert(owner, "in prone position")
 
 #undef EIGENSTASIUM_MAX_BUFFER
 #undef EIGENSTASIUM_STABILISATION_RATE

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -469,7 +469,7 @@
 
 /datum/status_effect/crawling/on_remove()
 	if(owner.body_position == LYING_DOWN)
-		to_chat(owner, "<span class='notice'>You assume a prone posistion.")
+		owner.balloon_alert(owner, "You assume a prone position.")
 
 #undef EIGENSTASIUM_MAX_BUFFER
 #undef EIGENSTASIUM_STABILISATION_RATE

--- a/code/game/objects/items/shrapnel.dm
+++ b/code/game/objects/items/shrapnel.dm
@@ -30,7 +30,7 @@
 	ricochet_chance = 70
 	shrapnel_type = /obj/item/shrapnel
 	ricochet_incidence_leeway = 60
-	hit_prone_targets = TRUE
+	hit_crawling_targets = TRUE
 	sharpness = SHARP_EDGED
 	wound_bonus = 30
 	embedding = list(embed_chance=70, ignore_throwspeed_threshold=TRUE, fall_chance=1)
@@ -60,7 +60,7 @@
 	embedding = list(embed_chance=55, fall_chance=2, jostle_chance=7, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.7, pain_mult=3, jostle_pain_mult=3, rip_time=15)
 
 /obj/projectile/bullet/pellet/stingball/on_ricochet(atom/A)
-	hit_prone_targets = TRUE // ducking will save you from the first wave, but not the rebounds
+	hit_crawling_targets = TRUE // ducking will save you from the first wave, but not the rebounds
 
 /obj/projectile/bullet/pellet/stingball/mega
 	name = "megastingball pellet"

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -31,6 +31,8 @@
 			adjust_nutrition(-(HUNGER_FACTOR/10))
 			if(m_intent == MOVE_INTENT_RUN)
 				adjust_nutrition(-(HUNGER_FACTOR/10))
+	if(body_position == LYING_DOWN)
+		apply_status_effect(STATUS_EFFECT_CRAWLING)
 
 
 /mob/living/carbon/set_usable_legs(new_value)

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -30,7 +30,7 @@
 	loaded_projectile.original = target
 	loaded_projectile.firer = user
 	loaded_projectile.fired_from = fired_from
-	loaded_projectile.hit_crawling_targets = user.combat_mode
+	loaded_projectile.hit_crawling_targets = TRUE
 	if (zone_override)
 		loaded_projectile.def_zone = zone_override
 	else

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -30,7 +30,7 @@
 	loaded_projectile.original = target
 	loaded_projectile.firer = user
 	loaded_projectile.fired_from = fired_from
-	loaded_projectile.hit_prone_targets = user.combat_mode
+	loaded_projectile.hit_crawling_targets = user.combat_mode
 	if (zone_override)
 		loaded_projectile.def_zone = zone_override
 	else

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -506,6 +506,8 @@
 			return FALSE
 		if(HAS_TRAIT(L, TRAIT_IMMOBILIZED) && HAS_TRAIT(L, TRAIT_FLOORED) && HAS_TRAIT(L, TRAIT_HANDS_BLOCKED))
 			return FALSE
+		if(L.body_position == LYING_DOWN && !L.has_status_effect(STATUS_EFFECT_CRAWLING))
+			return FALSE
 		if(!hit_prone_targets)
 			if(!L.density)
 				return FALSE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -159,7 +159,7 @@
 	///If we have a shrapnel_type defined, these embedding stats will be passed to the spawned shrapnel type, which will roll for embedding on the target
 	var/list/embedding
 	///If TRUE, hit mobs even if they're on the floor and not our target
-	var/hit_prone_targets = FALSE
+	var/hit_crawling_targets = FALSE
 	///For what kind of brute wounds we're rolling for, if we're doing such a thing. Lasers obviously don't care since they do burn instead.
 	var/sharpness = NONE
 	///How much we want to drop both wound_bonus and bare_wound_bonus (to a minimum of 0 for the latter) per tile, for falloff purposes
@@ -508,11 +508,9 @@
 			return FALSE
 		if(L.body_position == LYING_DOWN && !L.has_status_effect(STATUS_EFFECT_CRAWLING))
 			return FALSE
-		if(!hit_prone_targets)
+		if(!hit_crawling_targets)
 			if(!L.density)
 				return FALSE
-			if(L.body_position != LYING_DOWN)
-				return TRUE
 	return TRUE
 
 /**

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -42,7 +42,7 @@
 		projectile_obj.preparePixelProjectile(target, source, modifiers, spread)
 		if(source.client && isliving(source)) //dont want it to happen from syndie mecha npc mobs, they do direct fire anyways
 			var/mob/living/shooter = source
-			projectile_obj.hit_prone_targets = shooter.combat_mode
+			projectile_obj.hit_crawling_targets = shooter.combat_mode
 		projectile_obj.fire()
 		if(!projectile_obj.suppressed && firing_effect_type)
 			new firing_effect_type(get_turf(src), chassis.dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
![tactical resting](https://user-images.githubusercontent.com/55666666/135190134-e8e7887a-b391-41cd-aa02-a1414a340863.PNG)

## About The Pull Request
This PR acts as an alternative I proposed for tactical resting.


In short: If you drop to the ground and don't move, bullets fired that were not aimed directly at your sprite directly will fly overhead. If you move while prone you lose this effect until you stay still for 6 seconds, or of course, you could just stand up and lay back down later.


For a longer explanation with more context on the goals of this change, see the following design document: https://hackmd.io/7t8n7f8HSkmIg7o7aLRk1A

This PR as-is is pretty bare-boned. I would like your opinion on the following changes I hesitated to make.
1. Most importantly, should this do away with the current system of not hitting shots on prone targets while not in combat mode? It seems a bit redundant and could add to confusion amongst players by making systems too complex. I'll probably remove it unless some good reasons I'm missing are e brought to my attention.
2. Tweaking. Are six seconds to regain this benefit too long? too short? I've only messed around with it solo and it feels alright as is. But I'm not fully confident the same is true in an actual game.
3. Chat Feedback. Currently, the only chat feedback I thought was necessary was a notification that you were back into a prone position after not moving for six seconds after you started crawling. Although notifications that say "you have started crawling and now bullets will hit you" or "you are prone and bullets will now pass over you" are very possible, I'm unsure how useful or annoying these would be.
4. Potentially out of scope, but there was talk about other debuffs given to crawling characters like an accuracy penalty or something.

If you have any strong arguments for these topics I'd love to hear them even if it is in incoherent angry babble.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
See the design document for full deets, but in short, this improves consistency and adds an element to ranged combat without being annoyingly abusable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: itseasytosee
add: Tactical resting has its revenge and it's better than ever! Going prone will make bullets not aimed at you directly pass over you unless you have been crawling on the ground recently.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
