### PR TITLE
Monkeys Can Click on Worn Backpacks to Open Them, Killing Ancient Bug

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -492,23 +492,36 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	return TRUE
 
 /obj/item/attack_paw(mob/user, list/modifiers)
+	. = ..()
+	if(.)
+		return
 	if(!user)
 		return
 	if(anchored)
 		return
 
+	. = TRUE
+
+	if(!(interaction_flags_item & INTERACT_ITEM_ATTACK_HAND_PICKUP)) //See if we're supposed to auto pickup.
+		return
+
+	//If the item is in a storage item, take it out
 	SEND_SIGNAL(loc, COMSIG_TRY_STORAGE_TAKE, src, user.loc, TRUE)
+	if(QDELETED(src)) //moving it out of the storage to the floor destroyed it.
+		return
 
 	if(throwing)
 		throwing.finalize(FALSE)
 	if(loc == user)
-		if(!user.temporarilyRemoveItemFromInventory(src))
+		if(!allow_attack_hand_drop(user) || !user.temporarilyRemoveItemFromInventory(src))
 			return
 
+	. = FALSE
 	pickup(user)
 	add_fingerprint(user)
 	if(!user.put_in_active_hand(src, FALSE, FALSE))
 		user.dropItemToGround(src)
+		return TRUE
 
 /obj/item/attack_alien(mob/user, list/modifiers)
 	var/mob/living/carbon/alien/ayy = user


### PR DESCRIPTION
## About The Pull Request

Fixes #37518 , which has been in the game for much longer than 3 years.  I'd estimate it's been around since monkeys were conceived, with the initial attempt to fix it being back in 2013 (Pull Request #846), over 8 years ago.

Allows monkeys to open worn backpacks instead of needing to drag them onto their sprite.  Cause of this is the awful thing that is attack_paw, which is by far one of the greatest evils of our time but I'm not the one to fix that.  On a technical level, this PR just adds some of the checks attack_hand does while omitting any balance-changing ones in order to fix this issue.

Do note that due to the nature of this fix, this might fix other monkey item bugs as well or cause unintentional behavior, but I can't think of anything bad coming from this.

## Why It's Good For The Game

Makes it much, much easier to use a backpack as a monkey.  Also finally puts this long-standing bug to rest.

## Changelog

:cl:
fix: Monkeys can now open worn backpacks by clicking on them.
/:cl: