### PR TITLE
runtime fix for reagent instant_react proc

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -1119,6 +1119,8 @@
 	var/sum_purity = 0
 	for(var/_reagent in cached_required_reagents)//this is not an object
 		var/datum/reagent/reagent = has_reagent(_reagent)
+		if (!reagent)
+			continue
 		sum_purity += reagent.purity
 		remove_reagent(_reagent, (multiplier * cached_required_reagents[_reagent]), safety = 1)
 	sum_purity /= cached_required_reagents.len


### PR DESCRIPTION
## About The Pull Request

*Runtime in holder.dm, line 1122: Cannot read 0.purity x 882*

## Why It's Good For The Game

runtime fix

## Changelog

N/A, no noticeable difference