### PR TITLE
Fixing Lavaland Mining Shuttle 

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -617,6 +617,7 @@
 	name = "Mining Shuttle Airlock";
 	opacity = 0
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/production)
 "ck" = (
@@ -626,6 +627,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/production)
 "cl" = (
@@ -4500,6 +4502,7 @@
 	name = "Mining Shuttle Airlock";
 	opacity = 0
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/production)
 "WQ" = (
@@ -18983,7 +18986,7 @@ aj
 aj
 ab
 br
-bP
+Rx
 br
 ab
 aj
@@ -19754,7 +19757,7 @@ Gh
 bn
 bC
 Lu
-bP
+Rx
 cl
 cH
 cO


### PR DESCRIPTION

## About The Pull Request

Added a few cables to Lavaland Mining leading up to the mining shuttle so it can charge while in Lavaland, fixes #61825

## Why It's Good For The Game

Makes so that miners aren't stranded on lavaland and being forced to add cables to the structure. 

:cl:
fix: Added a few cables to Lavaland Mining for charging
/:cl:

