### PR TITLE
multiple unary devices on one turf

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -72,6 +72,8 @@
 #define PIPING_ALL_COLORS (1<<4)
 /// can bridge over pipenets
 #define PIPING_BRIDGE (1<<5)
+/// can place more than one on a turf if properly separated
+#define PIPING_DISTANCE_PREFERENCE (1<<6)
 
 // Ventcrawling bitflags, handled in var/vent_movement
 ///Allows for ventcrawling to occur. All atmospheric machines have this flag on by default. Cryo is the exception

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -274,6 +274,9 @@ Buildable meters
 	return FALSE
 
 /obj/item/pipe/proc/check_separation(obj/machinery/atmospherics/machine)
+	var/our_init_dirs = SSair.get_init_dirs(pipe_type, fixed_dir(), p_init_dir)
+	if(machine.get_init_directions() != REVERSE_DIR(our_init_dirs) && machine.get_init_directions() != our_init_dirs)
+		return FALSE
 	if((machine.piping_layer == PIPING_LAYER_MIN && piping_layer == PIPING_LAYER_MAX) || (machine.piping_layer == PIPING_LAYER_MAX && piping_layer == PIPING_LAYER_MIN))
 		return TRUE
 	return FALSE

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -162,6 +162,8 @@ Buildable meters
 	for(var/obj/machinery/atmospherics/machine in loc)
 		// Only one dense/requires density object per tile, eg connectors/cryo/heater/coolers.
 		if(machine.pipe_flags & flags & PIPING_ONE_PER_TURF)
+			if((machine.pipe_flags & flags & PIPING_DISTANCE_PREFERENCE) && check_separation(machine))
+				continue
 			to_chat(user, span_warning("Something is hogging the tile!"))
 			return TRUE
 		// skip checks if we don't overlap layers, either by being on the same layer or by something being on all layers
@@ -269,6 +271,11 @@ Buildable meters
 			return TRUE
 		return FALSE
 	// No smart pipes involved, the conflict can't be solved this way.
+	return FALSE
+
+/obj/item/pipe/proc/check_separation(obj/machinery/atmospherics/machine)
+	if((machine.piping_layer == PIPING_LAYER_MIN && piping_layer == PIPING_LAYER_MAX) || (machine.piping_layer == PIPING_LAYER_MAX && piping_layer == PIPING_LAYER_MIN))
+		return TRUE
 	return FALSE
 
 /obj/item/pipe/proc/build_pipe(obj/machinery/atmospherics/A)

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -12,6 +12,8 @@
 	pipe_state = "injector"
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF //really helpful in building gas chambers for xenomorphs
 
+	pipe_flags = PIPING_ONE_PER_TURF | PIPING_DISTANCE_PREFERENCE
+
 	///Variable used for radio frequency injection
 	var/injecting = FALSE
 	///Rate of operation of the device

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -12,6 +12,8 @@
 	pipe_state = "pvent"
 	vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE | VENTCRAWL_ENTRANCE_ALLOWED
 
+	pipe_flags = PIPING_ONE_PER_TURF | PIPING_DISTANCE_PREFERENCE
+
 /obj/machinery/atmospherics/components/unary/passive_vent/update_icon_nopipes()
 	cut_overlays()
 	if(showpipe)

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -11,7 +11,7 @@
 	hide = TRUE
 	shift_underlay_only = FALSE
 
-	pipe_flags = PIPING_ONE_PER_TURF
+	pipe_flags = PIPING_ONE_PER_TURF | PIPING_DISTANCE_PREFERENCE
 	pipe_state = "connector"
 	custom_reconcilation = TRUE
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -20,6 +20,8 @@
 	pipe_state = "uvent"
 	vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE | VENTCRAWL_ENTRANCE_ALLOWED
 
+	pipe_flags = PIPING_ONE_PER_TURF | PIPING_DISTANCE_PREFERENCE
+
 	///Direction of pumping the gas (RELEASING or SIPHONING)
 	var/pump_direction = RELEASING
 	///Should we check internal pressure, external pressure, both or none? (EXT_BOUND, INT_BOUND, NO_BOUND)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -17,6 +17,8 @@
 	pipe_state = "scrubber"
 	vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE | VENTCRAWL_ENTRANCE_ALLOWED
 
+	pipe_flags = PIPING_ONE_PER_TURF | PIPING_DISTANCE_PREFERENCE
+
 	///The mode of the scrubber (SCRUBBING or SIPHONING)
 	var/scrubbing = SCRUBBING //0 = siphoning, 1 = scrubbing
 	///The list of gases we are filtering

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -80,7 +80,7 @@
 
 	set_anchored(TRUE) //Prevent movement
 	pixel_x = new_port.pixel_x
-	pixel_y = new_port.pixel_y
+	pixel_y = new_port.pixel_y + 5
 
 	SSair.start_processing_machine(src)
 	update_appearance()
@@ -171,7 +171,14 @@
 		update_appearance()
 		change_density(TRUE)
 		return TRUE
-	var/obj/machinery/atmospherics/components/unary/portables_connector/possible_port = locate(/obj/machinery/atmospherics/components/unary/portables_connector) in loc
+
+	var/obj/machinery/atmospherics/components/unary/portables_connector/possible_port
+	for(var/obj/machinery/atmospherics/components/unary/portables_connector/port in loc)
+		if(port.connected_device)
+			continue
+		possible_port = port
+		break //found the port, let's get out of here
+
 	if(!possible_port)
 		to_chat(user, span_notice("Nothing happens."))
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR allows atmos players to place 2 unary devices on one turf, provided that they are placed on the ends of the piping layers (layer 1 and layer 5). 
![image](https://user-images.githubusercontent.com/42839747/137343850-c6b265d5-5867-4b22-9e20-b01b57b1b0cc.png)
Now with multi canisters setups (supports also pumps and scrubbers)
![image](https://user-images.githubusercontent.com/42839747/137390005-2e9e4b2b-e037-4d7a-9110-d9ab12d3afbc.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You're able to build more dynamic setups that can handle more difficult gas mixtures, in a limited space or if you want more throughput. It could also lead in an interesting mix and match, in the creation of a 1 tile mixing room where you inject gases and scrub the products.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
expansion: you can now place 2 one port devices on the same turf (like scrubbers, vents, injectors) but only if they are in the opposite extremes of the piping layers (layer 1 and layer 5)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
