### PR TITLE
Make tooltips use one popper, fixing mount lag

### DIFF
--- a/tgui/packages/tgui-bench/tests/Tooltip.test.tsx
+++ b/tgui/packages/tgui-bench/tests/Tooltip.test.tsx
@@ -1,0 +1,20 @@
+import { Box, Tooltip } from "tgui/components";
+import { createRenderer } from "tgui/renderer";
+
+const render = createRenderer();
+
+export const ListOfTooltips = () => {
+  const nodes: JSX.Element[] = [];
+
+  for (let i = 0; i < 100; i++) {
+    nodes.push(
+      <Tooltip key={i} content={`This is from tooltip ${i}`} position="bottom">
+        <Box as="span" backgroundColor="blue" fontSize="48px" m={1}>
+          Tooltip #{i}
+        </Box>
+      </Tooltip>
+    );
+  }
+
+  render(<div>{nodes}</div>);
+};

--- a/tgui/packages/tgui/components/Tooltip.tsx
+++ b/tgui/packages/tgui/components/Tooltip.tsx
@@ -1,9 +1,6 @@
 
-import { Placement } from '@popperjs/core';
-import { Component, findDOMfromVNode, InfernoNode } from 'inferno';
-import { Popper } from "./Popper";
-
-const DEFAULT_PLACEMENT = "top";
+import { createPopper, Placement, VirtualElement } from '@popperjs/core';
+import { Component, findDOMfromVNode, InfernoNode, render } from 'inferno';
 
 type TooltipProps = {
   children?: InfernoNode;
@@ -15,17 +12,42 @@ type TooltipState = {
   hovered: boolean;
 };
 
-const DISABLE_EVENT_LISTENERS = [{
-  name: "eventListeners",
-  enabled: false,
-}];
+const DEFAULT_OPTIONS = {
+  modifiers: [{
+    name: "eventListeners",
+    enabled: false,
+  }],
+};
+
+const NULL_RECT = {
+  width: 0,
+  height: 0,
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+};
 
 export class Tooltip extends Component<TooltipProps, TooltipState> {
-  state = {
-    hovered: false,
+  // Mounting poppers is really laggy because popper.js is very slow.
+  // Thus, instead of using the Popper component, Tooltip creates ONE popper
+  // and stores every tooltip inside that.
+  // This means you can never have two tooltips at once, for instance.
+  static renderedTooltip: HTMLDivElement | undefined;
+  static singletonPopper: ReturnType<typeof createPopper> | undefined;
+  static currentHoveredElement: Element | undefined;
+  static virtualElement: VirtualElement = {
+    getBoundingClientRect: () => {
+      const hoveredElement = Tooltip.currentHoveredElement;
+      if (hoveredElement) {
+        return hoveredElement.getBoundingClientRect();
+      } else {
+        return NULL_RECT;
+      }
+    },
   };
 
-  componentDidMount() {
+  getDOMNode() {
     // HACK: We don't want to create a wrapper, as it could break the layout
     // of consumers, so we do the inferno equivalent of `findDOMNode(this)`.
     // My attempt to avoid this was a render prop that passed in
@@ -34,47 +56,95 @@ export class Tooltip extends Component<TooltipProps, TooltipState> {
     // This code is copied from `findDOMNode` in inferno-extras.
     // Because this component is written in TypeScript, we will know
     // immediately if this internal variable is removed.
-    const domNode = findDOMfromVNode(this.$LI, true);
+    return findDOMfromVNode(this.$LI, true);
+  }
+
+  componentDidMount() {
+    const domNode = this.getDOMNode();
 
     if (!domNode) {
       return;
     }
 
     domNode.addEventListener("mouseenter", () => {
-      this.setState({
-        hovered: true,
-      });
+      let renderedTooltip = Tooltip.renderedTooltip;
+      if (renderedTooltip === undefined) {
+        renderedTooltip = document.createElement("div");
+        renderedTooltip.className = "Tooltip";
+        document.body.appendChild(renderedTooltip);
+        Tooltip.renderedTooltip = renderedTooltip;
+      }
+
+      Tooltip.currentHoveredElement = domNode;
+
+      renderedTooltip.style.opacity = "1";
+
+      this.renderPopperContent();
     });
 
     domNode.addEventListener("mouseleave", () => {
-      this.setState({
-        hovered: false,
-      });
+      this.fadeOut();
     });
   }
 
-  render() {
-    return (
-      <Popper
-        options={{
-          placement: this.props.position || "auto",
-          modifiers: DISABLE_EVENT_LISTENERS,
-        }}
-        popperContent={
-          <div
-            className="Tooltip"
-            style={{
-              opacity: this.state.hovered ? 1 : 0,
-            }}>
-            {this.props.content}
-          </div>
+  fadeOut() {
+    if (Tooltip.currentHoveredElement !== this.getDOMNode()) {
+      return;
+    }
+
+    Tooltip.currentHoveredElement = undefined;
+    Tooltip.renderedTooltip!.style.opacity = "0";
+  }
+
+  renderPopperContent() {
+    const renderedTooltip = Tooltip.renderedTooltip;
+    if (!renderedTooltip) {
+      return;
+    }
+
+    render(
+      <span>{this.props.content}</span>,
+      renderedTooltip,
+      () => {
+        let singletonPopper = Tooltip.singletonPopper;
+        if (singletonPopper === undefined) {
+          singletonPopper = createPopper(
+            Tooltip.virtualElement,
+            renderedTooltip!,
+            {
+              ...DEFAULT_OPTIONS,
+              placement: this.props.position || "auto",
+            }
+          );
+
+          Tooltip.singletonPopper = singletonPopper;
+        } else {
+          singletonPopper.setOptions({
+            ...DEFAULT_OPTIONS,
+            placement: this.props.position || "auto",
+          });
+
+          singletonPopper.update();
         }
-        additionalStyles={{
-          "pointer-events": "none",
-          "z-index": 2,
-        }}>
-        {this.props.children}
-      </Popper>
+      },
+      this.context,
     );
+  }
+
+  componentDidUpdate() {
+    if (Tooltip.currentHoveredElement !== this.getDOMNode()) {
+      return;
+    }
+
+    this.renderPopperContent();
+  }
+
+  componentWillUnmount() {
+    // NYI: Fade away tooltip if this is the current hovered one
+    this.fadeOut();
+  }
+
+  render() {
+    return this.props.children;
   }
 }

--- a/tgui/packages/tgui/components/Tooltip.tsx
+++ b/tgui/packages/tgui/components/Tooltip.tsx
@@ -136,7 +136,6 @@ export class Tooltip extends Component<TooltipProps, TooltipState> {
   }
 
   componentWillUnmount() {
-    // NYI: Fade away tooltip if this is the current hovered one
     this.fadeOut();
   }
 

--- a/tgui/packages/tgui/components/Tooltip.tsx
+++ b/tgui/packages/tgui/components/Tooltip.tsx
@@ -37,14 +37,10 @@ export class Tooltip extends Component<TooltipProps, TooltipState> {
   static singletonPopper: ReturnType<typeof createPopper> | undefined;
   static currentHoveredElement: Element | undefined;
   static virtualElement: VirtualElement = {
-    getBoundingClientRect: () => {
-      const hoveredElement = Tooltip.currentHoveredElement;
-      if (hoveredElement) {
-        return hoveredElement.getBoundingClientRect();
-      } else {
-        return NULL_RECT;
-      }
-    },
+    getBoundingClientRect: () => (
+      Tooltip.currentHoveredElement?.getBoundingClientRect()
+        ?? NULL_RECT
+    ),
   };
 
   getDOMNode() {

--- a/tgui/packages/tgui/styles/components/Tooltip.scss
+++ b/tgui/packages/tgui/styles/components/Tooltip.scss
@@ -15,7 +15,7 @@ $border-radius: base.$border-radius !default;
   padding: 0.5em 0.75em;
   pointer-events: none;
   text-align: left;
-  transition: all 150ms ease-out;
+  transition: opacity 150ms ease-out;
   background-color: $background-color;
   color: $color;
   box-shadow: 0.1em 0.1em 1.25em -0.1em rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In the [last episode](https://github.com/tgstation/tgstation/pull/61343), I fixed update lag. This is what made the R&D console laggy to *scroll through*.

In this episode, we fix *mount lag*, which is what makes the R&D console laggy to open and search through, since it has to constantly make the new tooltips.

This is done by using a trick [tippy.js](https://atomiks.github.io/tippyjs/#singleton) uses, where they create *one* popper instance for multiple tooltips, then just move it around. I decided to emulate this by moving the popper stuff to Tooltip itself. The Popper component still exists as some non-tooltip consumers for it exist, such as preferences menu clothing selection. This is done through the ugliest code of my fucking life, but in a way that's totally transparent to consumers.




https://user-images.githubusercontent.com/35135081/135373321-a1b25732-5d94-4f51-b6bb-191256a48548.mp4

https://user-images.githubusercontent.com/35135081/135373333-650b30ce-9ebd-454d-8262-f263df03fa34.mp4



https://user-images.githubusercontent.com/35135081/135373353-cf63403c-24a5-402e-a91b-595a0b99ab1c.mp4

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: UI with tooltips will now be much faster to create them, such as R&D console searching or preferences menu tab switching.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
