### PR TITLE
makes it so lockers/crates can have access electronics removed/inserted

### DIFF
--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -202,6 +202,7 @@
 	name = "mail crate"
 	desc = "A certified post crate from CentCom."
 	icon_state = "mail"
+	can_install_electronics = FALSE
 
 /obj/structure/closet/crate/mail/update_icon_state()
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -418,8 +418,8 @@
 		update_appearance()
 	else if (can_install_electronics && W.tool_behaviour == TOOL_SCREWDRIVER\
 			&& (secure || electronics) && !locked && (welded || !can_weld_shut))
-		user.visible_message(span_notice("[user] begins to pry the electronics from the [src]."),\
-			span_notice("You begin to pry the electronics from the [src]..."))
+		user.visible_message(span_notice("[user] begins to remove the electronics from the [src]."),\
+			span_notice("You begin to remove the electronics from the [src]..."))
 		var/had_electronics = !!electronics
 		var/was_secure = secure
 		if (!do_after(user, 40, target = src))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -333,9 +333,9 @@
 		if(ispath(material_drop) && material_drop_amount)
 			new material_drop(loc, material_drop_amount)
 		if (electronics)
-			var/obj/item/electronics/airlock/ae = electronics
+			var/obj/item/electronics/airlock/electronics_ref = electronics
 			electronics = null
-			ae.forceMove(drop_location())
+			electronics_ref.forceMove(drop_location())
 	qdel(src)
 
 /obj/structure/closet/atom_break(damage_flag)
@@ -402,7 +402,7 @@
 			&& !secure && !electronics && !locked && (welded || !can_weld_shut) && !broken)
 		user.visible_message(span_notice("[user] installs the electronics into the [src]."),\
 			span_notice("You start to install electronics into the [src]..."))
-		if (!do_after(user, 40, target = src))
+		if (!do_after(user, 4 SECONDS, target = src))
 			return FALSE
 		if (electronics || secure)
 			return FALSE
@@ -422,23 +422,23 @@
 			span_notice("You begin to remove the electronics from the [src]..."))
 		var/had_electronics = !!electronics
 		var/was_secure = secure
-		if (!do_after(user, 40, target = src))
+		if (!do_after(user, 4 SECONDS, target = src))
 			return FALSE
 		if ((had_electronics && !electronics) || (was_secure && !secure))
 			return FALSE
-		var/obj/item/electronics/airlock/ae
+		var/obj/item/electronics/airlock/electronics_ref
 		if (!electronics)
-			ae = new /obj/item/electronics/airlock(loc)
+			electronics_ref = new /obj/item/electronics/airlock(loc)
 			gen_access()
 			if (req_one_access.len)
-				ae.one_access = 1
-				ae.accesses = req_one_access
+				electronics_ref.one_access = 1
+				electronics_ref.accesses = req_one_access
 			else
-				ae.accesses = req_access
+				electronics_ref.accesses = req_access
 		else
-			ae = electronics
+			electronics_ref = electronics
 			electronics = null
-			ae.forceMove(drop_location())
+			electronics_ref.forceMove(drop_location())
 		secure = FALSE
 		update_appearance()
 	else if(!user.combat_mode)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -64,6 +64,9 @@
 	var/divable = TRUE
 	/// true whenever someone with the strong pull component is dragging this, preventing opening
 	var/strong_grab = FALSE
+	///electronics for access
+	var/obj/item/electronics/airlock/electronics
+	var/can_install_electronics = TRUE
 
 /obj/structure/closet/Initialize(mapload)
 	if(mapload && !opened) // if closed, any item at the crate's loc is put in the contents
@@ -79,6 +82,7 @@
 /obj/structure/closet/Destroy()
 	dump_contents()
 	QDEL_NULL(door_obj)
+	QDEL_NULL(electronics)
 	return ..()
 
 /obj/structure/closet/update_appearance(updates=ALL)
@@ -325,8 +329,13 @@
 		return open(user)
 
 /obj/structure/closet/deconstruct(disassembled = TRUE)
-	if(ispath(material_drop) && material_drop_amount && !(flags_1 & NODECONSTRUCT_1))
-		new material_drop(loc, material_drop_amount)
+	if (!(flags_1 & NODECONSTRUCT_1))
+		if(ispath(material_drop) && material_drop_amount)
+			new material_drop(loc, material_drop_amount)
+		if (electronics)
+			var/obj/item/electronics/airlock/ae = electronics
+			electronics = null
+			ae.forceMove(drop_location())
 	qdel(src)
 
 /obj/structure/closet/atom_break(damage_flag)
@@ -389,6 +398,49 @@
 		user.visible_message(span_notice("[user] [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground."), \
 						span_notice("You [anchored ? "anchored" : "unanchored"] \the [src] [anchored ? "to" : "from"] the ground."), \
 						span_hear("You hear a ratchet."))
+	else if (can_install_electronics && istype(W, /obj/item/electronics/airlock)\
+			&& !secure && !electronics && !locked && (welded || !can_weld_shut) && !broken)
+		user.visible_message(span_notice("[user] installs the electronics into the [src]."),\
+			span_notice("You start to install electronics into the [src]..."))
+		if (!do_after(user, 40, target = src))
+			return FALSE
+		if (electronics || secure)
+			return FALSE
+		if (!user.transferItemToLoc(W, src))
+			return FALSE
+		to_chat(user, span_notice("You install the electronics."))
+		electronics = W
+		if (electronics.one_access)
+			req_one_access = electronics.accesses
+		else
+			req_access = electronics.accesses
+		secure = TRUE
+		update_appearance()
+	else if (can_install_electronics && W.tool_behaviour == TOOL_SCREWDRIVER\
+			&& (secure || electronics) && !locked && (welded || !can_weld_shut))
+		user.visible_message(span_notice("[user] begins to pry the electronics from the [src]."),\
+			span_notice("You begin to pry the electronics from the [src]..."))
+		var/had_electronics = !!electronics
+		var/was_secure = secure
+		if (!do_after(user, 40, target = src))
+			return FALSE
+		if ((had_electronics && !electronics) || (was_secure && !secure))
+			return FALSE
+		var/obj/item/electronics/airlock/ae
+		if (!electronics)
+			ae = new /obj/item/electronics/airlock(loc)
+			gen_access()
+			if (req_one_access.len)
+				ae.one_access = 1
+				ae.accesses = req_one_access
+			else
+				ae.accesses = req_access
+		else
+			ae = electronics
+			electronics = null
+			ae.forceMove(drop_location())
+		secure = FALSE
+		update_appearance()
 	else if(!user.combat_mode)
 		var/item_is_id = W.GetID()
 		if(!item_is_id)

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -20,6 +20,7 @@
 	var/foldedbag_path = /obj/item/bodybag
 	var/obj/item/bodybag/foldedbag_instance = null
 	var/tagged = FALSE // so closet code knows to put the tag overlay back
+	can_install_electronics = FALSE
 
 /obj/structure/closet/body_bag/Destroy()
 	// If we have a stored bag, and it's in nullspace (not in someone's hand), delete it.

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -21,6 +21,7 @@
 	var/move_speed_multiplier = 1
 	var/move_delay = FALSE
 	var/egged = 0
+	can_install_electronics = FALSE
 
 /obj/structure/closet/cardboard/relaymove(mob/living/user, direction)
 	if(opened || move_delay || user.incapacitated() || !isturf(loc) || !has_gravity(loc))

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -28,6 +28,18 @@
 		AddElement(/datum/element/climbable, climb_time = crate_climb_time, climb_stun = 0)
 	update_appearance()
 
+/obj/structure/closet/crate/update_overlays()
+	. = ..()
+	if(broken)
+		. += "securecrateemag"
+		return
+	if(locked)
+		. += "securecrater"
+		return
+	if(secure)
+		. += "securecrateg"
+		return
+
 /obj/structure/closet/crate/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
 	if(!istype(mover, /obj/structure/closet))
@@ -96,6 +108,7 @@
 	close_sound = 'sound/machines/wooden_closet_close.ogg'
 	open_sound_volume = 25
 	close_sound_volume = 50
+	can_install_electronics = FALSE
 
 /obj/structure/closet/crate/maint
 
@@ -127,6 +140,7 @@
 	desc = "A heavy, metal trashcart with wheels."
 	name = "trash cart"
 	icon_state = "trashcart"
+	can_install_electronics = FALSE
 
 /obj/structure/closet/crate/trashcart/Moved()
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates/bins.dm
+++ b/code/game/objects/structures/crates_lockers/crates/bins.dm
@@ -7,6 +7,7 @@
 	anchored = TRUE
 	horizontal = FALSE
 	delivery_icon = null
+	can_install_electronics = FALSE
 
 /obj/structure/closet/crate/bin/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -14,6 +14,7 @@
 	close_sound_volume = 50
 	contents_pressure_protection = 0.8
 	var/obj/item/tank/internals/emergency_oxygen/tank
+	can_install_electronics = FALSE
 
 /obj/structure/closet/crate/critter/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates/large.dm
+++ b/code/game/objects/structures/crates_lockers/crates/large.dm
@@ -11,6 +11,7 @@
 	close_sound = 'sound/machines/wooden_closet_close.ogg'
 	open_sound_volume = 25
 	close_sound_volume = 50
+	can_install_electronics = FALSE
 
 	// Stops people from "diving into" a crate you can't open normally
 	divable = FALSE

--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -9,22 +9,11 @@
 	var/tamperproof = 0
 	damage_deflection = 25
 
-/obj/structure/closet/crate/secure/update_overlays()
-	. = ..()
-	if(broken)
-		. += "securecrateemag"
-		return
-	if(locked)
-		. += "securecrater"
-		return
-	. += "securecrateg"
-
 /obj/structure/closet/crate/secure/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)
 	if(prob(tamperproof) && damage_amount >= DAMAGE_PRECISION)
 		boom()
 	else
 		return ..()
-
 
 /obj/structure/closet/crate/secure/proc/boom(mob/user)
 	if(user)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -5,6 +5,7 @@
 	desc = "It's watching you closely."
 	icon_state = "necrocrate"
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	can_install_electronics = FALSE
 
 /obj/structure/closet/crate/necropolis/tendril
 	desc = "It's watching you suspiciously. You need a skeleton key to open it."

--- a/code/modules/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -128,6 +128,7 @@
 	cutting_tool = /obj/item/shovel
 	var/lead_tomb = FALSE
 	var/first_open = FALSE
+	can_install_electronics = FALSE
 
 /obj/structure/closet/crate/grave/filled/PopulateContents()  //GRAVEROBBING IS NOW A FEATURE
 	..()


### PR DESCRIPTION
## About The Pull Request

title

They can only have electronics inserted if they
- are welded shut (if they can be welded)
- don't have electronics already and aren't secure

They can only have electronics removed if they
- are welded shut (if they can be welded)
- are unlocked
- are secure (even if they don't have electronics, then it'll create them)

## Why It's Good For The Game

better locker locking + fun things

## Changelog
:cl:
add: makes it so lockers/crates can have access electronics removed/inserted
/:cl: