### PR TITLE
Fixing Tramstation maint bar doors

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -24519,7 +24519,7 @@
 /area/security/prison/workout)
 "gNI" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
+	req_one_access_txt = "12;25"
 	},
 /obj/machinery/duct,
 /obj/structure/cable,
@@ -36423,7 +36423,7 @@
 /area/maintenance/tram/right)
 "lra" = (
 /obj/machinery/door/airlock/maintenance_hatch{
-	req_one_access_txt = "12"
+	req_one_access_txt = "12;25"
 	},
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -54737,7 +54737,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Bar Excess Storage";
-	req_one_access_txt = "12"
+	req_one_access_txt = "12;25"
 	},
 /obj/machinery/duct,
 /turf/open/floor/plating,


### PR DESCRIPTION
## About The Pull Request

Fixing trammstation maint bar doors that did not had access to the bartender. (Also this is my first time doing mapping stuff and actually making changes, if a made a mistake please let me know and I'll fix it to get it approved.)

## Why It's Good For The Game

The bartender needs access to the surrounding maint in the bar and the bar excess storage room, fixes #61578


:cl:
fix: Fixes access on Maint airlocks on the tramstation bar
/:cl: