### PR TITLE
(Maybe) fixes panic-bunker rejecting people it shouldn't when interviews is enabled

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -336,9 +336,7 @@
 
 /datum/config_entry/flag/panic_bunker // prevents people the server hasn't seen before from connecting
 
-/// Living time in minutes that a player needs to pass the panic bunker. Defaults to -1 (no one without a DB entry can connect).
-/datum/config_entry/number/panic_bunker_living
-	default = -1
+/datum/config_entry/number/panic_bunker_living // living time in minutes that a player needs to pass the panic bunker
 
 /// Flag for requiring players who would otherwise be denied access by the panic bunker to complete a written interview
 /datum/config_entry/flag/panic_bunker_interview

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -336,7 +336,9 @@
 
 /datum/config_entry/flag/panic_bunker // prevents people the server hasn't seen before from connecting
 
-/datum/config_entry/number/panic_bunker_living // living time in minutes that a player needs to pass the panic bunker
+/// Living time in minutes that a player needs to pass the panic bunker. Defaults to -1 (no one without a DB entry can connect).
+/datum/config_entry/number/panic_bunker_living
+	default = -1
 
 /// Flag for requiring players who would otherwise be denied access by the panic bunker to complete a written interview
 /datum/config_entry/flag/panic_bunker_interview

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -571,7 +571,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		return
 
 	var/client_is_in_db = query_client_in_db.NextRow()
-	// If we aren't an admin, and the flag is set / the panic bunker is enabled.
+	// If we aren't an admin, and the flag is set (the panic bunker is enabled).
 	if(CONFIG_GET(flag/panic_bunker) && !holder && !GLOB.deadmins[ckey])
 		// The amount of hours needed to bypass the panic bunker.
 		var/living_recs = CONFIG_GET(number/panic_bunker_living)
@@ -581,7 +581,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		// Check to see if our client should be rejected.
 		// If interviews are on, we should let anyone through, ideally.
 		if(!CONFIG_GET(flag/panic_bunker_interview))
-			// This client was rejected and is not allowed to join.
+			// If we don't have panic_bunker_living set and the client is not in the DB, reject them.
+			// Otherwise, if we do have a panic_bunker_living set, check if they have enough minutes played.
 			if((!living_recs && !client_is_in_db) || living_recs >= minutes)
 				var/reject_message = "Failed Login: [key] - [client_is_in_db ? "":"New "]Account attempting to connect during panic bunker, but\
 					[living_recs == -1 ? " was rejected due to no prior connections to game servers (no database entry)":" they do not have the required living time [minutes]/[living_recs]"]."

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -571,14 +571,34 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		return
 
 	var/client_is_in_db = query_client_in_db.NextRow()
-	//If we aren't an admin, and the flag is set
+	// If we aren't an admin, and the flag is set / the panic bunker is enabled.
 	if(CONFIG_GET(flag/panic_bunker) && !holder && !GLOB.deadmins[ckey])
+		// The amount of hours needed to bypass the panic bunker. If -1, no value is set.
 		var/living_recs = CONFIG_GET(number/panic_bunker_living)
-		//Relies on pref existing, but this proc is only called after that occurs, so we're fine.
+		// This relies on prefs existing, but this proc is only called after that occurs, so we're fine.
 		var/minutes = get_exp_living(pure_numeric = TRUE)
-		if((minutes < living_recs && !CONFIG_GET(flag/panic_bunker_interview)) || (isnull(living_recs) && !client_is_in_db))
+		var/reject_this_client = FALSE
+
+		// Check to see if our client should be rejected.
+		// If interviews are on, we should let anyone through, ideally.
+		if(!CONFIG_GET(flag/panic_bunker_interview))
+			// We're using the default value (for panic_bunker_living hours)
+			if(living_recs == -1)
+				// If we don't have a panic_bunker_living time set, and
+				// the person joining is not in the DB, reject them.
+				if(!client_is_in_db)
+					reject_this_client = TRUE
+
+			// We have a set living_recs value (probably, 0 to infinity)
+			else if(minutes < living_recs)
+				// If we have a panic_bunker_living time set, but
+				// panic bunker interviews are disabled, reject them.
+				reject_this_client = TRUE
+
+		// This client was rejected and is not allowed to join.
+		if(reject_this_client)
 			var/reject_message = "Failed Login: [key] - [client_is_in_db ? "":"New "]Account attempting to connect during panic bunker, but\
-			[isnull(living_recs) ? " they do not have the required living time [minutes]/[living_recs]": " was rejected"]."
+				[living_recs == -1 ? " they do not have the required living time [minutes]/[living_recs]": " was rejected"]."
 			log_access(reject_message)
 			message_admins(span_adminnotice("[reject_message]"))
 			var/message = CONFIG_GET(string/panic_bunker_message)

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -576,9 +576,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		var/living_recs = CONFIG_GET(number/panic_bunker_living)
 		//Relies on pref existing, but this proc is only called after that occurs, so we're fine.
 		var/minutes = get_exp_living(pure_numeric = TRUE)
-		if((minutes < living_recs && !CONFIG_GET(flag/panic_bunker_interview)) || (!living_recs && !client_is_in_db))
+		if((minutes < living_recs && !CONFIG_GET(flag/panic_bunker_interview)) || (isnull(living_recs) && !client_is_in_db))
 			var/reject_message = "Failed Login: [key] - [client_is_in_db ? "":"New "]Account attempting to connect during panic bunker, but\
-			[living_recs ? "they do not have the required living time [minutes]/[living_recs]": "was rejected"]"
+			[isnull(living_recs) ? " they do not have the required living time [minutes]/[living_recs]": " was rejected"]."
 			log_access(reject_message)
 			message_admins(span_adminnotice("[reject_message]"))
 			var/message = CONFIG_GET(string/panic_bunker_message)


### PR DESCRIPTION
## About The Pull Request

This pr (maybe) fixes #61383 . Testing it is difficult as I don't know how to set up a DB on local - I suggest a testmerge on Manuel? 

- If panic bunker interviews are enabled, everyone should be able to connect - either they have enough hours and don't need an interview or are a new player and will enter an interview. 
- If panic bunker interviews are disabled, we then check `panic_bunker_living`.
   - If 0, we only check for whether the client has a database entry. 
   - If a set number, we check for the client's playtime vs that number. (Players underneath the living playtime, will be prompted to fill out an interview)

#60289 made it so people who should bypass the panic bunker to enter an interview were wrongfully rejected. 

Since the default value for living time was 0, and the time we use on the game servers was 0, it ALWAYS rejected new players from entering the game, even if interviews was enabled.

## Why It's Good For The Game

I've seen SO MANY new players get bounced off the panic bunker when they should've been allowed to fill out an interview, it's tragic

## Changelog

:cl: Melbert
fix: Fixes people getting rejected by the panic bunker when they probably shouldn't have been (if you can read this, it probably doesn't affect you anymore)
/:cl: