### PR TITLE
fixes infinitely burning durand shields

### DIFF
--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -151,7 +151,7 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 	///To keep track of things during the animation
 	var/switching = FALSE
 	var/currentuser
-	resistance_flags = LAVA_PROOF | FIRE_PROOF //The shield should not take damage from fire or lava, that's the mech's job
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF //The shield should not take damage from fire,  lava, or acid; that's the mech's job.
 
 
 /obj/durand_shield/Initialize(mapload, _chassis, _layer, _dir)

--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -151,6 +151,7 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 	///To keep track of things during the animation
 	var/switching = FALSE
 	var/currentuser
+	resistance_flags = LAVA_PROOF | FIRE_PROOF //The shield should not take damage from fire or lava, that's the mech's job
 
 
 /obj/durand_shield/Initialize(mapload, _chassis, _layer, _dir)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives the durand's shield FIREPROOF, LAVAPROOF and ACIDPROOF = true, so that it doesn't burn infinitely and drain your battery, even when disabled. Mechs themselves already are fireproof or acidproof but that's not being taken to account in the shield damage calculation.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
fixes #61662
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: durand shield will no longer burn forever or take fire/acid damage from the environment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
