### PR TITLE
CE blueprints: Fix structural overlay

### DIFF
--- a/code/__DEFINES/turfs.dm
+++ b/code/__DEFINES/turfs.dm
@@ -10,9 +10,12 @@
 //supposedly the fastest way to do this according to https://gist.github.com/Giacom/be635398926bb463b42a
 ///Returns a list of turf in a square
 #define RANGE_TURFS(RADIUS, CENTER) \
+	RECT_TURFS(RADIUS, RADIUS, CENTER)
+
+#define RECT_TURFS(H_RADIUS, V_RADIUS, CENTER) \
 	block( \
-	locate(max(CENTER.x-(RADIUS),1),          max(CENTER.y-(RADIUS),1),          CENTER.z), \
-	locate(min(CENTER.x+(RADIUS),world.maxx), min(CENTER.y+(RADIUS),world.maxy), CENTER.z) \
+	locate(max(CENTER.x-(H_RADIUS),1),          max(CENTER.y-(V_RADIUS),1),          CENTER.z), \
+	locate(min(CENTER.x+(H_RADIUS),world.maxx), min(CENTER.y+(V_RADIUS),world.maxy), CENTER.z) \
 	)
 
 ///Returns all turfs in a zlevel

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -115,14 +115,14 @@
 
 	attack_self(usr) //this is not the proper way, but neither of the old update procs work! it's too ancient and I'm tired shush.
 
-/obj/item/areaeditor/blueprints/proc/get_images(turf/T, viewsize)
+/obj/item/areaeditor/blueprints/proc/get_images(turf/central_turf, viewsize)
 	. = list()
 	var/list/dimensions = getviewsize(viewsize)
 	var/horizontal_radius = dimensions[1] / 2
 	var/vertical_radius = dimensions[2] / 2
-	for(var/turf/TT as anything in RECT_TURFS(horizontal_radius, vertical_radius, T))
-		if(TT.blueprint_data)
-			. += TT.blueprint_data
+	for(var/turf/nearby_turf as anything in RECT_TURFS(horizontal_radius, vertical_radius, central_turf))
+		if(nearby_turf.blueprint_data)
+			. += nearby_turf.blueprint_data
 
 /obj/item/areaeditor/blueprints/proc/set_viewer(mob/user, message = "")
 	if(user?.client)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -117,10 +117,10 @@
 
 /obj/item/areaeditor/blueprints/proc/get_images(turf/T, viewsize)
 	. = list()
-	var/list/dims = getviewsize(viewsize)
-	var/h_radius = dims[1] / 2
-	var/v_radius = dims[2] / 2
-	for(var/turf/TT in RECT_TURFS(h_radius, v_radius, T))
+	var/list/dimensions = getviewsize(viewsize)
+	var/horizontal_radius = dimensions[1] / 2
+	var/vertical_radius = dimensions[2] / 2
+	for(var/turf/TT as anything in RECT_TURFS(horizontal_radius, vertical_radius, T))
 		if(TT.blueprint_data)
 			. += TT.blueprint_data
 

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -117,7 +117,10 @@
 
 /obj/item/areaeditor/blueprints/proc/get_images(turf/T, viewsize)
 	. = list()
-	for(var/turf/TT in view(viewsize, T))
+	var/list/dims = getviewsize(viewsize)
+	var/h_radius = dims[1] / 2
+	var/v_radius = dims[2] / 2
+	for(var/turf/TT in RECT_TURFS(h_radius, v_radius, T))
 		if(TT.blueprint_data)
 			. += TT.blueprint_data
 
@@ -126,7 +129,7 @@
 		if(viewing)
 			clear_viewer()
 		viewing = user.client
-		showing = get_images(get_turf(user), viewing.view)
+		showing = get_images(get_turf(viewing.eye || user), viewing.view)
 		viewing.images |= showing
 		if(message)
 			to_chat(user, message)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -117,7 +117,7 @@
 
 /obj/item/areaeditor/blueprints/proc/get_images(turf/T, viewsize)
 	. = list()
-	for(var/turf/TT in RANGE_TURFS(viewsize, T))
+	for(var/turf/TT in view(viewsize, T))
 		if(TT.blueprint_data)
 			. += TT.blueprint_data
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -525,6 +525,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /turf/proc/add_blueprints(atom/movable/AM)
 	var/image/I = new
+	I.plane = GAME_PLANE
+	I.layer = OBJ_LAYER
 	I.appearance = AM.appearance
 	I.appearance_flags = RESET_COLOR|RESET_ALPHA|RESET_TRANSFORM
 	I.loc = src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

CE blueprints come with a niche but situationally useful ability to view the original atmos, disposals, and power cable layout.

This has suffered a fair amount of bitrot. Not only was this not updated to use the plane and layer variables, but it also didn't handle any client running in widescreen mode - `RANGE_TURFS` requires a numerical parameter for its `radius` parameter, and cannot handle a modern viewstring such as "17x17".

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #59198.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The CE's blueprints can now once again show an overlay of the station's original structural layout! Cleaning up after an explosion is now - well, realistically, just as frustrating as ever, but it looks nice!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
