### PR TITLE
Changes Plasmamen belt tanks volume and the rate that their lungs consume plasma to 1/4 of the previous value.

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -39,6 +39,8 @@
 #define TANK_MAX_RELEASE_PRESSURE (ONE_ATMOSPHERE*3)
 /// The default initial value gas tanks release valves are set to. (At least the ones containing pure plasma/oxygen.)
 #define TANK_DEFAULT_RELEASE_PRESSURE 16
+/// The default initial value gas plasmamen tanks releases valves are set to.
+#define TANK_PLASMAMAN_RELEASE_PRESSURE 4
 /// The internal temperature in kelvins at which a handheld gas tank begins to take damage.
 #define TANK_MELT_TEMPERATURE 1000000
 /// The internal pressure in kPa at which a handheld gas tank begins to take damage.

--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -106,7 +106,7 @@
 	inhand_icon_state = "plasmaman_tank"
 	tank_holder_icon_state = null
 	force = 10
-	distribute_pressure = TANK_DEFAULT_RELEASE_PRESSURE
+	distribute_pressure = TANK_PLASMAMAN_RELEASE_PRESSURE
 
 /obj/item/tank/internals/plasmaman/populate_gas()
 	air_contents.assert_gas(/datum/gas/plasma)
@@ -125,7 +125,7 @@
 	worn_icon = null
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
-	volume = 24 //enough so they need to refill but not that often to be a chore
+	volume = 6 //same size as the engineering ones but plasmamen have special lungs that consume less plasma per breath
 	w_class = WEIGHT_CLASS_SMALL //thanks i forgot this
 
 /obj/item/tank/internals/plasmaman/belt/full/populate_gas()

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -497,7 +497,7 @@
 	icon_state = "lungs-plasma"
 
 	safe_oxygen_min = 0 //We don't breathe this
-	safe_plasma_min = 16 //We breathe THIS!
+	safe_plasma_min = 4 //We breathe THIS!
 	safe_plasma_max = 0
 
 /obj/item/organ/lungs/slime

--- a/code/modules/unit_tests/breath.dm
+++ b/code/modules/unit_tests/breath.dm
@@ -32,5 +32,44 @@
 
 	TEST_ASSERT(!lab_rat.has_alert("not_enough_oxy"), "Humans can't get a full breath from the standard initial_gas_mix on a turf")
 
+/datum/unit_test/breath_sanity_plasmamen
+
+/datum/unit_test/breath_sanity_plasmamen/Run()
+	var/mob/living/carbon/human/species/plasma/lab_rat = allocate(/mob/living/carbon/human/species/plasma)
+	var/obj/item/clothing/mask/breath/tube = allocate(/obj/item/clothing/mask/breath)
+	var/obj/item/tank/internals/plasmaman/source = allocate(/obj/item/tank/internals/plasmaman)
+
+	lab_rat.equip_to_slot_if_possible(tube, ITEM_SLOT_MASK)
+	lab_rat.equip_to_slot_if_possible(source, ITEM_SLOT_HANDS)
+	source.toggle_internals(lab_rat)
+
+	lab_rat.breathe()
+
+	TEST_ASSERT(!lab_rat.has_alert("not_enough_plas"), "Plasmamen can't get a full breath from standard plasma tanks")
+	lab_rat.clear_alert("not_enough_plas")
+
+	//Prep the mob
+	lab_rat.forceMove(run_loc_floor_bottom_left)
+	source.toggle_internals(lab_rat)
+	TEST_ASSERT(!lab_rat.internal, "toggle_internals() failed to toggle internals")
+
+/datum/unit_test/breath_sanity_ashwalker
+
+/datum/unit_test/breath_sanity_ashwalker/Run()
+	var/mob/living/carbon/human/species/lizard/ashwalker/lab_rat = allocate(/mob/living/carbon/human/species/lizard/ashwalker)
+
+	//Prep the mob
+	lab_rat.forceMove(run_loc_floor_bottom_left)
+
+	var/turf/open/to_fill = run_loc_floor_bottom_left
+	//Prep the floor
+	to_fill.initial_gas_mix = LAVALAND_DEFAULT_ATMOS
+	to_fill.air = new
+	to_fill.air.copy_from_turf(to_fill)
+
+	lab_rat.breathe()
+
+	TEST_ASSERT(!lab_rat.has_alert("not_enough_oxy"), "Ashwalkers can't get a full breath from the standard initial_gas_mix on a turf")
+
 
 

--- a/code/modules/unit_tests/breath.dm
+++ b/code/modules/unit_tests/breath.dm
@@ -76,4 +76,4 @@
 	//Reset initial_gas_mix to avoid future issues on other tests
 	var/turf/open/to_fill = run_loc_floor_bottom_left
 	to_fill.initial_gas_mix = OPENTURF_DEFAULT_ATMOS
-
+	return ..()

--- a/code/modules/unit_tests/breath.dm
+++ b/code/modules/unit_tests/breath.dm
@@ -72,6 +72,8 @@
 
 	TEST_ASSERT(!lab_rat.has_alert("not_enough_oxy"), "Ashwalkers can't get a full breath from the Lavaland's initial_gas_mix on a turf")
 
+/datum/unit_test/breath_sanity_ashwalker/Destroy()
 	//Reset initial_gas_mix to avoid future issues on other tests
+	var/turf/open/to_fill = run_loc_floor_bottom_left
 	to_fill.initial_gas_mix = OPENTURF_DEFAULT_ATMOS
 

--- a/code/modules/unit_tests/breath.dm
+++ b/code/modules/unit_tests/breath.dm
@@ -32,6 +32,7 @@
 
 	TEST_ASSERT(!lab_rat.has_alert("not_enough_oxy"), "Humans can't get a full breath from the standard initial_gas_mix on a turf")
 
+/// Tests to make sure plasmaman can breath from their internal tanks
 /datum/unit_test/breath_sanity_plasmamen
 
 /datum/unit_test/breath_sanity_plasmamen/Run()
@@ -45,14 +46,14 @@
 
 	lab_rat.breathe()
 
-	TEST_ASSERT(!lab_rat.has_alert("not_enough_plas"), "Plasmamen can't get a full breath from standard plasma tanks")
+	TEST_ASSERT(!lab_rat.has_alert("not_enough_plas"), "Plasmamen can't get a full breath from a standard plasma tank")
 	lab_rat.clear_alert("not_enough_plas")
 
 	//Prep the mob
-	lab_rat.forceMove(run_loc_floor_bottom_left)
 	source.toggle_internals(lab_rat)
-	TEST_ASSERT(!lab_rat.internal, "toggle_internals() failed to toggle internals")
+	TEST_ASSERT(!lab_rat.internal, "Plasmaman toggle_internals() failed to toggle internals")
 
+/// Tests to make sure ashwalkers can breath from the lavaland air
 /datum/unit_test/breath_sanity_ashwalker
 
 /datum/unit_test/breath_sanity_ashwalker/Run()
@@ -69,7 +70,8 @@
 
 	lab_rat.breathe()
 
-	TEST_ASSERT(!lab_rat.has_alert("not_enough_oxy"), "Ashwalkers can't get a full breath from the standard initial_gas_mix on a turf")
+	TEST_ASSERT(!lab_rat.has_alert("not_enough_oxy"), "Ashwalkers can't get a full breath from the Lavaland's initial_gas_mix on a turf")
 
-
+	//Reset initial_gas_mix to avoid future issues on other tests
+	to_fill.initial_gas_mix = OPENTURF_DEFAULT_ATMOS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Plasmamen belt tank volume is 24, the extended engineering one is 6 and the emergency internals are 3.
The issue balance wise is that all of those have the same pocket size and can be printed at the same Research tier, this results on smart atmos/engineers printing a plasmamen belt tank and filling it with O2 so their internals can last for almost 2 hours instead of the 24 minutes of the extended O2.

Now they have the same volume but plasmamen lungs were rebalanced to consume plasma at a lower rate. To be clear, it will have no effect on how long the internal last for a plasmamen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes a no skill trick that gives you internals that will last for all shift, you can still make those but it will take a tiny bit of effort now.

Also a small step to make internals balanced.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Guillaume Prata
balance: Plasmamen belt tanks volume and the rate that their lungs consume plasma got lowered to 1/4 to stop the easy 2 hour long O2 inside a plasmamen belt tank trick. It doesn't change how long the internals last for plasmamen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
