### PR TITLE
Adds follow button to families cellphone messages

### DIFF
--- a/code/modules/antagonists/gang/cellphone.dm
+++ b/code/modules/antagonists/gang/cellphone.dm
@@ -51,8 +51,8 @@ GLOBAL_LIST_EMPTY(gangster_cell_phones)
 		if(get_dist(player_mob, src) > 7 || player_mob.z != z) //they're out of range of normal hearing
 			if(!(player_mob.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
 				continue
-			var/link = FOLLOW_LINK(player_mob, src)	
-			to_chat(player_mob, span_gangradio("[link] <b>[speaker.name]</b> \[CELL: [gang_id]\] says, \"[message]\""))
+		var/link = FOLLOW_LINK(player_mob, src)	
+		to_chat(player_mob, span_gangradio("[link] <b>[speaker.name]</b> \[CELL: [gang_id]\] says, \"[message]\""))
 		
 /obj/item/gangster_cellphone/proc/say_message(message, atom/movable/speaker)
 	for(var/mob/living/carbon/human/cellphone_hearer in get_turf(src))

--- a/code/modules/antagonists/gang/cellphone.dm
+++ b/code/modules/antagonists/gang/cellphone.dm
@@ -51,7 +51,6 @@ GLOBAL_LIST_EMPTY(gangster_cell_phones)
 		if(get_dist(player_mob, src) > 7 || player_mob.z != z) //they're out of range of normal hearing
 			if(!(player_mob.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
 				continue
-		if(istype(player_mob, /mob/dead/observer))
 			var/link = FOLLOW_LINK(player_mob, src)	
 			to_chat(player_mob, span_gangradio("[link] <b>[speaker.name]</b> \[CELL: [gang_id]\] says, \"[message]\""))
 		

--- a/code/modules/antagonists/gang/cellphone.dm
+++ b/code/modules/antagonists/gang/cellphone.dm
@@ -51,8 +51,10 @@ GLOBAL_LIST_EMPTY(gangster_cell_phones)
 		if(get_dist(player_mob, src) > 7 || player_mob.z != z) //they're out of range of normal hearing
 			if(!(player_mob.client.prefs.chat_toggles & CHAT_GHOSTEARS)) //they're talking normally and we have hearing at any range off
 				continue
-		to_chat(player_mob, span_gangradio("<b>[speaker.name]</b> \[CELL: [gang_id]\] says, \"[message]\""))
-
+		if(istype(player_mob, /mob/dead/observer))
+			var/link = FOLLOW_LINK(player_mob, src)	
+			to_chat(player_mob, span_gangradio("[link] <b>[speaker.name]</b> \[CELL: [gang_id]\] says, \"[message]\""))
+		
 /obj/item/gangster_cellphone/proc/say_message(message, atom/movable/speaker)
 	for(var/mob/living/carbon/human/cellphone_hearer in get_turf(src))
 		if(HAS_TRAIT(cellphone_hearer, TRAIT_DEAF))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pull request adds a follow button before messages that are sent using the gangster cellphone from families. Wasn't sure what to label it, if it is not QoL feel free to change it. See image below
![image](https://user-images.githubusercontent.com/79515258/136259806-605fb7d6-e14d-4141-ae55-fc027db0af88.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You can now orbit people when you click the F button beside the families cellphone message, like you can with most other types of messages
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: you can orbit people who send messages using the gangster cellphone from families
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
