### PR TITLE
Fix easy power gen abuse by increasing coil numbers on N2 setups

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -175,6 +175,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ZAP_GENERATES_POWER (1<<5)
 /// Zaps with this flag will generate less power through tesla coils
 #define ZAP_LOW_POWER_GEN (1<<6)
+/// Zaps with this flag will use a different type of power conversion in the coils
+#define ZAP_MAIN_POWER_GEN (1<<7)
 
 #define ZAP_DEFAULT_FLAGS ZAP_MOB_STUN | ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE
 #define ZAP_FUSION_FLAGS ZAP_OBJ_DAMAGE | ZAP_MOB_DAMAGE | ZAP_MOB_STUN

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -656,11 +656,12 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			var/co2_power_increase = max(gas_comp[/datum/gas/carbon_dioxide] * 2, 1)
 			supermatter_zap(
 				zapstart = src,
-				range = 3,
-				zap_str = 2.5 * power * power_multiplier * pressure_multiplier * co2_power_increase,
-				zap_flags = ZAP_SUPERMATTER_FLAGS,
+				range = 4,
+				zap_str = 260 * power * power_multiplier * pressure_multiplier * co2_power_increase,
+				zap_flags = ZAP_SUPERMATTER_FLAGS | ZAP_MAIN_POWER_GEN,
 				zap_cutoff = 300,
-				power_level = power
+				power_level = power,
+				change_radius = FALSE
 			)
 			last_power_zap = world.time
 
@@ -1150,7 +1151,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		if(PYRO_ANOMALY)
 			new /obj/effect/anomaly/pyro(local_turf, 200, FALSE)
 
-/obj/machinery/proc/supermatter_zap(atom/zapstart = src, range = 5, zap_str = 4000, zap_flags = ZAP_SUPERMATTER_FLAGS, list/targets_hit = list(), zap_cutoff = 1500, power_level = 0, zap_icon = DEFAULT_ZAP_ICON_STATE)
+/obj/machinery/proc/supermatter_zap(atom/zapstart = src, range = 5, zap_str = 4000, zap_flags = ZAP_SUPERMATTER_FLAGS, list/targets_hit = list(), zap_cutoff = 1500, power_level = 0, zap_icon = DEFAULT_ZAP_ICON_STATE, change_radius = TRUE)
 	if(QDELETED(zapstart))
 		return
 	. = zapstart.dir
@@ -1279,7 +1280,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	if(target_turf?.return_air())
 		pressure = max(1,target_turf.return_air().return_pressure())
 	//We get our range with the strength of the zap and the pressure, the higher the former and the lower the latter the better
-	var/new_range = clamp(zap_str / pressure * 10, 2, 7)
+	var/new_range = range
+	if(change_radius)
+		new_range = clamp(zap_str / pressure * 10, 2, 7)
 	var/zap_count = 1
 	if(prob(5))
 		zap_str -= (zap_str/10)
@@ -1287,7 +1290,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	for(var/j in 1 to zap_count)
 		if(zap_count > 1)
 			targets_hit = targets_hit.Copy() //Pass by ref begone
-		supermatter_zap(target, new_range, zap_str, zap_flags, targets_hit, zap_cutoff, power_level, zap_icon)
+		supermatter_zap(target, new_range, zap_str, zap_flags, targets_hit, zap_cutoff, power_level, zap_icon, change_radius)
 
 /obj/overlay/psy
 	icon = 'icons/obj/supermatter.dmi'

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1262,6 +1262,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			zap_str /= 3
 
 	else if(isliving(target))//If we got a fleshbag on our hands
+		if(zap_flags & ZAP_MAIN_POWER_GEN)
+			zap_str /= 30 //should lose power much faster.
 		var/mob/living/creature = target
 		creature.set_shocked()
 		addtimer(CALLBACK(creature, /mob/living/proc/reset_shocked), 1 SECONDS)
@@ -1274,6 +1276,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	else
 		zap_str = target.zap_act(zap_str, zap_flags)
+		if(zap_flags & ZAP_MAIN_POWER_GEN)
+			zap_str /= 30 //should lose power much faster.
 	//This gotdamn variable is a boomer and keeps giving me problems
 	var/turf/target_turf = get_turf(target)
 	var/pressure = 1

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -1,3 +1,5 @@
+#define COIL_POWER_CONVERSION_MULTIPLIER 0.9
+
 /obj/machinery/power/tesla_coil
 	name = "tesla coil"
 	desc = "For the union!"
@@ -106,8 +108,11 @@
 	if(zap_flags & ZAP_LOW_POWER_GEN)
 		power /= 10
 	zap_buckle_check(power)
-	var/power_removed = powernet ? power * input_power_multiplier : power
-	stored_energy += max((power_removed - 80) * 200, 0)
+	var/power_removed = powernet ? power * COIL_POWER_CONVERSION_MULTIPLIER : 0
+	if(zap_flags & ZAP_MAIN_POWER_GEN)
+		stored_energy += power_removed
+	else
+		stored_energy += max((power_removed - 80) * 200, 0)
 	return max(power - power_removed, 0) //You get back the amount we didn't use
 
 /obj/machinery/power/tesla_coil/proc/zap()
@@ -163,3 +168,5 @@
 		return 0
 	else
 		. = ..()
+
+#undef COIL_POWER_CONVERSION_MULTIPLIER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Someone (i think maurukas ) brought up that there is a way to cheese the zaps to give more power on roundstart N2 setup simply by making more coils and removing grounding rods. This was never meant to be as the 4 roundstart coils should absorb most if not all the power the SM releases (granting a more than enough 400 kW average). 
What this PR does is to make the baseline zap more powerful and give them a specialized flag that coils recognize and use a different calculation check to absorb their energy. This will prevent increased power generation by just adding more coils without increasing the SM MeV itself. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less cheese, proper power gen
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: fixed an unwanted tesla coil power multiplication by using more tesla coils on roundstart setups
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
