### PR TITLE
runtime fixes for old calls of do_teleport

### DIFF
--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -203,7 +203,7 @@
 		linked = FALSE
 		return
 	to_chat(owner, span_warning("You're pulled through spacetime!"))
-	do_teleport(owner, get_turf(linked_target), null, TRUE, channel = TELEPORT_CHANNEL_QUANTUM)
+	do_teleport(owner, get_turf(linked_target), null, channel = TELEPORT_CHANNEL_QUANTUM)
 	owner.playsound_local(owner, 'sound/magic/repulse.ogg', 100, FALSE)
 	linked_target = null
 	linked = FALSE

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -183,7 +183,7 @@
 					else if(!isobserver(ROI))
 						continue
 
-				do_teleport(ROI, get_turf(target_pad),null,TRUE,null,null,null,null,TRUE, channel = TELEPORT_CHANNEL_QUANTUM)
+				do_teleport(ROI, get_turf(target_pad), no_effects = TRUE, channel = TELEPORT_CHANNEL_QUANTUM)
 				CHECK_TICK
 
 /obj/machinery/quantumpad/proc/initMappedLink()

--- a/code/modules/antagonists/abductor/equipment/glands/quantum.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/quantum.dm
@@ -24,7 +24,7 @@
 		return
 	var/turf/T = get_turf(owner)
 	do_teleport(owner, get_turf(entangled_mob),null,channel = TELEPORT_CHANNEL_QUANTUM)
-	do_teleport(entangled_mob, T,null,channel = TELEPORT_CHANNEL_QUANTUM)
+	do_teleport(entangled_mob, T, null, channel = TELEPORT_CHANNEL_QUANTUM)
 	to_chat(owner, span_warning("You suddenly find yourself somewhere else!"))
 	to_chat(entangled_mob, span_warning("You suddenly find yourself somewhere else!"))
 	if(!active_mind_control) //Do not reset entangled mob while mind control is active

--- a/code/modules/antagonists/abductor/equipment/glands/quantum.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/quantum.dm
@@ -23,8 +23,8 @@
 		entangled_mob = null
 		return
 	var/turf/T = get_turf(owner)
-	do_teleport(owner, get_turf(entangled_mob),null,TRUE,channel = TELEPORT_CHANNEL_QUANTUM)
-	do_teleport(entangled_mob, T,null,TRUE,channel = TELEPORT_CHANNEL_QUANTUM)
+	do_teleport(owner, get_turf(entangled_mob),null,channel = TELEPORT_CHANNEL_QUANTUM)
+	do_teleport(entangled_mob, T,null,channel = TELEPORT_CHANNEL_QUANTUM)
 	to_chat(owner, span_warning("You suddenly find yourself somewhere else!"))
 	to_chat(entangled_mob, span_warning("You suddenly find yourself somewhere else!"))
 	if(!active_mind_control) //Do not reset entangled mob while mind control is active

--- a/code/modules/antagonists/abductor/equipment/glands/quantum.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/quantum.dm
@@ -23,7 +23,7 @@
 		entangled_mob = null
 		return
 	var/turf/T = get_turf(owner)
-	do_teleport(owner, get_turf(entangled_mob),null,channel = TELEPORT_CHANNEL_QUANTUM)
+	do_teleport(owner, get_turf(entangled_mob), null, channel = TELEPORT_CHANNEL_QUANTUM)
 	do_teleport(entangled_mob, T, null, channel = TELEPORT_CHANNEL_QUANTUM)
 	to_chat(owner, span_warning("You suddenly find yourself somewhere else!"))
 	to_chat(entangled_mob, span_warning("You suddenly find yourself somewhere else!"))

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -74,4 +74,4 @@ GLOBAL_LIST_EMPTY(all_wormholes) // So we can pick wormholes to teleport to
 				hard_target = P.loc
 		if(!hard_target)
 			return
-		do_teleport(M, hard_target, TRUE, FALSE, FALSE, channel = TELEPORT_CHANNEL_WORMHOLE) ///You will appear adjacent to the beacon
+		do_teleport(M, hard_target, 1, null, null, channel = TELEPORT_CHANNEL_WORMHOLE) ///You will appear adjacent to the beacon

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -74,4 +74,4 @@ GLOBAL_LIST_EMPTY(all_wormholes) // So we can pick wormholes to teleport to
 				hard_target = P.loc
 		if(!hard_target)
 			return
-		do_teleport(M, hard_target, 1, 1, 0, 0, channel = TELEPORT_CHANNEL_WORMHOLE) ///You will appear adjacent to the beacon
+		do_teleport(M, hard_target, 1, 0, 0, channel = TELEPORT_CHANNEL_WORMHOLE) ///You will appear adjacent to the beacon

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -74,4 +74,4 @@ GLOBAL_LIST_EMPTY(all_wormholes) // So we can pick wormholes to teleport to
 				hard_target = P.loc
 		if(!hard_target)
 			return
-		do_teleport(M, hard_target, 1, 0, 0, channel = TELEPORT_CHANNEL_WORMHOLE) ///You will appear adjacent to the beacon
+		do_teleport(M, hard_target, TRUE, FALSE, FALSE, channel = TELEPORT_CHANNEL_WORMHOLE) ///You will appear adjacent to the beacon


### PR DESCRIPTION
## About The Pull Request

title

trying to call the argument forced when it was removed

quantum pad has had no_effects turned on because that's what it was supposed to be apparently, if you take out the faulty forced

noticed because of this runtime caused by a quantum pad

*Runtime in teleport.dm, line 100: Cannot execute 1.attach(). x109*

## Why It's Good For The Game

fixes

## Changelog

:cl:
fix: quantum pads and other things with fault do_teleport calls no longer cause runtimes
/:cl: