### PR TITLE
Fixes metastation's disposals mailing caused by extra pipes

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -8659,9 +8659,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bOJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51692,9 +51689,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "qlY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -61425,13 +61419,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/lab)
-"tLA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "tLK" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/three,
@@ -92528,7 +92515,7 @@ jFF
 iNd
 mlx
 doJ
-tLA
+lZy
 dne
 hCI
 doJ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Metastation's disposals mailing was completely broken pretty much as soon as any package left cargo. It would get sorted away from waste recycling, then would get shot out of a corner bit into cargo maint. Not good. A straight pipe was also on that tile, but I guess it favored connecting to the extra unintended pipe, resulting in packages never reaching their destination. I also got rid of two other phantom straight pipes that didn't have any reason to exist, as they weren't even connected to anything.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cargo mailing is actually quite nice for dealing with large bulk orders ordered through department budgets by command staff. I just wish it would actually work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:PotatoMasher
fix: Fixes metastation's disposals mailing system by removing an extra unintended pipe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
