### PR TITLE
Meta and Delta chapels now have pews in lieu of stools or chairs.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3650,7 +3650,7 @@
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
 "awL" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/pew,
 /turf/open/floor/iron{
 	icon_state = "chapel"
 	},
@@ -6325,8 +6325,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aUZ" = (
-/obj/structure/chair/wood,
 /obj/machinery/light/directional/west,
+/obj/structure/chair/pew/left,
 /turf/open/floor/iron{
 	dir = 8;
 	icon_state = "chapel"
@@ -24820,6 +24820,13 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/science)
+"dmB" = (
+/obj/structure/chair/pew/right,
+/turf/open/floor/iron{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/service/chapel)
 "dmC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -34731,6 +34738,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"eqF" = (
+/obj/structure/chair/pew/right,
+/turf/open/floor/iron{
+	icon_state = "chapel"
+	},
+/area/service/chapel)
 "eqG" = (
 /obj/structure/table/wood,
 /obj/item/stack/package_wrap{
@@ -39007,7 +39020,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fHP" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/pew,
 /turf/open/floor/iron{
 	dir = 1;
 	icon_state = "chapel"
@@ -48437,10 +48450,10 @@
 /turf/closed/wall,
 /area/engineering/atmos/upper)
 "irb" = (
-/obj/structure/chair/wood,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/chair/pew,
 /turf/open/floor/iron{
 	dir = 8;
 	icon_state = "chapel"
@@ -48967,10 +48980,10 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "iCu" = (
-/obj/structure/chair/wood,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/chair/pew/left,
 /turf/open/floor/iron{
 	icon_state = "chapel"
 	},
@@ -55603,8 +55616,8 @@
 /turf/open/floor/carpet,
 /area/service/library)
 "kBG" = (
-/obj/structure/chair/wood,
 /obj/machinery/newscaster/directional/west,
+/obj/structure/chair/pew/left,
 /turf/open/floor/iron{
 	dir = 1;
 	icon_state = "chapel"
@@ -57208,7 +57221,7 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "lbr" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/pew,
 /turf/open/floor/iron{
 	dir = 4;
 	icon_state = "chapel"
@@ -61038,13 +61051,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "mcW" = (
-/obj/structure/chair/wood,
 /obj/machinery/camera{
 	c_tag = "Chapel - Starboard";
 	dir = 8;
 	name = "chapel camera"
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/structure/chair/pew/right,
 /turf/open/floor/iron{
 	icon_state = "chapel"
 	},
@@ -61121,6 +61134,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"mdJ" = (
+/obj/structure/chair/pew/left,
+/turf/open/floor/iron{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/service/chapel)
 "mdV" = (
 /obj/machinery/power/solar{
 	id = "aftport";
@@ -89755,9 +89775,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uyr" = (
-/obj/structure/chair/wood,
 /obj/machinery/light/directional/east,
 /obj/machinery/newscaster/directional/east,
+/obj/structure/chair/pew/right,
 /turf/open/floor/iron{
 	icon_state = "chapel"
 	},
@@ -91308,6 +91328,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"uVw" = (
+/obj/structure/chair/pew/left,
+/turf/open/floor/iron{
+	dir = 1;
+	icon_state = "chapel"
+	},
+/area/service/chapel)
 "uVx" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sign/nanotrasen{
@@ -99294,7 +99321,7 @@
 /turf/open/floor/iron/dark/corner,
 /area/engineering/atmos)
 "xoE" = (
-/obj/structure/chair/wood,
+/obj/structure/chair/pew/right,
 /turf/open/floor/iron{
 	dir = 8;
 	icon_state = "chapel"
@@ -99855,6 +99882,13 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/service/library/abandoned)
+"xxe" = (
+/obj/structure/chair/pew,
+/turf/open/floor/iron{
+	dir = 8;
+	icon_state = "chapel"
+	},
+/area/service/chapel)
 "xxj" = (
 /obj/structure/table,
 /obj/item/trash/raisins,
@@ -136366,7 +136400,7 @@ sOY
 paX
 paX
 joK
-xoE
+mdJ
 kBG
 aUZ
 aAb
@@ -136880,7 +136914,7 @@ xtI
 paX
 ufW
 cmw
-xoE
+xxe
 fHP
 xoE
 nOd
@@ -137137,8 +137171,8 @@ wfC
 paX
 ufW
 ygu
-awL
-lbr
+eqF
+dmB
 ljv
 oCI
 ljv
@@ -137651,8 +137685,8 @@ lFj
 paX
 wzg
 wEP
-xoE
-fHP
+mdJ
+uVw
 jhp
 wEP
 niX
@@ -138165,7 +138199,7 @@ voe
 paX
 paX
 wEP
-xoE
+xxe
 fHP
 irb
 sYe
@@ -138423,7 +138457,7 @@ paX
 paX
 tKZ
 mcW
-lbr
+dmB
 uyr
 rbm
 ljv

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -11676,7 +11676,7 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "cyP" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/pew/left,
 /turf/open/floor/iron/chapel{
 	dir = 8
 	},
@@ -15014,13 +15014,13 @@
 /area/security/prison)
 "dmF" = (
 /obj/effect/turf_decal/tile/neutral,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /mob/living/simple_animal/bot/cleanbot{
 	auto_patrol = 1;
 	icon_state = "cleanbot1";
 	name = "Mopficcer Sweepsky"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -55412,7 +55412,7 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/medbay/central)
 "rHb" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/pew/right,
 /turf/open/floor/iron/chapel{
 	dir = 4
 	},
@@ -56019,8 +56019,8 @@
 /turf/closed/wall,
 /area/command/teleporter)
 "rTh" = (
-/obj/structure/chair/stool/directional/north,
 /obj/effect/landmark/event_spawn,
+/obj/structure/chair/pew/left,
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
@@ -63844,7 +63844,7 @@
 /turf/closed/wall,
 /area/medical/pharmacy)
 "uHH" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/pew/left,
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
@@ -67256,7 +67256,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "vRX" = (
-/obj/structure/chair/stool/directional/north,
+/obj/structure/chair/pew/right,
 /turf/open/floor/iron/chapel,
 /area/service/chapel)
 "vRZ" = (


### PR DESCRIPTION
## About The Pull Request
Title. IceBox, Tram and Kilo already have pews in their chapel areas.

## Why It's Good For The Game
It makes Meta and Delta chapels less repulsive.

## Changelog

:cl:
expansion: Meta and Delta chapels now have pews in lieu of stools or chairs.
/:cl:
