### PR TITLE
custom say emotes, or in other words, radio emotes

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -54,6 +54,8 @@
 
 #define MODE_SING "sing"
 
+#define MODE_CUSTOM_SAY "custom_say"
+
 //Spans. Robot speech, italics, etc. Applied in compose_message().
 #define SPAN_ROBOT "robot"
 #define SPAN_YELL "yell"

--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -54,7 +54,9 @@
 
 #define MODE_SING "sing"
 
-#define MODE_CUSTOM_SAY "custom_say"
+#define MODE_CUSTOM_SAY_EMOTE "custom_say"
+
+#define MODE_CUSTOM_SAY_ERASE_INPUT "erase_input"
 
 //Spans. Robot speech, italics, etc. Applied in compose_message().
 #define SPAN_ROBOT "robot"

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -296,8 +296,9 @@
 	. = ..()
 	if(radio_freq || !broadcasting || get_dist(src, speaker) > canhear_range)
 		return
-	var/filtered_mods = list()
+	var/filtered_mods
 	if (message_mods[MODE_CUSTOM_SAY_EMOTE])
+		filtered_mods = list()
 		filtered_mods[MODE_CUSTOM_SAY_EMOTE] = message_mods[MODE_CUSTOM_SAY_EMOTE]
 		filtered_mods[MODE_CUSTOM_SAY_ERASE_INPUT] = message_mods[MODE_CUSTOM_SAY_ERASE_INPUT]
 	if(message_mods[RADIO_EXTENSION] == MODE_L_HAND || message_mods[RADIO_EXTENSION] == MODE_R_HAND)
@@ -309,7 +310,7 @@
 			if (idx && (idx % 2) == (message_mods[RADIO_EXTENSION] == MODE_L_HAND))
 				return
 
-	talk_into(speaker, raw_message, , spans, language=message_language, filtered_mods)
+	talk_into(speaker, raw_message, , spans, language=message_language, message_mods=filtered_mods)
 
 // Checks if this radio can receive on the given frequency.
 /obj/item/radio/proc/can_receive(freq, level)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -296,9 +296,8 @@
 	. = ..()
 	if(radio_freq || !broadcasting || get_dist(src, speaker) > canhear_range)
 		return
-	var/filtered_mods
+	var/filtered_mods = list()
 	if (message_mods[MODE_CUSTOM_SAY_EMOTE])
-		filtered_mods = list()
 		filtered_mods[MODE_CUSTOM_SAY_EMOTE] = message_mods[MODE_CUSTOM_SAY_EMOTE]
 		filtered_mods[MODE_CUSTOM_SAY_ERASE_INPUT] = message_mods[MODE_CUSTOM_SAY_ERASE_INPUT]
 	if(message_mods[RADIO_EXTENSION] == MODE_L_HAND || message_mods[RADIO_EXTENSION] == MODE_R_HAND)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -296,7 +296,10 @@
 	. = ..()
 	if(radio_freq || !broadcasting || get_dist(src, speaker) > canhear_range)
 		return
-
+	var/filtered_mods = list()
+	if (message_mods[MODE_CUSTOM_SAY_EMOTE])
+		filtered_mods[MODE_CUSTOM_SAY_EMOTE] = message_mods[MODE_CUSTOM_SAY_EMOTE]
+		filtered_mods[MODE_CUSTOM_SAY_ERASE_INPUT] = message_mods[MODE_CUSTOM_SAY_ERASE_INPUT]
 	if(message_mods[RADIO_EXTENSION] == MODE_L_HAND || message_mods[RADIO_EXTENSION] == MODE_R_HAND)
 		// try to avoid being heard double
 		if (loc == speaker && ismob(speaker))
@@ -306,7 +309,7 @@
 			if (idx && (idx % 2) == (message_mods[RADIO_EXTENSION] == MODE_L_HAND))
 				return
 
-	talk_into(speaker, raw_message, , spans, language=message_language)
+	talk_into(speaker, raw_message, , spans, language=message_language, filtered_mods)
 
 // Checks if this radio can receive on the given frequency.
 /obj/item/radio/proc/can_receive(freq, level)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -97,7 +97,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		spans |= SPAN_YELL
 
 	var/spanned = attach_spans(input, spans)
-	return "[say_mod(input, message_mods)], \"[spanned]\""
+	return "[say_mod(input, message_mods)][spanned ? ", \"[spanned]\"" : ""]"
 
 /// Transforms the speech emphasis mods from [/atom/movable/proc/say_emphasis] into the appropriate HTML tags. Includes escaping.
 #define ENCODE_HTML_EMPHASIS(input, char, html, varname) \
@@ -115,21 +115,25 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 #undef ENCODE_HTML_EMPHASIS
 
+/atom/movable/proc/quoteless_say_quote(input, list/spans = list(speech_span), message_mods)
+	var/pos = findtext(input, "*")
+	return pos ? copytext(input, pos + 1) : input
+
 /atom/movable/proc/lang_treat(atom/movable/speaker, datum/language/language, raw_message, list/spans, list/message_mods = list(), no_quote = FALSE)
 	if(has_language(language))
 		var/atom/movable/AM = speaker.GetSource()
 		if(AM) //Basically means "if the speaker is virtual"
-			return no_quote ? raw_message : AM.say_quote(raw_message, spans, message_mods)
+			return no_quote ? AM.quoteless_say_quote(raw_message, spans, message_mods) : AM.say_quote(raw_message, spans, message_mods)
 		else
-			return no_quote ? raw_message : speaker.say_quote(raw_message, spans, message_mods)
+			return no_quote ? speaker.quoteless_say_quote(raw_message, spans, message_mods) : speaker.say_quote(raw_message, spans, message_mods)
 	else if(language)
 		var/atom/movable/AM = speaker.GetSource()
 		var/datum/language/D = GLOB.language_datum_instances[language]
 		raw_message = D.scramble(raw_message)
 		if(AM)
-			return no_quote ? raw_message : AM.say_quote(raw_message, spans, message_mods)
+			return no_quote ? AM.quoteless_say_quote(raw_message, spans, message_mods) : AM.say_quote(raw_message, spans, message_mods)
 		else
-			return no_quote ? raw_message : speaker.say_quote(raw_message, spans, message_mods)
+			return no_quote ? speaker.quoteless_say_quote(raw_message, spans, message_mods) : speaker.say_quote(raw_message, spans, message_mods)
 	else
 		return "makes a strange sound."
 
@@ -145,8 +149,14 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		return returntext
 	return "[copytext_char("[freq]", 1, 4)].[copytext_char("[freq]", 4, 5)]"
 
-/proc/attach_spans(input, list/spans)
-	return "[message_spans_start(spans)][input]</span>"
+/atom/movable/proc/attach_spans(input, list/spans)
+	var/customsayverb = findtext(input,"*")
+	if (customsayverb)
+		input = capitalize(copytext(input, customsayverb + length(input[customsayverb])))
+	if (input)
+		return "[message_spans_start(spans)][input]</span>"
+	else
+		return
 
 /proc/message_spans_start(list/spans)
 	var/output = "<span class='"

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -149,7 +149,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		return returntext
 	return "[copytext_char("[freq]", 1, 4)].[copytext_char("[freq]", 4, 5)]"
 
-/atom/movable/proc/attach_spans(input, list/spans)
+/proc/attach_spans(input, list/spans)
 	return "[message_spans_start(spans)][input]</span>"
 
 /proc/message_spans_start(list/spans)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -275,7 +275,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		// Create map text prior to modifying message for goonchat, sign lang edition
 		if (client?.prefs.read_preference(/datum/preference/toggle/enable_runechat) && !(stat == UNCONSCIOUS || stat == HARD_CRIT || is_blind(src)) && (client.prefs.read_preference(/datum/preference/toggle/enable_runechat_non_mobs) || ismob(speaker)))
 			if (message_mods[MODE_CUSTOM_SAY_ERASE_INPUT])
-				create_chat_message(speaker, message_language, message_mods[MODE_CUSTOM_SAY_EMOTE], spans, EMOTE_MESSAGE)
+				create_chat_message(speaker, null, message_mods[MODE_CUSTOM_SAY_EMOTE], spans, EMOTE_MESSAGE)
 			else
 				create_chat_message(speaker, message_language, raw_message, spans)
 
@@ -299,7 +299,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	// Create map text prior to modifying message for goonchat
 	if (client?.prefs.read_preference(/datum/preference/toggle/enable_runechat) && !(stat == UNCONSCIOUS || stat == HARD_CRIT) && (client.prefs.read_preference(/datum/preference/toggle/enable_runechat_non_mobs) || ismob(speaker)) && can_hear())
 		if (message_mods[MODE_CUSTOM_SAY_ERASE_INPUT])
-			create_chat_message(speaker, message_language, message_mods[MODE_CUSTOM_SAY_EMOTE], spans, EMOTE_MESSAGE)
+			create_chat_message(speaker, null, message_mods[MODE_CUSTOM_SAY_EMOTE], spans, EMOTE_MESSAGE)
 		else
 			create_chat_message(speaker, message_language, raw_message, spans)
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -452,7 +452,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 	return 0
 
-/mob/living/say_mod(input, message_mods)
+/mob/living/say_mod(input, list/message_mods = list())
 	if(message_mods[WHISPER_MODE] == MODE_WHISPER)
 		. = verb_whisper
 	else if(message_mods[WHISPER_MODE] == MODE_WHISPER_CRIT)

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -445,7 +445,13 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 
 	return 0
 
-/mob/living/say_mod(input, list/message_mods = list())
+/mob/living/say_mod(input, message_mods)
+	if(message_mods == MODE_WHISPER_CRIT)
+		return ..()
+	var/customsayverb = findtext(input, "*")
+	if(customsayverb)
+		message_mods = MODE_CUSTOM_SAY
+		return lowertext(copytext_char(input, 1, customsayverb))
 	if(message_mods[WHISPER_MODE] == MODE_WHISPER)
 		. = verb_whisper
 	else if(message_mods[WHISPER_MODE] == MODE_WHISPER_CRIT)
@@ -464,6 +470,12 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			. = "gibbers"
 	else
 		. = ..()
+
+/proc/uncostumize_say(input, message_mods)
+	. = input
+	if(message_mods == MODE_CUSTOM_SAY)
+		var/customsayverb = findtext(input, "*")
+		return lowertext(copytext_char(input, 1, customsayverb))
 
 /mob/living/whisper(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	if(!message)

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -103,6 +103,17 @@
 
 ///The amount of items we are looking for in the message
 #define MESSAGE_MODS_LENGTH 6
+
+/mob/proc/check_for_custom_say_emote(message, list/mods)
+	var/customsaypos = findtext(message, "*")
+	if(!customsaypos)
+		return message
+	mods[MODE_CUSTOM_SAY_EMOTE] = lowertext(copytext_char(message, 1, customsaypos))
+	message = copytext(message, customsaypos + 1)
+	if (!message)
+		mods[MODE_CUSTOM_SAY_ERASE_INPUT] = TRUE
+		message = "an interesting thing to say"
+	return message
 /**
  * Extracts and cleans message of any extenstions at the begining of the message
  * Inserts the info into the passed list, returns the cleaned message

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -110,7 +110,10 @@
 		return message
 	mods[MODE_CUSTOM_SAY_EMOTE] = lowertext(copytext_char(message, 1, customsaypos))
 	message = copytext(message, customsaypos + 1)
-	if (!message)
+	var/emote_ban = is_banned_from(ckey, "Emote")
+	if (emote_ban)
+		mods[MODE_CUSTOM_SAY_EMOTE] = null
+	if (!message && !emote_ban)
 		mods[MODE_CUSTOM_SAY_ERASE_INPUT] = TRUE
 		message = "an interesting thing to say"
 	return message

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -108,12 +108,11 @@
 	var/customsaypos = findtext(message, "*")
 	if(!customsaypos)
 		return message
+	if (is_banned_from(ckey, "Emote"))
+		return copytext(message, customsaypos + 1)
 	mods[MODE_CUSTOM_SAY_EMOTE] = lowertext(copytext_char(message, 1, customsaypos))
 	message = copytext(message, customsaypos + 1)
-	var/emote_ban = is_banned_from(ckey, "Emote")
-	if (emote_ban)
-		mods[MODE_CUSTOM_SAY_EMOTE] = null
-	if (!message && !emote_ban)
+	if (!message)
 		mods[MODE_CUSTOM_SAY_ERASE_INPUT] = TRUE
 		message = "an interesting thing to say"
 	return message


### PR DESCRIPTION
## About The Pull Request

title


![Screenshot 2021-10-15 175819](https://user-images.githubusercontent.com/49109742/137470173-ff503e03-2040-45a1-bd4d-24c4b4d2adb2.png)

In order, going from top to bottom, what was said to make those lines:
- ";screams!*"
- ";,o taps his mic before saying*testing, testing, one two, one two."
- ";taps his mic before saying*testing, testing, one two, one two."
- (with forked tongue) ";taps his mic before saying*testing, testing, one two, one two."

it also works when not on the radio as well of course, don't worry.

### The format is:
"[radio keys/language keys/etc][the say emote]*[what should be said]"

## Why It's Good For The Game

fun things?

## Changelog

:cl:
add: custom say emotes, or in other words, radio emotes. The format is for example "screams and shouts*damnit!" with any relevant radio keys, language keys and all that used as normal, for example, ";,o screams and shouts*damnit!" or you can use just the emote, ie, ";screams!*"
/:cl: