### PR TITLE
SM Zap: Fix forked target selection

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1287,9 +1287,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		zap_str -= (zap_str/10)
 		zap_count += 1
 	for(var/j in 1 to zap_count)
+		var/child_targets_hit = targets_hit
 		if(zap_count > 1)
-			targets_hit = targets_hit.Copy() //Pass by ref begone
-		supermatter_zap(target, new_range, zap_str, zap_flags, targets_hit, zap_cutoff, power_level, zap_icon)
+			child_targets_hit = targets_hit.Copy() //Pass by ref begone
+		supermatter_zap(target, new_range, zap_str, zap_flags, child_targets_hit, zap_cutoff, power_level, zap_icon)
 
 /obj/overlay/psy
 	icon = 'icons/obj/supermatter.dmi'


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Supermatter forked lightning can now hit targets previously used by a sibling.

The default setup - and anything using two grounding rods - was still entirely safe, as "pass by ref begone" code did allow target reuse in ancestors. Any split could only exclude one grounding rod, and if one branch split again, neither branch's targets would be passed back to the target list of the first split.

The same issue was not present in `proc/tesla_zap`. Probably still shouldn't have two of these, though.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

```dm
//Pass by ref begone
```
for real this time


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed supermatter lightning bolt target selection. Previously, two grounding rods were always* safe. Now, one grounding rod is always* safe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
