### PR TITLE
Bluespace anomalies: Don't teleport camera entities

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -283,7 +283,7 @@
 			for (var/atom/movable/A in urange(12, FROM )) // iterate thru list of mobs in the area
 				if(istype(A, /obj/item/beacon))
 					continue // don't teleport beacons because that's just insanely stupid
-				if(istype(A, /mob/camera))
+				if(iscameramob(A))
 					continue // Don't mess with AI eye, blob eye, xenobio or advanced cameras
 				if(A.anchored)
 					continue

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -283,6 +283,8 @@
 			for (var/atom/movable/A in urange(12, FROM )) // iterate thru list of mobs in the area
 				if(istype(A, /obj/item/beacon))
 					continue // don't teleport beacons because that's just insanely stupid
+				if(istype(A, /mob/camera))
+					continue // Don't mess with AI eye, blob eye, xenobio or advanced cameras
 				if(A.anchored)
 					continue
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This means that AI eye, Blob Overmind eye, advanced camera consoles and the Xeniobiology console will no longer be teleported by the bluespace anomaly event.

This is particularly relevant for the Xenobiology console, as the camera is not supposed to be able to see outside of their area, or be able to move back from outside of their area.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #61884

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Bluespace anomalies will no longer teleport camera eyes, such as AI eye, Blob Overmind eye, Advanced Camera consoles, or the Xenobiology Slime management console. This is particularly relevant for the Xenobiology advanced slime console, as the eye cannot move outside of, or while outside of, the area the console is in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
