### PR TITLE
cutting logs with a hatchet no longer produces runtimes by merging qdeleted stacks

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -57,7 +57,13 @@
 		var/seed_modifier = 0
 		if(seed)
 			seed_modifier = round(seed.potency / 25)
-		new plank_type(user.loc, 1 + seed_modifier)
+		var/obj/item/stack/plank = new plank_type(user.loc, 1 + seed_modifier, FALSE)
+		var/old_plank_amount = plank.amount
+		for (var/obj/item/stack/ST in user.loc)
+			if (ST != plank && istype(ST, plank_type) && ST.amount < ST.max_amount)
+				ST.attackby(plank, user) //we try to transfer all old unfinished stacks to the new stack we created.
+		if (plank.amount > old_plank_amount)
+			to_chat(user, span_notice("You add the newly-formed [plank_name] to the stack. It now contains [plank.amount] [plank_name]."))
 		qdel(src)
 
 	if(CheckAccepted(W))

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -57,7 +57,7 @@
 		var/seed_modifier = 0
 		if(seed)
 			seed_modifier = round(seed.potency / 25)
-		var/obj/item/stack/plank = new plank_type(user.loc, 1 + seed_modifier)
+		new plank_type(user.loc, 1 + seed_modifier)
 		qdel(src)
 
 	if(CheckAccepted(W))

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -58,12 +58,6 @@
 		if(seed)
 			seed_modifier = round(seed.potency / 25)
 		var/obj/item/stack/plank = new plank_type(user.loc, 1 + seed_modifier)
-		var/old_plank_amount = plank.amount
-		for(var/obj/item/stack/ST in user.loc)
-			if(ST != plank && istype(ST, plank_type) && ST.amount < ST.max_amount)
-				ST.attackby(plank, user) //we try to transfer all old unfinished stacks to the new stack we created.
-		if(plank.amount > old_plank_amount)
-			to_chat(user, span_notice("You add the newly-formed [plank_name] to the stack. It now contains [plank.amount] [plank_name]."))
 		qdel(src)
 
 	if(CheckAccepted(W))


### PR DESCRIPTION
## About The Pull Request

title

*Runtime in stack.dm, 452: Stack merge attempted on qdeleted target stack.*

it edits four lines instead of one because I removed them at first, then was too lazy to copypaste it from the code back in, and so hand typed it, and my propensity for adding spaces shone through

## Why It's Good For The Game

runtime fix

## Changelog

not noticeable enough of a change