### PR TITLE
Fixed hand grabbing messages appearing when they shouldn't

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -317,9 +317,9 @@
 			if(ishuman(M))
 				var/mob/living/carbon/human/grabbed_human = M
 				var/grabbed_by_hands = (zone_selected == "l_arm" || zone_selected == "r_arm") && grabbed_human.usable_hands > 0
-				M.visible_message(span_warning("[src] grabs [M] [(grabbed_by_hands)? "by their hands":"passively"]!"), \
-								span_warning("[src] grabs you [(grabbed_by_hands)? "by your hands":"passively"]!"), null, null, src)
-				to_chat(src, span_notice("You grab [M] [(grabbed_by_hands)? "by their hands":"passively"]!"))
+				M.visible_message(span_warning("[src] grabs [M] [grabbed_by_hands ? "by their hands":"passively"]!"), \
+								span_warning("[src] grabs you [grabbed_by_hands ? "by your hands":"passively"]!"), null, null, src)
+				to_chat(src, span_notice("You grab [M] [grabbed_by_hands ? "by their hands":"passively"]!"))
 			else
 				M.visible_message(span_warning("[src] grabs [M] passively!"), \
 								span_warning("[src] grabs you passively!"), null, null, src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -311,12 +311,12 @@
 
 	if(ismob(AM))
 		var/mob/M = AM
-
+		var/mob/living/carbon/human/grabbed_human = M
 		log_combat(src, M, "grabbed", addition="passive grab")
 		if(!supress_message && !(iscarbon(AM) && HAS_TRAIT(src, TRAIT_STRONG_GRABBER)))
-			M.visible_message(span_warning("[src] grabs [M] [(zone_selected == "l_arm" || zone_selected == "r_arm" && ishuman(M))? "by their hands":"passively"]!"), \
-							span_warning("[src] grabs you [(zone_selected == "l_arm" || zone_selected == "r_arm" && ishuman(M))? "by your hands":"passively"]!"), null, null, src)
-			to_chat(src, span_notice("You grab [M] [(zone_selected == "l_arm" || zone_selected == "r_arm" && ishuman(M))? "by their hands":"passively"]!"))
+			M.visible_message(span_warning("[src] grabs [M] [((zone_selected == "l_arm" || zone_selected == "r_arm") && ishuman(M) && grabbed_human.usable_hands > 0)? "by their hands":"passively"]!"), \
+							span_warning("[src] grabs you [((zone_selected == "l_arm" || zone_selected == "r_arm") && ishuman(M) && grabbed_human.usable_hands > 0)? "by your hands":"passively"]!"), null, null, src)
+			to_chat(src, span_notice("You grab [M] [((zone_selected == "l_arm" || zone_selected == "r_arm") && ishuman(M) && grabbed_human.usable_hands > 0)? "by their hands":"passively"]!"))
 		if(!iscarbon(src))
 			M.LAssailant = null
 		else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -311,12 +311,20 @@
 
 	if(ismob(AM))
 		var/mob/M = AM
-		var/mob/living/carbon/human/grabbed_human = M
+
 		log_combat(src, M, "grabbed", addition="passive grab")
 		if(!supress_message && !(iscarbon(AM) && HAS_TRAIT(src, TRAIT_STRONG_GRABBER)))
-			M.visible_message(span_warning("[src] grabs [M] [((zone_selected == "l_arm" || zone_selected == "r_arm") && ishuman(M) && grabbed_human.usable_hands > 0)? "by their hands":"passively"]!"), \
-							span_warning("[src] grabs you [((zone_selected == "l_arm" || zone_selected == "r_arm") && ishuman(M) && grabbed_human.usable_hands > 0)? "by your hands":"passively"]!"), null, null, src)
-			to_chat(src, span_notice("You grab [M] [((zone_selected == "l_arm" || zone_selected == "r_arm") && ishuman(M) && grabbed_human.usable_hands > 0)? "by their hands":"passively"]!"))
+			if(ishuman(M))
+				var/mob/living/carbon/human/grabbed_human = M
+				var/grabbed_by_hands = (zone_selected == "l_arm" || zone_selected == "r_arm") && grabbed_human.usable_hands > 0
+				M.visible_message(span_warning("[src] grabs [M] [(grabbed_by_hands)? "by their hands":"passively"]!"), \
+								span_warning("[src] grabs you [(grabbed_by_hands)? "by your hands":"passively"]!"), null, null, src)
+				to_chat(src, span_notice("You grab [M] [(grabbed_by_hands)? "by their hands":"passively"]!"))
+			else
+				M.visible_message(span_warning("[src] grabs [M] passively!"), \
+								span_warning("[src] grabs you passively!"), null, null, src)
+				to_chat(src, span_notice("You grab [M] passively!"))
+
 		if(!iscarbon(src))
 			M.LAssailant = null
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When you grab someone by the hands, even if the target doesn't have hands, they will still grab you by the hands.

## Why It's Good For The Game

You cannot grab hands that aren't there!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
spellcheck: No more phantom hand grabbing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
