### PR TITLE
Monkified Mutation Gives Generic Monkey Name Again

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -182,16 +182,20 @@
 	time_coeff = 2
 	locked = TRUE //Species specific, keep out of actual gene pool
 	var/datum/species/original_species = /datum/species/human
+	var/original_name
 
 /datum/mutation/human/race/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
 	if(!ismonkey(owner))
 		original_species = owner.dna.species.type
+		original_name = owner.real_name
+		owner.fully_replace_character_name(null, "monkey ([rand(1,999)])")
 	. = owner.monkeyize()
 
 /datum/mutation/human/race/on_losing(mob/living/carbon/human/owner)
 	if(owner && owner.stat != DEAD && (owner.dna.mutations.Remove(src)) && ismonkey(owner))
+		owner.fully_replace_character_name(null, original_name)
 		. = owner.humanize(original_species)
 
 /datum/mutation/human/glow


### PR DESCRIPTION
## About The Pull Request

This PR re-adds a mechanic lost during the monkey species refactor where the monkified mutation gave the afflicted a generic monkey name as opposed to keeping their original name.

## Why It's Good For The Game

This feature was forgotten about during the monkey species rework.  Plus, it makes more sense that in looking at a monkified person that they are only identifiable as a generic monkey as opposed to knowing exactly who they are.

## Changelog
:cl:
fix: Players with the monkified mutation now have a generic monkey name as opposed to their actual name again.
/:cl: