### PR TITLE
Add undocumented render debug command to the rendering documentation

### DIFF
--- a/code/_onclick/hud/rendering/_render_readme.md
+++ b/code/_onclick/hud/rendering/_render_readme.md
@@ -12,6 +12,10 @@ When you create an atom, this will always create an internal byond structure cal
 
 Finally, we arrive at clientside behavior, where we have two main clientside functions: GetMapIcons, and Render. GetMapIcons is repsonsible for actual rendering calculations on the clientside, such as "Group Icons and Set bounds", which performs clientside calculations for transform matrixes. Note that particles here are handled in a seperate thread and are not diplayed in the clientside profiler. Render handles the actual drawing of the screen.
 
+For debugging rendering issues its reccomended you do two things:
+A) Talk to someone who has inside knowledge(like lummox) about it, most of this is undocumented and bugs often
+B) Use the undocumented debug printer which reads of data on icons rendering, this is very dense but can be useful in some cases. To use: Right click top tab -> Options & Messages -> Client -> Command -> Enter ".debug profile mapicons" and press Enter -> go to your Byond directory and find BYOND/cfg/mapicons.json . Yes this is one giant one-line json.
+
 ## Known internal snowflake
 The following is an incomplete list of pitfalls that come from byond snowflake that are known, this list is obviously incomplete.
 


### PR DESCRIPTION
.debug profile mapicons
prints a massive oneline json with the data of all currently onscreen rendering objects