### PR TITLE
Cleanup Flagged Issues are now auto-closed after 7 days.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,8 @@ jobs:
         stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being auto closed in ~ 7 days, please address any outstanding review items and ensure your PR is finished, if these are all true and you are auto-staled anyway, you need to actively ask maintainers if your PR will be merged. Once you have done any of the previous actions then you should request a maintainer remove the stale label on your PR, to reset the stale timer. If you feel no maintainer will respond in that time, you may wish to close this PR youself, while you seek maintainer comment, as you will then be able to reopen the PR yourself"
         days-before-stale: 7
         days-before-close: 7
-        days-before-issue-stale: -1
-        days-before-issue-close: -1
         stale-pr-label: 'Stale'
+        days-before-issue-stale: -1
+        stale-issue-label: 'Cleanup Flagged'
+        remove-issue-stale-when-updated: false
         exempt-pr-labels: 'RED LABEL,Good First PR'


### PR DESCRIPTION
## About The Pull Request
We have a cleanup flagged label for issues that should be closed soon because they are either non-issues or may have been already fixed or couldn't be reproduced et similar, but it's currently nothing more than a reminder that most issue jannies don't use or routinely check and could as well be automated.

## Why It's Good For The Game
See above.

## Changelog
N/A