### PR TITLE
Tramstation Wirenet rework + Maint tile changes

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -38825,6 +38825,9 @@
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "mrp" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -9875,6 +9875,7 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "bgo" = (
@@ -14494,6 +14495,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "dbr" = (
@@ -15541,6 +15543,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"dwF" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/tram/mid)
 "dwS" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -20471,6 +20482,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "fns" = (
@@ -21806,7 +21818,8 @@
 	name = "Tunnel Access";
 	req_one_access_txt = "12"
 	},
-/turf/open/floor/iron/smooth,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "fNu" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
@@ -23966,6 +23979,7 @@
 	c_tag = "Maintenance - Central Tram Tunnel 2";
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "gDz" = (
@@ -24271,6 +24285,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "gJw" = (
@@ -24667,7 +24682,7 @@
 /area/commons/dorms)
 "gQw" = (
 /obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "gQF" = (
@@ -24688,7 +24703,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "gRw" = (
@@ -25468,7 +25482,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -26553,7 +26566,7 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "hAg" = (
@@ -28078,6 +28091,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "igT" = (
@@ -32591,10 +32605,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"jQr" = (
-/obj/structure/cable/layer1,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "jQF" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -32758,7 +32768,7 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "jUN" = (
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/central)
 "jUP" = (
 /obj/structure/closet/emcloset,
@@ -34921,6 +34931,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "kKu" = (
@@ -36440,6 +36451,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "lpd" = (
@@ -38265,7 +38277,8 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
-/turf/open/floor/iron/smooth,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "mfj" = (
 /obj/structure/table/reinforced,
@@ -38906,6 +38919,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "mtB" = (
@@ -40473,6 +40487,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"ncD" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/tram/mid)
 "ncI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron/white,
@@ -40497,6 +40523,11 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"ndc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/tram/mid)
 "ndl" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
@@ -41601,6 +41632,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
 "nDT" = (
@@ -46419,6 +46451,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "pyh" = (
@@ -47070,6 +47103,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "pJU" = (
@@ -49686,6 +49720,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "qJp" = (
@@ -53929,6 +53964,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"svy" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/tram/mid)
 "svC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -54889,6 +54930,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "sPs" = (
@@ -55408,6 +55450,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "sZK" = (
@@ -56613,6 +56656,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "tvB" = (
@@ -58699,6 +58743,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "umR" = (
@@ -59436,10 +59481,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"uDu" = (
-/obj/structure/cable/layer1,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
 "uDD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
@@ -60518,6 +60559,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "vcn" = (
@@ -63156,6 +63198,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "wgT" = (
@@ -63314,12 +63358,6 @@
 /obj/machinery/medical_kiosk,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"wjB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/maintenance/starboard/central)
 "wjR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -67529,6 +67567,7 @@
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/cockroach,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
 "xNa" = (
@@ -68864,6 +68903,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "yka" = (
@@ -95079,7 +95119,7 @@ qrK
 mfy
 qUZ
 trQ
-jQr
+kbj
 xHR
 xVq
 mfy
@@ -95336,7 +95376,7 @@ qrK
 gUw
 gUw
 rnh
-jQr
+kbj
 qvF
 aNT
 gUw
@@ -95593,9 +95633,9 @@ qrK
 qrK
 gUw
 mfy
-jQr
-jQr
-uDu
+kbj
+kbj
+xMn
 gUw
 eCl
 dhe
@@ -98896,11 +98936,11 @@ mtm
 kKa
 tvo
 xMZ
-cJa
-cJa
-cJa
-cJa
-wDw
+svy
+svy
+svy
+svy
+dwF
 fTY
 aHH
 dhe
@@ -99157,7 +99197,7 @@ aMP
 aMP
 aMP
 vQt
-wDw
+dwF
 aHH
 aHH
 dhe
@@ -99414,7 +99454,7 @@ aMP
 aMP
 aMP
 vQt
-wDw
+dwF
 aHH
 dhe
 dhe
@@ -99928,14 +99968,14 @@ aMP
 xmS
 aMP
 vQt
-qCp
+ncD
 fNs
-ifs
-ifs
-ifs
-ifs
-ifs
-ifs
+ndc
+ndc
+ndc
+ndc
+ndc
+ndc
 mfe
 daZ
 wUA
@@ -106844,7 +106884,7 @@ nBz
 lVv
 dUQ
 wsm
-wjB
+xDF
 hJa
 jYQ
 agX

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -5,7 +5,7 @@
 	req_one_access_txt = null
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "aac" = (
 /turf/closed/wall/r_wall,
@@ -56,14 +56,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "aaA" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/mob/living/simple_animal/parrot/poly,
 /obj/machinery/button/door/directional/west{
 	id = "atmos";
 	name = "Atmospherics Lockdown";
@@ -81,6 +80,7 @@
 	pixel_y = -8;
 	req_access_txt = "10"
 	},
+/mob/living/simple_animal/parrot/poly,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "aaB" = (
@@ -99,7 +99,7 @@
 	req_one_access_txt = null
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/right)
 "aaN" = (
 /obj/effect/turf_decal/stripes/line,
@@ -158,7 +158,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "aba" = (
@@ -173,6 +172,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Command Wing Hallway"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "abf" = (
@@ -296,13 +296,13 @@
 /area/science/robotics/mechbay)
 "abN" = (
 /obj/structure/reagent_dispensers/beerkeg,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/bar)
 "abW" = (
 /turf/closed/wall,
 /area/service/lawoffice)
 "abY" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "acb" = (
@@ -318,8 +318,8 @@
 	name = "Cleaning Closet"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
 "acj" = (
@@ -327,8 +327,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/status_display/ai/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "acp" = (
@@ -372,7 +372,7 @@
 	req_one_access_txt = null
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
 "acH" = (
 /obj/machinery/door/airlock/hatch{
@@ -382,7 +382,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "acM" = (
 /obj/machinery/chem_master/condimaster{
@@ -405,8 +406,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "acP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
 "acS" = (
@@ -488,14 +489,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/center)
 "adr" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "ads" = (
 /obj/machinery/door/airlock/hatch{
@@ -506,7 +509,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/right)
 "adu" = (
 /obj/machinery/door/airlock/hatch{
@@ -514,7 +517,7 @@
 	req_one_access_txt = null
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/right)
 "adv" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
@@ -593,10 +596,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "adR" = (
@@ -621,7 +624,7 @@
 	req_one_access_txt = null
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/center)
 "adU" = (
 /obj/structure/musician/piano{
@@ -778,9 +781,9 @@
 /area/service/library)
 "aeP" = (
 /obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "aeQ" = (
 /obj/structure/table/wood,
@@ -811,14 +814,6 @@
 	dir = 1
 	},
 /area/service/chapel)
-"aeX" = (
-/obj/structure/closet/crate,
-/obj/item/pickaxe/mini,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "afe" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/button/crematorium{
@@ -837,14 +832,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
-"afk" = (
-/obj/machinery/shower{
-	pixel_y = 24
-	},
-/obj/structure/curtain,
-/obj/structure/cable,
-/turf/open/floor/iron/freezer,
-/area/security/prison/shower)
 "afn" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -871,7 +858,7 @@
 "afs" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "afu" = (
 /obj/structure/table,
@@ -888,7 +875,6 @@
 /area/commons/storage/art)
 "afv" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
@@ -1080,9 +1066,9 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "agk" = (
@@ -1128,10 +1114,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"agC" = (
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/service/chapel)
 "agF" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -1180,7 +1162,6 @@
 	},
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/service/bar)
@@ -1239,19 +1220,19 @@
 "ahn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "aho" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "aht" = (
 /obj/effect/turf_decal/tile/bar,
@@ -1281,7 +1262,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
@@ -1304,24 +1284,14 @@
 	id = "rndlab1";
 	name = "Research and Development Shutter"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/lab)
-"ahE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
 "ahH" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
@@ -1528,8 +1498,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aiF" = (
@@ -1620,7 +1590,6 @@
 /area/command/teleporter)
 "ajp" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
@@ -1653,7 +1622,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "ajz" = (
@@ -1681,7 +1649,6 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "ajD" = (
@@ -1970,6 +1937,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "akS" = (
@@ -2000,7 +1968,6 @@
 	},
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
-/obj/structure/cable,
 /obj/machinery/light/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
@@ -2030,11 +1997,6 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/security/checkpoint)
-"alc" = (
-/obj/structure/cable,
-/obj/structure/table,
-/turf/open/floor/iron/freezer,
-/area/commons/toilet/restrooms)
 "ald" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/airalarm/directional/north,
@@ -2045,7 +2007,6 @@
 /area/commons/toilet/restrooms)
 "ale" = (
 /obj/item/kirbyplants/dead,
-/obj/structure/cable,
 /obj/machinery/requests_console/directional/north{
 	announcementConsole = 1;
 	department = "Research Director's Desk";
@@ -2099,7 +2060,6 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
@@ -2109,7 +2069,6 @@
 	id = "briglockdown";
 	name = "brig shutters"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
 "alr" = (
@@ -2153,11 +2112,6 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/science/genetics)
-"alA" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "alB" = (
 /obj/structure/closet/secure_closet/chief_medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -2216,6 +2170,13 @@
 	},
 /turf/open/floor/carpet,
 /area/cargo/qm)
+"alU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "alW" = (
 /turf/closed/wall,
 /area/commons/storage/tools)
@@ -2250,7 +2211,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "ami" = (
@@ -2269,7 +2229,6 @@
 /area/engineering/engine_smes)
 "amm" = (
 /obj/effect/spawner/random/vending/colavend,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/bar)
 "amn" = (
@@ -2278,7 +2237,6 @@
 	id = "briglockdown";
 	name = "brig shutters"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
 "amp" = (
@@ -2288,13 +2246,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
-"amq" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/brig)
 "amr" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -2312,8 +2263,8 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "amx" = (
@@ -2385,7 +2336,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -2422,7 +2372,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "amU" = (
@@ -2445,7 +2394,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -2470,6 +2418,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "anl" = (
@@ -2501,7 +2450,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "anv" = (
@@ -2513,13 +2461,12 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "anw" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "anz" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "anB" = (
@@ -2575,7 +2522,6 @@
 /area/security/brig)
 "anK" = (
 /obj/item/kirbyplants/random,
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/chapel)
 "anL" = (
@@ -2592,8 +2538,8 @@
 /turf/open/floor/glass,
 /area/commons/dorms)
 "anP" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "anQ" = (
@@ -2666,7 +2612,6 @@
 /area/command/heads_quarters/ce)
 "aof" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
 "aoh" = (
@@ -2685,6 +2630,7 @@
 "aok" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "aor" = (
@@ -2707,8 +2653,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "aov" = (
@@ -2728,8 +2674,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aoz" = (
@@ -2755,7 +2701,6 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -2780,7 +2725,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/corner,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -2791,8 +2735,8 @@
 /obj/machinery/computer/prisoner/management{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aoN" = (
@@ -2807,7 +2751,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "aoR" = (
@@ -2846,7 +2789,6 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
 	name = "Cell 3 Locker"
@@ -2895,8 +2837,8 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/multitool,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "aph" = (
@@ -2908,8 +2850,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "apj" = (
@@ -2981,7 +2923,9 @@
 /area/hallway/secondary/entry)
 "apv" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "apw" = (
 /obj/structure/sign/plaques/kiddie/badger{
@@ -3031,12 +2975,12 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/light_switch/directional/north,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "apJ" = (
@@ -3054,16 +2998,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/art)
-"apL" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "apO" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -3090,7 +3024,6 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -3179,7 +3112,6 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -3210,13 +3142,14 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "aql" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "aqm" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "aqn" = (
@@ -3255,8 +3188,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "aqw" = (
@@ -3283,8 +3216,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "aqA" = (
@@ -3295,7 +3228,6 @@
 /obj/item/wrench,
 /obj/item/crowbar,
 /obj/item/radio,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "aqD" = (
@@ -3330,8 +3262,8 @@
 "aqH" = (
 /obj/structure/table,
 /obj/item/beacon,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "aqI" = (
@@ -3356,11 +3288,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"aqN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ai_monitored/command/storage/eva)
 "aqO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -3395,8 +3322,8 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "aqS" = (
@@ -3419,7 +3346,6 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -3470,7 +3396,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "arf" = (
@@ -3482,7 +3407,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "arg" = (
@@ -3493,7 +3417,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -3505,7 +3428,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "ari" = (
@@ -3555,7 +3477,6 @@
 "arn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "aro" = (
@@ -3585,17 +3506,17 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
 /obj/structure/reagent_dispensers/peppertank/directional/east,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "arr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "arv" = (
@@ -3607,8 +3528,8 @@
 "arx" = (
 /obj/machinery/mechpad,
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "ary" = (
@@ -3657,7 +3578,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 8;
@@ -3718,7 +3638,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
@@ -3730,6 +3649,7 @@
 /obj/item/stock_parts/manipulator,
 /obj/item/stock_parts/manipulator,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/lab)
 "arT" = (
@@ -3740,7 +3660,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "arW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -3805,11 +3726,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "ash" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -3846,6 +3767,7 @@
 	dir = 9
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "asl" = (
@@ -3883,11 +3805,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "ast" = (
 /obj/structure/table/wood,
@@ -3910,11 +3832,12 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/center)
 "asy" = (
 /obj/machinery/door/airlock/external{
@@ -3927,7 +3850,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/center)
 "asz" = (
 /obj/structure/table,
@@ -3955,7 +3879,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/center)
 "asG" = (
 /obj/structure/table/glass,
@@ -3970,8 +3895,8 @@
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 9
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "asJ" = (
@@ -3990,11 +3915,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
 "asN" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
@@ -4012,9 +3938,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
 /mob/living/simple_animal/pet/cat/runtime,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "asQ" = (
@@ -4089,7 +4015,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "ath" = (
@@ -4140,23 +4065,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"ato" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
-"atp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "att" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -4191,8 +4099,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "atB" = (
@@ -4205,21 +4113,8 @@
 	name = "sorting disposal pipe (Medical General)";
 	sortTypes = list(9,10,11,27)
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/tram/center)
-"atC" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
 /area/hallway/primary/tram/center)
 "atD" = (
 /obj/machinery/door/airlock/external{
@@ -4229,12 +4124,12 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/center)
 "atE" = (
 /obj/machinery/door/airlock/external{
@@ -4244,11 +4139,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/right)
 "atG" = (
 /obj/structure/bed,
@@ -4291,19 +4185,12 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/right)
 "atM" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
-"atN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/right)
 "atO" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 1
@@ -4426,6 +4313,7 @@
 	name = "sorting disposal pipe (Science General)";
 	sortTypes = list(12,13,14,23,28)
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "auu" = (
@@ -4450,7 +4338,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aux" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/right)
 "auA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -4524,10 +4412,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/entry)
-"auN" = (
-/obj/structure/ladder,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "auO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -4539,7 +4423,7 @@
 "auP" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
 "auU" = (
 /obj/machinery/light/small/directional/south,
@@ -4687,14 +4571,10 @@
 "avn" = (
 /turf/closed/wall,
 /area/hallway/primary/tram/center)
-"avq" = (
-/obj/structure/ladder,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/center)
 "avs" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/center)
 "avu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -4719,7 +4599,6 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
@@ -4733,8 +4612,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "avK" = (
@@ -4826,9 +4705,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "avY" = (
@@ -4838,9 +4717,9 @@
 /area/hallway/primary/tram/right)
 "awd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "awf" = (
@@ -4944,6 +4823,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "awx" = (
@@ -5072,8 +4952,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "axf" = (
@@ -5131,8 +5011,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "axu" = (
@@ -5164,9 +5044,9 @@
 /area/science/xenobiology)
 "axz" = (
 /obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/mixing)
 "axB" = (
@@ -5237,17 +5117,13 @@
 /area/tcommsat/computer)
 "axP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "axR" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/tram/right)
-"axT" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "axW" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -5267,6 +5143,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "aya" = (
@@ -5298,6 +5175,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "ayg" = (
@@ -5325,6 +5203,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "ayo" = (
@@ -5352,7 +5231,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "ays" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -5397,7 +5275,6 @@
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "ayD" = (
@@ -5410,7 +5287,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "ayG" = (
 /obj/structure/table,
@@ -5449,7 +5326,6 @@
 /area/service/bar)
 "ayK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "ayR" = (
@@ -5476,7 +5352,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Atmospherics South-East";
 	dir = 1;
@@ -5487,6 +5362,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/firealarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ayX" = (
@@ -5499,7 +5375,6 @@
 	name = "Turbine Access";
 	req_access_txt = "24"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -5508,15 +5383,16 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aza" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "azc" = (
@@ -5537,7 +5413,6 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "azj" = (
-/obj/structure/cable,
 /turf/open/floor/iron/goonplaque,
 /area/hallway/secondary/entry)
 "azk" = (
@@ -5599,6 +5474,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable,
 /turf/open/floor/vault,
 /area/hallway/primary/tram/left)
 "azz" = (
@@ -5685,7 +5561,6 @@
 	id = "hop";
 	name = "privacy shutters"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hop)
 "azP" = (
@@ -5766,7 +5641,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/light/directional/north,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -5887,7 +5761,8 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "aAX" = (
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
 "aBa" = (
 /turf/open/floor/iron,
@@ -5946,7 +5821,6 @@
 /area/cargo/storage)
 "aBD" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint)
 "aBF" = (
@@ -5988,7 +5862,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/radio,
 /turf/open/floor/iron,
@@ -6032,7 +5905,7 @@
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "aCd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -6046,7 +5919,8 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "aCl" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -6186,7 +6060,8 @@
 /area/command/heads_quarters/hop)
 "aCP" = (
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
 "aCR" = (
 /obj/structure/table/wood,
@@ -6229,6 +6104,7 @@
 	name = "Library Desk";
 	req_access_txt = "37"
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "aDa" = (
@@ -6254,12 +6130,13 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "aDm" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/center)
 "aDn" = (
 /obj/structure/table/wood,
@@ -6285,6 +6162,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aDs" = (
@@ -6294,6 +6172,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aDt" = (
@@ -6328,6 +6207,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aDw" = (
@@ -6360,6 +6240,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aDB" = (
@@ -6428,7 +6309,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/right)
 "aDY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -6556,6 +6437,7 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "aEq" = (
@@ -6563,7 +6445,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aEr" = (
@@ -6580,6 +6461,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aEs" = (
@@ -6619,6 +6501,7 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aEA" = (
@@ -6763,11 +6646,11 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/center)
 "aEZ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/center)
 "aFa" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -6784,6 +6667,7 @@
 	},
 /obj/effect/turf_decal/caution,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aFb" = (
@@ -6798,6 +6682,7 @@
 	},
 /obj/effect/turf_decal/caution,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aFc" = (
@@ -6834,12 +6719,13 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "aFh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "aFi" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -6895,12 +6781,13 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/center)
 "aFs" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/left)
 "aFt" = (
 /obj/structure/railing/corner{
@@ -6972,8 +6859,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aFH" = (
@@ -7003,7 +6890,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/right)
 "aFL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -7134,6 +7021,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/central)
 "aGp" = (
@@ -7195,6 +7083,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/end,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/left)
 "aGD" = (
@@ -7315,12 +7204,13 @@
 /area/science/research)
 "aHg" = (
 /obj/machinery/light/small/directional/east,
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Civilian - Upper Power Hatch";
 	dir = 9
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "aHh" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -7551,6 +7441,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aHZ" = (
@@ -7625,12 +7516,12 @@
 "aIo" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/right)
 "aIq" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "aIu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -7710,8 +7601,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "aIX" = (
@@ -7761,16 +7652,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
-"aJk" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Tunnel Access";
-	req_one_access_txt = "12"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "aJo" = (
 /turf/closed/wall,
 /area/maintenance/central/secondary)
@@ -7781,12 +7662,14 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/central/secondary)
 "aJH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "aJK" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "aJL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -7796,7 +7679,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aJN" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
@@ -7806,6 +7688,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "aJO" = (
@@ -8033,19 +7916,19 @@
 /turf/open/floor/iron,
 /area/security/prison/mess)
 "aNe" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/left)
 "aNi" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/right)
 "aNj" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/right)
 "aNk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8085,6 +7968,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "aNF" = (
@@ -8097,6 +7981,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "aNG" = (
@@ -8198,10 +8083,10 @@
 "aOB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "aOD" = (
 /obj/machinery/light/directional/west,
@@ -8236,12 +8121,13 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "aOO" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "aOP" = (
 /turf/closed/wall,
@@ -8329,12 +8215,13 @@
 "aPw" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/right)
 "aPx" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "aPz" = (
 /obj/machinery/door/airlock/external{
@@ -8360,10 +8247,10 @@
 "aPM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "aPT" = (
@@ -8393,12 +8280,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aQb" = (
@@ -8497,7 +8384,6 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aQR" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -8508,14 +8394,15 @@
 	req_access_txt = "11"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "aQS" = (
-/obj/structure/cable,
 /obj/machinery/light/small/directional/north,
 /obj/machinery/power/apc/auto_name/east,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "aQT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -8534,12 +8421,13 @@
 	req_one_access_txt = "47"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "aQY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "aQZ" = (
@@ -8726,10 +8614,10 @@
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "aRT" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "aRU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -8828,9 +8716,9 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "aSl" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "aSq" = (
 /turf/open/floor/iron,
@@ -8861,8 +8749,16 @@
 "aSN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/ai/directional/north,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"aSZ" = (
+/obj/machinery/plumbing/synthesizer{
+	reagent_id = /datum/reagent/water
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central)
 "aTa" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -8945,8 +8841,8 @@
 "aTY" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aTZ" = (
@@ -9011,7 +8907,6 @@
 "aUx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -9019,6 +8914,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aUy" = (
@@ -9220,6 +9116,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "aWt" = (
@@ -9377,6 +9274,7 @@
 	dir = 4
 	},
 /obj/structure/fluff/tram_rail/floor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "aYI" = (
@@ -9418,7 +9316,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aZb" = (
@@ -9436,11 +9333,6 @@
 "aZc" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/bot/medbot{
-	auto_patrol = 1;
-	desc = "A little medical robot. He looks somewhat overwhelmed.";
-	name = "Emergency T.R.A.M Unit"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -9449,6 +9341,11 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
+	},
+/mob/living/simple_animal/bot/medbot{
+	auto_patrol = 1;
+	desc = "A little medical robot. He looks somewhat overwhelmed.";
+	name = "Emergency T.R.A.M Unit"
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
@@ -9491,7 +9388,7 @@
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/four,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/port/aft)
 "aZC" = (
 /obj/structure/ladder,
@@ -9599,7 +9496,6 @@
 "bay" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
@@ -9607,6 +9503,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "baC" = (
@@ -9636,6 +9533,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "baK" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "baP" = (
@@ -9681,7 +9579,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "bcf" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -9730,6 +9628,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
 /area/medical/virology)
+"bcy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron/smooth,
+/area/maintenance/department/medical)
 "bcB" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -9771,7 +9674,6 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "bdC" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -9783,6 +9685,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "bdI" = (
@@ -9813,7 +9716,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "bes" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -9822,6 +9724,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "bet" = (
@@ -9830,12 +9733,12 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "beB" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "beR" = (
 /obj/machinery/door/poddoor/incinerator_ordmix,
@@ -9846,12 +9749,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bfg" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "bfh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -9905,7 +9802,6 @@
 /obj/machinery/power/emitter/welded{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "bfN" = (
@@ -9914,10 +9810,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bgc" = (
@@ -9926,7 +9822,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
 /area/service/library)
@@ -9943,6 +9838,7 @@
 	c_tag = "Maintenance - West Tram Tunnel 1";
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "bgh" = (
@@ -9992,10 +9888,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "bgD" = (
@@ -10025,10 +9921,6 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
-"bgL" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "bgX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -10087,6 +9979,12 @@
 	},
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
+"bhL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/port/fore)
 "bhR" = (
 /turf/closed/wall,
 /area/engineering/break_room)
@@ -10097,12 +9995,12 @@
 /area/hallway/secondary/entry)
 "bid" = (
 /obj/machinery/light/directional/north,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "big" = (
@@ -10150,11 +10048,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "bjY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -10163,17 +10059,9 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"bjZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rndlab1";
-	name = "Research and Development Shutter"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/science/lab)
 "bka" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -10204,12 +10092,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
 	name = "sorting disposal pipe (Cargo)";
 	sortType = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "bkS" = (
@@ -10223,7 +10111,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "bkY" = (
 /turf/closed/wall/r_wall,
@@ -10285,7 +10173,6 @@
 "bnd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -10371,16 +10258,16 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "boh" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "box" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10422,12 +10309,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "bpp" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "bpv" = (
 /obj/machinery/door/firedoor,
@@ -10453,7 +10341,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/secondary)
 "bpL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10462,7 +10350,7 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "bqL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -10479,7 +10367,6 @@
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -10558,12 +10445,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "bsi" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "bsl" = (
@@ -10641,6 +10529,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/status_display/ai/directional/north,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "buJ" = (
@@ -10672,10 +10561,10 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "bvw" = (
@@ -10717,10 +10606,10 @@
 /area/maintenance/disposal/incinerator)
 "bwi" = (
 /obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bws" = (
@@ -10748,7 +10637,7 @@
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/screwdriver,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "bxd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10761,7 +10650,7 @@
 "bxg" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "bxi" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -10770,19 +10659,18 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "bxo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/landmark/start/depsec/medical,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -10791,6 +10679,7 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "bxw" = (
@@ -10836,10 +10725,10 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel Hall"
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/chapel)
 "byy" = (
@@ -10862,13 +10751,13 @@
 	pixel_y = -8
 	},
 /obj/effect/landmark/start/ai,
-/obj/structure/cable,
 /obj/machinery/button/door/directional/south{
 	id = "AI Core shutters";
 	name = "AI Core Shutters Control";
 	pixel_x = 24;
 	req_access_txt = "16"
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
 "byD" = (
@@ -10904,6 +10793,11 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/science/research)
+"bzm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "bzs" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -10950,11 +10844,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "bAE" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "bAH" = (
@@ -10984,7 +10879,7 @@
 "bAS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/secondary)
 "bAW" = (
 /obj/structure/rack,
@@ -11022,9 +10917,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bCC" = (
@@ -11048,12 +10943,12 @@
 "bDg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "bDF" = (
 /obj/machinery/airalarm/directional/north,
@@ -11079,9 +10974,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "bFc" = (
@@ -11139,7 +11034,7 @@
 "bFS" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/crew_quarters/dorms)
 "bFT" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -11243,11 +11138,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "bJm" = (
@@ -11394,6 +11289,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "bMJ" = (
@@ -11402,6 +11298,13 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"bMK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "bMT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11416,9 +11319,9 @@
 	id = "Xenolab";
 	name = "test chamber blast door"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "bNj" = (
@@ -11464,6 +11367,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bOv" = (
@@ -11473,12 +11377,12 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "bOz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "bOD" = (
@@ -11492,8 +11396,8 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "bOF" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "bOQ" = (
@@ -11504,9 +11408,9 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "bPg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
 "bPl" = (
@@ -11528,18 +11432,17 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "bPA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Command - Bridge South";
 	dir = 1
 	},
 /obj/machinery/newscaster/security_unit/directional/south,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/bridge)
 "bQi" = (
@@ -11602,6 +11505,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
 "bRH" = (
@@ -11621,12 +11525,12 @@
 "bRO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/tram/right)
 "bRV" = (
@@ -11684,10 +11588,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"bTa" = (
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/command/heads_quarters/hos)
 "bTb" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -11708,12 +11608,12 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "bTG" = (
@@ -11741,9 +11641,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/disposalpipe/trunk/multiz/down,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "bUp" = (
@@ -11754,10 +11654,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bUB" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "bUC" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -11765,6 +11665,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "bUF" = (
@@ -11774,6 +11675,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"bUL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/port/central)
 "bUO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -11796,10 +11702,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "bVr" = (
@@ -11807,10 +11713,10 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "bVX" = (
-/obj/structure/cable,
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "bWe" = (
@@ -11907,10 +11813,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "bXP" = (
@@ -11922,7 +11828,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "bYn" = (
@@ -11954,6 +11860,11 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/science/research)
+"bYM" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "bZi" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
@@ -11973,11 +11884,11 @@
 /area/science/research)
 "bZE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "bZI" = (
@@ -12014,7 +11925,7 @@
 "cay" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "caI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12046,8 +11957,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cbN" = (
@@ -12058,8 +11969,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/mixing)
-"ccj" = (
+"ccc" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
+"ccj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
@@ -12067,6 +11982,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ccG" = (
@@ -12104,7 +12020,6 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cdV" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -12114,7 +12029,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding/sec,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -12155,14 +12069,14 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/light/small/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "cfk" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "cfm" = (
 /obj/structure/table,
@@ -12180,7 +12094,7 @@
 "cfo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "cfy" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -12192,7 +12106,7 @@
 "cfH" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "cfJ" = (
 /obj/structure/table/glass,
@@ -12222,14 +12136,14 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "cgv" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/right)
 "cgy" = (
 /obj/effect/turf_decal/stripes/line{
@@ -12306,29 +12220,30 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "cix" = (
 /obj/structure/table,
 /obj/item/clothing/mask/gas/monkeymask,
 /obj/item/food/monkeycube,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "ciB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/screwdriver,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "ciD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "ciO" = (
 /obj/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "ciS" = (
@@ -12363,6 +12278,7 @@
 	network = list("ss13","cargo")
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "cjF" = (
@@ -12370,15 +12286,20 @@
 	name = "Tunnel Access";
 	req_one_access_txt = "12"
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/central)
-"cjM" = (
 /obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/central)
+"cjG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/four,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central/secondary)
+"cjM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -12399,12 +12320,12 @@
 "ckh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "ckj" = (
 /obj/machinery/light/small/directional/south,
@@ -12441,6 +12362,12 @@
 	},
 /turf/open/floor/iron,
 /area/tcommsat/computer)
+"ckV" = (
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/central)
 "cld" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -12471,10 +12398,10 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "clU" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
 "cmf" = (
@@ -12594,8 +12521,8 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/meter,
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "cpF" = (
@@ -12654,13 +12581,13 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/south{
 	freerange = 1;
 	frequency = 1447;
 	listening = 0;
 	name = "Private Channel"
 	},
+/obj/structure/cable,
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cqJ" = (
@@ -12677,8 +12604,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cqR" = (
@@ -12713,6 +12640,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/caution,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "csa" = (
@@ -12723,14 +12651,14 @@
 "csb" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/port/aft)
 "cso" = (
 /turf/closed/wall,
 /area/command/heads_quarters/hos)
 "csq" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "csu" = (
@@ -12744,9 +12672,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "csN" = (
@@ -12824,7 +12752,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "cuD" = (
@@ -12855,6 +12782,9 @@
 "cvo" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "cvC" = (
@@ -12886,10 +12816,10 @@
 /area/commons/dorms)
 "cwe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cwi" = (
@@ -12920,6 +12850,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cwr" = (
@@ -12927,15 +12858,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
-"cwv" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/checkpoint/supply)
 "cwB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/crew_quarters/dorms)
 "cwJ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -12947,10 +12873,10 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "cxq" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "cxX" = (
@@ -13000,8 +12926,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding/techstorage,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "czF" = (
@@ -13024,12 +12950,12 @@
 /turf/open/floor/plating,
 /area/science/research)
 "czM" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "czP" = (
@@ -13037,6 +12963,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "czV" = (
@@ -13051,6 +12978,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "cAg" = (
@@ -13076,12 +13004,12 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cAA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13089,6 +13017,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "cAL" = (
@@ -13153,13 +13082,13 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cBY" = (
@@ -13205,22 +13134,22 @@
 "cCM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "cDv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "cDx" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -13260,7 +13189,6 @@
 "cEX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/junction/flip{
@@ -13268,6 +13196,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cEY" = (
@@ -13307,9 +13236,9 @@
 /area/hallway/secondary/construction/engineering)
 "cFH" = (
 /obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/crew_quarters/dorms)
 "cFO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -13394,6 +13323,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "cHA" = (
@@ -13402,6 +13332,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
+"cHD" = (
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria{
+	dir = 5
+	},
+/area/command/heads_quarters/rd)
 "cHW" = (
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/circuit,
@@ -13429,6 +13365,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "cIu" = (
@@ -13446,7 +13383,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cID" = (
@@ -13506,6 +13442,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "cJx" = (
@@ -13568,7 +13505,7 @@
 "cKo" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "cKs" = (
 /obj/effect/turf_decal/tile/blue{
@@ -13592,10 +13529,10 @@
 "cKE" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "cKT" = (
@@ -13607,8 +13544,8 @@
 "cLD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "cMi" = (
@@ -13624,9 +13561,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "cMo" = (
@@ -13656,10 +13593,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "cMW" = (
@@ -13670,6 +13607,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "cMY" = (
@@ -13680,17 +13618,17 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "cNk" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cNm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/port/fore)
 "cNu" = (
 /obj/structure/disposalpipe/segment,
@@ -13725,8 +13663,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "cOS" = (
@@ -13754,7 +13692,7 @@
 "cPu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "cPG" = (
 /obj/effect/turf_decal/siding/wood{
@@ -13785,6 +13723,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/service/kitchen)
+"cQn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "cQG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -13858,7 +13801,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "cRi" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
@@ -13899,7 +13841,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/mid)
 "cRt" = (
 /obj/machinery/computer/shuttle/mining{
@@ -13916,12 +13858,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"cRy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/main)
 "cRH" = (
 /obj/structure/urinal/directional/north,
 /obj/structure/window/reinforced{
@@ -14020,12 +13956,12 @@
 "cTo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "cTs" = (
 /obj/structure/stairs/south,
@@ -14112,7 +14048,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -14121,6 +14056,7 @@
 	c_tag = "Command - Bridge Right Airlock";
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "cUl" = (
@@ -14149,6 +14085,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "cUB" = (
@@ -14215,8 +14152,8 @@
 "cVj" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "cVm" = (
@@ -14268,7 +14205,6 @@
 /area/cargo/sorting)
 "cVT" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
 "cWa" = (
@@ -14298,7 +14234,6 @@
 "cWr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
@@ -14306,6 +14241,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cWu" = (
@@ -14334,6 +14270,7 @@
 	name = "Commons Area"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "cXe" = (
@@ -14362,9 +14299,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/bluespace_vendor/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "cXM" = (
@@ -14433,18 +14370,18 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/light_switch/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cYX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cZa" = (
@@ -14492,14 +14429,13 @@
 "cZN" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/crew_quarters/dorms)
 "cZO" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "cZS" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -14518,6 +14454,7 @@
 "daf" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "daq" = (
@@ -14557,7 +14494,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "dbr" = (
@@ -14576,9 +14512,9 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "dbE" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "dbG" = (
@@ -14611,9 +14547,9 @@
 	id = "kitchencounter";
 	name = "Kitchen Counter Shutters"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "dbW" = (
@@ -14647,7 +14583,7 @@
 "dcD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "dcJ" = (
 /obj/effect/turf_decal/bot,
@@ -14745,9 +14681,9 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "dfo" = (
@@ -14764,7 +14700,7 @@
 "dft" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "dfy" = (
 /obj/effect/turf_decal/tile/bar,
@@ -14774,7 +14710,6 @@
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "dfG" = (
@@ -14806,12 +14741,12 @@
 /turf/closed/mineral/random/stationside/asteroid/porus,
 /area/mine/explored)
 "dhi" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/camera{
 	c_tag = "Solar - Aft Port Control";
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "dhk" = (
@@ -14825,6 +14760,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "dho" = (
@@ -14841,10 +14777,10 @@
 /area/security/prison)
 "dhr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/junction/flip,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "did" = (
@@ -14889,7 +14825,6 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "dja" = (
-/obj/structure/cable,
 /obj/machinery/door_timer{
 	id = "medcell";
 	name = "Medical Cell";
@@ -14910,11 +14845,11 @@
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 26
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "djo" = (
@@ -14947,17 +14882,6 @@
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"djP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/engineering{
-	name = "Power Access Hatch";
-	req_access_txt = "11"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "dko" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -14965,7 +14889,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/sink{
 	pixel_y = 15
 	},
@@ -14977,10 +14900,10 @@
 "dkF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "dkG" = (
@@ -15045,10 +14968,10 @@
 	name = "Power Access Hatch";
 	req_access_txt = "11"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/central)
 "dlR" = (
 /obj/effect/turf_decal/stripes{
@@ -15066,17 +14989,16 @@
 "dlX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/right)
 "dmx" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "dmM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -15088,6 +15010,7 @@
 	name = "AI Upload Access";
 	req_access_txt = "16"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "dmZ" = (
@@ -15095,7 +15018,8 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "dns" = (
 /obj/structure/table/wood,
@@ -15108,6 +15032,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "dnN" = (
@@ -15144,7 +15069,7 @@
 "doe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "dot" = (
 /obj/machinery/door/airlock/external{
@@ -15166,7 +15091,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "tcomms-entrance"
 	},
@@ -15174,6 +15098,7 @@
 	name = "Telecommunications";
 	req_access_txt = "61"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "doC" = (
@@ -15197,7 +15122,6 @@
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "dpv" = (
@@ -15211,7 +15135,6 @@
 "dpH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/grimy,
 /area/service/library)
@@ -15220,7 +15143,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "dpO" = (
 /obj/structure/grille,
@@ -15240,8 +15164,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/status_display/ai/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "dqk" = (
@@ -15251,7 +15175,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -15259,6 +15182,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/gateway)
 "dqq" = (
@@ -15269,10 +15193,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "dqE" = (
@@ -15320,6 +15244,14 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"drI" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/port/aft)
 "drK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/weldingtool,
@@ -15441,7 +15373,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -15462,10 +15393,10 @@
 "dua" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "dul" = (
@@ -15477,7 +15408,6 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "duA" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
@@ -15538,11 +15468,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "dvg" = (
@@ -15559,10 +15489,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "dvJ" = (
@@ -15580,7 +15510,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "dvM" = (
-/obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding/engineering,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15589,6 +15518,7 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "dvT" = (
@@ -15608,14 +15538,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"dwR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "dwS" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -15646,6 +15571,7 @@
 "dxS" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "dya" = (
@@ -15679,9 +15605,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "dyH" = (
@@ -15692,6 +15618,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dzd" = (
@@ -15708,6 +15635,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "dzy" = (
@@ -15720,13 +15648,13 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "dzJ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dzR" = (
@@ -15785,13 +15713,12 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "dAu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "dAC" = (
@@ -15805,10 +15732,10 @@
 "dAU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/chapel)
 "dAW" = (
@@ -15818,7 +15745,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -15830,6 +15756,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "dBf" = (
@@ -15870,12 +15797,13 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "dCn" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/science/research)
 "dCq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -15927,13 +15855,13 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
 	name = "Garden"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "dDS" = (
@@ -15953,7 +15881,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
 "dEp" = (
 /obj/structure/chair/stool/directional/south,
@@ -16050,6 +15978,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "dGK" = (
@@ -16059,9 +15988,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "dGP" = (
@@ -16107,6 +16036,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "dHl" = (
@@ -16114,6 +16044,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/depsec/engineering,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "dHx" = (
@@ -16127,7 +16058,7 @@
 "dHz" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "dHG" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -16170,7 +16101,7 @@
 "dIc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wrench,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "dIm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -16224,11 +16155,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "dIV" = (
@@ -16286,6 +16217,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "dJA" = (
@@ -16402,6 +16334,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "dLn" = (
@@ -16430,6 +16363,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "dLD" = (
@@ -16438,6 +16372,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "dMe" = (
@@ -16447,7 +16382,6 @@
 	name = "Cargo Cell";
 	req_access_txt = "63"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
@@ -16460,6 +16394,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "dMg" = (
@@ -16473,11 +16408,11 @@
 /obj/effect/turf_decal/trimline/purple/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
 "dMl" = (
@@ -16493,7 +16428,6 @@
 	name = "Containment Pen #8";
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiobottomright";
@@ -16517,7 +16451,6 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -16593,9 +16526,9 @@
 "dPa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "dPv" = (
 /obj/structure/cable,
@@ -16604,10 +16537,10 @@
 "dPF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dPO" = (
@@ -16621,6 +16554,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "dPU" = (
@@ -16654,18 +16588,19 @@
 	c_tag = "Hallway - North-West Escape Wing Entry";
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "dQK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
 "dQU" = (
 /obj/structure/disposalpipe/segment{
@@ -16676,7 +16611,7 @@
 "dRg" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/center)
 "dRm" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -16759,7 +16694,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "dSY" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
@@ -16816,11 +16750,11 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "dUn" = (
@@ -16866,8 +16800,8 @@
 	},
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/light/small/directional/east,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "dVd" = (
@@ -16889,6 +16823,7 @@
 	dir = 1
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "dVz" = (
@@ -16896,7 +16831,6 @@
 /turf/open/openspace,
 /area/science/xenobiology)
 "dVA" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
@@ -16915,6 +16849,7 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "dVL" = (
@@ -16958,19 +16893,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"dXk" = (
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central)
 "dXs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"dXv" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/lab)
 "dXB" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -17003,10 +16935,10 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "dXP" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "dXT" = (
 /obj/machinery/navbeacon/wayfinding/library,
@@ -17019,8 +16951,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "dXY" = (
 /obj/effect/turf_decal/tile/bar,
@@ -17032,7 +16963,6 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "dXZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -17041,11 +16971,15 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "dYi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/old,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "dYu" = (
@@ -17132,14 +17066,14 @@
 /area/hallway/primary/central)
 "dZk" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "dZx" = (
 /obj/machinery/door/airlock/hatch,
@@ -17148,7 +17082,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/left)
 "dZF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17181,6 +17115,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "eaf" = (
@@ -17236,8 +17171,8 @@
 /obj/item/coin/plasma,
 /obj/item/paper/fluff/gateway,
 /obj/item/melee/chainofcommand,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "ebC" = (
@@ -17282,6 +17217,11 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/security/office)
+"eck" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/commons/lounge)
 "ecy" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -17399,8 +17339,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "efe" = (
@@ -17433,7 +17373,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "efA" = (
@@ -17453,10 +17392,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "efT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/bridge)
 "efY" = (
@@ -17497,7 +17436,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -17509,7 +17447,8 @@
 	pixel_x = 9;
 	pixel_y = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "egz" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -17522,6 +17461,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "egB" = (
@@ -17576,11 +17516,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/security/prison/shower)
-"ehZ" = (
+"ehP" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/turf/open/floor/plating,
+/area/commons/lounge)
+"ehZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/central)
 "eig" = (
 /obj/machinery/door/firedoor,
@@ -17613,7 +17559,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "eiE" = (
@@ -17762,6 +17707,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "elU" = (
@@ -17796,10 +17742,10 @@
 "emk" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/cargo/storage)
 "emq" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17807,6 +17753,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "emw" = (
@@ -17902,7 +17849,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "enP" = (
 /obj/effect/turf_decal/tile/bar,
@@ -17953,13 +17900,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "eoL" = (
@@ -17982,9 +17929,9 @@
 "eoW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "epb" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -17996,10 +17943,10 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "epw" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "epM" = (
@@ -18008,10 +17955,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "eqd" = (
@@ -18054,7 +18001,7 @@
 "eqM" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/secondary)
 "eqP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18228,7 +18175,6 @@
 	name = "Containment Pen #2";
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiotopleft";
@@ -18239,15 +18185,9 @@
 "etV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"etW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "etY" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -18264,8 +18204,8 @@
 "euo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "euF" = (
@@ -18338,8 +18278,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "ews" = (
@@ -18404,17 +18344,17 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "ewS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "ewV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18424,12 +18364,12 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "ewW" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "exe" = (
@@ -18475,16 +18415,16 @@
 "exW" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "eyb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "eyf" = (
@@ -18519,7 +18459,6 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "ezk" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18529,6 +18468,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ezo" = (
@@ -18553,12 +18493,12 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "ezV" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ezX" = (
@@ -18600,8 +18540,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "eAL" = (
@@ -18632,8 +18572,8 @@
 "eCi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eCj" = (
@@ -18645,6 +18585,7 @@
 /obj/effect/turf_decal/caution{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "eCl" = (
@@ -18731,10 +18672,10 @@
 /area/hallway/primary/tram/center)
 "eDx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "eDz" = (
@@ -18815,12 +18756,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/cargo/storage)
 "eEH" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -18919,7 +18858,8 @@
 "eGH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "eGL" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
@@ -18931,6 +18871,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "eHc" = (
@@ -18939,9 +18880,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "eHH" = (
 /turf/open/floor/iron,
@@ -18973,7 +18914,6 @@
 	codes_txt = "patrol;next_patrol=4-TunnelMidDoor";
 	location = "3-TunnelMid"
 	},
-/obj/structure/cable,
 /obj/item/reagent_containers/food/drinks/bottle/beer/almost_empty,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
@@ -19003,7 +18943,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "eIC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19035,13 +18975,12 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "eJC" = (
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "eJE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "eJG" = (
 /obj/machinery/keycard_auth{
@@ -19060,13 +18999,13 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "eJO" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "eJP" = (
@@ -19096,7 +19035,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
 "eKr" = (
@@ -19110,7 +19048,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "eLO" = (
 /obj/structure/sign/warning/docking,
@@ -19148,6 +19086,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "eMr" = (
@@ -19179,6 +19118,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "eMU" = (
@@ -19211,7 +19151,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "eNH" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -19234,9 +19173,9 @@
 "eNY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "eOc" = (
@@ -19246,16 +19185,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"eOn" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "eOu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19283,6 +19212,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "eOQ" = (
@@ -19303,6 +19233,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "ePd" = (
@@ -19318,8 +19249,8 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "ePf" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "ePq" = (
@@ -19358,7 +19289,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "tcomms-entrance"
 	},
@@ -19366,6 +19296,7 @@
 	name = "Telecommunications";
 	req_access_txt = "61"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "eRe" = (
@@ -19443,6 +19374,7 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/caution,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "eSy" = (
@@ -19490,12 +19422,11 @@
 "eTh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
 "eTs" = (
@@ -19534,11 +19465,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"eTY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "eUc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -19636,9 +19562,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "eVL" = (
@@ -19659,12 +19585,12 @@
 "eVW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "eVY" = (
@@ -19722,10 +19648,10 @@
 	name = "Gravity Generator Area";
 	req_access_txt = "19; 61"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "eWv" = (
@@ -19789,7 +19715,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "eXN" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage";
 	req_access_txt = "18"
@@ -19802,15 +19727,18 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "eXV" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
+"eYr" = (
+/turf/open/floor/iron/grimy,
+/area/security/detectives_office)
 "eYw" = (
 /obj/structure/chair/stool/directional/east,
 /obj/effect/landmark/xeno_spawn,
@@ -19822,9 +19750,9 @@
 "eYG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "eYL" = (
 /turf/open/floor/circuit,
@@ -19841,6 +19769,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "eZr" = (
@@ -19888,7 +19817,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -19897,6 +19825,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "eZX" = (
@@ -19990,6 +19919,7 @@
 	c_tag = "Hallway - North-East Escape Wing Entry";
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "fbD" = (
@@ -20005,9 +19935,9 @@
 /area/engineering/supermatter)
 "fbQ" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/window/reinforced/spawner,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/theater)
 "fbR" = (
@@ -20125,10 +20055,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 24
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "fdl" = (
@@ -20151,17 +20081,17 @@
 /turf/open/floor/plating,
 /area/medical/storage)
 "fes" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "ffh" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/crew_quarters/dorms)
 "ffk" = (
 /obj/structure/chair,
@@ -20183,7 +20113,6 @@
 /area/cargo/miningdock)
 "ffs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "ffR" = (
@@ -20247,9 +20176,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "fhe" = (
 /obj/effect/turf_decal/stripes/line,
@@ -20313,7 +20243,7 @@
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "fhR" = (
@@ -20340,14 +20270,13 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "fiQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/starboard/central)
 "fiT" = (
@@ -20374,6 +20303,7 @@
 	name = "sorting disposal pipe (Security)";
 	sortTypes = list(7,8)
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "fjs" = (
@@ -20384,12 +20314,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
-"fjy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "fjG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -20415,10 +20339,10 @@
 "fle" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "flq" = (
@@ -20439,16 +20363,17 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/north,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "flA" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "fmd" = (
@@ -20469,8 +20394,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter)
 "fmj" = (
@@ -20524,7 +20449,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -20592,12 +20516,12 @@
 "fog" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "for" = (
 /turf/open/floor/iron/cafeteria,
@@ -20654,6 +20578,9 @@
 	network = list("ss13","Service")
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "fpc" = (
@@ -20663,10 +20590,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "fpi" = (
@@ -20688,7 +20615,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "fpk" = (
@@ -20697,13 +20623,13 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "fpr" = (
@@ -20723,11 +20649,11 @@
 /turf/open/floor/plating/catwalk_floor,
 /area/command/gateway)
 "fpx" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "fpJ" = (
@@ -20739,11 +20665,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "fpO" = (
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -20751,23 +20677,24 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "fpX" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "fqi" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiobottomright";
 	name = "Xenobio Bottom Right Pen Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "fqq" = (
@@ -20798,13 +20725,13 @@
 "fqL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fqO" = (
@@ -20828,10 +20755,10 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "fra" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "frk" = (
@@ -20842,16 +20769,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
-"fry" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/structure/grille/broken,
-/obj/item/stack/rods,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "frB" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -20867,7 +20784,7 @@
 "frK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "frL" = (
 /obj/effect/landmark/event_spawn,
@@ -20894,6 +20811,7 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "fsL" = (
@@ -20914,8 +20832,8 @@
 "ftQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/holopad/secure,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "fub" = (
@@ -20927,6 +20845,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"fuc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "fuq" = (
 /obj/machinery/door/airlock/research{
 	id_tag = "ResearchExt";
@@ -20945,6 +20870,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-entrance-left"
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Sciencelockdown";
+	name = "Research Lockdown Blastdoor"
+	},
 /turf/open/floor/iron,
 /area/science/research)
 "fuv" = (
@@ -20954,11 +20883,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
-"fuw" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/break_room)
 "fux" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -20969,12 +20893,12 @@
 /area/maintenance/tram/mid)
 "fuB" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "fuC" = (
 /obj/structure/disposalpipe/segment{
@@ -20994,7 +20918,6 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -21003,6 +20926,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "fuK" = (
@@ -21055,6 +20979,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "fvH" = (
@@ -21080,7 +21005,7 @@
 /obj/machinery/power/turbine{
 	luminosity = 2
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "fwn" = (
@@ -21097,7 +21022,6 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "fwp" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	name = "sorting disposal pipe (Genetics)";
 	sortType = 23
@@ -21110,7 +21034,6 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorms South";
@@ -21234,14 +21157,14 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fzc" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "fzd" = (
 /obj/structure/table,
@@ -21300,7 +21223,7 @@
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/clothing/mask/breath,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "fAM" = (
 /obj/structure/table/wood,
@@ -21362,13 +21285,13 @@
 "fBs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "fBx" = (
@@ -21493,7 +21416,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "fDM" = (
 /turf/open/floor/iron/stairs/medium,
@@ -21583,7 +21506,7 @@
 /obj/machinery/igniter{
 	id = "Incinerator"
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "fGd" = (
@@ -21639,6 +21562,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "fHY" = (
@@ -21665,7 +21589,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/status_display/evac/directional/south,
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -21681,8 +21604,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable,
 /obj/machinery/status_display/evac/directional/west,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "fJq" = (
@@ -21732,8 +21655,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "fKH" = (
@@ -21748,18 +21671,18 @@
 /obj/item/stack/cable_coil/five,
 /obj/item/storage/toolbox/electrical,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/right)
 "fKU" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "fLD" = (
 /obj/machinery/door/airlock/highsecurity{
@@ -21768,9 +21691,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "fLF" = (
 /obj/effect/landmark/start/cook,
@@ -21782,6 +21705,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "fLV" = (
@@ -21816,6 +21740,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "fMM" = (
@@ -21851,7 +21776,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/right)
 "fNi" = (
 /obj/structure/chair{
@@ -21875,14 +21800,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fNs" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Tunnel Access";
 	req_one_access_txt = "12"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/mid)
 "fNu" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
@@ -21896,8 +21820,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "fNC" = (
@@ -21918,7 +21842,6 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "fNQ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
@@ -21931,7 +21854,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
+/area/maintenance/tram/left)
+"fNT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "fNU" = (
 /obj/machinery/hydroponics/soil,
@@ -22012,11 +21940,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "fPc" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	name = "sorting disposal pipe (Virology)";
 	sortType = 27
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fPm" = (
@@ -22036,10 +21964,17 @@
 "fPJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/chapel,
 /area/service/chapel)
+"fPK" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "fPQ" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced,
@@ -22142,11 +22077,11 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/bluespace_vendor/south,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "fQS" = (
@@ -22168,7 +22103,6 @@
 	},
 /obj/structure/chair/sofa/corp/left,
 /obj/effect/landmark/start/assistant,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "fRy" = (
@@ -22186,11 +22120,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
 "fRC" = (
@@ -22202,14 +22136,14 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
 "fRD" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "fRN" = (
 /obj/structure/table/reinforced,
@@ -22231,19 +22165,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/maintenance/disposal)
-"fRU" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/checkpoint/engineering)
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/disposal)
 "fSd" = (
 /obj/structure/railing{
 	dir = 4
@@ -22297,7 +22226,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "fSF" = (
 /turf/open/floor/plating/elevatorshaft,
@@ -22325,10 +22254,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "fTt" = (
@@ -22342,10 +22271,10 @@
 "fTC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "fTF" = (
 /obj/machinery/door/airlock/external{
@@ -22370,12 +22299,12 @@
 "fUN" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/central)
 "fVf" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "fVi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -22404,7 +22333,6 @@
 /area/cargo/miningdock)
 "fVU" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
@@ -22445,6 +22373,13 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"fWI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "fWU" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -22503,9 +22438,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "fYd" = (
@@ -22567,7 +22502,6 @@
 "fZk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Mining Maintenance Access";
 	req_access_txt = "48"
@@ -22576,10 +22510,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "fZn" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/sorting/mail{
@@ -22587,6 +22520,7 @@
 	name = "sorting disposal pipe (HoS)";
 	sortType = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "fZp" = (
@@ -22625,6 +22559,11 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
+"gag" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central)
 "gal" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -22669,6 +22608,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "gbV" = (
@@ -22695,12 +22635,12 @@
 "gco" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "gcq" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -22735,7 +22675,6 @@
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -22744,11 +22683,11 @@
 "gcX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "gdr" = (
@@ -22817,7 +22756,6 @@
 /area/engineering/atmos)
 "geu" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/break_room)
 "gex" = (
@@ -22839,15 +22777,14 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "geR" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "geT" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
@@ -22868,6 +22805,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "geY" = (
@@ -22904,11 +22842,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"gfr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "gfB" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/four,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "gfH" = (
 /obj/effect/turf_decal/tile/blue{
@@ -22922,8 +22867,8 @@
 "ggh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "ggn" = (
@@ -22976,6 +22921,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ghn" = (
@@ -23010,8 +22956,8 @@
 "gik" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "giA" = (
@@ -23058,10 +23004,10 @@
 "gkt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "gkF" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -23132,12 +23078,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "glC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
 "glI" = (
@@ -23146,8 +23094,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "glQ" = (
@@ -23198,11 +23146,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "gnC" = (
@@ -23217,6 +23165,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/port/central)
+"goc" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/library)
 "gog" = (
 /obj/effect/turf_decal/trimline/white/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23289,9 +23243,9 @@
 /area/science/robotics/lab)
 "gpB" = (
 /obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "gqc" = (
@@ -23437,6 +23391,9 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "gst" = (
@@ -23533,8 +23490,8 @@
 "guJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "gvc" = (
@@ -23542,8 +23499,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "gvt" = (
@@ -23583,7 +23540,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
@@ -23601,6 +23557,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Escape Wing"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "gvY" = (
@@ -23610,17 +23567,16 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
 	sortType = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "gwh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/meter,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "gwj" = (
@@ -23635,7 +23591,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "gwU" = (
@@ -23646,16 +23601,16 @@
 "gwZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/chapel)
 "gxi" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/security)
 "gxl" = (
 /obj/structure/chair/comfy/black{
@@ -23709,6 +23664,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "gyz" = (
@@ -23747,23 +23703,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/service/hydroponics)
 "gzs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
-"gzC" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
+"gzz" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/tram/mid)
+/area/hallway/primary/tram/right)
 "gAb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -23780,9 +23736,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "gAo" = (
@@ -23796,18 +23752,17 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/camera{
 	c_tag = "Secure - Tech Storage";
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "gAp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-maint-passthrough"
@@ -23816,7 +23771,8 @@
 	req_one_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "gAt" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -23829,14 +23785,14 @@
 /obj/item/stack/cable_coil/five,
 /obj/item/storage/toolbox/electrical,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "gAB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "gAL" = (
 /obj/structure/table,
@@ -23848,13 +23804,13 @@
 /area/security/office)
 "gAR" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Custodial Water Synth Access";
 	req_access_txt = "26"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/crew_quarters/dorms)
 "gAX" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -23914,6 +23870,7 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "gBD" = (
@@ -23922,7 +23879,7 @@
 	},
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/center)
 "gBH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -23988,6 +23945,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
 "gDg" = (
@@ -24030,9 +23988,9 @@
 "gDW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/right)
 "gEb" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -24079,6 +24037,7 @@
 "gEG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "gET" = (
@@ -24121,10 +24080,10 @@
 /area/security/processing)
 "gFt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "gFD" = (
 /obj/effect/spawner/random/trash/food_packaging,
@@ -24262,7 +24221,6 @@
 	name = "Security Desk";
 	req_access_txt = "63"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
 "gIt" = (
@@ -24282,7 +24240,7 @@
 "gIN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/crew_quarters/dorms)
 "gIO" = (
 /obj/effect/turf_decal/stripes{
@@ -24301,25 +24259,26 @@
 "gIX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "50"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/cargo/storage)
 "gJj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "gJw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "gJC" = (
@@ -24349,37 +24308,42 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
 /area/command/heads_quarters/rd)
+"gJW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "gJZ" = (
 /turf/open/floor/plating,
 /area/commons/vacant_room/office)
 "gKi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "gKu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "gKx" = (
@@ -24423,10 +24387,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/sign/departments/restroom{
 	pixel_y = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "gLi" = (
@@ -24480,7 +24444,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "gMG" = (
@@ -24505,7 +24468,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "gNb" = (
 /obj/effect/spawner/random/vending/colavend,
@@ -24551,10 +24515,10 @@
 	req_one_access_txt = "12;25"
 	},
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "gNL" = (
 /obj/machinery/camera{
@@ -24564,11 +24528,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"gNU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
 "gNY" = (
 /obj/structure/lattice,
 /turf/open/openspace/airless/planetary,
@@ -24594,6 +24553,9 @@
 /obj/machinery/camera{
 	c_tag = "Maintenance - Escape Pod";
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -24631,7 +24593,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "gOY" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -24658,7 +24620,6 @@
 "gPh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry";
 	req_access_txt = "33"
@@ -24672,6 +24633,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "gPp" = (
@@ -24693,18 +24655,19 @@
 "gPN" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "gPW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "gQw" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable/layer1,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "gQF" = (
@@ -24781,10 +24744,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "gSr" = (
@@ -24822,14 +24785,15 @@
 /area/security/checkpoint/science)
 "gSD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "gSF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "gSJ" = (
@@ -24849,6 +24813,11 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-entrance-right"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "Sciencelockdown";
+	name = "Research Lockdown Blastdoor"
 	},
 /turf/open/floor/iron,
 /area/science/research)
@@ -24941,18 +24910,8 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "gTY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"gUa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "gUe" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -24993,7 +24952,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
@@ -25014,8 +24972,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "gVh" = (
@@ -25047,11 +25005,11 @@
 "gVF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "gVL" = (
@@ -25122,20 +25080,19 @@
 "gWQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "gXe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "gXs" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "gYh" = (
@@ -25158,10 +25115,10 @@
 "gYm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "gYs" = (
@@ -25189,7 +25146,6 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "gZj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -25197,24 +25153,26 @@
 	},
 /obj/item/shard,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "gZq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "gZs" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "hag" = (
@@ -25288,7 +25246,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -25316,7 +25273,8 @@
 /obj/structure/ladder,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
 "hcW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25409,10 +25367,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "heW" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
 "hfk" = (
@@ -25454,10 +25412,10 @@
 "hfA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/assembly/mousetrap/armed,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "hfO" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -25514,6 +25472,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "hgr" = (
@@ -25526,10 +25485,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
 "hgE" = (
@@ -25560,11 +25519,11 @@
 /obj/effect/turf_decal/tile,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Arrivals - North Docking Hall";
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "hhx" = (
@@ -25596,7 +25555,6 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "hhU" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -25627,6 +25585,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/security/prison/shower)
 "hjB" = (
@@ -25634,7 +25593,8 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "hjV" = (
 /obj/machinery/door/firedoor,
@@ -25650,7 +25610,6 @@
 "hkb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
@@ -25727,6 +25686,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
+"hlf" = (
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/port/fore)
 "hlq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -25750,7 +25714,6 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "hlD" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Air Tank Access";
 	req_access_txt = "5"
@@ -25758,6 +25721,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/virology)
 "hlG" = (
@@ -25780,8 +25744,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "hlR" = (
@@ -25855,8 +25819,8 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "hmt" = (
@@ -25925,11 +25889,11 @@
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "hmS" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "hmX" = (
@@ -25939,13 +25903,13 @@
 	},
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/chair/stool/bar/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	name = "sorting disposal pipe (Bar)";
 	sortType = 19
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "hnF" = (
@@ -25954,6 +25918,7 @@
 "hod" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "hoF" = (
@@ -25966,9 +25931,9 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "hoU" = (
@@ -25976,10 +25941,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "hoX" = (
@@ -25987,9 +25952,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "hoY" = (
@@ -26008,9 +25973,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "hpE" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -26019,7 +25984,6 @@
 /turf/open/floor/iron,
 /area/science/research)
 "hpM" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -26028,6 +25992,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "hqc" = (
@@ -26041,8 +26006,8 @@
 /area/hallway/primary/tram/center)
 "hqn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "hqC" = (
@@ -26062,12 +26027,24 @@
 /area/maintenance/tram/mid)
 "hqP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/carpet,
 /area/service/library)
+"hrd" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "hrn" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -26189,10 +26166,10 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "hsZ" = (
@@ -26244,7 +26221,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -26252,6 +26228,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "htt" = (
@@ -26275,6 +26252,7 @@
 	dir = 8;
 	network = list("ss13","rd","xeno")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "htR" = (
@@ -26342,9 +26320,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "hvc" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "hvi" = (
@@ -26395,7 +26373,7 @@
 "hvZ" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/port/aft)
 "hwj" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -26403,8 +26381,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "hwy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -26432,24 +26409,24 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hxx" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "hxB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/item/assembly/mousetrap/armed,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "hym" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26459,15 +26436,19 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
+"hyK" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/starboard/central)
 "hzf" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "hzj" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
@@ -26478,7 +26459,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "hzo" = (
 /obj/structure/table/reinforced,
@@ -26493,16 +26475,17 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "hzt" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "hzw" = (
@@ -26543,6 +26526,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"hAd" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/office)
 "hAe" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table/glass,
@@ -26565,7 +26553,7 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "hAg" = (
@@ -26576,7 +26564,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "hAH" = (
 /obj/machinery/computer/robotics,
@@ -26648,12 +26636,12 @@
 "hCC" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/corner,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "hCQ" = (
@@ -26684,23 +26672,30 @@
 "hEc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/right)
 "hEi" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
+"hEy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "hEC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 1;
@@ -26720,8 +26715,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hES" = (
@@ -26742,7 +26737,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/research{
@@ -26753,6 +26747,11 @@
 	req_access_txt = "55"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobiomain";
+	name = "Xenobiology Lockdown Blastdoor"
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "hFV" = (
@@ -26780,7 +26779,6 @@
 /turf/open/floor/glass,
 /area/commons/dorms)
 "hGC" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
@@ -26836,16 +26834,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"hHx" = (
-/obj/structure/sign/barsign{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "hHy" = (
 /obj/structure/bed/pod{
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
@@ -26931,9 +26919,9 @@
 "hJa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "hJh" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -27048,6 +27036,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "hKW" = (
@@ -27055,14 +27044,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"hLk" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "hLp" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -27073,12 +27054,12 @@
 /area/engineering/supermatter/room)
 "hLw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
 	name = "sorting disposal pipe (Atmospherics)";
 	sortType = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hLA" = (
@@ -27111,6 +27092,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "hLV" = (
@@ -27159,7 +27141,7 @@
 "hNl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "hNp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27171,10 +27153,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hNx" = (
-/obj/structure/cable,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Security Outpost";
 	network = list("ss13","engineering","Security")
@@ -27306,8 +27288,8 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "hQD" = (
@@ -27361,6 +27343,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "hQY" = (
@@ -27438,10 +27421,10 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "hSj" = (
-/obj/structure/cable,
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "hTa" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
@@ -27544,12 +27527,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
-"hWd" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "hWg" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -27560,9 +27537,9 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "hWm" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "hWq" = (
@@ -27604,6 +27581,7 @@
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer/on{
 	name = "euthanization chamber freezer"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "hYd" = (
@@ -27612,28 +27590,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"hYp" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "hYq" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = 32
 	},
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/right)
 "hYr" = (
 /obj/effect/spawner/structure/window,
@@ -27642,6 +27605,12 @@
 	},
 /turf/open/floor/plating,
 /area/service/kitchen/diner)
+"hYs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "hYz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -27649,6 +27618,7 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
 "hYA" = (
@@ -27694,6 +27664,7 @@
 /obj/structure/fluff/tram_rail/floor{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "hZp" = (
@@ -27706,7 +27677,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -27732,8 +27702,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "hZT" = (
@@ -27759,6 +27729,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "iao" = (
@@ -27798,8 +27769,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "ibe" = (
@@ -27847,6 +27818,7 @@
 /obj/structure/fluff/tram_rail/floor{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "icg" = (
@@ -27917,7 +27889,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/secondary)
 "idY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -27929,7 +27901,6 @@
 "iea" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	name = "sorting disposal pipe (Pharmacy)";
@@ -27941,6 +27912,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "iem" = (
@@ -27954,7 +27926,6 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "iep" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -27963,6 +27934,7 @@
 	name = "Xenobio Top Left Blast Door";
 	req_access_txt = "55"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ies" = (
@@ -27971,13 +27943,18 @@
 	pixel_x = -8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "ieG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"ieH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/department/medical)
 "ieJ" = (
 /obj/item/stack/ore/iron,
 /turf/open/floor/plating/asteroid/airless,
@@ -28024,13 +28001,11 @@
 /area/security/interrogation)
 "ifn" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "ifs" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/mid)
 "ify" = (
 /obj/structure/ladder,
@@ -28041,16 +28016,16 @@
 /turf/closed/wall/r_wall,
 /area/science/breakroom)
 "ifD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "ifI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/stairs/medium,
 /area/service/theater)
 "ifW" = (
@@ -28123,7 +28098,6 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "ihi" = (
@@ -28131,9 +28105,9 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "ihF" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "ihG" = (
@@ -28147,8 +28121,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "ihH" = (
@@ -28205,6 +28179,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/east,
 /obj/machinery/newscaster/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "iiH" = (
@@ -28254,7 +28229,6 @@
 /area/medical/medbay/central)
 "ijy" = (
 /obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
@@ -28264,6 +28238,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "ijz" = (
@@ -28276,7 +28251,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ijQ" = (
-/obj/structure/cable,
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
@@ -28343,11 +28317,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"ikt" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/mine/explored)
 "iku" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28380,15 +28349,24 @@
 "ikO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "ikR" = (
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
+"ilo" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/port/fore)
+"ilv" = (
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/maintenance/tram/mid)
 "ilF" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
@@ -28401,6 +28379,14 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"ilP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ilR" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -28417,7 +28403,7 @@
 	dir = 1;
 	luminosity = 2
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "imG" = (
@@ -28443,7 +28429,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "inb" = (
@@ -28460,6 +28445,10 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/service/theater)
+"inv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central/secondary)
 "inR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -28550,15 +28539,15 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "ipc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/cargo)
 "ipr" = (
 /obj/machinery/door/airlock{
@@ -28586,9 +28575,9 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "ipX" = (
@@ -28661,12 +28650,12 @@
 /area/cargo/miningdock)
 "isc" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "isk" = (
@@ -28676,9 +28665,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "iti" = (
@@ -28688,10 +28677,10 @@
 "itl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "itx" = (
 /obj/structure/table/glass,
@@ -28725,7 +28714,7 @@
 "itO" = (
 /obj/machinery/navbeacon/wayfinding/dockescpod3,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "itR" = (
 /obj/machinery/door/airlock/engineering{
@@ -28758,7 +28747,8 @@
 	c_tag = "Hallway - Upper East Power Hatch";
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/right)
 "iuw" = (
 /obj/effect/turf_decal/stripes/line,
@@ -28773,6 +28763,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "iuF" = (
@@ -28815,6 +28806,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ivZ" = (
@@ -28895,7 +28887,6 @@
 	req_access_txt = "39"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -28911,6 +28902,7 @@
 	pixel_y = -24;
 	req_access_txt = "39"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ixa" = (
@@ -28935,10 +28927,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ixA" = (
@@ -28947,6 +28939,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "ixB" = (
@@ -28969,20 +28962,20 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-left"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ixQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "ixV" = (
@@ -29019,8 +29012,8 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "iyI" = (
@@ -29036,33 +29029,23 @@
 /obj/structure/chair/office,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "iyS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
-"iyT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "iyU" = (
 /obj/structure/chair{
 	dir = 8
@@ -29166,10 +29149,10 @@
 /area/security/processing)
 "iAc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "iAe" = (
@@ -29210,6 +29193,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
 "iBD" = (
@@ -29217,7 +29201,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "iBI" = (
 /obj/structure/frame/machine,
@@ -29322,7 +29306,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -29346,6 +29329,7 @@
 	normaldoorcontrol = 1;
 	req_access_txt = "63"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "iDJ" = (
@@ -29392,13 +29376,13 @@
 "iEv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "iEG" = (
@@ -29409,7 +29393,6 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "iEH" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
@@ -29417,7 +29400,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "iEV" = (
 /obj/structure/chair/office{
@@ -29511,7 +29495,6 @@
 "iFK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Medical - Chief Medical Officer's Office";
@@ -29582,7 +29565,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/three,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "iGB" = (
 /obj/machinery/door/airlock/security/glass{
@@ -29591,13 +29574,13 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "iHc" = (
@@ -29605,10 +29588,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "iHi" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/station_engineer,
@@ -29658,8 +29641,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "iHP" = (
@@ -29706,7 +29689,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "iJa" = (
@@ -29861,8 +29843,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
 /obj/machinery/door/firedoor/heavy,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "iLD" = (
@@ -29916,14 +29898,14 @@
 	c_tag = "Hallway - Lower East Power Hatch";
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/right)
 "iMo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "iMI" = (
 /obj/effect/turf_decal/sand/plating,
@@ -29978,11 +29960,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "iOm" = (
@@ -30022,6 +30004,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Command Wing Hallway"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "iPd" = (
@@ -30094,6 +30077,11 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"iPX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "iQg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -30136,10 +30124,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "iQv" = (
@@ -30180,8 +30168,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "iQD" = (
@@ -30245,7 +30233,6 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
 	pixel_x = -6;
 	pixel_y = 6
@@ -30257,6 +30244,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "iTv" = (
@@ -30273,9 +30261,9 @@
 	dir = 1
 	},
 /obj/structure/chair/stool/bar/directional/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "iUq" = (
@@ -30293,12 +30281,12 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
 "iUt" = (
@@ -30330,20 +30318,17 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
 "iUK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
-"iUL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "iVc" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -30372,7 +30357,7 @@
 /obj/item/pickaxe/rusted,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/screwdriver,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "iVt" = (
 /obj/machinery/door/airlock/grunge{
@@ -30433,7 +30418,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/seven,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "iXg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30443,18 +30428,18 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "iXl" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "iXq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "iXt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -30493,10 +30478,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "iYi" = (
@@ -30518,9 +30503,9 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "iYu" = (
@@ -30536,7 +30521,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 16
 	},
@@ -30566,6 +30550,7 @@
 /obj/item/pipe_dispenser,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "iZt" = (
@@ -30628,14 +30613,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "jae" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "jaz" = (
 /obj/effect/turf_decal/stripes{
@@ -30656,6 +30642,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/science/research)
+"jaH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "jaX" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -30680,12 +30673,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
-"jbT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
 "jco" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/corner,
@@ -30724,10 +30711,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "jcN" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "jcU" = (
@@ -30762,8 +30749,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "jdv" = (
@@ -30793,6 +30780,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-entrance-right"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/research)
 "jdK" = (
@@ -30801,7 +30789,6 @@
 /turf/open/floor/plating,
 /area/mine/explored)
 "jdR" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -30815,13 +30802,13 @@
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
 "jeq" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "jeu" = (
 /obj/effect/turf_decal/delivery,
@@ -30847,9 +30834,9 @@
 "jeV" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jfn" = (
@@ -30869,7 +30856,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/right)
 "jfP" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -30901,7 +30889,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "jgq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -30910,9 +30898,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "jgz" = (
@@ -30946,13 +30934,13 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "jhd" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/limb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "jhg" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
@@ -31000,7 +30988,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "jhU" = (
@@ -31017,7 +31004,7 @@
 "jiz" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/right)
 "jiL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -31037,8 +31024,8 @@
 "jiR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/maint)
 "jjI" = (
@@ -31083,12 +31070,12 @@
 "jjX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/left)
 "jkh" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -31110,7 +31097,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
@@ -31148,10 +31134,10 @@
 "jlz" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "jlG" = (
@@ -31161,12 +31147,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "jlH" = (
@@ -31175,20 +31161,20 @@
 	req_access_txt = "20"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/captain)
 "jlO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "jlT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -31215,9 +31201,9 @@
 	req_one_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/cargo)
 "jmC" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -31239,11 +31225,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "jnv" = (
@@ -31257,19 +31243,18 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "jnZ" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "joh" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -31278,6 +31263,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "joC" = (
@@ -31312,6 +31298,7 @@
 /obj/structure/sign/poster/official/pda_ad{
 	pixel_y = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "jps" = (
@@ -31325,12 +31312,12 @@
 "jpt" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "jpF" = (
@@ -31338,8 +31325,8 @@
 /area/space/nearstation)
 "jpM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/status_display/ai/directional/north,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "jpW" = (
@@ -31416,7 +31403,7 @@
 	req_one_access_txt = "12;33"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "jrp" = (
 /obj/structure/closet/firecloset,
@@ -31436,12 +31423,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
-"jrH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "jrL" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
@@ -31495,7 +31476,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/right)
 "jto" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -31514,10 +31495,10 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "jtG" = (
@@ -31544,7 +31525,7 @@
 /obj/structure/girder,
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "juj" = (
 /obj/structure/window/reinforced{
@@ -31570,12 +31551,12 @@
 	c_tag = "Civilian - Library South Bookcases";
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "juE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -31610,7 +31591,8 @@
 /obj/structure/girder,
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "jvH" = (
 /obj/effect/turf_decal/stripes/line{
@@ -31627,12 +31609,11 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "jwv" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "31;48"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "jwD" = (
 /obj/structure/lattice,
@@ -31652,10 +31633,10 @@
 "jxm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/security/prison)
 "jxy" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31666,9 +31647,9 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/cargo)
 "jxE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -31702,7 +31683,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "jxU" = (
@@ -31710,8 +31690,8 @@
 	id = "portsolar";
 	name = "Port Solar Array"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "jxY" = (
@@ -31765,12 +31745,13 @@
 "jzs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "jzt" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "jzH" = (
@@ -32001,9 +31982,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "jEn" = (
@@ -32042,13 +32023,6 @@
 "jED" = (
 /turf/open/floor/iron,
 /area/engineering/main)
-"jEG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "jFi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -32073,6 +32047,7 @@
 	dir = 4;
 	network = list("ss13","rd","xeno")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "jFR" = (
@@ -32102,7 +32077,6 @@
 	name = "Library Desk";
 	req_access_txt = "37"
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/library)
@@ -32149,13 +32123,12 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "jIn" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/door_timer{
 	id = "Cell 4";
 	name = "Cell 4";
@@ -32177,12 +32150,12 @@
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "jIQ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "jIS" = (
@@ -32243,13 +32216,6 @@
 "jJo" = (
 /turf/closed/wall,
 /area/cargo/sorting)
-"jKa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/engineering/main)
 "jKg" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -32266,11 +32232,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Command - Bridge Left Airlock";
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "jKs" = (
@@ -32296,7 +32262,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
@@ -32308,6 +32273,7 @@
 	dir = 8;
 	network = list("ss13","Security")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "jKG" = (
@@ -32358,7 +32324,6 @@
 /obj/item/folder/blue,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/neck/stethoscope,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
@@ -32425,7 +32390,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/cargo/storage)
 "jMF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -32438,14 +32403,14 @@
 /area/medical/medbay/central)
 "jMM" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "jMY" = (
 /obj/machinery/computer/security{
@@ -32464,7 +32429,7 @@
 /obj/structure/disposalpipe/trunk/multiz/down,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "jNr" = (
 /obj/machinery/light/small/directional/south,
@@ -32486,11 +32451,11 @@
 /area/hallway/secondary/exit/departure_lounge)
 "jOl" = (
 /obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/blood_filter,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "jOz" = (
@@ -32521,6 +32486,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "jOU" = (
@@ -32539,7 +32505,6 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "jPc" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -32548,6 +32513,7 @@
 	name = "Xenobio Top right Blast Door";
 	req_access_txt = "55"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "jPe" = (
@@ -32578,12 +32544,12 @@
 "jPA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "jPI" = (
 /turf/closed/wall/r_wall,
@@ -32625,6 +32591,10 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"jQr" = (
+/obj/structure/cable/layer1,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "jQF" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -32644,7 +32614,6 @@
 "jRa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "jRh" = (
@@ -32656,17 +32625,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"jRt" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Ladder Access Hatch";
-	req_one_access_txt = null
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/center)
 "jRz" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -32715,8 +32673,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "jSw" = (
@@ -32756,7 +32714,6 @@
 /area/security/processing)
 "jTP" = (
 /obj/machinery/power/smes/engineering,
-/obj/structure/cable,
 /obj/machinery/light/directional/west,
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
@@ -32766,6 +32723,7 @@
 	dir = 5;
 	network = list("ss13","engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "jUw" = (
@@ -32836,19 +32794,18 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
 "jVH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/status_display/ai/directional/south,
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -32869,8 +32826,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /mob/living/simple_animal/bot/floorbot,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/maint)
 "jWc" = (
@@ -32890,10 +32847,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "jWg" = (
@@ -32929,9 +32886,9 @@
 /turf/open/floor/iron,
 /area/science/research)
 "jWO" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "jWP" = (
@@ -32993,7 +32950,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera{
@@ -33001,6 +32957,7 @@
 	dir = 9;
 	network = list("ss13","rd")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "jXF" = (
@@ -33028,6 +32985,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "jYw" = (
@@ -33042,7 +33000,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "jYB" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
@@ -33054,8 +33011,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
+"jYQ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/starboard/central)
 "jZn" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
@@ -33090,6 +33052,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"jZU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/secondary)
 "jZX" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -33179,10 +33148,9 @@
 "kaY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/security)
 "kbb" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/library)
@@ -33275,6 +33243,7 @@
 /obj/structure/disposalpipe/sorting/mail/flip{
 	sortType = 17
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "kcl" = (
@@ -33300,13 +33269,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology East";
 	dir = 9;
 	network = list("ss13","rd","xeno")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "kct" = (
@@ -33324,7 +33293,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/mid)
 "kcC" = (
 /obj/machinery/computer/apc_control{
@@ -33415,12 +33384,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "keg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "ken" = (
@@ -33429,7 +33399,6 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/inspector,
@@ -33437,6 +33406,7 @@
 	pixel_x = -5;
 	pixel_y = 12
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "ker" = (
@@ -33469,7 +33439,6 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "keO" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/depsec/science,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33487,13 +33456,23 @@
 "kfa" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"kfA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "kfJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "kga" = (
@@ -33515,7 +33494,8 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/center)
 "kgx" = (
 /obj/structure/railing{
@@ -33599,7 +33579,7 @@
 	},
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "khB" = (
 /obj/structure/flora/ausbushes/sunnybush,
@@ -33645,6 +33625,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "kiP" = (
@@ -33733,8 +33714,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "kkE" = (
@@ -33815,10 +33796,10 @@
 "klt" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "kly" = (
@@ -33828,18 +33809,25 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "klD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/secondary)
+"klK" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/main)
 "kmr" = (
 /obj/effect/landmark/start/depsec/engineering,
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "kmO" = (
@@ -33861,8 +33849,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/medical/coldroom)
 "knj" = (
@@ -33889,7 +33877,6 @@
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
 "knE" = (
-/obj/structure/cable,
 /obj/machinery/power/apc{
 	areastring = "/area/security/prison/safe";
 	dir = 1;
@@ -33897,7 +33884,8 @@
 	pixel_y = 23
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "knV" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -33916,9 +33904,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "koj" = (
@@ -33941,8 +33929,8 @@
 "koq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "kot" = (
@@ -33951,10 +33939,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "koJ" = (
@@ -33963,8 +33951,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "koV" = (
@@ -33984,7 +33972,7 @@
 "kpe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
 "kpp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -33995,6 +33983,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "kpr" = (
@@ -34015,13 +34004,14 @@
 	c_tag = "Hallway - Upper West Power Hatch";
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
 "kpR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "kqy" = (
@@ -34045,7 +34035,8 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "kqN" = (
 /obj/effect/mapping_helpers/iannewyear,
@@ -34072,7 +34063,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Civilian - Lounge South-West";
@@ -34113,12 +34103,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
 "krW" = (
@@ -34167,6 +34157,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "ktp" = (
@@ -34240,9 +34231,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "kuX" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/cargo)
 "kuY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -34262,9 +34253,9 @@
 /area/service/bar)
 "kvs" = (
 /obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/cargo)
 "kvx" = (
 /obj/effect/turf_decal/stripes{
@@ -34282,21 +34273,21 @@
 	name = "Server Room";
 	req_access_txt = "61"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "kvZ" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "kwj" = (
 /obj/effect/turf_decal/tile/bar,
@@ -34304,11 +34295,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/stool/bar/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "kwy" = (
@@ -34339,6 +34330,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"kwY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "kxn" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -34358,6 +34354,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "kxN" = (
@@ -34374,15 +34371,16 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "kyp" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "kzh" = (
@@ -34433,6 +34431,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "kzq" = (
@@ -34450,13 +34449,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "kzx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kzH" = (
@@ -34535,6 +34535,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "kBG" = (
@@ -34592,6 +34593,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "kDm" = (
@@ -34599,6 +34601,10 @@
 	dir = 1
 	},
 /obj/effect/landmark/blobstart,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "kDu" = (
@@ -34610,6 +34616,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"kDv" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/window/reinforced/spawner,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/theater)
 "kDL" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 5
@@ -34653,11 +34665,11 @@
 "kEA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/cut,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "kFu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -34679,6 +34691,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "kGh" = (
@@ -34690,8 +34703,8 @@
 "kGk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "kGp" = (
@@ -34736,7 +34749,7 @@
 /obj/structure/disposalpipe/trunk/multiz,
 /obj/structure/closet/secure_closet/engineering_electrical,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "kGW" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -34780,6 +34793,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "kHS" = (
@@ -34787,7 +34801,8 @@
 	req_one_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "kId" = (
 /obj/structure/chair/office/light{
@@ -34822,8 +34837,8 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "kIL" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "kIO" = (
@@ -35018,7 +35033,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "kMn" = (
 /obj/structure/tank_dispenser{
@@ -35029,8 +35044,8 @@
 "kMo" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/machinery/disposal/bin,
-/obj/structure/cable,
 /obj/structure/disposalpipe/trunk,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "kNk" = (
@@ -35061,6 +35076,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "kOa" = (
@@ -35139,15 +35155,15 @@
 /area/engineering/storage/tech)
 "kPn" = (
 /obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 1
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "kPz" = (
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "kPK" = (
@@ -35170,7 +35186,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -35184,7 +35199,6 @@
 /turf/open/floor/iron,
 /area/maintenance/port/central)
 "kQE" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
@@ -35196,6 +35210,7 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "kQF" = (
@@ -35226,12 +35241,6 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"kRr" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "kRZ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
@@ -35243,7 +35252,8 @@
 "kSf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "kSh" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -35256,6 +35266,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "kSB" = (
@@ -35327,12 +35338,12 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "kTA" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "kTB" = (
@@ -35351,6 +35362,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "kTM" = (
@@ -35398,11 +35410,11 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "kUQ" = (
@@ -35433,7 +35445,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kUW" = (
@@ -35447,6 +35458,7 @@
 "kVl" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "kVx" = (
@@ -35458,6 +35470,7 @@
 	pixel_y = -4
 	},
 /obj/item/clothing/head/cone,
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "kVz" = (
@@ -35477,12 +35490,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Arrivals - North Docking Wing";
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kVF" = (
@@ -35513,7 +35526,6 @@
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -35539,6 +35551,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "kWB" = (
@@ -35665,6 +35678,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
+"kZq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/port/aft)
 "kZs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35679,13 +35697,13 @@
 "kZA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "kZF" = (
 /obj/machinery/computer/station_alert{
@@ -35711,9 +35729,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kZX" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "lad" = (
@@ -35794,7 +35812,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "lbB" = (
 /obj/structure/chair/office/light{
@@ -35821,15 +35839,15 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/light_switch/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "lct" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "lcH" = (
@@ -35840,10 +35858,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "lcO" = (
@@ -35862,7 +35880,7 @@
 "ldj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "ldk" = (
 /obj/effect/turf_decal/bot,
@@ -35882,8 +35900,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "lds" = (
@@ -35955,10 +35973,10 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "lev" = (
@@ -35978,14 +35996,15 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "lfe" = (
-/obj/structure/cable,
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lfi" = (
@@ -36011,8 +36030,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "lfx" = (
@@ -36051,6 +36070,11 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/science/mixing)
+"lgr" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/starboard/central)
 "lgw" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -36087,6 +36111,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lgI" = (
@@ -36102,14 +36127,12 @@
 /area/service/hydroponics)
 "lhM" = (
 /obj/structure/closet/secure_closet/research_director,
-/obj/structure/cable,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
 /area/command/heads_quarters/rd)
 "lhO" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
 	name = "SERVER ROOM";
@@ -36121,8 +36144,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "lil" = (
@@ -36137,16 +36160,16 @@
 "lit" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "liL" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "lju" = (
@@ -36157,7 +36180,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ljS" = (
@@ -36207,13 +36229,6 @@
 "lkH" = (
 /turf/open/floor/iron,
 /area/security/prison/mess)
-"lkK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/hallway/primary/tram/center)
 "lkN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -36239,12 +36254,12 @@
 /area/commons/vacant_room/commissary)
 "llY" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "lma" = (
@@ -36276,7 +36291,6 @@
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "lmw" = (
-/obj/structure/cable,
 /obj/machinery/flasher/directional/north{
 	id = "AI"
 	},
@@ -36285,7 +36299,6 @@
 "lmI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry";
 	req_access_txt = "33"
@@ -36301,6 +36314,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lnq" = (
@@ -36308,7 +36322,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
 	name = "privacy shutter"
@@ -36324,6 +36337,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "lnC" = (
@@ -36384,20 +36398,20 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "loj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "lor" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "loK" = (
@@ -36487,12 +36501,12 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12;25"
 	},
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "lrp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -36518,9 +36532,10 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "lrP" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "lsc" = (
 /obj/machinery/light/small/directional/north,
@@ -36528,13 +36543,18 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/bar)
+"lsj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central)
 "lsA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "lsF" = (
@@ -36686,14 +36706,9 @@
 "lvw" = (
 /turf/closed/wall,
 /area/mine/explored)
-"lvJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/processing)
 "lwa" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lwr" = (
@@ -36708,7 +36723,6 @@
 /area/medical/storage)
 "lwt" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
 	name = "SERVER ROOM";
@@ -36748,6 +36762,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison/mess)
+"lyf" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "lyN" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/tile/neutral{
@@ -36774,6 +36795,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/maint)
+"lzu" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Power Access Hatch";
+	req_access_txt = "50"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/department/cargo)
 "lAa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36805,6 +36834,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"lAB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/tram/right)
 "lAC" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -36815,7 +36848,6 @@
 "lAF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "lAH" = (
@@ -36854,7 +36886,6 @@
 /area/science/research)
 "lBt" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
 	name = "privacy shutter"
@@ -36901,11 +36932,11 @@
 /area/mine/explored)
 "lBW" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "lCc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36926,6 +36957,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "lCu" = (
@@ -36963,6 +36995,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "lCH" = (
@@ -36970,7 +37003,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/crowbar,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "lCL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36986,11 +37019,11 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Arrivals - North Hall";
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "lDa" = (
@@ -37012,7 +37045,6 @@
 /turf/open/openspace/airless/planetary,
 /area/space/nearstation)
 "lDh" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37034,7 +37066,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "lDw" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
@@ -37043,26 +37074,18 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "lDT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/library)
-"lDW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "lEo" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lEr" = (
@@ -37073,6 +37096,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "lFi" = (
@@ -37100,10 +37124,10 @@
 "lFo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "lFp" = (
@@ -37122,7 +37146,7 @@
 "lFI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "lGg" = (
 /obj/effect/landmark/event_spawn,
@@ -37166,14 +37190,13 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "lGQ" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "lGY" = (
@@ -37190,11 +37213,11 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "lHl" = (
@@ -37210,13 +37233,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"lHu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/secondary)
 "lHL" = (
 /obj/item/crowbar/large,
 /obj/structure/rack,
@@ -37227,6 +37243,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "lIu" = (
@@ -37313,7 +37330,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/left)
 "lJt" = (
 /obj/machinery/camera{
@@ -37348,7 +37365,7 @@
 "lJR" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
 "lKj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37401,8 +37418,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "lKO" = (
@@ -37417,8 +37434,8 @@
 "lLc" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/light/small/directional/east,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "lLq" = (
@@ -37444,12 +37461,15 @@
 /obj/machinery/button/door/directional/east{
 	id = "cargowarehouse"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "lMb" = (
 /obj/structure/punching_bag,
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "lMe" = (
@@ -37478,7 +37498,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "lMH" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -37576,8 +37597,8 @@
 /area/hallway/primary/central)
 "lOJ" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "lON" = (
@@ -37638,21 +37659,21 @@
 "lPt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Research Maintnenace";
 	req_one_access_txt = "47"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/science/research)
 "lPJ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "lPN" = (
 /obj/machinery/door/airlock/security/glass{
@@ -37716,8 +37737,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "lRU" = (
@@ -37726,7 +37747,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/mid)
 "lSf" = (
 /obj/structure/table,
@@ -37744,8 +37765,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/maint)
 "lSt" = (
@@ -37829,6 +37850,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "lTD" = (
@@ -37866,6 +37888,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"lUp" = (
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "lUE" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/navbeacon/wayfinding/med,
@@ -37879,7 +37907,6 @@
 /area/engineering/atmos)
 "lUT" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
@@ -37907,8 +37934,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "lVC" = (
@@ -37978,6 +38005,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
+"lXc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central/secondary)
 "lXu" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -37997,11 +38029,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/structure/table/glass,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lYN" = (
@@ -38018,11 +38050,11 @@
 /area/service/hydroponics)
 "lZG" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiobottomleft";
 	name = "Xenobio Bottom Left Pen Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "lZO" = (
@@ -38031,12 +38063,12 @@
 /turf/open/floor/iron,
 /area/science/storage)
 "man" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
 	name = "sorting disposal pipe (Research Director's Office)";
 	sortType = 13
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "maZ" = (
@@ -38061,12 +38093,12 @@
 "mbh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "mbt" = (
@@ -38083,7 +38115,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "mbD" = (
@@ -38098,7 +38129,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "mbO" = (
 /obj/effect/turf_decal/sand/plating,
@@ -38125,15 +38156,16 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "mdg" = (
-/obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding/teleporter,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "mdk" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet/firecloset,
 /obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/center)
 "mdu" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -38164,19 +38196,19 @@
 "mdA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mdR" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
 "mdU" = (
@@ -38226,7 +38258,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "mfe" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -38234,7 +38265,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/mid)
 "mfj" = (
 /obj/structure/table/reinforced,
@@ -38247,13 +38278,13 @@
 "mfx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Medical Maintenance";
 	req_access_txt = "5"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
 "mfy" = (
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -38363,6 +38394,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mjd" = (
@@ -38386,6 +38418,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"mjD" = (
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "mjF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -38404,8 +38439,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/bounty_board/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "mjQ" = (
@@ -38427,12 +38462,12 @@
 /area/science/research)
 "mks" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "mkw" = (
@@ -38474,10 +38509,10 @@
 "mkV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/chapel)
 "mlb" = (
@@ -38516,7 +38551,7 @@
 "mlE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "mlV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38528,7 +38563,7 @@
 "mma" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/mess,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "mmo" = (
 /obj/structure/table/glass,
@@ -38635,7 +38670,6 @@
 "mpm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
@@ -38643,6 +38677,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "mpr" = (
@@ -38656,7 +38691,7 @@
 "mpz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "mpT" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -38699,9 +38734,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "mqu" = (
@@ -38818,8 +38853,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/structure/cable,
 /obj/machinery/status_display/evac/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "msa" = (
@@ -38857,6 +38892,7 @@
 	pixel_x = -3;
 	pixel_y = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "mtm" = (
@@ -38867,7 +38903,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "mtB" = (
 /obj/machinery/airalarm/directional/north,
@@ -39002,9 +39038,9 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "mwf" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "mwx" = (
@@ -39088,9 +39124,9 @@
 	name = "Captain's Desk";
 	req_access_txt = "20"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "myx" = (
@@ -39100,10 +39136,9 @@
 "myz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/sand/plating,
 /obj/item/assembly/mousetrap/armed,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "myC" = (
 /obj/machinery/conveyor{
@@ -39119,9 +39154,9 @@
 "myI" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "myL" = (
@@ -39183,17 +39218,17 @@
 	name = "EVA Storage";
 	req_access_txt = "18"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "mzF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "mzK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39231,13 +39266,13 @@
 "mAB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Permabrig Maintenance";
 	req_access_txt = "1"
 	},
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
 "mAC" = (
@@ -39246,32 +39281,26 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/central)
-"mAL" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/supermatter/room)
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/central)
 "mAT" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/virology)
 "mBn" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/chaplain,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "mBz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "mBA" = (
 /obj/effect/turf_decal/sand,
@@ -39293,21 +39322,21 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "mCl" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "mCm" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "mCy" = (
@@ -39321,8 +39350,17 @@
 "mDh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
+"mDC" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/commons/lounge)
 "mEf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -39396,6 +39434,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "mGH" = (
@@ -39420,13 +39459,12 @@
 "mGO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/sand/plating,
 /obj/item/assembly/mousetrap/armed,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "mGV" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -39448,7 +39486,6 @@
 	name = "Containment Pen #7";
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiobottomright";
@@ -39464,11 +39501,17 @@
 /obj/structure/ore_box,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"mHY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/iron/smooth,
+/area/maintenance/department/medical)
 "mIu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/assembly/mousetrap/armed,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "mIG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -39528,21 +39571,26 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
 /obj/item/gun/syringe,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "mJH" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"mJV" = (
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/starboard/central)
 "mKa" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "mKc" = (
@@ -39568,7 +39616,7 @@
 	},
 /obj/item/trash/tray,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/crew_quarters/dorms)
 "mKP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -39580,7 +39628,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "mLc" = (
 /obj/machinery/door/airlock/security/glass{
@@ -39596,7 +39644,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "mLj" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/depsec/science,
 /obj/effect/turf_decal/trimline/red/arrow_cw,
 /obj/effect/decal/cleanable/dirt,
@@ -39630,12 +39677,12 @@
 "mLu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "mNe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -39714,6 +39761,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "mON" = (
@@ -39751,7 +39799,6 @@
 /area/engineering/atmos)
 "mPH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -39867,20 +39914,20 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "mRL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "mRN" = (
@@ -39903,12 +39950,12 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "mRY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "mSe" = (
@@ -39934,9 +39981,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/lab)
 "mSE" = (
@@ -39995,6 +40042,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
+"mTY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/starboard/secondary)
 "mUL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/assembly/mousetrap/armed,
@@ -40011,10 +40062,10 @@
 "mVb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "mVj" = (
@@ -40066,10 +40117,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-left"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "mWs" = (
@@ -40082,8 +40133,8 @@
 /area/service/hydroponics)
 "mWt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "mWv" = (
@@ -40094,7 +40145,7 @@
 	pixel_y = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "mWF" = (
 /obj/machinery/light/directional/north,
@@ -40206,7 +40257,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "mZd" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -40231,9 +40282,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "mZD" = (
@@ -40254,6 +40305,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "nac" = (
@@ -40283,7 +40335,7 @@
 "nai" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "naC" = (
 /obj/machinery/light/small/directional/north,
@@ -40356,12 +40408,12 @@
 "nbH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "nbR" = (
 /obj/structure/table,
@@ -40373,12 +40425,12 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "nbU" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "nbY" = (
@@ -40431,6 +40483,7 @@
 "ncO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ncZ" = (
@@ -40459,8 +40512,16 @@
 "ndq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wrench,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
+"ndt" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	req_one_access_txt = "12"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central/secondary)
 "ndy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40523,6 +40584,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "ngB" = (
@@ -40562,6 +40624,7 @@
 /area/medical/virology)
 "nhq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "nhJ" = (
@@ -40592,7 +40655,7 @@
 "nii" = (
 /obj/item/assembly/mousetrap/armed,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "nim" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -40612,12 +40675,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"njU" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
+"njg" = (
+/obj/structure/table/wood/fancy,
+/obj/item/flashlight/lantern,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "njY" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -40626,7 +40689,7 @@
 /area/service/kitchen)
 "nkC" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/crew_quarters/dorms)
 "nkI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -40641,7 +40704,6 @@
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
@@ -40682,14 +40744,22 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "nmb" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"nmd" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "nmu" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Power Access Hatch";
@@ -40720,6 +40790,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "nnT" = (
@@ -40738,11 +40809,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/maint)
-"nnZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
 "nog" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -40764,9 +40830,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "noL" = (
@@ -40777,12 +40843,8 @@
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wrench,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/port/aft)
-"npy" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "npC" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -40797,7 +40859,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "npM" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "rdoffice";
 	name = "Research Director's Shutters"
@@ -40860,9 +40921,9 @@
 /area/engineering/supermatter/room)
 "nre" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
 "nrn" = (
@@ -40887,10 +40948,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "nrv" = (
@@ -40901,14 +40962,13 @@
 "nrE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "nrF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "nrP" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -40936,7 +40996,7 @@
 "nsk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "nsl" = (
 /obj/effect/turf_decal/trimline/white/line{
@@ -40978,10 +41038,10 @@
 "nsQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "ntd" = (
@@ -41010,6 +41070,7 @@
 	},
 /obj/machinery/status_display/evac/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "ntr" = (
@@ -41029,15 +41090,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
-"ntt" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/security/prison)
 "ntH" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
@@ -41087,8 +41139,8 @@
 /area/cargo/miningdock)
 "nvm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
 /obj/machinery/vending/wallmed/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "nvp" = (
@@ -41119,7 +41171,6 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/left)
 "nwg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -41128,6 +41179,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "nwq" = (
@@ -41136,7 +41188,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "nwu" = (
@@ -41163,11 +41214,11 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "nwO" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
 	dir = 4
@@ -41227,8 +41278,8 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "nxZ" = (
@@ -41273,6 +41324,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "nyp" = (
@@ -41320,6 +41372,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "nzt" = (
@@ -41360,12 +41413,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
 	name = "Auxiliary Tool Storage";
 	req_access_txt = "12"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "nAd" = (
@@ -41376,6 +41429,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "nAf" = (
@@ -41413,12 +41467,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/science/research)
 "nBz" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "nBB" = (
@@ -41444,9 +41498,9 @@
 	req_access_txt = "10; 13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "nBN" = (
@@ -41478,7 +41532,6 @@
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "nCl" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -41487,6 +41540,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "nDr" = (
@@ -41527,7 +41581,6 @@
 	req_access_txt = "28"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -41536,6 +41589,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "nDM" = (
@@ -41568,6 +41622,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "nEl" = (
@@ -41595,7 +41650,6 @@
 "nEM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
@@ -41604,6 +41658,7 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "nEN" = (
@@ -41617,7 +41672,6 @@
 /area/engineering/atmospherics_engine)
 "nFd" = (
 /obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -41625,6 +41679,7 @@
 	c_tag = "Medical - Main North";
 	network = list("ss13","medbay")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "nFe" = (
@@ -41649,12 +41704,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "nGc" = (
@@ -41719,16 +41774,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "nGX" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "nHd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
@@ -41740,11 +41795,12 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "nHk" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "nHp" = (
 /obj/structure/table/wood,
@@ -41754,8 +41810,8 @@
 "nHJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "nHL" = (
@@ -41771,11 +41827,11 @@
 "nIg" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/right)
 "nIq" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/service/kitchen/coldroom)
 "nIw" = (
@@ -41801,10 +41857,10 @@
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "nID" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -41816,7 +41872,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "interro-court"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/security/courtroom)
 "nIG" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -41852,6 +41909,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "nJc" = (
@@ -41887,7 +41945,6 @@
 "nJo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -41895,6 +41952,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "nJr" = (
@@ -41905,6 +41963,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "nJs" = (
@@ -41931,7 +41990,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "nJH" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/janitor,
 /turf/open/floor/iron,
 /area/service/janitor)
@@ -41942,7 +42000,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
 "nKs" = (
@@ -41972,12 +42029,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
 	name = "sorting disposal pipe (Dorms)";
 	sortType = 26
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "nLc" = (
@@ -42006,9 +42063,9 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/sand/plating,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
 "nLN" = (
 /obj/effect/turf_decal/tile/red{
@@ -42059,13 +42116,6 @@
 /obj/structure/reagent_dispensers/peppertank/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
-"nMI" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "nML" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -42073,10 +42123,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "nNb" = (
@@ -42150,7 +42200,6 @@
 /turf/open/floor/iron/freezer,
 /area/security/prison/shower)
 "nNX" = (
-/obj/structure/cable,
 /obj/structure/altar_of_gods,
 /obj/item/storage/book/bible,
 /turf/open/floor/iron/dark,
@@ -42187,7 +42236,6 @@
 "nOe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/door/window/southleft{
 	name = "Desk Door";
 	req_access_txt = "63"
@@ -42196,11 +42244,11 @@
 /area/security/checkpoint)
 "nOn" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiotopleft";
 	name = "Xenobio Topleft Pen Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "nOu" = (
@@ -42218,7 +42266,8 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "nOJ" = (
 /obj/effect/turf_decal/tile/blue{
@@ -42227,9 +42276,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/closet/athletic_mixed,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "nOP" = (
@@ -42294,9 +42343,9 @@
 /area/science/xenobiology)
 "nPS" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "nQg" = (
@@ -42337,8 +42386,8 @@
 "nRE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "nSb" = (
@@ -42364,9 +42413,9 @@
 "nSi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "nSo" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -42399,6 +42448,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"nST" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/central)
 "nSU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -42417,7 +42471,7 @@
 "nTf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/meter,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "nTl" = (
@@ -42541,6 +42595,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "nVA" = (
@@ -42567,12 +42622,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "nWi" = (
@@ -42599,7 +42654,6 @@
 	},
 /obj/structure/chair/office,
 /obj/effect/landmark/start/warden,
-/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "nWz" = (
@@ -42646,7 +42700,6 @@
 /turf/open/floor/iron/dark,
 /area/hallway/primary/central)
 "nXb" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Atmospherics Incinerator";
@@ -42695,11 +42748,11 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "nXN" = (
@@ -42707,15 +42760,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
 "nXS" = (
-/obj/structure/cable,
 /obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "nYd" = (
@@ -42726,7 +42778,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/chem_mass_spec,
 /turf/open/floor/iron/white,
@@ -42759,10 +42810,10 @@
 "nZK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "oab" = (
 /obj/structure/toilet{
@@ -42787,8 +42838,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "obn" = (
@@ -42806,10 +42857,10 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "obY" = (
@@ -42831,12 +42882,12 @@
 "ocn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "ocI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -42855,7 +42906,6 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -42863,12 +42913,13 @@
 	c_tag = "Maintenance - East Tram Tunnel 3";
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "ocW" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "odg" = (
 /obj/structure/disposalpipe/segment,
@@ -42926,7 +42977,7 @@
 "ofx" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "ofB" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -42964,9 +43015,10 @@
 	name = "Ladder Access Hatch";
 	req_one_access_txt = null
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "ogJ" = (
 /obj/effect/turf_decal/tile/blue{
@@ -42990,7 +43042,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "ohj" = (
 /obj/structure/table/wood,
@@ -43013,7 +43065,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -43026,7 +43077,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /mob/living/simple_animal/bot/secbot{
@@ -43037,6 +43087,7 @@
 	name = "Sergeant-at-Armsky";
 	weaponscheck = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "ohw" = (
@@ -43046,8 +43097,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"ohA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "ohD" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -43057,24 +43114,24 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "oid" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "oii" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/three,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "oim" = (
 /obj/structure/table/glass,
@@ -43101,6 +43158,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "oiX" = (
@@ -43120,8 +43178,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "ojq" = (
@@ -43180,8 +43238,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "okh" = (
@@ -43212,7 +43270,7 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_atmos{
 	dir = 8
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "oky" = (
@@ -43287,7 +43345,7 @@
 /area/hallway/primary/central)
 "olu" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "olE" = (
 /obj/machinery/navbeacon/wayfinding/tcomms,
@@ -43340,7 +43398,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "omZ" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
@@ -43359,9 +43417,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/light/directional/west,
 /obj/machinery/newscaster/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "one" = (
@@ -43387,7 +43445,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology South";
 	dir = 1;
@@ -43396,6 +43453,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "onV" = (
@@ -43417,7 +43475,6 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "oop" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -43428,6 +43485,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ooT" = (
@@ -43467,10 +43525,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "oqn" = (
@@ -43507,14 +43565,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
-"oqW" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "orn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -43612,8 +43662,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "ouE" = (
@@ -43621,12 +43671,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "ouL" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "ouR" = (
@@ -43648,8 +43698,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "ovf" = (
@@ -43669,7 +43719,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -43691,6 +43740,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "ovq" = (
@@ -43793,8 +43843,8 @@
 /area/service/hydroponics)
 "owU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable,
 /obj/machinery/status_display/ai/directional/west,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "owX" = (
@@ -43803,6 +43853,7 @@
 	},
 /obj/machinery/status_display/ai/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "oxc" = (
@@ -43815,7 +43866,6 @@
 	},
 /area/commons/vacant_room/office)
 "oxf" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/stool/directional/north,
@@ -43828,6 +43878,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "oxi" = (
@@ -43847,6 +43898,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
+"oxJ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "oxN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43907,7 +43963,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ozp" = (
@@ -43920,10 +43975,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ozu" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "ozN" = (
@@ -43949,10 +44004,10 @@
 "ozU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "ozW" = (
 /obj/machinery/light/directional/east,
@@ -44002,12 +44057,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"oAJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "oAT" = (
 /obj/machinery/door/airlock{
 	id_tag = "private_m";
@@ -44017,22 +44066,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/commons/dorms)
-"oBg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "oBl" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "oBm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "oBs" = (
@@ -44084,13 +44125,13 @@
 /area/maintenance/solars/port/aft)
 "oDj" = (
 /obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/psychology)
 "oDr" = (
@@ -44107,6 +44148,7 @@
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "oDL" = (
@@ -44169,7 +44211,6 @@
 /area/ai_monitored/command/storage/eva)
 "oES" = (
 /obj/machinery/computer/security/hos,
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "oEU" = (
@@ -44185,14 +44226,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"oEV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "oEZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -44236,11 +44269,11 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "oFz" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "oFA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -44268,12 +44301,8 @@
 /area/cargo/miningdock)
 "oHI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Cargo - Upper Power Hatch";
-	dir = 6;
-	network = list("ss13","cargo")
-	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/cargo/storage)
 "oHS" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -44293,13 +44322,13 @@
 /area/ai_monitored/security/armory)
 "oHX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/sorting/mail{
 	name = "sorting disposal pipe (Custodial Closet)";
 	sortType = 22
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "oIj" = (
@@ -44309,7 +44338,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "oIo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -44401,16 +44430,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"oJH" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/security/prison)
 "oJJ" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
@@ -44430,11 +44449,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "cytologylockdown";
 	name = "Cytology Lockdown"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "oJO" = (
@@ -44504,7 +44523,7 @@
 /obj/structure/closet/emcloset,
 /obj/item/flashlight,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "oKN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -44523,7 +44542,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "oKZ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -44540,6 +44558,7 @@
 	name = "KEEP CLEAR: TRAM DOCKING AREA sign";
 	pixel_y = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "oLf" = (
@@ -44583,7 +44602,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/mid)
 "oMa" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -44638,7 +44657,6 @@
 /area/engineering/main)
 "oNe" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
 "oNg" = (
@@ -44652,16 +44670,15 @@
 "oNh" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/structure/window/reinforced/spawner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "oNm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -44670,10 +44687,10 @@
 	req_access_txt = "11"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/left)
 "oNq" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -44683,7 +44700,8 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "oND" = (
 /obj/structure/disposalpipe/segment,
@@ -44699,8 +44717,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "oNR" = (
@@ -44741,20 +44759,20 @@
 "oOy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "oOK" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "oOP" = (
@@ -44852,6 +44870,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "oRa" = (
@@ -44919,6 +44938,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "oSp" = (
@@ -44948,9 +44968,9 @@
 "oTv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
 "oTx" = (
 /obj/machinery/door/airlock/command/glass{
@@ -44990,7 +45010,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -45044,8 +45063,8 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/art)
 "oVa" = (
@@ -45057,10 +45076,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "oVf" = (
@@ -45081,9 +45100,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "oVk" = (
@@ -45113,20 +45132,20 @@
 "oWk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "oWx" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "oWE" = (
@@ -45181,8 +45200,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "oYd" = (
@@ -45194,14 +45213,22 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "oYl" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/radshelter/civil)
+"oYq" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "oYA" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -45240,7 +45267,6 @@
 /obj/structure/rack,
 /obj/item/electronics/airlock,
 /obj/item/stack/cable_coil/five,
-/obj/structure/cable,
 /obj/item/electronics/apc,
 /turf/open/floor/iron/airless,
 /area/mine/explored)
@@ -45349,10 +45375,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "paJ" = (
@@ -45400,12 +45426,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/science/storage)
-"pbT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "pbU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -45428,6 +45448,7 @@
 	name = "Escape Wing"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "pcp" = (
@@ -45446,7 +45467,6 @@
 	name = "Server Access";
 	req_access_txt = "30"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/iron/dark,
 /area/science/server)
@@ -45521,13 +45541,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"pdA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/central)
 "pec" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -45558,10 +45571,10 @@
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
 "pfC" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "pfK" = (
@@ -45592,12 +45605,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "pgd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45610,7 +45623,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "pgh" = (
 /obj/item/storage/toolbox/electrical,
@@ -45679,8 +45693,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
 "phM" = (
@@ -45704,11 +45718,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
-"piZ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "pjh" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -45721,17 +45730,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/blobstart,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/security)
-"pjw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/central)
 "pjH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -45745,13 +45747,14 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Commons Area"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "pjL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding/aiupload,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "pjO" = (
@@ -45764,7 +45767,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "pjP" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -45776,6 +45778,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/secondary)
 "pjS" = (
@@ -45852,14 +45855,14 @@
 /obj/effect/spawner/random/maintenance/two,
 /obj/item/flashlight,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "pmg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
 "pmi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -45930,13 +45933,12 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Radstorm Shelter"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
 "pnv" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -45944,6 +45946,7 @@
 	name = "sorting disposal pipe (Kitchen)";
 	sortType = 20
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "pnE" = (
@@ -45971,8 +45974,8 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "pof" = (
@@ -46084,7 +46087,6 @@
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "pqm" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -46093,9 +46095,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "pqM" = (
@@ -46118,8 +46120,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "prd" = (
@@ -46130,12 +46132,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/bluespace_vendor/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"prA" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/engineering/supermatter/room)
 "prE" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -46149,7 +46148,6 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "psh" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/engineering{
@@ -46157,7 +46155,8 @@
 	req_access_txt = "11"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "psi" = (
 /obj/machinery/door/airlock/research{
@@ -46176,6 +46175,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-entrance-right"
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Sciencelockdown";
+	name = "Research Lockdown Blastdoor"
+	},
 /turf/open/floor/iron,
 /area/science/research)
 "pss" = (
@@ -46191,7 +46194,7 @@
 "psw" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "psZ" = (
 /obj/machinery/seed_extractor,
@@ -46204,6 +46207,11 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"pti" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai)
 "ptl" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -46222,7 +46230,6 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "ptL" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -46230,6 +46237,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ptQ" = (
@@ -46266,6 +46274,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "puK" = (
@@ -46316,9 +46325,9 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "pvt" = (
-/obj/structure/cable,
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pvw" = (
@@ -46336,7 +46345,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "pwt" = (
@@ -46450,6 +46458,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/corner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "pzb" = (
@@ -46488,21 +46497,26 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"pzL" = (
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central/secondary)
 "pzR" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/right)
 "pzX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/item/assembly/mousetrap/armed,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "pAc" = (
 /obj/structure/disposalpipe/segment{
@@ -46527,7 +46541,6 @@
 	req_access_txt = "39"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -46544,6 +46557,7 @@
 	pixel_y = 24;
 	req_access_txt = "39"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "pAt" = (
@@ -46585,12 +46599,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "pAW" = (
@@ -46627,10 +46641,10 @@
 "pBq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "pBF" = (
@@ -46679,8 +46693,8 @@
 	dir = 9
 	},
 /obj/machinery/light/directional/north,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "pCN" = (
@@ -46774,7 +46788,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "pEe" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/security{
 	id_tag = "scidoor";
 	name = "Security Post - Science";
@@ -46853,6 +46866,11 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"pEZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/starboard/central)
 "pFx" = (
 /obj/structure/chair/pew/left{
 	dir = 4
@@ -46893,10 +46911,10 @@
 "pGf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "pGq" = (
@@ -46940,12 +46958,14 @@
 /obj/machinery/light/floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/security/prison/shower)
 "pHp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "pHr" = (
@@ -46970,19 +46990,13 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "pHI" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pHW" = (
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
-"pIb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/maint)
 "pIh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -47002,8 +47016,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "pIz" = (
@@ -47053,7 +47067,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "pJU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47068,8 +47082,8 @@
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
 "pKi" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "pKj" = (
@@ -47140,10 +47154,10 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /mob/living/carbon/human/species/monkey/punpun,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "pLh" = (
@@ -47222,8 +47236,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "pMR" = (
@@ -47243,6 +47257,7 @@
 	dir = 5
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "pNr" = (
@@ -47263,16 +47278,15 @@
 /turf/open/floor/iron,
 /area/maintenance/port/central)
 "pNt" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "pNu" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "Secure Gate";
 	name = "brig shutters"
@@ -47320,7 +47334,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/secondary)
 "pOk" = (
 /obj/effect/turf_decal/trimline/green/line{
@@ -47405,10 +47419,10 @@
 "pPE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "pPM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -47433,7 +47447,8 @@
 	pixel_y = -32
 	},
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/right)
 "pQj" = (
 /obj/structure/chair{
@@ -47484,22 +47499,22 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "pRK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "pRL" = (
 /obj/machinery/light/directional/south,
@@ -47527,7 +47542,6 @@
 "pSd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
@@ -47537,6 +47551,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "pSq" = (
@@ -47574,7 +47589,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "pSS" = (
 /obj/machinery/holopad,
@@ -47660,16 +47676,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"pUM" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron,
-/area/security/checkpoint/escape)
 "pVe" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "pVo" = (
@@ -47681,6 +47694,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "pVB" = (
@@ -47704,6 +47718,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "pVU" = (
@@ -47749,6 +47764,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-entrance-left"
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Sciencelockdown";
+	name = "Research Lockdown Blastdoor"
+	},
 /turf/open/floor/iron,
 /area/science/research)
 "pXe" = (
@@ -47789,7 +47808,6 @@
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
 "pXP" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Water Closet";
 	req_access_txt = "26"
@@ -47797,7 +47815,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "pXQ" = (
 /obj/structure/cable/multilayer/multiz,
@@ -47829,6 +47848,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "pYu" = (
@@ -47888,17 +47908,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"pZg" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/security/prison)
 "pZq" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -47922,12 +47931,12 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "qae" = (
@@ -47938,6 +47947,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
 "qaY" = (
@@ -48024,6 +48034,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"qdf" = (
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central)
+"qdg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "qdu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -48047,6 +48069,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "qeg" = (
@@ -48122,11 +48145,11 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -48134,7 +48157,7 @@
 "qeZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "qfo" = (
 /obj/item/stack/cable_coil/cut,
@@ -48174,6 +48197,13 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
+"qgw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "qgA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -48184,7 +48214,6 @@
 "qgC" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
@@ -48193,12 +48222,12 @@
 "qgE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "qgI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -48230,7 +48259,6 @@
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/item/paper_bin{
 	pixel_x = -3;
 	pixel_y = 7
@@ -48243,6 +48271,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "qhf" = (
@@ -48257,6 +48286,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"qhp" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "qhs" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/iron/dark/telecomms,
@@ -48281,8 +48317,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/box,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "qhF" = (
@@ -48395,7 +48431,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qjB" = (
@@ -48438,7 +48473,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -48458,14 +48492,18 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
 "qlg" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"qlj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central)
 "qlt" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48491,7 +48529,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/four,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "qlV" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -48508,7 +48546,6 @@
 /area/maintenance/tram/right)
 "qmm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "qmu" = (
@@ -48609,7 +48646,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/matter_bin{
 	pixel_x = 3;
@@ -48617,6 +48653,7 @@
 	},
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/micro_laser,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/lab)
 "qnB" = (
@@ -48627,14 +48664,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "qnL" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "qnY" = (
@@ -48653,12 +48691,11 @@
 "qor" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "qoF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -48691,6 +48728,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "qpj" = (
@@ -48811,9 +48849,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "qqU" = (
@@ -48831,15 +48869,16 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qrv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/mess,
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "qrC" = (
@@ -48863,6 +48902,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
+"qsa" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "qsk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -48870,9 +48913,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
 "qss" = (
@@ -48883,7 +48926,6 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "qsJ" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
@@ -48913,17 +48955,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"qth" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "qtk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48936,15 +48971,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"qtB" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "quF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/glass/bucket,
@@ -48990,8 +49016,8 @@
 /turf/open/floor/iron,
 /area/science/storage)
 "qvT" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "qwl" = (
@@ -49008,6 +49034,7 @@
 /obj/effect/turf_decal/caution,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "qwy" = (
@@ -49028,7 +49055,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/port/fore)
 "qwT" = (
 /obj/structure/toilet,
@@ -49087,6 +49114,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "qyg" = (
@@ -49105,7 +49133,6 @@
 	name = "Containment Pen #1";
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiotopleft";
@@ -49130,14 +49157,14 @@
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
 "qyS" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "qze" = (
 /turf/closed/wall,
@@ -49196,10 +49223,10 @@
 "qAY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qBk" = (
@@ -49242,13 +49269,18 @@
 /obj/item/tank/internals/oxygen,
 /obj/item/clothing/mask/gas,
 /obj/item/wrench,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
+/area/maintenance/port/fore)
+"qBF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "qBP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
 "qBS" = (
 /obj/docking_port/stationary/random{
@@ -49263,7 +49295,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qCl" = (
@@ -49278,6 +49309,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "qCp" = (
@@ -49303,7 +49335,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "qDY" = (
@@ -49357,10 +49388,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qEJ" = (
@@ -49452,12 +49483,12 @@
 "qGc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/item/clothing/head/cone{
 	pixel_y = -8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "qGf" = (
 /obj/machinery/light/directional/west,
@@ -49467,7 +49498,6 @@
 /obj/machinery/power/emitter/welded{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "qGm" = (
@@ -49498,6 +49528,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/caution,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "qGv" = (
@@ -49520,7 +49551,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -49551,7 +49581,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/obj/structure/cable,
 /obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint)
@@ -49659,7 +49688,7 @@
 "qJp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/chair,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "qJu" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
@@ -49677,9 +49706,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "qKk" = (
@@ -49770,16 +49799,21 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"qLM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "qLV" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "qMk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49806,6 +49840,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "qNe" = (
@@ -49866,6 +49901,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"qOp" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "qOr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -49910,11 +49949,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/terminal{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "qQj" = (
@@ -49932,13 +49971,13 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "qQI" = (
@@ -50027,8 +50066,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/item/stack/tile/wood,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "qRI" = (
@@ -50047,7 +50086,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/door_timer{
 	id = "Cell 1";
 	name = "Cell 1";
@@ -50071,10 +50109,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "qSg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "qSj" = (
@@ -50125,11 +50163,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qUO" = (
@@ -50244,6 +50282,7 @@
 	dir = 9;
 	network = list("ss13","rd")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/research)
 "qWF" = (
@@ -50258,19 +50297,18 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "qWI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "qWQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-maint-passthrough"
@@ -50281,7 +50319,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "qXi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50319,10 +50358,10 @@
 /area/hallway/primary/central)
 "qYw" = (
 /obj/structure/bed/dogbed/mcgriff,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /mob/living/simple_animal/pet/dog/pug/mcgriff,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "qYM" = (
@@ -50340,6 +50379,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "qZI" = (
@@ -50367,7 +50407,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "rah" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/hatch{
@@ -50375,7 +50414,8 @@
 	req_access_txt = "47"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/science/xenobiology)
 "raq" = (
 /obj/structure/table/glass,
@@ -50394,11 +50434,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-right"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "raw" = (
@@ -50437,19 +50477,19 @@
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
 "raO" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "47"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/research)
 "raY" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/crew_quarters/dorms)
 "rbe" = (
 /obj/structure/railing{
@@ -50463,8 +50503,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "rbr" = (
@@ -50521,7 +50561,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/three,
 /obj/item/relic,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "rcc" = (
 /turf/open/floor/plating,
@@ -50540,22 +50580,22 @@
 "rcB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "rcI" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "rcN" = (
@@ -50563,7 +50603,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/left)
 "rdd" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -50584,15 +50624,15 @@
 /area/cargo/miningdock)
 "rdF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
 "rdM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "rdO" = (
@@ -50620,12 +50660,12 @@
 	name = "Service Wing Hallway"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "rdR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -50695,8 +50735,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/bluespace_vendor/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "rgq" = (
@@ -50719,6 +50759,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "rgz" = (
@@ -50738,20 +50779,20 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/commons/vacant_room/commissary)
 "rgO" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "rgT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rgX" = (
@@ -50815,13 +50856,14 @@
 	name = "Service Wing Hallway"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "rij" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "riv" = (
@@ -50900,8 +50942,8 @@
 	name = "Server Room";
 	req_access_txt = "61"
 	},
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "rjI" = (
@@ -51030,6 +51072,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "rmz" = (
@@ -51061,11 +51104,11 @@
 "rnt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "rnH" = (
@@ -51073,9 +51116,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "rnT" = (
@@ -51084,7 +51127,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "roe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -51126,10 +51169,14 @@
 /obj/effect/landmark/tram/right_part,
 /turf/open/floor/vault,
 /area/hallway/primary/tram/right)
+"rpa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "rpd" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "rpo" = (
 /obj/effect/turf_decal/sand/plating,
@@ -51148,6 +51195,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "rpI" = (
@@ -51259,7 +51307,8 @@
 "rsL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "rsN" = (
 /obj/effect/turf_decal/sand,
@@ -51276,7 +51325,6 @@
 "rsR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -51284,6 +51332,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "rsT" = (
@@ -51301,7 +51350,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "rtj" = (
 /obj/structure/disposalpipe/segment{
@@ -51367,8 +51416,8 @@
 "rvx" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "rvS" = (
@@ -51393,12 +51442,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"rwo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/command/heads_quarters/captain)
 "rwq" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor2";
@@ -51415,7 +51458,6 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
 "rwz" = (
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/power/terminal{
 	dir = 8
@@ -51476,7 +51518,6 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "rye" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/station_engineer,
@@ -51507,10 +51548,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "ryt" = (
@@ -51523,10 +51564,10 @@
 "ryv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "ryA" = (
@@ -51541,7 +51582,6 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -51558,23 +51598,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"ryY" = (
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "rzc" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/vault,
 /area/hallway/primary/tram/center)
 "rzp" = (
@@ -51604,6 +51634,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"rzA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/secondary)
 "rzK" = (
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
@@ -51637,10 +51674,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "rzR" = (
@@ -51662,8 +51699,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
 "rAq" = (
@@ -51671,10 +51708,10 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "rAr" = (
@@ -51682,10 +51719,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "rAw" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/ladder,
@@ -51695,12 +51732,12 @@
 /obj/effect/turf_decal/trimline/brown/filled/end{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/research)
 "rAz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -51711,16 +51748,17 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rAI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "rBt" = (
@@ -51744,8 +51782,8 @@
 "rCv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rCG" = (
@@ -51765,7 +51803,8 @@
 "rDk" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "rDl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -51831,21 +51870,8 @@
 	id = "forestarboard";
 	name = "Starboard Solar Control"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
-"rFs" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/tram/mid)
 "rFu" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
@@ -51965,7 +51991,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "rIS" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -51975,6 +52000,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/secondary)
 "rJa" = (
@@ -52010,6 +52036,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rJN" = (
@@ -52022,11 +52049,11 @@
 "rJP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rJV" = (
@@ -52042,8 +52069,8 @@
 /area/medical/virology)
 "rKf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "rKk" = (
@@ -52053,7 +52080,6 @@
 "rKm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/highsecurity{
@@ -52062,7 +52088,8 @@
 	security_level = 4
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/security/prison)
 "rKu" = (
 /obj/effect/turf_decal/tile/blue{
@@ -52090,6 +52117,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "rLI" = (
@@ -52132,6 +52160,7 @@
 "rLU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "rLX" = (
@@ -52162,12 +52191,12 @@
 "rNl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "rNy" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -52217,8 +52246,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "rNP" = (
@@ -52261,6 +52290,7 @@
 	dir = 6;
 	network = list("ss13","minisat")
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "rOW" = (
@@ -52293,12 +52323,12 @@
 "rPe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/commons/lounge)
 "rPf" = (
@@ -52309,22 +52339,22 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "rPj" = (
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "rPp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "rPq" = (
 /obj/effect/turf_decal/loading_area,
@@ -52372,15 +52402,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"rQB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central/secondary)
 "rQC" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard)
 "rQE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "rQH" = (
@@ -52419,7 +52455,7 @@
 	req_one_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/port/aft)
 "rRE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -52450,15 +52486,28 @@
 /area/tcommsat/computer)
 "rSg" = (
 /obj/machinery/holopad,
-/obj/structure/cable,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"rSr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"rSu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
+/area/hallway/primary/tram/right)
 "rSJ" = (
 /obj/structure/chair{
 	dir = 8
@@ -52487,6 +52536,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/work)
+"rTt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron/smooth,
+/area/maintenance/tram/mid)
 "rTy" = (
 /obj/structure/chair{
 	dir = 4
@@ -52513,7 +52567,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "rUM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -52521,6 +52575,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "rUN" = (
@@ -52534,7 +52589,6 @@
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/taperecorder,
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "rUT" = (
@@ -52553,6 +52607,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "rVq" = (
@@ -52583,7 +52638,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "rVW" = (
@@ -52605,6 +52659,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"rWi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/secondary)
 "rWj" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "armory";
@@ -52666,7 +52727,7 @@
 "rWR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/right)
 "rXk" = (
 /obj/effect/turf_decal/tile/bar,
@@ -52714,18 +52775,13 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/service)
 "rXO" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"rXZ" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "rYa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -52741,10 +52797,10 @@
 /area/maintenance/tram/mid)
 "rYe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "rYj" = (
@@ -52851,12 +52907,12 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "saA" = (
@@ -52875,23 +52931,11 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"sbC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/main)
 "sbH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/chapel{
 	dir = 4
 	},
@@ -52970,7 +53014,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
@@ -52978,6 +53021,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "sdh" = (
@@ -53087,14 +53131,14 @@
 "sfW" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "sgd" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/port/fore)
 "sge" = (
 /obj/machinery/door/airlock{
@@ -53125,7 +53169,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/assembly/mousetrap/armed,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
 "shF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -53133,14 +53177,15 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "shS" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "shW" = (
@@ -53151,13 +53196,12 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "shY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/navbeacon/wayfinding/det,
 /turf/open/floor/iron/grimy,
@@ -53182,12 +53226,12 @@
 /turf/closed/wall,
 /area/tcommsat/computer)
 "siP" = (
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Solar - Starboard Control";
 	dir = 5
 	},
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "siT" = (
@@ -53259,12 +53303,12 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "skj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "skL" = (
@@ -53334,7 +53378,6 @@
 	name = "Containment Pen #4";
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiotopright";
@@ -53388,7 +53431,7 @@
 "snL" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/center)
 "snN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -53418,7 +53461,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
 	frequency = 1449;
@@ -53428,6 +53470,11 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobiomain";
+	name = "Xenobiology Lockdown Blastdoor"
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -53526,6 +53573,11 @@
 /obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"spS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/turf/open/floor/iron/smooth,
+/area/maintenance/central/secondary)
 "spW" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -53557,17 +53609,17 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "sqb" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "sqn" = (
@@ -53631,24 +53683,26 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "srM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Security - Upper Power Hatch";
 	dir = 6;
 	network = list("ss13","Security")
 	},
 /obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/security)
 "srR" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/assembly/mousetrap/armed,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "srV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53713,7 +53767,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53721,6 +53774,7 @@
 	c_tag = "Arrivals - South Hall";
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "stl" = (
@@ -53765,12 +53819,12 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "stX" = (
@@ -53791,11 +53845,11 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
 "sur" = (
@@ -53864,11 +53918,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "svq" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "svC" = (
@@ -53946,7 +54001,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
 	name = "Commons Area"
 	},
@@ -53969,7 +54023,7 @@
 "sxO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "sxP" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -54046,9 +54100,9 @@
 "szt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "szH" = (
 /obj/structure/chair{
@@ -54069,10 +54123,12 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "sAj" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "sAz" = (
@@ -54084,7 +54140,7 @@
 "sAK" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "sAN" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -54158,7 +54214,7 @@
 "sBA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/central)
 "sBJ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -54191,10 +54247,10 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "sCA" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/service/kitchen)
 "sCD" = (
@@ -54231,6 +54287,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
@@ -54262,7 +54319,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "sDu" = (
@@ -54312,7 +54368,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/security/processing)
@@ -54340,7 +54395,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/service/library)
@@ -54364,12 +54418,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "sFj" = (
-/obj/structure/cable,
 /obj/machinery/flasher/directional/east{
 	id = "AI";
 	pixel_y = 26
@@ -54384,7 +54436,7 @@
 	c_tag = "Hallway - Lower West Power Hatch";
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "sFC" = (
 /obj/structure/bed,
@@ -54413,7 +54465,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
 "sGN" = (
 /obj/machinery/light/directional/west,
@@ -54462,6 +54514,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "sHG" = (
@@ -54474,7 +54527,7 @@
 	dir = 4;
 	reagent_id = /datum/reagent/water
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/crew_quarters/dorms)
 "sHP" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -54532,8 +54585,8 @@
 	},
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "sKc" = (
@@ -54553,6 +54606,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "sKw" = (
@@ -54565,7 +54619,7 @@
 	id = "incineratorturbine"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "sKS" = (
@@ -54613,10 +54667,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "sLy" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "sLE" = (
@@ -54625,7 +54679,6 @@
 /area/mine/explored)
 "sLF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/service/library)
@@ -54651,12 +54704,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "sMb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
@@ -54700,6 +54753,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "sMM" = (
@@ -54721,11 +54775,11 @@
 /area/service/kitchen/diner)
 "sNm" = (
 /obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
 	name = "Air to Distro"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/virology)
 "sNq" = (
@@ -54758,9 +54812,9 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "sOu" = (
@@ -54777,6 +54831,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "sOQ" = (
@@ -54808,16 +54863,16 @@
 	req_one_access_txt = "12;25"
 	},
 /obj/machinery/duct,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "sPj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/secondary)
 "sPl" = (
@@ -54831,7 +54886,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "sPs" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
@@ -54843,9 +54898,9 @@
 "sPN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/right)
 "sPU" = (
 /obj/structure/disposalpipe/trunk/multiz{
@@ -54858,7 +54913,6 @@
 	name = "Containment Pen #3";
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiotopright";
@@ -54894,10 +54948,10 @@
 /area/science/misc_lab)
 "sQE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "sQP" = (
@@ -54907,7 +54961,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -54915,6 +54968,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
 "sRg" = (
@@ -54970,7 +55024,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "sSh" = (
@@ -55013,6 +55066,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "sSU" = (
@@ -55043,7 +55097,7 @@
 "sTg" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "sTm" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -55066,6 +55120,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "sTF" = (
@@ -55083,7 +55138,6 @@
 /area/maintenance/tram/right)
 "sUQ" = (
 /obj/machinery/suit_storage_unit/rd,
-/obj/structure/cable,
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
@@ -55203,20 +55257,20 @@
 	name = "Law Office";
 	req_access_txt = "38"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "sXp" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sXv" = (
@@ -55261,11 +55315,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	name = "sorting disposal pipe (Quartermaster's Office)";
 	sortType = 3
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "sXN" = (
@@ -55273,7 +55327,6 @@
 /area/tcommsat/computer)
 "sXZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -55293,10 +55346,10 @@
 	req_access_txt = "5;6"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "sYs" = (
@@ -55375,6 +55428,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "sZY" = (
@@ -55412,7 +55466,6 @@
 /turf/open/floor/iron,
 /area/security/prison/mess)
 "tbl" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -55495,15 +55548,15 @@
 "tcT" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/crew_quarters/dorms)
 "tdf" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "tdp" = (
@@ -55584,10 +55637,10 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "teD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "teF" = (
@@ -55704,10 +55757,10 @@
 "thr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "thA" = (
@@ -55750,6 +55803,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"thR" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "thT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -55774,7 +55834,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Departures - West Main";
 	dir = 9
@@ -55821,7 +55880,6 @@
 "tis" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
@@ -55830,6 +55888,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/secondary)
 "tiC" = (
@@ -55883,8 +55942,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "tka" = (
 /turf/open/floor/circuit/green,
@@ -55948,14 +56006,6 @@
 /obj/structure/grille,
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
-"tls" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
 "tlz" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -55970,6 +56020,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "tlH" = (
@@ -55999,12 +56050,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Security - Brig Upper West";
 	dir = 4;
 	network = list("ss13","Security")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "tmI" = (
@@ -56023,11 +56074,11 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "tnm" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tnB" = (
@@ -56194,9 +56245,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "tpK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -56234,8 +56285,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "tqq" = (
@@ -56257,8 +56308,8 @@
 	id = "Xenolab";
 	name = "test chamber blast door"
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "tqw" = (
@@ -56291,15 +56342,10 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/gateway)
-"tqL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/cargo/miningdock)
 "tqT" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/ordnance_mixing_input{
 	dir = 4
@@ -56323,6 +56369,7 @@
 /area/cargo/miningdock)
 "trx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "trK" = (
@@ -56337,12 +56384,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "tsp" = (
@@ -56410,6 +56457,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"tte" = (
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/tram/right)
 "ttn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -56475,12 +56527,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "tuw" = (
@@ -56491,13 +56543,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tuA" = (
@@ -56532,8 +56584,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "tvn" = (
@@ -56643,6 +56695,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/corner,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "txD" = (
@@ -56651,7 +56704,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "txX" = (
@@ -56662,8 +56714,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "tyc" = (
@@ -56746,11 +56798,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "tBs" = (
 /obj/machinery/telecomms/server/presets/science,
@@ -56760,16 +56812,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"tBC" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "tBO" = (
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
@@ -56876,7 +56918,6 @@
 /area/service/chapel/office)
 "tEb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/item/wallframe/apc,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -56905,7 +56946,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/commons/lounge)
@@ -56932,7 +56972,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "tEW" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -56943,14 +56984,15 @@
 	pixel_y = -32
 	},
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
 "tFo" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "tFt" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -56975,6 +57017,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"tFL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "tFP" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -56984,6 +57034,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "tGc" = (
@@ -56992,14 +57043,13 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "tGd" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "tGh" = (
@@ -57040,12 +57090,10 @@
 "tHm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/grimy,
 /area/service/library)
 "tHG" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
@@ -57091,11 +57139,11 @@
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "tIC" = (
@@ -57235,8 +57283,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "tLf" = (
@@ -57253,9 +57301,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "tLv" = (
@@ -57266,7 +57314,6 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "tLw" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Engineering Maintenance";
 	req_access_txt = "11"
@@ -57278,7 +57325,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "tLy" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -57286,6 +57334,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/fluff/tram_rail/floor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "tLF" = (
@@ -57306,8 +57355,8 @@
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "tLQ" = (
@@ -57334,7 +57383,6 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "tMk" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -57389,13 +57437,13 @@
 /turf/open/floor/iron,
 /area/science/research)
 "tMW" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "tNb" = (
@@ -57419,12 +57467,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/departments/mait{
 	pixel_x = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "tNv" = (
@@ -57436,6 +57484,16 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
+"tND" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "tNM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
@@ -57444,11 +57502,22 @@
 "tNX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
+"tOc" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "tOh" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/rnd_secure_all,
@@ -57498,6 +57567,7 @@
 	name = "sorting disposal pipe (Xenobiology)";
 	sortType = 28
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "tOA" = (
@@ -57511,7 +57581,8 @@
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "tOK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -57519,16 +57590,17 @@
 	req_one_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "tPz" = (
 /obj/structure/bed/maint,
 /obj/structure/sign/poster/contraband/rip_badger{
 	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "tPS" = (
@@ -57554,7 +57626,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "tQc" = (
 /obj/structure/table,
@@ -57599,8 +57671,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "tRt" = (
@@ -57637,6 +57709,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "tSI" = (
@@ -57646,6 +57719,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"tTd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/engine_smes)
 "tTg" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge Access";
@@ -57655,13 +57733,13 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-right"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "tTm" = (
@@ -57677,7 +57755,7 @@
 /obj/structure/table,
 /obj/item/multitool,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/right)
 "tTA" = (
 /obj/structure/ladder,
@@ -57730,14 +57808,14 @@
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "tUF" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "tUM" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -57751,14 +57829,14 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	req_one_access_txt = "12"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci-maint-passthrough"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "tVj" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -57776,11 +57854,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "tVk" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/commons/lounge)
 "tVq" = (
@@ -57802,8 +57879,8 @@
 /area/command/heads_quarters/rd)
 "tVF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "tVO" = (
@@ -57851,6 +57928,7 @@
 /area/science/xenobiology)
 "tWK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "tWP" = (
@@ -57903,20 +57981,20 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "tYd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "tYf" = (
@@ -57969,7 +58047,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/right)
 "tZl" = (
 /obj/effect/turf_decal/arrows/red{
@@ -58010,15 +58088,14 @@
 "tZE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding/cargo,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "tZH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
 "tZI" = (
@@ -58076,6 +58153,14 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"ucf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Sciencelockdown";
+	name = "Research Lockdown Blastdoor"
+	},
+/turf/open/floor/plating,
+/area/science/research)
 "uch" = (
 /obj/machinery/door/airlock/research{
 	glass = 1;
@@ -58093,12 +58178,12 @@
 "ucm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "ucp" = (
@@ -58153,7 +58238,7 @@
 "udg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "udB" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -58185,7 +58270,6 @@
 /turf/open/floor/iron/dark,
 /area/science/genetics)
 "uec" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -58263,8 +58347,8 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "ufP" = (
@@ -58277,6 +58361,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ufR" = (
@@ -58305,8 +58392,8 @@
 "ugq" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
 "ugr" = (
@@ -58364,7 +58451,7 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "uhK" = (
 /obj/machinery/door/airlock/hatch{
@@ -58433,10 +58520,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "uiX" = (
@@ -58471,13 +58558,13 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "ujs" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/limb,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/secondary)
 "ujz" = (
 /obj/docking_port/stationary{
@@ -58609,7 +58696,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "umR" = (
 /obj/structure/industrial_lift/tram{
@@ -58698,11 +58785,11 @@
 "uoY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	name = "sorting disposal pipe (Law Office)";
 	sortType = 29
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "uoZ" = (
@@ -58782,7 +58869,6 @@
 /area/cargo/storage)
 "uqR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -58796,6 +58882,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "urN" = (
@@ -58853,32 +58940,19 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "usW" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "uta" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
-"utc" = (
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "utD" = (
-/obj/structure/cable,
 /obj/machinery/light_switch/directional/north{
 	pixel_x = 12
 	},
@@ -58896,6 +58970,13 @@
 "utS" = (
 /turf/open/floor/iron,
 /area/science/misc_lab)
+"uue" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mine/explored)
 "uuo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -58927,13 +59008,13 @@
 /area/science/mixing/chamber)
 "uuG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "uvq" = (
@@ -58973,7 +59054,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -58982,11 +59062,11 @@
 	name = "Security Maintenance";
 	req_access_txt = "1"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/security/office)
 "uwv" = (
 /obj/structure/disposalpipe/segment,
@@ -58998,10 +59078,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "uwx" = (
@@ -59037,7 +59117,6 @@
 /area/ai_monitored/command/nuke_storage)
 "uxB" = (
 /obj/structure/table,
-/obj/structure/cable,
 /obj/item/folder/white,
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/camera{
@@ -59045,6 +59124,7 @@
 	dir = 6;
 	network = list("ss13","rd")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "uxR" = (
@@ -59068,7 +59148,6 @@
 "uyb" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/door_assembly/door_assembly_ext,
-/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "uyh" = (
@@ -59076,12 +59155,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Cargo - Mining South-West";
 	dir = 9;
 	network = list("ss13","cargo")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "uyr" = (
@@ -59103,8 +59182,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "uyS" = (
@@ -59112,7 +59191,8 @@
 	pixel_y = -32
 	},
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/center)
 "uyV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -59133,7 +59213,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/seven,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "uzL" = (
 /obj/machinery/disposal/bin,
@@ -59162,7 +59242,7 @@
 "uAd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "uAe" = (
 /obj/structure/transit_tube,
@@ -59204,7 +59284,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "uBm" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -59228,6 +59309,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "uBB" = (
@@ -59236,10 +59318,10 @@
 	req_access_txt = "58"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "uBC" = (
@@ -59249,24 +59331,25 @@
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "uBG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "uCf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "uCh" = (
@@ -59314,14 +59397,14 @@
 "uCO" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "uCZ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "uDb" = (
@@ -59350,6 +59433,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"uDu" = (
+/obj/structure/cable/layer1,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "uDD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
@@ -59387,6 +59474,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "uEE" = (
@@ -59401,7 +59489,6 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "uEX" = (
@@ -59500,10 +59587,10 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "uHk" = (
@@ -59573,9 +59660,9 @@
 "uHQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "uIa" = (
@@ -59588,7 +59675,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/mess,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/port/aft)
 "uIr" = (
 /obj/structure/ladder,
@@ -59661,6 +59748,15 @@
 /obj/structure/stairs/north,
 /turf/open/floor/iron/stairs/medium,
 /area/cargo/miningdock)
+"uJH" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/commons/lounge)
 "uJK" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -59678,6 +59774,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/research)
 "uKe" = (
@@ -59696,7 +59793,6 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -59711,7 +59807,6 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "uKm" = (
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Service - Upper Power Hatch";
 	dir = 6;
@@ -59719,7 +59814,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/central)
 "uKH" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -59743,7 +59839,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
 "uLa" = (
 /obj/machinery/door/airlock/hatch{
@@ -59757,10 +59853,10 @@
 "uLr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "uLy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59868,11 +59964,11 @@
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "uMV" = (
@@ -59880,6 +59976,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
 "uNc" = (
@@ -59909,6 +60006,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "uOF" = (
@@ -59955,10 +60053,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "uPs" = (
@@ -59987,11 +60085,11 @@
 /area/science/mixing)
 "uQq" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiotopright";
 	name = "Xenobio Top Right Pen Blast Door"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "uQv" = (
@@ -60020,6 +60118,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -60038,7 +60137,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -60070,19 +60168,26 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "uSw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "uSH" = (
 /turf/open/openspace,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"uSK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "uSL" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -60121,6 +60226,7 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "uTr" = (
@@ -60216,14 +60322,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"uXw" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/tram/mid)
 "uXz" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
@@ -60233,7 +60332,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
@@ -60262,6 +60360,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "uYT" = (
@@ -60270,13 +60369,13 @@
 "uYZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
 	name = "Power Access Hatch";
 	req_access_txt = "11"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/security)
 "uZp" = (
 /obj/structure/disposalpipe/segment,
@@ -60312,6 +60411,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/fluff/tram_rail/floor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "uZJ" = (
@@ -60329,7 +60429,6 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "van" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
@@ -60339,6 +60438,7 @@
 	name = "sorting disposal pipe (Xenobiology)";
 	sortType = 28
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "vas" = (
@@ -60367,8 +60467,8 @@
 /area/engineering/supermatter/room)
 "vaN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "vaX" = (
@@ -60378,7 +60478,6 @@
 "vbb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "vbr" = (
@@ -60441,12 +60540,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/spawner/random/trash/mess,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "vcF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "vcO" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -60457,17 +60556,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"vcR" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/service/bar)
 "vdf" = (
 /obj/machinery/computer/shuttle/mining/common{
 	dir = 8
@@ -60507,6 +60595,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"veb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/department/cargo)
 "vem" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -60538,13 +60630,17 @@
 /area/science/xenobiology)
 "veF" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
 "veM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
+/area/hallway/primary/tram/right)
+"vft" = (
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/right)
 "vfF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -60557,12 +60653,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
 	name = "sorting disposal pipe (Toxins)";
 	sortType = 25
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "vgz" = (
@@ -60572,8 +60668,8 @@
 /obj/effect/turf_decal/tile,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "vgG" = (
@@ -60612,13 +60708,19 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
-"vif" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"vil" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/maintenance/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "vio" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -60646,6 +60748,9 @@
 "vjC" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "vjF" = (
@@ -60678,8 +60783,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/table/glass,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vkJ" = (
@@ -60692,13 +60797,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "vkR" = (
@@ -60708,7 +60813,6 @@
 /obj/machinery/shower{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -60729,7 +60833,6 @@
 "vll" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -60739,6 +60842,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vlt" = (
@@ -60778,13 +60882,11 @@
 /area/commons/vacant_room/office)
 "vlK" = (
 /obj/effect/turf_decal/sand,
-/obj/structure/cable,
 /obj/item/wallframe/apc,
 /turf/open/floor/iron/airless,
 /area/mine/explored)
 "vlW" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
 "vlZ" = (
@@ -60797,7 +60899,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -60859,11 +60960,11 @@
 /obj/machinery/modular_computer/console/preset/civilian,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "voB" = (
@@ -60903,6 +61004,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "vpD" = (
@@ -60987,13 +61089,13 @@
 "vrD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vrI" = (
@@ -61015,7 +61117,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "vrY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61030,7 +61132,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/service/hydroponics)
 "vss" = (
 /turf/open/floor/iron/stairs/medium{
@@ -61058,7 +61160,7 @@
 "vsY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "vtd" = (
 /obj/structure/tank_holder/extinguisher,
@@ -61070,12 +61172,12 @@
 "vtj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	name = "sorting disposal pipe (Medical)";
 	sortType = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vtw" = (
@@ -61104,11 +61206,11 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "vuO" = (
@@ -61135,9 +61237,9 @@
 /area/command/heads_quarters/hop)
 "vvI" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/crew_quarters/dorms)
 "vvQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61173,12 +61275,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "vxp" = (
@@ -61186,6 +61288,7 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/janitor)
 "vxD" = (
@@ -61228,17 +61331,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/left)
 "vyF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "vzg" = (
 /obj/machinery/smartfridge/organ,
@@ -61284,6 +61388,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "vAt" = (
@@ -61368,6 +61473,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "vBt" = (
@@ -61414,23 +61520,13 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
-"vCy" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/service/bar)
 "vCE" = (
 /turf/closed/wall/rock/porous,
 /area/maintenance/starboard/secondary)
 "vCG" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/four,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "vCI" = (
@@ -61439,12 +61535,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "vDd" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "vDn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -61483,7 +61579,7 @@
 "vDX" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "vDZ" = (
 /obj/structure/table,
@@ -61499,7 +61595,7 @@
 "vEb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "vEx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -61549,12 +61645,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Security - Detective's Office";
 	dir = 6;
 	network = list("ss13","Security")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "vEY" = (
@@ -61579,7 +61675,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/table,
 /obj/item/radio/off,
 /obj/item/screwdriver{
@@ -61655,7 +61750,6 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
 	name = "Cell 2 Locker"
@@ -61678,15 +61772,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"vGW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/service/kitchen)
 "vHm" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/security/prison)
 "vHo" = (
 /obj/machinery/conveyor{
@@ -61703,10 +61792,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "vHs" = (
@@ -61715,7 +61804,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
 "vHt" = (
 /obj/effect/spawner/random/structure/crate,
@@ -61726,13 +61815,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/security/prison/workout)
-"vHH" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/tram/left)
 "vHM" = (
 /obj/effect/turf_decal/siding/thinplating/end,
 /turf/open/floor/iron/dark,
@@ -61794,10 +61876,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "vJu" = (
@@ -61897,13 +61979,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vLb" = (
@@ -61916,8 +61998,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/storage/art)
 "vLd" = (
@@ -61978,6 +62060,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"vMw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "vMK" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab";
@@ -61991,8 +62081,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "vMN" = (
@@ -62002,14 +62092,15 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "vMR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "vNg" = (
@@ -62019,6 +62110,7 @@
 /area/maintenance/department/cargo)
 "vNk" = (
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "vNp" = (
@@ -62029,6 +62121,7 @@
 /obj/structure/fluff/tram_rail/floor{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "vNI" = (
@@ -62047,8 +62140,8 @@
 	c_tag = "Hallway - Central Escape Wing Entry";
 	dir = 5
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "vNM" = (
@@ -62142,14 +62235,15 @@
 "vPO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /mob/living/simple_animal/bot/secbot/pingsky{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vQc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "vQn" = (
@@ -62171,7 +62265,6 @@
 	name = "Supermatter Engine Room";
 	req_one_access_txt = "10;24"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
@@ -62181,6 +62274,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/supermatter/room)
 "vQC" = (
@@ -62195,7 +62289,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
@@ -62227,8 +62320,8 @@
 /obj/machinery/flasher/directional/west{
 	id = "AI"
 	},
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "vRh" = (
@@ -62236,9 +62329,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "vRk" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -62253,13 +62346,18 @@
 "vRm" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Cargo - Upper Power Hatch";
+	dir = 6;
+	network = list("ss13","cargo")
+	},
 /turf/open/floor/plating,
 /area/cargo/storage)
 "vRS" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "vRU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -62270,12 +62368,12 @@
 "vRY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "vSe" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -62285,9 +62383,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "vSq" = (
@@ -62333,7 +62431,7 @@
 	dir = 6;
 	network = list("ss13","cargo")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "vST" = (
 /obj/effect/decal/cleanable/dirt,
@@ -62361,7 +62459,6 @@
 /turf/open/floor/iron,
 /area/maintenance/port/central)
 "vTV" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
@@ -62381,7 +62478,7 @@
 	},
 /obj/item/relic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/crew_quarters/dorms)
 "vUF" = (
 /obj/machinery/pinpointer_dispenser,
@@ -62408,11 +62505,11 @@
 "vVa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vVu" = (
@@ -62477,7 +62574,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "vWt" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -62492,10 +62590,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"vWy" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "vWH" = (
 /obj/structure/table/glass,
 /obj/machinery/microwave,
@@ -62521,14 +62615,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/mess)
-"vWS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "vWW" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "scicell";
@@ -62548,7 +62634,6 @@
 "vXl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -62556,6 +62641,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "vXx" = (
@@ -62573,7 +62659,6 @@
 	name = "Gravity Generator Room";
 	req_access_txt = "19;23"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -62586,6 +62671,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "vYn" = (
@@ -62649,12 +62735,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "vZm" = (
@@ -62669,10 +62755,10 @@
 "vZn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "vZz" = (
@@ -62697,7 +62783,7 @@
 	},
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "vZR" = (
 /obj/machinery/door/airlock/mining/glass{
@@ -62710,7 +62796,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "vZU" = (
@@ -62726,7 +62811,6 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "wag" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock{
@@ -62734,6 +62818,7 @@
 	req_access_txt = "28"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/service/kitchen/coldroom)
 "wak" = (
@@ -62760,11 +62845,11 @@
 /area/medical/virology)
 "waC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "waG" = (
@@ -62783,7 +62868,6 @@
 /area/hallway/primary/tram/center)
 "wbm" = (
 /obj/machinery/power/smes,
-/obj/structure/cable,
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
 	},
@@ -62830,7 +62914,7 @@
 "wcA" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "wcM" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -62877,6 +62961,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wdJ" = (
@@ -62891,7 +62976,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "wdR" = (
@@ -62923,11 +63007,12 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Commons Area"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "wej" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "wel" = (
@@ -62935,7 +63020,6 @@
 	name = "Bar Storage";
 	req_access_txt = "25"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
@@ -62954,7 +63038,6 @@
 "weA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -62962,6 +63045,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "weC" = (
@@ -62992,12 +63076,12 @@
 "weV" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable,
 /obj/machinery/button/door/directional/south{
 	id = "engsm";
 	name = "Radiation Shutters Control";
 	req_access_txt = "10"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "wfn" = (
@@ -63010,7 +63094,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/left)
 "wfu" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -63023,8 +63107,8 @@
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "wfV" = (
@@ -63047,9 +63131,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "wgM" = (
@@ -63068,6 +63152,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "wgT" = (
@@ -63080,6 +63165,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "whs" = (
@@ -63111,11 +63197,11 @@
 "whP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "whS" = (
@@ -63146,10 +63232,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "wic" = (
@@ -63169,7 +63255,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
@@ -63178,10 +63263,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "wit" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -63192,7 +63277,6 @@
 	id = "AI";
 	pixel_x = 20
 	},
-/obj/structure/cable,
 /obj/machinery/door/window{
 	atom_integrity = 300;
 	base_state = "rightsecure";
@@ -63201,6 +63285,7 @@
 	name = "Primary AI Core Access";
 	req_access_txt = "16"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "wiA" = (
@@ -63211,12 +63296,12 @@
 /turf/open/floor/plating,
 /area/maintenance/tram/mid)
 "wjj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "wjq" = (
@@ -63227,10 +63312,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wjB" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "wjR" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -63274,10 +63359,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wkL" = (
@@ -63357,8 +63442,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "wmf" = (
@@ -63368,9 +63453,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/navbeacon/wayfinding/bar,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "wml" = (
@@ -63387,9 +63472,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "wmv" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -63398,21 +63483,21 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/medical/coldroom)
 "wmz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "wmA" = (
@@ -63470,9 +63555,9 @@
 /area/ai_monitored/security/armory)
 "woi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "wos" = (
@@ -63482,13 +63567,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"wou" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "woF" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three"
@@ -63497,7 +63575,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "woI" = (
 /obj/machinery/door/airlock{
@@ -63577,6 +63655,13 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"wqT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "wry" = (
 /obj/structure/chair{
 	dir = 8
@@ -63595,7 +63680,6 @@
 /area/security/brig)
 "wrB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
@@ -63613,12 +63697,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
 "wrQ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "wsh" = (
@@ -63635,8 +63719,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/sand/plating,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "wsp" = (
@@ -63649,7 +63733,8 @@
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet/emcloset,
 /obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
 "wsJ" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -63659,8 +63744,8 @@
 /area/security/checkpoint/science)
 "wsL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "wsP" = (
@@ -63688,8 +63773,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/misc_lab)
 "wtB" = (
@@ -63725,6 +63810,7 @@
 	id = "cytologysecure";
 	name = "Secure Pen Lockdown"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/cytology)
 "wux" = (
@@ -63796,6 +63882,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "wve" = (
@@ -63833,10 +63920,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/lounge)
 "wvq" = (
@@ -63860,12 +63947,12 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "wvZ" = (
@@ -63888,13 +63975,13 @@
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
 "wwk" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "wws" = (
@@ -63913,16 +64000,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ai_monitored/security/armory)
-"wwy" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "wwC" = (
 /turf/closed/wall,
 /area/science/lab)
@@ -63946,12 +64023,12 @@
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "wxb" = (
@@ -63976,9 +64053,18 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
+"wxB" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "wxC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "wxO" = (
@@ -64042,7 +64128,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
 "wyE" = (
 /obj/structure/table/glass,
@@ -64073,20 +64159,20 @@
 "wyH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "wyO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "wyP" = (
@@ -64116,7 +64202,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wzB" = (
@@ -64124,7 +64209,7 @@
 	pixel_y = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/central/secondary)
 "wzC" = (
 /obj/structure/chair,
@@ -64133,15 +64218,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"wzZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "wAe" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -64200,13 +64276,14 @@
 	pixel_y = 7
 	},
 /obj/item/pen/fourcolor,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "wBM" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/four,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "wBO" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -64239,6 +64316,7 @@
 /area/security/prison/rec)
 "wBZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "wCv" = (
@@ -64267,7 +64345,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/tram/right)
 "wCV" = (
 /obj/docking_port/stationary{
@@ -64361,7 +64439,8 @@
 	pixel_x = 9;
 	pixel_y = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "wGe" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -64424,6 +64503,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "wHp" = (
@@ -64439,8 +64519,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wHr" = (
@@ -64453,6 +64533,7 @@
 	},
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "wHx" = (
@@ -64505,7 +64586,7 @@
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/center)
 "wIq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -64580,9 +64661,9 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "wJI" = (
@@ -64599,6 +64680,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/central)
 "wJK" = (
@@ -64626,6 +64708,7 @@
 	dir = 10
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "wJP" = (
@@ -64649,6 +64732,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "wKs" = (
@@ -64659,7 +64743,6 @@
 	name = "Turbine Access";
 	req_access_txt = "24"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -64669,6 +64752,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "wKG" = (
@@ -64690,7 +64774,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/cut,
 /obj/item/wirecutters,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/starboard/central)
 "wKR" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -64704,15 +64788,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
-"wKV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "wKY" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/port/central)
 "wLb" = (
 /obj/machinery/computer/camera_advanced/xenobio,
@@ -64744,7 +64823,7 @@
 "wLD" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/security)
 "wLL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -64766,6 +64845,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wMp" = (
@@ -64776,6 +64856,7 @@
 /obj/effect/landmark/start/depsec/engineering,
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "wNd" = (
@@ -64788,6 +64869,7 @@
 	c_tag = "Civilian - Courtroom";
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "wNf" = (
@@ -64809,7 +64891,6 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "wNw" = (
-/obj/structure/cable,
 /obj/structure/chair{
 	dir = 4
 	},
@@ -64827,13 +64908,12 @@
 "wNA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "wNK" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/window/brigdoor{
@@ -64890,9 +64970,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "wOB" = (
@@ -64914,10 +64994,10 @@
 /area/engineering/main)
 "wOI" = (
 /obj/machinery/power/smes,
-/obj/structure/cable,
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "wON" = (
@@ -64946,7 +65026,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
 "wPB" = (
 /obj/effect/turf_decal/trimline/red/corner{
@@ -64983,7 +65063,6 @@
 /area/security/prison)
 "wPP" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/preopen{
 	id = "ceprivacy";
 	name = "privacy shutter"
@@ -65002,7 +65081,6 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/right)
 "wQn" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -65010,6 +65088,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "wQs" = (
@@ -65054,8 +65133,8 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wRo" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "wRF" = (
@@ -65089,6 +65168,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "wSI" = (
@@ -65098,9 +65178,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "wSO" = (
@@ -65147,6 +65227,7 @@
 	dir = 9
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "wTO" = (
@@ -65187,7 +65268,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "wUA" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -65196,6 +65276,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/construction/engineering)
 "wUT" = (
@@ -65217,10 +65298,10 @@
 "wVu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "wVD" = (
 /obj/machinery/seed_extractor,
@@ -65258,10 +65339,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "wVU" = (
@@ -65269,9 +65350,9 @@
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "wVV" = (
@@ -65356,9 +65437,9 @@
 "wXl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "wXt" = (
@@ -65386,7 +65467,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/port/central)
 "wYp" = (
 /obj/structure/disposalpipe/trunk/multiz{
@@ -65396,7 +65477,6 @@
 	name = "Containment Pen #6";
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiobottomleft";
@@ -65425,10 +65505,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
 "wYR" = (
@@ -65443,7 +65523,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Civilian - Library North Bookcases";
 	dir = 1
@@ -65455,16 +65534,17 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/depsec/supply,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "wZe" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer/on{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "wZm" = (
@@ -65562,7 +65642,6 @@
 	name = "Power Storage";
 	req_access_txt = "11"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -65573,6 +65652,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "xbu" = (
@@ -65584,7 +65664,6 @@
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "xbH" = (
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/security/brig)
@@ -65614,38 +65693,38 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
 	name = "sorting disposal pipe (Detective's Office)";
 	sortType = 30
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "xcD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "xcH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "xcL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "xdg" = (
@@ -65679,12 +65758,12 @@
 /area/science/breakroom)
 "xdJ" = (
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/crew_quarters/dorms)
 "xdP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -65699,10 +65778,9 @@
 "xdW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "xdZ" = (
-/obj/structure/cable,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65776,6 +65854,15 @@
 "xeZ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"xfa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/brig)
 "xft" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -65797,12 +65884,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "xfD" = (
@@ -65831,13 +65918,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /obj/machinery/camera{
 	c_tag = "Science - Experimentor Lab";
 	dir = 1;
 	network = list("ss13","rd")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "xfZ" = (
@@ -65908,7 +65995,8 @@
 	name = "Ordnance Lab Maintenance";
 	req_one_access_txt = "47"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "xis" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -65916,7 +66004,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "xiI" = (
 /obj/effect/landmark/carpspawn,
@@ -65927,13 +66015,13 @@
 	name = "Detective's Office";
 	req_access_txt = "4"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "xiT" = (
@@ -65941,9 +66029,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "xiV" = (
@@ -66031,7 +66119,6 @@
 	name = "Bar Door";
 	req_one_access_txt = "25;28"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera{
@@ -66039,6 +66126,7 @@
 	dir = 6
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "xkv" = (
@@ -66049,17 +66137,18 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "xkN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
 	name = "sorting disposal pipe (CMO's Office)";
 	sortType = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xkR" = (
@@ -66078,11 +66167,11 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "xlb" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xlh" = (
@@ -66119,7 +66208,7 @@
 	req_one_access_txt = "12"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/cargo)
 "xlC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66138,7 +66227,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -66186,7 +66274,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/medical)
 "xnc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66204,13 +66292,13 @@
 "xnp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xnt" = (
@@ -66280,24 +66368,24 @@
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
 "xoh" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/central)
 "xoi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/starboard/secondary)
 "xor" = (
 /obj/effect/spawner/structure/window,
@@ -66358,7 +66446,6 @@
 	name = "Containment Pen #5";
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobiobottomleft";
@@ -66369,19 +66456,6 @@
 "xqx" = (
 /turf/open/floor/iron/white,
 /area/science/explab)
-"xqK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "xri" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -66415,8 +66489,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "xrK" = (
@@ -66428,8 +66502,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/structure/cable,
 /obj/machinery/status_display/ai/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "xrY" = (
@@ -66545,6 +66619,7 @@
 	id = "AI";
 	pixel_y = -26
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "xtb" = (
@@ -66567,28 +66642,20 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/depsec/supply,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"xtw" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "xtP" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "xuo" = (
@@ -66775,6 +66842,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "xyz" = (
@@ -66839,7 +66907,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/six,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "xAh" = (
 /obj/effect/turf_decal/trimline/white/line{
@@ -66881,10 +66949,10 @@
 /turf/open/floor/plating/airless,
 /area/mine/explored)
 "xAt" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/department/cargo)
 "xBm" = (
 /mob/living/simple_animal/bot/floorbot,
@@ -66906,6 +66974,7 @@
 /area/security/brig)
 "xBB" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "xCh" = (
@@ -66918,8 +66987,8 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
 "xCH" = (
@@ -66947,13 +67016,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"xCW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "xCZ" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/light_switch/directional/south,
@@ -66962,11 +67024,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"xDs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "xDt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -66991,6 +67048,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"xDF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
+/area/maintenance/starboard/central)
 "xEr" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -67031,15 +67094,16 @@
 /obj/structure/sign/picture_frame/portrait/bar{
 	pixel_y = 28
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
 "xFv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/screwdriver,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "xFM" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -67099,9 +67163,9 @@
 /area/medical/medbay/central)
 "xGK" = (
 /obj/machinery/holopad,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/bridge)
 "xGU" = (
@@ -67203,12 +67267,12 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/structure/cable,
 /obj/machinery/requests_console/directional/north{
 	department = "AI";
 	departmentType = 5;
 	name = "AI Requests Console"
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "xIj" = (
@@ -67306,37 +67370,36 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "xKe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "xKk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Atmospherics Maintenance";
 	req_one_access_txt = "24"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "xKn" = (
 /obj/machinery/button/door/directional/south{
-	id = "Biohazard";
-	name = "Biohazard Shutter Control";
+	id = "Sciencelockdown";
+	name = "Science Lockdown Toggle";
 	pixel_x = -6;
 	req_access_txt = "47"
 	},
 /obj/machinery/button/door/directional/south{
-	id = "rnd2";
+	id = "rndlab1";
 	name = "Research Lab Shutter Control";
 	pixel_x = 6;
 	req_access_txt = "47"
@@ -67396,8 +67459,8 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/holopad/secure,
+/obj/structure/cable,
 /turf/open/floor/glass/reinforced,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "xLE" = (
@@ -67546,10 +67609,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "xOP" = (
@@ -67597,7 +67660,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/central)
 "xPw" = (
 /obj/machinery/seed_extractor,
@@ -67609,7 +67673,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/right)
 "xPD" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -67671,9 +67736,9 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "xRx" = (
@@ -67685,10 +67750,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "xRE" = (
@@ -67700,11 +67765,11 @@
 	name = "Power Access Hatch";
 	req_access_txt = "11"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "xRS" = (
 /obj/structure/window/reinforced{
@@ -67751,6 +67816,7 @@
 	dir = 6;
 	network = list("aicore")
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "xSI" = (
@@ -67766,8 +67832,8 @@
 	pixel_x = -6;
 	pixel_y = -24
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "xSW" = (
@@ -67811,8 +67877,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"xTR" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/maintenance/port/fore)
 "xTU" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/item/stack/sheet/iron,
@@ -67848,13 +67921,13 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "xUq" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/escape)
 "xUr" = (
@@ -67865,6 +67938,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
 "xUz" = (
@@ -67899,8 +67973,8 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
 "xVg" = (
@@ -67919,7 +67993,8 @@
 	req_access_txt = "22"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "xVp" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -67927,12 +68002,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central/secondary)
 "xVq" = (
 /obj/machinery/telecomms/server/presets/common,
@@ -67975,8 +68050,8 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "xVP" = (
@@ -68089,6 +68164,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/flip,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xXs" = (
@@ -68128,6 +68204,7 @@
 /obj/effect/turf_decal/caution{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/left)
 "xXP" = (
@@ -68160,17 +68237,18 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "xYC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/aft)
 "xYL" = (
 /obj/structure/disposalpipe/segment,
@@ -68184,28 +68262,37 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "xZa" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"xZb" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/lounge)
 "xZf" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xZg" = (
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "xZj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "xZp" = (
@@ -68242,14 +68329,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"xZL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "xZR" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -68286,7 +68365,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/crew_quarters/dorms)
 "yah" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68297,10 +68376,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "yak" = (
@@ -68319,12 +68398,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "yaX" = (
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk_floor,
 /area/maintenance/port/fore)
 "ybr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -68372,10 +68451,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "ybL" = (
@@ -68485,8 +68564,8 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/structure/cable,
 /obj/machinery/light_switch/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "yev" = (
@@ -68522,6 +68601,18 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"yfs" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "yft" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
 	dir = 4
@@ -68594,7 +68685,6 @@
 "ygI" = (
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/theater)
 "ygM" = (
@@ -68638,7 +68728,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "yid" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -68676,7 +68765,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "yiT" = (
@@ -68745,13 +68833,13 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "yjD" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "yjS" = (
@@ -68760,8 +68848,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "yjT" = (
@@ -68804,7 +68892,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "ykx" = (
@@ -83653,17 +83740,17 @@ aBM
 ahI
 ahI
 ahI
-azZ
-azZ
-azZ
-azZ
-azZ
-azZ
-azZ
-iJa
-azZ
+qBF
+qBF
+qBF
+qBF
+qBF
+qBF
+qBF
+bhL
+qBF
 kHS
-aKu
+kZq
 aKl
 aKl
 aKl
@@ -83909,7 +83996,7 @@ dhe
 aBM
 ahI
 qwP
-azZ
+qBF
 xFv
 ahI
 ahI
@@ -83921,7 +84008,7 @@ ahI
 ahI
 aKl
 jzs
-aKu
+kZq
 aZx
 aKl
 dhe
@@ -84165,8 +84252,8 @@ dhe
 dhe
 aBM
 ahI
-xFN
-azZ
+hlf
+qBF
 ahI
 ahI
 arm
@@ -84178,7 +84265,7 @@ bfh
 jIX
 aKl
 aKl
-aKu
+kZq
 csb
 aKl
 dhe
@@ -84422,8 +84509,8 @@ dhe
 dhe
 dhe
 ahI
-hin
-azZ
+xTR
+qBF
 ahI
 aYI
 etc
@@ -84435,7 +84522,7 @@ aMr
 aRc
 aAb
 aKl
-aKu
+kZq
 hvZ
 aKl
 dhe
@@ -84680,7 +84767,7 @@ dhe
 ahI
 ahI
 ahI
-azZ
+qBF
 ahI
 amU
 nGz
@@ -84692,7 +84779,7 @@ aMr
 jJi
 aRQ
 aKl
-aKu
+kZq
 aKl
 aKl
 aKl
@@ -85460,7 +85547,7 @@ aCa
 aCa
 aCa
 aCa
-nGz
+goc
 aFN
 aVX
 aVX
@@ -85922,7 +86009,7 @@ nTn
 pcH
 fnk
 ofB
-eTY
+gEc
 nGc
 pmL
 oSp
@@ -85974,7 +86061,7 @@ and
 aeF
 aRg
 aCa
-nGz
+goc
 aFN
 aKE
 aKE
@@ -86203,19 +86290,19 @@ azZ
 azZ
 azZ
 azZ
-azZ
-azZ
+bzm
+bMK
 ahI
 dhe
 dhe
 dhe
 dhe
 ahI
-azZ
+bMK
 ahI
 lDv
 xFN
-azZ
+bMK
 xFN
 dsx
 ahI
@@ -86436,7 +86523,7 @@ oJf
 bCC
 eNH
 pmL
-eTY
+gEc
 mLp
 pmL
 dho
@@ -86468,7 +86555,7 @@ ahI
 ahI
 ahI
 ahI
-azZ
+ilo
 ahI
 ahI
 ahI
@@ -86723,7 +86810,7 @@ yaX
 yaX
 yaX
 yaX
-fry
+yaX
 yaX
 yaX
 yaX
@@ -86947,9 +87034,9 @@ lHo
 lHo
 lHo
 lHo
-eTY
+gEc
 qGN
-eTY
+gEc
 lHo
 lHo
 lHo
@@ -86984,10 +87071,10 @@ ahI
 ahI
 ahI
 qBx
-azZ
+ilo
 fog
-azZ
-azZ
+ilo
+ilo
 ahI
 oZm
 fyx
@@ -87462,7 +87549,7 @@ kLl
 aWt
 cIh
 uXd
-oAJ
+ubs
 pmL
 cIh
 aWt
@@ -87751,17 +87838,17 @@ dhe
 dhe
 dhe
 aEc
-aMK
+fNT
 aIq
 aJt
-aMK
+fNT
 aNe
-aNe
+fNT
 lJr
 sFv
 aJt
 aIq
-aMK
+fNT
 aEc
 dhe
 aCa
@@ -88009,13 +88096,13 @@ dhe
 dhe
 aEc
 wcA
-aMK
+fNT
 aJt
 cKo
 nvY
 aIq
 tKK
-aMK
+fNT
 aJt
 qeZ
 aOO
@@ -88233,7 +88320,7 @@ kdx
 aWt
 cIh
 wSO
-oAJ
+ubs
 pmL
 cIh
 aWt
@@ -88302,7 +88389,7 @@ aKl
 aKl
 aKl
 kVx
-aKu
+uSK
 ebN
 uqv
 aKl
@@ -88490,7 +88577,7 @@ rYA
 cIh
 cIh
 cel
-oAJ
+ubs
 sPW
 cIh
 cIh
@@ -88771,14 +88858,14 @@ dhe
 dhe
 dhe
 aaB
-pjw
-pjw
 jae
-acg
-acg
-acg
-acg
-acg
+jae
+jae
+iti
+iti
+iti
+iti
+iti
 aaB
 aEc
 oKZ
@@ -89028,7 +89115,7 @@ dhe
 dhe
 dhe
 aaB
-pjw
+jae
 aaB
 aaB
 aaB
@@ -89053,7 +89140,7 @@ cuz
 txD
 txD
 txD
-nwu
+mDC
 efs
 efs
 gwR
@@ -89063,7 +89150,7 @@ efs
 tEN
 iDl
 krp
-eAG
+uJH
 okf
 eAG
 hoX
@@ -89285,7 +89372,7 @@ dhe
 dhe
 dhe
 aaB
-pjw
+jae
 aaB
 jco
 laB
@@ -89542,7 +89629,7 @@ aaB
 aaB
 aaB
 aaB
-pjw
+jae
 aaB
 sGS
 eUy
@@ -89795,11 +89882,11 @@ rpo
 mwz
 dhe
 aaB
-pjw
-pjw
-pjw
-pjw
-pjw
+jae
+jae
+jae
+jae
+jae
 aaB
 fPR
 nsG
@@ -90052,7 +90139,7 @@ nLc
 wZm
 dhe
 aaB
-pjw
+jae
 yiT
 yiT
 yiT
@@ -90309,9 +90396,9 @@ csa
 lvw
 dhe
 aaB
-pjw
+jae
 yiT
-alA
+bUL
 xCO
 yiT
 mqc
@@ -90332,7 +90419,7 @@ gwU
 bgd
 aEc
 aOX
-paH
+xZb
 aQd
 aQy
 aII
@@ -90568,7 +90655,7 @@ dhe
 aaB
 gkt
 fLD
-pjw
+jae
 wKY
 yiT
 vDu
@@ -91573,7 +91660,7 @@ emw
 xdr
 eWF
 oxt
-fLV
+hrd
 teD
 kuN
 obn
@@ -91834,7 +91921,7 @@ hLR
 pva
 afv
 gpn
-afk
+eve
 hje
 cJD
 wvG
@@ -92091,7 +92178,7 @@ iux
 gEc
 qlg
 gpn
-afk
+eve
 ehO
 cJD
 wvG
@@ -92112,7 +92199,7 @@ dhe
 dhe
 dhe
 aaB
-acg
+bUL
 aaB
 aaB
 aaB
@@ -92162,8 +92249,8 @@ aKl
 aKl
 dPa
 qGc
-ebN
-gnC
+drI
+uue
 gnC
 jdK
 dhe
@@ -92346,7 +92433,7 @@ ccM
 ccM
 tFP
 rij
-rXZ
+pmL
 gpn
 gpn
 gpn
@@ -92370,8 +92457,8 @@ dhe
 dhe
 aaB
 eGH
-acg
-acg
+bUL
+bUL
 aaB
 jqt
 pNr
@@ -92628,7 +92715,7 @@ ngS
 aaB
 aaB
 aaB
-acg
+bUL
 aaB
 aaB
 aaB
@@ -92644,7 +92731,7 @@ aMK
 gwU
 aNY
 aOH
-aEc
+aJt
 aPT
 rPe
 aXA
@@ -92860,9 +92947,9 @@ cRh
 cRh
 hES
 pNt
-ntt
-oJH
-oJH
+nUJ
+pzp
+pzp
 xVf
 cRh
 iUC
@@ -92901,8 +92988,8 @@ aMK
 gwU
 qrV
 asY
-aEc
-aPT
+aJt
+eck
 tVk
 aXA
 avP
@@ -92910,8 +92997,8 @@ avP
 avP
 awm
 mkV
-agC
-agC
+avP
+avP
 anK
 avP
 avP
@@ -93116,7 +93203,7 @@ rTo
 gTG
 gTG
 qMv
-pZg
+xVf
 teW
 ccM
 ccM
@@ -93142,7 +93229,7 @@ sDW
 vTE
 vBy
 aaB
-acg
+bUL
 aaB
 dhe
 aBM
@@ -93158,8 +93245,8 @@ aMK
 gwU
 tMs
 aEc
-aEc
-aPT
+aJt
+ehP
 ijQ
 aXA
 avP
@@ -93184,8 +93271,8 @@ aat
 fPs
 aJo
 nSi
-bbb
-neO
+ndt
+rSr
 cUX
 neO
 aJo
@@ -93415,8 +93502,8 @@ aMK
 gwU
 rbJ
 tTA
-aEc
-aPT
+aJt
+eck
 tqz
 aXA
 aeV
@@ -93656,7 +93743,7 @@ nXi
 sDW
 acg
 aaB
-acg
+bUL
 aaB
 dhe
 aBM
@@ -93672,7 +93759,7 @@ aMK
 gwU
 uHL
 aEc
-aEc
+aJt
 aPT
 aPT
 aXA
@@ -93913,7 +94000,7 @@ uMG
 siZ
 mgP
 aaB
-acg
+bUL
 aaB
 dhe
 dhe
@@ -94170,7 +94257,7 @@ eiT
 aaB
 aaB
 aaB
-acg
+bUL
 aaB
 dhe
 dhe
@@ -94415,7 +94502,7 @@ dhe
 dhe
 aac
 jmR
-vLw
+nST
 aac
 bsZ
 aGF
@@ -94671,7 +94758,7 @@ dhe
 dhe
 dhe
 aac
-adA
+dXk
 hzf
 iEH
 hzf
@@ -94684,7 +94771,7 @@ dhe
 dhe
 dhe
 aaB
-acg
+bUL
 aaB
 aBM
 aBM
@@ -94941,7 +95028,7 @@ dhe
 dhe
 dhe
 aaB
-acg
+bUL
 aaB
 aBM
 aBM
@@ -94965,7 +95052,7 @@ apw
 avI
 bFc
 avI
-arJ
+njg
 nNX
 arJ
 afx
@@ -94989,7 +95076,7 @@ qrK
 mfy
 qUZ
 trQ
-kbj
+jQr
 xHR
 xVq
 mfy
@@ -95173,7 +95260,7 @@ dhe
 aGF
 cPu
 rPj
-vLw
+qlj
 aGF
 dhe
 dhe
@@ -95198,7 +95285,7 @@ dhe
 dhe
 dhe
 aaB
-acg
+bUL
 aaB
 aBM
 aBM
@@ -95214,7 +95301,7 @@ rjS
 ddj
 hJL
 uSn
-aMK
+fNT
 aEc
 dhe
 axc
@@ -95222,7 +95309,7 @@ afU
 aDS
 aAp
 anX
-aQe
+qOp
 mBn
 aQe
 aoc
@@ -95246,7 +95333,7 @@ qrK
 gUw
 gUw
 rnh
-kbj
+jQr
 qvF
 aNT
 gUw
@@ -95430,7 +95517,7 @@ dhe
 aGF
 vEb
 rPj
-rsL
+lsj
 aGF
 dhe
 dhe
@@ -95455,7 +95542,7 @@ dhe
 dhe
 dhe
 aaB
-acg
+bUL
 vzN
 aBM
 aBM
@@ -95471,7 +95558,7 @@ ucp
 ucp
 aEc
 aEc
-aMK
+fNT
 aEc
 dhe
 axc
@@ -95503,9 +95590,9 @@ qrK
 qrK
 gUw
 mfy
-kbj
-kbj
-xMn
+jQr
+jQr
+uDu
 gUw
 eCl
 dhe
@@ -95685,9 +95772,9 @@ dhe
 dhe
 dhe
 aGF
-pwt
+aSZ
 rPj
-vLw
+qlj
 aGF
 dhe
 dhe
@@ -95712,7 +95799,7 @@ dhe
 dhe
 dhe
 aaB
-acg
+bUL
 vzN
 aBM
 aBM
@@ -95759,7 +95846,7 @@ rjc
 rVq
 kvP
 kbj
-kbj
+mfy
 wSk
 weC
 hAf
@@ -95969,7 +96056,7 @@ aGF
 dhe
 dhe
 aaB
-acg
+bUL
 vzN
 aBM
 aBM
@@ -95985,7 +96072,7 @@ uJk
 uJk
 aHH
 aEc
-aMK
+fNT
 aEc
 dhe
 dhe
@@ -95999,14 +96086,14 @@ siT
 aJy
 qgE
 hxB
-dFg
+lXc
 dAl
 cfH
 uCO
-neO
-neO
+inv
+inv
 beB
-neO
+inv
 aJy
 mrp
 vrn
@@ -96015,7 +96102,7 @@ fOI
 siu
 qrK
 qrK
-gUw
+xMn
 kbj
 kbj
 kbj
@@ -96217,7 +96304,7 @@ hzf
 hzf
 hzf
 hzf
-vLw
+qlj
 aGF
 cFv
 vLw
@@ -96226,7 +96313,7 @@ aGF
 dhe
 dhe
 aaB
-acg
+bUL
 aaB
 oJR
 aBM
@@ -96242,7 +96329,7 @@ nxj
 cAg
 faf
 oLT
-aMK
+fNT
 aEc
 tAh
 tAh
@@ -96508,7 +96595,7 @@ sXA
 xeJ
 aJy
 aJy
-djP
+psh
 aJy
 aJy
 nbH
@@ -96520,7 +96607,7 @@ efY
 aJy
 khx
 beB
-vHt
+pzL
 aJy
 wJK
 vrn
@@ -96720,9 +96807,9 @@ dhe
 dhe
 aGF
 vLw
-vLw
-vLw
-vLw
+alU
+jaH
+wqT
 aGF
 wZm
 oXC
@@ -96735,12 +96822,12 @@ lPJ
 aGF
 pwt
 qhG
-qhG
+lUp
 vZK
-qhG
+qdf
 dcD
 eLo
-vLw
+nST
 aGF
 aBM
 aBM
@@ -96764,7 +96851,7 @@ gTq
 doC
 cBt
 aJy
-neO
+inv
 cTo
 aOB
 aOB
@@ -96777,7 +96864,7 @@ aml
 aJy
 ofx
 beB
-neO
+inv
 aJy
 cYC
 iqJ
@@ -96994,10 +97081,10 @@ aac
 aac
 aac
 aac
-qhG
-vLw
-vLw
-vLw
+qdf
+qlj
+nST
+nST
 aGF
 dhe
 aBM
@@ -97252,7 +97339,7 @@ hSj
 lPJ
 xRM
 fpX
-vLw
+nST
 rsL
 aGF
 aGF
@@ -97505,12 +97592,12 @@ aGF
 lPJ
 aac
 foZ
-adA
+dXk
 pYP
 aac
 fpX
-vLw
-vLw
+qlj
+qlj
 myW
 iTv
 bfI
@@ -98019,9 +98106,9 @@ aGF
 lPJ
 aGF
 fRD
-xtw
-xtw
-xtw
+lBW
+lBW
+lBW
 aho
 fuB
 fuB
@@ -98029,7 +98116,7 @@ fuB
 fuB
 fuB
 jMM
-vLw
+qlj
 dft
 aHH
 fhR
@@ -98064,7 +98151,7 @@ aov
 ofX
 mkS
 aJS
-sbC
+tgg
 jED
 cni
 wMp
@@ -98266,15 +98353,15 @@ jgz
 xux
 rdS
 aGF
-vLw
+kwY
 aGF
 fRD
-xtw
-xtw
-xtw
-xtw
+lBW
+lBW
+lBW
+lBW
 jeq
-xtw
+lBW
 kvZ
 aej
 aej
@@ -98286,7 +98373,7 @@ aej
 aej
 aej
 dZk
-vLw
+qlj
 vcF
 aHH
 aHH
@@ -98343,7 +98430,7 @@ fbD
 pCw
 ntj
 mPH
-mAL
+pKM
 kVP
 ffs
 mnk
@@ -98523,7 +98610,7 @@ crx
 vvW
 txi
 gIe
-txi
+kfA
 uhu
 jnZ
 afq
@@ -98543,7 +98630,7 @@ kSB
 duH
 aej
 dZk
-vLw
+qlj
 doe
 aHH
 aqI
@@ -98574,9 +98661,9 @@ gqH
 aln
 kZF
 aIG
-aJS
+tTd
 xbl
-aJS
+tTd
 aIG
 eRd
 wMp
@@ -98602,8 +98689,8 @@ ciD
 oVv
 pKM
 paJ
-prA
-prA
+rcc
+rcc
 qGj
 qGj
 tBO
@@ -98780,7 +98867,7 @@ ovm
 rFR
 jss
 aGF
-dft
+tFL
 aGF
 jnZ
 afq
@@ -99053,7 +99140,7 @@ aej
 aej
 aej
 aej
-hHx
+mXZ
 mbD
 gNI
 fpX
@@ -99092,7 +99179,7 @@ xIj
 pqm
 jED
 bnR
-jbT
+pqm
 jED
 upb
 jED
@@ -99100,7 +99187,7 @@ jED
 jED
 hsv
 jED
-cni
+klK
 gnw
 cjg
 dXs
@@ -99310,10 +99397,10 @@ dhe
 dhe
 dhe
 aej
-nMI
+sNT
 rUM
 aej
-vLw
+qlj
 aGF
 mpz
 iXd
@@ -99346,13 +99433,13 @@ aQE
 ewL
 fcp
 gdY
-jKa
+aQE
 jdR
 iHi
-jKa
-jKa
+aQE
+aQE
 cjM
-cRy
+hsv
 rye
 pqm
 pqm
@@ -99567,7 +99654,7 @@ aej
 aej
 aej
 aej
-hLk
+bnm
 ksI
 aej
 aej
@@ -99603,7 +99690,7 @@ lTa
 rqB
 uYT
 lOJ
-fRU
+gUn
 uYT
 hTn
 jED
@@ -99838,7 +99925,7 @@ aMP
 xmS
 aMP
 vQt
-rFs
+qCp
 fNs
 ifs
 ifs
@@ -99884,7 +99971,7 @@ bdI
 bdI
 wKG
 jqb
-gNU
+mlb
 pKM
 tBO
 mRn
@@ -100074,14 +100161,14 @@ nUP
 dxK
 akg
 kJx
-oFj
+kDv
 kXp
 pjS
 pHr
 aej
 aZE
 gRy
-bmX
+ahV
 ahV
 qCm
 oKC
@@ -100089,13 +100176,13 @@ bgh
 jSq
 aej
 rsP
-fbu
+ilv
 wiA
 aMP
 aMP
 aMP
 iVL
-gzC
+myc
 mRa
 mRa
 mRa
@@ -100144,10 +100231,10 @@ ciD
 gXs
 kXu
 paJ
-prA
-prA
+rcc
+rcc
 bfM
-prA
+rcc
 tBO
 dhe
 dhe
@@ -100321,7 +100408,7 @@ jMq
 amK
 amK
 amK
-oEV
+omw
 wag
 hWm
 hWm
@@ -100346,13 +100433,13 @@ aej
 aej
 aej
 rsP
-fbu
+ilv
 wiA
 aMP
 aMP
 aMP
 vQt
-qtB
+wDw
 mRa
 afD
 aga
@@ -100578,7 +100665,7 @@ iKE
 vss
 lYO
 amK
-vif
+omw
 jZY
 bNT
 nIq
@@ -100609,7 +100696,7 @@ aMP
 aMP
 aMP
 vQt
-qtB
+wDw
 mRa
 afN
 agb
@@ -100621,7 +100708,7 @@ diZ
 afB
 fuI
 xwc
-fuw
+geu
 eyf
 emj
 fNC
@@ -100835,7 +100922,7 @@ qMp
 vss
 lYO
 amK
-vif
+omw
 jZY
 cNC
 bOz
@@ -100846,7 +100933,7 @@ gqr
 pzb
 oka
 ifI
-vcR
+ova
 kwj
 hmX
 ova
@@ -100860,13 +100947,13 @@ aLL
 bLN
 oIo
 naO
-fbu
-uXw
-uXw
-uXw
-uXw
-uXw
-qtB
+ilv
+cJa
+cJa
+cJa
+cJa
+cJa
+wDw
 mRa
 afO
 afD
@@ -101092,7 +101179,7 @@ xgo
 vss
 lYO
 amK
-vif
+omw
 jZY
 imK
 nIq
@@ -101111,13 +101198,13 @@ ahV
 reZ
 uMw
 aGN
-vCy
+qCm
 ahU
 aTa
 bLN
 ezd
 xFg
-fbu
+ilv
 wiA
 aMP
 aMP
@@ -101135,7 +101222,7 @@ qPM
 afB
 pyc
 xwc
-fuw
+geu
 eyf
 cGs
 rgq
@@ -101349,7 +101436,7 @@ wlm
 amK
 amK
 amK
-vif
+omw
 jZY
 auC
 kKv
@@ -101368,13 +101455,13 @@ vDH
 reZ
 xpu
 mGf
-vCy
+qCm
 fXP
 aej
 aej
 aej
 rbF
-fbu
+ilv
 wiA
 aMP
 aMP
@@ -101606,7 +101693,7 @@ kUm
 amK
 rrj
 amK
-vif
+omw
 jZY
 atV
 obY
@@ -101625,7 +101712,7 @@ uMt
 reZ
 ahV
 ahV
-vCy
+qCm
 gtd
 bgh
 jSq
@@ -101863,7 +101950,7 @@ amK
 amK
 amK
 amK
-vif
+omw
 jZY
 jZY
 jZY
@@ -102132,7 +102219,7 @@ qKk
 aNR
 aej
 agP
-ahV
+bmX
 reZ
 aej
 aej
@@ -102399,7 +102486,7 @@ uMR
 aej
 nai
 aGF
-vLw
+qlj
 rbZ
 aHH
 oWx
@@ -102654,7 +102741,7 @@ aej
 sNT
 vuG
 lra
-utc
+jMM
 aGF
 mYS
 aHH
@@ -102911,7 +102998,7 @@ bKU
 jzR
 vSZ
 aej
-ryY
+qLV
 lBW
 lBW
 cjF
@@ -103168,8 +103255,8 @@ aej
 xNp
 qPI
 aej
-qhG
-vLw
+ckV
+qlj
 doe
 aHH
 lTD
@@ -103425,8 +103512,8 @@ aej
 aej
 aej
 aej
-qhG
-vLw
+ckV
+qlj
 uAd
 aHH
 aHH
@@ -103452,7 +103539,7 @@ tnL
 tnL
 usM
 xap
-vEy
+ilP
 akU
 aJy
 vrP
@@ -103673,17 +103760,17 @@ dhe
 dhe
 aGF
 iHc
-qhG
-qhG
+ckV
+ckV
 vWs
-qhG
-qhG
-qhG
-qhG
+ckV
+ckV
+ckV
+ckV
 tOF
-qhG
-qhG
-ebn
+ckV
+ckV
+gag
 uzy
 aHH
 qiX
@@ -103706,7 +103793,7 @@ ikr
 xsT
 kiP
 pDm
-iAe
+pDm
 qje
 wzp
 ozn
@@ -104996,8 +105083,8 @@ aJo
 vCG
 lMb
 aJo
-njU
-oBg
+inv
+dpI
 oxc
 kDS
 qVO
@@ -105252,9 +105339,9 @@ dhe
 aJo
 tPz
 aJH
-phM
-vDX
-oBg
+eIr
+inv
+dpI
 aJy
 cAo
 whM
@@ -105494,7 +105581,7 @@ jUx
 iLD
 mri
 lRU
-xmS
+rTt
 aHH
 oJR
 dhe
@@ -105510,8 +105597,8 @@ aJo
 msT
 kDm
 aJo
-qlR
-oBg
+inv
+dpI
 aJo
 jwD
 bNm
@@ -105751,7 +105838,7 @@ eMU
 eMU
 aHH
 aHH
-aMP
+ifs
 aHH
 aBM
 dhe
@@ -106025,8 +106112,8 @@ aJo
 aJo
 aJo
 mma
-oBg
-neO
+dpI
+rQB
 aJy
 wux
 cNX
@@ -106242,7 +106329,7 @@ aBM
 adS
 exW
 jlO
-aeX
+uAT
 adS
 aBM
 aBM
@@ -106265,7 +106352,7 @@ jrz
 jrz
 aHI
 aHH
-aMP
+ifs
 aHH
 oJR
 iox
@@ -106281,9 +106368,9 @@ aBM
 cAL
 xjM
 rxe
-neO
-oBg
-neO
+inv
+dpI
+spS
 aJy
 dTm
 dTm
@@ -106522,7 +106609,7 @@ sUv
 pSq
 brE
 wCC
-aMP
+ifs
 aHH
 ieJ
 ieJ
@@ -106539,8 +106626,8 @@ aJo
 aJo
 aJo
 ofx
-oBg
-neO
+dpI
+cjG
 aJy
 kEz
 uAn
@@ -106727,36 +106814,36 @@ dhe
 dhe
 rQC
 rFp
-adk
+ePt
 ePt
 knV
 knV
 knV
 nBz
 nBz
-cwr
-nBz
 nBz
 cwr
-dhe
-dhe
-aBM
-aBM
-dhe
-dhe
-dhe
-aBM
-aBM
-aBM
 cwr
 cwr
+dhe
+dhe
+aBM
+aBM
+dhe
+dhe
+dhe
+aBM
+aBM
+aBM
+nBz
+nBz
 nBz
 lVv
 dUQ
 wsm
 wjB
-pdA
-aet
+hJa
+jYQ
 agX
 aee
 aeo
@@ -106795,7 +106882,7 @@ dhe
 dhe
 dhe
 aJo
-vWS
+geR
 kEA
 aJo
 aJy
@@ -107005,7 +107092,7 @@ dhe
 dhe
 dhe
 aBM
-cwr
+nBz
 aBM
 qgs
 adS
@@ -107013,7 +107100,7 @@ adS
 adS
 jIg
 uSw
-aet
+jYQ
 adS
 adS
 adS
@@ -107052,7 +107139,7 @@ aJo
 aJo
 aJo
 aJo
-oBg
+dpI
 sAK
 aJo
 fwy
@@ -107234,14 +107321,14 @@ aBM
 aBM
 aBM
 aBM
-aRN
+wgT
 aBM
 aBM
 aBM
 aBM
 aBM
 knV
-adk
+ePt
 knV
 pgh
 aBM
@@ -107259,16 +107346,16 @@ aBM
 aBM
 dhe
 dhe
-cwr
-cwr
-cwr
-cwr
+nBz
+nBz
+nBz
+nBz
 aBM
 aBM
 aBM
 aBM
 adS
-vjC
+hyK
 jlO
 eJE
 adS
@@ -107309,7 +107396,7 @@ eYG
 eYG
 eYG
 eYG
-vWS
+geR
 vDX
 aJo
 ify
@@ -107508,15 +107595,15 @@ dhe
 aBM
 aBM
 aBM
-cwr
 nBz
-cwr
-cwr
 nBz
-cwr
-cwr
-cwr
-cwr
+nBz
+nBz
+nBz
+nBz
+nBz
+nBz
+nBz
 aBM
 aBM
 aBM
@@ -107566,11 +107653,11 @@ aJy
 aJy
 aJy
 aJy
-oBg
+dpI
 rgO
 aJo
 fwy
-neO
+qdg
 aJo
 dhe
 dhe
@@ -107766,7 +107853,7 @@ dhe
 dhe
 dhe
 aBM
-wgT
+aRN
 aBM
 aBM
 aBM
@@ -107823,7 +107910,7 @@ iSp
 aiE
 rJa
 aJy
-oBg
+dpI
 oii
 aJo
 aJo
@@ -108012,7 +108099,7 @@ pOx
 aBM
 aBM
 aBM
-aRN
+wgT
 aBM
 dhe
 bnN
@@ -108080,13 +108167,13 @@ nlQ
 nSt
 mqI
 aJy
-vWS
-oBg
-xZL
-oBg
-oBg
-oBg
-oBg
+geR
+dpI
+dpI
+dpI
+dpI
+dpI
+dpI
 jhd
 aJo
 qlR
@@ -108279,8 +108366,8 @@ dhe
 aBM
 vlK
 oZi
-wgT
-wgT
+aRN
+aRN
 lvw
 dhe
 rLt
@@ -108526,7 +108613,7 @@ pOx
 pOx
 aBM
 aBM
-wgT
+aRN
 aBM
 dhe
 dhe
@@ -108601,9 +108688,9 @@ bpL
 aJy
 dhe
 aJo
-etW
+nSi
 aJo
-neO
+inv
 dmx
 aJy
 rzp
@@ -108779,11 +108866,11 @@ aBM
 aBM
 aBM
 aBM
-wgT
+aRN
 aBM
 aBM
 aBM
-wgT
+aRN
 aBM
 aBM
 dhe
@@ -108858,7 +108945,7 @@ aYL
 aJy
 dhe
 aJo
-etW
+nSi
 aJo
 aJo
 aJo
@@ -109040,7 +109127,7 @@ pOx
 pOx
 pOx
 pOx
-wgT
+aRN
 aBM
 aBM
 dhe
@@ -109115,7 +109202,7 @@ aJy
 aJy
 oJR
 aJo
-etW
+nSi
 aJo
 dhe
 dhe
@@ -109352,8 +109439,8 @@ aHI
 aHI
 xPb
 tzc
-aet
-aet
+fuc
+fWI
 aJo
 eYG
 aJy
@@ -109372,7 +109459,7 @@ aZC
 wmE
 aBM
 aJo
-etW
+nSi
 aJo
 aBM
 dhe
@@ -109552,8 +109639,8 @@ jwD
 jwD
 rmz
 wgT
-wgT
-wgT
+aRN
+aRN
 aBM
 aBM
 aBM
@@ -109629,7 +109716,7 @@ hbz
 nQJ
 aBM
 aJo
-etW
+nSi
 aJo
 ssQ
 aBM
@@ -109851,7 +109938,7 @@ sEo
 dHa
 aeu
 qrv
-aet
+fuc
 adS
 hhC
 aHI
@@ -109863,14 +109950,14 @@ rvc
 uom
 hft
 aOM
-aPx
-aPx
-aPx
-aPx
-aPx
-aPx
+lgr
+lgr
+lgr
+lgr
+lgr
+lgr
 cCM
-aet
+jYQ
 qJp
 aeu
 wGY
@@ -109886,7 +109973,7 @@ der
 wcv
 dVo
 aJo
-etW
+nSi
 aJo
 iox
 aBM
@@ -110143,7 +110230,7 @@ der
 dhe
 dhe
 aJo
-etW
+nSi
 aJo
 aBM
 dhe
@@ -110360,10 +110447,10 @@ rvx
 adS
 adS
 hJa
-hNl
-hNl
-hNl
-hNl
+xDF
+xDF
+xDF
+xDF
 mIu
 ies
 hNl
@@ -110400,7 +110487,7 @@ der
 dhe
 dhe
 aJo
-etW
+nSi
 aJo
 dhe
 dhe
@@ -110409,8 +110496,8 @@ pfK
 lPd
 lPd
 nOn
-wwy
-oqW
+qZl
+kfJ
 lZG
 lPd
 lPd
@@ -110584,7 +110671,7 @@ jwD
 unm
 aBM
 aBM
-aRN
+wgT
 aBM
 aBM
 aBM
@@ -110874,12 +110961,12 @@ qJe
 xNa
 vkb
 sMb
-tqL
+iWV
 eGl
 npX
 cEk
 aeu
-aet
+pEZ
 adS
 aet
 aHI
@@ -110911,14 +110998,14 @@ wYR
 msN
 ndy
 wwt
-aRO
+mTY
 bAS
 aRL
 rIS
 mvv
 aRL
-aRO
-aRO
+mTY
+mTY
 wwt
 mOo
 klo
@@ -111178,8 +111265,8 @@ oFz
 oFz
 rah
 bes
-fjy
-fjy
+vaN
+vaN
 rSg
 iay
 tni
@@ -111379,7 +111466,7 @@ uUu
 gzb
 amg
 qoJ
-kgN
+tND
 sHb
 uJC
 fDM
@@ -111388,7 +111475,7 @@ eMG
 cXe
 hmw
 bay
-tqL
+iWV
 rTL
 nAu
 npU
@@ -111426,13 +111513,13 @@ bhj
 rAI
 tTI
 ujs
-aRO
+mTY
 aRL
 tis
 vBt
 aRL
-aRO
-aRO
+mTY
+mTY
 wwt
 nth
 dnT
@@ -111636,7 +111723,7 @@ uUu
 sHb
 ami
 nhq
-kgN
+tND
 sHb
 sHb
 sHb
@@ -111910,7 +111997,7 @@ iXq
 iXq
 iXq
 wmu
-aJk
+aOM
 fpk
 pmY
 aMY
@@ -111951,8 +112038,8 @@ pfK
 lPd
 lPd
 uQq
-eOn
-bfg
+ngv
+kVl
 fqi
 lPd
 lPd
@@ -112199,7 +112286,7 @@ klD
 aRT
 aSl
 xoi
-lHu
+oFz
 aRL
 dhe
 dhe
@@ -112419,7 +112506,7 @@ uBG
 hcW
 adS
 cIN
-iUL
+aet
 drK
 adS
 adS
@@ -112455,7 +112542,7 @@ der
 klD
 klD
 klD
-ahE
+xoi
 aRL
 aRL
 dhe
@@ -112712,7 +112799,7 @@ wbE
 wbE
 wbE
 klD
-ahE
+xoi
 aRL
 dhe
 dhe
@@ -112933,7 +113020,7 @@ xeq
 juI
 adS
 tEb
-iUL
+aet
 adS
 adS
 jlO
@@ -112969,7 +113056,7 @@ beR
 beR
 beR
 klD
-ahE
+xoi
 aRL
 dhe
 dhe
@@ -113709,20 +113796,20 @@ adS
 jlO
 aHI
 aIo
-aMY
+lAB
 aMG
 nIg
 iJW
 aJf
 lON
-aMY
+lAB
 aMG
-aMY
+lAB
 aPw
 aHI
 jlO
 tFo
-aet
+qgw
 aet
 aeu
 miq
@@ -113965,8 +114052,8 @@ dhe
 adS
 jlO
 aHI
-aMY
-aJf
+lAB
+tte
 aMG
 fKQ
 aNi
@@ -113974,8 +114061,8 @@ gDW
 tZh
 iLW
 aMG
-aJf
-aMY
+tte
+lAB
 aHI
 jlO
 adS
@@ -114228,7 +114315,7 @@ aMG
 tTu
 aNj
 gDW
-aMY
+lAB
 jiz
 aMG
 aHI
@@ -114311,7 +114398,7 @@ cID
 cSm
 wOm
 lzb
-pIb
+fhq
 jiR
 fhq
 lSm
@@ -114503,7 +114590,7 @@ bgo
 lMe
 fbR
 fKH
-wAe
+mjD
 nZk
 kJX
 uaJ
@@ -114511,7 +114598,7 @@ sqn
 jXs
 rbt
 wwt
-ahE
+xoi
 aRL
 aRL
 aRL
@@ -114741,12 +114828,12 @@ jlO
 jlO
 jlO
 jlO
-jEG
+hJa
 jlO
 jlO
 jlO
 jlO
-tzc
+mJV
 boh
 exW
 adS
@@ -114760,7 +114847,7 @@ pkG
 lMe
 plm
 iPd
-wAe
+mjD
 rAr
 xBB
 dPS
@@ -114996,11 +115083,11 @@ dhe
 adS
 adS
 adS
-aet
+jYQ
 jgj
 itO
 wKQ
-aet
+jYQ
 adS
 adS
 adS
@@ -115018,7 +115105,7 @@ vqq
 igr
 igr
 igr
-tls
+igr
 qnj
 cbi
 qTI
@@ -115282,9 +115369,9 @@ mSi
 mSi
 mSi
 wwt
-aRO
-aRO
-aRO
+rzA
+jZU
+rWi
 aRL
 dhe
 sQi
@@ -115512,7 +115599,7 @@ dhe
 dhe
 adS
 gOj
-aet
+gfr
 vjC
 adS
 dhe
@@ -150726,7 +150813,7 @@ avy
 wxA
 awt
 hxx
-dwR
+jDZ
 bCo
 dDP
 koi
@@ -152011,7 +152098,7 @@ ayD
 ayD
 aET
 tLk
-qth
+akM
 aEq
 kUV
 aYT
@@ -152249,7 +152336,7 @@ pII
 hmh
 qCU
 vTV
-aqN
+fsa
 xlp
 tpP
 wuT
@@ -152262,12 +152349,12 @@ aGH
 app
 auD
 pJU
-axT
-axT
+aBa
+aBa
 azj
-axT
-axT
-dwR
+aBa
+aBa
+jDZ
 aCH
 aSD
 axp
@@ -152762,8 +152849,8 @@ dcJ
 pII
 tVj
 qCU
-vTV
-aqN
+hYs
+fsa
 jeU
 nOY
 jOU
@@ -153037,7 +153124,7 @@ jNq
 ayE
 gOU
 uKV
-apv
+aAX
 awF
 anG
 anG
@@ -153260,8 +153347,8 @@ geq
 bxF
 wkE
 aoP
-amq
-amq
+fZp
+fZp
 fZp
 xvf
 ieT
@@ -153277,7 +153364,7 @@ pII
 cUB
 oEO
 wuy
-aqN
+fsa
 cXs
 kZX
 mLo
@@ -153287,7 +153374,7 @@ goB
 mdg
 aqH
 hkC
-apv
+aAX
 lJR
 awF
 hjB
@@ -153297,7 +153384,7 @@ mKW
 kpB
 awF
 lJR
-apv
+aAX
 anG
 ngF
 cMW
@@ -153544,17 +153631,17 @@ voB
 azG
 ajJ
 hkC
-apv
+aAX
 auP
 awF
 apv
 pXQ
 lJR
 hak
-apv
+aAX
 awF
 dDU
-apv
+aAX
 anG
 cvW
 fpN
@@ -154021,9 +154108,9 @@ aBM
 aBM
 dOV
 dOV
-lvJ
+sck
 vQC
-lvJ
+sck
 dOV
 oKB
 jsk
@@ -154050,7 +154137,7 @@ nPS
 bgA
 tQM
 tQM
-xqK
+eDT
 kiQ
 hkC
 hkC
@@ -154295,7 +154382,7 @@ aof
 amT
 anz
 amn
-apL
+apY
 uCE
 gmV
 rgX
@@ -154316,7 +154403,7 @@ eDT
 pgc
 iOT
 nnA
-auY
+oxJ
 eCj
 axW
 axW
@@ -154324,7 +154411,7 @@ wcM
 axW
 axW
 eSx
-pPM
+oYq
 uEA
 cXa
 pYt
@@ -154611,7 +154698,7 @@ dhe
 aBM
 aBM
 aBM
-ikt
+aRN
 aBM
 aBM
 aBM
@@ -154803,7 +154890,7 @@ hOq
 iaY
 nrn
 xQU
-cCB
+xfa
 apA
 xkv
 pNu
@@ -154847,12 +154934,12 @@ dBM
 dwa
 srq
 kzp
-sXx
-sXx
+yfs
+yfs
 kzp
-sXx
-sXx
-cRo
+yfs
+yfs
+vil
 iiG
 kGg
 uRU
@@ -155111,7 +155198,7 @@ akE
 akE
 iBK
 akE
-aGj
+thR
 jVH
 aOb
 aOb
@@ -155319,7 +155406,7 @@ qzt
 ahB
 liL
 anz
-gUa
+pNu
 aoB
 vGS
 vGu
@@ -155574,7 +155661,7 @@ goY
 cbN
 alq
 amT
-xDs
+liL
 anJ
 xkv
 pNu
@@ -155641,7 +155728,7 @@ aBM
 aBM
 aBM
 aBM
-aRN
+wgT
 aBM
 aBM
 aBM
@@ -155882,7 +155969,7 @@ akE
 amI
 dEp
 akE
-aGj
+thR
 vma
 eWv
 aIg
@@ -156156,7 +156243,7 @@ aBM
 aBM
 aBM
 aBM
-ikt
+aRN
 aBM
 aBM
 aBM
@@ -156602,7 +156689,7 @@ nsQ
 tsL
 alq
 amT
-xDs
+liL
 anQ
 xkv
 pNu
@@ -156653,7 +156740,7 @@ akE
 aky
 apz
 akE
-xAk
+nmd
 juE
 lnR
 aIg
@@ -156674,7 +156761,7 @@ aBM
 aRN
 aBM
 aBM
-hWd
+rmz
 aYr
 aYr
 aYr
@@ -156930,8 +157017,8 @@ aBM
 aRN
 aRN
 aRN
-ikt
-ikt
+wgT
+wgT
 aYr
 aYr
 aYr
@@ -157167,7 +157254,7 @@ akE
 akE
 bAN
 akE
-aGj
+thR
 fIz
 aOb
 aOb
@@ -157427,7 +157514,7 @@ ond
 iiX
 dGK
 aOb
-alc
+aNl
 aNl
 aOb
 aOb
@@ -157441,7 +157528,7 @@ dhe
 aBM
 aBM
 aBM
-aRN
+wgT
 aBM
 jxU
 jxU
@@ -157630,7 +157717,7 @@ xkv
 xkv
 xkv
 jIn
-cCB
+xfa
 anB
 iwp
 xWS
@@ -157682,7 +157769,7 @@ aWe
 aWe
 fSd
 aoa
-sES
+tOc
 wgK
 guJ
 nRE
@@ -157698,10 +157785,10 @@ aBM
 aBM
 aBM
 aBM
+wgT
+aBM
+aBM
 aRN
-aBM
-aBM
-ikt
 aBM
 aBM
 aBM
@@ -157887,7 +157974,7 @@ lSt
 jBw
 amn
 anc
-wzZ
+xfa
 anz
 amn
 amT
@@ -157914,7 +158001,7 @@ xcc
 puy
 aba
 dLg
-avc
+fPK
 xXC
 axY
 oVG
@@ -158216,7 +158303,7 @@ aRN
 aBM
 aBM
 aBM
-aRN
+wgT
 aBM
 aBM
 aBM
@@ -158383,7 +158470,7 @@ aBM
 aBM
 vlW
 oES
-bTa
+vWh
 rUP
 xZj
 nbU
@@ -158680,7 +158767,7 @@ isc
 sac
 wLS
 aGh
-ayS
+eYr
 dGz
 asb
 anG
@@ -158723,7 +158810,7 @@ aBM
 aBM
 aBM
 aBM
-ikt
+aRN
 aRN
 hkw
 aRN
@@ -158942,7 +159029,7 @@ lER
 aER
 anG
 arV
-auN
+lJR
 anG
 axX
 fve
@@ -158950,7 +159037,7 @@ azB
 wUT
 axX
 anG
-auN
+lJR
 lrP
 awF
 aGC
@@ -158980,7 +159067,7 @@ dhe
 dhe
 aBM
 aBM
-ikt
+wgT
 aBM
 aBM
 aBM
@@ -159187,7 +159274,7 @@ qvh
 hBq
 ezo
 ewV
-rwo
+bsq
 myf
 keg
 jts
@@ -159246,7 +159333,7 @@ aBM
 aBM
 aBM
 aBM
-ikt
+aRN
 aBM
 aBM
 aBM
@@ -159455,7 +159542,7 @@ aTW
 wQZ
 lJl
 anG
-vHH
+arV
 tEZ
 anG
 axX
@@ -159465,7 +159552,7 @@ qbg
 axX
 anG
 nLJ
-kRr
+lrP
 anG
 dhe
 dhe
@@ -160264,7 +160351,7 @@ nBz
 nBH
 iXl
 ojj
-wKV
+wBZ
 wBZ
 uec
 pTU
@@ -160758,12 +160845,12 @@ nBz
 nBz
 nBz
 urC
-cwr
-cwr
-cwr
-cwr
-cwr
-cwr
+nBz
+nBz
+nBz
+nBz
+nBz
+nBz
 lvw
 lvw
 dhe
@@ -161020,8 +161107,8 @@ dhe
 dhe
 dhe
 dhe
-cwr
-cwr
+nBz
+nBz
 lvw
 dhe
 dhe
@@ -161284,9 +161371,9 @@ nBz
 nBz
 nBz
 nBz
-cwr
-cwr
-cwr
+nBz
+nBz
+nBz
 nBz
 dhe
 dhe
@@ -161787,7 +161874,7 @@ dhe
 dhe
 hce
 kpe
-lDW
+oTv
 xna
 hce
 dhe
@@ -162301,9 +162388,9 @@ lbM
 lbM
 xzX
 fzc
-wou
+oTv
 lbM
-wWF
+ieH
 ldj
 lbM
 fQb
@@ -162552,13 +162639,13 @@ jpW
 aRN
 lbM
 lCH
-wWF
-wWF
-fiT
+ieH
+ieH
+mHY
 mzF
-wWF
+ieH
 nrF
-wou
+oTv
 pmg
 tNX
 aFh
@@ -162778,7 +162865,7 @@ mvT
 ucq
 edz
 tLc
-npy
+aAL
 hgA
 pfa
 aAL
@@ -162808,7 +162895,7 @@ avn
 avn
 aEW
 lbM
-wWF
+ieH
 lbM
 lbM
 lbM
@@ -162818,7 +162905,7 @@ lbM
 lbM
 lbM
 oTv
-wWF
+ieH
 lbM
 ate
 boT
@@ -163322,7 +163409,7 @@ avn
 avn
 aEY
 lbM
-wWF
+ieH
 lbM
 mNG
 hrp
@@ -163332,7 +163419,7 @@ wsp
 hGC
 lbM
 oTv
-wWF
+ieH
 lbM
 vzg
 oKi
@@ -163568,7 +163655,7 @@ kaL
 dhe
 avn
 kgr
-avq
+dRg
 avn
 ayd
 qyp
@@ -163579,7 +163666,7 @@ avn
 dRg
 aEZ
 jre
-voF
+bcy
 lbM
 akr
 uaI
@@ -163836,7 +163923,7 @@ avn
 aDm
 aEZ
 lbM
-wWF
+ieH
 lbM
 ecY
 mde
@@ -164093,7 +164180,7 @@ avn
 avn
 adT
 lbM
-wWF
+ieH
 lbM
 jUS
 qQI
@@ -164321,7 +164408,7 @@ wrF
 amE
 wrF
 wrF
-hYp
+jlG
 wrF
 aqE
 qXI
@@ -164572,9 +164659,9 @@ swA
 swA
 vSq
 cav
-xCW
-xCW
-xCW
+awd
+awd
+awd
 koq
 koq
 koq
@@ -165899,7 +165986,7 @@ wMj
 kef
 ghi
 ivP
-jGq
+iPX
 vkF
 uht
 nso
@@ -166120,7 +166207,7 @@ mjt
 hvc
 vUo
 iMM
-vGW
+gzs
 jMv
 tDr
 jMv
@@ -166150,8 +166237,8 @@ aDz
 aFg
 aGo
 gbU
-vWy
-vWy
+ggn
+ggn
 jad
 bqL
 bhn
@@ -166417,7 +166504,7 @@ rXO
 xZf
 kbz
 kxP
-bGD
+qLM
 hYz
 jli
 aUk
@@ -166634,7 +166721,7 @@ cek
 hvc
 jmu
 pdm
-vGW
+gzs
 ihG
 ajQ
 aqp
@@ -166674,7 +166761,7 @@ eLP
 tYi
 uKg
 iIX
-sLq
+gKY
 asM
 akS
 pXL
@@ -166931,7 +167018,7 @@ ncO
 lYw
 uht
 aHQ
-sLq
+gKY
 sLq
 pEn
 tOr
@@ -167145,7 +167232,7 @@ llY
 cEY
 amK
 bmm
-iyT
+cGf
 nJA
 aGY
 pcP
@@ -167916,7 +168003,7 @@ wgM
 cQU
 sVV
 aYt
-pbT
+upd
 aYt
 iEW
 dSj
@@ -168170,17 +168257,17 @@ mXD
 pFz
 ays
 wjj
-ays
-ays
-ays
-ays
-ays
-ays
-ays
+koq
+koq
+koq
+koq
+koq
+koq
+koq
 pnv
 cNk
-ays
-ays
+koq
+koq
 koq
 bfN
 tCJ
@@ -168225,7 +168312,7 @@ ggn
 ggn
 fPc
 pHI
-piZ
+ggn
 cYX
 rAz
 vqs
@@ -168446,8 +168533,8 @@ eNY
 koq
 koq
 koq
-qlP
-qlP
+gJW
+gJW
 heE
 rdP
 atB
@@ -168498,8 +168585,8 @@ abJ
 iDc
 ocI
 qLi
-qLi
-qLi
+dhe
+dhe
 dhe
 dhe
 dhe
@@ -168707,7 +168794,7 @@ xDx
 xDx
 jHv
 kqz
-jRt
+adm
 avn
 avn
 ayd
@@ -168964,7 +169051,7 @@ jPI
 jPI
 jPI
 jPI
-lkK
+asE
 avs
 avn
 ayd
@@ -169221,7 +169308,7 @@ cQc
 sHG
 xIJ
 jPI
-lkK
+asE
 dRg
 avn
 ayd
@@ -169478,7 +169565,7 @@ rrL
 oyJ
 xIJ
 jPI
-atC
+asv
 avn
 avn
 ayd
@@ -169749,7 +169836,7 @@ aEZ
 lbM
 wWF
 lbM
-wZq
+rpa
 mIG
 irj
 dCv
@@ -169979,7 +170066,7 @@ dhe
 dhe
 dhe
 oOP
-fGX
+veb
 aiF
 uGj
 uPQ
@@ -170236,7 +170323,7 @@ dhe
 dhe
 dhe
 oOP
-fGX
+veb
 aiF
 aiF
 aiF
@@ -170493,7 +170580,7 @@ dhe
 dhe
 dhe
 oOP
-fGX
+veb
 oOP
 dhe
 dhe
@@ -170750,7 +170837,7 @@ oOP
 oOP
 oOP
 oOP
-fGX
+veb
 oOP
 dhe
 dhe
@@ -171003,11 +171090,11 @@ oOP
 oOP
 oOP
 oOP
-fGX
-fGX
-fGX
-fGX
-fGX
+veb
+veb
+veb
+veb
+veb
 oOP
 dhe
 dhe
@@ -171255,12 +171342,12 @@ dhe
 dhe
 dhe
 oOP
-fGX
+veb
 mDh
-fGX
+veb
 vsY
-fGX
-fGX
+veb
+veb
 oOP
 oOP
 oOP
@@ -171774,7 +171861,7 @@ vNg
 bFV
 kvs
 oOP
-fGX
+veb
 oOP
 dhe
 dhe
@@ -173317,21 +173404,21 @@ dhe
 dhe
 oOP
 xAt
-fGX
-fGX
-fGX
-fGX
+veb
+veb
+veb
+veb
 bxg
-fGX
+veb
 oOP
 dhe
 oOP
 rpd
-fGX
-fGX
-fGX
-fGX
-fGX
+veb
+veb
+veb
+veb
+veb
 oOP
 xPx
 pPZ
@@ -173579,16 +173666,16 @@ pQB
 pQB
 pQB
 pQB
-fGX
+veb
 oOP
 dhe
 oOP
-fGX
+veb
 eUe
 eUe
 eUe
 eUe
-fGX
+veb
 oOP
 atK
 aod
@@ -173831,24 +173918,24 @@ dhe
 oOP
 oOP
 kuX
-pQB
+lzu
 oHI
 emk
 sDF
 pQB
-fGX
+veb
 oOP
 oOP
 oOP
-fGX
+veb
 pQB
 wHz
 hzo
 pQB
-fGX
+veb
 xlA
-atN
-avY
+xPx
+vft
 aod
 ayt
 pCN
@@ -173856,7 +173943,7 @@ aAQ
 gSR
 ayt
 aod
-avY
+vft
 aux
 axR
 ssR
@@ -174086,17 +174173,17 @@ dhe
 dhe
 dhe
 oOP
-kuX
-kuX
+veb
+veb
 pQB
 vRm
 jMz
 eEt
 pQB
 mlE
-fGX
-fGX
-fGX
+veb
+veb
+veb
 vsY
 pQB
 rqE
@@ -174104,7 +174191,7 @@ gEq
 pQB
 pQB
 pQB
-atN
+xPx
 dlX
 aod
 ayt
@@ -175147,7 +175234,7 @@ aEb
 ryJ
 mON
 aHu
-lar
+ucf
 hRI
 owK
 lar
@@ -175641,7 +175728,7 @@ ufF
 pXz
 xtb
 yeO
-cwv
+veF
 iGB
 veF
 yeO
@@ -175934,7 +176021,7 @@ vmv
 utD
 lev
 sDb
-lev
+cHD
 asN
 vmv
 vzu
@@ -176672,7 +176759,7 @@ lft
 pRJ
 cxq
 ggh
-ufr
+hAd
 uCf
 sAj
 eOI
@@ -176932,7 +177019,7 @@ aqy
 jRW
 sfT
 lau
-awh
+gzz
 bFp
 ayt
 omi
@@ -177189,7 +177276,7 @@ aqy
 oCq
 nLs
 auh
-awf
+wxB
 hla
 ayt
 pCN
@@ -177464,7 +177551,7 @@ akw
 bJd
 kvg
 xXB
-dXv
+xeG
 hta
 mkw
 cXQ
@@ -177703,7 +177790,7 @@ xtb
 xtb
 xtb
 aun
-awh
+gzz
 axM
 ayt
 omi
@@ -177721,7 +177808,7 @@ der
 der
 kvg
 kvg
-bjZ
+oky
 nac
 oky
 wwC
@@ -177744,7 +177831,7 @@ hvU
 dGu
 dGu
 mAl
-ato
+nzq
 ixA
 bFg
 dGu
@@ -177960,7 +178047,7 @@ xNV
 xNV
 aoh
 aur
-awk
+hEy
 axM
 ayt
 omi
@@ -178001,7 +178088,7 @@ dGu
 dGu
 dGu
 qRS
-atp
+mln
 etV
 qRI
 dGu
@@ -178214,7 +178301,7 @@ oEZ
 vKO
 uJw
 orv
-uJw
+ccc
 aok
 aus
 wTL
@@ -178231,7 +178318,7 @@ rLM
 hBt
 pjY
 rqf
-lar
+ucf
 hRI
 owK
 lar
@@ -178258,7 +178345,7 @@ dGu
 dGu
 dGu
 qRS
-atp
+mln
 etV
 qRI
 dGu
@@ -178486,7 +178573,7 @@ aEm
 aFZ
 aGz
 gyu
-uJw
+ccc
 txz
 gSJ
 uJQ
@@ -178515,7 +178602,7 @@ hvU
 dGu
 dGu
 mAl
-ato
+nzq
 lCG
 bFg
 dGu
@@ -178551,8 +178638,8 @@ aYr
 aYr
 aYr
 mLq
-mLq
 hdo
+mLq
 leZ
 leZ
 uSH
@@ -179064,8 +179151,8 @@ gNY
 gNY
 mLq
 mLq
-mLq
 hdo
+mLq
 mLq
 leZ
 leZ
@@ -179251,7 +179338,7 @@ aux
 lds
 avY
 owJ
-aux
+rSu
 axR
 aDX
 aux
@@ -179335,7 +179422,7 @@ rQa
 cTx
 dqK
 oQZ
-bcC
+pti
 bcC
 uoZ
 bEQ
@@ -179502,7 +179589,7 @@ nKs
 aqm
 aod
 aux
-avY
+vft
 axR
 aux
 rWR
@@ -179510,7 +179597,7 @@ rWR
 jfz
 ium
 axR
-avY
+vft
 aux
 aod
 ovn
@@ -179578,8 +179665,8 @@ aYr
 aYr
 mLq
 mLq
-mLq
 hdo
+mLq
 mLq
 leZ
 leZ
@@ -179738,7 +179825,7 @@ rpI
 xjT
 cNG
 ovy
-ovy
+vMw
 dLD
 lCt
 wDe
@@ -179762,7 +179849,7 @@ aod
 aod
 axR
 aux
-aux
+rWR
 sPN
 cgv
 aux
@@ -179994,7 +180081,7 @@ wDe
 vtd
 bsW
 ybt
-bsW
+lyf
 bsW
 dhl
 hrG
@@ -180092,8 +180179,8 @@ aYr
 aYr
 mLq
 mLq
-mLq
 hdo
+mLq
 mLq
 leZ
 leZ
@@ -180269,7 +180356,7 @@ src
 oKN
 wld
 fsu
-nDW
+hbU
 wHo
 gvW
 fHW
@@ -180359,11 +180446,11 @@ eEo
 uoZ
 tiC
 dtL
-myx
+dtL
 ciO
 tdH
 xKb
-myx
+dtL
 gsu
 uoZ
 bEQ
@@ -180510,7 +180597,7 @@ jUw
 elk
 gsa
 uKh
-xHg
+qhp
 ehn
 wDe
 dhe
@@ -180537,7 +180624,7 @@ wxC
 wXl
 uYH
 wxC
-nDW
+hbU
 wHf
 tCx
 cmf
@@ -180606,8 +180693,8 @@ gNY
 gNY
 mLq
 mLq
-mLq
 hdo
+mLq
 mLq
 leZ
 leZ
@@ -180617,9 +180704,9 @@ uoZ
 jZu
 dbJ
 oEz
-bgL
+rUY
 sFj
-bgL
+rUY
 gbV
 rUY
 uoZ
@@ -181121,8 +181208,8 @@ aYr
 aYr
 aYr
 mLq
-mLq
 hdo
+mLq
 leZ
 leZ
 uSH
@@ -181305,7 +181392,7 @@ qHU
 jsj
 gBY
 bjX
-cTX
+bYM
 jOk
 gBY
 pYX
@@ -181557,7 +181644,7 @@ tGm
 leY
 eqT
 oNe
-tBC
+nXw
 eHH
 uMQ
 vDn
@@ -181812,16 +181899,16 @@ aBM
 uEX
 kri
 ccG
-pUM
+eqT
 oNe
-tBC
-dNy
-dNy
+nXw
+eHH
+eHH
 gXe
 jqu
 thX
 are
-vZU
+ohA
 vZU
 fxr
 jbm
@@ -182078,7 +182165,7 @@ hzC
 ujA
 gBY
 arf
-eHH
+dNy
 cZO
 eHH
 jbm
@@ -182335,7 +182422,7 @@ hzC
 bsM
 loN
 arg
-eHH
+dNy
 eHH
 eHH
 jbm
@@ -182588,13 +182675,13 @@ hKF
 wuW
 kzt
 jOS
-jrH
+hzC
 taS
 loN
 arh
 ark
-ark
-ark
+qsa
+qsa
 arn
 ybL
 gBY
@@ -182845,14 +182932,14 @@ uEX
 gBY
 gBY
 aEN
-hzC
+cQn
 bsM
 loN
 ffk
+dNy
 eHH
 eHH
-eHH
-aro
+jbm
 oKj
 gBY
 aBM
@@ -183100,16 +183187,16 @@ gBY
 wLe
 xxk
 aEj
-nnZ
+qjT
 nXw
-hzC
+cQn
 taS
 loN
 ffk
+dNy
 eHH
 eHH
-eHH
-aro
+jbm
 khm
 gBY
 aBM
@@ -183359,13 +183446,13 @@ nLj
 vxD
 jhT
 pvw
-hzC
+cQn
 ujA
 qlJ
 tqs
-eHH
+dNy
 qnL
-eHH
+dNy
 aro
 arp
 gBY
@@ -183614,7 +183701,7 @@ qjT
 izq
 eHH
 cIZ
-nnZ
+qjT
 nXw
 mwy
 uMQ
@@ -183871,7 +183958,7 @@ qjT
 cqu
 gDI
 fTk
-nnZ
+qjT
 mZd
 wmH
 vSz

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -17220,7 +17220,7 @@
 "eck" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/commons/lounge)
 "ecy" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -17520,7 +17520,7 @@
 /obj/machinery/power/apc/auto_name/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/commons/lounge)
 "ehZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28259,7 +28259,7 @@
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/commons/lounge)
 "ijR" = (
 /obj/effect/turf_decal/bot,
@@ -52332,7 +52332,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/commons/lounge)
 "rPf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57861,7 +57861,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/catwalk_floor,
 /area/commons/lounge)
 "tVq" = (
 /obj/structure/closet/radiation,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Completely rips out the old wirenet and replaces it with a repathed one with more redundancies to reduce random acts of mice violence on the powergrid. Also renovates maintenance with the cool catwalk tiles since nowhere else uses them. Also a few misc fixes involving missing pipes and blast doors/buttons missing their counterparts.

## Why It's Good For The Game

Hopefully addresses the powernet complaints the map had.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: MMMiracles
add: Tramstation's maintenance now has new catwalk tiles covering the various piping/wiring throughout.
fix: Tramstation's powernet should be slightly more resistant to bouts of power outages caused by rogue syndicate mice operatives.
fix: Patched up a few missed spots involving pipe/wiring for departments like Botany/Courtroom.
/:cl:

Fixes #61923

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
![image](https://user-images.githubusercontent.com/9276171/136637358-6e306612-e97b-48e4-8b86-49d58eba1ce7.png)
![image](https://user-images.githubusercontent.com/9276171/136637446-19e88f25-5402-4b76-8a35-c506555dfc4d.png)


see it looks pretty cool

