### PR TITLE
Fixes base lighting appearance inheritance (corner shadows bug see pics inside)

### DIFF
--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -59,6 +59,7 @@
 	lighting_effect.blend_mode = BLEND_ADD
 	lighting_effect.alpha = base_lighting_alpha
 	lighting_effect.color = base_lighting_color
+	lighting_effect.appearance_flags = RESET_TRANSFORM | RESET_ALPHA | RESET_COLOR
 	for(var/turf/T in src)
 		T.add_overlay(lighting_effect)
 		T.luminosity = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When turfs which apply a transform on init like most which use advanced smoothing not only were they shifting their position, almost always down and to the left, but they were taking the base lighting overlay with them and leaving behind a faux drop shadow of complete darkness plus if shifting towards non base lit areas it could light up their top and right edges.

This PR fixes it. Here are some examples of transforming turfs in base lit areas:
Sometimes the darkness is not pure black because I am a ghost, but I assure you it is to `/living` mobs
![image](https://user-images.githubusercontent.com/64715958/136715599-4634fbde-a39d-4c83-baa3-dcf7a652f09d.png)
Here is an example anyone can find in any tg server, the rupee room far down and left of centcom, notice the extra "shadows" indicated by my ms paint arrows:
![image](https://user-images.githubusercontent.com/64715958/136715818-244ea043-89b7-41d1-8517-8de796589bd0.png)

## Why It's Good For The Game

Fix good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed base lighting appearance inheritance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
