### PR TITLE
 Fixes holoparas breaking their user's glasses when manifesting. 

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -226,6 +226,8 @@
 	SIGNAL_HANDLER
 	if(damaged_clothes == CLOTHING_SHREDDED)
 		return
+	if(IN_INVENTORY)
+		return
 	if(isliving(movable))
 		var/mob/living/crusher = movable
 		if(crusher.m_intent != MOVE_INTENT_WALK && (!(crusher.movement_type & (FLYING|FLOATING)) || crusher.buckled))

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -226,7 +226,7 @@
 	SIGNAL_HANDLER
 	if(damaged_clothes == CLOTHING_SHREDDED)
 		return
-	if(IN_INVENTORY)
+	if(item_flags & IN_INVENTORY)
 		return
 	if(isliving(movable))
 		var/mob/living/crusher = movable

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -8,7 +8,6 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	name = "Guardian Spirit"
 	real_name = "Guardian Spirit"
 	desc = "A mysterious being that stands by its charge, ever vigilant."
-	movement_type = FLOATING
 	speak_emote = list("hisses")
 	gender = NEUTER
 	mob_biotypes = NONE
@@ -68,6 +67,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 /mob/living/simple_animal/hostile/guardian/Initialize(mapload, theme)
 	GLOB.parasites += src
 	updatetheme(theme)
+	AddElement(/datum/element/simple_flying)
 	. = ..()
 
 /mob/living/simple_animal/hostile/guardian/med_hud_set_health()

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	name = "Guardian Spirit"
 	real_name = "Guardian Spirit"
 	desc = "A mysterious being that stands by its charge, ever vigilant."
+	movement_type = FLOATING
 	speak_emote = list("hisses")
 	gender = NEUTER
 	mob_biotypes = NONE
@@ -67,7 +68,6 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 /mob/living/simple_animal/hostile/guardian/Initialize(mapload, theme)
 	GLOB.parasites += src
 	updatetheme(theme)
-	AddElement(/datum/element/simple_flying)
 	. = ..()
 
 /mob/living/simple_animal/hostile/guardian/med_hud_set_health()


### PR DESCRIPTION
## About The Pull Request

Fixes holoparas breaking their user's glasses when manifesting: https://github.com/tgstation/tgstation/issues/61767

Adds a check for IN_INVENTORY when a mob moves onto the same turf as glasses. 
![image](https://user-images.githubusercontent.com/40315842/136784624-150ddb8e-fd8f-45f1-8b55-4c0a3470cb65.png)

Fixes #61767

## Why It's Good For The Game
Fixes the holoparas breaking their users glasses when manifesting bug.

## Changelog

:cl:
fix: Fixes the holoparas breaking their users glasses when manifesting bug.
/:cl:

