### PR TITLE
Use ckeys instead of keys in key name helper proc and new_player login.

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -362,7 +362,7 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
 		else
 			if(include_link)
 				. += "<a href='?priv_msg=[ckey]'>"
-			. += ckey
+			. += key
 		if(!C)
 			. += "\[DC\]"
 

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -362,7 +362,7 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
 		else
 			if(include_link)
 				. += "<a href='?priv_msg=[ckey]'>"
-			. += key
+			. += ckey
 		if(!C)
 			. += "\[DC\]"
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1,13 +1,13 @@
 ////////////////////////////////
 /proc/message_admins(msg)
-	msg = "<span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message linkify\">[msg]</span></span>"
+	msg = "<span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message\">[msg]</span></span>"
 	to_chat(GLOB.admins,
 		type = MESSAGE_TYPE_ADMINLOG,
 		html = msg,
 		confidential = TRUE)
 
 /proc/relay_msg_admins(msg)
-	msg = "<span class=\"admin\"><span class=\"prefix\">RELAY:</span> <span class=\"message linkify\">[msg]</span></span>"
+	msg = "<span class=\"admin\"><span class=\"prefix\">RELAY:</span> <span class=\"message\">[msg]</span></span>"
 	to_chat(GLOB.admins,
 		type = MESSAGE_TYPE_ADMINLOG,
 		html = msg,

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -1,7 +1,7 @@
 /mob/dead/new_player/Login()
 	if(!client)
 		return
-	name = ckey
+
 	if(CONFIG_GET(flag/use_exp_tracking))
 		client.set_exp_from_db()
 		client.set_db_player_flags()

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -1,6 +1,7 @@
 /mob/dead/new_player/Login()
 	if(!client)
 		return
+	name = ckey
 	if(CONFIG_GET(flag/use_exp_tracking))
 		client.set_exp_from_db()
 		client.set_db_player_flags()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A number of admin messaging procs will take an entire message (ckeys and all), linkify them and post them into chat. (e.g `/proc/message_admins()`
![image](https://user-images.githubusercontent.com/24975989/135728612-95edc0a3-8796-402f-8181-524c2a070447.png)

With URL ckeys, the `/proc/key_name` can create valid or not-quite-valid URLs depending on whether include_link is set.

With `include_link = TRUE`, /mob/dead/new_player names that inherit the key (BYOND sets the mob's name to their this automatically in or just before /mob/dead/new_player/Login() from what my debugging can ascertain, since we never explicitly set it) can create not-quite-valid URLs as below:
![image](https://user-images.githubusercontent.com/24975989/135728562-13558493-d145-492b-9109-c67e568081b9.png)

Where the first Www.timberpoes.com is wrapped in a href to admin PM (and is not an external URL) whereas the second is parsed as a link to `Www.timberpoes.com)` and is an external URL.

With `include_link = FALSE` we instead get a fully parsed and fully formed URL.
![image](https://user-images.githubusercontent.com/24975989/135728710-ecc85aa1-e67a-453a-8a5d-89294ae55af1.png)

Which when clicked on, sends the user to www.ckey.com/(ckey) in their browser.

As a result, I have removed linkify from the two admin messaging/relaying procs.

`/proc/message_admins()` and `/proc/relay_msg_admins()` will no longer promote anything that would previously trigger the URL regex into being linkified.

We will now assume that if a message was intended to have a clickable URL in it, that it will have already been linkified elsewhere in the code - either through being linkified already, or by having an explicit href link added to it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

No more trolling admins with URLs as key names.

No more messaging admins then linkifying keys by accident when the original message did not have admin PM functionality built into it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
admin: Admins should no longer get trolled by URL keys creating clickable links that look the same as admin PM shortcuts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
