### PR TITLE
Holding Facility Overhaul

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -244,6 +244,10 @@
 	},
 /turf/open/floor/sepia,
 /area/centcom/holding)
+"bO" = (
+/obj/effect/landmark/holding_facility,
+/turf/open/floor/wood/large,
+/area/centcom/holding)
 "bS" = (
 /obj/structure/closet{
 	anchored = 1;
@@ -410,7 +414,6 @@
 /obj/structure/chair/sofa/corp/left{
 	pixel_y = 6
 	},
-/obj/effect/landmark/holding_facility,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
 "cQ" = (
@@ -560,6 +563,11 @@
 /obj/item/instrument/saxophone,
 /turf/open/floor/wood/parquet,
 /area/centcom/holding)
+"dO" = (
+/obj/machinery/light/directional/south,
+/obj/effect/landmark/holding_facility,
+/turf/open/floor/wood/large,
+/area/centcom/holding)
 "dQ" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/tile,
@@ -612,27 +620,6 @@
 "ed" = (
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood/parquet,
-/area/centcom/holding)
-"ei" = (
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding{
-	color = "#2e2e2e"
-	},
-/obj/effect/landmark/holding_facility,
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
 /area/centcom/holding)
 "ej" = (
 /obj/effect/turf_decal/siding/wood,
@@ -1025,7 +1012,6 @@
 /obj/structure/chair/sofa/corp/right{
 	pixel_y = 6
 	},
-/obj/effect/landmark/holding_facility,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
 "gK" = (
@@ -1133,10 +1119,6 @@
 "hl" = (
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
-"hn" = (
-/mob/living/basic/cow,
-/turf/open/floor/grass,
-/area/centcom/holding)
 "hr" = (
 /turf/open/floor/plating/sandy_dirt,
 /area/centcom/holding)
@@ -1291,10 +1273,6 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/rcl/pre_loaded,
 /turf/open/floor/plating/catwalk_floor,
-/area/centcom/holding)
-"ig" = (
-/obj/effect/spawner/random/entertainment/arcade,
-/turf/open/floor/wood,
 /area/centcom/holding)
 "ik" = (
 /obj/structure/kitchenspike,
@@ -4513,10 +4491,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/centcom/ferry)
-"oV" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "oW" = (
 /obj/structure/flora/bush,
 /obj/effect/light_emitter{
@@ -4853,10 +4827,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/centcom/ferry)
-"py" = (
-/obj/machinery/smartfridge,
-/turf/closed/indestructible/wood,
-/area/centcom/holding)
 "pz" = (
 /turf/open/space/basic,
 /area/centcom/ferry)
@@ -5032,11 +5002,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/ferry)
-"pS" = (
-/obj/structure/table,
-/obj/item/stack/package_wrap,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
 "pT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5056,10 +5021,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/ert)
-"pV" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
 "pW" = (
 /obj/effect/landmark/ai_multicam_room,
 /turf/open/ai_visible,
@@ -5434,10 +5395,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/ert)
-"qH" = (
-/obj/structure/urinal/directional/north,
-/turf/open/floor/iron/white,
-/area/centcom/holding)
 "qI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6946,14 +6903,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/centcom/evac)
-"tW" = (
-/obj/structure/rack,
-/obj/item/nullrod/claymore{
-	damtype = "stamina";
-	force = 30
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "tX" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
@@ -7575,28 +7524,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
-"vs" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
-"vt" = (
-/obj/structure/rack,
-/obj/item/nullrod/claymore/katana{
-	damtype = "stamina";
-	force = 30
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "vu" = (
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/food/drinks/bottle/rum,
@@ -7967,23 +7894,6 @@
 	},
 /turf/open/floor/carpet,
 /area/wizard_station)
-"wf" = (
-/obj/structure/closet{
-	anchored = 1;
-	name = "Plasmaman suits"
-	},
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "wk" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -8274,6 +8184,13 @@
 	},
 /turf/open/floor/iron,
 /area/syndicate_mothership/control)
+"xb" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/obj/effect/landmark/holding_facility,
+/turf/open/floor/wood/large,
+/area/centcom/holding)
 "xc" = (
 /obj/machinery/door/airlock/external{
 	name = "Ferry Airlock"
@@ -8467,15 +8384,6 @@
 "xA" = (
 /turf/open/floor/plating/beach/sand,
 /area/centcom/holding)
-"xB" = (
-/mob/living/simple_animal/bot/medbot{
-	desc = "When engaged in combat, the vanquishing of thine enemy can be the warrior's only concern.";
-	name = "Hattori";
-	radio_key = null;
-	stationary_mode = 1
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "xC" = (
 /obj/structure/chair/stool/bar/directional/east,
 /obj/effect/turf_decal/siding/wood/corner,
@@ -8639,15 +8547,6 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
-"yd" = (
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/light/directional/west,
-/turf/open/floor/grass,
-/area/centcom/holding)
 "yf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -8888,12 +8787,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/grass,
 /area/wizard_station)
-"yM" = (
-/obj/structure/table/wood/shuttle_bar,
-/obj/structure/safe/floor,
-/obj/item/seeds/cherry/bomb,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "yP" = (
 /obj/effect/turf_decal/tile/dark,
 /obj/effect/turf_decal/tile/dark{
@@ -8923,7 +8816,6 @@
 /area/centcom/holding)
 "yR" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/effect/landmark/holding_facility,
 /obj/structure/chair/wood{
 	dir = 8
 	},
@@ -8962,25 +8854,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/control)
-"yV" = (
-/obj/structure/closet{
-	anchored = 1;
-	desc = "A storage unit for plasmaman internals, courtesy of the Spider Clan.";
-	icon_state = "emergency";
-	name = "Plasmaman emergency closet"
-	},
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "yX" = (
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron/dark,
@@ -9413,15 +9286,6 @@
 	dir = 1
 	},
 /area/centcom/holding)
-"zV" = (
-/obj/structure/closet/secure_closet/freezer/meat/open,
-/obj/item/food/fishmeat/carp,
-/obj/item/food/fishmeat/carp,
-/obj/item/food/fishmeat/carp,
-/obj/item/food/fishmeat/carp,
-/obj/item/food/fishmeat/carp,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
 "zW" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/effect/turf_decal/tile/yellow/half{
@@ -9438,12 +9302,6 @@
 /turf/open/floor/iron/textured_half{
 	dir = 4
 	},
-/area/centcom/holding)
-"zX" = (
-/obj/structure/table,
-/obj/machinery/light/directional/north,
-/obj/item/soap/deluxe,
-/turf/open/floor/iron/cafeteria,
 /area/centcom/holding)
 "zZ" = (
 /obj/effect/turf_decal/tile/brown{
@@ -9951,27 +9809,6 @@
 /obj/item/food/grown/coffee,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
-"Bo" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
-"Bs" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Bu" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -10274,10 +10111,6 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
-"BV" = (
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/closed/indestructible/wood,
-/area/centcom/holding)
 "BY" = (
 /obj/item/toy/figure/syndie,
 /turf/open/floor/plating/asteroid/snow/airless,
@@ -10820,13 +10653,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/evac)
-"CT" = (
-/turf/open/floor/wood,
-/area/centcom/holding)
-"CV" = (
-/obj/structure/chair/stool/directional/south,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "CX" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/storage/belt/security/full,
@@ -11594,10 +11420,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/engine/cult,
 /area/wizard_station)
-"ED" = (
-/obj/machinery/vending/boozeomat,
-/turf/closed/indestructible/wood,
-/area/centcom/holding)
 "EE" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/tile/neutral{
@@ -11808,29 +11630,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/three)
-"Fa" = (
-/obj/structure/table/wood,
-/obj/item/instrument/piano_synth,
-/obj/item/instrument/guitar,
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
-"Fb" = (
-/obj/structure/musician/piano,
-/obj/machinery/light/directional/west,
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
-"Fc" = (
-/obj/structure/sign/barsign{
-	pixel_y = 32
-	},
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
-"Fe" = (
-/obj/structure/table/wood,
-/obj/item/food/sashimi,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Fg" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/tile/green{
@@ -11846,17 +11645,6 @@
 /area/centcom/control)
 "Fh" = (
 /turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
-"Fi" = (
-/obj/structure/chair/wood/wings{
-	dir = 3
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Fj" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
 /area/centcom/holding)
 "Fl" = (
 /obj/effect/turf_decal/siding/wood{
@@ -12185,18 +11973,6 @@
 	},
 /turf/open/floor/stone,
 /area/centcom/holding)
-"FW" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
-"FX" = (
-/turf/open/floor/iron/stairs,
-/area/centcom/holding)
 "FY" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -12363,10 +12139,6 @@
 	},
 /turf/open/lava,
 /area/wizard_station)
-"Gs" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Gt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -12736,12 +12508,6 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/space,
 /area/wizard_station)
-"GY" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "GZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -12826,14 +12592,6 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/arena_source)
-"Hm" = (
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/light/directional/east,
-/turf/open/floor/grass,
-/area/centcom/holding)
 "Hn" = (
 /obj/structure/sink{
 	dir = 4;
@@ -13033,10 +12791,6 @@
 	},
 /turf/open/space,
 /area/space)
-"HH" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "HI" = (
 /obj/structure/sink{
 	dir = 4;
@@ -13144,24 +12898,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/tdome/tdomeobserve)
-"HQ" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "sink";
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
 "HR" = (
 /obj/structure/sink{
 	dir = 8;
@@ -13941,14 +13677,6 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron,
 /area/tdome/arena)
-"JE" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "sink";
-	pixel_y = 28
-	},
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
 "JF" = (
 /obj/machinery/computer/camera_advanced/abductor{
 	team_number = 1
@@ -14555,12 +14283,6 @@
 "KS" = (
 /turf/closed/wall/mineral/titanium/interior,
 /area/centcom/evac)
-"KT" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "KU" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/blue,
@@ -15000,44 +14722,6 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plating/catwalk_floor,
 /area/centcom/holding)
-"Ms" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Mu" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
-"Mw" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
-"Mx" = (
-/obj/machinery/light/directional/east,
-/obj/structure/rack,
-/obj/item/nullrod/claymore/saber/red{
-	damtype = "stamina";
-	force = 30
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "MA" = (
 /obj/structure/chair/stool/bar/directional/east,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -15086,16 +14770,6 @@
 	},
 /turf/open/floor/wood,
 /area/wizard_station)
-"MG" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/eastright{
-	dir = 8;
-	name = "Animal Pen"
-	},
-/turf/open/floor/grass,
-/area/centcom/holding)
 "MH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -15114,28 +14788,10 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
-"MK" = (
-/obj/structure/mineral_door/paperframe{
-	name = "Dojo"
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
-"MM" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
 "MO" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Guest House Entrance"
 	},
-/area/centcom/holding)
-"MR" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
-"MT" = (
-/obj/machinery/processor,
-/turf/open/floor/iron/cafeteria,
 /area/centcom/holding)
 "MW" = (
 /obj/effect/turf_decal/tile/yellow/half{
@@ -15242,46 +14898,6 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/tdomeobserve)
-"Nm" = (
-/obj/structure/closet/crate,
-/obj/item/vending_refill/autodrobe,
-/obj/item/stack/sheet/paperframes/fifty,
-/obj/item/stack/sheet/paperframes/fifty,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Nn" = (
-/obj/structure/closet/secure_closet/hydroponics{
-	locked = 0
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
-"Nv" = (
-/obj/structure/table,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
-"Nw" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/iron/white,
-/area/centcom/holding)
-"Ny" = (
-/obj/machinery/modular_computer/console/preset/research,
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "NB" = (
 /turf/open/floor/plating/ironsand{
 	color = "#525252";
@@ -15316,35 +14932,12 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/control)
-"NJ" = (
-/obj/structure/table,
-/obj/item/book/manual/hydroponics_pod_people,
-/obj/item/seeds/pumpkin/blumpkin,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
 "NO" = (
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
 "NS" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plating/catwalk_floor,
-/area/centcom/holding)
-"NT" = (
-/obj/structure/window/paperframe{
-	CanAtmosPass = 0
-	},
-/turf/open/floor/wood,
 /area/centcom/holding)
 "NU" = (
 /obj/machinery/door/airlock/centcom{
@@ -15458,19 +15051,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
-"Op" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/button/door/indestructible{
-	id = "lmrestroom";
-	name = "Lock Control";
-	pixel_y = -28
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
 "Oq" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -15544,11 +15124,6 @@
 	dir = 4
 	},
 /area/centcom/holding)
-"OG" = (
-/obj/structure/dresser,
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "OL" = (
 /turf/closed/indestructible/rock,
 /area/centcom/holding)
@@ -15574,23 +15149,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
-"OU" = (
-/obj/item/clothing/under/costume/jabroni,
-/obj/item/clothing/under/costume/geisha,
-/obj/item/clothing/under/costume/kilt,
-/obj/structure/closet,
-/obj/item/clothing/under/costume/roman,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "OZ" = (
 /mob/living/basic/cow{
 	name = "Yuna"
 	},
 /turf/open/floor/grass,
-/area/centcom/holding)
-"Pa" = (
-/obj/machinery/washing_machine,
-/turf/open/floor/iron/white,
 /area/centcom/holding)
 "Pd" = (
 /obj/item/clothing/shoes/galoshes{
@@ -15621,10 +15184,6 @@
 	},
 /turf/open/floor/sepia,
 /area/centcom/holding)
-"Ph" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Pi" = (
 /obj/effect/turf_decal/tile/yellow/half,
 /obj/effect/turf_decal/tile/yellow/half{
@@ -15649,25 +15208,12 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/ferry)
-"Pl" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
 "Pm" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/four)
 "Pn" = (
 /turf/open/floor/plating/catwalk_floor,
-/area/centcom/holding)
-"Po" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
 /area/centcom/holding)
 "Pq" = (
 /obj/structure/filingcabinet/filingcabinet,
@@ -15684,11 +15230,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/supply)
-"Pr" = (
-/obj/structure/table,
-/obj/item/book/manual/chef_recipes,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
 "Pv" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -15703,12 +15244,6 @@
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /turf/open/floor/iron,
 /area/centcom/supplypod)
-"PA" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
 "PC" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -15741,20 +15276,6 @@
 	dir = 1
 	},
 /area/centcom/holding)
-"PI" = (
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
 "PK" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -15762,24 +15283,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/one)
-"PL" = (
-/obj/machinery/autolathe,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"PO" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
 "PP" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/item/food/grown/chili,
@@ -15798,15 +15301,6 @@
 /obj/item/food/grown/watermelon,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
-"PQ" = (
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "PV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15816,23 +15310,6 @@
 "PW" = (
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/three)
-"PX" = (
-/obj/machinery/computer/arcade/battle,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"PY" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
 "PZ" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/tile,
@@ -15861,17 +15338,6 @@
 "Qe" = (
 /turf/open/ai_visible,
 /area/ai_multicam_room)
-"Qg" = (
-/obj/structure/closet,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/iv_drip,
-/obj/item/roller,
-/obj/item/storage/firstaid/regular,
-/obj/item/reagent_containers/medigel/synthflesh,
-/obj/item/reagent_containers/medigel/synthflesh,
-/obj/item/reagent_containers/medigel/synthflesh,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Qi" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -15881,18 +15347,6 @@
 	pixel_y = 4
 	},
 /turf/open/floor/plating/catwalk_floor,
-/area/centcom/holding)
-"Qj" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/sake,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Qk" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/grass,
 /area/centcom/holding)
 "Ql" = (
 /obj/machinery/light/small/directional/west,
@@ -15931,10 +15385,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating/sandy_dirt,
 /area/centcom/holding)
-"Qu" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Qx" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
@@ -15962,30 +15412,6 @@
 /obj/item/clothing/under/costume/kilt,
 /obj/item/clothing/under/costume/roman,
 /turf/open/floor/wood/parquet,
-/area/centcom/holding)
-"QH" = (
-/obj/machinery/chem_master/condimaster{
-	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
-	name = "BrewMaster 2199";
-	pixel_x = -4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
-"QI" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
 /area/centcom/holding)
 "QJ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -16042,16 +15468,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
-"QT" = (
-/obj/machinery/chem_dispenser/drinks,
-/turf/closed/indestructible/wood,
-/area/centcom/holding)
-"QW" = (
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	locked = 0
-	},
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
 "Ra" = (
 /obj/effect/turf_decal/tile/dark,
 /obj/effect/turf_decal/tile/dark{
@@ -16065,24 +15481,6 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/sepia,
-/area/centcom/holding)
-"Rd" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
-"Re" = (
-/obj/structure/mineral_door/paperframe,
-/turf/open/floor/wood,
 /area/centcom/holding)
 "Rf" = (
 /obj/structure/rack,
@@ -16099,42 +15497,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood/parquet,
 /area/centcom/holding)
-"Rh" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/centcom/holding)
-"Ri" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Rj" = (
-/obj/machinery/vending/hydroseeds,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
 "Rk" = (
 /obj/machinery/defibrillator_mount/directional/north,
 /obj/machinery/stasis,
 /turf/open/floor/sepia,
-/area/centcom/holding)
-"Rm" = (
-/obj/structure/chair/wood/wings{
-	dir = 3
-	},
-/turf/open/floor/wood,
 /area/centcom/holding)
 "Ro" = (
 /obj/structure/table/wood,
@@ -16168,10 +15534,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
-"Rw" = (
-/obj/machinery/door/window/westleft,
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
 "Ry" = (
 /obj/structure/window/paperframe{
 	CanAtmosPass = 0
@@ -16213,15 +15575,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/wood/parquet,
 /area/centcom/holding)
-"RM" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
 "RN" = (
 /turf/open/floor/iron/stairs/medium,
 /area/centcom/holding)
@@ -16230,15 +15583,6 @@
 /obj/item/storage/box/alienhandcuffs,
 /turf/open/floor/plating/abductor,
 /area/abductor_ship)
-"RS" = (
-/obj/machinery/light/directional/west,
-/obj/structure/rack,
-/obj/item/nullrod/claymore/glowing{
-	damtype = "stamina";
-	force = 30
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "RY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -16307,21 +15651,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
-"Sw" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
 "Sz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -16329,16 +15658,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/ert)
-"SB" = (
-/obj/structure/curtain,
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/machinery/shower{
-	pixel_y = 12
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
 "SD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -16348,14 +15667,6 @@
 "SF" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/sepia,
-/area/centcom/holding)
-"SG" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/turf/open/floor/iron/cafeteria,
 /area/centcom/holding)
 "SH" = (
 /obj/structure/closet/secure_closet/personal,
@@ -16394,11 +15705,6 @@
 /obj/item/food/meat/slab/synthmeat,
 /turf/open/floor/plating/catwalk_floor,
 /area/centcom/holding)
-"SN" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
 "SP" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -16419,32 +15725,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/one)
-"SU" = (
-/obj/structure/table/wood,
-/obj/item/camera/detective{
-	desc = "A polaroid camera with extra capacity for social media marketing.";
-	name = "Professional camera"
-	},
-/obj/item/camera_film,
-/obj/item/wallframe/newscaster,
-/obj/item/paper_bin,
-/obj/item/pen/fountain,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"SW" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
 "SX" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
@@ -16490,10 +15770,6 @@
 /turf/open/floor/iron/textured_half{
 	dir = 4
 	},
-/area/centcom/holding)
-"Tb" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/wood,
 /area/centcom/holding)
 "Tc" = (
 /obj/effect/turf_decal/tile/brown{
@@ -16551,33 +15827,6 @@
 /obj/item/food/grown/redbeet,
 /turf/open/floor/plating/catwalk_floor,
 /area/centcom/holding)
-"Tn" = (
-/obj/structure/table/wood/fancy,
-/obj/item/candle/infinite{
-	pixel_y = 6
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Tq" = (
-/obj/structure/table/wood/shuttle_bar,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/multitool,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Tr" = (
-/obj/structure/closet/chefcloset,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
-"Tu" = (
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/grass,
-/area/centcom/holding)
 "Tv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/stone,
@@ -16624,14 +15873,6 @@
 	dir = 1
 	},
 /area/centcom/holding)
-"TB" = (
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
-"TC" = (
-/obj/machinery/door/window/eastright,
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
 "TF" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -16658,11 +15899,6 @@
 	name = "Freezer"
 	},
 /turf/open/floor/stone,
-/area/centcom/holding)
-"TK" = (
-/obj/structure/table/wood/shuttle_bar,
-/obj/structure/mirror/directional/north,
-/turf/open/floor/wood,
 /area/centcom/holding)
 "TM" = (
 /obj/effect/turf_decal/tile/yellow/half{
@@ -16730,10 +15966,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/centcom/control)
-"Ud" = (
-/obj/effect/landmark/holding_facility,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Ue" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/ert_spawn,
@@ -16761,36 +15993,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/centcom/ferry)
-"Uh" = (
-/obj/machinery/light/directional/east,
-/obj/structure/rack,
-/obj/item/nullrod/claymore/darkblade{
-	damtype = "stamina";
-	force = 30
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Um" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/shovel/spade,
-/obj/item/wirecutters,
-/obj/item/wrench,
-/obj/item/watertank,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/centcom/holding)
 "Un" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome";
@@ -16833,10 +16035,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/holding)
-"UE" = (
-/obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "UF" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/easel,
@@ -16855,10 +16053,6 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
-"UJ" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "UM" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -16911,12 +16105,6 @@
 /obj/item/kitchen/knife,
 /turf/open/floor/iron/cafeteria,
 /area/centcom/holding)
-"UT" = (
-/obj/structure/chair/wood/wings{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "UU" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/vending/snack/orange,
@@ -16962,11 +16150,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/two)
-"Vm" = (
-/obj/machinery/gibber,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
 "Vn" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -16984,36 +16167,6 @@
 /obj/machinery/griddle,
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
-"Vu" = (
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced/fulltile,
-/obj/machinery/light/directional/south,
-/turf/open/floor/grass,
-/area/centcom/holding)
-"Vv" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
-"Vz" = (
-/obj/machinery/vending/wallmed/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
-"VA" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white,
-/area/centcom/holding)
-"VF" = (
-/obj/structure/rack,
-/obj/item/nullrod/scythe/vibro{
-	damtype = "stamina";
-	force = 30
-	},
-/turf/open/floor/wood,
 /area/centcom/holding)
 "VN" = (
 /obj/structure/table/wood,
@@ -17080,7 +16233,6 @@
 /area/centcom/evac)
 "We" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/effect/landmark/holding_facility,
 /obj/structure/chair/wood{
 	dir = 4
 	},
@@ -17090,12 +16242,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
 /area/syndicate_mothership/control)
-"Wm" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
 "Wr" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
@@ -17231,23 +16377,6 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/arena_source)
-"WY" = (
-/obj/structure/mineral_door/paperframe{
-	name = "Arcade"
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Xd" = (
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/grass,
-/area/centcom/holding)
-"Xe" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Xg" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
@@ -17264,27 +16393,6 @@
 "Xh" = (
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/four)
-"Xo" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
-"Xr" = (
-/obj/effect/turf_decal/tile/yellow/half,
-/obj/effect/turf_decal/tile/yellow/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding{
-	color = "#2e2e2e"
-	},
-/obj/effect/landmark/holding_facility,
-/turf/open/floor/iron/textured_half{
-	dir = 4
-	},
-/area/centcom/holding)
 "Xs" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -17360,16 +16468,6 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
-"XL" = (
-/obj/machinery/door/airlock/wood,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"XM" = (
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "XN" = (
 /obj/structure/rack,
 /obj/item/nullrod/claymore{
@@ -17414,23 +16512,6 @@
 	},
 /turf/open/floor/plating/ashplanet/wateryrock,
 /area/centcom/holding)
-"Ya" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Yf" = (
-/obj/structure/table/wood,
-/obj/item/food/chawanmushi,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Yh" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"Ym" = (
-/obj/machinery/computer/arcade/orion_trail,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Yn" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/supplypod)
@@ -17447,15 +16528,6 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/arena_source)
-"Yq" = (
-/obj/structure/chair/wood/wings{
-	dir = 8
-	},
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = 28
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Ys" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/large,
@@ -17471,10 +16543,6 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/tdomeobserve)
-"Yu" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
 "Yv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -17513,50 +16581,12 @@
 "YC" = (
 /turf/open/floor/wood/large,
 /area/centcom/holding)
-"YJ" = (
-/obj/item/reagent_containers/food/condiment/enzyme,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/structure/closet/crate,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
-"YL" = (
-/obj/machinery/vending/clothing,
-/turf/open/floor/wood,
-/area/centcom/holding)
-"YN" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/mob/living/simple_animal/chicken,
-/turf/open/floor/grass,
-/area/centcom/holding)
-"YQ" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker,
-/turf/open/floor/iron/cafeteria,
-/area/centcom/holding)
-"YV" = (
-/obj/machinery/light/directional/west,
-/obj/structure/rack,
-/obj/item/nullrod/claymore/saber{
-	damtype = "stamina";
-	force = 30
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "YZ" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
 /area/centcom/evac)
-"Za" = (
-/obj/machinery/door/airlock/wood{
-	id_tag = "lmrestroom"
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Zi" = (
 /obj/structure/toilet,
 /obj/structure/window/reinforced/survival_pod{
@@ -17597,14 +16627,6 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
-"Zs" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21";
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/centcom/holding)
 "Zt" = (
 /turf/open/floor/wood/parquet,
 /area/centcom/holding)
@@ -17612,15 +16634,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light/directional/north,
 /turf/open/floor/grass,
-/area/centcom/holding)
-"Zx" = (
-/mob/living/simple_animal/bot/medbot{
-	desc = "A little medical robot. You can make out the word \"sincerity\" on its chassis.";
-	name = "Hijikata";
-	radio_key = null;
-	stationary_mode = 1
-	},
-/turf/open/floor/wood,
 /area/centcom/holding)
 "Zy" = (
 /obj/structure/bed/dogbed/cayenne{
@@ -17697,16 +16710,6 @@
 /obj/item/camera_film,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/wood/tile,
-/area/centcom/holding)
-"ZU" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/centcom/holding)
-"ZW" = (
-/turf/open/floor/iron/white,
 /area/centcom/holding)
 "ZX" = (
 /obj/machinery/door/airlock/centcom{
@@ -38476,7 +37479,7 @@ dY
 dY
 Oi
 MW
-Xr
+AD
 ej
 YC
 YC
@@ -39504,7 +38507,7 @@ dY
 dY
 Oi
 yT
-ei
+ic
 dl
 YC
 YC
@@ -41560,7 +40563,7 @@ dY
 dY
 Oi
 MW
-Xr
+AD
 SP
 YC
 YC
@@ -41819,8 +40822,8 @@ Oi
 dB
 hg
 Sm
-YC
-aA
+bO
+dO
 fO
 fO
 fO
@@ -42076,8 +41079,8 @@ Nd
 fO
 fO
 fO
-eZ
-YC
+xb
+bO
 bS
 Ry
 gH
@@ -42333,8 +41336,8 @@ Oi
 Og
 fb
 Sm
-YC
-YC
+bO
+bO
 hB
 Ry
 cP
@@ -42588,10 +41591,10 @@ dY
 dY
 Oi
 yT
-ei
+ic
 RE
-YC
-YC
+bO
+bO
 fO
 fO
 fO
@@ -50054,38 +49057,38 @@ aa
 aa
 aa
 aa
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -50311,38 +49314,38 @@ aa
 aa
 aa
 aa
-Nd
-PO
-PO
-PO
-Sw
-PO
-PO
-PO
-Nd
-QI
-VA
-Op
-Nd
-Rm
-Tn
-UT
-yd
-CT
-CT
-XM
-NT
-ig
-CV
-CT
-NT
-CT
-oV
-CT
-CT
-oV
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -50568,38 +49571,38 @@ aa
 aa
 aa
 aa
-Nd
-HQ
-PY
-PY
-PY
-PY
-PY
-PY
-Nd
-qH
-ZW
-ZW
-Za
-CT
-CT
-CT
-Tu
-CT
-CT
-Tn
-NT
-Zs
-CT
-CT
-NT
-CT
-CT
-CT
-CT
-CT
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -50825,38 +49828,38 @@ aa
 aa
 aa
 aa
-Nd
-Mu
-QH
-Bo
-vs
-Rj
-PI
-Rd
-Nd
-Pa
-ZW
-ZW
-Nd
-CT
-CT
-CT
-CT
-CT
-CT
-GY
-NT
-ig
-CV
-CT
-NT
-CT
-CT
-CT
-CT
-CT
-HH
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -51082,38 +50085,38 @@ aa
 aa
 aa
 aa
-Nd
-PY
-PY
-PY
-PY
-PY
-PY
-PY
-Nd
-SB
-ZW
-Nw
-Nd
-CT
-CT
-CT
-Ph
-CT
-Tu
-Vu
-Nd
-Gs
-CT
-CT
-WY
-CT
-CT
-CT
-CT
-CT
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -51339,38 +50342,38 @@ aa
 aa
 aa
 aa
-Nd
-PY
-NJ
-SW
-PY
-Um
-Nn
-PY
-Nd
-Nd
-Nd
-Nd
-Nd
-CT
-CT
-XM
-QL
-CT
-CT
-XM
-NT
-PX
-CV
-CT
-NT
-CT
-CT
-CT
-CT
-CT
-HH
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -51596,38 +50599,38 @@ aa
 aa
 aa
 aa
-Nd
-Nd
-Nd
-Nd
-XL
-Nd
-Nd
-py
-Nd
-CT
-oV
-CT
-XL
-CT
-CT
-Tn
-Tu
-CT
-CT
-Tn
-NT
-Ms
-CT
-CT
-NT
-CT
-CT
-CT
-CT
-CT
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -51853,38 +50856,38 @@ aa
 aa
 aa
 aa
-Nd
-PL
-CT
-oV
-CT
-CT
-CT
-CT
-Yh
-CT
-Nd
-Nd
-Nd
-Gs
-CT
-GY
-Tu
-CT
-CT
-GY
-NT
-Ym
-CV
-CT
-NT
-CT
-Qu
-CT
-CT
-Qu
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -52110,38 +51113,38 @@ aa
 aa
 aa
 aa
-Nd
-Tq
-CT
-MG
-YN
-Nd
-Vm
-Fh
-zV
-Nd
-Nd
-Fa
-KT
-CT
-CT
-CT
-CT
-CT
-CT
-HH
-Nd
-CT
-CT
-CT
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -52367,38 +51370,38 @@ aa
 aa
 aa
 aa
-Nd
-CT
-CT
-Rh
-Mm
-Nd
-MT
-Fh
-Yu
-Nd
-Fb
-Sd
-KT
-CT
-CT
-Sd
-Sd
-Sd
-Sd
-Sd
-Re
-CT
-CT
-CT
-NT
-vt
-YV
-OU
-OU
-RS
-VF
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -52624,38 +51627,38 @@ aa
 aa
 aa
 aa
-Nd
-CT
-CT
-Rh
-hn
-Nd
-Pr
-Fh
-QW
-Nd
-Fc
-Sd
-KT
-CT
-CT
-Sd
-Sd
-Sd
-Sd
-Sd
-Nd
-Gs
-Zx
-CT
-MK
-CT
-CT
-CT
-CT
-CT
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -52881,38 +51884,38 @@ aa
 aa
 aa
 aa
-Nd
-Nd
-XL
-Nd
-Nd
-Nd
-JE
-Fh
-YQ
-Nd
-MR
-Sd
-FW
-CT
-CT
-Sd
-Sd
-Sd
-Sd
-Sd
-Re
-CT
-CT
-CT
-NT
-PQ
-XM
-CT
-XM
-XM
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -53138,38 +52141,38 @@ aa
 aa
 aa
 aa
-Nd
-yM
-CT
-oV
-CT
-Nd
-SG
-Fh
-Vv
-Nd
-Nd
-Sd
-FX
-CT
-CT
-CT
-CT
-CT
-CT
-HH
-Nd
-UJ
-Ud
-Ud
-NT
-RM
-Po
-Rw
-Po
-ZU
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -53395,38 +52398,38 @@ aa
 aa
 aa
 aa
-Nd
-OG
-CT
-CT
-CT
-Nd
-zX
-Fh
-pS
-Nd
-Nd
-Nd
-Nd
-Gs
-CT
-XM
-Tu
-CT
-CT
-XM
-NT
-CT
-Ud
-Ud
-NT
-Wm
-Sd
-Sd
-Sd
-MM
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -53652,38 +52655,38 @@ aa
 aa
 aa
 aa
-Nd
-TK
-CT
-CT
-CT
-Nd
-QA
-Fh
-Nv
-ED
-oV
-Yf
-UE
-CT
-CT
-Tn
-Xd
-CT
-CT
-Tn
-NT
-yV
-Ud
-Ud
-NT
-Wm
-Sd
-Sd
-Sd
-MM
-xB
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -53909,38 +52912,38 @@ aa
 aa
 aa
 aa
-Nd
-YL
-CT
-CT
-CT
-Nd
-Xo
-Fh
-Fh
-py
-CT
-Ya
-UE
-CT
-CT
-GY
-Tu
-CT
-CT
-GY
-NT
-wf
-Ud
-Ud
-NT
-Wm
-Sd
-Sd
-Sd
-MM
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -54166,38 +53169,38 @@ aa
 aa
 aa
 aa
-Nd
-Xe
-CT
-CT
-CT
-Nd
-TB
-Fh
-Fh
-BV
-CT
-Fe
-UE
-CT
-CT
-CT
-Ph
-CT
-Qk
-Vu
-Nd
-Gs
-Ud
-Ud
-NT
-Mw
-PA
-TC
-PA
-Pl
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -54423,38 +53426,38 @@ aa
 aa
 aa
 aa
-Nd
-Ny
-CT
-CT
-CT
-Nd
-Vz
-Fh
-YJ
-QT
-CT
-Ya
-UE
-CT
-CT
-CT
-CT
-CT
-CT
-XM
-NT
-CT
-CT
-CT
-NT
-Yq
-GY
-CT
-GY
-GY
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -54680,38 +53683,38 @@ aa
 aa
 aa
 aa
-Nd
-Bs
-Ri
-CT
-CT
-XL
-Fh
-Fh
-Fh
-XL
-CT
-Qj
-UE
-CT
-CT
-CT
-Tu
-CT
-CT
-Tn
-NT
-CT
-CT
-CT
-MK
-CT
-CT
-CT
-CT
-CT
-CT
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -54937,38 +53940,38 @@ aa
 aa
 aa
 aa
-Nd
-SU
-CT
-Qu
-Nm
-Nd
-SN
-pV
-Tr
-Nd
-Fj
-Nd
-Nd
-Fi
-Tn
-UT
-Hm
-CT
-CT
-GY
-NT
-CT
-CT
-CT
-NT
-vt
-Mx
-Qg
-Tb
-Uh
-tW
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -55194,38 +54197,38 @@ aa
 aa
 aa
 aa
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -52,6 +52,15 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/arena_source)
+"al" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "am" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -86,6 +95,42 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/arena_source)
+"av" = (
+/obj/item/mop,
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
+"az" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/centcom/holding)
+"aA" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/large,
+/area/centcom/holding)
+"aF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/door/airlock/wood{
+	name = "Kitchen"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"aH" = (
+/obj/machinery/vending/cigarette/syndicate,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "aP" = (
 /obj/structure/chair{
 	dir = 1
@@ -94,6 +139,12 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/centcom/evac)
+"aS" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table/wood/fancy/green,
+/obj/effect/spawner/random/entertainment/gambling,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "aW" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdomehea";
@@ -105,11 +156,267 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/tdome/arena_source)
+"ba" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"bc" = (
+/obj/structure/table/wood,
+/obj/item/food/grown/tea/astra,
+/obj/item/food/grown/soybeans,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"bi" = (
+/obj/structure/closet/crate,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/multitool,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
+"bo" = (
+/obj/machinery/gibber,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
 "bp" = (
 /obj/item/trash/sosjerky,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
+"bs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"bu" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"bv" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"bw" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/grass,
+/area/centcom/holding)
+"bC" = (
+/obj/machinery/door/airlock/wood{
+	name = "Red Team"
+	},
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"bE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/turf/open/floor/iron/cafeteria,
+/area/centcom/holding)
+"bI" = (
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/obj/item/soap/syndie,
+/obj/structure/curtain,
+/obj/machinery/door/window/survival_pod,
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/holding)
+"bL" = (
+/obj/structure/chair/stool/bar/directional/east,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"bN" = (
+/obj/effect/turf_decal/tile/dark,
+/obj/effect/turf_decal/tile/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"bS" = (
+/obj/structure/closet{
+	anchored = 1;
+	name = "Plasmaman suits"
+	},
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman/engineering,
+/obj/item/clothing/under/plasmaman/botany,
+/obj/item/clothing/under/plasmaman/janitor,
+/obj/item/clothing/under/plasmaman/chef,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman/engineering,
+/obj/item/clothing/head/helmet/space/plasmaman/botany,
+/obj/item/clothing/head/helmet/space/plasmaman/janitor,
+/obj/item/clothing/head/helmet/space/plasmaman/white,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"bT" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"bX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"cc" = (
+/obj/structure/closet/crate/bin,
+/obj/item/soap/syndie,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"cf" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"ci" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/cafeteria,
+/area/centcom/holding)
+"cl" = (
+/obj/machinery/vending/boozeomat,
+/turf/closed/wall/mineral/wood,
+/area/centcom/holding)
+"cr" = (
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/centcom/holding)
+"cv" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 4
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/centcom/holding)
+"cx" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/storage/book/bible,
+/turf/open/floor/wood/large,
+/area/centcom/holding)
+"cz" = (
+/obj/structure/chair/bronze{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"cE" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 5
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
+"cG" = (
+/obj/effect/turf_decal/tile/dark,
+/obj/effect/turf_decal/tile/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/basket,
+/obj/machinery/light/directional/west,
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"cH" = (
+/obj/structure/closet,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/iv_drip,
+/obj/item/roller,
+/obj/item/storage/firstaid/regular,
+/obj/item/reagent_containers/medigel/synthflesh,
+/obj/item/reagent_containers/medigel/synthflesh,
+/obj/item/reagent_containers/medigel/synthflesh,
+/obj/item/organ/heart/cybernetic/tier2,
+/obj/item/organ/heart/cybernetic/tier2,
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"cJ" = (
+/obj/structure/bookcase/random/fiction,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"cN" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/airlock/wood{
+	name = "Custodial Closet"
+	},
+/turf/open/floor/stone,
+/area/centcom/holding)
+"cP" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/sofa/corp/left{
+	pixel_y = 6
+	},
+/obj/effect/landmark/holding_facility,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"cQ" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
 "da" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral{
@@ -125,6 +432,59 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
+"df" = (
+/obj/structure/rack,
+/obj/item/nullrod/claymore/saber/red{
+	damtype = "stamina";
+	force = 30
+	},
+/obj/item/nullrod/claymore/katana{
+	damtype = "stamina";
+	force = 30;
+	pixel_x = -8;
+	pixel_y = -1
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"dj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "Dining Hall"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"dk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "Botanical Garden"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"dl" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "Guest Suite *B"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"dm" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "dn" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -139,6 +499,54 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/grimy,
 /area/centcom/control)
+"dq" = (
+/turf/open/floor/stone,
+/area/centcom/holding)
+"dr" = (
+/mob/living/simple_animal/bot/medbot{
+	desc = "A little medical robot. You can make out the word \"sincerity\" on its chassis.";
+	name = "Hijikata";
+	radio_key = null;
+	stationary_mode = 1
+	},
+/turf/open/floor/wood/large,
+/area/centcom/holding)
+"dt" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"dv" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/centcom/holding)
+"dB" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 5
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/centcom/holding)
+"dI" = (
+/obj/structure/window/paperframe{
+	CanAtmosPass = 0
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "dK" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdomegen";
@@ -146,6 +554,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/tdome/arena_source)
+"dM" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/instrument/piano_synth,
+/obj/item/instrument/saxophone,
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"dQ" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "dR" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -163,6 +581,142 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
+"dS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/plating/sandy_dirt,
+/area/centcom/holding)
+"dT" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/clothing/mask/animal/pig,
+/obj/item/clothing/mask/animal/horsehead,
+/obj/item/clothing/mask/animal/rat,
+/obj/item/clothing/mask/fakemoustache{
+	pixel_y = 9
+	},
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"dY" = (
+/turf/open/floor/plating/asteroid/basalt/airless,
+/area/centcom/holding)
+"eb" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
+"ed" = (
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"ei" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e"
+	},
+/obj/effect/landmark/holding_facility,
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
+"ej" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "Guest Suite *A"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"eo" = (
+/obj/structure/toilet/greyscale{
+	dir = 4
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/structure/mirror/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/holding)
+"ep" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
+"eq" = (
+/obj/structure/chair/bronze{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"es" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"et" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/plating/sandy_dirt,
+/area/centcom/holding)
+"ew" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/bookmanagement,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"ex" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 9
+	},
+/obj/structure/dresser,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/centcom/holding)
 "ey" = (
 /obj/machinery/flasher{
 	id = "tdomeflash";
@@ -173,6 +727,15 @@
 "ez" = (
 /turf/open/floor/circuit/green,
 /area/tdome/arena_source)
+"eJ" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/obj/item/camera_film,
+/turf/open/floor/wood/large,
+/area/centcom/holding)
 "eP" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -181,6 +744,33 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
+"eR" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/centcom/holding)
+"eT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock/wood{
+	name = "Washroom"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"eU" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light/directional/east,
+/turf/open/floor/grass,
+/area/centcom/holding)
+"eW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "eX" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
@@ -193,6 +783,12 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/arena_source)
+"eZ" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/large,
+/area/centcom/holding)
 "fa" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -200,15 +796,123 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/centcom/ferry)
+"fb" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 10
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/toy/mecha/phazon,
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/centcom/holding)
+"fe" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/stone,
+/area/centcom/holding)
+"ff" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"fg" = (
+/turf/closed/indestructible/weeb,
+/area/centcom/holding)
 "fj" = (
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/wood,
 /area/centcom/ferry)
+"fo" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
+"fp" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/structure/mirror/directional/east,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/holding)
+"fq" = (
+/obj/machinery/duct,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"fs" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 10
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/toy/figure/syndie,
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/centcom/holding)
+"fu" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 6
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
 "fx" = (
 /obj/machinery/igniter/on,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/tdome/arena_source)
+"fD" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "fE" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -217,6 +921,24 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/centcom/evac)
+"fI" = (
+/obj/machinery/door/airlock/wood{
+	name = "Blue Team"
+	},
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"fK" = (
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"fM" = (
+/turf/closed/indestructible/fakedoor{
+	name = "Guest House Back Entrance"
+	},
+/area/centcom/holding)
+"fO" = (
+/turf/closed/wall/mineral/wood,
+/area/centcom/holding)
 "fR" = (
 /obj/item/food/egg/rainbow{
 	desc = "I bet you think you're pretty clever... well you are.";
@@ -224,6 +946,19 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"fT" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 4;
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 7;
+	pixel_y = -4
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "fX" = (
 /turf/closed/indestructible/riveted,
 /area/start)
@@ -235,6 +970,49 @@
 /obj/effect/landmark/ctf,
 /turf/open/space/basic,
 /area/space)
+"gd" = (
+/obj/structure/closet/crate,
+/obj/item/vending_refill/autodrobe,
+/obj/item/stack/sheet/paperframes/fifty,
+/obj/item/stack/sheet/paperframes/fifty,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/box/lights/mixed,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
+"ge" = (
+/obj/machinery/defibrillator_mount/directional/south,
+/obj/machinery/stasis,
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"gi" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 6
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/syndie,
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/centcom/holding)
+"gk" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/toy/spinningtoy,
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
 "gt" = (
 /obj/effect/landmark/mafia_game_area,
 /turf/open/space/basic,
@@ -242,6 +1020,39 @@
 "gu" = (
 /turf/closed/indestructible/splashscreen,
 /area/start)
+"gH" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/sofa/corp/right{
+	pixel_y = 6
+	},
+/obj/effect/landmark/holding_facility,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"gK" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/arcade/amputation{
+	dir = 1
+	},
+/turf/open/floor/eighties/red,
+/area/centcom/holding)
+"gP" = (
+/obj/effect/turf_decal/tile/dark,
+/obj/effect/turf_decal/tile/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "gQ" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/red,
@@ -255,9 +1066,70 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/arena)
+"gS" = (
+/obj/machinery/processor,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
+"gV" = (
+/mob/living/simple_animal/bot/medbot{
+	desc = "When engaged in combat, the vanquishing of thine enemy can be the warrior's only concern.";
+	name = "Momo";
+	radio_key = null;
+	stationary_mode = 1
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"gW" = (
+/obj/item/flashlight/lantern,
+/turf/open/floor/plating/ironsand{
+	color = "#525252";
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/centcom/holding)
+"gZ" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/centcom/holding)
+"hb" = (
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"hg" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 6
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/toy/katana{
+	desc = "As seen in your favourite Japanese cartoon.";
+	name = "anime katana"
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
 "hh" = (
 /turf/closed/indestructible/rock/snow,
 /area/syndicate_mothership)
+"hj" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/cafeteria,
+/area/centcom/holding)
+"hk" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
 "hl" = (
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
@@ -265,9 +1137,77 @@
 /mob/living/basic/cow,
 /turf/open/floor/grass,
 /area/centcom/holding)
+"hr" = (
+/turf/open/floor/plating/sandy_dirt,
+/area/centcom/holding)
+"hw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
+"hy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "East Wing"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"hB" = (
+/obj/structure/closet{
+	anchored = 1;
+	desc = "A storage unit for plasmaman internals, courtesy of the Spider Clan.";
+	icon_state = "emergency";
+	name = "Plasmaman emergency closet"
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "hH" = (
 /turf/open/floor/holofloor/hyperspace,
 /area/space)
+"hI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
+"hL" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 5
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/centcom/holding)
 "hO" = (
 /obj/structure/table/wood/fancy,
 /obj/item/storage/dice{
@@ -275,6 +1215,10 @@
 	},
 /turf/open/floor/carpet,
 /area/wizard_station)
+"hR" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
 "hU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -290,9 +1234,72 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
+"hX" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 10
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/syndie,
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
+"ic" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e"
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
+"id" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/table/wood/fancy/green,
+/obj/item/candle/infinite{
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"ie" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/rcl/pre_loaded,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
 "ig" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/wood,
+/area/centcom/holding)
+"ik" = (
+/obj/structure/kitchenspike,
+/obj/item/gun/magic/hook,
+/turf/open/floor/plating/catwalk_floor,
 /area/centcom/holding)
 "il" = (
 /turf/closed/indestructible/riveted,
@@ -1298,6 +2305,9 @@
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership/control)
+"kw" = (
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/holding)
 "kx" = (
 /obj/structure/filingcabinet/medical,
 /obj/effect/turf_decal/stripes/line{
@@ -3922,6 +4932,20 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/ferry)
+"pK" = (
+/obj/structure/reagent_dispensers/plumbed,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"pL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/centcom/holding)
 "pM" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -6243,6 +7267,16 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron,
 /area/centcom/supply)
+"uI" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/wrench{
+	pixel_y = -16
+	},
+/obj/item/wirecutters{
+	pixel_y = 3
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "uJ" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
@@ -6262,6 +7296,10 @@
 	},
 /turf/open/floor/iron,
 /area/syndicate_mothership/control)
+"uM" = (
+/obj/machinery/icecream_vat,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
 "uO" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Shuttle Control Office";
@@ -6522,6 +7560,21 @@
 	},
 /turf/open/floor/carpet,
 /area/wizard_station)
+"vp" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"vr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 4;
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "vs" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/tile/green{
@@ -6566,6 +7619,12 @@
 /obj/item/toy/nuke,
 /turf/open/floor/wood,
 /area/syndicate_mothership/control)
+"vz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "vA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
@@ -6925,6 +7984,12 @@
 /obj/item/clothing/head/helmet/space/plasmaman,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"wk" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/centcom/holding)
 "wl" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
@@ -7185,6 +8250,19 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/carpet,
 /area/wizard_station)
+"wR" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
+"wX" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/structure/mirror/directional/west,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/holding)
 "wY" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Equipment Room";
@@ -7386,6 +8464,9 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet,
 /area/wizard_station)
+"xA" = (
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
 "xB" = (
 /mob/living/simple_animal/bot/medbot{
 	desc = "When engaged in combat, the vanquishing of thine enemy can be the warrior's only concern.";
@@ -7394,6 +8475,15 @@
 	stationary_mode = 1
 	},
 /turf/open/floor/wood,
+/area/centcom/holding)
+"xC" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"xF" = (
+/obj/structure/bookcase/random/reference,
+/turf/open/floor/carpet/black,
 /area/centcom/holding)
 "xG" = (
 /turf/open/floor/iron/dark,
@@ -7565,6 +8655,9 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
+"yg" = (
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "yj" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -7800,6 +8893,61 @@
 /obj/structure/safe/floor,
 /obj/item/seeds/cherry/bomb,
 /turf/open/floor/wood,
+/area/centcom/holding)
+"yP" = (
+/obj/effect/turf_decal/tile/dark,
+/obj/effect/turf_decal/tile/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/washing_machine,
+/obj/machinery/light/directional/east,
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"yQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 1
+	},
+/turf/open/floor/eighties/red,
+/area/centcom/holding)
+"yR" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/landmark/holding_facility,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
+"yT" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 1
+	},
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
 /area/centcom/holding)
 "yU" = (
 /obj/machinery/door/firedoor,
@@ -8230,6 +9378,41 @@
 	},
 /turf/open/floor/grass,
 /area/wizard_station)
+"zS" = (
+/obj/structure/table/reinforced,
+/obj/item/food/grown/tea/astra{
+	pixel_y = 13
+	},
+/obj/item/food/grown/soybeans{
+	pixel_y = 13
+	},
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
+/turf/open/floor/iron/cafeteria,
+/area/centcom/holding)
+"zU" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 10
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
 "zV" = (
 /obj/structure/closet/secure_closet/freezer/meat/open,
 /obj/item/food/fishmeat/carp,
@@ -8238,6 +9421,23 @@
 /obj/item/food/fishmeat/carp,
 /obj/item/food/fishmeat/carp,
 /turf/open/floor/iron/cafeteria,
+/area/centcom/holding)
+"zW" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
 /area/centcom/holding)
 "zX" = (
 /obj/structure/table,
@@ -8498,9 +9698,42 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/grass,
 /area/wizard_station)
+"AD" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e"
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/centcom/holding)
+"AG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "AH" = (
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/one)
+"AJ" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "AL" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -8695,6 +9928,29 @@
 /obj/item/food/meat/slab/xeno,
 /turf/open/floor/grass,
 /area/wizard_station)
+"Bk" = (
+/obj/machinery/vending/clothing,
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"Bn" = (
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/food/grown/rice,
+/obj/item/food/grown/rice,
+/obj/item/food/grown/rice,
+/obj/item/food/grown/rice,
+/obj/item/food/grown/rice,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/onion,
+/obj/item/food/grown/onion,
+/obj/item/food/grown/onion/red,
+/obj/item/food/grown/onion/red,
+/obj/item/food/grown/coffee,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "Bo" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -9157,6 +10413,16 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"Cn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 4;
+	pixel_x = -4
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "Co" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -9744,6 +11010,26 @@
 "Di" = (
 /turf/closed/indestructible/riveted,
 /area/ai_multicam_room)
+"Dl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
+"Dn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock/wood{
+	name = "Bar"
+	},
+/obj/machinery/duct,
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "Dq" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/turf_decal/stripes/line{
@@ -9801,6 +11087,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/control)
+"Dw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "Dojo"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "Dx" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
@@ -10560,6 +11858,13 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Fl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/stone,
+/area/centcom/holding)
 "Fm" = (
 /obj/machinery/shower{
 	dir = 4
@@ -10699,6 +12004,33 @@
 	},
 /turf/open/floor/iron/white,
 /area/tdome/tdomeobserve)
+"FA" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 5
+	},
+/obj/structure/dresser,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
+"FC" = (
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
 "FD" = (
 /obj/machinery/shower{
 	dir = 4
@@ -10835,6 +12167,24 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"FU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "Blue"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"FV" = (
+/obj/structure/chair/pew/left{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/centcom/holding)
 "FW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -10846,6 +12196,22 @@
 /area/centcom/holding)
 "FX" = (
 /turf/open/floor/iron/stairs,
+/area/centcom/holding)
+"FY" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/structure/beebox{
+	name = "Shrine"
+	},
+/turf/open/floor/wood,
 /area/centcom/holding)
 "Gb" = (
 /obj/machinery/shower{
@@ -11001,6 +12367,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Gt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/vending/hydronutrients,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "Gu" = (
 /obj/machinery/door/airlock/silver{
 	name = "Shower"
@@ -11039,6 +12412,9 @@
 	},
 /turf/open/lava/airless,
 /area/wizard_station)
+"GA" = (
+/turf/open/floor/plating/ashplanet/wateryrock,
+/area/centcom/holding)
 "GC" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -11706,6 +13082,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/tdome/tdomeobserve)
+"HL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/vault/rock,
+/area/centcom/holding)
 "HM" = (
 /obj/structure/chair,
 /obj/effect/landmark/thunderdome/observe,
@@ -12135,6 +13517,12 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
 /area/tdome/tdomeadmin)
+"Iy" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
 "Iz" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdomegen";
@@ -12595,6 +13983,12 @@
 "JI" = (
 /turf/closed/indestructible/fakeglass,
 /area/tdome/tdomeadmin)
+"JK" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "JL" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/green,
@@ -13034,6 +14428,13 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/tdome/tdomeadmin)
+"Kz" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/large,
+/area/centcom/holding)
 "KA" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -13063,6 +14464,12 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/grimy,
 /area/centcom/control)
+"KE" = (
+/obj/structure/table/wood,
+/obj/item/toy/plush/goatplushie,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "KF" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -13581,8 +14988,17 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/arena)
+"Ml" = (
+/obj/structure/bookcase/random/adult,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "Mm" = (
 /turf/open/floor/grass,
+/area/centcom/holding)
+"Mn" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/crayons,
+/turf/open/floor/plating/catwalk_floor,
 /area/centcom/holding)
 "Ms" = (
 /obj/item/kirbyplants{
@@ -13622,6 +15038,13 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"MA" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "MB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -13636,6 +15059,15 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
+"MC" = (
+/obj/structure/flora/rock/pile,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating/ashplanet/wateryrock,
+/area/centcom/holding)
 "MD" = (
 /obj/effect/light_emitter{
 	set_cap = 1;
@@ -13664,6 +15096,18 @@
 	},
 /turf/open/floor/grass,
 /area/centcom/holding)
+"MH" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "Performance Room"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "MI" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table/wood,
@@ -13680,6 +15124,11 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"MO" = (
+/turf/closed/indestructible/fakedoor{
+	name = "Guest House Entrance"
+	},
+/area/centcom/holding)
 "MR" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/black,
@@ -13688,8 +15137,75 @@
 /obj/machinery/processor,
 /turf/open/floor/iron/cafeteria,
 /area/centcom/holding)
+"MW" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 1
+	},
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
+"MX" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/book/manual/hydroponics_pod_people,
+/obj/item/paper/guides/jobs/hydroponics,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
+"Nc" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
 "Nd" = (
 /turf/closed/indestructible/wood,
+/area/centcom/holding)
+"Nf" = (
+/obj/effect/turf_decal/tile/dark,
+/obj/effect/turf_decal/tile/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/washing_machine,
+/turf/open/floor/sepia,
 /area/centcom/holding)
 "Nh" = (
 /obj/structure/table/wood,
@@ -13711,6 +15227,10 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/supply)
+"Nj" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/plating/sandy_dirt,
+/area/centcom/holding)
 "Nk" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome";
@@ -13762,6 +15282,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"NB" = (
+/turf/open/floor/plating/ironsand{
+	color = "#525252";
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/centcom/holding)
 "ND" = (
 /obj/structure/table/wood,
 /obj/item/storage/dice,
@@ -13770,6 +15296,15 @@
 "NE" = (
 /turf/open/floor/iron,
 /area/centcom/supplypod/pod_storage)
+"NF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "NG" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -13801,6 +15336,10 @@
 "NO" = (
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
+"NS" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
 "NT" = (
 /obj/structure/window/paperframe{
 	CanAtmosPass = 0
@@ -13817,6 +15356,78 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/control)
+"NW" = (
+/obj/structure/closet/secure_closet/freezer/meat/open,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/bear,
+/obj/item/food/meat/slab/bear,
+/obj/item/food/meat/slab/bear,
+/obj/item/food/meat/slab/bear,
+/obj/item/food/meat/slab/bear,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/obj/item/food/meat/slab/monkey,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
+"NX" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/large,
+/area/centcom/holding)
+"Ob" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/egg_box,
+/obj/item/reagent_containers/food/condiment/flour{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/condiment/rice{
+	pixel_y = 12
+	},
+/turf/open/floor/iron/cafeteria,
+/area/centcom/holding)
+"Oe" = (
+/obj/structure/closet/crate/bin,
+/obj/item/clothing/suit/xenos,
+/obj/item/clothing/head/xenos,
+/obj/item/xenos_claw,
+/obj/item/grown/log/bamboo,
+/obj/item/grown/log/bamboo,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
+"Og" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 9
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
+"Oi" = (
+/turf/closed/indestructible/opsglass,
+/area/centcom/holding)
 "Oj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -13870,9 +15481,41 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/two)
+"Os" = (
+/obj/structure/flora/rock/jungle{
+	pixel_x = -12;
+	pixel_y = 15
+	},
+/turf/open/floor/plating/ashplanet/wateryrock,
+/area/centcom/holding)
+"Ou" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "Shrine"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"Ov" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/shovel/spade{
+	pixel_y = -14
+	},
+/obj/item/cultivator,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "OA" = (
 /turf/open/floor/iron/freezer,
 /area/syndicate_mothership/control)
+"OB" = (
+/obj/machinery/oven,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/cafeteria,
+/area/centcom/holding)
 "OC" = (
 /obj/machinery/door/poddoor/ert,
 /obj/effect/turf_decal/delivery,
@@ -13888,10 +15531,26 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
+"OF" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/centcom/holding)
 "OG" = (
 /obj/structure/dresser,
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
+/area/centcom/holding)
+"OL" = (
+/turf/closed/indestructible/rock,
 /area/centcom/holding)
 "OP" = (
 /obj/effect/turf_decal/delivery,
@@ -13906,6 +15565,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/centcom/ferry)
+"OT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "OU" = (
 /obj/item/clothing/under/costume/jabroni,
 /obj/item/clothing/under/costume/geisha,
@@ -13914,13 +15582,65 @@
 /obj/item/clothing/under/costume/roman,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"OZ" = (
+/mob/living/basic/cow{
+	name = "Yuna"
+	},
+/turf/open/floor/grass,
+/area/centcom/holding)
 "Pa" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/white,
 /area/centcom/holding)
+"Pd" = (
+/obj/item/clothing/shoes/galoshes{
+	pixel_y = -8
+	},
+/obj/item/storage/belt/janitor{
+	pixel_x = 2;
+	pixel_y = -4
+	},
+/obj/item/watertank/janitor{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/item/pushbroom{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/machinery/duct,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
+"Pf" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "Ph" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood,
+/area/centcom/holding)
+"Pi" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 8
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
 /area/centcom/holding)
 "Pj" = (
 /obj/structure/chair/comfy/brown{
@@ -13940,6 +15660,9 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/four)
+"Pn" = (
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
 "Po" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -13986,6 +15709,38 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"PC" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/obj/item/camera/detective{
+	desc = "A polaroid camera with extra capacity for social media marketing.";
+	name = "Professional camera"
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
+"PD" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 4
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
 "PI" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/green{
@@ -14025,6 +15780,24 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/holding)
+"PP" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/item/food/grown/chili,
+/obj/item/food/grown/chili,
+/obj/item/food/grown/chili,
+/obj/item/food/grown/chili,
+/obj/item/food/grown/chili,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/milk,
+/obj/item/reagent_containers/food/condiment/soymilk,
+/obj/item/reagent_containers/food/condiment/soymilk,
+/obj/item/storage/fancy/egg_box,
+/obj/item/food/grown/citrus/lime,
+/obj/item/food/grown/citrus/orange,
+/obj/item/food/grown/citrus/lemon,
+/obj/item/food/grown/watermelon,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "PQ" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -14060,6 +15833,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/holding)
+"PZ" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
+"Qa" = (
+/obj/structure/table/wood,
+/obj/item/food/chawanmushi,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"Qc" = (
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/centcom/holding)
 "Qd" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album/syndicate{
@@ -14085,6 +15872,16 @@
 /obj/item/reagent_containers/medigel/synthflesh,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Qi" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/reagent_dispensers/plumbed{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
 "Qj" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/sake,
@@ -14097,10 +15894,43 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/centcom/holding)
+"Ql" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
+"Qm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "Electrical Room"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"Qo" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "Qq" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/centcom/ferry)
+"Qr" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
+"Qt" = (
+/obj/item/flashlight/lantern,
+/turf/open/floor/plating/sandy_dirt,
+/area/centcom/holding)
 "Qu" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood,
@@ -14114,6 +15944,24 @@
 "QA" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/iron/cafeteria,
+/area/centcom/holding)
+"QC" = (
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
+"QD" = (
+/obj/structure/closet,
+/obj/item/clothing/under/costume/jabroni,
+/obj/item/clothing/under/costume/geisha,
+/obj/item/clothing/under/costume/kilt,
+/obj/item/clothing/under/costume/roman,
+/turf/open/floor/wood/parquet,
 /area/centcom/holding)
 "QH" = (
 /obj/machinery/chem_master/condimaster{
@@ -14139,6 +15987,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/holding)
+"QJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "QL" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -14163,6 +16017,16 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod)
+"QQ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/airlock/wood{
+	name = "Toilet"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "QS" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
@@ -14188,6 +16052,20 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/centcom/holding)
+"Ra" = (
+/obj/effect/turf_decal/tile/dark,
+/obj/effect/turf_decal/tile/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "Rd" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/green{
@@ -14205,6 +16083,21 @@
 "Re" = (
 /obj/structure/mineral_door/paperframe,
 /turf/open/floor/wood,
+/area/centcom/holding)
+"Rf" = (
+/obj/structure/rack,
+/obj/item/nullrod/claymore/saber{
+	damtype = "stamina";
+	force = 30;
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/item/nullrod/claymore/katana{
+	damtype = "stamina";
+	force = 30
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood/parquet,
 /area/centcom/holding)
 "Rh" = (
 /obj/structure/window/reinforced{
@@ -14232,6 +16125,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/holding)
+"Rk" = (
+/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/stasis,
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "Rm" = (
 /obj/structure/chair/wood/wings{
 	dir = 3
@@ -14246,6 +16144,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
+"Rp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/item/wallframe/newscaster{
+	pixel_x = -6
+	},
+/obj/item/flashlight/lamp/bananalamp{
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
+"Rt" = (
+/turf/open/water,
+/area/centcom/holding)
 "Ru" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -14257,6 +16172,12 @@
 /obj/machinery/door/window/westleft,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"Ry" = (
+/obj/structure/window/paperframe{
+	CanAtmosPass = 0
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "RA" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -14265,6 +16186,33 @@
 /obj/effect/spawner/xmastree,
 /turf/open/floor/iron,
 /area/syndicate_mothership/control)
+"RD" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"RE" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "Guest Suite *D"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"RG" = (
+/obj/machinery/modular_computer/console/preset/research{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
+"RL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
 "RM" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -14273,6 +16221,9 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/black,
+/area/centcom/holding)
+"RN" = (
+/turf/open/floor/iron/stairs/medium,
 /area/centcom/holding)
 "RQ" = (
 /obj/structure/closet/abductor,
@@ -14288,6 +16239,34 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"RY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "Red"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"Sa" = (
+/mob/living/simple_animal/bot/medbot{
+	desc = "When engaged in combat, the vanquishing of thine enemy can be the warrior's only concern.";
+	name = "Hattori";
+	radio_key = null;
+	stationary_mode = 1
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"Sb" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/sake{
+	pixel_y = 15
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "Sd" = (
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
@@ -14298,6 +16277,26 @@
 "Si" = (
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/two)
+"Sm" = (
+/obj/structure/window/paperframe{
+	CanAtmosPass = 0
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"Sn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/closet/crate/bin{
+	pixel_y = 6
+	},
+/turf/open/floor/stone,
+/area/centcom/holding)
 "Su" = (
 /turf/open/floor/iron,
 /area/centcom/supplypod)
@@ -14340,6 +16339,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/holding)
+"SD" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"SF" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "SG" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -14352,10 +16361,53 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
+"SL" = (
+/obj/structure/rack,
+/obj/item/nullrod/scythe/vibro{
+	damtype = "stamina";
+	force = 30;
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/nullrod/claymore/glowing{
+	damtype = "stamina";
+	force = 30
+	},
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"SM" = (
+/obj/structure/closet/secure_closet/freezer/meat/open,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/fishmeat,
+/obj/item/food/meat/slab/rawcrab,
+/obj/item/food/meat/slab/rawcrab,
+/obj/item/food/meat/slab/rawcrab,
+/obj/item/food/meat/slab/rawcrab,
+/obj/item/food/meat/slab/rawcrab,
+/obj/item/food/meat/slab/synthmeat,
+/obj/item/food/meat/slab/synthmeat,
+/obj/item/food/meat/slab/synthmeat,
+/obj/item/food/meat/slab/synthmeat,
+/obj/item/food/meat/slab/synthmeat,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
 "SN" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/iron/cafeteria,
+/area/centcom/holding)
+"SP" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/mineral_door/paperframe{
+	name = "Guest Suite *C"
+	},
+/turf/open/floor/sepia,
 /area/centcom/holding)
 "SS" = (
 /obj/effect/turf_decal/tile/brown,
@@ -14393,6 +16445,52 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/holding)
+"SX" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"SY" = (
+/obj/effect/turf_decal/tile/dark,
+/obj/effect/turf_decal/tile/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/clothing/suit/hawaiian{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/hawaiian,
+/obj/item/clothing/suit/hawaiian{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/hawaiian,
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"Ta" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 9
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/centcom/holding)
 "Tb" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/wood,
@@ -14404,6 +16502,18 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/two)
+"Te" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/centcom/holding)
+"Tg" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
 "Tj" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
@@ -14414,6 +16524,33 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod)
+"Tk" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/grass,
+/area/centcom/holding)
+"Tl" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open{
+	name = "freezer"
+	},
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/berries,
+/obj/item/food/grown/berries,
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/cherries,
+/obj/item/food/grown/cherries,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/food/grown/redbeet,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
 "Tn" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle/infinite{
@@ -14441,6 +16578,17 @@
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/centcom/holding)
+"Tv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/stone,
+/area/centcom/holding)
+"Tw" = (
+/obj/structure/chair/bronze{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "Ty" = (
 /obj/structure/table/reinforced,
 /obj/item/camera,
@@ -14453,6 +16601,29 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/three)
+"TA" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 6
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/toy/figure/ninja,
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
 "TB" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/iron/cafeteria,
@@ -14461,10 +16632,70 @@
 /obj/machinery/door/window/eastright,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"TF" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/centcom/holding)
+"TI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/window/paperframe{
+	CanAtmosPass = 0
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"TJ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/airlock/wood{
+	name = "Freezer"
+	},
+/turf/open/floor/stone,
+/area/centcom/holding)
 "TK" = (
 /obj/structure/table/wood/shuttle_bar,
 /obj/structure/mirror/directional/north,
 /turf/open/floor/wood,
+/area/centcom/holding)
+"TM" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 9
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
+"TQ" = (
+/obj/structure/flora/tree/dead,
+/turf/open/floor/plating/asteroid/basalt/wasteland{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/centcom/holding)
+"TS" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/duct,
+/obj/item/clothing/suit/apron,
+/turf/open/floor/plating/catwalk_floor,
 /area/centcom/holding)
 "TT" = (
 /obj/structure/table/reinforced,
@@ -14478,6 +16709,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
+"TX" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "TY" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -14562,13 +16800,55 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
 /area/tdome/tdomeobserve)
+"Up" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/mineral_door/paperframe{
+	name = "Spectator's Lounge"
+	},
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "Uw" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
+"Uz" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/centcom/holding)
+"UB" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"UC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/chem_master/condimaster{
+	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
+	name = "BrewMaster 2199";
+	pixel_x = -4
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "UE" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/wood,
+/area/centcom/holding)
+"UF" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/easel,
+/obj/item/canvas/twentythree_twentythree,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
+"UG" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/vault/rock,
 /area/centcom/holding)
 "UH" = (
 /obj/machinery/light/directional/west,
@@ -14616,16 +16896,65 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
+"UQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/arcade/battle{
+	dir = 1
+	},
+/turf/open/floor/eighties/red,
+/area/centcom/holding)
+"US" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/chef_recipes,
+/obj/item/kitchen/knife,
+/turf/open/floor/iron/cafeteria,
+/area/centcom/holding)
 "UT" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"UU" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/vending/snack/orange,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"UY" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/asteroid/basalt/airless,
+/area/centcom/holding)
+"UZ" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 1
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/centcom/holding)
 "Vc" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/iron/dark,
 /area/centcom/control)
+"Vj" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "Vk" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -14642,6 +16971,20 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/three)
+"Vo" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"Vt" = (
+/obj/machinery/griddle,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/iron/cafeteria,
+/area/centcom/holding)
 "Vu" = (
 /obj/structure/flora/ausbushes/fernybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -14672,6 +17015,12 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"VN" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "VP" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -14682,6 +17031,25 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/four)
+"VR" = (
+/obj/machinery/light/small/directional/south,
+/obj/structure/chair/pew/right{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/centcom/holding)
+"VS" = (
+/obj/effect/turf_decal/tile/dark,
+/obj/effect/turf_decal/tile/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/sepia,
+/area/centcom/holding)
+"VU" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
 "VX" = (
 /obj/structure/chair/stool/directional/east,
 /obj/effect/landmark/start/nukeop,
@@ -14691,6 +17059,12 @@
 	},
 /turf/open/floor/iron,
 /area/syndicate_mothership/control)
+"Wb" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 20
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "Wc" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -14704,6 +17078,14 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/evac)
+"We" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/landmark/holding_facility,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "Wj" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
@@ -14727,6 +17109,17 @@
 	},
 /turf/open/floor/iron,
 /area/tdome/arena_source)
+"Ws" = (
+/obj/machinery/vending/coffee{
+	custom_premium_price = 0;
+	custom_price = 0;
+	default_price = 0;
+	extra_price = 0;
+	fair_market_price = 0;
+	name = "\improper Jim Norton's Quebecois Coffee"
+	},
+/turf/open/floor/wood/large,
+/area/centcom/holding)
 "Wt" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -14734,6 +17127,33 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/four)
+"Ww" = (
+/obj/structure/table/wood,
+/obj/item/food/sashimi,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"WA" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/wood/large,
+/area/centcom/holding)
+"WB" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"WC" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "WE" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -14750,6 +17170,13 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/centcom/ferry)
+"WH" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/biogenerator,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "WJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Administration";
@@ -14841,6 +17268,23 @@
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/cafeteria,
 /area/centcom/holding)
+"Xr" = (
+/obj/effect/turf_decal/tile/yellow/half,
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e"
+	},
+/obj/effect/landmark/holding_facility,
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/centcom/holding)
 "Xs" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -14860,6 +17304,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
 /area/centcom/control)
+"Xx" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/sepia,
+/area/centcom/holding)
 "Xy" = (
 /obj/machinery/door/airlock/external{
 	name = "Ferry Airlock"
@@ -14872,6 +17320,10 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/ferry)
+"XA" = (
+/obj/machinery/photocopier,
+/turf/open/floor/plating/catwalk_floor,
+/area/centcom/holding)
 "XD" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -14879,6 +17331,35 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/one)
+"XF" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 6
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
+"XH" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
+/obj/machinery/duct,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "XL" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/wood,
@@ -14889,10 +17370,50 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"XN" = (
+/obj/structure/rack,
+/obj/item/nullrod/claymore{
+	damtype = "stamina";
+	force = 30;
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/nullrod/claymore/darkblade{
+	damtype = "stamina";
+	force = 30;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"XO" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/toy/toy_xeno,
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"XR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "XT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/supplypod)
+"XU" = (
+/obj/structure/flora/rock/pile,
+/turf/open/floor/plating/ironsand{
+	color = "#525252";
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/centcom/holding)
+"XY" = (
+/obj/structure/flora/rock/pile/largejungle{
+	pixel_y = -3
+	},
+/turf/open/floor/plating/ashplanet/wateryrock,
+/area/centcom/holding)
 "Ya" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -14935,6 +17456,10 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Ys" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/large,
+/area/centcom/holding)
 "Yt" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
@@ -14957,6 +17482,27 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/centcom/supplypod)
+"Yx" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 8
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
 "YA" = (
 /obj/machinery/door/airlock/centcom{
 	locked = 1;
@@ -14964,6 +17510,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/control)
+"YC" = (
+/turf/open/floor/wood/large,
+/area/centcom/holding)
 "YJ" = (
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -15008,6 +17557,46 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Zi" = (
+/obj/structure/toilet,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/machinery/door/window/survival_pod,
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/holding)
+"Zk" = (
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#2e2e2e";
+	dir = 1
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/centcom/holding)
+"Zn" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/storage/box/holy/follower,
+/turf/open/floor/wood/large,
+/area/centcom/holding)
+"Zr" = (
+/obj/structure/table/wood,
+/obj/machinery/light/directional/south,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
 "Zs" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -15015,6 +17604,14 @@
 	pixel_y = 3
 	},
 /turf/open/floor/wood,
+/area/centcom/holding)
+"Zt" = (
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"Zu" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/light/directional/north,
+/turf/open/floor/grass,
 /area/centcom/holding)
 "Zx" = (
 /mob/living/simple_animal/bot/medbot{
@@ -15024,6 +17621,46 @@
 	stationary_mode = 1
 	},
 /turf/open/floor/wood,
+/area/centcom/holding)
+"Zy" = (
+/obj/structure/bed/dogbed/cayenne{
+	name = "Paprika's bed"
+	},
+/mob/living/simple_animal/hostile/carp/cayenne{
+	aggro_vision_range = 1;
+	desc = "It's Paprika! One of the Spider Clan's lovable Space Carp!";
+	faction = list("neutral");
+	name = "Paprika";
+	real_name = "Paprika"
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"ZA" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 4;
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5;
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/holding)
+"ZG" = (
+/obj/structure/musician/piano{
+	icon_state = "piano"
+	},
+/turf/open/floor/plating/beach/sand,
+/area/centcom/holding)
+"ZI" = (
+/obj/structure/chair/bronze{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/black,
 /area/centcom/holding)
 "ZJ" = (
 /obj/machinery/door/airlock/centcom{
@@ -15038,6 +17675,12 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/evac)
+"ZL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/plating/sandy_dirt,
+/area/centcom/holding)
 "ZQ" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -15048,6 +17691,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/four)
+"ZR" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/closet/crate/bin,
+/obj/item/camera_film,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 "ZU" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -15069,6 +17719,15 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/supply)
+"ZY" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/wood/parquet,
+/area/centcom/holding)
+"ZZ" = (
+/obj/machinery/vending/hydroseeds,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood/tile,
+/area/centcom/holding)
 
 (1,1,1) = {"
 aa
@@ -31711,17 +34370,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+OL
+OL
+OL
+OL
+OL
+OL
+OL
+OL
+OL
+OL
 aa
 aa
 aa
@@ -31963,26 +34622,26 @@ hl
 hh
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+OL
+OL
+OL
+OL
+OL
+dY
+Qc
+Qc
+dY
+UY
+dY
+dY
+Qc
+Qc
+OL
+OL
+OL
+OL
+OL
 Di
 Qe
 Qe
@@ -32220,26 +34879,26 @@ hl
 hh
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+Qc
+dY
+dY
+dY
+dY
+dY
+dY
+Qc
+dY
+Qc
+dY
+Nd
+Nd
+Nd
+Nd
+Nd
+OL
 Di
 Qe
 Qe
@@ -32476,27 +35135,27 @@ hl
 hl
 hh
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+OL
+Qc
+dY
+Nd
+Nd
+Nd
+Nd
+Nd
+dY
+Qc
+Qc
+dY
+dY
+dY
+Nd
+Tl
+hk
+bo
+Nd
+OL
 Di
 Qe
 Qe
@@ -32733,27 +35392,27 @@ BY
 hl
 hh
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+dY
+fg
+bE
+Ob
+zS
+Nd
+Nd
+fg
+fg
+fg
+fg
+Nd
+Nd
+SM
+Pn
+gS
+Nd
+OL
 Di
 Qe
 Qe
@@ -32989,28 +35648,28 @@ BY
 Cp
 BY
 hh
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+OL
+dY
+dY
+dY
+fg
+Vt
+Fh
+hj
+fO
+AJ
+fT
+ZA
+Bn
+PP
+pK
+fO
+NW
+Pn
+uM
+Nd
+OL
 Di
 Qe
 Qe
@@ -33246,28 +35905,28 @@ hl
 BY
 hl
 hh
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+Qc
+dY
+Nd
+OB
+ci
+ci
+Dn
+fq
+fq
+fq
+fq
+fq
+fq
+TJ
+Pn
+wR
+ik
+Nd
+OL
 Di
 Qe
 Qe
@@ -33503,28 +36162,28 @@ hl
 hl
 hl
 hh
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+dY
+dY
+fg
+QA
+ci
+Fh
+fO
+Wb
+XH
+Sd
+Sd
+bu
+cc
+fO
+fO
+fO
+fO
+Nd
+OL
 Di
 Qe
 Qe
@@ -33760,28 +36419,28 @@ hh
 hh
 hh
 hh
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+TQ
+dY
+dY
+fg
+US
+cr
+Fh
+fO
+cl
+VN
+Sd
+Sd
+bc
+fO
+fO
+Rt
+Rt
+Rt
+fg
+OL
 Di
 Qe
 Qe
@@ -34011,34 +36670,34 @@ xG
 xG
 zx
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+OL
+OL
+OL
+OL
+OL
+dY
+dY
+dY
+dY
+dY
+Nd
+Nd
+Nd
+aF
+fO
+KE
+Ww
+Sb
+Qa
+SX
+Zr
+fO
+Rt
+Rt
+Rt
+fg
+OL
 Di
 Qe
 Qe
@@ -34268,34 +36927,34 @@ xG
 xG
 zx
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+OL
+Qc
+dY
+dY
+dY
+TQ
+dY
+Qc
+dY
+dY
+Qc
+Nd
+RD
+QL
+ff
+MA
+bL
+bL
+xC
+ff
+QL
+pL
+pL
+pL
+Nd
+OL
 Di
 Qe
 Qe
@@ -34525,34 +37184,34 @@ xG
 xG
 zx
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+OL
+OL
+dY
+dY
+dY
+dY
+dY
+dY
+dY
+UY
+dY
+dY
+Oi
+hb
+SF
+yg
+QJ
+ba
+ba
+SD
+yg
+Sn
+xA
+xA
+xA
+fg
+OL
 Di
 Qe
 Qe
@@ -34782,34 +37441,34 @@ xG
 xG
 zx
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+dY
+dY
+dY
+Qc
+dY
+dY
+dY
+TQ
+dY
+dY
+Oi
+hb
+SF
+yg
+yg
+QL
+QL
+yg
+yg
+Fl
+xA
+FC
+xA
+fg
+OL
 Di
 Qe
 Qe
@@ -35039,34 +37698,34 @@ xG
 xG
 zx
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+dY
+TQ
+dY
+Qc
+Qc
+dY
+dY
+dY
+Qc
+dY
+Nd
+Xx
+QL
+yg
+yg
+eq
+ZI
+yg
+yg
+Fl
+xA
+xA
+VU
+Nd
+OL
 Di
 Qe
 Qe
@@ -35296,34 +37955,34 @@ xG
 yX
 zy
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+TQ
+dY
+dY
+dY
+Nd
+Nd
+Nd
+Nd
+fg
+fg
+Nd
+Nd
+Nd
+Ry
+fO
+PZ
+yg
+id
+aS
+yg
+yg
+Fl
+xA
+ZG
+xA
+fg
+OL
 Di
 Qe
 Qe
@@ -35553,34 +38212,34 @@ ng
 ng
 ng
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+dY
+dY
+Oi
+ex
+hX
+dI
+YC
+YC
+gK
+Ry
+ZR
+Ws
+fO
+yg
+yg
+cz
+Tw
+yg
+yg
+fe
+xA
+hR
+xA
+fg
+OL
 Di
 Qe
 Qe
@@ -35808,36 +38467,36 @@ sk
 sk
 sk
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+OL
+OL
+UY
+Qc
+dY
+dY
+Oi
+MW
+Xr
+ej
+YC
+YC
+UQ
+Ry
+We
+YC
+fO
+dj
+dj
+fO
+fO
+dj
+dj
+Nd
+Nd
+Nd
+Nd
+Nd
+OL
 Di
 Qe
 Qe
@@ -36065,36 +38724,36 @@ ue
 xL
 sk
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+dY
+dY
+dY
+Qc
+Oi
+dB
+TA
+dI
+YC
+YC
+yQ
+Ry
+PC
+YC
+Te
+vz
+dQ
+fO
+UU
+YC
+YC
+fg
+Qc
+dY
+dY
+dY
+OL
 Di
 Qe
 Qe
@@ -36322,36 +38981,36 @@ sk
 xM
 xP
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+Qc
+dY
+dY
+dY
+UY
+Qc
+Nd
+fO
+fO
+fO
+eZ
+aA
+fO
+fO
+yR
+YC
+eJ
+vz
+dQ
+fO
+fO
+eZ
+YC
+Nd
+dY
+UY
+Qc
+dY
+OL
 Di
 Qe
 Qe
@@ -36579,36 +39238,36 @@ sk
 sk
 yl
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+Qc
+dY
+TQ
+dY
+dY
+dY
+Oi
+Og
+fs
+Sm
+YC
+YC
+fD
+fO
+fO
+eZ
+wk
+vz
+dQ
+cJ
+Ry
+YC
+YC
+fg
+dY
+Qc
+dY
+dY
+OL
 Di
 Qe
 Qe
@@ -36836,36 +39495,36 @@ sk
 sk
 ym
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+dY
+dY
+dY
+dY
+Oi
+yT
+ei
+dl
+YC
+YC
+bs
+RN
+RN
+YC
+YC
+vz
+dQ
+cJ
+Ry
+YC
+YC
+fg
+dY
+dY
+dY
+dY
+OL
 Di
 Qe
 Qe
@@ -37093,36 +39752,36 @@ sk
 ua
 yl
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+UY
+dY
+dY
+TQ
+dY
+Oi
+FA
+gi
+Sm
+YC
+YC
+bs
+RN
+RN
+YC
+YC
+hI
+cf
+fO
+fO
+eZ
+YC
+Nd
+dY
+dY
+TQ
+dY
+OL
 Di
 Di
 Di
@@ -37350,42 +40009,42 @@ sk
 sk
 yl
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+dY
+dY
+dY
+Nd
+Nd
+fO
+fO
+fO
+eZ
+YC
+fO
+fO
+fO
+fO
+OT
+bX
+Sd
+ew
+Ry
+YC
+YC
+fg
+Qc
+dY
+dY
+Qc
+OL
+OL
+OL
+OL
+OL
+OL
+OL
 aa
 aa
 aa
@@ -37607,42 +40266,42 @@ sk
 sk
 yl
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+TQ
+dY
+dY
+dY
+dY
+fg
+Zi
+wX
+fO
+bN
+YC
+YC
+cG
+SY
+Ry
+bv
+Sd
+Qo
+Sd
+JK
+Ry
+YC
+YC
+fg
+dY
+dY
+eR
+dY
+dY
+dY
+dY
+UY
+OL
+OL
+OL
 aa
 aa
 aa
@@ -37864,42 +40523,42 @@ sk
 xO
 sp
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+Qc
+dY
+Qc
+fg
+Zi
+kw
+eT
+VS
+dr
+YC
+gP
+Ra
+Ry
+bv
+vp
+fO
+UB
+Zy
+fO
+eZ
+YC
+Nd
+Qc
+dY
+dY
+dY
+dY
+TQ
+dY
+Qc
+dY
+OL
+OL
 aa
 aa
 aa
@@ -38121,42 +40780,42 @@ ui
 sp
 sk
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+dY
+UY
+Qc
+fg
+bI
+fp
+fO
+bN
+YC
+YC
+yP
+Nf
+Ry
+bv
+Sd
+TX
+Sd
+es
+Ry
+YC
+aA
+Nd
+fg
+fg
+Nd
+dY
+dY
+dY
+dY
+dY
+UY
+UY
+OL
 aa
 aa
 aa
@@ -38378,42 +41037,42 @@ ng
 ng
 ng
 ng
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+dY
+dY
+TQ
+dY
+dY
+Nd
+Nd
+fO
+fO
+fO
+eZ
+YC
+fO
+fO
+fO
+fO
+Vo
+ba
+Sd
+ew
+Ry
+YC
+YC
+QL
+HL
+UG
+Nd
+XU
+gW
+NB
+XU
+NB
+gW
+XU
+OL
 aa
 aa
 aa
@@ -38635,42 +41294,42 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+OL
+dY
+dY
+dY
+dY
+dY
+Oi
+ex
+hX
+Sm
+YC
+YC
+bs
+RN
+RN
+YC
+YC
+NF
+QJ
+fO
+fO
+eZ
+YC
+Uz
+dq
+dq
+MO
+NB
+NB
+NB
+NB
+NB
+NB
+NB
+OL
 aa
 aa
 aa
@@ -38893,41 +41552,41 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+OL
+Qc
+UY
+dY
+dY
+dY
+Oi
+MW
+Xr
+SP
+YC
+YC
+bs
+RN
+RN
+YC
+YC
+Dl
+dQ
+xF
+Ry
+YC
+YC
+Uz
+dq
+dq
+MO
+NB
+NB
+NB
+NB
+NB
+NB
+NB
+OL
 aa
 aa
 aa
@@ -39150,41 +41809,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
+OL
+dY
+TQ
+dY
+Qc
+Oi
+dB
+hg
+Sm
+YC
+aA
+fO
+fO
+fO
+eZ
+YC
+Rp
+dQ
+Ml
+Ry
+YC
+YC
+QL
+FV
+VR
 Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-aa
+NB
+gW
+XU
+NB
+NB
+gW
+XU
+OL
 aa
 aa
 aa
@@ -39408,40 +42067,40 @@ aa
 aa
 aa
 aa
-aa
+OL
+dY
+dY
+dY
+dY
 Nd
-PO
-PO
-PO
-Sw
-PO
-PO
-PO
+fO
+fO
+fO
+eZ
+YC
+bS
+Ry
+gH
+YC
+YC
+al
+dQ
+fO
+fO
+YC
+aA
 Nd
-QI
-VA
-Op
+fg
+fg
 Nd
-Rm
-Tn
-UT
-yd
-CT
-CT
-XM
-NT
-ig
-CV
-CT
-NT
-CT
-oV
-CT
-CT
-oV
-CT
-Nd
-aa
+dY
+dY
+dY
+dY
+UY
+dY
+Qc
+OL
 aa
 aa
 aa
@@ -39665,40 +42324,40 @@ aa
 aa
 aa
 aa
-aa
+OL
+dY
+dY
+UY
+dY
+Oi
+Og
+fb
+Sm
+YC
+YC
+hB
+Ry
+cP
+YC
+YC
+vz
+dQ
+aH
+fO
+YC
+YC
 Nd
-HQ
-PY
-PY
-PY
-PY
-PY
-PY
-Nd
-qH
-ZW
-ZW
-Za
-CT
-CT
-CT
-Tu
-CT
-CT
-Tn
-NT
-Zs
-CT
-CT
-NT
-CT
-CT
-CT
-CT
-CT
-CT
-Nd
-aa
+Qc
+Qc
+dY
+dY
+dY
+dY
+TQ
+dY
+dY
+dY
+OL
 aa
 aa
 aa
@@ -39922,40 +42581,40 @@ aa
 aa
 aa
 aa
-aa
+OL
+TQ
+dY
+dY
+dY
+Oi
+yT
+ei
+RE
+YC
+YC
+fO
+fO
+fO
+hy
+hy
+fO
+fO
+fO
+fO
+hy
+hy
 Nd
-Mu
-QH
-Bo
-vs
-Rj
-PI
-Rd
-Nd
-Pa
-ZW
-ZW
-Nd
-CT
-CT
-CT
-CT
-CT
-CT
-GY
-NT
-ig
-CV
-CT
-NT
-CT
-CT
-CT
-CT
-CT
-HH
-Nd
-aa
+Qc
+UY
+dY
+dY
+TQ
+dY
+dY
+dY
+Qc
+eR
+OL
 aa
 aa
 aa
@@ -40178,41 +42837,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
+OL
+dY
+dY
+dY
+Qc
+Oi
+FA
+gi
+Sm
+WA
+WA
+fO
+eo
+QQ
+YC
+YC
+QL
+GA
+GA
+QL
+YC
+YC
+Oi
+UY
+dY
 Nd
-PY
-PY
-PY
-PY
-PY
-PY
-PY
 Nd
-SB
-ZW
-Nw
 Nd
-CT
-CT
-CT
-Ph
-CT
-Tu
-Vu
 Nd
-Gs
-CT
-CT
-WY
-CT
-CT
-CT
-CT
-CT
-CT
 Nd
-aa
+Nd
+Nd
+OL
+OL
 aa
 aa
 aa
@@ -40435,41 +43094,41 @@ aa
 aa
 aa
 aa
-aa
-aa
-Nd
-PY
-NJ
-SW
-PY
-Um
-Nn
-PY
+OL
+dY
+dY
+dY
+dY
+TQ
 Nd
 Nd
 Nd
 Nd
+fg
+fg
 Nd
-CT
-CT
-XM
+Nd
+Nd
+YC
+YC
 QL
-CT
-CT
-XM
-NT
-PX
-CV
-CT
-NT
-CT
-CT
-CT
-CT
-CT
-HH
+GA
+XY
+QL
+YC
+YC
+Oi
+dY
+dY
 Nd
-aa
+XA
+cQ
+RG
+Tg
+Mn
+Nd
+OL
+OL
 aa
 aa
 aa
@@ -40692,41 +43351,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
+TQ
+UY
+Qc
+dY
+dY
+dY
+dY
+UY
+Qc
+dY
+dY
+dY
+Qc
+Oi
+YC
+YC
+QL
+GA
+GA
+QL
+YC
+YC
 Nd
+dY
+Qc
 Nd
+gd
+Pn
+Pn
+Qr
+ie
 Nd
-Nd
-XL
-Nd
-Nd
-py
-Nd
-CT
-oV
-CT
-XL
-CT
-CT
-Tn
-Tu
-CT
-CT
-Tn
-NT
-Ms
-CT
-CT
-NT
-CT
-CT
-CT
-CT
-CT
-CT
-Nd
-aa
+OL
+OL
 aa
 aa
 aa
@@ -40949,41 +43608,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
+dY
+dY
+Qc
+Qc
+dY
+dY
+dY
+dY
+Qc
+Qc
+dY
+UY
+dY
+Oi
+YC
+YC
+QL
+GA
+Os
+QL
+YC
+YC
 Nd
-PL
-CT
-oV
-CT
-CT
-CT
-CT
-Yh
-CT
+fg
+fg
 Nd
+bi
+Pn
+Pn
+Pn
+NS
 Nd
-Nd
-Gs
-CT
-GY
-Tu
-CT
-CT
-GY
-NT
-Ym
-CV
-CT
-NT
-CT
-Qu
-CT
-CT
-Qu
-CT
-Nd
-aa
+OL
+OL
 aa
 aa
 aa
@@ -41206,41 +43865,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
 Nd
-Tq
-CT
-MG
-YN
+fg
+fM
+fg
 Nd
-Vm
-Fh
-zV
+fg
+fg
+fg
+fg
+Nd
+fg
+fg
+fg
+Nd
+eZ
+YC
+fO
+Ry
+Ry
+fO
+eZ
+YC
+fO
+Cn
+vr
+fO
+TI
+Qm
+TI
+fO
+fO
 Nd
 Nd
-Fa
-KT
-CT
-CT
-CT
-CT
-CT
-CT
-HH
-Nd
-CT
-CT
-CT
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-aa
+OL
 aa
 aa
 aa
@@ -41463,41 +44122,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
 Nd
-CT
-CT
-Rh
-Mm
+cx
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+NX
+YC
+YC
+NX
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+Kz
+fO
+UF
+Pd
 Nd
-MT
-Fh
-Yu
-Nd
-Fb
-Sd
-KT
-CT
-CT
-Sd
-Sd
-Sd
-Sd
-Sd
-Re
-CT
-CT
-CT
-NT
-vt
-YV
-OU
-OU
-RS
-VF
-Nd
-aa
+OL
 aa
 aa
 aa
@@ -41720,41 +44379,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
 Nd
-CT
-CT
-Rh
-hn
+Zn
+YC
+YC
+Ys
+YC
+YC
+YC
+YC
+Ys
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+YC
+cN
+Pn
+av
 Nd
-Pr
-Fh
-QW
-Nd
-Fc
-Sd
-KT
-CT
-CT
-Sd
-Sd
-Sd
-Sd
-Sd
-Nd
-Gs
-Zx
-CT
-MK
-CT
-CT
-CT
-CT
-CT
-CT
-Nd
-aa
+OL
 aa
 aa
 aa
@@ -41977,41 +44636,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
+Nd
+TI
+Ou
+TI
+fO
+TI
+MH
+MH
+TI
+fO
+TI
+Dw
+TI
+fO
+Ry
+Ry
+fO
+Ry
+Ry
+fO
+TI
+Dw
+TI
+fO
+TI
+TI
+dk
+dk
+TI
+fO
+fO
 Nd
 Nd
-XL
-Nd
-Nd
-Nd
-JE
-Fh
-YQ
-Nd
-MR
-Sd
-FW
-CT
-CT
-Sd
-Sd
-Sd
-Sd
-Sd
-Re
-CT
-CT
-CT
-NT
-PQ
-XM
-CT
-XM
-XM
-CT
-Nd
-aa
+OL
 aa
 aa
 aa
@@ -42234,41 +44893,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
 Nd
-yM
-CT
-oV
-CT
+Qt
+hr
+Qt
+fO
+Iy
+Zt
+Zt
+Iy
+fO
+cH
+hb
+Vj
+fO
+WC
+es
+WB
+es
+bu
+fO
+Pf
+hb
+cH
+fO
+Oe
+yg
+yg
+yg
+yg
+Ql
+dm
 Nd
-SG
-Fh
-Vv
-Nd
-Nd
-Sd
-FX
-CT
-CT
-CT
-CT
-CT
-CT
-HH
-Nd
-UJ
-Ud
-Ud
-NT
-RM
-Po
-Rw
-Po
-ZU
-CT
-Nd
-aa
+OL
+OL
 aa
 aa
 aa
@@ -42491,41 +45150,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
 Nd
-OG
-CT
-CT
-CT
+hr
+ZL
+hr
+fO
+Zt
+Zt
+Zt
+Zt
+fO
+Rk
+gV
+hb
+Up
+AG
+AG
+AG
+AG
+AG
+Up
+hb
+Sa
+ge
+fO
+UC
+XR
+XR
+XR
+XR
+fo
+WH
 Nd
-zX
-Fh
-pS
-Nd
-Nd
-Nd
-Nd
-Gs
-CT
-XM
-Tu
-CT
-CT
-XM
-NT
-CT
-Ud
-Ud
-NT
-Wm
-Sd
-Sd
-Sd
-MM
-CT
-Nd
-aa
+OL
+OL
 aa
 aa
 aa
@@ -42748,41 +45407,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
 Nd
-TK
-CT
-CT
-CT
+Nj
+FY
+et
+fO
+Zt
+Zt
+Zt
+Zt
+fO
+dt
+hb
+Vj
+fO
+bT
+es
+es
+es
+es
+fO
+Pf
+hb
+dt
+fO
+bw
+Tk
+dv
+Mm
+Mm
+hw
+Tk
 Nd
-QA
-Fh
-Nv
-ED
-oV
-Yf
-UE
-CT
-CT
-Tn
-Xd
-CT
-CT
-Tn
-NT
-yV
-Ud
-Ud
-NT
-Wm
-Sd
-Sd
-Sd
-MM
-xB
-Nd
-aa
+OL
+OL
 aa
 aa
 aa
@@ -43005,41 +45664,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
 Nd
-YL
-CT
-CT
-CT
+Qt
+dS
+Qt
+fO
+Ta
+Yx
+Pi
+zU
+fO
+TI
+RY
+TI
+fO
+Tv
+Tv
+Tv
+Tv
+Tv
+fO
+TI
+FU
+TI
+fO
+Zu
+Mm
+Mm
+gZ
+Tk
+hw
+Tk
 Nd
-Xo
-Fh
-Fh
-py
-CT
-Ya
-UE
-CT
-CT
-GY
-Tu
-CT
-CT
-GY
-NT
-wf
-Ud
-Ud
-NT
-Wm
-Sd
-Sd
-Sd
-MM
-CT
-Nd
-aa
+OL
+OL
 aa
 aa
 aa
@@ -43262,41 +45921,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
 Nd
-Xe
-CT
-CT
-CT
 Nd
-TB
-Fh
-Fh
-BV
-CT
-Fe
-UE
-CT
-CT
-CT
-Ph
-CT
-Qk
-Vu
 Nd
-Gs
-Ud
-Ud
-NT
-Mw
-PA
-TC
-PA
-Pl
-CT
 Nd
-aa
+Nd
+Nc
+OF
+ep
+zW
+fO
+QD
+Zt
+Iy
+RL
+TM
+Pi
+Yx
+Pi
+zU
+RL
+Iy
+Zt
+QD
+fO
+OZ
+Mm
+Mm
+az
+TF
+hw
+Tk
+Nd
+OL
+OL
 aa
 aa
 aa
@@ -43519,41 +46178,41 @@ aa
 aa
 aa
 aa
-aa
-aa
+OL
 Nd
-Ny
-CT
-CT
-CT
+OL
+OL
+OL
 Nd
-Vz
-Fh
-YJ
-QT
-CT
-Ya
-UE
-CT
-CT
-CT
-CT
-CT
-CT
-XM
-NT
-CT
-CT
-CT
-NT
-Yq
-GY
-CT
-GY
-GY
-CT
+hL
+PD
+cv
+fu
+fO
+XN
+Zt
+Zt
+bC
+UZ
+ep
+OF
+ep
+AD
+RL
+fK
+Zt
+SL
+fO
+Tk
+gZ
+Mm
+eU
+Mm
+hw
+Tk
 Nd
-aa
+Nd
+OL
 aa
 aa
 aa
@@ -43778,39 +46437,39 @@ aa
 aa
 aa
 aa
-Nd
-Bs
-Ri
-CT
-CT
-XL
-Fh
-Fh
-Fh
-XL
-CT
-Qj
-UE
-CT
-CT
-CT
-Tu
-CT
-CT
-Tn
-NT
-CT
-CT
-CT
-MK
-CT
-CT
-CT
-CT
-CT
-CT
-Nd
 aa
+aa
+aa
+Nd
+Bk
+dT
+dM
+ZY
+fO
+df
+Zt
+ed
+RL
+Zk
+OF
+ep
+OF
+ic
+RL
+fK
+Zt
+Rf
+fO
+MC
+MC
+MC
+fO
+Qi
+eb
+eW
+Gt
+Nd
+OL
 aa
 aa
 aa
@@ -44035,39 +46694,39 @@ aa
 aa
 aa
 aa
-Nd
-SU
-CT
-Qu
-Nm
-Nd
-SN
-pV
-Tr
-Nd
-Fj
-Nd
-Nd
-Fi
-Tn
-UT
-Hm
-CT
-CT
-GY
-NT
-CT
-CT
-CT
-NT
-vt
-Mx
-Qg
-Tb
-Uh
-tW
-Nd
 aa
+aa
+aa
+Nd
+fg
+fg
+fg
+fg
+Nd
+gk
+Zt
+ed
+RL
+UZ
+ep
+OF
+ep
+AD
+fI
+Zt
+Zt
+XO
+Nd
+Nd
+Nd
+Nd
+Nd
+TS
+yg
+yg
+ZZ
+Nd
+OL
 aa
 aa
 aa
@@ -44292,39 +46951,39 @@ aa
 aa
 aa
 aa
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
-Nd
 aa
+aa
+aa
+Nd
+OL
+OL
+OL
+OL
+Nd
+fg
+fg
+fg
+Nd
+cE
+cv
+PD
+cv
+XF
+Nd
+fg
+fg
+fg
+Nd
+dY
+Qc
+dY
+Nd
+QC
+uI
+Ov
+MX
+Nd
+OL
 aa
 aa
 aa
@@ -44557,31 +47216,31 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+OL
+OL
+OL
+Nd
+fg
+fg
+fg
+fg
+fg
+Nd
+OL
+OL
+OL
+Nd
+OL
+OL
+OL
+Nd
+fg
+fg
+fg
+fg
+Nd
+OL
 aa
 aa
 aa
@@ -47395,38 +50054,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
 aa
 aa
 aa
@@ -47652,38 +50311,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+PO
+PO
+PO
+Sw
+PO
+PO
+PO
+Nd
+QI
+VA
+Op
+Nd
+Rm
+Tn
+UT
+yd
+CT
+CT
+XM
+NT
+ig
+CV
+CT
+NT
+CT
+oV
+CT
+CT
+oV
+CT
+Nd
 aa
 aa
 aa
@@ -47909,38 +50568,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+HQ
+PY
+PY
+PY
+PY
+PY
+PY
+Nd
+qH
+ZW
+ZW
+Za
+CT
+CT
+CT
+Tu
+CT
+CT
+Tn
+NT
+Zs
+CT
+CT
+NT
+CT
+CT
+CT
+CT
+CT
+CT
+Nd
 aa
 aa
 aa
@@ -48166,38 +50825,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Mu
+QH
+Bo
+vs
+Rj
+PI
+Rd
+Nd
+Pa
+ZW
+ZW
+Nd
+CT
+CT
+CT
+CT
+CT
+CT
+GY
+NT
+ig
+CV
+CT
+NT
+CT
+CT
+CT
+CT
+CT
+HH
+Nd
 aa
 aa
 aa
@@ -48423,38 +51082,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+PY
+PY
+PY
+PY
+PY
+PY
+PY
+Nd
+SB
+ZW
+Nw
+Nd
+CT
+CT
+CT
+Ph
+CT
+Tu
+Vu
+Nd
+Gs
+CT
+CT
+WY
+CT
+CT
+CT
+CT
+CT
+CT
+Nd
 aa
 aa
 aa
@@ -48680,38 +51339,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+PY
+NJ
+SW
+PY
+Um
+Nn
+PY
+Nd
+Nd
+Nd
+Nd
+Nd
+CT
+CT
+XM
+QL
+CT
+CT
+XM
+NT
+PX
+CV
+CT
+NT
+CT
+CT
+CT
+CT
+CT
+HH
+Nd
 aa
 aa
 aa
@@ -48937,38 +51596,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Nd
+Nd
+Nd
+XL
+Nd
+Nd
+py
+Nd
+CT
+oV
+CT
+XL
+CT
+CT
+Tn
+Tu
+CT
+CT
+Tn
+NT
+Ms
+CT
+CT
+NT
+CT
+CT
+CT
+CT
+CT
+CT
+Nd
 aa
 aa
 aa
@@ -49194,38 +51853,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+PL
+CT
+oV
+CT
+CT
+CT
+CT
+Yh
+CT
+Nd
+Nd
+Nd
+Gs
+CT
+GY
+Tu
+CT
+CT
+GY
+NT
+Ym
+CV
+CT
+NT
+CT
+Qu
+CT
+CT
+Qu
+CT
+Nd
 aa
 aa
 aa
@@ -49451,38 +52110,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Tq
+CT
+MG
+YN
+Nd
+Vm
+Fh
+zV
+Nd
+Nd
+Fa
+KT
+CT
+CT
+CT
+CT
+CT
+CT
+HH
+Nd
+CT
+CT
+CT
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
 aa
 aa
 aa
@@ -49708,38 +52367,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+CT
+CT
+Rh
+Mm
+Nd
+MT
+Fh
+Yu
+Nd
+Fb
+Sd
+KT
+CT
+CT
+Sd
+Sd
+Sd
+Sd
+Sd
+Re
+CT
+CT
+CT
+NT
+vt
+YV
+OU
+OU
+RS
+VF
+Nd
 aa
 aa
 aa
@@ -49965,38 +52624,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+CT
+CT
+Rh
+hn
+Nd
+Pr
+Fh
+QW
+Nd
+Fc
+Sd
+KT
+CT
+CT
+Sd
+Sd
+Sd
+Sd
+Sd
+Nd
+Gs
+Zx
+CT
+MK
+CT
+CT
+CT
+CT
+CT
+CT
+Nd
 aa
 aa
 aa
@@ -50222,38 +52881,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Nd
+XL
+Nd
+Nd
+Nd
+JE
+Fh
+YQ
+Nd
+MR
+Sd
+FW
+CT
+CT
+Sd
+Sd
+Sd
+Sd
+Sd
+Re
+CT
+CT
+CT
+NT
+PQ
+XM
+CT
+XM
+XM
+CT
+Nd
 aa
 aa
 aa
@@ -50479,38 +53138,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+yM
+CT
+oV
+CT
+Nd
+SG
+Fh
+Vv
+Nd
+Nd
+Sd
+FX
+CT
+CT
+CT
+CT
+CT
+CT
+HH
+Nd
+UJ
+Ud
+Ud
+NT
+RM
+Po
+Rw
+Po
+ZU
+CT
+Nd
 aa
 aa
 aa
@@ -50736,38 +53395,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+OG
+CT
+CT
+CT
+Nd
+zX
+Fh
+pS
+Nd
+Nd
+Nd
+Nd
+Gs
+CT
+XM
+Tu
+CT
+CT
+XM
+NT
+CT
+Ud
+Ud
+NT
+Wm
+Sd
+Sd
+Sd
+MM
+CT
+Nd
 aa
 aa
 aa
@@ -50993,38 +53652,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+TK
+CT
+CT
+CT
+Nd
+QA
+Fh
+Nv
+ED
+oV
+Yf
+UE
+CT
+CT
+Tn
+Xd
+CT
+CT
+Tn
+NT
+yV
+Ud
+Ud
+NT
+Wm
+Sd
+Sd
+Sd
+MM
+xB
+Nd
 aa
 aa
 aa
@@ -51250,38 +53909,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+YL
+CT
+CT
+CT
+Nd
+Xo
+Fh
+Fh
+py
+CT
+Ya
+UE
+CT
+CT
+GY
+Tu
+CT
+CT
+GY
+NT
+wf
+Ud
+Ud
+NT
+Wm
+Sd
+Sd
+Sd
+MM
+CT
+Nd
 aa
 aa
 aa
@@ -51507,38 +54166,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Xe
+CT
+CT
+CT
+Nd
+TB
+Fh
+Fh
+BV
+CT
+Fe
+UE
+CT
+CT
+CT
+Ph
+CT
+Qk
+Vu
+Nd
+Gs
+Ud
+Ud
+NT
+Mw
+PA
+TC
+PA
+Pl
+CT
+Nd
 aa
 aa
 aa
@@ -51764,38 +54423,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Ny
+CT
+CT
+CT
+Nd
+Vz
+Fh
+YJ
+QT
+CT
+Ya
+UE
+CT
+CT
+CT
+CT
+CT
+CT
+XM
+NT
+CT
+CT
+CT
+NT
+Yq
+GY
+CT
+GY
+GY
+CT
+Nd
 aa
 aa
 aa
@@ -52021,38 +54680,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Bs
+Ri
+CT
+CT
+XL
+Fh
+Fh
+Fh
+XL
+CT
+Qj
+UE
+CT
+CT
+CT
+Tu
+CT
+CT
+Tn
+NT
+CT
+CT
+CT
+MK
+CT
+CT
+CT
+CT
+CT
+CT
+Nd
 aa
 aa
 aa
@@ -52278,38 +54937,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+SU
+CT
+Qu
+Nm
+Nd
+SN
+pV
+Tr
+Nd
+Fj
+Nd
+Nd
+Fi
+Tn
+UT
+Hm
+CT
+CT
+GY
+NT
+CT
+CT
+CT
+NT
+vt
+Mx
+Qg
+Tb
+Uh
+tW
+Nd
 aa
 aa
 aa
@@ -52535,38 +55194,38 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
+Nd
 aa
 aa
 aa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -393,6 +393,7 @@
 /obj/item/reagent_containers/medigel/synthflesh,
 /obj/item/organ/heart/cybernetic/tier2,
 /obj/item/organ/heart/cybernetic/tier2,
+/obj/item/defibrillator,
 /turf/open/floor/sepia,
 /area/centcom/holding)
 "cJ" = (
@@ -640,6 +641,7 @@
 	pixel_x = 11
 	},
 /obj/structure/mirror/directional/east,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/holding)
 "ep" = (
@@ -891,6 +893,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/tdome/arena_source)
+"fA" = (
+/obj/machinery/light/floor{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
+/area/centcom/holding)
 "fD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -9062,6 +9073,11 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/centcom/supplypod/loading/two)
+"zv" = (
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
+/area/centcom/holding)
 "zx" = (
 /obj/structure/closet/syndicate/personal,
 /obj/effect/turf_decal/stripes/line{
@@ -12185,7 +12201,13 @@
 /turf/open/lava/airless,
 /area/wizard_station)
 "GA" = (
-/turf/open/floor/plating/ashplanet/wateryrock,
+/obj/machinery/light/floor{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/centcom/holding)
 "GC" = (
 /obj/structure/table,
@@ -14750,7 +14772,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/plating/ashplanet/wateryrock,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/centcom/holding)
 "MD" = (
 /obj/effect/light_emitter{
@@ -15066,7 +15090,13 @@
 	pixel_x = -12;
 	pixel_y = 15
 	},
-/turf/open/floor/plating/ashplanet/wateryrock,
+/obj/machinery/light/floor{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/centcom/holding)
 "Ou" = (
 /obj/effect/turf_decal/siding/wood{
@@ -15525,7 +15555,9 @@
 /turf/open/floor/wood/tile,
 /area/centcom/holding)
 "Rt" = (
-/turf/open/water,
+/turf/open/water{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/centcom/holding)
 "Ru" = (
 /obj/effect/turf_decal/stripes/line{
@@ -16132,6 +16164,15 @@
 	dir = 4
 	},
 /area/centcom/holding)
+"Va" = (
+/obj/machinery/light/floor{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
+/area/centcom/holding)
 "Vc" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/iron/dark,
@@ -16510,7 +16551,9 @@
 /obj/structure/flora/rock/pile/largejungle{
 	pixel_y = -3
 	},
-/turf/open/floor/plating/ashplanet/wateryrock,
+/turf/open/floor/plating/ashplanet/wateryrock{
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
+	},
 /area/centcom/holding)
 "Yn" = (
 /turf/closed/indestructible/riveted,
@@ -41859,7 +41902,7 @@ YC
 YC
 QL
 GA
-GA
+Va
 QL
 YC
 YC
@@ -42115,7 +42158,7 @@ Nd
 YC
 YC
 QL
-GA
+zv
 XY
 QL
 YC
@@ -42372,8 +42415,8 @@ Oi
 YC
 YC
 QL
-GA
-GA
+zv
+zv
 QL
 YC
 YC
@@ -42629,7 +42672,7 @@ Oi
 YC
 YC
 QL
-GA
+fA
 Os
 QL
 YC

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -41,6 +41,25 @@
 	icon = 'icons/turf/shuttleold.dmi'
 	icon_state = "block"
 
+/turf/closed/indestructible/weeb
+	name = "paper wall"
+	desc = "Reinforced paper walling. Someone really doesn't you to leave."
+	icon = 'icons/obj/smooth_structures/paperframes.dmi'
+	icon_state = "paperframes-0"
+	base_icon_state = "paperframes"
+	smoothing_flags = SMOOTH_BITMASK
+	smoothing_groups = list(SMOOTH_GROUP_PAPERFRAME)
+	canSmoothWith = list(SMOOTH_GROUP_PAPERFRAME)
+	var/static/mutable_appearance/indestructible_paper = mutable_appearance('icons/obj/smooth_structures/paperframes.dmi',icon_state = "paper", layer = CLOSED_TURF_LAYER - 0.1)
+
+/turf/closed/indestructible/weeb/Initialize(mapload)
+	. = ..()
+	update_appearance()
+
+/turf/closed/indestructible/weeb/update_overlays()
+	. = ..()
+	. += indestructible_paper
+
 /turf/closed/indestructible/sandstone
 	name = "sandstone wall"
 	desc = "A wall with sandstone plating. Rough."


### PR DESCRIPTION
## About The Pull Request

When it comes to mapping this year, I believe we have done an absolutely fantastic job with bringing our stations into 2021. Everyone who has had a hand in that seriously deserves a pat on the back because you have all done amazing work. You have done so well, in fact that some of our older maps in comparison, feel seriously out of place. Some of these aren't a problem, yet. That's more due to a lack of use if anything though (I'm looking at you, Gateway Missions). Some of them, are engaged with by our players pretty often, and thus deserve some attention. This PR falls under the latter. 

## Why It's Good For The Game

Maps are the foremost thing that immerse our players in the game world. They are the metaphorical stage to /tgstations/ play. When maps look out of place, like they don't belong in the game anymore, it can sour the overall experience. The Holding Facility is a map that players engage with on a consistent enough basis to warrant a revisit. This updated version promises to be more fun to explore, while providing a tad bit more for enterprising players to do. 


![Holding Facility Done](https://user-images.githubusercontent.com/33048583/135587539-d13c50a0-a989-43cc-99d5-aae9a8722f5f.png)

## Changelog

:cl:
expansion: Remaps the Holding Facility into 2021 Standards
code: Indestructible paper wall support. It's better than the alternative. 
/:cl:
