### PR TITLE
Surgeries that repair organs will now actually repair organs

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -351,8 +351,8 @@
 		if(reagents.has_reagent(/datum/reagent/toxin/formaldehyde, 1) || reagents.has_reagent(/datum/reagent/cryostylane)) // No organ decay if the body contains formaldehyde.
 			return
 		for(var/V in internal_organs)
-			var/obj/item/organ/O = V
-			O.on_death(delta_time, times_fired) //Needed so organs decay while inside the body.
+			var/obj/item/organ/organ = V
+			organ.on_death(delta_time, times_fired) //Needed so organs decay while inside the body.
 
 /mob/living/carbon/handle_diseases(delta_time, times_fired)
 	for(var/thing in diseases)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -121,7 +121,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	applyOrganDamage(decay_factor * maxHealth * delta_time)
 
 /obj/item/organ/proc/on_life(delta_time, times_fired) //repair organ damage if the organ is not failing
-	check_failing_thresholds(owner) // Check if an organ should/shouldnt be failing
+	check_failing_thresholds() // Check if an organ should/shouldnt be failing
 	if(organ_flags & ORGAN_FAILING)
 		handle_failing_organs(delta_time)
 		return
@@ -187,6 +187,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 ///SETS an organ's damage to the amount "damage_amount", and in doing so clears or sets the failing flag, good for when you have an effect that should fix an organ if broken
 /obj/item/organ/proc/setOrganDamage(damage_amount) //use mostly for admin heals
 	applyOrganDamage(damage_amount - damage)
+	check_failing_thresholds() // Apply organ damage, then check if it's failing afterwards
 
 /** check_damage_thresholds
  * input: mob/organ_owner (a mob, the owner of the organ we call the proc on)
@@ -213,11 +214,8 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		if(prev_damage == maxHealth)
 			return now_fixed
 
-/**check_failing_thresholds
- * input: mob/organ_owner (a mob, the owner of the organ we call the proc on)
- * output: failing organ flags on a failing/no longer failing organ.
- */
-/obj/item/organ/proc/check_failing_thresholds(mob/organ_owner)
+///Checks if an organ should/shouldn't be failing and gives the appropriate organ flag
+/obj/item/organ/proc/check_failing_thresholds()
 	if(damage >= maxHealth)
 		organ_flags |= ORGAN_FAILING
 	if(damage < maxHealth)


### PR DESCRIPTION
## About The Pull Request

Since on_life is only called while someone is alive, doing a surgery such as coronary bypass on a dead person wouldn't remove their failing organ flag, and as such would instantly kill the organ again after the surgery.

## Why It's Good For The Game

Surgeries work again for MDs to repair non functional organs without strange reagent

## Changelog

:cl:
fix: Surgeries that repair organs will once again repair the organ.
/:cl:

Again, GBP no update tag please, I caused this.