### PR TITLE
checks for client in some of the more noteworthy uses of glob.player_list

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -489,6 +489,8 @@ GLOBAL_LIST_EMPTY(species_list)
 	message = span_deadsay("[source]<span class='linkify'>[message]</span>")
 
 	for(var/mob/M in GLOB.player_list)
+		if (!M.client)
+			continue
 		var/chat_toggles = TOGGLES_DEFAULT_CHAT
 		var/toggles = TOGGLES_DEFAULT
 		var/list/ignoring

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -36,4 +36,6 @@ SUBSYSTEM_DEF(input)
 
 /datum/controller/subsystem/input/fire()
 	for(var/mob/user as anything in GLOB.keyloop_list)
+		if (!user.client)
+			continue
 		user.focus?.keyLoop(user.client)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -332,6 +332,8 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 				continue //Remove if underlying cause (likely byond issue) is fixed. See TG PR #49004.
 			if(player_mob.stat != DEAD) //not dead, not important
 				continue
+			if (!player_mob.client)
+				continue
 			if(get_dist(player_mob, src) > 7 || player_mob.z != z) //they're out of range of normal hearing
 				if(eavesdrop_range)
 					if(!(player_mob.client.prefs.chat_toggles & CHAT_GHOSTWHISPER)) //they're whispering and we have hearing whispers at any range off


### PR DESCRIPTION
## About The Pull Request

title
null checks
_Runtime in mobs.dm, line 492: Cannot read null.prefs x116_
_Runtime in living_say.dm, line 343: Cannot read null.prefs x62_

and so on

## Why It's Good For The Game

runtime go poof

## Changelog
not applicable in all honesty