### PR TITLE
Fixes pipes not fulfulling nicotine withdrawal

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -569,7 +569,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	return ..()
 
 /obj/item/clothing/mask/cigarette/pipe/process(delta_time)
-	var/turf/location = get_turf(src)
 	var/mob/living/M = loc
 	if(isliving(loc))
 		M.IgniteMob()

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -571,6 +571,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/pipe/process(delta_time)
 	var/mob/living/living_smoker = loc
 	if(isliving(loc))
+		var/mob/living/living_smoker = loc
 		living_smoker.IgniteMob()
 	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
 		var/datum/gas_mixture/air = return_air()
@@ -581,6 +582,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	smoketime -= delta_time * (1 SECONDS)
 	if(smoketime <= 0)
 		if(ismob(loc))
+			var/mob/living/living_smoker = loc
 			to_chat(living_smoker, span_notice("Your [name] goes out."))
 			lit = FALSE
 			icon_state = icon_off

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -569,30 +569,30 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	return ..()
 
 /obj/item/clothing/mask/cigarette/pipe/process(delta_time)
-	var/mob/living/M = loc
+	var/mob/living/living_smoker = loc
 	if(isliving(loc))
-		M.IgniteMob()
+		living_smoker.IgniteMob()
 	if(!reagents.has_reagent(/datum/reagent/oxygen)) //cigarettes need oxygen
 		var/datum/gas_mixture/air = return_air()
-		if(!air || !air.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
+		if(!air?.has_gas(/datum/gas/oxygen, 1)) //or oxygen on a tile to burn
 			extinguish()
 			return
 
 	smoketime -= delta_time * (1 SECONDS)
 	if(smoketime <= 0)
 		if(ismob(loc))
-			to_chat(M, span_notice("Your [name] goes out."))
+			to_chat(living_smoker, span_notice("Your [name] goes out."))
 			lit = FALSE
 			icon_state = icon_off
 			inhand_icon_state = icon_off
-			M.update_inv_wear_mask()
+			living_smoker.update_inv_wear_mask()
 			packeditem = FALSE
 			name = "empty [initial(name)]"
 		STOP_PROCESSING(SSobj, src)
 		return
 
 	open_flame(heat)
-	if((reagents?.total_volume) && COOLDOWN_FINISHED(src, drag_cooldown))
+	if(reagents?.total_volume && COOLDOWN_FINISHED(src, drag_cooldown))
 		COOLDOWN_START(src, drag_cooldown, dragtime)
 		handle_reagents()
 

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -569,7 +569,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	return ..()
 
 /obj/item/clothing/mask/cigarette/pipe/process(delta_time)
-	var/mob/living/living_smoker = loc
 	if(isliving(loc))
 		var/mob/living/living_smoker = loc
 		living_smoker.IgniteMob()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pipes were not satisfying nicotine withdrawal when puffing on them.
It seems cigarettes' process() was redone, but pipes were completely forgotten about.

Fixes https://github.com/tgstation/tgstation/issues/61990

## Why It's Good For The Game

You should be able to feed your addiction by any means necessary.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Pipes now properly fulfill your nicotine cravings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
