### PR TITLE
Borgs can close morgue trays now.

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -327,7 +327,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	return attack_hand(user, modifiers)
 
 /obj/structure/tray/attack_robot(mob/user, list/modifiers)
-    return attack_hand(user, modifiers)
+	return attack_hand(user, modifiers)
 
 /obj/structure/tray/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -326,6 +326,9 @@ GLOBAL_LIST_EMPTY(crematoriums)
 /obj/structure/tray/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)
 
+/obj/structure/tray/attack_robot(mob/user, list/modifiers)
+    return attack_hand(user, modifiers)
+
 /obj/structure/tray/attack_hand(mob/user, list/modifiers)
 	. = ..()
 	if(.)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cyborgs can open/close a morgue if the click on the main structure but they couldn't interact with the trays if they are open, instead needing to click on the main structure to close it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less borgs screaming at doctors to come save them from a tray trap.
![I hate my life](https://user-images.githubusercontent.com/55374212/136482932-5016183e-bac9-430e-921a-29cc29a81a1b.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Guillaume Prata
fix: Cyborgs can interact with a morgue tray to close it now, instead of needing to interact with the main structure.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
