### PR TITLE
the "no organics on shuttle" objective now only counts actually organic creatures

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -394,21 +394,21 @@ GLOBAL_LIST_EMPTY(objectives)
 
 /datum/objective/block
 	name = "no organics on shuttle"
-	explanation_text = "Do not allow any organic lifeforms to escape on the shuttle alive."
+	explanation_text = "Do not allow any organic lifeforms with sapience to escape on the shuttle alive."
 	martyr_compatible = 1
 
 /datum/objective/block/check_completion()
 	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
 		return TRUE
 	for(var/mob/living/player in GLOB.player_list)
-		if(player.mind && player.stat != DEAD && !issilicon(player))
+		if(player.mind && player.stat != DEAD && (player.mob_biotypes & MOB_ORGANIC))
 			if(get_area(player) in SSshuttle.emergency.shuttle_areas)
 				return FALSE
 	return TRUE
 
 /datum/objective/purge
 	name = "no mutants on shuttle"
-	explanation_text = "Ensure no mutant humanoid species are present aboard the escape shuttle."
+	explanation_text = "Ensure no nonhuman humanoid species with sapience are present aboard the escape shuttle."
 	martyr_compatible = TRUE
 
 /datum/objective/purge/check_completion()


### PR DESCRIPTION
## About The Pull Request

The "don't allow any organics to escape on the emergency shuttle alive" objective no longer counts inorganic species like golems, plasmamen, androids, etc.

Some malf AI objectives have had their descriptions updated to reflect them only caring about player-controlled creatures.

## Why It's Good For The Game

Makes this objective both more interesting and harder to misinterpret.

I considered making undead creatures count as being organic for this objective as well, but eh, they're, like, not alive, right? But they count as being alive for other objectives... Fuck it, let's just stick with what the biotype names say.

## Changelog

:cl: ATHATH
fix: The "don't allow any organics to escape on the emergency shuttle alive" objective no longer counts inorganic species like golems, plasmamen, androids, etc.
qol: Some malf AI objectives have had their descriptions updated to reflect them only caring about player-controlled creatures.
/:cl: