### PR TITLE
Ovens can now be researched

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -332,6 +332,7 @@
 		"griddle",
 		"microwave",
 		"monkey_recycler",
+		"oven",
 		"processor",
 		"reagentgrinder",
 		"smartfridge",


### PR DESCRIPTION
## About The Pull Request

Ovens already have a design and an ID attached to it, and oven trays as well (oven trays can be researched too), but ovens is the odd one out. This makes them able to be researched like any other kitchen machine.
It seems it was meant to be researchable, but they just forgot to add it.

## Why It's Good For The Game

Ovens can be built without having to deconstruct an old one.

## Changelog

:cl:
fix: Oven boards can now be researched with the rest of the kitchen's machinery.
/:cl: