### PR TITLE
FIxes combat hypospray locking out to 5u transfer when used in hand.

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -70,6 +70,7 @@
 	inhand_icon_state = "combat_hypo"
 	icon_state = "combat_hypo"
 	volume = 90
+	possible_transfer_amounts = list(5,10)
 	ignore_flags = 1 // So they can heal their comrades.
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 30, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/atropine = 15)
 
@@ -92,6 +93,7 @@
 	inhand_icon_state = "holy_hypo"
 	icon_state = "holy_hypo"
 	volume = 250
+	possible_transfer_amounts = list(5,10,15,20,25,30,50)
 	list_reagents = list(/datum/reagent/water/holywater = 150, /datum/reagent/peaceborg/tire = 50, /datum/reagent/peaceborg/confuse = 50)
 	amount_per_transfer_from_this = 50
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -33,8 +33,8 @@
 
 	//Always log attemped injects for admins
 	var/list/injected = list()
-	for(var/datum/reagent/reagent in reagents.reagent_list)
-		injected += reagent.name
+	for(var/datum/reagent/injected_reagent in reagents.reagent_list)
+		injected += injected_reagent.name
 	var/contained = english_list(injected)
 	log_combat(user, affected_mob, "attempted to inject", src, "([contained])")
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -20,15 +20,15 @@
 /obj/item/reagent_containers/hypospray/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)
 
-/obj/item/reagent_containers/hypospray/attack(mob/living/mob, mob/user)
-	inject(mob, user)
+/obj/item/reagent_containers/hypospray/attack(mob/living/affected_mob, mob/user)
+	inject(affected_mob, user)
 
 ///Handles all injection checks, injection and logging.
-/obj/item/reagent_containers/hypospray/proc/inject(mob/living/mob, mob/user)
+/obj/item/reagent_containers/hypospray/proc/inject(mob/living/affected_mob, mob/user)
 	if(!reagents.total_volume)
 		to_chat(user, span_warning("[src] is empty!"))
 		return FALSE
-	if(!iscarbon(mob))
+	if(!iscarbon(affected_mob))
 		return FALSE
 
 	//Always log attemped injects for admins
@@ -36,23 +36,23 @@
 	for(var/datum/reagent/reagent in reagents.reagent_list)
 		injected += reagent.name
 	var/contained = english_list(injected)
-	log_combat(user, mob, "attempted to inject", src, "([contained])")
+	log_combat(user, affected_mob, "attempted to inject", src, "([contained])")
 
-	if(reagents.total_volume && (ignore_flags || mob.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE))) // Ignore flag should be checked first or there will be an error message.
-		to_chat(mob, span_warning("You feel a tiny prick!"))
-		to_chat(user, span_notice("You inject [mob] with [src]."))
+	if(reagents.total_volume && (ignore_flags || affected_mob.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE))) // Ignore flag should be checked first or there will be an error message.
+		to_chat(affected_mob, span_warning("You feel a tiny prick!"))
+		to_chat(user, span_notice("You inject [affected_mob] with [src]."))
 		var/fraction = min(amount_per_transfer_from_this/reagents.total_volume, 1)
 
 
-		if(mob.reagents)
+		if(affected_mob.reagents)
 			var/trans = 0
 			if(!infinite)
-				trans = reagents.trans_to(mob, amount_per_transfer_from_this, transfered_by = user, methods = INJECT)
+				trans = reagents.trans_to(affected_mob, amount_per_transfer_from_this, transfered_by = user, methods = INJECT)
 			else
-				reagents.expose(mob, INJECT, fraction)
-				trans = reagents.copy_to(mob, amount_per_transfer_from_this)
+				reagents.expose(affected_mob, INJECT, fraction)
+				trans = reagents.copy_to(affected_mob, amount_per_transfer_from_this)
 			to_chat(user, span_notice("[trans] unit\s injected. [reagents.total_volume] unit\s remaining in [src]."))
-			log_combat(user, mob, "injected", src, "([contained])")
+			log_combat(user, affected_mob, "injected", src, "([contained])")
 		return TRUE
 	return FALSE
 
@@ -121,7 +121,7 @@
 	user.visible_message(span_suicide("[user] begins to choke on \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return OXYLOSS//ironic. he could save others from oxyloss, but not himself.
 
-/obj/item/reagent_containers/hypospray/medipen/inject(mob/living/M, mob/user)
+/obj/item/reagent_containers/hypospray/medipen/inject(mob/living/affected_mob, mob/user)
 	. = ..()
 	if(.)
 		reagents.maximum_volume = 0 //Makes them useless afterwards
@@ -232,9 +232,9 @@
 	base_icon_state = "stimpen"
 	volume = 30
 	amount_per_transfer_from_this = 30
-	list_reagents = list( /datum/reagent/medicine/epinephrine = 8, /datum/reagent/medicine/c2/aiuri = 8, /datum/reagent/medicine/c2/libital = 8 ,/datum/reagent/medicine/leporazine = 6)
+	list_reagents = list( /datum/reagent/medicine/epinephrine = 8, /datum/reagent/medicine/c2/aiuri = 8, /datum/reagent/medicine/c2/libital = 8, /datum/reagent/medicine/leporazine = 6)
 
-/obj/item/reagent_containers/hypospray/medipen/survival/inject(mob/living/mob, mob/user)
+/obj/item/reagent_containers/hypospray/medipen/survival/inject(mob/living/affected_mob, mob/user)
 	if(lavaland_equipment_pressure_check(get_turf(user)))
 		amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
 		return ..()
@@ -244,7 +244,7 @@
 		return
 
 	to_chat(user,span_notice("You start manually releasing the low-pressure gauge..."))
-	if(!do_mob(user, mob, 10 SECONDS, interaction_key = DOAFTER_SOURCE_SURVIVALPEN))
+	if(!do_mob(user, affected_mob, 10 SECONDS, interaction_key = DOAFTER_SOURCE_SURVIVALPEN))
 		return
 
 	amount_per_transfer_from_this = initial(amount_per_transfer_from_this) * 0.5

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -20,8 +20,8 @@
 /obj/item/reagent_containers/hypospray/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)
 
-/obj/item/reagent_containers/hypospray/attack(mob/living/M, mob/user)
-	inject(M, user)
+/obj/item/reagent_containers/hypospray/attack(mob/living/mob, mob/user)
+	inject(mob, user)
 
 ///Handles all injection checks, injection and logging.
 /obj/item/reagent_containers/hypospray/proc/inject(mob/living/mob, mob/user)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -24,35 +24,35 @@
 	inject(M, user)
 
 ///Handles all injection checks, injection and logging.
-/obj/item/reagent_containers/hypospray/proc/inject(mob/living/M, mob/user)
+/obj/item/reagent_containers/hypospray/proc/inject(mob/living/mob, mob/user)
 	if(!reagents.total_volume)
 		to_chat(user, span_warning("[src] is empty!"))
 		return FALSE
-	if(!iscarbon(M))
+	if(!iscarbon(mob))
 		return FALSE
 
 	//Always log attemped injects for admins
 	var/list/injected = list()
-	for(var/datum/reagent/R in reagents.reagent_list)
-		injected += R.name
+	for(var/datum/reagent/reagent in reagents.reagent_list)
+		injected += reagent.name
 	var/contained = english_list(injected)
-	log_combat(user, M, "attempted to inject", src, "([contained])")
+	log_combat(user, mob, "attempted to inject", src, "([contained])")
 
-	if(reagents.total_volume && (ignore_flags || M.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE))) // Ignore flag should be checked first or there will be an error message.
-		to_chat(M, span_warning("You feel a tiny prick!"))
-		to_chat(user, span_notice("You inject [M] with [src]."))
+	if(reagents.total_volume && (ignore_flags || mob.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE))) // Ignore flag should be checked first or there will be an error message.
+		to_chat(mob, span_warning("You feel a tiny prick!"))
+		to_chat(user, span_notice("You inject [mob] with [src]."))
 		var/fraction = min(amount_per_transfer_from_this/reagents.total_volume, 1)
 
 
-		if(M.reagents)
+		if(mob.reagents)
 			var/trans = 0
 			if(!infinite)
-				trans = reagents.trans_to(M, amount_per_transfer_from_this, transfered_by = user, methods = INJECT)
+				trans = reagents.trans_to(mob, amount_per_transfer_from_this, transfered_by = user, methods = INJECT)
 			else
-				reagents.expose(M, INJECT, fraction)
-				trans = reagents.copy_to(M, amount_per_transfer_from_this)
+				reagents.expose(mob, INJECT, fraction)
+				trans = reagents.copy_to(mob, amount_per_transfer_from_this)
 			to_chat(user, span_notice("[trans] unit\s injected. [reagents.total_volume] unit\s remaining in [src]."))
-			log_combat(user, M, "injected", src, "([contained])")
+			log_combat(user, mob, "injected", src, "([contained])")
 		return TRUE
 	return FALSE
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -93,7 +93,7 @@
 	inhand_icon_state = "holy_hypo"
 	icon_state = "holy_hypo"
 	volume = 250
-	possible_transfer_amounts = list(5,10,15,20,25,30,50)
+	possible_transfer_amounts = list(25,50)
 	list_reagents = list(/datum/reagent/water/holywater = 150, /datum/reagent/peaceborg/tire = 50, /datum/reagent/peaceborg/confuse = 50)
 	amount_per_transfer_from_this = 50
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -234,7 +234,7 @@
 	amount_per_transfer_from_this = 30
 	list_reagents = list( /datum/reagent/medicine/epinephrine = 8, /datum/reagent/medicine/c2/aiuri = 8, /datum/reagent/medicine/c2/libital = 8 ,/datum/reagent/medicine/leporazine = 6)
 
-/obj/item/reagent_containers/hypospray/medipen/survival/inject(mob/living/M, mob/user)
+/obj/item/reagent_containers/hypospray/medipen/survival/inject(mob/living/mob, mob/user)
 	if(lavaland_equipment_pressure_check(get_turf(user)))
 		amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
 		return ..()
@@ -244,7 +244,7 @@
 		return
 
 	to_chat(user,span_notice("You start manually releasing the low-pressure gauge..."))
-	if(!do_mob(user, M, 10 SECONDS, interaction_key = DOAFTER_SOURCE_SURVIVALPEN))
+	if(!do_mob(user, mob, 10 SECONDS, interaction_key = DOAFTER_SOURCE_SURVIVALPEN))
 		return
 
 	amount_per_transfer_from_this = initial(amount_per_transfer_from_this) * 0.5


### PR DESCRIPTION
## About The Pull Request
Adds several transfer values to the combat hypospray variant.

## Why It's Good For The Game
I used a nukie combat hypospray in hand and i locked myself to 5u injections of the chem mix since you can't switch back to 10u injection rate. This fixes that

## Changelog
:cl:
fix: fixes combat hypospray locking itself out from 10u transfers to 5u when used in-hand
/:cl:
