### PR TITLE
Vending machines now use their name as a title for their UI

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -735,7 +735,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 /obj/machinery/vending/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		ui = new(user, src, "Vending")
+		ui = new(user, src, "Vending", name)
 		ui.open()
 
 /obj/machinery/vending/ui_static_data(mob/user)

--- a/tgui/packages/tgui/interfaces/Vending.tsx
+++ b/tgui/packages/tgui/interfaces/Vending.tsx
@@ -200,7 +200,6 @@ export const Vending = (props, context) => {
   inventory = inventory.filter(item => !!item);
   return (
     <Window
-      title="Vending Machine"
       width={450}
       height={600}>
       <Window.Content scrollable>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR makes vending machines use their name as a title for their UI instead of all of them being titled as "Vending Machine", which I personally think is more handy to know, so you can tell what exact vendor are you browsing.

**Example image:**

![VendingTitles](https://user-images.githubusercontent.com/43862960/135362824-a84c47ec-531d-44b6-9534-35598f1bfaa2.png)

## Why It's Good For The Game

More easily identify which vending machine are you browsing.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Arkatos
qol: Vending machines now use their name as a title for their UI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
