### PR TITLE
Undoes "Removes CHECK_TICK from overlays, following the same theory as instant explosions" (#58382)

### DIFF
--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -54,6 +54,11 @@ SUBSYSTEM_DEF(overlays)
 			UNSETEMPTY(A.remove_overlays)
 			STAT_STOP_STOPWATCH
 			STAT_LOG_ENTRY(stats, A.type)
+		if(mc_check)
+			if(MC_TICK_CHECK)
+				break
+		else
+			CHECK_TICK
 	if (count)
 		queue.Cut(1,count+1)
 		count = 0


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I have a feeling it was causing more overtime then maptick savings.

This is mostly done for testing on live, so we can see if it has any apprechiable effect on maptick, and if it helps td, by how much

## Why It's Good For The Game

We've started using overlays more often in place of vis_contents. Want to see if the overtime hit is reflected in maptick gains or not 
![image](https://user-images.githubusercontent.com/58055496/135991044-167f24d5-3ca8-4018-8ada-6b78e29962b9.png)
