### PR TITLE
Adds the CIRCUIT_FLAG_REFUSE_MODULE circuit flag.

### DIFF
--- a/code/__DEFINES/wiremod.dm
+++ b/code/__DEFINES/wiremod.dm
@@ -104,6 +104,8 @@
 #define CIRCUIT_FLAG_HIDDEN (1<<4)
 /// This circuit component has been marked as a component that has instant execution and will show up in the UI as so. This will only cause a visual change.
 #define CIRCUIT_FLAG_INSTANT (1<<5)
+/// This circuit component can't be loaded in module component. Saves us some headaches.
+#define CIRCUIT_FLAG_REFUSE_MODULE (1<<6)
 
 // Datatype flags
 /// The datatype supports manual inputs

--- a/code/modules/wiremod/components/abstract/module.dm
+++ b/code/modules/wiremod/components/abstract/module.dm
@@ -47,6 +47,9 @@
 	return ..()
 
 /obj/item/integrated_circuit/module/add_component(obj/item/circuit_component/to_add, mob/living/user)
+	if(to_add.circuit_flags & CIRCUIT_FLAG_REFUSE_MODULE)
+		to_chat(user, "[to_add] is incompatible with module components.")
+		return
 	. = ..()
 	if(attached_module)
 		attached_module.circuit_size += to_add.circuit_size

--- a/code/modules/wiremod/components/abstract/module.dm
+++ b/code/modules/wiremod/components/abstract/module.dm
@@ -48,7 +48,7 @@
 
 /obj/item/integrated_circuit/module/add_component(obj/item/circuit_component/to_add, mob/living/user)
 	if(to_add.circuit_flags & CIRCUIT_FLAG_REFUSE_MODULE)
-		balloon_alert(user, "doesn't fit into [attached_module.name]!")
+		balloon_alert(user, "doesn't fit into module!")
 		return
 	. = ..()
 	if(attached_module)

--- a/code/modules/wiremod/components/abstract/module.dm
+++ b/code/modules/wiremod/components/abstract/module.dm
@@ -48,7 +48,7 @@
 
 /obj/item/integrated_circuit/module/add_component(obj/item/circuit_component/to_add, mob/living/user)
 	if(to_add.circuit_flags & CIRCUIT_FLAG_REFUSE_MODULE)
-		to_chat(user, "[to_add] is incompatible with module components.")
+		balloon_alert(user, "doesn't fit into [attached_module.name]!")
 		return
 	. = ..()
 	if(attached_module)

--- a/code/modules/wiremod/components/action/mmi.dm
+++ b/code/modules/wiremod/components/action/mmi.dm
@@ -6,6 +6,7 @@
 /obj/item/circuit_component/mmi
 	display_name = "Man-Machine Interface"
 	desc = "A component that allows MMI to enter shells to send output signals."
+	circuit_flags = CIRCUIT_FLAG_REFUSE_MODULE
 
 	/// The message to send to the MMI in the shell.
 	var/datum/port/input/message

--- a/code/modules/wiremod/core/component.dm
+++ b/code/modules/wiremod/core/component.dm
@@ -81,9 +81,6 @@
 		trigger_output = add_output_port("Triggered", PORT_TYPE_SIGNAL, order = 2)
 	if(circuit_flags & CIRCUIT_FLAG_INSTANT)
 		ui_color = "orange"
-	if(circuit_flags & CIRCUIT_FLAG_REFUSE_MODULE)
-		desc += " Incompatible with module components."
-
 
 /obj/item/circuit_component/Destroy()
 	if(parent)
@@ -98,6 +95,11 @@
 	QDEL_LIST(output_ports)
 	QDEL_LIST(input_ports)
 	return ..()
+
+/obj/item/circuit_component/examine(mob/user)
+	. = ..()
+	if(circuit_flags & CIRCUIT_FLAG_REFUSE_MODULE)
+		. += span_notitce("It's incompatible with module components.")
 
 /**
  * Called when a shell is registered from the component/the component is added to a circuit.

--- a/code/modules/wiremod/core/component.dm
+++ b/code/modules/wiremod/core/component.dm
@@ -81,6 +81,8 @@
 		trigger_output = add_output_port("Triggered", PORT_TYPE_SIGNAL, order = 2)
 	if(circuit_flags & CIRCUIT_FLAG_INSTANT)
 		ui_color = "orange"
+	if(circuit_flags & CIRCUIT_FLAG_REFUSE_MODULE)
+		desc += " Incompatible with module components."
 
 
 /obj/item/circuit_component/Destroy()

--- a/code/modules/wiremod/core/component.dm
+++ b/code/modules/wiremod/core/component.dm
@@ -99,7 +99,7 @@
 /obj/item/circuit_component/examine(mob/user)
 	. = ..()
 	if(circuit_flags & CIRCUIT_FLAG_REFUSE_MODULE)
-		. += span_notitce("It's incompatible with module components.")
+		. += span_notice("It's incompatible with module components.")
 
 /**
  * Called when a shell is registered from the component/the component is added to a circuit.


### PR DESCRIPTION
## About The Pull Request
Components like the MMI one can't be added to circuits more than once since they may register signals with same proctype and similar things which make for some tangled up race conditions if more than one is present.
Unfortunately this safety can be bypassed - with little gain alas, an MMI can't be inserted by attacking the component with it. it needs a shell - by using a module component. That's no good. So I'm adding a flag that can be used to stop certain components from being added to module components.

## Why It's Good For The Game
See above.

## Changelog

:cl:
fix: MMI components can't be no longer attached to modules. This was causing race conditions with other MMI components present in the circuit (not much of a good thing).
/:cl:
