### PR TITLE
Fixes the mind.name of evolved aliens not being updated (for real this time)

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -127,8 +127,8 @@ Des: Removes all infected images from the alien.
 		new_xeno.name = name
 		new_xeno.real_name = real_name
 	if(mind)
-		mind.transfer_to(new_xeno)
 		mind.name = new_xeno.real_name
+		mind.transfer_to(new_xeno)
 	qdel(src)
 
 /mob/living/carbon/alien/can_hold_items(obj/item/I)


### PR DESCRIPTION
## About The Pull Request
In #61595, I forgot that `mind.transfer_to()` sets the mind variable of the current mob to null. So i'm moving that `mind.name = new_xeno.real_name` statement above the proc call.

## Why It's Good For The Game
Fixing a 2 weeks old mistake.

## Changelog
:cl:
fix: Fixes the mind name of aliens not being updated when evolving (for real this time)
/:cl: