### PR TITLE
Fixes 2 issues with the unbanning panel and adds a reban button.

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -701,23 +701,24 @@
 			var/ban_datetime = query_unban_search_bans.item[2]
 			var/ban_round_id  = query_unban_search_bans.item[3]
 			var/role = query_unban_search_bans.item[4]
-			//make the href for unban here so only the search parameters are passed
-			var/unban_href = "<a href='?_src_=holder;[HrefToken()];unbanid=[ban_id];unbankey=[player_key];unbanadminkey=[admin_key];unbanip=[player_ip];unbancid=[player_cid];unbanrole=[role];unbanpage=[page]'>Unban</a>"
 			var/expiration_time = query_unban_search_bans.item[5]
 			//we don't cast duration as num because if the duration is large enough to be converted to scientific notation by byond then the + character gets lost when passed through href causing SQL to interpret '4.321e 007' as '4'
 			var/duration = query_unban_search_bans.item[6]
 			var/expired = query_unban_search_bans.item[7]
 			var/applies_to_admins = text2num(query_unban_search_bans.item[8])
 			var/reason = query_unban_search_bans.item[9]
-			player_key = query_unban_search_bans.item[10]
-			player_ip = query_unban_search_bans.item[11]
-			player_cid = query_unban_search_bans.item[12]
-			admin_key = query_unban_search_bans.item[13]
+			var/banned_player_key = query_unban_search_bans.item[10]
+			var/banned_player_ip = query_unban_search_bans.item[11]
+			var/banned_player_cid = query_unban_search_bans.item[12]
+			var/banning_admin_key = query_unban_search_bans.item[13]
 			var/edits = query_unban_search_bans.item[14]
 			var/unban_datetime = query_unban_search_bans.item[15]
 			var/unban_key = query_unban_search_bans.item[16]
 			var/unban_round_id = query_unban_search_bans.item[17]
 			var/target = ban_target_string(player_key, player_ip, player_cid)
+
+			var/unban_href = "<a href='?_src_=holder;[HrefToken()];unbanid=[ban_id];unbankey=[banned_player_key];unbanadminkey=[banning_admin_key];unbanip=[banned_player_ip];unbancid=[banned_player_cid];unbanrole=[role];unbanpage=[page]'>Unban</a>"
+
 			output += "<div class='banbox'><div class='header [unban_datetime ? "unbanned" : "banned"]'><b>[target]</b>[applies_to_admins ? " <b>ADMIN</b>" : ""] banned by <b>[admin_key]</b> from <b>[role]</b> on <b>[ban_datetime]</b> during round <b>#[ban_round_id]</b>.<br>"
 			if(!expiration_time)
 				output += "<b>Permanent ban</b>."

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -753,7 +753,7 @@
 		return
 	var/kn = key_name(usr)
 	var/kna = key_name_admin(usr)
-	var/change_message = "[usr.client.key] unbanned [target] from [role]<hr>"
+	var/change_message = "[usr.client.key] unbanned [target] from [role] on [SQLtime()] during round #[GLOB.round_id]<hr>"
 	var/datum/db_query/query_unban = SSdbcore.NewQuery({"
 		UPDATE [format_table_name("ban")] SET
 			unbanned_datetime = NOW(),
@@ -793,7 +793,7 @@
 		return
 	var/kn = key_name(usr)
 	var/kna = key_name_admin(usr)
-	var/change_message = "[usr.client.key] re-activated ban of [target] from [role]<hr>"
+	var/change_message = "[usr.client.key] re-activated ban of [target] from [role] on [SQLtime()] during round #[GLOB.round_id]<hr>"
 	var/datum/db_query/query_reban = SSdbcore.NewQuery({"
 		UPDATE [format_table_name("ban")] SET
 			unbanned_datetime = NULL,

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1961,7 +1961,8 @@
 		var/role = href_list["rebanrole"]
 		var/page = href_list["rebanpage"]
 		var/admin_key = href_list["rebanadminkey"]
-		reban(ban_id, player_key, player_ip, player_cid, role, page, admin_key)
+		var/applies_to_admins = href_list["applies_to_admins"]
+		reban(ban_id, applies_to_admins, player_key, player_ip, player_cid, role, page, admin_key)
 
 	else if(href_list["unbanlog"])
 		var/ban_id = href_list["unbanlog"]

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1953,6 +1953,16 @@
 		var/admin_key = href_list["unbanadminkey"]
 		unban(ban_id, player_key, player_ip, player_cid, role, page, admin_key)
 
+	else if(href_list["rebanid"])
+		var/ban_id = href_list["rebanid"]
+		var/player_key = href_list["rebankey"]
+		var/player_ip = href_list["rebanip"]
+		var/player_cid = href_list["rebancid"]
+		var/role = href_list["rebanrole"]
+		var/page = href_list["rebanpage"]
+		var/admin_key = href_list["rebanadminkey"]
+		reban(ban_id, player_key, player_ip, player_cid, role, page, admin_key)
+
 	else if(href_list["unbanlog"])
 		var/ban_id = href_list["unbanlog"]
 		ban_log(ban_id)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Issue 1: In the big while loop in `/datum/admins/proc/unban_panel`, the player_key, player_ip, player_cid and admin_key variables were inherited from outside of the while loop's scope.

`var/unban_href = "<a href='?_src_=holder;[HrefToken()];unbanid=[ban_id];unbankey=[player_key];unbanadminkey=[admin_key];unbanip=[player_ip];unbancid=[player_cid];unbanrole=[role];unbanpage=[page]'>Unban</a>"` used these vars in the first iteration of the while loop before they were set by the actual ban information. At this point in time, these vars contain what was in the search query in the unbanning panel.

As a result, when the banned player's key wasn't filled in attempting to unban a player...
![image](https://user-images.githubusercontent.com/24975989/137370378-e0cc3606-bc29-4ae7-ae2f-64a0c7c02956.png)

Would result in a message like this:
![image](https://user-images.githubusercontent.com/24975989/137370419-71299a0a-d4f2-416d-bb9c-625f27354930.png)

The worst case scenario is that the href would use the player_key, player_ip, player_cid and admin_key from the previous iteration of the while loop in this off-by-1 error.

As a result, the unbanning panel could list a confirmation prompt that confirmed incorrect ban details (for a ban next to the selected one). This was purely a visual bug, since the banid would always be set properly so unbanning would apply to the ban selected, it would just mislead in the confirmation dialog and make it look like it was for another ban.

I've stopped using these parent scope vars and now use only local scope vars. I've also moved creation of this href to later on in the code as part of fixing issue 3.

Issue 2: The tgui_input with the Yes/No prompt can return 3 states: Yes if the Yes button is pushed, No if the No button is pushed and null if the input is X'd out of. The check only early returned if `No` was returned and would continue as normal with the unban if `Yes` or `null` were returned.

![4LTNr2oqYL](https://user-images.githubusercontent.com/24975989/137370860-ab7adf1f-7e80-46b9-bf34-d9eea7abed1d.gif)

We only ever want to proceed if the admin selects Yes, so I modified it to now early return if any non-Yes input is returned.

Issue 3: If you do the wrong unban by accident (as highlighted by Issue 1 and compounded by Issue 2) there is no way to reactivate the ban. You have to place a whole new ban.

As a result, I have added a reban button that nulls the unbanned_ keys in the database.

![image](https://user-images.githubusercontent.com/24975989/137371621-69eb5924-1da9-42b3-a749-89d66f50156d.png)

The re-banned ban at the bottom matches the stats for all the banned variations.

![4XmINmUmvy](https://user-images.githubusercontent.com/24975989/137371722-06497f7e-4021-4eb6-8416-68335c36d132.gif)

I have added edit tracking for unbanning and rebanning to support this new feature more fully.
![image](https://user-images.githubusercontent.com/24975989/137374347-cd1c6e00-f5f9-4789-8aca-43e1ed95c0d8.png)

Review adjustments:

The check for placing additional admin bans has been pulled into its own proc, `/datum/admins/proc/can_place_additional_admin_ban()`

Creating, editing and rebanning now use this proc to ensure that admin bans can only be placed if the appropriate criteria is met.

Notifying a banned player of their ban as well as kicking for server bans has been pulled into its own proc, `/datum/admins/proc/notify_all_banned_players()`

Creating, editing and rebanning all use this proc. This proc is pretty much universal and incorporates all behaviours of all other procs that used to have their own bespoke handling.

This means that editing bans now displays the appeal URL alongside the edit reason to players thanks to this unified behaviour. Editing server bans where the changes include CID, IP or ckey will now kick any players matching the new details similar to creating a new ban.

Rebanning will kick any players matching the ban details if the ban was a server ban.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes admins happy.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed an issue where the unbanning panel would give inaccurate information about the ban in the unban confirmation prompts.
fix: Fixed an issue where clicking the X to close out the confirmation popup on the unbanning panel acted as if you'd pressed Yes.
admin: Added a reban button to the unbanning panel. This allows an admin to quickly and easily re-apply a ban they've removed and replaces the unban button when a ban has been removed. As a result, accidentally removing the wrong ban no longer requires the admin to place a second brand new ban on top of the old one.
admin: Editing the IP, ckey or CID of a server ban will now kick any players matching the edited ban's new details.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
