### PR TITLE
Brings recycling results of advanced tools up to their printing costs

### DIFF
--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -103,20 +103,20 @@
 
 /obj/item/multitool/ai_detect/proc/show_hud(mob/user)
 	if(user && hud_type)
-		var/atom/movable/screen/plane_master/camera_static/PM = user.hud_used.plane_masters["[CAMERA_STATIC_PLANE]"]
-		PM.alpha = 64
-		var/datum/atom_hud/H = GLOB.huds[hud_type]
-		if(!H.hudusers[user])
-			H.add_hud_to(user)
+		var/atom/movable/screen/plane_master/camera_static/ai_detect_plane = user.hud_used.plane_masters["[CAMERA_STATIC_PLANE]"]
+		ai_detect_plane.alpha = 64
+		var/datum/atom_hud/hud = GLOB.huds[hud_type]
+		if(!hud.hudusers[user])
+			hud.add_hud_to(user)
 		eye.eye_user = user
 		eye.setLoc(get_turf(src))
 
 /obj/item/multitool/ai_detect/proc/remove_hud(mob/user)
 	if(user && hud_type)
-		var/atom/movable/screen/plane_master/camera_static/PM = user.hud_used.plane_masters["[CAMERA_STATIC_PLANE]"]
-		PM.alpha = 255
-		var/datum/atom_hud/H = GLOB.huds[hud_type]
-		H.remove_hud_from(user)
+		var/atom/movable/screen/plane_master/camera_static/ai_detect_plane = user.hud_used.plane_masters["[CAMERA_STATIC_PLANE]"]
+		ai_detect_plane.alpha = 255
+		var/datum/atom_hud/hud = GLOB.huds[hud_type]
+		hud.remove_hud_from(user)
 		if(eye)
 			eye.setLoc(null)
 			eye.eye_user = null
@@ -167,6 +167,7 @@
 	desc = "An omni-technological interface."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "multitool"
+	custom_materials = list(/datum/material/iron = 5000, /datum/material/silver = 2500, /datum/material/plasma = 5000, /datum/material/titanium = 2000, /datum/material/diamond = 2000)
 	toolspeed = 0.1
 
 /obj/item/multitool/cyborg

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -36,6 +36,7 @@
 	desc = "A hard-light crowbar. It appears to pry by itself, without any effort required."
 	icon = 'icons/obj/abductor.dmi'
 	usesound = 'sound/weapons/sonic_jackhammer.ogg'
+	custom_materials = list(/datum/material/iron = 5000, /datum/material/silver = 2500, /datum/material/plasma = 1000, /datum/material/titanium = 2000, /datum/material/diamond = 2000)
 	icon_state = "crowbar"
 	toolspeed = 0.1
 
@@ -67,7 +68,7 @@
 	worn_icon_state = "jawsoflife"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	custom_materials = list(/datum/material/iron=150,/datum/material/silver=50,/datum/material/titanium=25)
+	custom_materials = list(/datum/material/iron = 4500, /datum/material/silver = 2500, /datum/material/titanium = 3500)
 	usesound = 'sound/items/jaws_pry.ogg'
 	force = 15
 	toolspeed = 0.7
@@ -115,23 +116,23 @@
 		user.visible_message(span_suicide("[user] is wrapping \the [src] around [user.p_their()] neck. It looks like [user.p_theyre()] trying to rip [user.p_their()] head off!"))
 		playsound(loc, 'sound/items/jaws_cut.ogg', 50, TRUE, -1)
 		if(iscarbon(user))
-			var/mob/living/carbon/C = user
-			var/obj/item/bodypart/BP = C.get_bodypart(BODY_ZONE_HEAD)
-			if(BP)
-				BP.drop_limb()
+			var/mob/living/carbon/suicide_victim = user
+			var/obj/item/bodypart/target_bodypart = suicide_victim.get_bodypart(BODY_ZONE_HEAD)
+			if(target_bodypart)
+				target_bodypart.drop_limb()
 				playsound(loc, "desecration", 50, TRUE, -1)
 	return (BRUTELOSS)
 
-/obj/item/crowbar/power/attack(mob/living/carbon/C, mob/user)
-	if(istype(C) && C.handcuffed && tool_behaviour == TOOL_WIRECUTTER)
-		user.visible_message(span_notice("[user] cuts [C]'s restraints with [src]!"))
-		qdel(C.handcuffed)
+/obj/item/crowbar/power/attack(mob/living/carbon/attacked_carbon, mob/user)
+	if(istype(attacked_carbon) && attacked_carbon.handcuffed && tool_behaviour == TOOL_WIRECUTTER)
+		user.visible_message(span_notice("[user] cuts [attacked_carbon]'s restraints with [src]!"))
+		qdel(attacked_carbon.handcuffed)
 		return
-	else if(istype(C) && C.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND) && tool_behaviour == TOOL_WIRECUTTER)
-		user.visible_message(span_notice("[user] attempts to cut the durathread strand from around [C]'s neck."))
-		if(do_after(user, 1.5 SECONDS, C))
-			user.visible_message(span_notice("[user] succesfully cuts the durathread strand from around [C]'s neck."))
-			C.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
+	else if(istype(attacked_carbon) && attacked_carbon.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND) && tool_behaviour == TOOL_WIRECUTTER)
+		user.visible_message(span_notice("[user] attempts to cut the durathread strand from around [attacked_carbon]'s neck."))
+		if(do_after(user, 1.5 SECONDS, attacked_carbon))
+			user.visible_message(span_notice("[user] succesfully cuts the durathread strand from around [attacked_carbon]'s neck."))
+			attacked_carbon.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
 			playsound(loc, usesound, 50, TRUE, -1)
 		return
 	else

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -60,6 +60,7 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "screwdriver_a"
 	inhand_icon_state = "screwdriver_nuke"
+	custom_materials = list(/datum/material/iron=5000, /datum/material/silver=2500, /datum/material/plasma = 1000, /datum/material/titanium = 2000, /datum/material/diamond = 2000)
 	usesound = 'sound/items/pshoom.ogg'
 	toolspeed = 0.1
 	random_color = FALSE
@@ -78,7 +79,7 @@
 	worn_icon_state = "drill"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	custom_materials = list(/datum/material/iron=150,/datum/material/silver=50,/datum/material/titanium=25) //done for balance reasons, making them high value for research, but harder to get
+	custom_materials = list(/datum/material/iron=3500, /datum/material/silver=1500, /datum/material/titanium=2500) //what research value?
 	force = 8 //might or might not be too high, subject to change
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 8

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -99,11 +99,11 @@
 	return (FIRELOSS)
 
 
-/obj/item/weldingtool/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		flamethrower_screwdriver(I, user)
-	else if(istype(I, /obj/item/stack/rods))
-		flamethrower_rods(I, user)
+/obj/item/weldingtool/attackby(obj/item/tool, mob/user, params)
+	if(tool.tool_behaviour == TOOL_SCREWDRIVER)
+		flamethrower_screwdriver(tool, user)
+	else if(istype(tool, /obj/item/stack/rods))
+		flamethrower_rods(tool, user)
 	else
 		. = ..()
 	update_appearance()
@@ -113,24 +113,24 @@
 	dyn_explosion(src, plasmaAmount/5, explosion_cause = src)//20 plasma in a standard welder has a 4 power explosion. no breaches, but enough to kill/dismember holder
 	qdel(src)
 
-/obj/item/weldingtool/attack(mob/living/carbon/human/H, mob/living/user)
-	if(!istype(H))
+/obj/item/weldingtool/attack(mob/living/carbon/human/attacked_humanoid, mob/living/user)
+	if(!istype(attacked_humanoid))
 		return ..()
 
-	var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
+	var/obj/item/bodypart/affecting = attacked_humanoid.get_bodypart(check_zone(user.zone_selected))
 
 	if(affecting && affecting.status == BODYPART_ROBOTIC && !user.combat_mode)
-		if(src.use_tool(H, user, 0, volume=50, amount=1))
-			if(user == H)
-				user.visible_message(span_notice("[user] starts to fix some of the dents on [H]'s [affecting.name]."),
-					span_notice("You start fixing some of the dents on [H == user ? "your" : "[H]'s"] [affecting.name]."))
-				if(!do_mob(user, H, 50))
+		if(src.use_tool(attacked_humanoid, user, 0, volume=50, amount=1))
+			if(user == attacked_humanoid)
+				user.visible_message(span_notice("[user] starts to fix some of the dents on [attacked_humanoid]'s [affecting.name]."),
+					span_notice("You start fixing some of the dents on [attacked_humanoid == user ? "your" : "[attacked_humanoid]'s"] [affecting.name]."))
+				if(!do_mob(user, attacked_humanoid, 50))
 					return
-			item_heal_robotic(H, user, 15, 0)
+			item_heal_robotic(attacked_humanoid, user, 15, 0)
 	else
 		return ..()
 
-/obj/item/weldingtool/afterattack(atom/O, mob/user, proximity)
+/obj/item/weldingtool/afterattack(atom/attacked_atom, mob/user, proximity)
 	. = ..()
 	if(!proximity)
 		return
@@ -138,18 +138,18 @@
 	if(isOn())
 		handle_fuel_and_temps(1, user)
 
-		if(!QDELETED(O) && isliving(O)) // can't ignite something that doesn't exist
-			var/mob/living/L = O
-			if(L.IgniteMob())
-				message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(L)] on fire with [src] at [AREACOORD(user)]")
-				log_game("[key_name(user)] set [key_name(L)] on fire with [src] at [AREACOORD(user)]")
+		if(!QDELETED(attacked_atom) && isliving(attacked_atom)) // can't ignite something that doesn't exist
+			var/mob/living/attacked_mob = attacked_atom
+			if(attacked_mob.IgniteMob())
+				message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(attacked_mob)] on fire with [src] at [AREACOORD(user)]")
+				log_game("[key_name(user)] set [key_name(attacked_mob)] on fire with [src] at [AREACOORD(user)]")
 
-	if(!status && O.is_refillable())
-		reagents.trans_to(O, reagents.total_volume, transfered_by = user)
-		to_chat(user, span_notice("You empty [src]'s fuel tank into [O]."))
+	if(!status && attacked_atom.is_refillable())
+		reagents.trans_to(attacked_atom, reagents.total_volume, transfered_by = user)
+		to_chat(user, span_notice("You empty [src]'s fuel tank into [attacked_atom]."))
 		update_appearance()
 
-/obj/item/weldingtool/attack_qdeleted(atom/O, mob/user, proximity)
+/obj/item/weldingtool/attack_qdeleted(atom/attacked_atom, mob/user, proximity)
 	. = ..()
 	if(!proximity)
 		return
@@ -157,11 +157,11 @@
 	if(isOn())
 		handle_fuel_and_temps(1, user)
 
-		if(!QDELETED(O) && isliving(O)) // can't ignite something that doesn't exist
-			var/mob/living/L = O
-			if(L.IgniteMob())
-				message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(L)] on fire with [src] at [AREACOORD(user)]")
-				log_game("[key_name(user)] set [key_name(L)] on fire with [src] at [AREACOORD(user)]")
+		if(!QDELETED(attacked_atom) && isliving(attacked_atom)) // can't ignite something that doesn't exist
+			var/mob/living/attacked_mob = attacked_atom
+			if(attacked_mob.IgniteMob())
+				message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(attacked_mob)] on fire with [src] at [AREACOORD(user)]")
+				log_game("[key_name(user)] set [key_name(attacked_mob)] on fire with [src] at [AREACOORD(user)]")
 
 
 /obj/item/weldingtool/attack_self(mob/user)
@@ -275,7 +275,7 @@
 		return FALSE
 
 
-/obj/item/weldingtool/proc/flamethrower_screwdriver(obj/item/I, mob/user)
+/obj/item/weldingtool/proc/flamethrower_screwdriver(obj/item/tool, mob/user)
 	if(welding)
 		to_chat(user, span_warning("Turn it off first!"))
 		return
@@ -288,23 +288,23 @@
 		reagents.flags |= OPENCONTAINER
 	add_fingerprint(user)
 
-/obj/item/weldingtool/proc/flamethrower_rods(obj/item/I, mob/user)
+/obj/item/weldingtool/proc/flamethrower_rods(obj/item/tool, mob/user)
 	if(!status)
-		var/obj/item/stack/rods/R = I
-		if (R.use(1))
-			var/obj/item/flamethrower/F = new /obj/item/flamethrower(user.loc)
-			if(!remove_item_from_storage(F))
-				user.transferItemToLoc(src, F, TRUE)
-			F.weldtool = src
+		var/obj/item/stack/rods/used_rods = tool
+		if (used_rods.use(1))
+			var/obj/item/flamethrower/flamethrower_frame = new /obj/item/flamethrower(user.loc)
+			if(!remove_item_from_storage(flamethrower_frame))
+				user.transferItemToLoc(src, flamethrower_frame, TRUE)
+			flamethrower_frame.weldtool = src
 			add_fingerprint(user)
 			to_chat(user, span_notice("You add a rod to a welder, starting to build a flamethrower."))
-			user.put_in_hands(F)
+			user.put_in_hands(flamethrower_frame)
 		else
 			to_chat(user, span_warning("You need one rod to start building a flamethrower!"))
 
-/obj/item/weldingtool/ignition_effect(atom/A, mob/user)
-	if(use_tool(A, user, 0, amount=1))
-		return span_notice("[user] casually lights [A] with [src], what a badass.")
+/obj/item/weldingtool/ignition_effect(atom/ignitable_atom, mob/user)
+	if(use_tool(ignitable_atom, user, 0, amount=1))
+		return span_notice("[user] casually lights [ignitable_atom] with [src], what a badass.")
 	else
 		return ""
 
@@ -349,6 +349,7 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "welder"
 	toolspeed = 0.1
+	custom_materials = list(/datum/material/iron = 5000, /datum/material/silver = 2500, /datum/material/plasma = 5000, /datum/material/titanium = 2000, /datum/material/diamond = 2000)
 	light_system = NO_LIGHT_SUPPORT
 	light_range = 0
 	change_icons = FALSE
@@ -372,7 +373,7 @@
 	icon_state = "exwelder"
 	inhand_icon_state = "exwelder"
 	max_fuel = 40
-	custom_materials = list(/datum/material/iron=70, /datum/material/glass=120)
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500, /datum/material/plasma = 1500, /datum/material/uranium = 200)
 	change_icons = 0
 	can_off_process = 1
 	light_range = 1

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -373,7 +373,7 @@
 	icon_state = "exwelder"
 	inhand_icon_state = "exwelder"
 	max_fuel = 40
-	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500, /datum/material/plasma = 1500, /datum/material/uranium = 200)
+	custom_materials = list(/datum/material/iron = 1000, /datum/material/glass = 500, /datum/material/plasma = 1500, /datum/material/uranium = 200)
 	change_icons = 0
 	can_off_process = 1
 	light_range = 1

--- a/code/game/objects/items/tools/wirecutters.dm
+++ b/code/game/objects/items/tools/wirecutters.dm
@@ -45,16 +45,16 @@
 		set_greyscale(colors=list(wirecutter_colors[our_color]))
 	return ..()
 
-/obj/item/wirecutters/attack(mob/living/carbon/C, mob/user)
-	if(istype(C) && C.handcuffed && istype(C.handcuffed, /obj/item/restraints/handcuffs/cable))
-		user.visible_message(span_notice("[user] cuts [C]'s restraints with [src]!"))
-		qdel(C.handcuffed)
+/obj/item/wirecutters/attack(mob/living/carbon/attacked_carbon, mob/user)
+	if(istype(attacked_carbon) && attacked_carbon.handcuffed && istype(attacked_carbon.handcuffed, /obj/item/restraints/handcuffs/cable))
+		user.visible_message(span_notice("[user] cuts [attacked_carbon]'s restraints with [src]!"))
+		qdel(attacked_carbon.handcuffed)
 		return
-	else if(istype(C) && C.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND))
-		user.visible_message(span_notice("[user] attempts to cut the durathread strand from around [C]'s neck."))
-		if(do_after(user, 1.5 SECONDS, C))
-			user.visible_message(span_notice("[user] succesfully cuts the durathread strand from around [C]'s neck."))
-			C.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
+	else if(istype(attacked_carbon) && attacked_carbon.has_status_effect(STATUS_EFFECT_CHOKINGSTRAND))
+		user.visible_message(span_notice("[user] attempts to cut the durathread strand from around [attacked_carbon]'s neck."))
+		if(do_after(user, 1.5 SECONDS, attacked_carbon))
+			user.visible_message(span_notice("[user] succesfully cuts the durathread strand from around [attacked_carbon]'s neck."))
+			attacked_carbon.remove_status_effect(STATUS_EFFECT_CHOKINGSTRAND)
 			playsound(loc, usesound, 50, TRUE, -1)
 		return
 	else
@@ -69,6 +69,7 @@
 	name = "alien wirecutters"
 	desc = "Extremely sharp wirecutters, made out of a silvery-green metal."
 	icon = 'icons/obj/abductor.dmi'
+	custom_materials = list(/datum/material/iron = 5000, /datum/material/silver = 2500, /datum/material/plasma = 1000, /datum/material/titanium = 2000, /datum/material/diamond = 2000)
 	icon_state = "cutters"
 	toolspeed = 0.1
 	random_color = FALSE

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -32,6 +32,7 @@
 	desc = "A polarized wrench. It causes anything placed between the jaws to turn."
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "wrench"
+	custom_materials = list(/datum/material/iron = 5000, /datum/material/silver = 2500, /datum/material/plasma = 1000, /datum/material/titanium = 2000, /datum/material/diamond = 2000)
 	usesound = 'sound/effects/empulse.ogg'
 	toolspeed = 0.1
 
@@ -65,8 +66,8 @@
 	sleep(20)
 	if(!user)
 		return
-	for(var/obj/item/W in user)
-		user.dropItemToGround(W)
+	for(var/obj/item/suicide_wrench in user)
+		user.dropItemToGround(suicide_wrench)
 	suicider = user.real_name
 	user.dust()
 	return OXYLOSS
@@ -91,7 +92,7 @@
 /obj/item/wrench/combat/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/transforming, \
-		force_on = 6, \
+		force_on = 6, \ /* this has got to be a joke, an energy wrench is whacking people harder by ONE brute more*/
 		throwforce_on = 8, \
 		hitsound_on = hitsound, \
 		w_class_on = WEIGHT_CLASS_NORMAL, \

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -92,7 +92,7 @@
 /obj/item/wrench/combat/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/transforming, \
-		force_on = 6, \ /* this has got to be a joke, an energy wrench is whacking people harder by ONE brute more*/
+		force_on = 6, \
 		throwforce_on = 8, \
 		hitsound_on = hitsound, \
 		w_class_on = WEIGHT_CLASS_NORMAL, \

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -57,8 +57,8 @@
 	tool_behaviour = TOOL_CAUTERY
 	toolspeed = 1
 
-/obj/item/cautery/ignition_effect(atom/A, mob/user)
-	. = span_notice("[user] touches the end of [src] to \the [A], igniting it with a puff of smoke.")
+/obj/item/cautery/ignition_effect(atom/ignitable_atom, mob/user)
+	. = span_notice("[user] touches the end of [src] to \the [ignitable_atom], igniting it with a puff of smoke.")
 
 /obj/item/cautery/augment
 	desc = "A heated element that cauterizes wounds."
@@ -69,6 +69,7 @@
 	desc = "It projects a high power laser used for medical applications."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "e_cautery"
+	custom_materials = list(/datum/material/iron = 4000, /datum/material/glass = 2000, /datum/material/plasma = 2000, /datum/material/uranium = 3000, /datum/material/titanium = 3000)
 	hitsound = 'sound/items/welder.ogg'
 	toolspeed = 0.7
 	light_system = MOVABLE_LIGHT
@@ -240,20 +241,20 @@
 	item_flags = NOBLUDGEON
 	var/list/advanced_surgeries = list()
 
-/obj/item/surgical_processor/afterattack(obj/item/O, mob/user, proximity)
+/obj/item/surgical_processor/afterattack(obj/item/design_holder, mob/user, proximity)
 	. = ..()
 	if(!proximity)
 		return
-	if(istype(O, /obj/item/disk/surgery))
-		to_chat(user, span_notice("You load the surgery protocol from [O] into [src]."))
-		var/obj/item/disk/surgery/D = O
-		if(do_after(user, 10, target = O))
-			advanced_surgeries |= D.surgeries
+	if(istype(design_holder, /obj/item/disk/surgery))
+		to_chat(user, span_notice("You load the surgery protocol from [design_holder] into [src]."))
+		var/obj/item/disk/surgery/surgery_disk = design_holder
+		if(do_after(user, 10, target = design_holder))
+			advanced_surgeries |= surgery_disk.surgeries
 		return TRUE
-	if(istype(O, /obj/machinery/computer/operating))
-		to_chat(user, span_notice("You copy surgery protocols from [O] into [src]."))
-		var/obj/machinery/computer/operating/OC = O
-		if(do_after(user, 10, target = O))
+	if(istype(design_holder, /obj/machinery/computer/operating))
+		to_chat(user, span_notice("You copy surgery protocols from [design_holder] into [src]."))
+		var/obj/machinery/computer/operating/OC = design_holder
+		if(do_after(user, 10, target = design_holder))
 			advanced_surgeries |= OC.advanced_surgeries
 		return TRUE
 	return
@@ -263,6 +264,7 @@
 	desc = "An advanced scalpel which uses laser technology to cut."
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "e_scalpel"
+	custom_materials = list(/datum/material/iron = 6000, /datum/material/glass = 1500, /datum/material/silver = 2000, /datum/material/gold = 1500, /datum/material/diamond = 200, /datum/material/titanium = 4000)
 	hitsound = 'sound/weapons/blade1.ogg'
 	force = 16
 	toolspeed = 0.7
@@ -310,6 +312,7 @@
 	name = "mechanical pinches"
 	desc = "An agglomerate of rods and gears."
 	icon = 'icons/obj/surgery.dmi'
+	custom_materials = list(/datum/material/iron = 12000, /datum/material/glass = 4000, /datum/material/silver = 4000, /datum/material/titanium = 5000)
 	icon_state = "adv_retractor"
 	toolspeed = 0.7
 
@@ -359,14 +362,14 @@
 	sharpness = SHARP_EDGED
 	custom_premium_price = PAYCHECK_MEDIUM * 14
 
-/obj/item/shears/attack(mob/living/M, mob/living/user)
-	if(!iscarbon(M) || user.combat_mode)
+/obj/item/shears/attack(mob/living/amputee, mob/living/user)
+	if(!iscarbon(amputee) || user.combat_mode)
 		return ..()
 
 	if(user.zone_selected == BODY_ZONE_CHEST)
 		return ..()
 
-	var/mob/living/carbon/patient = M
+	var/mob/living/carbon/patient = amputee
 
 	if(HAS_TRAIT(patient, TRAIT_NODISMEMBER))
 		to_chat(user, span_warning("The patient's limbs look too sturdy to amputate."))


### PR DESCRIPTION
## About The Pull Request
Advanced tools have either been using their parent basic tools' custom_materials or their custom_materials were lowered for what I presume was destructive experimentor work. This counts for recycling these items in an autolathe as well. In the first case, alien tools were made out of the same material amount as their basic counterparts, and in the second case - the recycling results were heavily lowered.
Also kills off some single-letter vars since I'm here.
## Why It's Good For The Game
Alien tools are much more complex and aren't made out of simple iron and glass. Power tools have lost their value for research point generation purposes. Recycling a hand drill on accident only for it to turn up as measly 250 total material is weird.
## Changelog
:cl:
fix: fixed abductor and advanced tools' recycling results being heavily diminished or taken from their basic counterparts
/:cl:

