### PR TITLE
Disables radiation contamination.

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -58,7 +58,7 @@ Ask ninjanomnom if they're around
 
 // WARNING: The defines below could have disastrous consequences if tweaked incorrectly. See: The great SM purge of Oct.6.2017
 // contamination_strength = (strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT
-#define RAD_MINIMUM_CONTAMINATION 350 // How strong does a radiation wave have to be to contaminate objects
+#define RAD_MINIMUM_CONTAMINATION INFINITY // How strong does a radiation wave have to be to contaminate objects
 #define RAD_CONTAMINATION_STR_COEFFICIENT 0.25 // Higher means higher strength scaling contamination strength
 #define RAD_DISTANCE_COEFFICIENT 1 // Lower means further rad spread
 

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -97,14 +97,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	beauty_modifier = 0.3 //It shines so beautiful
 	armor_modifiers = list(MELEE = 1.5, BULLET = 1.4, LASER = 0.5, ENERGY = 0.5, BOMB = 0, BIO = 0, RAD = 0, FIRE = 1, ACID = 1)
 
-/datum/material/uranium/on_applied(atom/source, amount, material_flags)
-	. = ..()
-	source.AddComponent(/datum/component/radioactive, amount / 50, source, 0) //half-life of 0 because we keep on going. amount / 50 means 40 radiation per sheet.
-
-/datum/material/uranium/on_removed(atom/source, amount, material_flags)
-	. = ..()
-	qdel(source.GetComponent(/datum/component/radioactive))
-
 /datum/material/uranium/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.reagents.add_reagent(/datum/reagent/uranium, rand(4, 6))
 	source_item?.reagents?.add_reagent(/datum/reagent/uranium, source_item.reagents.total_volume*(2/5))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sets #RAD_MINIMUM_CONTAMINATION to INFINITY, effectively making radiation unable to contaminate anything.

Also gets rid of uranium radiation, since uranium sheets are handheld and can be hidden in a bag.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The biggest underlying issue with radiation is that it can contaminate other objects. Irradiated objects are supposed to glow green, but an item hidden in a bag (or even held in a hand) will not be visibly radioactive to other players. Allegedly there's also a possibility of organs becoming contaminated, which sounds like not fun for anyone involved.

Contamination ought to be either completely reworked or completely removed. However, we're on a short window to make radiation not terribad or we risk losing all of radiation completely. With this change, only objects specifically coded to release radiation will do so, and nothing else will be put into that state. This means standing next to an active supermatter with no gear on is bad for your health, but you won't drag medbay down with you.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Radiation no longer spreads to objects in its best attempt to out-do virology as a death plague.
balance: Uranium sheets are no longer radioactive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
