### PR TITLE
toggle random events on/off no longer sends unspanned feedback to user

### DIFF
--- a/code/modules/admin/verbs/server.dm
+++ b/code/modules/admin/verbs/server.dm
@@ -6,12 +6,7 @@
 	set desc = "Toggles random events such as meteors, black holes, blob (but not space dust) on/off"
 	var/new_are = !CONFIG_GET(flag/allow_random_events)
 	CONFIG_SET(flag/allow_random_events, new_are)
-	if(new_are)
-		to_chat(usr, "Random events enabled", confidential = TRUE)
-		message_admins("Admin [key_name_admin(usr)] has enabled random events.")
-	else
-		to_chat(usr, "Random events disabled", confidential = TRUE)
-		message_admins("Admin [key_name_admin(usr)] has disabled random events.")
+	message_admins("[key_name_admin(usr)] has [new_are ? "enabled" : "disabled"] random events.")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Random Events", "[new_are ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/toggle_hub()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The verb already messages admins and pressing the verb requires you to be an admin. to_chat entirely unneeded!

## Why It's Good For The Game

see above, it wasn't really doing anything.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: toggle random events doesn't uselessly include a message to the user, only to admins... which the user is.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
