### PR TITLE
Broken Secways will say it's broken, rather than the component.

### DIFF
--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -185,7 +185,7 @@
 
 	if(keycheck(user) && the_secway.eddie_murphy)
 		if(COOLDOWN_FINISHED(src, message_cooldown))
-			the_secway.visible_message(span_warning("[src] sputters and refuses to move!"))
+			the_secway.visible_message(span_warning("[the_secway] sputters and refuses to move!"))
 			playsound(get_turf(the_secway), 'sound/effects/stall.ogg', 70)
 			COOLDOWN_START(src, message_cooldown, 0.75 SECONDS)
 		return COMPONENT_DRIVER_BLOCK_MOVE


### PR DESCRIPTION
## About The Pull Request

changes it from 
"/datum/component/riding/vehicle/secway sputters and refuses to move!"
to
"The secway sputters and refuses to move!"

## Why It's Good For The Game

Bug fix

## Changelog

:cl:
fix: Secways will now say it's broken, rather than it's component.
/:cl: