### PR TITLE
Allows emagged and syndicate borgs to self-detonate

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -81,14 +81,7 @@
 			if(allowed(usr))
 				var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
 				if(can_control(usr, R) && !..())
-					var/turf/T = get_turf(R)
-					message_admins(span_notice("[ADMIN_LOOKUPFLW(usr)] detonated [key_name_admin(R, R.client)] at [ADMIN_VERBOSEJMP(T)]!"))
-					log_game("[key_name(usr)] detonated [key_name(R)]!")
-					log_combat(usr, R, "detonated cyborg")
-
-					if(R.connected_ai)
-						to_chat(R.connected_ai, "<br><br>[span_alert("ALERT - Cyborg detonation detected: [R.name]")]<br>")
-					R.self_destruct()
+					R.self_destruct(usr)
 			else
 				to_chat(usr, span_danger("Access Denied."))
 		if("stopbot")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -91,6 +91,25 @@
 		modularInterface = new /obj/item/modular_computer/tablet/integrated/syndicate(src)
 	return ..()
 
+/**
+ * Sets the tablet theme and icon
+ *
+ * These variables are based on if the borg is a syndicate type or is emagged. This gets used in model change code
+ * and also borg emag code.
+ */
+/mob/living/silicon/robot/proc/set_modularInterface_theme()
+	if(istype(model, /obj/item/robot_model/syndicate) || emagged)
+		modularInterface.device_theme = "syndicate"
+		modularInterface.icon_state = "tablet-silicon-syndicate"
+		modularInterface.icon_state_powered = "tablet-silicon-syndicate"
+		modularInterface.icon_state_unpowered = "tablet-silicon-syndicate"
+	else
+		modularInterface.device_theme = "ntos"
+		modularInterface.icon_state = "tablet-silicon"
+		modularInterface.icon_state_powered = "tablet-silicon"
+		modularInterface.icon_state_unpowered = "tablet-silicon"
+	modularInterface.update_icon()
+
 //If there's an MMI in the robot, have it ejected when the mob goes away. --NEO
 /mob/living/silicon/robot/Destroy()
 	var/atom/T = drop_location()//To hopefully prevent run time errors.
@@ -329,7 +348,14 @@
 		add_overlay(head_overlay)
 	update_fire()
 
-/mob/living/silicon/robot/proc/self_destruct()
+/mob/living/silicon/robot/proc/self_destruct(mob/usr)
+	var/turf/groundzero = get_turf(src)
+	message_admins(span_notice("[ADMIN_LOOKUPFLW(usr)] detonated [key_name_admin(src, client)] at [ADMIN_VERBOSEJMP(groundzero)]!"))
+	log_game("[key_name(usr)] detonated [key_name(src)]!")
+	log_combat(usr, src, "detonated cyborg")
+	if(connected_ai)
+		to_chat(connected_ai, "<br><br>[span_alert("ALERT - Cyborg detonation detected: [name]")]<br>")
+
 	if(emagged)
 		QDEL_NULL(mmi)
 		explosion(src, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 4, flame_range = 2)
@@ -395,6 +421,7 @@
 		throw_alert("hacked", /atom/movable/screen/alert/hacked)
 	else
 		clear_alert("hacked")
+	set_modularInterface_theme()
 
 /// Special handling for getting hit with a light eater
 /mob/living/silicon/robot/proc/on_light_eater(mob/living/silicon/robot/source, datum/light_eater)

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -185,6 +185,7 @@
 	cyborg.update_module_innate()
 	new_model.rebuild_modules()
 	cyborg.radio.recalculateChannels()
+	cyborg.set_modularInterface_theme()
 
 	INVOKE_ASYNC(new_model, .proc/do_transform_animation)
 	qdel(src)

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -58,8 +58,9 @@
 	data["printerTonerMax"] = borgo.tonermax //It's a variable, might as well use it
 	data["thrustersInstalled"] = borgo.ionpulse //If we have a thruster uprade
 	data["thrustersStatus"] = "[borgo.ionpulse_on?"ACTIVE":"DISABLED"]" //Feedback for thruster status
+	data["selfDestructAble"] = (borgo.emagged || istype(borgo, /mob/living/silicon/robot/model/syndicate/))
 
-	//DEBUG -- Cover, TRUE for locked
+	//Cover, TRUE for locked
 	data["cover"] = "[borgo.locked? "LOCKED":"UNLOCKED"]"
 	//Ability to move. FAULT if lockdown wire is cut, DISABLED if borg locked, ENABLED otherwise
 	data["locomotion"] = "[borgo.wires.is_cut(WIRE_LOCKDOWN)?"FAULT":"[borgo.lockcharge?"DISABLED":"ENABLED"]"]"
@@ -134,6 +135,12 @@
 		if("lampIntensity")
 			borgo.lamp_intensity = params["ref"]
 			borgo.toggle_headlamp(FALSE, TRUE)
+
+		if("selfDestruct")
+			if(borgo.stat) //No detonation while stunned
+				return
+			if(borgo.emagged || istype(borgo, /mob/living/silicon/robot/model/syndicate/)) //This option shouldn't even be showing otherwise
+				borgo.self_destruct(borgo)
 
 /**
  * Forces a full update of the UI, if currently open.

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -137,7 +137,7 @@
 			borgo.toggle_headlamp(FALSE, TRUE)
 
 		if("selfDestruct")
-			if(borgo.stat) //No detonation while stunned
+			if(borgo.stat || borgo.lockcharge) //No detonation while stunned or locked down
 				return
 			if(borgo.emagged || istype(borgo, /mob/living/silicon/robot/model/syndicate/)) //This option shouldn't even be showing otherwise
 				borgo.self_destruct(borgo)

--- a/tgui/packages/tgui/interfaces/NtosRobotact.js
+++ b/tgui/packages/tgui/interfaces/NtosRobotact.js
@@ -38,6 +38,7 @@ export const NtosRobotactContent = (props, context) => {
     printerTonerMax,
     thrustersInstalled,
     thrustersStatus,
+    selfDestructAble,
   } = data;
   const borgName = data.name || [];
   const borgType = data.designation || [];
@@ -207,6 +208,15 @@ export const NtosRobotactContent = (props, context) => {
                         <Button
                           content={thrustersStatus}
                           onClick={() => act('toggleThrusters')} />
+                      </LabeledList.Item>
+                    )}
+                    {!!selfDestructAble && (
+                      <LabeledList.Item
+                        label="Self Destruct">
+                        <Button.Confirm
+                          content="ACTIVATE"
+                          color="red"
+                          onClick={() => act('selfDestruct')} />
                       </LabeledList.Item>
                     )}
                   </LabeledList>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Once upon a time, when borgs could access machines from any distance once the window was open, borgs could self-detonate as a combat strategy. At some point, machine access for borgs was confined to being nearby the device, which removed self-detonation (except when near the console) as a side effect. This PR re-adds the ability for emagged and syndicate borgs by placing a confirm-type button into their RoboTact app (Actions section, under the Status tab).

Stunned or locked borgs cannot self-destruct.

Additionally, logging for borg detonations has been moved out of the robot console and into the borg self_destruct() proc, to avoid duplicate code, and emagged borgs now have their tablet theme and icon changed to syndicate versions.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives emagged borgs an extra tool (that they used to have before) with the tradeoff that using it **will** round-remove them. 

Syndicate borgs are given a version that is much less damaging (unless they are emagged by a friendly nukie) but will leave their brain and *usually* the MMI intact.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Emagged and Syndicate borgs can now self-detonate. For emagged borgs, this destroys the MMI, so know what you're signing up for.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

![image](https://user-images.githubusercontent.com/37497534/135965895-e473aab2-673e-4cf3-bbe1-224c9587272d.png)
