### PR TITLE
runtime fix for nulled forensic component runtime

### DIFF
--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -31,6 +31,8 @@
 
 //Set ignoregloves to add prints irrespective of the mob having gloves on.
 /atom/proc/add_fingerprint(mob/M, ignoregloves = FALSE)
+	if (QDELING(src))
+		return
 	var/datum/component/forensics/D = AddComponent(/datum/component/forensics)
 	if (D)
 		. = D.add_fingerprint(M, ignoregloves)

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -32,7 +32,8 @@
 //Set ignoregloves to add prints irrespective of the mob having gloves on.
 /atom/proc/add_fingerprint(mob/M, ignoregloves = FALSE)
 	var/datum/component/forensics/D = AddComponent(/datum/component/forensics)
-	. = D.add_fingerprint(M, ignoregloves)
+	if (D)
+		. = D.add_fingerprint(M, ignoregloves)
 
 /atom/proc/add_fiber_list(list/fibertext) //ASSOC LIST FIBERTEXT = FIBERTEXT
 	if(length(fibertext))

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -34,8 +34,7 @@
 	if (QDELING(src))
 		return
 	var/datum/component/forensics/D = AddComponent(/datum/component/forensics)
-	if (D)
-		. = D.add_fingerprint(M, ignoregloves)
+	. = D?.add_fingerprint(M, ignoregloves)
 
 /atom/proc/add_fiber_list(list/fibertext) //ASSOC LIST FIBERTEXT = FIBERTEXT
 	if(length(fibertext))


### PR DESCRIPTION
## About The Pull Request

not actually certain if this is a fix or a cover up of the real problem to be honest...

**edit: nevermind, found the actual problem and made another commit that will fix it.**

*Runtime in detective_work.dm, line 35: Cannot execute null.add fingerprint(). x 36*

## Why It's Good For The Game

uhhh runtime fixing

## Changelog
N/A?