### PR TITLE
Fixed the join/ready buttons not reverting if the game fails to setup.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -1512,6 +1512,9 @@
 ///Called when the ticker sets up the game for start
 #define COMSIG_TICKER_ENTER_SETTING_UP "comsig_ticker_enter_setting_up"
 
+///Called when the ticker fails to set up the game for start
+#define COMSIG_TICKER_ERROR_SETTING_UP "comsig_ticker_error_setting_up"
+
 /// Called when the round has started, but before GAME_STATE_PLAYING
 #define COMSIG_TICKER_ROUND_STARTING "comsig_ticker_round_starting"
 

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -109,15 +109,26 @@
 
 /atom/movable/screen/lobby/button/ready/Initialize(mapload)
 	. = ..()
-	if(SSticker.current_state > GAME_STATE_PREGAME)
-		set_button_status(FALSE)
-	else
-		RegisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP, .proc/hide_ready_button)
+	switch(SSticker.current_state)
+		if(GAME_STATE_PREGAME, GAME_STATE_STARTUP)
+			RegisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP, .proc/hide_ready_button)
+		if(GAME_STATE_SETTING_UP)
+			set_button_status(FALSE)
+			RegisterSignal(SSticker, COMSIG_TICKER_ERROR_SETTING_UP, .proc/show_ready_button)
+		else
+			set_button_status(FALSE)
 
 /atom/movable/screen/lobby/button/ready/proc/hide_ready_button()
 	SIGNAL_HANDLER
 	set_button_status(FALSE)
 	UnregisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP)
+	RegisterSignal(SSticker, COMSIG_TICKER_ERROR_SETTING_UP, .proc/show_ready_button)
+
+/atom/movable/screen/lobby/button/ready/proc/show_ready_button()
+	SIGNAL_HANDLER
+	set_button_status(TRUE)
+	UnregisterSignal(SSticker, COMSIG_TICKER_ERROR_SETTING_UP)
+	RegisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP, .proc/hide_ready_button)
 
 /atom/movable/screen/lobby/button/ready/Click(location, control, params)
 	. = ..()
@@ -143,10 +154,14 @@
 
 /atom/movable/screen/lobby/button/join/Initialize(mapload)
 	. = ..()
-	if(SSticker.current_state > GAME_STATE_PREGAME)
-		set_button_status(TRUE)
-	else
-		RegisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP, .proc/show_join_button)
+	switch(SSticker.current_state)
+		if(GAME_STATE_PREGAME, GAME_STATE_STARTUP)
+			RegisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP, .proc/show_join_button)
+		if(GAME_STATE_SETTING_UP)
+			set_button_status(TRUE)
+			RegisterSignal(SSticker, COMSIG_TICKER_ERROR_SETTING_UP, .proc/hide_join_button)
+		else
+			set_button_status(TRUE)
 
 /atom/movable/screen/lobby/button/join/Click(location, control, params)
 	. = ..()
@@ -181,10 +196,17 @@
 		return
 	new_player.LateChoices()
 
-/atom/movable/screen/lobby/button/join/proc/show_join_button(status)
+/atom/movable/screen/lobby/button/join/proc/show_join_button()
 	SIGNAL_HANDLER
 	set_button_status(TRUE)
 	UnregisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP)
+	RegisterSignal(SSticker, COMSIG_TICKER_ERROR_SETTING_UP, .proc/hide_join_button)
+
+/atom/movable/screen/lobby/button/join/proc/hide_join_button()
+	SIGNAL_HANDLER
+	set_button_status(FALSE)
+	UnregisterSignal(SSticker, COMSIG_TICKER_ERROR_SETTING_UP)
+	RegisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP, .proc/show_join_button)
 
 /atom/movable/screen/lobby/button/observe
 	screen_loc = "TOP:-40,CENTER:-54"

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -188,6 +188,7 @@ SUBSYSTEM_DEF(ticker)
 				start_at = world.time + (CONFIG_GET(number/lobby_countdown) * 10)
 				timeLeft = null
 				Master.SetRunLevel(RUNLEVEL_LOBBY)
+				SEND_SIGNAL(src, COMSIG_TICKER_ERROR_SETTING_UP)
 
 		if(GAME_STATE_PLAYING)
 			mode.process(wait * 0.1)


### PR DESCRIPTION
## About The Pull Request
This will fix #61580

## Why It's Good For The Game
This will close #61580

## Changelog

:cl:
fix: Fixed the join/ready buttons not reverting if the game fails to setup.
/:cl:
