### PR TITLE
Butter bear attack fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -176,7 +176,7 @@
 		to_chat(src, span_notice("Your name is now <b>\"new_name\"</b>!"))
 		name = new_name
 
-/mob/living/simple_animal/hostile/bear/butter/AttackingTarget() //Makes some attacks by the butter bear slip those who dare cross its path.
+/mob/living/simple_animal/hostile/bear/butter/AttackingTarget() //Makes the butter bear's attacks against vertical targets slip said targets
 	. = ..()
 	if(. && isliving(target))
 		var/mob/living/L = target

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -136,6 +136,7 @@
 	obj_damage = 11
 	melee_damage_lower = 0
 	melee_damage_upper = 0
+	sharpness = NONE //it's made of butter
 	armour_penetration = 0
 	response_harm_continuous = "takes a bite out of"
 	response_harm_simple = "take a bite out of"

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -134,8 +134,8 @@
 	desc = "I can't believe its not a bear!"
 	faction = list("neutral", "russian")
 	obj_damage = 11
-	melee_damage_lower = 1
-	melee_damage_upper = 1
+	melee_damage_lower = 0
+	melee_damage_upper = 0
 	armour_penetration = 0
 	response_harm_continuous = "takes a bite out of"
 	response_harm_simple = "take a bite out of"
@@ -177,9 +177,10 @@
 		name = new_name
 
 /mob/living/simple_animal/hostile/bear/butter/AttackingTarget() //Makes some attacks by the butter bear slip those who dare cross its path.
-	if(isliving(target))
+	. = ..()
+	if(. && isliving(target))
 		var/mob/living/L = target
 		if((L.body_position == STANDING_UP))
 			L.Knockdown(20)
 			playsound(loc, 'sound/misc/slip.ogg', 15)
-			L.visible_message(span_danger("[L] slips on butter!"))
+			L.visible_message(span_danger("[L] slips on [src]'s butter!"))

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -178,7 +178,7 @@
 
 /mob/living/simple_animal/hostile/bear/butter/AttackingTarget() //Makes the butter bear's attacks against vertical targets slip said targets
 	. = ..()
-	if(. && isliving(target))
+	if(isliving(target)) //we don't check for . here, since attack_animal() (and thus AttackingTarget()) will return false if your damage dealt is 0
 		var/mob/living/L = target
 		if((L.body_position == STANDING_UP))
 			L.Knockdown(20)


### PR DESCRIPTION
## About The Pull Request

Butter bears can now attack structures, as they were intended to.

Fugu glanded butter bears can now break down walls, matching the behavior of other fugu glanded mobs.

Butter bears now have a melee_damage_lower of 0 and a melee_damage_upper of 0 instead of a melee_damage_lower of 1 and a melee_damage_upper of 1. Previously, those two variables had no effect on the attacks of butter bears, which always dealt no damage. They now do, meaning that a butter bear wearing bear armor or under the effects of a fugu gland can deal damage with its attacks.

Butter bear attacks are now considered to be blunt instead of sharp for the purposes of wounds.

Fixes https://github.com/tgstation/tgstation/issues/61250.

## Why It's Good For The Game

Butter bears were intended to be able to attack structures, as they were specifically given an obj_damage of 11 (as opposed to the 60 obj_damage of normal bears).

Other fugu glanded mobs can break down walls, the only reason that butter bears couldn't was because their AttackingTarget() code didn't call ..(), which appears to be an oversight.

Other mobs, like Ian, gain the ability to deal damage with their attacks if their melee damage variables are nonzeroes, and butter bears have no reason to be an exception.

Butter bears made of butter and their (lethal) attacks use a slapping sound, so their attacks should be considered to be blunt instead of sharp.

This PR has been tested on a private server.

## Changelog

:cl: ATHATH
fix: Butter bears can now attack objects, as they were intended to.
fix: Fugu glanded butter bears can now break down walls, matching the behavior of other fugu glanded mobs.
fix: Butter bears can now deal damage with their attacks if their melee damage variables (which are zero by default) become nonzero.
fix: Butter bear attacks are now considered to be blunt instead of sharp for the purposes of wounds.
/:cl: