### PR TITLE
Use airalarm/kitchen_cold_room where appropriate

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -17330,8 +17330,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "eJJ" = (
-/obj/machinery/airalarm/directional/west,
 /obj/structure/table,
+/obj/machinery/airalarm/kitchen_cold_room{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
 "eKm" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -58622,7 +58622,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/window/eastleft{
 	name = "Kitchen Delivery";
@@ -58630,6 +58629,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/airalarm/kitchen_cold_room{
+	pixel_y = 24
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -28421,8 +28421,10 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "imK" = (
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/icecream_vat,
+/obj/machinery/airalarm/kitchen_cold_room{
+	pixel_y = 24
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "imM" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the existing air alarm on IceBox, Meta, and Tram with the `kitchen_cold_room` variant which comes with appropriate settings.

- Delta doesn't have a kitchen cold room which is cold
- _maps/map_files/IceBoxStation/ never had a `kitchen_cold_room`
- Kilo doesn't have a kitchen cold room which is cold
- Meta lost its no-roundstart-alarms in 98d858f53
- _maps/map_files/tramstation/ never had a `kitchen_cold_room`

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Alarm fatigue bad, not that I expect people to start paying attention to the alarms any time soon

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Kitchen cold rooms which are cold (that is, those on Ice, Meta, and Tram) now have their air alarms configured to expect this.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
