### PR TITLE
Abandoned Zoo ruin: Fix tile duplication

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -594,15 +594,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/abandonedzoo)
 "LD" = (
-/obj/machinery/power/apc/unlocked{
-	dir = 8;
-	environ = 0;
-	lighting = 0;
-	name = "Worn-out APC";
-	pixel_x = -25
-	},
 /obj/structure/rack,
-/obj/item/melee/baton/security/cattleprod,
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
 /obj/machinery/power/apc/unlocked{
@@ -612,9 +604,7 @@
 	name = "Worn-out APC";
 	pixel_x = -25
 	},
-/obj/structure/rack,
 /obj/item/melee/baton/security/cattleprod,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "Mb" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The abandoned zoo space ruin had a tile which contained two copies of an APC, rack, stun prod, and wire cable. This removes one of each, fixing warnings about APCs and powernets. The duplicate stun prod isn't inherently an issue, but with everything else duplicated, it seemed likely that this was accidental too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fewer warnings, fewer broken invariants

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The Abandoned Zoo ruin no longer has duplicate copies of an APC, power cable, and rack on the same tile.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
