### PR TITLE
re-adds the yellow slimecore as an EMP-proof cell

### DIFF
--- a/code/modules/cargo/exports/xenobio.dm
+++ b/code/modules/cargo/exports/xenobio.dm
@@ -20,6 +20,11 @@
 	unit_name = "rare slime core"
 	export_types = list(/obj/item/slime_extract/silver,/obj/item/slime_extract/darkblue,/obj/item/slime_extract/darkpurple,/obj/item/slime_extract/yellow)
 
+/datum/export/slime/charged
+	cost = CARGO_CRATE_VALUE
+	unit_name = "EMP-proof slime core"
+	export_types = list(/obj/item/stock_parts/cell/emproof/slime)
+
 /datum/export/slime/hypercharged
 	cost = CARGO_CRATE_VALUE * 1.2
 	unit_name = "hypercharged slime core"

--- a/code/modules/cargo/exports/xenobio.dm
+++ b/code/modules/cargo/exports/xenobio.dm
@@ -22,7 +22,7 @@
 
 /datum/export/slime/charged
 	cost = CARGO_CRATE_VALUE
-	unit_name = "EMP-proof slime core"
+	unit_name = "\improper EMP-proof slime core"
 	export_types = list(/obj/item/stock_parts/cell/emproof/slime)
 
 /datum/export/slime/hypercharged

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -375,6 +375,15 @@
 /obj/item/stock_parts/cell/emproof/corrupt()
 	return
 
+/obj/item/stock_parts/cell/emproof/slime
+	name = "EMP-proof slime core"
+	desc = "A yellow slime core infused with plasma. Its organic nature makes it immune to EMPs."
+	icon = 'icons/mob/slimes.dmi'
+	icon_state = "yellow slime extract"
+	custom_materials = null
+	maxcharge = 5000
+	rating = 5
+
 /obj/item/stock_parts/cell/beam_rifle
 	name = "beam rifle capacitor"
 	desc = "A high powered capacitor that can provide huge amounts of energy in an instant."
@@ -402,15 +411,6 @@
 	var/area/A = get_area(src)
 	if(!A.lightswitch || !A.light_power)
 		charge = 0 //For naturally depowered areas, we start with no power
-
-/obj/item/stock_parts/cell/emproof/slime
-	name = "EMP-proof slime core"
-	desc = "A yellow slime core infused with plasma. Its organic nature makes it immune to EMPs."
-	icon = 'icons/mob/slimes.dmi'
-	icon_state = "yellow slime extract"
-	custom_materials = null
-	maxcharge = 5000
-	rating = 5
 
 /obj/item/stock_parts/cell/crystal_cell
 	name = "crystal power cell"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -403,6 +403,15 @@
 	if(!A.lightswitch || !A.light_power)
 		charge = 0 //For naturally depowered areas, we start with no power
 
+/obj/item/stock_parts/cell/emproof/slime
+	name = "EMP-proof slime core"
+	desc = "A yellow slime core infused with plasma. Its organic nature makes it immune to EMPs."
+	icon = 'icons/mob/slimes.dmi'
+	icon_state = "yellow slime extract"
+	custom_materials = null
+	maxcharge = 5000
+	rating = 5
+
 /obj/item/stock_parts/cell/crystal_cell
 	name = "crystal power cell"
 	desc = "A very high power cell made from crystallized plasma"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -404,7 +404,7 @@
 		charge = 0 //For naturally depowered areas, we start with no power
 
 /obj/item/stock_parts/cell/emproof/slime
-	name = "EMP-proof slime core"
+	name = "\improper EMP-proof slime core"
 	desc = "A yellow slime core infused with plasma. Its organic nature makes it immune to EMPs."
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "yellow slime extract"

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -267,6 +267,15 @@
 	empulse(get_turf(holder.my_atom), 3, 7)
 	..()
 
+/datum/chemical_reaction/slime/slimecell
+	required_reagents = list(/datum/reagent/toxin/plasma = 1)
+	required_container = /obj/item/slime_extract/yellow
+	required_other = TRUE
+
+/datum/chemical_reaction/slime/slimecell/on_reaction(datum/reagents/holder, created_volume)
+	new /obj/item/stock_parts/cell/emproof/slime(get_turf(holder.my_atom))
+	..()
+
 /datum/chemical_reaction/slime/slimeglow
 	required_reagents = list(/datum/reagent/water = 1)
 	required_container = /obj/item/slime_extract/yellow

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -260,7 +260,7 @@
 	name = "yellow slime extract"
 	icon_state = "yellow slime extract"
 	effectmod = "charged"
-	activate_reagents = list(/datum/reagent/blood,/datum/reagent/water)
+	activate_reagents = list(/datum/reagent/blood,/datum/reagent/toxin/plasma,/datum/reagent/water)
 
 /obj/item/slime_extract/yellow/activate(mob/living/carbon/human/user, datum/species/jelly/luminescent/species, activation_type)
 	switch(activation_type)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In #54198 yellow slimecores (And their reaction in #54569) were removed because a self-charging cell was pretty broken. I feel that removing it was too much, and instead their gimmick should have been replaced with something else. This PR makes it a 5,000 capacity EMP-proof cell (half a high-capacity). I got this idea after finding the 500 charge versions in engineering, but no one ever seems to use them. 

Note that only the cell is immune to EMPs. If a borg gets shot with the ion rifle, it'll still be hardstunned for 30 seconds, it just won't lose charge. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
adds a niche cell variant that engineering or robotics might use.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
expansion: The Yellow slimecore plasma reaction is back in the form of creating an EMP-proof cell.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
