### PR TITLE
Fix disky teleporting itself off the emergency shuttle on transit.

### DIFF
--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -73,7 +73,7 @@
 
 	return COMPONENT_BLOCK_MARK_RETRIEVAL
 
-/// Checks whether a given atom's loc is within bounds. Returns TRUE if it is, FALSE if it isn't.
+/// Checks whether a given atom's turf is within bounds. Returns TRUE if it is, FALSE if it isn't.
 /datum/component/stationloving/proc/atom_in_bounds(atom/atom_to_check)
 	var/static/list/allowed_shuttles = typecacheof(list(/area/shuttle/syndicate, /area/shuttle/escape, /area/shuttle/pod_1, /area/shuttle/pod_2, /area/shuttle/pod_3, /area/shuttle/pod_4))
 	var/static/list/disallowed_centcom_areas = typecacheof(list(/area/abductor_ship, /area/awaymission/errorroom))

--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -19,7 +19,7 @@
 	src.allow_item_destruction = allow_item_destruction
 
 	// Just in case something is being created outside of station/centcom
-	if(!destination_in_bounds(parent))
+	if(!atom_in_bounds(parent))
 		relocate()
 
 /datum/component/stationloving/InheritComponent(datum/component/stationloving/newc, original, inform_admins, allow_death)
@@ -52,7 +52,7 @@
 /datum/component/stationloving/proc/on_parent_z_change(datum/source, turf/old_turf, turf/new_turf)
 	SIGNAL_HANDLER
 
-	if(destination_in_bounds(parent))
+	if(atom_in_bounds(parent))
 		return
 
 	var/turf/current_turf = get_turf(parent)
@@ -73,11 +73,11 @@
 
 	return COMPONENT_BLOCK_MARK_RETRIEVAL
 
-/// Checks whether a given destination is within bounds. Returns TRUE if it is, FALSE if it isn't.
-/datum/component/stationloving/proc/destination_in_bounds(atom/destination)
+/// Checks whether a given atom's loc is within bounds. Returns TRUE if it is, FALSE if it isn't.
+/datum/component/stationloving/proc/atom_in_bounds(atom/atom_to_check)
 	var/static/list/allowed_shuttles = typecacheof(list(/area/shuttle/syndicate, /area/shuttle/escape, /area/shuttle/pod_1, /area/shuttle/pod_2, /area/shuttle/pod_3, /area/shuttle/pod_4))
 	var/static/list/disallowed_centcom_areas = typecacheof(list(/area/abductor_ship, /area/awaymission/errorroom))
-	var/turf/destination_turf = get_turf(destination)
+	var/turf/destination_turf = get_turf(atom_to_check)
 	if (!destination_turf)
 		return FALSE
 	var/area/destination_area = destination_turf.loc
@@ -87,7 +87,7 @@
 		if (is_type_in_typecache(destination_area, disallowed_centcom_areas))
 			return FALSE
 		return TRUE
-	if (is_reserved_level(destination.z))
+	if (is_reserved_level(destination_turf.z))
 		if (is_type_in_typecache(destination_area, allowed_shuttles))
 			return TRUE
 

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -136,6 +136,14 @@
 		var/turf/oldT = old_turfs[i]
 		var/turf/newT = new_turfs[i]
 		var/move_mode = old_turfs[oldT]
+
+		if(move_mode & MOVE_TURF)
+			oldT.onShuttleMove(newT, movement_force, movement_direction) //turfs
+
+		if(move_mode & MOVE_AREA)
+			var/area/shuttle_area = oldT.loc
+			shuttle_area.onShuttleMove(oldT, newT, underlying_old_area) //areas
+
 		if(move_mode & MOVE_CONTENTS)
 			for(var/k in oldT)
 				var/atom/movable/moving_atom = k
@@ -144,12 +152,6 @@
 				moving_atom.onShuttleMove(newT, oldT, movement_force, movement_direction, old_dock, src) //atoms
 				moved_atoms[moving_atom] = oldT
 
-		if(move_mode & MOVE_TURF)
-			oldT.onShuttleMove(newT, movement_force, movement_direction) //turfs
-
-		if(move_mode & MOVE_AREA)
-			var/area/shuttle_area = oldT.loc
-			shuttle_area.onShuttleMove(oldT, newT, underlying_old_area) //areas
 
 /obj/docking_port/mobile/proc/cleanup_runway(obj/docking_port/stationary/new_dock, list/old_turfs, list/new_turfs, list/areas_to_move, list/moved_atoms, rotation, movement_direction, area/underlying_old_area)
 	underlying_old_area.afterShuttleMove()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #61782

Did a minor cleanup in the stationloving component to better represent what the proc the `destination_in_bounds` proc actually did. It is now `atom_in_bounds` since it's called after the atom has moved and works on the atom's turf. This doesn't fix the problem, but it obfuscated things a bit since it was deceptively named.

The issue is that when the e-shuttle leaves the station, for every turf on the shuttle it first moves the turf's contents to hyperspace, then moves the turf to hyperspace, then changes the area. Since the player holding disky enters Hyperspace first then has the shuttle turf constructed around them, disky teleports back to the station because it enters a non-whitelisted location.

Instead of whitelisting Hyperspace, I changed the order of operations to turf transfer, area transfer and finally atom transfer. This fixes the issue (as now disky moves from z=2 to z=12 /area/shuttle/escape, where escape shuttle is whitelisted instead of z=12 /area/transit, where /area/transit is not whitelisted).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Captains can sleep tight at night knowing that Disky no longer fears escape shuttle rides at the end of the shift. The nuke disk will no longer teleport itself back to the station from the emergency shuttle when the emergency shuttle departs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
