### PR TITLE
Being affected by Venom slightly swells the victim.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -619,10 +619,7 @@
 	var/current_size = RESIZE_DEFAULT_SIZE
 
 /datum/reagent/toxin/venom/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	var/newsize = current_size
-	switch(volume)
-		if(0 to 19)
-			newsize = 1.1 * RESIZE_DEFAULT_SIZE
+	var/newsize = 1.1 * RESIZE_DEFAULT_SIZE
 	M.resize = newsize/current_size
 	current_size = newsize
 	M.update_transform()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -615,8 +615,18 @@
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	toxpwr = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	///Mob Size of the current mob sprite.
+	var/current_size = RESIZE_DEFAULT_SIZE
 
 /datum/reagent/toxin/venom/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	var/newsize = current_size
+	switch(volume)
+		if(0 to 19)
+			newsize = 1.1 * RESIZE_DEFAULT_SIZE
+	M.resize = newsize/current_size
+	current_size = newsize
+	M.update_transform()
+
 	toxpwr = 0.1 * volume
 	M.adjustBruteLoss((0.3 * volume) * REM * delta_time, 0)
 	. = TRUE
@@ -625,6 +635,12 @@
 		holder.remove_reagent(/datum/reagent/toxin/venom, 1.1)
 	else
 		..()
+
+/datum/reagent/toxin/venom/on_mob_end_metabolize(mob/living/M)
+	M.resize = RESIZE_DEFAULT_SIZE/current_size
+	current_size = RESIZE_DEFAULT_SIZE
+	M.update_transform()
+	..()
 
 /datum/reagent/toxin/fentanyl
 	name = "Fentanyl"


### PR DESCRIPTION
## About The Pull Request

If affected by mob venom, target will slightly swell up by 1.1 times it's current size while affected. The swelling goes down when the venom passes through the mob's body.  This is in parallel to most living being's response to real life venom, with swelling increasing when stung.

This affects carbons that are affected by toxins only.

## Why It's Good For The Game

Thought it'd be funny and interesting to see bee stings swelling up their targets after being stung. 
![image](https://user-images.githubusercontent.com/41715314/136673146-137d2203-4c92-4f6d-9aa1-6e36f32b3981.png)


Edit: Pictures Added.
![image](https://user-images.githubusercontent.com/41715314/137204495-6ef51ed5-1a57-4112-ac4d-8cab7332099e.png)


## Changelog

:cl:
expansion: Venom swells your mob when stung.
/:cl:
