### PR TITLE
fixes penetrator rounds phasing through vehicles

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -141,6 +141,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define PASSSTRUCTURE (1<<8)
 #define PASSFLAPS (1<<9)
 #define PASSDOORS (1<<10)
+#define PASSVEHICLE (1<<11)
 
 //Movement Types
 #define GROUND (1<<0)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -371,13 +371,13 @@
 	. = ..()
 	to_chat(owner,span_notice("You phase through reality, nothing is out of bounds!"))
 	owner.alpha = 180
-	owner.pass_flags |= PASSCLOSEDTURF | PASSGLASS | PASSGRILLE | PASSMACHINE | PASSSTRUCTURE | PASSTABLE | PASSMOB | PASSDOORS
+	owner.pass_flags |= PASSCLOSEDTURF | PASSGLASS | PASSGRILLE | PASSMACHINE | PASSSTRUCTURE | PASSTABLE | PASSMOB | PASSDOORS | PASSVEHICLE
 	location = get_turf(owner)
 
 /datum/status_effect/crucible_soul/on_remove()
 	to_chat(owner,span_notice("You regain your physicality, returning you to your original location..."))
 	owner.alpha = initial(owner.alpha)
-	owner.pass_flags &= ~(PASSCLOSEDTURF | PASSGLASS | PASSGRILLE | PASSMACHINE | PASSSTRUCTURE | PASSTABLE | PASSMOB | PASSDOORS)
+	owner.pass_flags &= ~(PASSCLOSEDTURF | PASSGLASS | PASSGRILLE | PASSMACHINE | PASSSTRUCTURE | PASSTABLE | PASSMOB | PASSDOORS | PASSVEHICLE)
 	owner.forceMove(location)
 	location = null
 	return ..()

--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -3,7 +3,7 @@
 /obj/effect/particle_effect/water
 	name = "water"
 	icon_state = "extinguish"
-	pass_flags = PASSTABLE | PASSMACHINE | PASSSTRUCTURE | PASSGRILLE | PASSBLOB
+	pass_flags = PASSTABLE | PASSMACHINE | PASSSTRUCTURE | PASSGRILLE | PASSBLOB | PASSVEHICLE
 	var/life = 15
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -33,8 +33,8 @@
 	name = "penetrator round"
 	icon_state = "gauss"
 	damage = 60
-	projectile_piercing = PASSMOB
-	projectile_phasing = (ALL & (~PASSMOB))
+	projectile_piercing = PASSMOB & PASSMACHINE
+	projectile_phasing = (ALL & (~PASSMOB & ~PASSMACHINE))
 	dismemberment = 0 //It goes through you cleanly.
 	paralyze = 0
 	breakthings = FALSE

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -33,8 +33,8 @@
 	name = "penetrator round"
 	icon_state = "gauss"
 	damage = 60
-	projectile_piercing = PASSMOB & PASSMACHINE
-	projectile_phasing = (ALL & (~PASSMOB & ~PASSMACHINE))
+	projectile_piercing = PASSMOB & PASSVEHICLE
+	projectile_phasing = (ALL & (~PASSMOB & ~PASSVEHICLE))
 	dismemberment = 0 //It goes through you cleanly.
 	paralyze = 0
 	breakthings = FALSE

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -8,7 +8,7 @@
 	density = TRUE
 	anchored = FALSE
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
-	pass_flags_self = PASSMACHINE
+	pass_flags_self = PASSVEHICLE
 	COOLDOWN_DECLARE(cooldown_vehicle_move)
 	var/list/mob/occupants //mob = bitflags of their control level.
 	///Maximum amount of passengers plus drivers


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When I gave vehicles the PASSMACHINE flag in #61793 I forgot that penetrator rounds existed leading to them completely ignoring mechs. This time I created a new flag for vehicles, added it to water particle effects, and excluded it from the penetrator rounds. 

Additionally this flag has been added to the heretic's phasing ability.

![2021-10-04_11-54-00](https://user-images.githubusercontent.com/51190031/135892669-4da525f8-3aa6-4e57-b04a-cb43cd00f65e.gif)

Please add the GBP: no update tag since this was my fault.

## Why It's Good For The Game

lazily copy pasting flags bad. Making new flags and implementing properly good.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: penetrator rounds will no longer ignore vehicles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
