### PR TITLE
Gives the Lavaland Syndie base its own ruin typepath

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -28,15 +28,15 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "ae" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "af" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ag" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -49,7 +49,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ah" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
@@ -60,14 +60,14 @@
 	req_access = null
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "ai" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "aj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -75,43 +75,43 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "ak" = (
 /obj/machinery/vending/boozeomat/syndicate_access,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "al" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/medical/syndicate_access,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "ap" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "aq" = (
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "as" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "at" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor{
 	id = "lavalandsyndi_chemistry"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "aF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "aL" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "aM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -120,12 +120,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "aQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "aR" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -138,7 +138,7 @@
 	name = "N2 to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "aW" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -151,7 +151,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "cA" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/chemistry,
@@ -160,7 +160,7 @@
 /obj/item/clothing/glasses/science,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "cG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -169,7 +169,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "cP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -179,21 +179,21 @@
 	name = "Plasma Out"
 	},
 /turf/open/floor/engine/plasma,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "dc" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "dg" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "di" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "do" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -205,7 +205,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "du" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/button/door{
@@ -218,7 +218,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -226,7 +226,7 @@
 /obj/machinery/chem_heater/withbuffer,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dw" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -234,7 +234,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -242,10 +242,10 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dy" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "dA" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/power/apc/syndicate{
@@ -261,17 +261,17 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dE" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma{
@@ -296,7 +296,7 @@
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dG" = (
 /obj/structure/lattice/catwalk,
 /turf/open/lava/smooth/lava_land_surface,
@@ -310,7 +310,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dK" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -333,7 +333,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "dL" = (
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
@@ -374,7 +374,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "dM" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -392,14 +392,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "dP" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "dQ" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "dR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -423,7 +423,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "dS" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -432,7 +432,7 @@
 	name = "Syndicate Research Experimentation Shutters"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "dT" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -443,32 +443,32 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dY" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "dZ" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/table/glass,
@@ -491,7 +491,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "ea" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -521,7 +521,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eb" = (
 /obj/structure/closet/crate,
 /obj/item/storage/toolbox/electrical{
@@ -529,7 +529,7 @@
 	},
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "ec" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate/medical,
@@ -543,7 +543,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "ed" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -559,7 +559,7 @@
 	},
 /obj/machinery/power/rad_collector,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "ee" = (
 /obj/structure/rack,
 /obj/item/flashlight{
@@ -575,7 +575,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "ef" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/power/apc/syndicate{
@@ -593,7 +593,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eg" = (
 /obj/structure/closet/firecloset/full{
 	anchored = 1
@@ -607,17 +607,17 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eh" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "ei" = (
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "ej" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -637,11 +637,11 @@
 	faction = list("neutral","Syndicate")
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "ek" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "el" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -657,7 +657,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "em" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/button/door{
@@ -681,7 +681,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "eo" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/syndicate,
@@ -702,7 +702,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "ep" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -721,7 +721,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "eq" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
@@ -738,7 +738,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "er" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -748,7 +748,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "es" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -756,13 +756,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "et" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "eu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -771,17 +771,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "ev" = (
 /turf/open/floor/iron/white/corner,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "ew" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/syndichem,
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "ex" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/firealarm/directional/west,
@@ -803,7 +803,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "ey" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -824,7 +824,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "ez" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -844,7 +844,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -870,7 +870,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -881,7 +881,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -892,12 +892,12 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -907,7 +907,7 @@
 /obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eF" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -915,14 +915,14 @@
 	id = "lavalandsyndi_cargo"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eG" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "eH" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -930,15 +930,15 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "eI" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "eJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "eK" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/bed/roller,
@@ -959,7 +959,7 @@
 	faction = list("neutral","Syndicate")
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "eL" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Monkey Pen";
@@ -977,7 +977,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "eM" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -994,7 +994,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "eN" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 1;
@@ -1014,7 +1014,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "eO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -1034,7 +1034,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "eP" = (
 /obj/structure/chair{
 	dir = 1
@@ -1056,7 +1056,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "eQ" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/reinforced,
@@ -1073,7 +1073,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "eR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -1081,7 +1081,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "eS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1089,13 +1089,13 @@
 /obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "eT" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "eU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1104,13 +1104,13 @@
 /obj/machinery/chem_dispenser/fullupgrade,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "eV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "eW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -1126,7 +1126,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eX" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -1142,7 +1142,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eY" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -1162,7 +1162,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "eZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -1177,12 +1177,12 @@
 	},
 /obj/machinery/power/rad_collector,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fa" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -1190,21 +1190,21 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1213,7 +1213,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "ff" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -1222,7 +1222,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "fg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
@@ -1231,7 +1231,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "fh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -1239,7 +1239,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "fi" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -1257,7 +1257,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "fj" = (
 /obj/structure/table/glass,
 /obj/structure/reagent_dispensers/virusfood/directional/north,
@@ -1270,7 +1270,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "fk" = (
 /obj/machinery/power/apc/syndicate{
 	name = "Experimentation Lab APC";
@@ -1289,7 +1289,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "fl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -1306,7 +1306,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "fm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -1317,12 +1317,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "fn" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "fo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -1335,14 +1335,14 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "fp" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/chemistry)
+/area/ruin/powered/syndicate_lava_base/chemistry)
 "fq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1358,7 +1358,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -1375,7 +1375,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fs" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -1392,7 +1392,7 @@
 /obj/item/circuitboard/machine/smoke_machine,
 /obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "ft" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate,
@@ -1416,7 +1416,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fu" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/airalarm/syndicate{
@@ -1445,21 +1445,21 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fw" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fx" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fy" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation B";
@@ -1468,7 +1468,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "fz" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation A";
@@ -1477,7 +1477,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "fA" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/infections{
@@ -1490,14 +1490,14 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "fB" = (
 /obj/structure/chair/stool/directional/south,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "fC" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/decal/cleanable/dirt,
@@ -1505,11 +1505,11 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "fD" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "fE" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/l3closet,
@@ -1519,14 +1519,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "fF" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shower{
 	pixel_y = 14
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "fG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -1547,13 +1547,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "fH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "fI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -1562,12 +1562,12 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "fO" = (
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "fW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -1588,7 +1588,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "fY" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/table,
@@ -1610,7 +1610,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "gb" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -1620,7 +1620,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "gc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1630,7 +1630,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "gd" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
@@ -1640,14 +1640,14 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "gf" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "gg" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = 32
@@ -1656,7 +1656,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "gh" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
@@ -1666,16 +1666,16 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "gj" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "gp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 5
@@ -1685,7 +1685,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -1694,7 +1694,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1703,14 +1703,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1721,7 +1721,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1733,7 +1733,7 @@
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -1744,7 +1744,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1756,7 +1756,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -1770,7 +1770,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -1783,7 +1783,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/virology{
@@ -1810,7 +1810,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1826,7 +1826,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gF" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -1838,7 +1838,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1848,7 +1848,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1859,7 +1859,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -1871,7 +1871,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gK" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -1885,7 +1885,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
@@ -1901,7 +1901,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
@@ -1911,7 +1911,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
@@ -1922,11 +1922,11 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gO" = (
 /obj/structure/sign/departments/cargo,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "gP" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
@@ -1934,18 +1934,18 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "gQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "gR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "gS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -1958,7 +1958,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "gT" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen";
@@ -1967,7 +1967,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gU" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -1985,11 +1985,11 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gV" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -1998,7 +1998,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gX" = (
 /obj/machinery/door_buttons/airlock_controller{
 	idExterior = "lavaland_syndie_virology_exterior";
@@ -2023,7 +2023,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "gY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -2041,7 +2041,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "gZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -2051,10 +2051,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ha" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -2065,7 +2065,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2074,18 +2074,18 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hd" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "he" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
@@ -2093,7 +2093,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hg" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -2102,7 +2102,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hh" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red,
@@ -2110,20 +2110,20 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hj" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -2131,17 +2131,17 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "hl" = (
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "hn" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "ho" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2158,7 +2158,7 @@
 	shuttleId = "syndie_cargo"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "hp" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/human/species/monkey{
@@ -2167,7 +2167,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "hq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -2176,7 +2176,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "hr" = (
 /mob/living/carbon/human/species/monkey{
 	faction = list("neutral","Syndicate")
@@ -2184,7 +2184,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "hs" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/decal/cleanable/dirt,
@@ -2197,7 +2197,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "ht" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -2210,7 +2210,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/science,
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "hu" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -2224,7 +2224,7 @@
 	amount = 10
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "hv" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/warning/deathsposal{
@@ -2238,7 +2238,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "hw" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
@@ -2246,7 +2246,7 @@
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hx" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -2263,17 +2263,17 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hy" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hz" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "hA" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/dirt,
@@ -2288,7 +2288,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "hB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -2297,14 +2297,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "hD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2314,7 +2314,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/part_replacer/bluespace/tier4,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "hE" = (
 /mob/living/carbon/human/species/monkey{
 	faction = list("neutral","Syndicate")
@@ -2322,7 +2322,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "hF" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -2330,7 +2330,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "hG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/human/species/monkey{
@@ -2339,24 +2339,24 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "hH" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_virology"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/virology)
+/area/ruin/powered/syndicate_lava_base/virology)
 "hI" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hK" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/warning/fire{
@@ -2369,7 +2369,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hL" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -2382,7 +2382,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hM" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m9mm,
@@ -2391,20 +2391,20 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "hN" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "hO" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "hP" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "hQ" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m9mm,
@@ -2412,14 +2412,14 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "hR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hS" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
@@ -2434,7 +2434,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "hT" = (
 /obj/machinery/vending/toyliberationstation{
 	req_access_txt = "150"
@@ -2444,7 +2444,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "hU" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -2454,7 +2454,7 @@
 	},
 /obj/structure/tank_dispenser/plasma,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "hV" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
@@ -2463,13 +2463,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/cargo)
+/area/ruin/powered/syndicate_lava_base/cargo)
 "hW" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hX" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
@@ -2479,7 +2479,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hY" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
@@ -2490,7 +2490,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "hZ" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -2506,7 +2506,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ia" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -2516,18 +2516,18 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ib" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "ic" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "id" = (
 /obj/structure/toilet{
 	pixel_y = 18
@@ -2551,17 +2551,17 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "ie" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms{
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "if" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ig" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -2591,7 +2591,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ij" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2600,13 +2600,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ik" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "il" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 2"
@@ -2614,7 +2614,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "im" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -2631,7 +2631,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "in" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 4"
@@ -2639,15 +2639,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "ip" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "iq" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ir" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -2664,7 +2664,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "is" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/turretid{
@@ -2679,7 +2679,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "it" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -2698,7 +2698,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "iu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2724,27 +2724,27 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ix" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "iy" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitories"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2756,7 +2756,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iB" = (
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
@@ -2767,11 +2767,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iD" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/firealarm/directional/north,
@@ -2780,7 +2780,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2791,7 +2791,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iF" = (
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/dirt,
@@ -2806,7 +2806,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iG" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -2817,7 +2817,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "iH" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -2826,7 +2826,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "iI" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/vault{
@@ -2844,23 +2844,23 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "iJ" = (
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "iK" = (
 /obj/machinery/syndicatebomb/self_destruct{
 	anchored = 1
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "iM" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/lavaland_atmos,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "iN" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "iO" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -2873,7 +2873,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "iP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
@@ -2881,7 +2881,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "iR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -2896,7 +2896,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -2911,7 +2911,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iT" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -2923,7 +2923,7 @@
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
@@ -2932,7 +2932,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -2947,7 +2947,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -2959,7 +2959,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
@@ -2974,7 +2974,7 @@
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iY" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -2992,7 +2992,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "iZ" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -3003,7 +3003,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ja" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 4
@@ -3018,7 +3018,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -3035,11 +3035,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jc" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -3056,7 +3056,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "je" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -3072,7 +3072,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "jg" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -3080,7 +3080,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "jh" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 3"
@@ -3088,7 +3088,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "ji" = (
 /obj/machinery/power/apc/syndicate{
 	dir = 8;
@@ -3103,10 +3103,10 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jj" = (
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jk" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/lavaland_atmos,
@@ -3120,7 +3120,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
@@ -3131,7 +3131,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jn" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 4
@@ -3140,21 +3140,21 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "jo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "jp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jq" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 8
@@ -3163,7 +3163,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "js" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/red{
@@ -3171,16 +3171,16 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ju" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "jv" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/suit_storage_unit/syndicate,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "jw" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -3190,7 +3190,7 @@
 	},
 /obj/item/crowbar,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "jx" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -3198,37 +3198,37 @@
 	id = "lavalandsyndi_bar"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "jy" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "jz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "jA" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m9mm,
 /obj/item/ammo_box/magazine/sniper_rounds,
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "jB" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "jC" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/unpowered/syndicate_lava_base/dormitories)
+/area/ruin/powered/syndicate_lava_base/dormitories)
 "jE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
@@ -3238,7 +3238,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -3258,7 +3258,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -3271,7 +3271,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "jH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -3284,7 +3284,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "jI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3302,7 +3302,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "jL" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -3325,7 +3325,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "jM" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/chair{
@@ -3338,7 +3338,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "jN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3351,38 +3351,38 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "jO" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "jP" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "jQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jR" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/departments/engineering,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "jU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -3394,7 +3394,7 @@
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "jV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -3407,7 +3407,7 @@
 /obj/effect/turf_decal/stripes,
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "jW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -3417,22 +3417,22 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "jY" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "jZ" = (
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "ka" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "kb" = (
 /obj/structure/rack{
 	dir = 8
@@ -3447,7 +3447,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "kc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 6
@@ -3458,7 +3458,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ke" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -3469,7 +3469,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "kf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -3479,7 +3479,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "kg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -3490,7 +3490,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "kh" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -3501,7 +3501,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ki" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
@@ -3509,7 +3509,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "kj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -3518,7 +3518,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "kk" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -3530,11 +3530,11 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "km" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3544,7 +3544,7 @@
 	name = "CO2"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -3558,7 +3558,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "ko" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -3575,13 +3575,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "kp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "kq" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 8;
@@ -3602,7 +3602,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "kr" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "150"
@@ -3612,13 +3612,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "ks" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "kt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3628,14 +3628,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "ku" = (
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "kv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "kw" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -3651,7 +3651,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "kx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -3665,7 +3665,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "ky" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3676,14 +3676,14 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kA" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/power/apc/syndicate{
@@ -3698,7 +3698,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3707,13 +3707,13 @@
 	name = "CO2"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kC" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
@@ -3724,7 +3724,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	frequency = 1442;
@@ -3733,23 +3733,23 @@
 	name = "CO2 out"
 	},
 /turf/open/floor/engine/co2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kF" = (
 /obj/machinery/meter/turf,
 /turf/open/floor/engine/n2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kH" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "kI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "kJ" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -3767,14 +3767,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "kK" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "kL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 10
@@ -3792,7 +3792,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "kM" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/vending/cigarette{
@@ -3801,7 +3801,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "kN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3809,14 +3809,14 @@
 	pixel_y = 28
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "kO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "kP" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -3824,17 +3824,17 @@
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "kQ" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "kR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay"
 	},
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "kS" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -3842,17 +3842,17 @@
 	name = "Medbay"
 	},
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "kT" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "kU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3865,7 +3865,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3874,7 +3874,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
 	dir = 5
@@ -3882,23 +3882,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "kZ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "la" = (
 /obj/machinery/portable_atmospherics/canister/tier_3,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "lb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue,
@@ -3910,22 +3910,22 @@
 	name = "O2 Layer Manifold"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "lc" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "ld" = (
 /turf/open/floor/engine/co2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "le" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/lavaland_atmos,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "lf" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/chair{
@@ -3934,7 +3934,7 @@
 /obj/machinery/firealarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lg" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -3949,11 +3949,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lh" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "li" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/syndicate{
@@ -3963,7 +3963,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
 	},
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lj" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
@@ -3974,7 +3974,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lk" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/east,
@@ -3992,14 +3992,14 @@
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "ll" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lm" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -4010,12 +4010,12 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "ln" = (
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "lo" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table,
@@ -4025,7 +4025,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "lp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4037,7 +4037,7 @@
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "lq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -4047,32 +4047,32 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "lr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "ls" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "lt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
 	name = "O2 to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "lu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
 	dir = 4;
 	name = "N2 to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "lv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4101,19 +4101,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "ly" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lA" = (
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lC" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
@@ -4122,11 +4122,11 @@
 	pixel_x = 6
 	},
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lF" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate,
@@ -4145,7 +4145,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lG" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes,
@@ -4155,20 +4155,20 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "lH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "lI" = (
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "lJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "lK" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -4176,7 +4176,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "lL" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -4201,7 +4201,7 @@
 /obj/item/weldingtool/largetank,
 /obj/item/analyzer,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "lM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -4209,28 +4209,28 @@
 /obj/structure/cable,
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "lN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4{
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "lO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "lR" = (
 /obj/machinery/meter/turf,
 /turf/open/floor/engine/o2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "lS" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "lT" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
@@ -4238,7 +4238,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "lU" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -4256,7 +4256,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lV" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -4270,17 +4270,17 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lW" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lX" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 5
@@ -4290,7 +4290,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "lZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -4300,7 +4300,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "ma" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -4314,7 +4314,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "mb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -4324,7 +4324,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "mc" = (
 /obj/item/storage/box/donkpockets{
 	pixel_x = -2;
@@ -4348,7 +4348,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "md" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
@@ -4356,11 +4356,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "me" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "mf" = (
 /obj/structure/sink{
 	dir = 8;
@@ -4372,7 +4372,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "mg" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/table,
@@ -4384,19 +4384,19 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "mh" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "mi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "mj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -4405,34 +4405,34 @@
 	name = "O2 to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "mk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
 	name = "O2 to Mix"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "ml" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
 	dir = 4;
 	name = "O2 to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "mm" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "mn" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "mo" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "mp" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -4440,16 +4440,16 @@
 	id = "lavalandsyndi_telecomms"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "mq" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "mr" = (
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "ms" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/warning/fire{
@@ -4460,7 +4460,7 @@
 /obj/item/flashlight/seclite,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "mt" = (
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 1
@@ -4468,7 +4468,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "mu" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -4476,7 +4476,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "mv" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/south,
@@ -4486,23 +4486,23 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "mw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "mx" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "my" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/item/food/chocolatebar,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "mz" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -4510,7 +4510,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "mA" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/bed/roller,
@@ -4521,26 +4521,26 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "mB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "mC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "mD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "mE" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
@@ -4553,24 +4553,24 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "mF" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "mG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "mH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "mI" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small/directional/south,
@@ -4581,7 +4581,7 @@
 	name = "Plasma to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "mJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
 	dir = 10;
@@ -4589,21 +4589,21 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "mM" = (
 /turf/open/floor/circuit/green,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "mN" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "mP" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "mQ" = (
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "mR" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/syndicate,
@@ -4615,7 +4615,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "mS" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
@@ -4625,15 +4625,15 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "mT" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "mU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "mX" = (
 /obj/structure/rack{
 	dir = 8
@@ -4652,7 +4652,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "mY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -4662,20 +4662,20 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "mZ" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "na" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "nb" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
@@ -4683,7 +4683,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "nc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /obj/machinery/computer/turbine_computer{
@@ -4691,13 +4691,13 @@
 	id = "syndie_lavaland_incineratorturbine"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "nd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "ne" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_syndicatelava{
@@ -4721,18 +4721,18 @@
 	},
 /obj/machinery/portable_atmospherics/canister/tier_3,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "nf" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "ng" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
 	dir = 5;
 	name = "Plasma to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "nh" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
 	use_power = 0
@@ -4749,7 +4749,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "ni" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4762,7 +4762,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "nj" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications Control";
@@ -4779,7 +4779,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "nk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -4795,7 +4795,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "nl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 4
@@ -4811,7 +4811,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "nm" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -4830,14 +4830,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "nn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "no" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -4846,7 +4846,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "np" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -4856,7 +4856,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nq" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4865,7 +4865,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -4876,7 +4876,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "ns" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -4897,7 +4897,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -4919,7 +4919,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -4935,7 +4935,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4948,7 +4948,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -4956,7 +4956,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -4970,7 +4970,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "ny" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -4982,7 +4982,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "nz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
@@ -4992,18 +4992,18 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "nA" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "nB" = (
 /obj/structure/table/reinforced,
 /obj/item/surgicaldrill,
 /obj/item/cautery,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "nC" = (
 /obj/structure/table/reinforced,
 /obj/item/retractor,
@@ -5012,18 +5012,18 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "nD" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/glass/incinerator/syndicatelava_interior,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "nE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "nH" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -5041,7 +5041,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "nI" = (
 /obj/machinery/computer/camera_advanced,
 /obj/effect/turf_decal/tile/neutral{
@@ -5055,7 +5055,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "nJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -5069,7 +5069,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "nK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 5
@@ -5089,7 +5089,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "nL" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications";
@@ -5113,7 +5113,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "nM" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -5126,7 +5126,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -5136,7 +5136,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nO" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -5148,7 +5148,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -5162,7 +5162,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nQ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -5176,7 +5176,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -5189,7 +5189,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -5206,7 +5206,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -5222,7 +5222,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nU" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/airalarm/syndicate{
@@ -5243,7 +5243,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
@@ -5256,28 +5256,28 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nW" = (
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "nZ" = (
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "oa" = (
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "ob" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "oc" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -5291,7 +5291,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "od" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -5302,14 +5302,14 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "oe" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_syndicatelava{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "of" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -5322,7 +5322,7 @@
 	pixel_x = 22
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "oh" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -5336,7 +5336,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "oi" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -5352,7 +5352,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "oj" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -5370,7 +5370,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "ok" = (
 /obj/structure/chair{
 	dir = 8
@@ -5391,7 +5391,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "ol" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -5405,7 +5405,7 @@
 /obj/item/mining_scanner,
 /obj/item/pickaxe,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "om" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
@@ -5413,7 +5413,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "on" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -5425,14 +5425,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "oo" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "op" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -5442,7 +5442,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "or" = (
 /obj/structure/rack{
 	dir = 8
@@ -5453,7 +5453,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/neck/stethoscope,
 /turf/open/floor/iron/white,
-/area/ruin/unpowered/syndicate_lava_base/medbay)
+/area/ruin/powered/syndicate_lava_base/medbay)
 "ot" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/glass/incinerator/syndicatelava_exterior,
@@ -5461,20 +5461,20 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "ou" = (
 /obj/machinery/computer/message_monitor{
 	dir = 1
 	},
 /obj/item/paper/monitorkey,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "ov" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/telecomms)
+/area/ruin/powered/syndicate_lava_base/telecomms)
 "ox" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -5482,17 +5482,17 @@
 	id = "lavalandsyndi_arrivals"
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "oz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "oA" = (
 /obj/machinery/igniter/incinerator_syndicatelava,
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "oB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
 	dir = 1;
@@ -5502,11 +5502,11 @@
 	pixel_y = -32
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "oC" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_aux,
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "oD" = (
 /obj/structure/sign/warning/xeno_mining{
 	pixel_x = -32
@@ -5515,7 +5515,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "oE" = (
 /obj/machinery/power/compressor{
 	comp_id = "syndie_lavaland_incineratorturbine";
@@ -5524,33 +5524,33 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "oF" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "oG" = (
 /obj/machinery/power/turbine{
 	luminosity = 2
 	},
 /obj/structure/cable,
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "oH" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_main,
 /turf/open/floor/engine/vacuum,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "oI" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "oP" = (
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "pJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -5560,35 +5560,35 @@
 	name = "Nitrogen Out"
 	},
 /turf/open/floor/engine/n2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "pQ" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = 32
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "qG" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = -32
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "rg" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/n2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "rF" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "sc" = (
 /turf/open/floor/engine/o2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "sl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "sw" = (
 /obj/effect/spawner/random/vending/snackvend{
 	hacked = 1
@@ -5605,34 +5605,34 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "sP" = (
 /obj/structure/cable,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "ta" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange{
 	dir = 8
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "tW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "uB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 5
 	},
 /obj/structure/cable,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "vu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "vX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
@@ -5640,17 +5640,17 @@
 	name = "Plasma Layer Manifold"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "wi" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 8;
 	volume_rate = 200
 	},
 /turf/open/floor/plating/lavaland_atmos,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "xn" = (
 /turf/open/floor/engine/n2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "yg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -5660,18 +5660,18 @@
 	name = "Oxygen Out"
 	},
 /turf/open/floor/engine/o2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "AH" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "BC" = (
 /obj/machinery/meter/turf,
 /turf/open/floor/engine/co2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "BF" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -5682,7 +5682,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "Cg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -5691,7 +5691,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "CG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 10
@@ -5700,29 +5700,29 @@
 	dir = 10
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "DF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "DL" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = 32
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "Ec" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "Ed" = (
 /obj/machinery/portable_atmospherics/canister/tier_3,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "Ev" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/rag{
@@ -5735,7 +5735,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "EZ" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
@@ -5743,7 +5743,7 @@
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "FN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/beer,
@@ -5759,7 +5759,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/unpowered/syndicate_lava_base/bar)
+/area/ruin/powered/syndicate_lava_base/bar)
 "Hu" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/bot,
@@ -5769,17 +5769,17 @@
 	name = "N2 to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "IH" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating/airless,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "IJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "IU" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/template_noop,
@@ -5790,33 +5790,33 @@
 	name = "Plasma to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "Lg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "Lp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "LQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "Ng" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "NF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "Oq" = (
 /obj/effect/spawner/random/vending/colavend{
 	hacked = 1
@@ -5829,35 +5829,35 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "Qv" = (
 /obj/structure/closet/firecloset/full{
 	anchored = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "Rl" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/o2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "Rq" = (
 /obj/machinery/meter/turf,
 /turf/open/floor/engine/plasma,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "RE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "RK" = (
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "RV" = (
 /obj/structure/sign/warning/fire,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "St" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
@@ -5867,7 +5867,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/arrivals)
+/area/ruin/powered/syndicate_lava_base/arrivals)
 "Tp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 4
@@ -5876,7 +5876,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "TC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 4
@@ -5885,39 +5885,39 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/unpowered/syndicate_lava_base/testlab)
+/area/ruin/powered/syndicate_lava_base/testlab)
 "TG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "Vd" = (
 /turf/open/floor/engine/plasma,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "Wt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4{
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/unpowered/syndicate_lava_base/main)
+/area/ruin/powered/syndicate_lava_base/main)
 "Xd" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "Yt" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/plasma,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "ZN" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/co2,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 "ZU" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/unpowered/syndicate_lava_base/engineering)
+/area/ruin/powered/syndicate_lava_base/engineering)
 
 (1,1,1) = {"
 IU

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -28,15 +28,15 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "ae" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "af" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ag" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -49,7 +49,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ah" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
@@ -60,14 +60,14 @@
 	req_access = null
 	},
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "ai" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "aj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -75,43 +75,43 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "ak" = (
 /obj/machinery/vending/boozeomat/syndicate_access,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "al" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/medical/syndicate_access,
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "ap" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "aq" = (
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "as" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "at" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor{
 	id = "lavalandsyndi_chemistry"
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "aF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "aL" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "aM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -120,12 +120,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "aQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "aR" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -138,7 +138,7 @@
 	name = "N2 to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "aW" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -151,7 +151,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "cA" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/chemistry,
@@ -160,7 +160,7 @@
 /obj/item/clothing/glasses/science,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "cG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -169,7 +169,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "cP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -179,21 +179,21 @@
 	name = "Plasma Out"
 	},
 /turf/open/floor/engine/plasma,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "dc" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "dg" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "di" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "do" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -205,7 +205,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "du" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/button/door{
@@ -218,7 +218,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -226,7 +226,7 @@
 /obj/machinery/chem_heater/withbuffer,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dw" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -234,7 +234,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -242,10 +242,10 @@
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dy" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "dA" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/power/apc/syndicate{
@@ -261,17 +261,17 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dE" = (
 /obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma{
@@ -296,7 +296,7 @@
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dG" = (
 /obj/structure/lattice/catwalk,
 /turf/open/lava/smooth/lava_land_surface,
@@ -310,7 +310,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dK" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -333,7 +333,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "dL" = (
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
@@ -374,7 +374,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "dM" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -392,14 +392,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "dP" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "dQ" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "dR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -423,7 +423,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "dS" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -432,7 +432,7 @@
 	name = "Syndicate Research Experimentation Shutters"
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "dT" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -443,32 +443,32 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dY" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "dZ" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/table/glass,
@@ -491,7 +491,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "ea" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -521,7 +521,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eb" = (
 /obj/structure/closet/crate,
 /obj/item/storage/toolbox/electrical{
@@ -529,7 +529,7 @@
 	},
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "ec" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate/medical,
@@ -543,7 +543,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "ed" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -559,7 +559,7 @@
 	},
 /obj/machinery/power/rad_collector,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "ee" = (
 /obj/structure/rack,
 /obj/item/flashlight{
@@ -575,7 +575,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "ef" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/power/apc/syndicate{
@@ -593,7 +593,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eg" = (
 /obj/structure/closet/firecloset/full{
 	anchored = 1
@@ -607,17 +607,17 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eh" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "ei" = (
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "ej" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -637,11 +637,11 @@
 	faction = list("neutral","Syndicate")
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "ek" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "el" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -657,7 +657,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "em" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/button/door{
@@ -681,7 +681,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "eo" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/syndicate,
@@ -702,7 +702,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "ep" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -721,7 +721,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "eq" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
@@ -738,7 +738,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "er" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -748,7 +748,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "es" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -756,13 +756,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "et" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "eu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -771,17 +771,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "ev" = (
 /turf/open/floor/iron/white/corner,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "ew" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/syndichem,
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "ex" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/firealarm/directional/west,
@@ -803,7 +803,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "ey" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -824,7 +824,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "ez" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -844,7 +844,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -870,7 +870,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -881,7 +881,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -892,12 +892,12 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -907,7 +907,7 @@
 /obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eF" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -915,14 +915,14 @@
 	id = "lavalandsyndi_cargo"
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eG" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "eH" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -930,15 +930,15 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "eI" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "eJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "eK" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/bed/roller,
@@ -959,7 +959,7 @@
 	faction = list("neutral","Syndicate")
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "eL" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Monkey Pen";
@@ -977,7 +977,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "eM" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -994,7 +994,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "eN" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 1;
@@ -1014,7 +1014,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "eO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -1034,7 +1034,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "eP" = (
 /obj/structure/chair{
 	dir = 1
@@ -1056,7 +1056,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "eQ" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/reinforced,
@@ -1073,7 +1073,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "eR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -1081,7 +1081,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "eS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1089,13 +1089,13 @@
 /obj/machinery/chem_master,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "eT" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "eU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1104,13 +1104,13 @@
 /obj/machinery/chem_dispenser/fullupgrade,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "eV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "eW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -1126,7 +1126,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eX" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
@@ -1142,7 +1142,7 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eY" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -1162,7 +1162,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "eZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -1177,12 +1177,12 @@
 	},
 /obj/machinery/power/rad_collector,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fa" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -1190,21 +1190,21 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1213,7 +1213,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "ff" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -1222,7 +1222,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "fg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
@@ -1231,7 +1231,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "fh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -1239,7 +1239,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "fi" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -1257,7 +1257,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "fj" = (
 /obj/structure/table/glass,
 /obj/structure/reagent_dispensers/virusfood/directional/north,
@@ -1270,7 +1270,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "fk" = (
 /obj/machinery/power/apc/syndicate{
 	name = "Experimentation Lab APC";
@@ -1289,7 +1289,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "fl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -1306,7 +1306,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "fm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -1317,12 +1317,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "fn" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "fo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -1335,14 +1335,14 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "fp" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/chemistry)
+/area/ruin/syndicate_lava_base/chemistry)
 "fq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1358,7 +1358,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -1375,7 +1375,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fs" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -1392,7 +1392,7 @@
 /obj/item/circuitboard/machine/smoke_machine,
 /obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "ft" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/structure/closet/crate,
@@ -1416,7 +1416,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fu" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/airalarm/syndicate{
@@ -1445,21 +1445,21 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fw" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fx" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fy" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation B";
@@ -1468,7 +1468,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "fz" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation A";
@@ -1477,7 +1477,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "fA" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/infections{
@@ -1490,14 +1490,14 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "fB" = (
 /obj/structure/chair/stool/directional/south,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "fC" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/decal/cleanable/dirt,
@@ -1505,11 +1505,11 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "fD" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "fE" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/l3closet,
@@ -1519,14 +1519,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "fF" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shower{
 	pixel_y = 14
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "fG" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -1547,13 +1547,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "fH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "fI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -1562,12 +1562,12 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "fO" = (
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "fW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -1588,7 +1588,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "fY" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/table,
@@ -1610,7 +1610,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "gb" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -1620,7 +1620,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "gc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1630,7 +1630,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "gd" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
@@ -1640,14 +1640,14 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "gf" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_y = -32
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "gg" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = 32
@@ -1656,7 +1656,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "gh" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
@@ -1666,16 +1666,16 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "gj" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "gp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 5
@@ -1685,7 +1685,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -1694,7 +1694,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1703,14 +1703,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1721,7 +1721,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1733,7 +1733,7 @@
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -1744,7 +1744,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1756,7 +1756,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -1770,7 +1770,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -1783,7 +1783,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/virology{
@@ -1810,7 +1810,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1826,7 +1826,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gF" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -1838,7 +1838,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1848,7 +1848,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -1859,7 +1859,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -1871,7 +1871,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gK" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -1885,7 +1885,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
@@ -1901,7 +1901,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
@@ -1911,7 +1911,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
@@ -1922,11 +1922,11 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gO" = (
 /obj/structure/sign/departments/cargo,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "gP" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
@@ -1934,18 +1934,18 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "gQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "gR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "gS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -1958,7 +1958,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "gT" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen";
@@ -1967,7 +1967,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gU" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -1985,11 +1985,11 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gV" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -1998,7 +1998,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gX" = (
 /obj/machinery/door_buttons/airlock_controller{
 	idExterior = "lavaland_syndie_virology_exterior";
@@ -2023,7 +2023,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "gY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -2041,7 +2041,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "gZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -2051,10 +2051,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ha" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -2065,7 +2065,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2074,18 +2074,18 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hd" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "he" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
@@ -2093,7 +2093,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hg" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -2102,7 +2102,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hh" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red,
@@ -2110,20 +2110,20 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hj" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -2131,17 +2131,17 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "hl" = (
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "hn" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "ho" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2158,7 +2158,7 @@
 	shuttleId = "syndie_cargo"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "hp" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/human/species/monkey{
@@ -2167,7 +2167,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "hq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -2176,7 +2176,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "hr" = (
 /mob/living/carbon/human/species/monkey{
 	faction = list("neutral","Syndicate")
@@ -2184,7 +2184,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "hs" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/decal/cleanable/dirt,
@@ -2197,7 +2197,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "ht" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -2210,7 +2210,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/glasses/science,
 /turf/open/floor/iron/white/side,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "hu" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -2224,7 +2224,7 @@
 	amount = 10
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "hv" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/warning/deathsposal{
@@ -2238,7 +2238,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "hw" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
@@ -2246,7 +2246,7 @@
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hx" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -2263,17 +2263,17 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hy" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hz" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "hA" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/dirt,
@@ -2288,7 +2288,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "hB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -2297,14 +2297,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "hD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2314,7 +2314,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/part_replacer/bluespace/tier4,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "hE" = (
 /mob/living/carbon/human/species/monkey{
 	faction = list("neutral","Syndicate")
@@ -2322,7 +2322,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "hF" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -2330,7 +2330,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "hG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/carbon/human/species/monkey{
@@ -2339,24 +2339,24 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "hH" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/preopen{
 	id = "lavalandsyndi_virology"
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/virology)
+/area/ruin/syndicate_lava_base/virology)
 "hI" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hK" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/warning/fire{
@@ -2369,7 +2369,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hL" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -2382,7 +2382,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hM" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m9mm,
@@ -2391,20 +2391,20 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "hN" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "hO" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "hP" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "hQ" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m9mm,
@@ -2412,14 +2412,14 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "hR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hS" = (
 /obj/structure/table/reinforced,
 /obj/item/folder,
@@ -2434,7 +2434,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "hT" = (
 /obj/machinery/vending/toyliberationstation{
 	req_access_txt = "150"
@@ -2444,7 +2444,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "hU" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -2454,7 +2454,7 @@
 	},
 /obj/structure/tank_dispenser/plasma,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "hV" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
@@ -2463,13 +2463,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/cargo)
+/area/ruin/syndicate_lava_base/cargo)
 "hW" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 10
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hX" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
@@ -2479,7 +2479,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hY" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
@@ -2490,7 +2490,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "hZ" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -2506,7 +2506,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ia" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -2516,18 +2516,18 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ib" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "ic" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "id" = (
 /obj/structure/toilet{
 	pixel_y = 18
@@ -2551,17 +2551,17 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "ie" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms{
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "if" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ig" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -2591,7 +2591,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ij" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2600,13 +2600,13 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ik" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "il" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 2"
@@ -2614,7 +2614,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "im" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -2631,7 +2631,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "in" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 4"
@@ -2639,15 +2639,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "ip" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "iq" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ir" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -2664,7 +2664,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "is" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/turretid{
@@ -2679,7 +2679,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "it" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -2698,7 +2698,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "iu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2724,27 +2724,27 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ix" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "iy" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitories"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2756,7 +2756,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iB" = (
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
@@ -2767,11 +2767,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iD" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/firealarm/directional/north,
@@ -2780,7 +2780,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -2791,7 +2791,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iF" = (
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/dirt,
@@ -2806,7 +2806,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iG" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -2817,7 +2817,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "iH" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -2826,7 +2826,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "iI" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/vault{
@@ -2844,23 +2844,23 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "iJ" = (
 /turf/open/floor/circuit/red,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "iK" = (
 /obj/machinery/syndicatebomb/self_destruct{
 	anchored = 1
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "iM" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/lavaland_atmos,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "iN" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "iO" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -2873,7 +2873,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "iP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
@@ -2881,7 +2881,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "iR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -2896,7 +2896,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -2911,7 +2911,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iT" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -2923,7 +2923,7 @@
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
@@ -2932,7 +2932,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -2947,7 +2947,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -2959,7 +2959,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
@@ -2974,7 +2974,7 @@
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iY" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -2992,7 +2992,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "iZ" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -3003,7 +3003,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ja" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 4
@@ -3018,7 +3018,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -3035,11 +3035,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jc" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/circuit/red,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -3056,7 +3056,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "je" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -3072,7 +3072,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "jg" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -3080,7 +3080,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "jh" = (
 /obj/machinery/door/airlock{
 	name = "Cabin 3"
@@ -3088,7 +3088,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "ji" = (
 /obj/machinery/power/apc/syndicate{
 	dir = 8;
@@ -3103,10 +3103,10 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jj" = (
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jk" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/lavaland_atmos,
@@ -3120,7 +3120,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
@@ -3131,7 +3131,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jn" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 4
@@ -3140,21 +3140,21 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "jo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "jp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jq" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate{
 	dir = 8
@@ -3163,7 +3163,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "js" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/red{
@@ -3171,16 +3171,16 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ju" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "jv" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/suit_storage_unit/syndicate,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "jw" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -3190,7 +3190,7 @@
 	},
 /obj/item/crowbar,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "jx" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -3198,37 +3198,37 @@
 	id = "lavalandsyndi_bar"
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "jy" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "jz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "jA" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m9mm,
 /obj/item/ammo_box/magazine/sniper_rounds,
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "jB" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "jC" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/grimy,
-/area/ruin/powered/syndicate_lava_base/dormitories)
+/area/ruin/syndicate_lava_base/dormitories)
 "jE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
@@ -3238,7 +3238,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -3258,7 +3258,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -3271,7 +3271,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "jH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -3284,7 +3284,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "jI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3302,7 +3302,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "jL" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -3325,7 +3325,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "jM" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/chair{
@@ -3338,7 +3338,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "jN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3351,38 +3351,38 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "jO" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "jP" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "jQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jR" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/departments/engineering,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "jU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -3394,7 +3394,7 @@
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "jV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -3407,7 +3407,7 @@
 /obj/effect/turf_decal/stripes,
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "jW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -3417,22 +3417,22 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "jY" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "jZ" = (
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "ka" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "kb" = (
 /obj/structure/rack{
 	dir = 8
@@ -3447,7 +3447,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "kc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 6
@@ -3458,7 +3458,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ke" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -3469,7 +3469,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "kf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -3479,7 +3479,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "kg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -3490,7 +3490,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "kh" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -3501,7 +3501,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ki" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
@@ -3509,7 +3509,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "kj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -3518,7 +3518,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "kk" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -3530,11 +3530,11 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "km" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3544,7 +3544,7 @@
 	name = "CO2"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -3558,7 +3558,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "ko" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -3575,13 +3575,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "kp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "kq" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 8;
@@ -3602,7 +3602,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "kr" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "150"
@@ -3612,13 +3612,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "ks" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "kt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3628,14 +3628,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "ku" = (
 /turf/open/floor/iron/white/side,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "kv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "kw" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -3651,7 +3651,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/iron/white/side,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "kx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -3665,7 +3665,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "ky" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -3676,14 +3676,14 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kA" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/power/apc/syndicate{
@@ -3698,7 +3698,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3707,13 +3707,13 @@
 	name = "CO2"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kC" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
@@ -3724,7 +3724,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	frequency = 1442;
@@ -3733,23 +3733,23 @@
 	name = "CO2 out"
 	},
 /turf/open/floor/engine/co2,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kF" = (
 /obj/machinery/meter/turf,
 /turf/open/floor/engine/n2,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kH" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "kI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "kJ" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -3767,14 +3767,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "kK" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "kL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 10
@@ -3792,7 +3792,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "kM" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/vending/cigarette{
@@ -3801,7 +3801,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "kN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3809,14 +3809,14 @@
 	pixel_y = 28
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "kO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "kP" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -3824,17 +3824,17 @@
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "kQ" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "kR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay"
 	},
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "kS" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -3842,17 +3842,17 @@
 	name = "Medbay"
 	},
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "kT" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "kU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3865,7 +3865,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3874,7 +3874,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
 	dir = 5
@@ -3882,23 +3882,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "kZ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "la" = (
 /obj/machinery/portable_atmospherics/canister/tier_3,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "lb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue,
@@ -3910,22 +3910,22 @@
 	name = "O2 Layer Manifold"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "lc" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "ld" = (
 /turf/open/floor/engine/co2,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "le" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/lavaland_atmos,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "lf" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/chair{
@@ -3934,7 +3934,7 @@
 /obj/machinery/firealarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lg" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -3949,11 +3949,11 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lh" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "li" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck/syndicate{
@@ -3963,7 +3963,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
 	},
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lj" = (
 /obj/machinery/door/window/southleft{
 	base_state = "right";
@@ -3974,7 +3974,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lk" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/east,
@@ -3992,14 +3992,14 @@
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "ll" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lm" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = null;
@@ -4010,12 +4010,12 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "ln" = (
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "lo" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table,
@@ -4025,7 +4025,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "lp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4037,7 +4037,7 @@
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "lq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -4047,32 +4047,32 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "lr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "ls" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "lt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
 	name = "O2 to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "lu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
 	dir = 4;
 	name = "N2 to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "lv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4101,19 +4101,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "ly" = (
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lA" = (
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lC" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
@@ -4122,11 +4122,11 @@
 	pixel_x = 6
 	},
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lF" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate,
@@ -4145,7 +4145,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lG" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes,
@@ -4155,20 +4155,20 @@
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "lH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "lI" = (
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "lJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "lK" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -4176,7 +4176,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "lL" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -4201,7 +4201,7 @@
 /obj/item/weldingtool/largetank,
 /obj/item/analyzer,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "lM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -4209,28 +4209,28 @@
 /obj/structure/cable,
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "lN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4{
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "lO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "lR" = (
 /obj/machinery/meter/turf,
 /turf/open/floor/engine/o2,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "lS" = (
 /obj/machinery/porta_turret/syndicate{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "lT" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
@@ -4238,7 +4238,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "lU" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -4256,7 +4256,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lV" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -4270,17 +4270,17 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lW" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lX" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 5
@@ -4290,7 +4290,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "lZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -4300,7 +4300,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "ma" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -4314,7 +4314,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "mb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -4324,7 +4324,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "mc" = (
 /obj/item/storage/box/donkpockets{
 	pixel_x = -2;
@@ -4348,7 +4348,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "md" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
@@ -4356,11 +4356,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "me" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "mf" = (
 /obj/structure/sink{
 	dir = 8;
@@ -4372,7 +4372,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "mg" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/table,
@@ -4384,19 +4384,19 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "mh" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "mi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "mj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -4405,34 +4405,34 @@
 	name = "O2 to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "mk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
 	name = "O2 to Mix"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "ml" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
 	dir = 4;
 	name = "O2 to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "mm" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "mn" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "mo" = (
 /turf/closed/wall/mineral/plastitanium/explosive,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "mp" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -4440,16 +4440,16 @@
 	id = "lavalandsyndi_telecomms"
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "mq" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "mr" = (
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "ms" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/warning/fire{
@@ -4460,7 +4460,7 @@
 /obj/item/flashlight/seclite,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "mt" = (
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 1
@@ -4468,7 +4468,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "mu" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -4476,7 +4476,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "mv" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/south,
@@ -4486,23 +4486,23 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "mw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "mx" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave,
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "my" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/item/food/chocolatebar,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "mz" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -4510,7 +4510,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "mA" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/bed/roller,
@@ -4521,26 +4521,26 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "mB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "mC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "mD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "mE" = (
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
@@ -4553,24 +4553,24 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "mF" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "mG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "mH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "mI" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small/directional/south,
@@ -4581,7 +4581,7 @@
 	name = "Plasma to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "mJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
 	dir = 10;
@@ -4589,21 +4589,21 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "mM" = (
 /turf/open/floor/circuit/green,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "mN" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "mP" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "mQ" = (
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "mR" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/syndicate,
@@ -4615,7 +4615,7 @@
 	req_access_txt = "150"
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "mS" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
@@ -4625,15 +4625,15 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "mT" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "mU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "mX" = (
 /obj/structure/rack{
 	dir = 8
@@ -4652,7 +4652,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "mY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -4662,20 +4662,20 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "mZ" = (
 /obj/machinery/sleeper/syndie{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "na" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "nb" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
@@ -4683,7 +4683,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "nc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /obj/machinery/computer/turbine_computer{
@@ -4691,13 +4691,13 @@
 	id = "syndie_lavaland_incineratorturbine"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "nd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "ne" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_syndicatelava{
@@ -4721,18 +4721,18 @@
 	},
 /obj/machinery/portable_atmospherics/canister/tier_3,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "nf" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "ng" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible{
 	dir = 5;
 	name = "Plasma to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "nh" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
 	use_power = 0
@@ -4749,7 +4749,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "ni" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4762,7 +4762,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "nj" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications Control";
@@ -4779,7 +4779,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "nk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -4795,7 +4795,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "nl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 4
@@ -4811,7 +4811,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "nm" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -4830,14 +4830,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "nn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "no" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -4846,7 +4846,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "np" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -4856,7 +4856,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nq" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4865,7 +4865,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -4876,7 +4876,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "ns" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -4897,7 +4897,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -4919,7 +4919,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -4935,7 +4935,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4948,7 +4948,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
@@ -4956,7 +4956,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -4970,7 +4970,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "ny" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -4982,7 +4982,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "nz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
@@ -4992,18 +4992,18 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "nA" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "nB" = (
 /obj/structure/table/reinforced,
 /obj/item/surgicaldrill,
 /obj/item/cautery,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "nC" = (
 /obj/structure/table/reinforced,
 /obj/item/retractor,
@@ -5012,18 +5012,18 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "nD" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/glass/incinerator/syndicatelava_interior,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "nE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "nH" = (
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
@@ -5041,7 +5041,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "nI" = (
 /obj/machinery/computer/camera_advanced,
 /obj/effect/turf_decal/tile/neutral{
@@ -5055,7 +5055,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "nJ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -5069,7 +5069,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "nK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 5
@@ -5089,7 +5089,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "nL" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications";
@@ -5113,7 +5113,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "nM" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -5126,7 +5126,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -5136,7 +5136,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nO" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -5148,7 +5148,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -5162,7 +5162,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nQ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -5176,7 +5176,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -5189,7 +5189,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 1
@@ -5206,7 +5206,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -5222,7 +5222,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nU" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/airalarm/syndicate{
@@ -5243,7 +5243,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
@@ -5256,28 +5256,28 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nW" = (
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "nZ" = (
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "oa" = (
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "ob" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "oc" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -5291,7 +5291,7 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "od" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -5302,14 +5302,14 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "oe" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_syndicatelava{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "of" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -5322,7 +5322,7 @@
 	pixel_x = 22
 	},
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "oh" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -5336,7 +5336,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "oi" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -5352,7 +5352,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "oj" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -5370,7 +5370,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "ok" = (
 /obj/structure/chair{
 	dir = 8
@@ -5391,7 +5391,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "ol" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -5405,7 +5405,7 @@
 /obj/item/mining_scanner,
 /obj/item/pickaxe,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "om" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red,
@@ -5413,7 +5413,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "on" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -5425,14 +5425,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "oo" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "op" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -5442,7 +5442,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "or" = (
 /obj/structure/rack{
 	dir = 8
@@ -5453,7 +5453,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/neck/stethoscope,
 /turf/open/floor/iron/white,
-/area/ruin/powered/syndicate_lava_base/medbay)
+/area/ruin/syndicate_lava_base/medbay)
 "ot" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/glass/incinerator/syndicatelava_exterior,
@@ -5461,20 +5461,20 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "ou" = (
 /obj/machinery/computer/message_monitor{
 	dir = 1
 	},
 /obj/item/paper/monitorkey,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "ov" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/telecomms)
+/area/ruin/syndicate_lava_base/telecomms)
 "ox" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -5482,17 +5482,17 @@
 	id = "lavalandsyndi_arrivals"
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "oz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 1
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "oA" = (
 /obj/machinery/igniter/incinerator_syndicatelava,
 /turf/open/floor/engine/vacuum,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "oB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
 	dir = 1;
@@ -5502,11 +5502,11 @@
 	pixel_y = -32
 	},
 /turf/open/floor/engine/vacuum,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "oC" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_aux,
 /turf/open/floor/engine/vacuum,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "oD" = (
 /obj/structure/sign/warning/xeno_mining{
 	pixel_x = -32
@@ -5515,7 +5515,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "oE" = (
 /obj/machinery/power/compressor{
 	comp_id = "syndie_lavaland_incineratorturbine";
@@ -5524,33 +5524,33 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/engine/vacuum,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "oF" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "oG" = (
 /obj/machinery/power/turbine{
 	luminosity = 2
 	},
 /obj/structure/cable,
 /turf/open/floor/engine/vacuum,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "oH" = (
 /obj/machinery/door/poddoor/incinerator_syndicatelava_main,
 /turf/open/floor/engine/vacuum,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "oI" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
 	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "oP" = (
 /obj/structure/sign/departments/chemistry,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "pJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -5560,35 +5560,35 @@
 	name = "Nitrogen Out"
 	},
 /turf/open/floor/engine/n2,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "pQ" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = 32
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "qG" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = -32
 	},
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "rg" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/n2,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "rF" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/plating/airless,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "sc" = (
 /turf/open/floor/engine/o2,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "sl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "sw" = (
 /obj/effect/spawner/random/vending/snackvend{
 	hacked = 1
@@ -5605,34 +5605,34 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "sP" = (
 /obj/structure/cable,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "ta" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange{
 	dir = 8
 	},
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating/airless,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "tW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "uB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 5
 	},
 /obj/structure/cable,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "vu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "vX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
@@ -5640,17 +5640,17 @@
 	name = "Plasma Layer Manifold"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "wi" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
 	dir = 8;
 	volume_rate = 200
 	},
 /turf/open/floor/plating/lavaland_atmos,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "xn" = (
 /turf/open/floor/engine/n2,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "yg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8;
@@ -5660,18 +5660,18 @@
 	name = "Oxygen Out"
 	},
 /turf/open/floor/engine/o2,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "AH" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "BC" = (
 /obj/machinery/meter/turf,
 /turf/open/floor/engine/co2,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "BF" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor,
@@ -5682,7 +5682,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "Cg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -5691,7 +5691,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "CG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 10
@@ -5700,29 +5700,29 @@
 	dir = 10
 	},
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "DF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "DL" = (
 /obj/structure/sign/warning/explosives/alt{
 	pixel_x = 32
 	},
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "Ec" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "Ed" = (
 /obj/machinery/portable_atmospherics/canister/tier_3,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "Ev" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/rag{
@@ -5735,7 +5735,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "EZ" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "150"
@@ -5743,7 +5743,7 @@
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "FN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/beer,
@@ -5759,7 +5759,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/ruin/powered/syndicate_lava_base/bar)
+/area/ruin/syndicate_lava_base/bar)
 "Hu" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/bot,
@@ -5769,17 +5769,17 @@
 	name = "N2 to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "IH" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating/airless,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "IJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "IU" = (
 /obj/effect/baseturf_helper/lava_land/surface,
 /turf/template_noop,
@@ -5790,33 +5790,33 @@
 	name = "Plasma to Mix"
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "Lg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "Lp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "LQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "Ng" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "NF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "Oq" = (
 /obj/effect/spawner/random/vending/colavend{
 	hacked = 1
@@ -5829,35 +5829,35 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "Qv" = (
 /obj/structure/closet/firecloset/full{
 	anchored = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "Rl" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/o2,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "Rq" = (
 /obj/machinery/meter/turf,
 /turf/open/floor/engine/plasma,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "RE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 9
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "RK" = (
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "RV" = (
 /obj/structure/sign/warning/fire,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "St" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external{
@@ -5867,7 +5867,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/arrivals)
+/area/ruin/syndicate_lava_base/arrivals)
 "Tp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 4
@@ -5876,7 +5876,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "TC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 4
@@ -5885,39 +5885,39 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ruin/powered/syndicate_lava_base/testlab)
+/area/ruin/syndicate_lava_base/testlab)
 "TG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "Vd" = (
 /turf/open/floor/engine/plasma,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "Wt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4{
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/powered/syndicate_lava_base/main)
+/area/ruin/syndicate_lava_base/main)
 "Xd" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "Yt" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/plasma,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "ZN" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/engine/co2,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 "ZU" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/powered/syndicate_lava_base/engineering)
+/area/ruin/syndicate_lava_base/engineering)
 
 (1,1,1) = {"
 IU

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -56,37 +56,37 @@
 
 //Syndicate lavaland base
 
-/area/ruin/powered/syndicate_lava_base/engineering
+/area/ruin/syndicate_lava_base/engineering
 	name = "Syndicate Lavaland Engineering"
 
-/area/ruin/powered/syndicate_lava_base/medbay
+/area/ruin/syndicate_lava_base/medbay
 	name = "Syndicate Lavaland Medbay"
 
-/area/ruin/powered/syndicate_lava_base/arrivals
+/area/ruin/syndicate_lava_base/arrivals
 	name = "Syndicate Lavaland Arrivals"
 
-/area/ruin/powered/syndicate_lava_base/bar
+/area/ruin/syndicate_lava_base/bar
 	name = "\improper Syndicate Lavaland Bar"
 
-/area/ruin/powered/syndicate_lava_base/main
+/area/ruin/syndicate_lava_base/main
 	name = "\improper Syndicate Lavaland Primary Hallway"
 
-/area/ruin/powered/syndicate_lava_base/cargo
+/area/ruin/syndicate_lava_base/cargo
 	name = "\improper Syndicate Lavaland Cargo Bay"
 
-/area/ruin/powered/syndicate_lava_base/chemistry
+/area/ruin/syndicate_lava_base/chemistry
 	name = "Syndicate Lavaland Chemistry"
 
-/area/ruin/powered/syndicate_lava_base/virology
+/area/ruin/syndicate_lava_base/virology
 	name = "Syndicate Lavaland Virology"
 
-/area/ruin/powered/syndicate_lava_base/testlab
+/area/ruin/syndicate_lava_base/testlab
 	name = "\improper Syndicate Lavaland Experimentation Lab"
 
-/area/ruin/powered/syndicate_lava_base/dormitories
+/area/ruin/syndicate_lava_base/dormitories
 	name = "\improper Syndicate Lavaland Dormitories"
 
-/area/ruin/powered/syndicate_lava_base/telecomms
+/area/ruin/syndicate_lava_base/telecomms
 	name = "\improper Syndicate Lavaland Telecommunications"
 
 //Xeno Nest

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -44,7 +44,7 @@
 	name = "\improper Elephant Graveyard"
 	icon_state = "green"
 
-/area/ruin/powered/syndicate_lava_base
+/area/ruin/syndicate_lava_base
 	name = "\improper Secret Base"
 	icon_state = "dk_yellow"
 	ambience_index = AMBIENCE_DANGER

--- a/code/game/area/areas/ruins/lavaland.dm
+++ b/code/game/area/areas/ruins/lavaland.dm
@@ -1,4 +1,5 @@
 //Lavaland Ruins
+//NOTICE: /unpowered means you never get power. Thanks Fikou
 
 /area/ruin/powered/beach
 	icon_state = "dk_yellow"
@@ -43,7 +44,7 @@
 	name = "\improper Elephant Graveyard"
 	icon_state = "green"
 
-/area/ruin/unpowered/syndicate_lava_base
+/area/ruin/powered/syndicate_lava_base
 	name = "\improper Secret Base"
 	icon_state = "dk_yellow"
 	ambience_index = AMBIENCE_DANGER
@@ -55,37 +56,37 @@
 
 //Syndicate lavaland base
 
-/area/ruin/unpowered/syndicate_lava_base/engineering
+/area/ruin/powered/syndicate_lava_base/engineering
 	name = "Syndicate Lavaland Engineering"
 
-/area/ruin/unpowered/syndicate_lava_base/medbay
+/area/ruin/powered/syndicate_lava_base/medbay
 	name = "Syndicate Lavaland Medbay"
 
-/area/ruin/unpowered/syndicate_lava_base/arrivals
+/area/ruin/powered/syndicate_lava_base/arrivals
 	name = "Syndicate Lavaland Arrivals"
 
-/area/ruin/unpowered/syndicate_lava_base/bar
+/area/ruin/powered/syndicate_lava_base/bar
 	name = "\improper Syndicate Lavaland Bar"
 
-/area/ruin/unpowered/syndicate_lava_base/main
+/area/ruin/powered/syndicate_lava_base/main
 	name = "\improper Syndicate Lavaland Primary Hallway"
 
-/area/ruin/unpowered/syndicate_lava_base/cargo
+/area/ruin/powered/syndicate_lava_base/cargo
 	name = "\improper Syndicate Lavaland Cargo Bay"
 
-/area/ruin/unpowered/syndicate_lava_base/chemistry
+/area/ruin/powered/syndicate_lava_base/chemistry
 	name = "Syndicate Lavaland Chemistry"
 
-/area/ruin/unpowered/syndicate_lava_base/virology
+/area/ruin/powered/syndicate_lava_base/virology
 	name = "Syndicate Lavaland Virology"
 
-/area/ruin/unpowered/syndicate_lava_base/testlab
+/area/ruin/powered/syndicate_lava_base/testlab
 	name = "\improper Syndicate Lavaland Experimentation Lab"
 
-/area/ruin/unpowered/syndicate_lava_base/dormitories
+/area/ruin/powered/syndicate_lava_base/dormitories
 	name = "\improper Syndicate Lavaland Dormitories"
 
-/area/ruin/unpowered/syndicate_lava_base/telecomms
+/area/ruin/powered/syndicate_lava_base/telecomms
 	name = "\improper Syndicate Lavaland Telecommunications"
 
 //Xeno Nest


### PR DESCRIPTION
## About The Pull Request

#62003 made it so that /unpowered areas actually do what they say they do. Unfortunately, previous mappers used /unpowered on areas that required powered. /unpowered currently makes it impossible to power a ruin.

## Why It's Good For The Game

Fixes: #62074
There's a lot of these that are probably broken, so I'm gonna go through and check these fixing them as I go.

## Changelog

:cl:
fix: The Lavaland Syndicate Base is now Powered again.
code: repathed /unpowered Syndicate Base areas to /powered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
