### PR TITLE
Updates the Goon Source code objective item to be on par with all other high risk items.

### DIFF
--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -137,6 +137,7 @@
 	icon = 'icons/obj/nuke_tools.dmi'
 	icon_state = "something_awful"
 	max_capacity = 512
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 // STEALING SUPERMATTER
 

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -201,11 +201,11 @@
 
 /// Master R&D server. As long as this still exists and still holds the HDD for the theft objective, research points generate at normal speed. Destroy it or an antag steals the HDD? Half research speed.
 /obj/machinery/rnd/server/master
+	max_integrity = 1800 //takes roughly ~15s longer to break then full deconstruction.
 	var/obj/item/computer_hardware/hard_drive/cluster/hdd_theft/source_code_hdd
 	var/deconstruction_state = HDD_PANEL_CLOSED
 	var/front_panel_screws = 4
 	var/hdd_wires = 6
-	max_integrity = 1800 //takes roughly ~15s longer to break then full deconstruction.
 
 /obj/machinery/rnd/server/master/Initialize(mapload)
 	. = ..()

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -210,6 +210,7 @@
 /obj/machinery/rnd/server/master/Initialize(mapload)
 	. = ..()
 	name = "\improper Master " + name
+	desc += "\nIt looks incredibly resistant to damage!"
 	source_code_hdd = new(src)
 	SSresearch.master_servers += src
 

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -205,6 +205,7 @@
 	var/deconstruction_state = HDD_PANEL_CLOSED
 	var/front_panel_screws = 4
 	var/hdd_wires = 6
+	max_integrity = 1800 //takes roughly ~15s longer to break then full deconstruction.
 
 /obj/machinery/rnd/server/master/Initialize(mapload)
 	. = ..()
@@ -215,9 +216,6 @@
 	add_overlay("RD-server-objective-stripes")
 
 /obj/machinery/rnd/server/master/Destroy()
-	if(source_code_hdd)
-		QDEL_NULL(source_code_hdd)
-
 	SSresearch.master_servers -= src
 
 	return ..()
@@ -318,12 +316,12 @@
 		if(usr)
 			var/mob/user = usr
 
-			message_admins("[ADMIN_LOOKUPFLW(user)] deconstructed [ADMIN_JMP(src)], destroying [source_code_hdd] inside.")
-			log_game("[key_name(user)] deconstructed [src], destroying [source_code_hdd] inside.")
+			message_admins("[ADMIN_LOOKUPFLW(user)] deconstructed [ADMIN_JMP(src)].")
+			log_game("[key_name(user)] deconstructed [src].")
 			return ..()
 
-		message_admins("[ADMIN_JMP(src)] has been deconstructed by an unknown user, destroying [source_code_hdd] inside.")
-		log_game("[src] has been deconstructed by an unknown user, destroying [source_code_hdd] inside.")
+		message_admins("[ADMIN_JMP(src)] has been deconstructed by an unknown user.")
+		log_game("[src] has been deconstructed by an unknown user.")
 
 	return ..()
 

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -219,6 +219,7 @@
 /obj/machinery/rnd/server/master/Destroy()
 	if (source_code_hdd && (deconstruction_state == HDD_OVERLOADED))
 		QDEL_NULL(source_code_hdd)
+
 	SSresearch.master_servers -= src
 
 	return ..()

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -217,6 +217,8 @@
 	add_overlay("RD-server-objective-stripes")
 
 /obj/machinery/rnd/server/master/Destroy()
+	if (source_code_hdd && (deconstruction_state == HDD_OVERLOADED))
+		QDEL_NULL(source_code_hdd)
 	SSresearch.master_servers -= src
 
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, all it takes to ruin an antagonist's round (assuming they have this objective) is to walk into the server room, and break the master server, as this will delete the drive inside. It is extremely weak, a fire axe will break it in less than 15 seconds. 

Not only that, but the drive itself is also not resistant, making it relatively easy to lose it and have it destroyed in various station emergencies.
Compared to every other high risk item, this doesn't make much sense, as they are all supposed to be virtually impossible to get rid off. 

**This does not effect the ninja's objective of destroying the drive.**

This ups the integrity of the master server, making it take ~15s longer to break it with a wielded fire axe, than it does to just deconstruct it. It also adds resistances to the drive itself, which brings it up to the same level as every other high risk item.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Closes https://github.com/tgstation/tgstation/issues/62128

## Why It's Good For The Game

As with other traitor objectives, the item shouldn't be easily destroyed, if at all. It takes nearly no effort to ruin someone's greentext, if they were to have this objective. As far as I can tell, the idea thus far has been to prevent objective item destruction, so this PR aims to update this item to follow that.

If there is a reason that this specific item should be able to be destroyed so easily, I'm perfectly fine with closing this PR.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: The Goon Source code item is now invulnerable to deletion (aside from ninja intervention), similar to every other high risk item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
