### PR TITLE
Thermomachine design icon fix

### DIFF
--- a/code/datums/greyscale/json_configs/thermomachine.json
+++ b/code/datums/greyscale/json_configs/thermomachine.json
@@ -1,5 +1,5 @@
 {
-	"thermo_0": [
+	"thermo_base": [
 		{
 			"type": "icon_state",
 			"icon_state": "temp_meter",

--- a/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/thermomachine.dm
@@ -110,7 +110,7 @@
 		else
 			icon_state = "thermo_1"
 		return ..()
-	icon_state = "thermo_0"
+	icon_state = "thermo_base"
 	return ..()
 
 /obj/machinery/atmospherics/components/binary/thermomachine/update_overlays()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR fixes a missing thermomachine design icon, which meant that the machine icon was not showing properly in the R&D Console UI. This also caused a warning each time game was initialized in the Dream Daemon log. Game was expecting thermo_base icon state, which was however not available in the thermomachine GAGS icon file.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Bugfix.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Arkatos
fix: Thermomachine design icon in the R&D Console UI will now show properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
