### PR TITLE
fixes pink crossbreeding allowing faction removal

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -818,7 +818,7 @@
 	var/faction_name
 
 /datum/status_effect/stabilized/pink/on_apply()
-	faction_name = owner.real_name
+	faction_name = REF(owner)
 	return ..()
 
 /datum/status_effect/stabilized/pink/tick()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

by the faction using real_name instead of a ref like all other factions that point to specific mobs do, the pink crossbreeding potion could be used to strip factions from mobs by setting your real name to the name of the faction and stripping it

## Why It's Good For The Game

exploit fix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: you can no longer exploit the pink crossbreeding power to strip factions from mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
