### PR TITLE
Adds the ability to long-term mute people from praying

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -273,7 +273,7 @@
 			break_counter = 0
 
 		var/list/other_job_lists = list(
-			"Abstract" = list("Appearance", "Emote", "Deadchat", "OOC"),
+			"Abstract" = list("Appearance", "Emote", "Deadchat", "OOC", "Pray"),
 			)
 		for(var/department in other_job_lists)
 			output += "<div class='column'><label class='rolegroup [ckey(department)]'>[tgui_fancy ? "<input type='checkbox' name='[department]' class='hidden' onClick='header_click_all_checkboxes(this)'>" : ""][department]</label><div class='content'>"

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -9,14 +9,17 @@
 	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	if(!msg)
 		return
-	log_prayer("[src.key]/([src.name]): [msg]")
 	if(usr.client)
 		if(usr.client.prefs.muted & MUTE_PRAY)
 			to_chat(usr, span_danger("You cannot pray (muted)."), confidential = TRUE)
 			return
 		if(src.client.handle_spam_prevention(msg,MUTE_PRAY))
 			return
+	if(is_banned_from(ckey, "Pray"))
+		to_chat(src, span_danger("You have been banned from praying."))
+		return
 
+	log_prayer("[src.key]/([src.name]): [msg]")
 	var/mutable_appearance/cross = mutable_appearance('icons/obj/storage.dmi', "bible")
 	var/font_color = "purple"
 	var/prayer_type = "PRAYER"


### PR DESCRIPTION
## About The Pull Request

This is basically copying what OOC uses to ban people long-term there, here.

## Why It's Good For The Game

Admins can only mute people from praying for a single round, but people who tend to get muted from prayers tend to not stop at a single round, much like OOC/Deadchat, so it would be nice for a way to ban them long-term without having to mute them every round.

## Changelog

:cl:
admin: Admins can now long-term prayer mute people.
/:cl: