### PR TITLE
Admins now get a little notice if they start responding to a ticket someone else is already responding to

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -176,12 +176,12 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	/// If any admins were online when the ticket was initialized
 	var/heard_by_no_admins = FALSE
 	/// The collection of interactions with this ticket. Use AddInteraction() or, preferably, admin_ticket_log()
-	var/list/_interactions
+	var/list/ticket_interactions
 	/// Statclick holder for the ticket
 	var/obj/effect/statclick/ahelp/statclick
 	/// Static counter used for generating each ticket ID
 	var/static/ticket_counter = 0
-	/// The list of admins currently responding to the opening ticket before it gets a response
+	/// The list of clients currently responding to the opening ticket before it gets a response
 	var/list/opening_responders
 
 /**
@@ -215,7 +215,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	TimeoutVerb()
 
 	statclick = new(null, src)
-	_interactions = list()
+	ticket_interactions = list()
 
 	if(is_bwoink)
 		AddInteraction("<font color='blue'>[key_name_admin(usr)] PM'd [LinkedReplyName()]</font>")
@@ -241,7 +241,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(heard_by_no_admins && usr && usr.ckey != initiator_ckey)
 		heard_by_no_admins = FALSE
 		send2adminchat(initiator_ckey, "Ticket #[id]: Answered by [key_name(usr)]")
-	_interactions += "[time_stamp()]: [formatted_message]"
+	ticket_interactions += "[time_stamp()]: [formatted_message]"
 
 //Removes the ahelp verb and returns it after 2 minutes
 /datum/admin_help/proc/TimeoutVerb()
@@ -444,7 +444,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	else
 		dat += "<b>DISCONNECTED</b>[FOURSPACES][ClosureLinks(ref_src)]<br>"
 	dat += "<br><b>Log:</b><br><br>"
-	for(var/I in _interactions)
+	for(var/I in ticket_interactions)
 		dat += "[I]<br>"
 
 	// Append any tickets also opened by this user if relevant

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -181,6 +181,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	var/obj/effect/statclick/ahelp/statclick
 	/// Static counter used for generating each ticket ID
 	var/static/ticket_counter = 0
+	/// The list of admins currently responding to the opening ticket before it gets a response
+	var/list/opening_responders
 
 /**
  * Call this on its own to create a ticket, don't manually assign current_ticket

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -66,26 +66,13 @@
 
 	var/message_prompt = "Message:"
 
-	if(AH?.opening_responders && length(AH._interactions) == 1)
+	if(AH?.opening_responders && length(AH.ticket_interactions) == 1)
 		SEND_SOUND(src, sound('sound/machines/buzz-sigh.ogg', volume=30))
-		message_prompt += "\n\n**This ticket is already being responded to by: "
-		var/num_of_responders = length(AH.opening_responders)
-		var/admins_counted = 0
-
-		for(var/client/iter_responder as anything in AH.opening_responders)
-			admins_counted++
-			message_prompt += "[iter_responder?.key]"
-			switch(num_of_responders - admins_counted)
-				if(0)
-				if(1)
-					message_prompt += " and "
-				else
-					message_prompt += ", "
-		message_prompt += "**"
+		message_prompt += "\n\n**This ticket is already being responded to by: [english_list(AH.opening_responders)]**"
 
 	if(AH)
 		message_admins("[key_name_admin(src)] has started replying to [key_name_admin(C, 0, 0)]'s admin help.")
-		if(length(AH._interactions) == 1) // add the admin who is currently responding to the list of people responding
+		if(length(AH.ticket_interactions) == 1) // add the admin who is currently responding to the list of people responding
 			LAZYADD(AH.opening_responders, src)
 
 	var/msg = input(src, message_prompt, "Private message to [C.holder?.fakekey ? "an Administrator" : key_name(C, 0, 0)].") as message|null

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -64,9 +64,53 @@
 
 	var/datum/admin_help/AH = C.current_ticket
 
+	var/message_prompt = "Message:"
+
+	if(AH?.opening_responders && length(AH._interactions) == 1)
+		SEND_SOUND(src, sound('sound/machines/buzz-sigh.ogg', volume=30))
+		message_prompt += "\n\n**This ticket is already being responded to by: "
+		var/num_of_responders = length(AH.opening_responders)
+		var/admins_counted = 0
+
+		for(var/client/iter_responder as anything in AH.opening_responders)
+			admins_counted++
+			message_prompt += "[iter_responder?.key]"
+			switch(num_of_responders - admins_counted)
+				if(0)
+				if(1)
+					message_prompt += " and "
+				else
+					message_prompt += ", "
+		message_prompt += "**"
+	else
+		var/num_of_responders = input(src, "how many fakes", "fake", 0)
+		if(num_of_responders)
+			var/list/fake = list()
+			for(var/i in 1 to num_of_responders)
+				fake += random_unique_name()
+			SEND_SOUND(src, sound('sound/machines/buzz-sigh.ogg', volume=30))
+			message_prompt += "\n\n**This ticket is already being responded to by: "
+			var/admins_counted = 0
+
+			for(var/nam in fake)
+				admins_counted++
+				message_prompt += "[nam]"
+				switch(num_of_responders - admins_counted)
+					if(0)
+					if(1)
+						message_prompt += " and "
+					else
+						message_prompt += ", "
+			message_prompt += "**"
+
+
 	if(AH)
 		message_admins("[key_name_admin(src)] has started replying to [key_name_admin(C, 0, 0)]'s admin help.")
-	var/msg = input(src,"Message:", "Private message to [C.holder?.fakekey ? "an Administrator" : key_name(C, 0, 0)].") as message|null
+		if(length(AH._interactions) == 1 && AH.opening_responders) // add the admin who is currently responding to the list of people responding
+			LAZYADD(AH.opening_responders, src)
+
+	var/msg = input(src, message_prompt, "Private message to [C.holder?.fakekey ? "an Administrator" : key_name(C, 0, 0)].") as message|null
+	LAZYREMOVE(AH.opening_responders, src)
 	if (!msg)
 		message_admins("[key_name_admin(src)] has cancelled their reply to [key_name_admin(C, 0, 0)]'s admin help.")
 		return

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -82,31 +82,10 @@
 				else
 					message_prompt += ", "
 		message_prompt += "**"
-	else
-		var/num_of_responders = input(src, "how many fakes", "fake", 0)
-		if(num_of_responders)
-			var/list/fake = list()
-			for(var/i in 1 to num_of_responders)
-				fake += random_unique_name()
-			SEND_SOUND(src, sound('sound/machines/buzz-sigh.ogg', volume=30))
-			message_prompt += "\n\n**This ticket is already being responded to by: "
-			var/admins_counted = 0
-
-			for(var/nam in fake)
-				admins_counted++
-				message_prompt += "[nam]"
-				switch(num_of_responders - admins_counted)
-					if(0)
-					if(1)
-						message_prompt += " and "
-					else
-						message_prompt += ", "
-			message_prompt += "**"
-
 
 	if(AH)
 		message_admins("[key_name_admin(src)] has started replying to [key_name_admin(C, 0, 0)]'s admin help.")
-		if(length(AH._interactions) == 1 && AH.opening_responders) // add the admin who is currently responding to the list of people responding
+		if(length(AH._interactions) == 1) // add the admin who is currently responding to the list of people responding
 			LAZYADD(AH.opening_responders, src)
 
 	var/msg = input(src, message_prompt, "Private message to [C.holder?.fakekey ? "an Administrator" : key_name(C, 0, 0)].") as message|null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Have you ever, as an admin, had someone reply to a ticket that you were already replying to without noticing you had it? Have you missed the log message for someone else having started to reply to the ticket before you went and started replying? Now there's a solution!

[![dreamseeker_2021-10-10_02-19-14.png](https://i.imgur.com/1OwWdbol.jpg)](https://i.imgur.com/1OwWdbo.png)
(Note that it will show the actual ckeys of the people responding, not the char names, I just used random names for testing)

If a ticket is totally fresh and doesn't have any responses/other interactions, anyone who starts responding to the ticket will be added to a list on the ticket (unless they cancel without messaging, where it removes them). If you start responding to the ticket while there's already people in that list, you'll get a little buzz and a list of the ckeys of people who are responding.

If there are already any responses/interactions with the ticket beyond the initial ahelp, this does not apply, I'm only interested in multiple people trying to be the first to respond to a ticket. This should allow admins to coordinate responding to tickets better.

(Please review this code to make sure I don't accidentally runtime anything that leaks admin actions! I tested it but clearly it's possible to miss things.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Helps admins coordinate responding to tickets easier
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Ryll/Shaps
admin: As an admin, if you start replying to a freshly submitted ticket that another admin is already replying to, you'll get a notice that someone already has it open when you get the prompt. Nice to let you know someone else is handling it, so you can coordinate replies better!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
