### PR TITLE
Fix Emitters, and everything that uses hitscan beams.

### DIFF
--- a/code/game/objects/effects/temporary_visuals/projectiles/projectile_effects.dm
+++ b/code/game/objects/effects/temporary_visuals/projectiles/projectile_effects.dm
@@ -38,6 +38,7 @@
 
 /obj/effect/projectile/proc/apply_vars(angle_override, p_x = 0, p_y = 0, color_override, scaling = 1, new_loc, increment = 0)
 	var/mutable_appearance/look = new(src)
+	look.plane = plane
 	look.pixel_x = p_x
 	look.pixel_y = p_y
 	if(color_override)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fixes Emitters, beam_rifle, and more.

The great rendering refactor (#61286) changed how rendering worked. Entities need to have a usable plane to render to. This isn't normally a problem, as sensible defaults are set very low in the type path. However, tracer effects use an appearance override, which was missing the plane definition.

This adds the plane to the appearance used when `apply_vars` is called, by copying it from the holding entity.

![beam-tracers](https://user-images.githubusercontent.com/14355175/136424612-9430d84f-42a7-4355-8647-082999523d3e.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

this took so long to hunt down I want to die

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The beams from Emitters, and all hitscan weaponry, now render properly again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
