### PR TITLE
Ends Lizard Oppression! Suits won't hide tails anymore.

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -835,40 +835,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	var/obj/item/bodypart/head/noggin = source.get_bodypart(BODY_ZONE_HEAD)
 
-	if(mutant_bodyparts["tail_lizard"])
-		if(source.wear_suit && (source.wear_suit.flags_inv & HIDEJUMPSUIT))
-			bodyparts_to_add -= "tail_lizard"
-
-	if(mutant_bodyparts["waggingtail_lizard"])
-		if(source.wear_suit && (source.wear_suit.flags_inv & HIDEJUMPSUIT))
-			bodyparts_to_add -= "waggingtail_lizard"
-		else if (mutant_bodyparts["tail_lizard"])
-			bodyparts_to_add -= "waggingtail_lizard"
-
-	if(mutant_bodyparts["tail_human"])
-		if(source.wear_suit && (source.wear_suit.flags_inv & HIDEJUMPSUIT))
-			bodyparts_to_add -= "tail_human"
-
-	if("tail_monkey" in mutant_bodyparts)
-		if(source.wear_suit && (source.wear_suit.flags_inv & HIDEJUMPSUIT))
-			bodyparts_to_add -= "tail_monkey"
-
-	if(mutant_bodyparts["waggingtail_human"])
-		if(source.wear_suit && (source.wear_suit.flags_inv & HIDEJUMPSUIT))
-			bodyparts_to_add -= "waggingtail_human"
-		else if (mutant_bodyparts["tail_human"])
-			bodyparts_to_add -= "waggingtail_human"
-
-	if(mutant_bodyparts["spines"])
-		if(!source.dna.features["spines"] || source.dna.features["spines"] == "None" || source.wear_suit && (source.wear_suit.flags_inv & HIDEJUMPSUIT))
-			bodyparts_to_add -= "spines"
-
-	if(mutant_bodyparts["waggingspines"])
-		if(!source.dna.features["spines"] || source.dna.features["spines"] == "None" || source.wear_suit && (source.wear_suit.flags_inv & HIDEJUMPSUIT))
-			bodyparts_to_add -= "waggingspines"
-		else if (mutant_bodyparts["tail"])
-			bodyparts_to_add -= "waggingspines"
-
 	if(mutant_bodyparts["ears"])
 		if(!source.dna.features["ears"] || source.dna.features["ears"] == "None" || source.head && (source.head.flags_inv & HIDEHAIR) || (source.wear_mask && (source.wear_mask.flags_inv & HIDEHAIR)) || !noggin || noggin.status == BODYPART_ROBOTIC)
 			bodyparts_to_add -= "ears"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Right now we have a flag `HIDEJUMPSUIT` that also hides tails from any species, now I can see what you are about to say, it makes sense for a space/fire/other suits to hide the tail so it doesn't freeze or burn but this system is heavily inconsistent for a few reasons: 

1- Moths can keep their wings safe on the outside of suits, in the void of space or on a plasma hellfire with no issues.
2- Some suits don't hide your tail but will protect you from the cold/heat, others hide but won't protect.
3- Having your tail/wings out has no real effect in game, so it's basically a few suits can be used to easily hide your identity and make you look like a human if you are a lizard, but not if you are a moth.
4- You can wag your tail while it is hidden and tail wagging actually gives you tackle armor, small and silly, but still invisible niche armor with no feedback.

On the top image you can see a moth enjoying their wings being free.
![spacesuit1](https://user-images.githubusercontent.com/55374212/136478003-e93e95a2-aab4-4ed6-8461-83b725b5f716.png)
On the bottom image you see everyone being happy, unless the Lizard and Felinid want to hide their identity for crimes, then they might be sad instead...
![spacesuits2](https://user-images.githubusercontent.com/55374212/136478006-f404fa03-54b3-4b48-b209-6313139d3750.png)

![PR approval](https://user-images.githubusercontent.com/55374212/136613341-783235ea-6c40-45e4-ae56-a91cadc9012e.png)
Just to be clear, when I started on the PR I had in mind to just fix some inconsistencies with a few suits but as I looked more into it, I would need to refactor the system fully and still would be hard to make it consistent. Since this has a real balance weight I changed the tone of the PR from a fix on clothing code to a full balance.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Other than fixing some inconsistencies, I think that choosing to play a non human should have pros and cons, not being able to easily hide as a Human is an interesting interaction for security and antagonists.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Guillaume Prata
balance: Lizards/Felinids rejoice! Suits won't hide your tail anymore and don't worry, it won't freeze in space. Do remember you can't easily hide your species now if you are going to commit crimes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
