### PR TITLE
Fix bow controlling dropped arrow

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -25,7 +25,7 @@
 	drawn = FALSE
 	if(chambered)
 		chambered.forceMove(drop_location())
-		chambered = magazine.get_round(keep = FALSE)
+		magazine.get_round(keep = FALSE)
 		chambered = null
 	update_appearance()
 

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -23,12 +23,10 @@
 
 /obj/item/gun/ballistic/bow/proc/drop_arrow()
 	drawn = FALSE
-	if(!chambered)
+	if(chambered)
+		chambered.forceMove(drop_location())
 		chambered = magazine.get_round(keep = FALSE)
-		return
-	if(!chambered)
-		return
-	chambered.forceMove(drop_location())
+		chambered = null
 	update_appearance()
 
 /obj/item/gun/ballistic/bow/chamber_round(keep_bullet = FALSE, spin_cylinder, replace_new_round)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When loading an arrow into a bow and firing the bow without drawing it, the arrow would drop and still be able to be dropped repeatedly, making the arrow follow the player on the ground. See before clip. Also resulted in cleaning up a pointless if statement.

Before clip:

https://user-images.githubusercontent.com/30943236/135733326-c3374db8-3d7a-4149-a99f-ec96f303a4ee.mp4

After clip:


https://user-images.githubusercontent.com/30943236/135733338-7329239f-5fda-4939-9054-d1c78b44ee29.mp4


This also fixes  #61843
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the bow work as one would expect it to, if an arrow is on the ground it can't be controlled by the bow until reloaded in the bow.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: fixed dropped arrows being controllable with the bow
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
