### PR TITLE
Fix double examine showing the examiner when nothing of interest was found

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -471,7 +471,7 @@
 		else
 			result = examinify.examine_more(src)
 			if(!length(result))
-				result += span_notice("<i>You examine [src] closer, but find nothing of interest...</i>")
+				result += span_notice("<i>You examine [examinify] closer, but find nothing of interest...</i>")
 	else
 		result = examinify.examine(src) // if a tree is examined but no client is there to see it, did the tree ever really exist?
 


### PR DESCRIPTION
## About The Pull Request

This PR fixes double-examine always showing the examiner having nothing of interest even though the examiner isn't being examined.
![image](https://user-images.githubusercontent.com/51863163/136737964-22aa9904-64ab-4145-b116-753e141f322e.png)

`examinify` is the var being examined, not `src`. 

## Why It's Good For The Game

Bugfix.

## Changelog

:cl: Melbert
fix: You no longer see yourself in everything you double examine
/:cl:
