### PR TITLE
Removes Spare Firelock from East Cargo Office Window

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -13918,7 +13918,6 @@
 "cWi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/sorting)


### PR DESCRIPTION

## About The Pull Request

This was the only firelock located on the Cargo Offices east section of windows. It effectively did nothing. 

## Why It's Good For The Game

Misplaced Firelock

## Changelog


:cl:
fix: The Nanotrasen Materials Reclamation Program has recycled the spare firelock trapped in the Cargo Offices east windows.
/:cl:
