### PR TITLE
Fixes riding abilities by sharing action buttons.

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -12,8 +12,13 @@
 	var/ordered = TRUE //If the button gets placed into the default bar
 
 /atom/movable/screen/movable/action_button/proc/can_use(mob/user)
-	if (linked_action)
-		return linked_action.owner == user
+	if(linked_action)
+		if(linked_action.owner == user)
+			return TRUE
+		for(var/datum/weakref/reference as anything in linked_action.sharers)
+			if(IS_WEAKREF_OF(user, reference))
+				return TRUE
+		return FALSE
 	else if (isobserver(user))
 		var/mob/dead/observer/O = user
 		return !O.observetarget

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -19,6 +19,8 @@
 	var/icon_icon = 'icons/hud/actions.dmi' //This is the file for the ACTION icon
 	var/button_icon_state = "default" //And this is the state for the action icon
 	var/mob/owner
+	///All mobs that are sharing our action button.
+	var/list/sharers = list()
 
 /datum/action/New(Target)
 	link_to(Target)
@@ -78,6 +80,12 @@
 	Remove(owner)
 
 /datum/action/proc/Remove(mob/M)
+	for(var/datum/weakref/reference as anything in sharers)
+		var/mob/freeloader = reference.resolve()
+		if(!freeloader)
+			continue
+		Unshare(freeloader)
+	sharers = null
 	if(M)
 		if(M.client)
 			M.client.screen -= button
@@ -148,6 +156,25 @@
 /datum/action/proc/OnUpdatedIcon()
 	SIGNAL_HANDLER
 	UpdateButtonIcon()
+
+//Adds our action button to the screen of another player
+/datum/action/proc/Share(mob/freeloader)
+	if(!freeloader.client)
+		return
+	sharers += WEAKREF(freeloader)
+	freeloader.client.screen += button
+	freeloader.update_action_buttons()
+
+//Removes our action button from the screen of another player
+/datum/action/proc/Unshare(mob/freeloader)
+	if(!freeloader.client)
+		return
+	for(var/freeloader_reference in sharers)
+		if(IS_WEAKREF_OF(freeloader, freeloader_reference))
+			sharers -= freeloader_reference
+			break
+	freeloader.client.screen -= button
+	freeloader.update_action_buttons()
 
 //Presets for item actions
 /datum/action/item_action
@@ -672,6 +699,27 @@
 		if(next_use_time > world.time)
 			START_PROCESSING(SSfastprocess, src)
 
+///Like a cooldown action, but with an associated proc holder.
+/datum/action/cooldown/spell_like
+
+/datum/action/cooldown/spell_like/New(Target)
+	..()
+	var/obj/effect/proc_holder/our_proc_holder = target
+	our_proc_holder.action = src
+	name = our_proc_holder.name
+	desc = our_proc_holder.desc
+	icon_icon = our_proc_holder.action_icon
+	button_icon_state = our_proc_holder.action_icon_state
+	background_icon_state = our_proc_holder.action_background_icon_state
+	button.name = name
+
+/datum/action/cooldown/spell_like/Trigger()
+	if(!..())
+		return FALSE
+	if(target)
+		var/obj/effect/proc_holder/our_proc_holder = target
+		our_proc_holder.Click()
+		return TRUE
 
 //Stickmemes
 /datum/action/item_action/stickmen

--- a/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
@@ -54,8 +54,16 @@
 	action_icon_state = "tentacle_slap"
 	action_background_icon_state = "bg_revenant"
 	ranged_mousepointer = 'icons/effects/mouse_pointers/supplypod_target.dmi'
+	base_action = /datum/action/cooldown/spell_like
+	///How long cooldown before we can use the ability again
 	var/cooldown = 12 SECONDS
-	var/current_cooldown = 0
+
+/obj/effect/proc_holder/tentacle_slap/Initialize(mapload, mob/living/new_owner)
+	. = ..()
+	if(!action)
+		return
+	var/datum/action/cooldown/our_action = action
+	our_action.cooldown_time = cooldown
 
 /obj/effect/proc_holder/tentacle_slap/Click(location, control, params)
 	. = ..()
@@ -63,14 +71,11 @@
 		return TRUE
 	fire(usr)
 
-/obj/effect/proc_holder/tentacle_slap/fire(mob/living/carbon/user)
-	if(current_cooldown > world.time)
-		to_chat(user, span_notice("This ability is still on cooldown."))
-		return
+/obj/effect/proc_holder/tentacle_slap/fire(mob/living/user)
 	if(active)
 		remove_ranged_ability(span_notice("You stop preparing to tentacle slap."))
 	else
-		add_ranged_ability(user, span_notice("You prepare your pimp-tentacle. <B>Left-click to slap a target!</B>"), TRUE)
+		add_ranged_ability(user, span_notice("You prepare [(IS_WEAKREF_OF(user, owner)) ? "your" : "their"] pimp-tentacle. <B>Left-click to slap a target!</B>"), TRUE)
 
 /obj/effect/proc_holder/tentacle_slap/InterceptClickOn(mob/living/caller, params, atom/target)
 	. = ..()
@@ -86,7 +91,7 @@
 		remove_ranged_ability()
 		return
 
-	if(!caller.Adjacent(target))
+	if(!beast_owner.Adjacent(target))
 		return
 
 	if(!isliving(target))
@@ -94,11 +99,20 @@
 
 	var/mob/living/living_target = target
 
+	if(!action.IsAvailable()) //extra check for safety since the ability is shared
+		remove_ranged_ability()
+		to_chat(caller, span_notice("This ability is still on cooldown."))
+		return
+
 	beast_owner.visible_message("<span class='warning>[beast_owner] slaps [living_target] with its tentacle!</span>", span_notice("You slap [living_target] with your tentacle."))
 	playsound(beast_owner, 'sound/effects/assslap.ogg', 90)
-	var/atom/throw_target = get_edge_target_turf(target, ranged_ability_user.dir)
+	var/atom/throw_target = get_edge_target_turf(target, beast_owner.dir)
 	living_target.throw_at(throw_target, 6, 4, beast_owner)
 	living_target.apply_damage(30)
-	current_cooldown = world.time + cooldown
 	remove_ranged_ability()
+
+	var/datum/action/cooldown/our_action = action
+	our_action.StartCooldown()
+
 	return TRUE
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes the long standing bugs with the riding ability system. 

Previously, when a riding ability was shared, the mount would permanently lose access to that ability, since Grant() removed them as the owner.

Now the rider just gets the mobs ability button added to their screen, and permission to use it. Thus both players have access to the ability simultaneously. 

This PR also changes the base action type of the tentacle slap proc holder to a new spell like cooldown action.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The new scheme allows both the rider and mount to have access to the ability simultaneously, so they can decide amongst themselves who is in charge of using the ability.

Losing your signature ability because someone tried to ride you feels like shit, especially when the point of the mob is to be ridden around like a war elephant. 

This adresses that.

The changes to the tentacle slap action also allows you to the see when the ability is on cooldown, which is a very nice QoL change that is long overdue.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: The tentacle slap ability button now goes red and displays a cooldown timer when on cooldown.
fix: Vat beasts now longer lose their ability when someone rides them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
