### PR TITLE
Increases the number of uses omegasoap has

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -78,7 +78,7 @@
 	desc = "The most advanced soap known to mankind."
 	icon_state = "soapomega"
 	cleanspeed = 3 //Only the truest of mind soul and body get one of these
-	uses = 301
+	uses = 9001
 
 /obj/item/soap/omega/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is using [src] to scrub themselves from the timeline! It looks like [user.p_theyre()] trying to commit suicide!"))


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently omegasoap, a difficult to produce bar of soap, only has 301 uses, barely over 3x the number of uses normal soap has (100). This pr increases it to 9001 uses, which just makes it nicer to use, and makes the omegasoap worth making in the first place.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Janitors go through this massive ordeal to make a super bar of soap and then have it break after 301 uses. As it stands there's not much reason to actually make this since it's far easier to just use a mop or space cleaner, or even spend your time in chemistry making a ton more normal soap. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Omegasoap now has far more uses than before. Janitors rejoice!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
