### PR TITLE
People banned from playing Swarmers cannot enter the Swarmer beacon

### DIFF
--- a/code/modules/swarmers/swarmer_objs.dm
+++ b/code/modules/swarmers/swarmer_objs.dm
@@ -63,7 +63,10 @@
 /obj/structure/swarmer_beacon/attack_ghost(mob/user)
 	. = ..()
 	if(processing_swarmer)
-		to_chat(user, "<b>A swarmer is currently being created.  Try again soon.</b>")
+		to_chat(user, "<b>A swarmer is currently being created. Try again soon.</b>")
+		return
+	if(is_banned_from(user.ckey, ROLE_SWARMER))
+		to_chat(user, span_danger("You are banned from playing as a Swarmer."))
 		return
 	que_swarmer(user)
 


### PR DESCRIPTION
## About The Pull Request

If you are banned from an antag, but no ghosts take your body, you get to stay in your body.
This means that someone banned from Swarmer can keep trying to join as a Swarmer and hope no one will take over their body, to bypass their ban.
To prevent this, banned people won't be able to form a swarmer body in the first place.

## Why It's Good For The Game

Swarmer-banned players cant play as Swarmers anymore.

## Changelog

:cl:
fix: Swarmers-banned ghosts can no longer create Swarmer bodies from the beacon.
/:cl: