### PR TITLE
Fix backwards morgue trays in icebox chapel

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -4578,10 +4578,10 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "tp" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
 /obj/machinery/light/directional/south,
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -5307,7 +5307,7 @@
 /area/maintenance/department/chapel)
 "wv" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 2
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1


### PR DESCRIPTION
## About The Pull Request

Ensures the morgue trays go towards the user instead of out into the wall.

## Why It's Good For The Game

Chaplains can actually use their morgues.

## Changelog

:cl: Melbert
fix: Icebox chapel morgue slabs are now all the right direction
/:cl:
