### PR TITLE
qdels IDs when cryo'ing, stops their accounts from being counted in economy + stops bank accounts that aren't bank accounts from being entered in the sseconomy list

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -498,7 +498,7 @@
 	var/total_players = GLOB.joined_player_list.len
 	var/static/list/typecache_bank = typecacheof(list(/datum/bank_account/department, /datum/bank_account/remote))
 	for(var/i in SSeconomy.bank_accounts_by_id | SSeconomy.cryod_accounts)
-		var/datum/bank_account/current_acc = SSeconomy.bank_accounts_by_id[i] ? SSeconomy.bank_accounts_by_id[i] : SSeconomy.cryod_accounts[i]
+		var/datum/bank_account/current_acc = SSeconomy.bank_accounts_by_id[i] || SSeconomy.cryod_accounts[i]
 		if(typecache_bank[current_acc.type])
 			continue
 		station_vault += current_acc.account_balance

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -497,8 +497,8 @@
 	///How many players joined the round.
 	var/total_players = GLOB.joined_player_list.len
 	var/static/list/typecache_bank = typecacheof(list(/datum/bank_account/department, /datum/bank_account/remote))
-	for(var/i in SSeconomy.bank_accounts_by_id)
-		var/datum/bank_account/current_acc = SSeconomy.bank_accounts_by_id[i]
+	for(var/i in SSeconomy.bank_accounts_by_id | SSeconomy.cryod_accounts)
+		var/datum/bank_account/current_acc = SSeconomy.bank_accounts_by_id[i] ? SSeconomy.bank_accounts_by_id[i] : SSeconomy.cryod_accounts[i]
 		if(typecache_bank[current_acc.type])
 			continue
 		station_vault += current_acc.account_balance

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -71,7 +71,7 @@ SUBSYSTEM_DEF(economy)
 	station_target_buffer += STATION_TARGET_BUFFER
 	for(var/account in bank_accounts_by_id)
 		var/datum/bank_account/bank_account = bank_accounts_by_id[account]
-		if(bank_account?.account_job)
+		if(bank_account?.account_job && !ispath(bank_account.account_job))
 			temporary_total += (bank_account.account_job.paycheck * STARTING_PAYCHECKS)
 		if(!istype(bank_account, /datum/bank_account/department))
 			station_total += bank_account.account_balance

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -49,6 +49,8 @@ SUBSYSTEM_DEF(economy)
 	var/mail_waiting = 0
 	/// Mail Holiday: AKA does mail arrive today? Always blocked on Sundays.
 	var/mail_blocked = FALSE
+	///Accounts that have cryo'd, so we can count them in the mr_moneybags check at roundend
+	var/cryod_accounts = list()
 
 /datum/controller/subsystem/economy/Initialize(timeofday)
 	var/budget_to_hand_out = round(budget_pool / department_accounts.len)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -263,10 +263,17 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 		announcer.announce("CRYOSTORAGE", mob_occupant.real_name, announce_rank, list())
 
 	visible_message(span_notice("[src] hums and hisses as it moves [mob_occupant.real_name] into storage."))
-
-	for (var/obj/item/card/id/id as anything in mob_occupant.get_all_contents_type(/obj/item/card/id))
-		if (id.registered_account && id.registered_account.add_to_accounts && length(id.registered_account.bank_cards) == 1) //don't want to get rid of it if there's another ID out there with it on it
-			qdel(id.registered_account)
+	var/list/cards_in_mob = mob_occupant.get_all_contents_type(/obj/item/card/id)
+	for (var/obj/item/card/id/id as anything in cards_in_mob)
+		var/datum/bank_account/checking_account = id.registered_account
+		if (checking_account && checking_account.add_to_accounts && length(checking_account.bank_cards))
+			var/all_cards_in_mob = TRUE
+			for (var/obj/item/card/id/id2 as anything in checking_account.bank_cards)
+				if (!(id2 in cards_in_mob))
+					all_cards_in_mob = FALSE
+			if (all_cards_in_mob)
+				SSeconomy.bank_accounts_by_id -= "[checking_account.account_id]"
+				SSeconomy.cryod_accounts["[checking_account.account_id]"] = checking_account
 		qdel(id)
 
 	for(var/obj/item/item_content as anything in mob_occupant)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -264,6 +264,11 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 	visible_message(span_notice("[src] hums and hisses as it moves [mob_occupant.real_name] into storage."))
 
+	for (var/obj/item/card/id/id as anything in mob_occupant.get_all_contents_type(/obj/item/card/id))
+		if (id.registered_account && id.registered_account.add_to_accounts && length(id.registered_account.bank_cards) == 1) //don't want to get rid of it if there's another ID out there with it on it
+			qdel(id.registered_account)
+		qdel(id)
+
 	for(var/obj/item/item_content as anything in mob_occupant)
 		if(!istype(item_content) || HAS_TRAIT(item_content, TRAIT_NODROP))
 			continue

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -17,7 +17,8 @@
 	account_holder = newname
 	account_job = job
 	payday_modifier = modifier
-	setup_unique_account_id()
+	if (add_to_accounts)
+		setup_unique_account_id()
 
 /datum/bank_account/Destroy()
 	if(add_to_accounts)


### PR DESCRIPTION
## About The Pull Request

title

even though I just said to lemoninthedark that I would condense all my little runtime fixes into one PR, this one should really go on its own

## Why It's Good For The Game

people who are no longer here will no longer affect the economy

*...and runtime fixes*

## Changelog

:cl:
qol: people who have cryo'd will no longer get counted in the economy
/:cl: