### PR TITLE
Adds dropper tool on right click for spray cans

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -802,7 +802,7 @@
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	if(target.color)
 		paint_color = target.color
-		to_chat(user, span_notice("You adjust the color of [src] to match [target]"))
+		to_chat(user, span_notice("You adjust the color of [src] to match [target]."))
 		update_appearance()
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	else

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -722,7 +722,7 @@
 		. += "It has [charges_left] use\s left."
 	else
 		. += "It is empty."
-	. += span_notice("Alt-click [src] to [ is_capped ? "take the cap off" : "put the cap on"].")
+	. += span_notice("Alt-click [src] to [ is_capped ? "take the cap off" : "put the cap on"]. Right-click a colored object to match its existing color.")
 
 /obj/item/toy/crayon/spraycan/afterattack(atom/target, mob/user, proximity, params)
 	if(!proximity)
@@ -800,6 +800,13 @@
 				playsound(user.loc, 'sound/effects/spray.ogg', 5, TRUE, 5)
 				limb.icon = style_list_icons[choice]
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	if(target.color)
+		paint_color = target.color
+		to_chat(user, span_notice("You adjust the color of the [src] to match [target]"))
+		update_appearance()
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	else
+		to_chat(user, span_warning("[target] is not colorful enough, you can't match its color!"))
 
 	return SECONDARY_ATTACK_CONTINUE_CHAIN
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -806,7 +806,7 @@
 		update_appearance()
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	else
-		to_chat(user, span_warning("[target] is not colorful enough, you can't match its color!"))
+		to_chat(user, span_warning("[target] is not colorful enough, you can't match that color!"))
 
 	return SECONDARY_ATTACK_CONTINUE_CHAIN
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -802,7 +802,7 @@
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	if(target.color)
 		paint_color = target.color
-		to_chat(user, span_notice("You adjust the color of the [src] to match [target]"))
+		to_chat(user, span_notice("You adjust the color of [src] to match [target]"))
 		update_appearance()
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	else


### PR DESCRIPTION
## About The Pull Request
When holding a spray can you can right click a colored object to match its color

## Why It's Good For The Game

Allows keeping a consistent and convenient palette of colors when making graffiti instead of constantly having to open menus to try to match existing color shades
![Screenshot_11](https://user-images.githubusercontent.com/38563876/137334446-d94df7ab-a639-4246-9488-3aff61dd50e1.png)

Doesn't work with paintings unfortunately as it's a completely different system that is beyond my pay grade

## Changelog

:cl:
qol: While holding a spraycan you may right click on existing graffiti or colored objects to set the spraycan to match that color
/:cl:
