### PR TITLE
Meta Medical Cold Room: Fix airlock properties

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -57009,7 +57009,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "sjt" = (
-/obj/machinery/door/airlock/medical,
+/obj/machinery/door/airlock/medical{
+	name = "Medical Cold Room";
+	req_access_txt = "5"
+	},
 /turf/open/floor/iron,
 /area/medical/coldroom)
 "sjF" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

MetaStation's Medical Cold Room has two airlocks, one to maintenance, and one to medbay central. The maintenance airlock is named "Medbay Maintenance" and requires `ACCESS_MEDICAL`. The main airlock had the default "airlock" name and did not have any access requirements.

This changes the interior airlock to be named "Medical Cold Room", to match the name of `/area/medial/coldroom`, and to require
`ACCESS_MEDICAL`, to match the maintenance airlock and most other medbay airlocks.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Seeing "airlock" on an opaque door to a new area makes me nervous

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The airlock to MetaStation's Medical Cold Room is now properly named and requires Medbay General access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
