### PR TITLE
Bullets only directly damage the SM so much

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -829,7 +829,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				investigate_log("has been powered for the first time.", INVESTIGATE_SUPERMATTER)
 				message_admins("[src] has been powered for the first time [ADMIN_JMP(src)].")
 				has_been_powered = TRUE
-	else if(takes_damage & (damage < emergency_point))
+	else if(takes_damage && (damage < emergency_point))
 		damage += projectile.damage * bullet_energy
 	return BULLET_ACT_HIT
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -832,7 +832,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	else if(takes_damage)
 		damage += (projectile.damage * bullet_energy) * clamp((emergency_point - damage) / emergency_point, 0, 1)
 		if(damage > damage_penalty_point)
-			visible_message(span_notice("The [src] compresses under stress, resisting further impacts!"))
+			visible_message(span_notice("[src] compresses under stress, resisting further impacts!"))
 	return BULLET_ACT_HIT
 
 /obj/machinery/power/supermatter_crystal/singularity_act()

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -829,7 +829,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				investigate_log("has been powered for the first time.", INVESTIGATE_SUPERMATTER)
 				message_admins("[src] has been powered for the first time [ADMIN_JMP(src)].")
 				has_been_powered = TRUE
-	else if(takes_damage)
+	else if(takes_damage & (damage < emergency_point))
 		damage += projectile.damage * bullet_energy
 	return BULLET_ACT_HIT
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -829,8 +829,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				investigate_log("has been powered for the first time.", INVESTIGATE_SUPERMATTER)
 				message_admins("[src] has been powered for the first time [ADMIN_JMP(src)].")
 				has_been_powered = TRUE
-	else if(takes_damage && (damage < emergency_point))
-		damage += projectile.damage * bullet_energy
+	else if(takes_damage)
+		damage += (projectile.damage * bullet_energy) * clamp((emergency_point - damage) / emergency_point, 0, 1)
 	return BULLET_ACT_HIT
 
 /obj/machinery/power/supermatter_crystal/singularity_act()

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -831,6 +831,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				has_been_powered = TRUE
 	else if(takes_damage)
 		damage += (projectile.damage * bullet_energy) * clamp((emergency_point - damage) / emergency_point, 0, 1)
+		if(damage > damage_penalty_point)
+			visible_message(span_notice("The [src] compresses under stress, resisting further impacts!"))
 	return BULLET_ACT_HIT
 
 /obj/machinery/power/supermatter_crystal/singularity_act()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Requested by @Mothblocks as an alternative to #62073

There is a broad consensus that being able to trigger an instantaneous delamination within the first few minutes of the round is not fun. The point has also been made that this is a valid antag strategy, and antag freedom is a policy. An antagonist has a legitimate reason to speed up a delamination, and if they invest the TC (or other effort), they should be able to do so.


## Why It's Good For The Game

This tries to strike a happy medium. The bullet damage to the crystal now drops off linearly. It receives full damage from bullets at full health, and drops to 0 damage at 700 (20% health). 700 is the emergency threshold where the crystal starts screaming for help on the common radio. Beyond this point the crystal needs to delaminate via the usual mechanisms that damage it.

This allows the antagonist to substantially accelerate a delamination, but gives the crew a chance to respond.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: The super matter crystal can no longer be immediately delaminated by firing a gun into it, only brought close to the delamination threshold.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
