### PR TITLE
Lower power generation from solars and pacmans

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -9,7 +9,7 @@
 	use_power = NO_POWER_USE
 
 	var/active = FALSE
-	var/power_gen = 2500
+	var/power_gen = 1500
 	var/power_output = 1
 	var/consumption = 0
 	var/base_icon = "portgen0"
@@ -114,6 +114,7 @@
 			temp_rating += SP.rating
 		else
 			consumption_coeff += SP.rating
+	power_gen = initial(power_gen) + 1000 * temp_rating
 	consumption = consumption_coeff / temp_rating
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
@@ -280,7 +281,7 @@
 	base_icon = "portgen1"
 	circuit = /obj/item/circuitboard/machine/pacman/super
 	sheet_path = /obj/item/stack/sheet/mineral/uranium
-	power_gen = 7500
+	power_gen = 6500
 	time_per_sheet = 85
 
 /obj/machinery/power/port_gen/pacman/super/overheat()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -9,7 +9,7 @@
 	use_power = NO_POWER_USE
 
 	var/active = FALSE
-	var/power_gen = 5000
+	var/power_gen = 2500
 	var/power_output = 1
 	var/consumption = 0
 	var/base_icon = "portgen0"
@@ -114,8 +114,8 @@
 			temp_rating += SP.rating
 		else
 			consumption_coeff += SP.rating
-	power_gen = round(initial(power_gen) * temp_rating * 2)
-	consumption = consumption_coeff
+	power_gen = round(initial(power_gen) * temp_rating)
+	consumption = consumption_coeff / temp_rating
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
 	. = ..()
@@ -281,7 +281,7 @@
 	base_icon = "portgen1"
 	circuit = /obj/item/circuitboard/machine/pacman/super
 	sheet_path = /obj/item/stack/sheet/mineral/uranium
-	power_gen = 15000
+	power_gen = 7500
 	time_per_sheet = 85
 
 /obj/machinery/power/port_gen/pacman/super/overheat()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -114,7 +114,6 @@
 			temp_rating += SP.rating
 		else
 			consumption_coeff += SP.rating
-	power_gen = round(initial(power_gen) * temp_rating)
 	consumption = consumption_coeff / temp_rating
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -1,4 +1,4 @@
-#define SOLAR_GEN_RATE 1500
+#define SOLAR_GEN_RATE 500
 #define OCCLUSION_DISTANCE 20
 
 /obj/machinery/power/solar


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Power generation has been all over the place, things that are means of emergency power can be used as "main engines"
Current solar power generation: 
-each solar panel can make a maximum of 1500 W
-this value is multiplied by a number between 0 and 1 based on the position of the sun
-at maximum power a cluster of solar panels (64 of them) will make almost 100 kW
-most stations have 4 of these clusters, meaning a total production of well over 300 kW and all of them have a SMES to store and release the energy.
Solars are capable of powering the station all by themself, rendering the SM totally useless.
Solar clusters now will produce a third of that amount, around 32 kW, meaning that they won't be enough to power the station, but contributing enough power for a lacking SM. (every solar panel will be reduced to 500 W)

Current pacman generation:
-at t1 they are able to make from 10 kW to 40 kW, quadruple that at t4 so from 40 kW to 160 kW. 
-a superpacman will produce from 30 kW to 120 kw at t1, from 120 kW to 480 kW at t4. 
These numbers are outrageously high coming from a piece of equipment made for emergencies and that can be easily bought from cargo at a low price of 1000 credits or build with a few pieces of stock parts.
Pacmans are now means to power a smal grid for power, or a small amount of APCs, not the whole station
Now pacmans will make power from 2.5 kW to 10 kW at t1 and from 5.5 kW to 22 kW at t4
and the superpacman will go from 7.5 kW to 30 kW at t1 and from 10.5 kW to 42 kW at t4
Now the tier will impact more what the consumption will be, more power = more consumption, more efficiency = less consumption, more power + more efficiency = they cancel each other (base level consumption)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Get the engineering gameplay more centered around learning and making the SM a better engine. 
Other means of power should not be able to produce much more than the base SM without effort, this also enforces the SM as the main engine that the station rely upon.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: singular solar panel power production changed from 1500 to 500, clusters of panels of 64 (majority of stations) will make around 32 kW
balance: pacman power production has been lowered to make power in a range that goes from 2.5 kW to 10 kW at t1 and from 5.5 kW to 22 kW at t4
balance: superpacman power production has been lowered to make power in a range that goes from 7.5 kW to 30 kW at t1 and from 10.5 kW to 42 kW at t4
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
