### PR TITLE
Tram Upper Fore: Remove a stray scrubbers pipe

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -5230,12 +5230,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
-"ays" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "ayt" = (
 /turf/open/openspace,
 /area/hallway/primary/tram/right)
@@ -168316,7 +168310,7 @@ pFz
 sdr
 mXD
 pFz
-ays
+pFz
 wjj
 koq
 koq


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

~~Atmospherics distro piping, waste piping, disposals pipes, and power cables were variously missing around the Hydroponics area of Tramstation.~~

~~This adds missing the pieces, restoring power and air to Hydroponics.~~

Latest Tram has almost all these fixes in it, now. All that's left is removing an extra scrubbers pipe that doesn't lead anywhere.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

it's what plants crave

Also fixes #61846

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Removed a scrubbers pipe that didn't lead anywhere near Upper Hydroponics on Tram.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
