### PR TITLE
Fix cable restraint not rendering in crafting menu

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -481,7 +481,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 	if(!user)
 		return
 
-	var/image/restraints_icon = image(icon = 'icons/obj/items_and_weapons.dmi', icon_state = "cuff")
+	var/image/restraints_icon = image(icon = 'icons/obj/restraints.dmi', icon_state = "cuff")
 	restraints_icon.maptext = MAPTEXT("<span [amount >= CABLE_RESTRAINTS_COST ? "" : "style='color: red'"]>[CABLE_RESTRAINTS_COST]</span>")
 
 	var/list/radial_menu = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixed the cable restraints not showing up in the radial crafting menu. This was caused by the cable restraint (cuff) icon being moved to the restraint.dmi file - I didn't see this old reference elsewhere in the code. (first TG commit, please let me know if I am missing anything.

Before:
![image](https://user-images.githubusercontent.com/30943236/135702268-2fad4d0c-d069-4657-a93d-d76d2763be08.png)

After:
![image](https://user-images.githubusercontent.com/30943236/135702275-4fec309b-efa5-4090-8e0e-7d3f8c6d5c81.png)


This fixes #61790

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This fix lets players see what they are crafting rather than an invisible/missing icon.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
🆑
fix: Fixed cable restraints icon being missing from the cable radial crafting menu
/🆑

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
