### PR TITLE
Fix random-spawns station trait spawning in bad spots (kilo + icebox)

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -5539,8 +5539,11 @@
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "Bb" = (
-/turf/open/floor/plating/snowed/icemoon,
-/area/hallway/secondary/service)
+/obj/item/flashlight/lantern{
+	light_on = 1
+	},
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
 "Bd" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -9602,10 +9605,6 @@
 "Tw" = (
 /turf/open/floor/iron,
 /area/cargo/storage)
-"Ty" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating/snowed/icemoon,
-/area/hallway/secondary/service)
 "Tz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -51948,9 +51947,9 @@ ak
 ak
 ak
 Et
-Ty
-Bb
-Bb
+mv
+mv
+mv
 Et
 Et
 fK
@@ -52976,7 +52975,7 @@ ak
 ak
 ak
 Jf
-Fp
+Bb
 Fp
 PG
 PG

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -6931,7 +6931,7 @@
 	name = "landing marker"
 	},
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "aJb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16995,7 +16995,7 @@
 /obj/structure/flora/ausbushes/fernybush,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bPN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
@@ -17009,13 +17009,13 @@
 /obj/structure/flora/grass/jungle/b,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bPR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/flora/ausbushes/palebush,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bPV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/decoration/glowstick,
@@ -17026,13 +17026,13 @@
 "bPX" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bPZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bQa" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
@@ -17144,10 +17144,6 @@
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid/lowpressure,
 /area/space/nearstation)
-"bQT" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
 "bQU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -17741,7 +17737,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bTU" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral{
@@ -17781,14 +17777,14 @@
 /obj/structure/flora/grass/jungle,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bUe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bUf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -17808,11 +17804,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
-"bUn" = (
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bUo" = (
 /obj/structure/sign/warning,
 /turf/closed/wall,
@@ -17824,7 +17816,7 @@
 /obj/structure/flora/ausbushes/palebush,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bUq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17866,7 +17858,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bUz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/gulag_item_reclaimer{
@@ -17894,7 +17886,7 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bUC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17902,7 +17894,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bUD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17910,7 +17902,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bUE" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -17919,28 +17911,28 @@
 /obj/structure/flora/ausbushes/palebush,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bUF" = (
 /obj/structure/flora/rock/pile,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bUI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "bUN" = (
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space)
 "bUO" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space)
 "bUP" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -21111,7 +21103,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space)
 "cig" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -21647,7 +21639,7 @@
 	width = 7
 	},
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space)
 "clm" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -22241,7 +22233,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space)
 "cou" = (
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall/rust,
@@ -22892,7 +22884,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "crI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -22906,7 +22898,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space)
 "crL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -23179,7 +23171,7 @@
 "ctu" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "ctw" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -23257,9 +23249,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
-"ctT" = (
-/turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
 "ctU" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -31829,7 +31818,7 @@
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "eOQ" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -32458,7 +32447,7 @@
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "eYL" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
@@ -52598,7 +52587,7 @@
 	name = "shuttle camera"
 	},
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "mAE" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -55251,7 +55240,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "nDP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -72700,7 +72689,7 @@
 	name = "shuttle camera"
 	},
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "uaP" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -74731,7 +74720,7 @@
 	name = "landing marker"
 	},
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "uRP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
@@ -76587,7 +76576,7 @@
 /obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/asteroid/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "vDB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -81180,7 +81169,7 @@
 	req_access_txt = "19"
 	},
 /turf/open/floor/plating/airless,
-/area/hallway/secondary/entry)
+/area/space/nearstation)
 "xrZ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -122208,10 +122197,10 @@ bEg
 bOC
 aIY
 bUI
-bQT
-bQT
+cHu
+cHu
 uaL
-bQT
+cHu
 crG
 bUI
 aIY
@@ -122472,7 +122461,7 @@ bUN
 bUN
 bUN
 bUd
-bPJ
+aeu
 aeu
 dtq
 iZU
@@ -122729,8 +122718,8 @@ bUN
 bUN
 bUN
 bUe
-bPJ
-bPJ
+aeu
+aeu
 lsw
 cMJ
 wPT
@@ -122987,7 +122976,7 @@ bUN
 bUN
 bUk
 bUE
-bPJ
+aeu
 deb
 iKn
 deb
@@ -123243,8 +123232,8 @@ bUN
 bUN
 bUN
 bUp
-bUn
-bPJ
+aUz
+aeu
 deb
 qSF
 kFL
@@ -123757,7 +123746,7 @@ bUN
 bUN
 bUN
 bUk
-bPJ
+aeu
 aeu
 iKn
 iQR
@@ -124014,7 +124003,7 @@ bUN
 bUN
 bUN
 bUk
-bPJ
+aeu
 aeu
 iKn
 sbk
@@ -124271,7 +124260,7 @@ bUN
 bUN
 bUN
 bUd
-bPJ
+aeu
 aeu
 deb
 dZP
@@ -124785,8 +124774,8 @@ bUN
 bUN
 bUN
 bUy
-bPJ
-bPJ
+aeu
+aeu
 bSr
 aeu
 aeu
@@ -125043,7 +125032,7 @@ bUN
 bUN
 bUA
 bUF
-bPJ
+aeu
 bSr
 aeu
 aeu
@@ -125288,8 +125277,8 @@ bPe
 bZC
 bPe
 bOc
-bPJ
-bPJ
+aeu
+aeu
 eOk
 bUN
 bUN
@@ -125300,7 +125289,7 @@ bUN
 bUN
 bUk
 ctu
-bPJ
+aeu
 bSr
 aeu
 aeU
@@ -125545,7 +125534,7 @@ bTG
 bYH
 bTR
 bRF
-bPJ
+aeu
 bPK
 bPZ
 bUN
@@ -125556,8 +125545,8 @@ bUN
 bUN
 bUN
 bUC
-ctT
-bPJ
+aeU
+aeu
 bSr
 aeu
 aUz
@@ -125802,8 +125791,8 @@ bTt
 qpz
 bZL
 bRF
-bPJ
-bPJ
+aeu
+aeu
 bTT
 bUO
 bUN
@@ -125813,8 +125802,8 @@ bUN
 bUN
 crK
 bUD
-bPJ
-bPJ
+aeu
+aeu
 bSr
 aeU
 aeU
@@ -126059,8 +126048,8 @@ ggt
 xoR
 jMb
 bOc
-bPJ
-bPJ
+aeu
+aeu
 uRK
 cic
 cic
@@ -126070,8 +126059,8 @@ cic
 cic
 cic
 xrW
-bPJ
-bPJ
+aeu
+aeu
 bSr
 aeU
 aeU


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
-changes some map area to not have area/hallway subtypes in those bad spots
-on ice removed an outside light and replaced with nearby lit lantern because not having this the same area means the light wouldn't be powered
-kilo got the direct shuttle area changed to space, and the surrounding area of sandy turf changed to the space/nearby area
Fixes: #61760 
Fixes: #61118 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
-stop spawning in bad spots on these maps
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: you will no longer spawn behind the arrivals shuttle on kilo or on ice wastes for icebox, when the stations has the random spawn trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
