### PR TITLE
Fix old photos being lost(?)

### DIFF
--- a/code/modules/photography/_pictures.dm
+++ b/code/modules/photography/_pictures.dm
@@ -105,7 +105,13 @@
 	if(!json[id])
 		return
 	var/datum/picture/P = new
-	P.deserialize_list(json[id])
+
+	// Old photos were saved as, and I shit you not, encoded JSON strings.
+	if (istext(json[id]))
+		P.deserialize_json(json[id])
+	else
+		P.deserialize_list(json[id])
+
 	return P
 
 /proc/log_path_from_picture_ID(id)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes old photos in the old braindead saving system not saving. I have a backup of some photo saves starting now, but can't promise anything, and if you lost them, they're probably just gone.

Finding this bug would've required some insanely frustrating testing, so I'm not too bent up about it.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Old photos from persistent photo albums will now no longer be lost.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
