### PR TITLE
Fix antagonist tooltip showing wrong description

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/AntagsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/AntagsPage.tsx
@@ -134,7 +134,7 @@ const AntagSelection = (props: {
                       ? `You are banned from ${antagonist.name}.`
                       : antagonist.description.map((text, index) => {
                         return (
-                          <div key={index}>
+                          <div key={antagonist.key + index}>
                             {text}
                             {
                               index !== antagonist.description.length - 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This fixes the TGUI where users hovers over antagonists in the preference menu. The problem was that when moving your mouse over multiple antags, their descriptions would be shown for other antags. 

Before video:
https://user-images.githubusercontent.com/30943236/136470845-3ec9bbf0-0453-4658-a895-4f8e89a8f5cb.mp4

After video:
https://user-images.githubusercontent.com/30943236/136470888-49ef7a77-f142-47c1-8178-78add8db906b.mp4


This was caused because the descriptions are an array that is iterated on and the key used for each description item is the index (`0` or `1`). The fix was to create a unique key, this was done by concatenating the antagonist key (example, Wizard is 'wizard') with the index (so `wizard0`, `wizard1`). 

This fixes #61949

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lets players properly see the description of each antag description.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: fixed antagonist preference tooltip showing wrong descriptions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
