### PR TITLE
Autolathe boards are now only printable by Cargo to increase interdepartmental cooperation.

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -417,14 +417,13 @@
 	build_path = /obj/item/circuitboard/machine/holopad
 	category = list ("Misc. Machinery")
 
-
 /datum/design/board/autolathe
 	name = "Machine Design (Autolathe Board)"
 	desc = "The circuit board for an autolathe."
 	id = "autolathe"
 	build_path = /obj/item/circuitboard/machine/autolathe
 	category = list ("Misc. Machinery")
-
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO
 
 /datum/design/board/recharger
 	name = "Machine Design (Weapon Recharger Board)"


### PR DESCRIPTION
## About The Pull Request

Autolathe boards are now only printable by Cargo to increase interdepartmental cooperation.

## Why It's Good For The Game

The autolathe is cargo's thing, and I'm tired of seeing Scientists literally never leave their department ever. The eggheads need to touch hallway tiles once every so often.

## Changelog

:cl:
balance: Autolathe boards are now only printable by Cargo to increase interdepartmental cooperation.
/:cl: