### PR TITLE
Choice Beacons now use TGUI menus

### DIFF
--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -24,7 +24,7 @@
 	var/list/display_names = generate_display_names()
 	if(!display_names.len)
 		return
-	var/choice = input(M,"Which item would you like to order?","Select an Item") as null|anything in sortList(display_names)
+	var/choice =  tgui_input_list(M, "Which item would you like to order?", "Select an Item", display_names)
 	if(!choice || !M.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		return
 

--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -24,7 +24,7 @@
 	var/list/display_names = generate_display_names()
 	if(!display_names.len)
 		return
-	var/choice =  tgui_input_list(M, "Which item would you like to order?", "Select an Item", display_names)
+	var/choice = tgui_input_list(M, "Which item would you like to order?", "Select an Item", display_names)
 	if(!choice || !M.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		return
 


### PR DESCRIPTION
## About The Pull Request

Choice beacons (Curators/Chaplains/Cooks/Any other that might exist) now use a TGUI menu rather than the default whitebox menu.

## Why It's Good For The Game

They look way better now.

![image](https://user-images.githubusercontent.com/53777086/136146756-9bdbb836-a287-4cd0-8021-78a043115c38.png)
![image](https://user-images.githubusercontent.com/53777086/136146759-d382f797-a9ae-42dc-874f-bd6d24e1c4e5.png)


## Changelog

:cl:
qol: Choice beacons now use a TGUI menu
/:cl: