### PR TITLE
Fixes the on fire overlay for monkeys.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -63,7 +63,7 @@ There are several things that need to be remembered:
 	..()
 
 /mob/living/carbon/human/update_fire()
-	..((fire_stacks > HUMAN_FIRE_STACK_ICON_NUM) ? "Standing" : "Generic_mob_burning")
+	..((fire_stacks > HUMAN_FIRE_STACK_ICON_NUM) ? dna.species.fire_overlay : "Generic_mob_burning")
 
 
 /* --------------------------------------- */

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -144,6 +144,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	/// The body temperature limit the body can take before it starts taking damage from cold.
 	var/bodytemp_cold_damage_limit = BODYTEMP_COLD_DAMAGE_LIMIT
 
+	/// The icon_state of the fire overlay added when sufficently ablaze and standing. see onfire.dmi
+	var/fire_overlay = "Standing"
+
 	///the species that body parts are surgically compatible with (found in _DEFINES/mobs.dm)
 	///current acceptable bitfields are HUMAN_BODY, ALIEN_BODY, LARVA_BODY, MONKEY_BODY, or NONE
 	var/allowed_animal_origin = HUMAN_BODY

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -38,6 +38,7 @@
 	BODY_ZONE_L_LEG = /obj/item/bodypart/l_leg/monkey,\
 	BODY_ZONE_R_LEG = /obj/item/bodypart/r_leg/monkey,\
 	BODY_ZONE_CHEST = /obj/item/bodypart/chest/monkey)
+	fire_overlay = "Monkey_burning"
 	dust_anim = "dust-m"
 	gib_anim = "gibbed-m"
 


### PR DESCRIPTION
## About The Pull Request
Monkeys were receiving the "Standing" overlay when ablaze, which is meant for human mobs.

## Why It's Good For The Game
Fixes another issues we have had since monkeys became a species datum.

## Changelog

:cl:
fix: Fixed monkeys having the wrong on fire overlay when ablaze.
/:cl:
