### PR TITLE
[DNM] [TM Candidate] Infuses certain vents with an aroma of garlic, repelling bat form vampires.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -513,6 +513,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_VENTCRAWLER_ALWAYS "ventcrawler_always"
 #define TRAIT_VENTCRAWLER_NUDE "ventcrawler_nude"
 
+/// Limited ability to ventcrawl. Can't exit vents in blacklisted areas such as armory/cap's quarters.
+#define TRAIT_VENTCRAWLER_VAMPIRE_BAT "ventcrawler_vampire_bat"
+
 /// Minor trait used for beakers, or beaker-ishes. [/obj/item/reagent_containers], to show that they've been used in a reagent grinder.
 #define TRAIT_MAY_CONTAIN_BLENDED_DUST "may_contain_blended_dust"
 

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -143,3 +143,15 @@
 	charge_max = 50
 	cooldown_min = 50
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
+
+/obj/effect/proc_holder/spell/targeted/shapeshift/bat/Shapeshift(mob/living/caster)
+	. = ..()
+
+	if(!.)
+		return
+
+	var/mob/living/simple_animal/hostile/retaliate/bat/bat_shape = .
+
+	REMOVE_TRAIT(bat_shape, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
+	ADD_TRAIT(bat_shape, TRAIT_VENTCRAWLER_VAMPIRE_BAT, INNATE_TRAIT)
+

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -36,7 +36,7 @@
 		to_chat(src, span_warning("You can't crawl around a welded vent!"))
 		return
 	if(HAS_TRAIT(src, TRAIT_VENTCRAWLER_VAMPIRE_BAT))
-		var/vent_area = get_area(ventcrawl_target)
+		var/area/vent_area = get_area(ventcrawl_target)
 		if(vent_area && (vent_area.type in vampire_bat_blacklist))
 			to_chat(src, span_warning("This vent is infused with an aroma of garlic. You can't crawl through it!"))
 			return

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -1,14 +1,17 @@
 // VENTCRAWLING
 // Handles the entrance and exit on ventcrawling
 /mob/living/proc/handle_ventcrawl(obj/machinery/atmospherics/components/ventcrawl_target)
+	var/static/list/vampire_bat_blacklist = typesof(/area/ai_monitored/security/armory) + typesof(/area/command/heads_quarters/captain)
+
 	// Being able to always ventcrawl trumps being only able to ventcrawl when wearing nothing
-	var/required_nudity = HAS_TRAIT(src, TRAIT_VENTCRAWLER_NUDE) && !HAS_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS)
+	var/required_nudity = HAS_TRAIT(src, TRAIT_VENTCRAWLER_NUDE) && (!HAS_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS) || !HAS_TRAIT(src, TRAIT_VENTCRAWLER_VAMPIRE_BAT))
 	// Cache the vent_movement bitflag var from atmos machineries
 	var/vent_movement = ventcrawl_target.vent_movement
 
 	if(!Adjacent(ventcrawl_target))
 		return
-	if(!HAS_TRAIT(src, TRAIT_VENTCRAWLER_NUDE) && !HAS_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS))
+
+	if(!HAS_TRAIT(src, TRAIT_VENTCRAWLER_NUDE) && !HAS_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS) && !HAS_TRAIT(src, TRAIT_VENTCRAWLER_VAMPIRE_BAT))
 		return
 	if(stat)
 		to_chat(src, span_warning("You must be conscious to do this!"))
@@ -32,6 +35,11 @@
 	if(ventcrawl_target.welded)
 		to_chat(src, span_warning("You can't crawl around a welded vent!"))
 		return
+	if(HAS_TRAIT(src, TRAIT_VENTCRAWLER_VAMPIRE_BAT))
+		var/vent_area = get_area(ventcrawl_target)
+		if(vent_area && (vent_area.type in vampire_bat_blacklist))
+			to_chat(src, span_warning("This vent is infused with an aroma of garlic. You can't crawl through it!"))
+			return
 
 	if(vent_movement & VENTCRAWL_ENTRANCE_ALLOWED)
 		//Handle the exit here


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

TM only PR created after request from someone on the admin team.

Adds a new trait for vampire bat ventcrawling. Adds this trait to shapeshifted bat forms only. This trait prevents vampires from entering/exiting vents in bat forms in specific blacklisted areas.

Current blacklisted areas are Cap's Quarters and Armory.

![image](https://user-images.githubusercontent.com/24975989/135571301-8ae5d2ed-fb1f-489a-bbcf-834720dcdabe.png)

If this proves to be useful or successful, can be hooked into the seasonal event permanently pending feedback.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->