### PR TITLE
Fix quirk blacklist not working

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -13,11 +13,11 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 
 	var/list/quirks = list() //Assoc. list of all roundstart quirk datum types; "name" = /path/
 	var/list/quirk_points = list() //Assoc. list of quirk names and their "point cost"; positive numbers are good traits, and negative ones are bad
-	var/list/quirk_blacklist = list() //A list of quirks that can not be used with each other. Format: list(quirk1,quirk2),list(quirk3,quirk4)
 	///An assoc list of quirks that can be obtained as a hardcore character, and their hardcore value.
-	var/list/hardcore_quirks = list()
+	var/list/hardcore_quirk = list()
 
-	var/static/list/quirks_blacklist = list(
+	/// A list of quirks that can not be used with each other. Format: list(quirk1,quirk2),list(quirk3,quirk4)
+	var/static/list/quirk_blacklist = list(
 		list("Blind","Nearsighted"),
 		list("Jolly","Depression","Apathetic","Hypersensitive"),
 		list("Ageusia","Vegetarian","Deviant Tastes"),
@@ -150,7 +150,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	var/list/new_quirks = list()
 	var/list/positive_quirks = list()
 	var/balance = 0
-	
+
 	var/list/all_quirks = get_quirks()
 
 	for (var/quirk_name in quirks)

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -14,7 +14,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	var/list/quirks = list() //Assoc. list of all roundstart quirk datum types; "name" = /path/
 	var/list/quirk_points = list() //Assoc. list of quirk names and their "point cost"; positive numbers are good traits, and negative ones are bad
 	///An assoc list of quirks that can be obtained as a hardcore character, and their hardcore value.
-	var/list/hardcore_quirk = list()
+	var/list/hardcore_quirks = list()
 
 	/// A list of quirks that can not be used with each other. Format: list(quirk1,quirk2),list(quirk3,quirk4)
 	var/static/list/quirk_blacklist = list(


### PR DESCRIPTION
## About The Pull Request

This pr fixes the quirk blacklist not functioning.

## Why It's Good For The Game

You can currently be blind AND nearsighted 

## Changelog

:cl: Melbert
fix: Quirks that once were not compatible are now incompatible again
/:cl:

