### PR TITLE
Nerfs bluespace launchpads by making them more obvious and nerfing the range.

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -1,3 +1,5 @@
+#define BEAM_FADE_TIME 1 SECONDS
+
 /obj/machinery/launchpad
 	name = "bluespace launchpad"
 	desc = "A bluespace pad able to thrust matter through bluespace, teleporting it to or from nearby locations."
@@ -12,12 +14,16 @@
 	var/stationary = TRUE //to prevent briefcase pad deconstruction and such
 	var/display_name = "Launchpad"
 	var/teleport_speed = 35
-	var/range = 15
+	var/range = 10
 	var/teleporting = FALSE //if it's in the process of teleporting
 	var/power_efficiency = 1
 	var/x_offset = 0
 	var/y_offset = 0
 	var/indicator_icon = "launchpad_target"
+	/// Determines if the bluespace launchpad is blatantly obvious on teleportation.
+	var/hidden = FALSE
+	/// The beam on teleportation
+	var/teleport_beam = "plasmabeam"
 
 /obj/machinery/launchpad/RefreshParts()
 	var/E = 0
@@ -108,6 +114,11 @@
 		y_offset = clamp(y, -range, range)
 	update_indicator()
 
+/obj/effect/ebeam/launchpad/Initialize(mapload)
+	. = ..()
+	animate(src, alpha = 0, flags = ANIMATION_PARALLEL, time = BEAM_FADE_TIME)
+
+
 /// Performs the teleport.
 /// sending - TRUE/FALSE depending on if the launch pad is teleporting *to* or *from* the target.
 /// alternate_log_name - An alternative name to use in logs, if `user` is not present..
@@ -132,6 +143,11 @@
 	playsound(get_turf(src), 'sound/weapons/flash.ogg', 25, TRUE)
 	teleporting = TRUE
 
+	if(!hidden)
+		playsound(target, 'sound/weapons/flash.ogg', 25, TRUE)
+		var/datum/effect_system/spark_spread/quantum/s = new /datum/effect_system/spark_spread/quantum
+		s.set_up(5, TRUE, target)
+		s.start()
 
 	sleep(teleport_speed)
 
@@ -143,6 +159,10 @@
 		return
 
 	teleporting = FALSE
+	if(!hidden)
+		// Takes twice as long to make sure it properly fades out.
+		Beam(target, icon_state = teleport_beam, time = BEAM_FADE_TIME*2, beam_type = /obj/effect/ebeam/launchpad)
+		playsound(target, 'sound/weapons/emitter2.ogg', 25, TRUE)
 
 	// use a lot of power
 	use_power(1000)
@@ -218,6 +238,7 @@
 	teleport_speed = 20
 	range = 8
 	stationary = FALSE
+	hidden = TRUE
 	var/closed = TRUE
 	var/obj/item/storage/briefcase/launchpad/briefcase
 

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -145,9 +145,9 @@
 
 	if(!hidden)
 		playsound(target, 'sound/weapons/flash.ogg', 25, TRUE)
-		var/datum/effect_system/spark_spread/quantum/s = new /datum/effect_system/spark_spread/quantum
-		s.set_up(5, TRUE, target)
-		s.start()
+		var/datum/effect_system/spark_spread/quantum/spark_system = new /datum/effect_system/spark_spread/quantum()
+		spark_system.set_up(5, TRUE, target)
+		spark_system.start()
 
 	sleep(teleport_speed)
 
@@ -416,3 +416,5 @@
 			sending = FALSE
 			teleport(usr, our_pad)
 			. = TRUE
+
+#undef BEAM_FADE_TIME

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -23,7 +23,7 @@
 	/// Determines if the bluespace launchpad is blatantly obvious on teleportation.
 	var/hidden = FALSE
 	/// The beam on teleportation
-	var/teleport_beam = "plasmabeam"
+	var/teleport_beam = "sm_arc_supercharged"
 
 /obj/machinery/launchpad/RefreshParts()
 	var/E = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Bluespace launchpad maximum range decreased from 60 to 40. Traitor launchpad unaffected.
Bluespace launchpads will now give a visual indication of the turf they are teleporting to/teleporting from as well as a noise notification. Does not apply to traitor launchpads.
Bluespace launchpads will now show a beam that fades out between the target turf and the launchpad after it has done the teleportation. Again, does not apply to traitor launchpads.

https://user-images.githubusercontent.com/37270891/136650247-1d08bfb5-cdf9-4a7e-991b-d648b8943b68.mp4

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Bluespace launchpads are a bit too strong right now, especially now that you can teleport people with circuit guns without them knowing they're about to be teleported and no one having any clue where they're teleported. This nerfs that by making it more obvious where someone has teleported off to. Also just decreases the maximum range because a 60 range telescience pad is actually a 120*120 box because it can go to -60 too.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Bluespace launchpad maximum range decreased from 60 to 40. Traitor launchpad unaffected.
balance: Bluespace launchpads will now give a visual indication of the turf they are teleporting to/teleporting from as well as a noise notification. Does not apply to traitor launchpads.
balance: Bluespace launchpads will now show a beam that fades out between the target turf and the launchpad after it has done the teleportation. Again, does not apply to traitor launchpads.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
