### PR TITLE
fixes an ice reaction oversight

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -177,4 +177,4 @@
 #define BLASTOFF_DANCE_MOVES_PER_SUPER_MOVE 3
 
 ///This is the center of a 1 degree deadband in which water will neither freeze to ice nor melt to liquid
-#define WATER_MATTERSTATE_CHANGE_TEMP 245.5 
+#define WATER_MATTERSTATE_CHANGE_TEMP 274.5


### PR DESCRIPTION
## About The Pull Request

see title. the previous ice fix, #60788, set what was supposed to be 274.5 to 245.5. this makes it nigh impossible to get pure cryostylane, and as such, hercuri.
## Why It's Good For The Game
oversight bad.
cobby is a dunce that doesn't know math
seriously how did you even fuck this up
i dont even play the game anymore, this is just annoying to look at in testing
## Changelog
:cl:
fix: ice reaction oversight, now freezes at the proper 274k instead of 245k
/:cl: