### PR TITLE
Makes firelocks delete themselves on spawn so that we can see if it actually causes problems with atmospherics in practice instead of just on paper.

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -28,7 +28,7 @@
 
 /obj/machinery/door/firedoor/Initialize(mapload)
 	. = ..()
-	qdel(src)
+	return INITIALIZE_HINT_QDEL
 
 /obj/machinery/door/firedoor/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -28,7 +28,7 @@
 
 /obj/machinery/door/firedoor/Initialize(mapload)
 	. = ..()
-	CalculateAffectingAreas()
+	qdel(src)
 
 /obj/machinery/door/firedoor/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Makes firelocks delete themselves on spawn so that we can see if it actually causes problems with atmospherics in practice instead of just on paper.

## Why It's Good For The Game

oranges jokingly said to remove firelocks, I replied we can't do that because of atmos, but then realized "wait, is that actually true though or is it just something we cargo-cult about and haven't actually tested". So, here's a PR we can use to test what atmos performance is when we don't have firelocks.

Firelocks are, frankly, not an enjoyable experience to deal with. They can shut down due to what is frankly non-important air differences, and provide no gameplay to the players other than sometimes trapping you in a room that you're dying in due to poor fire alarm placement/lack of crowbars.

Or, alternatively, it just randomly flips out and activates because the air on the tile next to it is two degrees hotter than the other tiles.

I also don't think it even blocks fires reliably, either.