### PR TITLE
Power generation (collectors, coils, grounding rods) cleanup

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
@@ -757,12 +757,12 @@
 /turf/open/floor/engine/airless,
 /area/icemoon/surface/outdoors)
 "dc" = (
-/obj/machinery/power/rad_collector,
+/obj/machinery/power/energy_accumulator/rad_collector,
 /obj/structure/cable,
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors)
 "dd" = (
-/obj/machinery/power/rad_collector,
+/obj/machinery/power/energy_accumulator/rad_collector,
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors)
 "de" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -557,7 +557,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/power/rad_collector,
+/obj/machinery/power/energy_accumulator/rad_collector,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "ee" = (
@@ -1175,7 +1175,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/power/rad_collector,
+/obj/machinery/power/energy_accumulator/rad_collector,
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "fa" = (

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -2853,7 +2853,7 @@
 /area/ruin/space/has_grav/ancientstation/betacorridor)
 "hK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/tesla_coil,
+/obj/machinery/power/energy_accumulator/tesla_coil,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "hL" = (
@@ -6302,7 +6302,7 @@
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "rZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/grounding_rod,
+/obj/machinery/power/energy_accumulator/grounding_rod,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "sy" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -64198,7 +64198,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/power/grounding_rod/anchored,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "nbH" = (
@@ -69492,7 +69492,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/power/tesla_coil/anchored,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "ozg" = (
@@ -77150,7 +77150,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "qKx" = (
-/obj/machinery/power/tesla_coil,
+/obj/machinery/power/energy_accumulator/tesla_coil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -84164,7 +84164,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/power/tesla_coil/anchored,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "sOa" = (
@@ -84424,7 +84424,7 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "sTy" = (
-/obj/machinery/power/tesla_coil,
+/obj/machinery/power/energy_accumulator/tesla_coil,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Engineering - Secure Storage";
@@ -86460,7 +86460,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/power/grounding_rod/anchored,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "tBF" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -27733,7 +27733,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/machinery/power/tesla_coil/anchored,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "kqc" = (
@@ -27831,7 +27831,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/machinery/power/tesla_coil/anchored,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "ksz" = (
@@ -38430,7 +38430,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/machinery/power/grounding_rod/anchored,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "pRo" = (
@@ -40295,7 +40295,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/machinery/power/grounding_rod/anchored,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "qTA" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -39149,7 +39149,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/power/grounding_rod/anchored,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -48270,7 +48270,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/power/tesla_coil/anchored,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -65940,7 +65940,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/power/tesla_coil/anchored,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
@@ -79783,7 +79783,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/power/grounding_rod/anchored,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31329,7 +31329,7 @@
 /obj/structure/window/reinforced/plasma,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/power/grounding_rod/anchored,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "iZM" = (
@@ -32906,7 +32906,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/power/grounding_rod/anchored,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "jFe" = (
@@ -39794,7 +39794,7 @@
 /obj/structure/window/reinforced/plasma,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/power/tesla_coil/anchored,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "mfM" = (
@@ -48248,7 +48248,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/power/tesla_coil/anchored,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "pdS" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -9694,7 +9694,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/structure/cable,
-/obj/machinery/power/tesla_coil/anchored,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "bdJ" = (
@@ -44996,7 +44996,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/structure/cable,
-/obj/machinery/power/grounding_rod/anchored,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "oTr" = (
@@ -55926,7 +55926,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/structure/cable,
-/obj/machinery/power/tesla_coil/anchored,
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "tiq" = (
@@ -64534,7 +64534,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/structure/cable,
-/obj/machinery/power/grounding_rod/anchored,
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "wGY" = (

--- a/_maps/shuttles/ferry_lighthouse.dmm
+++ b/_maps/shuttles/ferry_lighthouse.dmm
@@ -141,7 +141,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/transport)
 "aN" = (
-/obj/machinery/power/grounding_rod{
+/obj/machinery/power/energy_accumulator/grounding_rod{
 	anchored = 1
 	},
 /turf/open/floor/mineral/titanium/blue,

--- a/code/__HELPERS/maths.dm
+++ b/code/__HELPERS/maths.dm
@@ -80,13 +80,19 @@
 		return "[round(units * 0.000001, 0.001)] MJ"
 	return "[round(units * 0.000000001, 0.0001)] GJ"
 
+/proc/joules_to_energy(joules)
+	return joules * (1 SECONDS) / SSmachines.wait
+
+/proc/energy_to_joules(energy_units)
+	return energy_units * SSmachines.wait / (1 SECONDS)
+
 ///Format an energy value measured in Power Cell units.
 /proc/display_energy(units)
 	// APCs process every (SSmachines.wait * 0.1) seconds, and turn 1 W of
 	// excess power into watts when charging cells.
 	// With the current configuration of wait=20 and CELLRATE=0.002, this
 	// means that one unit is 1 kJ.
-	return display_joules(units * SSmachines.wait * 0.1 WATTS)
+	return display_joules(energy_to_joules(units) WATTS)
 
 ///chances are 1:value. anyprob(1) will always return true
 /proc/anyprob(value)

--- a/code/datums/wires/tesla_coil.dm
+++ b/code/datums/wires/tesla_coil.dm
@@ -1,13 +1,13 @@
 /datum/wires/tesla_coil
 	proper_name = "Tesla Coil"
 	randomize = TRUE //Only one wire don't need blueprints
-	holder_type = /obj/machinery/power/tesla_coil
+	holder_type = /obj/machinery/power/energy_accumulator/tesla_coil
 
 /datum/wires/tesla_coil/New(atom/holder)
 	wires = list(WIRE_ZAP)
 	..()
 
 /datum/wires/tesla_coil/on_pulse(wire)
-	var/obj/machinery/power/tesla_coil/C = holder
+	var/obj/machinery/power/energy_accumulator/tesla_coil/C = holder
 	C.zap()
 	..()

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -55,7 +55,7 @@
 /obj/item/circuitboard/machine/grounding_rod
 	name = "Grounding Rod (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
-	build_path = /obj/machinery/power/grounding_rod
+	build_path = /obj/machinery/power/energy_accumulator/grounding_rod
 	req_components = list(/obj/item/stock_parts/capacitor = 1)
 	needs_anchored = FALSE
 
@@ -142,7 +142,7 @@
 	name = "Tesla Controller (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	desc = "Does not let you shoot lightning from your hands."
-	build_path = /obj/machinery/power/tesla_coil
+	build_path = /obj/machinery/power/energy_accumulator/tesla_coil
 	req_components = list(/obj/item/stock_parts/capacitor = 1)
 	needs_anchored = FALSE
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -74,7 +74,7 @@
 /datum/export/large/tesla_coil
 	cost = CARGO_CRATE_VALUE * 2.25
 	unit_name = "tesla coil"
-	export_types = list(/obj/machinery/power/tesla_coil)
+	export_types = list(/obj/machinery/power/energy_accumulator/tesla_coil)
 
 /datum/export/large/supermatter
 	cost = CARGO_CRATE_VALUE * 16
@@ -84,7 +84,7 @@
 /datum/export/large/grounding_rod
 	cost = CARGO_CRATE_VALUE * 1.2
 	unit_name = "grounding rod"
-	export_types = list(/obj/machinery/power/grounding_rod)
+	export_types = list(/obj/machinery/power/energy_accumulator/grounding_rod)
 
 /datum/export/large/iv
 	cost = CARGO_CRATE_VALUE * 0.25

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -918,10 +918,10 @@
 	name = "Grounding Rod Crate"
 	desc = "Four grounding rods guaranteed to keep any uppity tesla coil's lightning under control."
 	cost = CARGO_CRATE_VALUE * 8
-	contains = list(/obj/machinery/power/grounding_rod,
-					/obj/machinery/power/grounding_rod,
-					/obj/machinery/power/grounding_rod,
-					/obj/machinery/power/grounding_rod)
+	contains = list(/obj/machinery/power/energy_accumulator/grounding_rod,
+					/obj/machinery/power/energy_accumulator/grounding_rod,
+					/obj/machinery/power/energy_accumulator/grounding_rod,
+					/obj/machinery/power/energy_accumulator/grounding_rod)
 	crate_name = "grounding rod crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
@@ -970,10 +970,10 @@
 	name = "Tesla Coil Crate"
 	desc = "Whether it's high-voltage executions, creating research points, or just plain old assistant electrofrying: This pack of four Tesla coils can do it all!"
 	cost = CARGO_CRATE_VALUE * 10
-	contains = list(/obj/machinery/power/tesla_coil,
-					/obj/machinery/power/tesla_coil,
-					/obj/machinery/power/tesla_coil,
-					/obj/machinery/power/tesla_coil)
+	contains = list(/obj/machinery/power/energy_accumulator/tesla_coil,
+					/obj/machinery/power/energy_accumulator/tesla_coil,
+					/obj/machinery/power/energy_accumulator/tesla_coil,
+					/obj/machinery/power/energy_accumulator/tesla_coil)
 	crate_name = "tesla coil crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 

--- a/code/modules/power/energy_accumulator.dm
+++ b/code/modules/power/energy_accumulator.dm
@@ -1,0 +1,56 @@
+/// (this*100)% of stored power outputted per tick.
+/// Doesn't change output total, lower numbers just increases the smoothing - taking longer to ramp up, and longer to drop away.
+/// 4% means an accumulator, when starting up for the first time:
+/// - emits   50% of what is being received after 40 seconds
+/// - emits   90% of what is being received after two minutes
+/// - emits   99% of what is being received after four minutes
+/// after having stored energy for at least 4-5 minutes, then dropping input to nothing:
+/// - emits   50% of what was previously being received after 40 seconds
+/// - emits   25% of what was previously being received after 79 seconds
+/// - emits   10% of what was previously being received after two minutes
+/// - emits    1% of what was previously being received after four minutes
+#define ACCUMULATOR_STORED_OUTPUT 0.04
+
+/// Abstract type for generators that accumulate energy over time and slowly release it
+/// eg. radiation collectors, tesla coils
+/obj/machinery/power/energy_accumulator
+	anchored = FALSE
+	density = TRUE
+	///Whether this accumulator should connect to and power a powernet
+	var/wants_powernet = TRUE
+	///The amount of energy that is currently inside the machine before being converted to electricity
+	var/stored_energy = 0
+
+/obj/machinery/power/energy_accumulator/proc/get_stored_joules()
+	return energy_to_joules(stored_energy)
+
+/obj/machinery/power/energy_accumulator/proc/get_power_output()
+	// Always consume at least 2kJ of energy if we have at least that much stored
+	return min(stored_energy, (stored_energy*ACCUMULATOR_STORED_OUTPUT)+joules_to_energy(2000))
+
+/obj/machinery/power/energy_accumulator/process(delta_time)
+	// NB: stored_energy is stored in energy units, a unit of measurement which already includes SSmachines.wait
+	// Do not multiply by delta_time here. It is already accounted for by being energy units.
+	var/power_produced = get_power_output()
+	release_energy(power_produced)
+	stored_energy -= power_produced
+
+/obj/machinery/power/energy_accumulator/proc/release_energy(power_produced)
+	if(wants_powernet)
+		add_avail(power_produced)
+
+/obj/machinery/power/energy_accumulator/should_have_node()
+	return wants_powernet && anchored
+
+/obj/machinery/power/energy_accumulator/set_anchored(anchorvalue)
+	. = ..()
+	if(isnull(.))
+		return //no need to process if we didn't change anything.
+	if(!wants_powernet)
+		return
+	if(!anchorvalue)
+		disconnect_from_network()
+		return
+	connect_to_network()
+
+#undef ACCUMULATOR_STORED_OUTPUT

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -1,26 +1,19 @@
 //radiation needs to be over this amount to get power
-#define RAD_COLLECTOR_EFFICIENCY 80
-#define RAD_COLLECTOR_COEFFICIENT 100
-//(this*100)% of stored power outputted per tick. Doesn't actualy change output total, lower numbers just means collectors output for longer in absence of a source
-#define RAD_COLLECTOR_STORED_OUT 0.04
-//Produces at least 1000 watts if it has more than that stored
-#define RAD_COLLECTOR_OUTPUT min(stored_energy, (stored_energy*RAD_COLLECTOR_STORED_OUT)+1000)
+#define RAD_COLLECTOR_THRESHOLD 80
+//amount of joules created for each rad point over RAD_COLLECTOR_THRESHOLD
+#define RAD_COLLECTOR_COEFFICIENT 200
 
-/obj/machinery/power/rad_collector
+/obj/machinery/power/energy_accumulator/rad_collector
 	name = "Radiation Collector Array"
 	desc = "A device which uses radiation and plasma to produce power."
 	icon = 'icons/obj/singularity.dmi'
 	icon_state = "ca"
-	anchored = FALSE
-	density = TRUE
 	req_access = list(ACCESS_ENGINE_EQUIP, ACCESS_ATMOSPHERICS)
 	max_integrity = 350
 	integrity_failure = 0.2
 	rad_insulation = RAD_EXTREME_INSULATION
 	///Stores the loaded tank instance
 	var/obj/item/tank/internals/plasma/loaded_tank = null
-	///The amount of energy that is currently inside the machine before being converted to electricity
-	var/stored_energy = 0 // stored_energy += (pulse_strength-RAD_COLLECTOR_EFFICIENCY)*RAD_COLLECTOR_COEFFICIENT
 	///Is the collector working?
 	var/active = FALSE
 	///Is the collector locked with an id?
@@ -30,17 +23,10 @@
 	///Multiplier for the amount of gas removed per tick
 	var/power_production_drain = 0.001
 
-/obj/machinery/power/rad_collector/anchored/Initialize(mapload)
-	. = ..()
-	set_anchored(TRUE)
+/obj/machinery/power/energy_accumulator/rad_collector/anchored
+	anchored = TRUE
 
-/obj/machinery/power/rad_collector/Destroy()
-	return ..()
-
-/obj/machinery/power/rad_collector/should_have_node()
-	return anchored
-
-/obj/machinery/power/rad_collector/process(delta_time)
+/obj/machinery/power/energy_accumulator/rad_collector/process(delta_time)
 	if(!loaded_tank)
 		return
 	var/datum/gas_mixture/tank_mix = loaded_tank.return_air()
@@ -55,11 +41,9 @@
 	tank_mix.gases[/datum/gas/tritium][MOLES] += gasdrained
 	tank_mix.garbage_collect()
 
-	var/power_produced = RAD_COLLECTOR_OUTPUT
-	add_avail(power_produced)
-	stored_energy -= power_produced
+	. = ..()
 
-/obj/machinery/power/rad_collector/interact(mob/user)
+/obj/machinery/power/energy_accumulator/rad_collector/interact(mob/user)
 	if(!anchored)
 		return
 	if(locked)
@@ -75,24 +59,14 @@
 	fuel = fuel ? fuel[MOLES] : 0
 	investigate_log("turned [active?"<font color='green'>on</font>":"<font color='red'>off</font>"] by [key_name(user)]. [loaded_tank?"Fuel: [round(fuel/0.29)]%":"<font color='red'>It is empty</font>"].", INVESTIGATE_SINGULO)
 
-/obj/machinery/power/rad_collector/can_be_unfasten_wrench(mob/user, silent)
+/obj/machinery/power/energy_accumulator/rad_collector/can_be_unfasten_wrench(mob/user, silent)
 	if(!loaded_tank)
 		return ..()
 	if(!silent)
 		to_chat(user, span_warning("Remove the plasma tank first!"))
 	return FAILED_UNFASTEN
 
-
-/obj/machinery/power/rad_collector/set_anchored(anchorvalue)
-	. = ..()
-	if(isnull(.))
-		return //no need to process if we didn't change anything.
-	if(!anchorvalue)
-		disconnect_from_network()
-		return
-	connect_to_network()
-
-/obj/machinery/power/rad_collector/attackby(obj/item/item, mob/user, params)
+/obj/machinery/power/energy_accumulator/rad_collector/attackby(obj/item/item, mob/user, params)
 	if(istype(item, /obj/item/tank/internals/plasma))
 		if(!anchored)
 			to_chat(user, span_warning("[src] needs to be secured to the floor first!"))
@@ -120,12 +94,12 @@
 	else
 		return ..()
 
-/obj/machinery/power/rad_collector/wrench_act(mob/living/user, obj/item/item)
+/obj/machinery/power/energy_accumulator/rad_collector/wrench_act(mob/living/user, obj/item/item)
 	. = ..()
 	default_unfasten_wrench(user, item)
 	return TRUE
 
-/obj/machinery/power/rad_collector/screwdriver_act(mob/living/user, obj/item/item)
+/obj/machinery/power/energy_accumulator/rad_collector/screwdriver_act(mob/living/user, obj/item/item)
 	if(..())
 		return TRUE
 	if(!loaded_tank)
@@ -134,7 +108,7 @@
 	to_chat(user, span_warning("Remove the plasma tank first!"))
 	return TRUE
 
-/obj/machinery/power/rad_collector/crowbar_act(mob/living/user, obj/item/I)
+/obj/machinery/power/energy_accumulator/rad_collector/crowbar_act(mob/living/user, obj/item/I)
 	if(loaded_tank)
 		if(!locked)
 			eject()
@@ -146,27 +120,23 @@
 	to_chat(user, span_warning("There isn't a tank loaded!"))
 	return TRUE
 
-/obj/machinery/power/rad_collector/return_analyzable_air()
+/obj/machinery/power/energy_accumulator/rad_collector/return_analyzable_air()
 	if(!loaded_tank)
 		return null
 	return loaded_tank.return_analyzable_air()
 
-/obj/machinery/power/rad_collector/examine(mob/user)
+/obj/machinery/power/energy_accumulator/rad_collector/examine(mob/user)
 	. = ..()
 	if(!active)
 		. += span_notice("<b>[src]'s display displays the words:</b> \"Power production mode. Please insert <b>Plasma</b>.\"")
-	// stored_energy is converted directly to watts every SSmachines.wait * 0.1 seconds.
-	// Therefore, its units are joules per SSmachines.wait * 0.1 seconds.
-	// So joules = stored_energy * SSmachines.wait * 0.1
-	var/joules = stored_energy * SSmachines.wait * 0.1
-	. += span_notice("[src]'s display states that it has stored <b>[display_joules(joules)]</b>, and is processing <b>[display_power(RAD_COLLECTOR_OUTPUT)]</b>.")
+	. += span_notice("[src]'s display states that it has stored <b>[display_joules(get_stored_joules())]</b>, and is processing <b>[display_power(get_power_output())]</b>.")
 
-/obj/machinery/power/rad_collector/atom_break(damage_flag)
+/obj/machinery/power/energy_accumulator/rad_collector/atom_break(damage_flag)
 	. = ..()
 	if(.)
 		eject()
 
-/obj/machinery/power/rad_collector/proc/eject()
+/obj/machinery/power/energy_accumulator/rad_collector/proc/eject()
 	locked = FALSE
 	var/obj/item/tank/internals/plasma/tank = loaded_tank
 	if (!tank)
@@ -180,12 +150,12 @@
 	else
 		update_appearance()
 
-/obj/machinery/power/rad_collector/rad_act(pulse_strength)
+/obj/machinery/power/energy_accumulator/rad_collector/rad_act(pulse_strength)
 	. = ..()
-	if(loaded_tank && active && pulse_strength > RAD_COLLECTOR_EFFICIENCY)
-		stored_energy += (pulse_strength-RAD_COLLECTOR_EFFICIENCY)*RAD_COLLECTOR_COEFFICIENT
+	if(loaded_tank && active && pulse_strength > RAD_COLLECTOR_THRESHOLD)
+		stored_energy += joules_to_energy((pulse_strength-RAD_COLLECTOR_THRESHOLD)*RAD_COLLECTOR_COEFFICIENT)
 
-/obj/machinery/power/rad_collector/update_overlays()
+/obj/machinery/power/energy_accumulator/rad_collector/update_overlays()
 	. = ..()
 	if(loaded_tank)
 		. += "ptank"
@@ -194,7 +164,7 @@
 	if(active)
 		. += loaded_tank ? "on" : "error"
 
-/obj/machinery/power/rad_collector/proc/toggle_power()
+/obj/machinery/power/energy_accumulator/rad_collector/proc/toggle_power()
 	active = !active
 	if(active)
 		icon_state = "ca_on"
@@ -205,7 +175,5 @@
 	update_appearance()
 	return
 
-#undef RAD_COLLECTOR_EFFICIENCY
+#undef RAD_COLLECTOR_THRESHOLD
 #undef RAD_COLLECTOR_COEFFICIENT
-#undef RAD_COLLECTOR_STORED_OUT
-#undef RAD_COLLECTOR_OUTPUT

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1179,8 +1179,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		if(target_type > COIL)
 			continue
 
-		if(istype(test, /obj/machinery/power/tesla_coil/))
-			var/obj/machinery/power/tesla_coil/coil = test
+		if(istype(test, /obj/machinery/power/energy_accumulator/tesla_coil/))
+			var/obj/machinery/power/energy_accumulator/tesla_coil/coil = test
 			if(coil.anchored && !(coil.obj_flags & BEING_SHOCKED) && !coil.panel_open && prob(70))//Diversity of death
 				if(target_type != COIL)
 					arc_targets = list()
@@ -1190,8 +1190,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		if(target_type > ROD)
 			continue
 
-		if(istype(test, /obj/machinery/power/grounding_rod/))
-			var/obj/machinery/power/grounding_rod/rod = test
+		if(istype(test, /obj/machinery/power/energy_accumulator/grounding_rod/))
+			var/obj/machinery/power/energy_accumulator/grounding_rod/rod = test
 			//We're adding machine damaging effects, rods need to be surefire
 			if(rod.anchored && !rod.panel_open)
 				if(target_type != ROD)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -1,10 +1,13 @@
-/obj/machinery/power/tesla_coil
+// zap needs to be over this amount to get power
+#define TESLA_COIL_THRESHOLD 80
+// each zap power unit produces 400 joules
+#define ZAP_TO_ENERGY(p) (joules_to_energy((p) * 400))
+
+/obj/machinery/power/energy_accumulator/tesla_coil
 	name = "tesla coil"
 	desc = "For the union!"
 	icon = 'icons/obj/tesla_engine/tesla_coil.dmi'
 	icon_state = "coil0"
-	anchored = FALSE
-	density = TRUE
 
 	// Executing a traitor caught releasing tesla was never this fun!
 	can_buckle = TRUE
@@ -21,8 +24,6 @@
 	var/zap_cooldown = 100
 	///Reference to the last zap done
 	var/last_zap = 0
-	///Amount of power stored inside the coil to be released in the powernet
-	var/stored_energy = 0
 
 	//Variables to calculate sound based on stored_energy to give engineers an audioclue of the magnitude of energy production.
 	///Calculated range of zap sounds based on power
@@ -30,19 +31,14 @@
 	///Calculated volume of zap sounds based on power
 	var/zap_sound_volume = 0
 
-/obj/machinery/power/tesla_coil/anchored
+/obj/machinery/power/energy_accumulator/tesla_coil/anchored
 	anchored = TRUE
 
-/obj/machinery/power/tesla_coil/Initialize(mapload)
+/obj/machinery/power/energy_accumulator/tesla_coil/Initialize(mapload)
 	. = ..()
 	wires = new /datum/wires/tesla_coil(src)
-	if(anchored)
-		connect_to_network()
 
-/obj/machinery/power/tesla_coil/should_have_node()
-	return anchored
-
-/obj/machinery/power/tesla_coil/RefreshParts()
+/obj/machinery/power/energy_accumulator/tesla_coil/RefreshParts()
 	var/power_multiplier = 0
 	zap_cooldown = 100
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)
@@ -50,29 +46,25 @@
 		zap_cooldown -= (C.rating * 20)
 	input_power_multiplier = (0.85 * (power_multiplier / 4)) //Max out at 85% efficency.
 
-/obj/machinery/power/tesla_coil/examine(mob/user)
+/obj/machinery/power/energy_accumulator/tesla_coil/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
-		. += span_notice("The status display reads: Power generation at <b>[input_power_multiplier*100]%</b>.<br>Shock interval at <b>[zap_cooldown*0.1]</b> seconds.")
+		. += span_notice("The status display reads:<br>" + \
+		  "Power generation at <b>[input_power_multiplier*100]%</b>.<br>" + \
+			"Shock interval at <b>[zap_cooldown*0.1]</b> seconds.<br>" + \
+			"Stored <b>[display_joules(get_stored_joules())]</b>.<br>" + \
+			"Processing <b>[display_power(get_power_output())]</b>.")
 
-/obj/machinery/power/tesla_coil/on_construction()
-	if(anchored)
-		connect_to_network()
-
-/obj/machinery/power/tesla_coil/default_unfasten_wrench(mob/user, obj/item/I, time = 20)
+/obj/machinery/power/energy_accumulator/tesla_coil/default_unfasten_wrench(mob/user, obj/item/I, time = 20)
 	. = ..()
 	if(. == SUCCESSFUL_UNFASTEN)
 		if(panel_open)
 			icon_state = "coil_open[anchored]"
 		else
 			icon_state = "coil[anchored]"
-		if(anchored)
-			connect_to_network()
-		else
-			disconnect_from_network()
 		update_cable_icons_on_turf(get_turf(src))
 
-/obj/machinery/power/tesla_coil/attackby(obj/item/W, mob/user, params)
+/obj/machinery/power/energy_accumulator/tesla_coil/attackby(obj/item/W, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "coil_open[anchored]", "coil[anchored]", W))
 		return
 
@@ -88,14 +80,12 @@
 
 	return ..()
 
-/obj/machinery/power/tesla_coil/process(delta_time)
-	var/power_produced = min(stored_energy, (stored_energy * 0.04) + 1000) * delta_time
-	add_avail(power_produced)
-	stored_energy -= power_produced
-	zap_sound_volume = min(stored_energy/100000, 100)
-	zap_sound_range = min(stored_energy/2000000, 10)
+/obj/machinery/power/energy_accumulator/tesla_coil/process(delta_time)
+	. = ..()
+	zap_sound_volume = min(energy_to_joules(stored_energy)/200000, 100)
+	zap_sound_range = min(energy_to_joules(stored_energy)/4000000, 10)
 
-/obj/machinery/power/tesla_coil/zap_act(power, zap_flags)
+/obj/machinery/power/energy_accumulator/tesla_coil/zap_act(power, zap_flags)
 	if(!anchored || panel_open)
 		return ..()
 	obj_flags |= BEING_SHOCKED
@@ -107,10 +97,10 @@
 		power /= 10
 	zap_buckle_check(power)
 	var/power_removed = powernet ? power * input_power_multiplier : power
-	stored_energy += max((power_removed - 80) * 200, 0)
+	stored_energy += max(ZAP_TO_ENERGY(power_removed - TESLA_COIL_THRESHOLD), 0)
 	return max(power - power_removed, 0) //You get back the amount we didn't use
 
-/obj/machinery/power/tesla_coil/proc/zap()
+/obj/machinery/power/energy_accumulator/tesla_coil/proc/zap()
 	if((last_zap + zap_cooldown) > world.time || !powernet)
 		return FALSE
 	last_zap = world.time
@@ -121,22 +111,30 @@
 	tesla_zap(src, 10, power, zap_flags)
 	zap_buckle_check(power)
 
-/obj/machinery/power/grounding_rod
+/obj/machinery/power/energy_accumulator/grounding_rod
 	name = "grounding rod"
 	desc = "Keeps an area from being fried by Edison's Bane."
 	icon = 'icons/obj/tesla_engine/tesla_coil.dmi'
 	icon_state = "grounding_rod0"
 	anchored = FALSE
 	density = TRUE
+	wants_powernet = FALSE
 
 	can_buckle = TRUE
 	buckle_lying = 0
 	buckle_requires_restraints = TRUE
 
-/obj/machinery/power/grounding_rod/anchored
+/obj/machinery/power/energy_accumulator/grounding_rod/anchored
 	anchored = TRUE
 
-/obj/machinery/power/grounding_rod/default_unfasten_wrench(mob/user, obj/item/I, time = 20)
+/obj/machinery/power/energy_accumulator/grounding_rod/examine(mob/user)
+	. = ..()
+	if(in_range(user, src) || isobserver(user))
+		. += span_notice("The status display reads:<br>" + \
+		  "Recently grounded <b>[display_joules(get_stored_joules())]</b>.<br>" + \
+			"This energy would sustainably release <b>[display_power(get_power_output())]</b>.")
+
+/obj/machinery/power/energy_accumulator/grounding_rod/default_unfasten_wrench(mob/user, obj/item/I, time = 20)
 	. = ..()
 	if(. == SUCCESSFUL_UNFASTEN)
 		if(panel_open)
@@ -144,7 +142,7 @@
 		else
 			icon_state = "grounding_rod[anchored]"
 
-/obj/machinery/power/grounding_rod/attackby(obj/item/W, mob/user, params)
+/obj/machinery/power/energy_accumulator/grounding_rod/attackby(obj/item/W, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "grounding_rod_open[anchored]", "grounding_rod[anchored]", W))
 		return
 
@@ -156,10 +154,14 @@
 
 	return ..()
 
-/obj/machinery/power/grounding_rod/zap_act(power, zap_flags)
+/obj/machinery/power/energy_accumulator/grounding_rod/zap_act(power, zap_flags)
 	if(anchored && !panel_open)
 		flick("grounding_rodhit", src)
 		zap_buckle_check(power)
+		stored_energy += ZAP_TO_ENERGY(power)
 		return 0
 	else
 		. = ..()
+
+#undef TESLA_COIL_THRESHOLD
+#undef ZAP_TO_ENERGY

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -192,7 +192,7 @@
 			return
 	if(!iscarbon(A))
 		return
-	for(var/obj/machinery/power/grounding_rod/GR in orange(src, 2))
+	for(var/obj/machinery/power/energy_accumulator/grounding_rod/GR in orange(src, 2))
 		if(GR.anchored)
 			return
 	var/mob/living/carbon/C = A
@@ -253,8 +253,8 @@
 		else if(closest_type >= COIL)
 			continue //no need checking these other things
 
-		else if(istype(A, /obj/machinery/power/tesla_coil))
-			var/obj/machinery/power/tesla_coil/C = A
+		else if(istype(A, /obj/machinery/power/energy_accumulator/tesla_coil))
+			var/obj/machinery/power/energy_accumulator/tesla_coil/C = A
 			if(!(C.obj_flags & BEING_SHOCKED))
 				closest_type = COIL
 				closest_atom = C
@@ -262,7 +262,7 @@
 		else if(closest_type >= ROD)
 			continue
 
-		else if(istype(A, /obj/machinery/power/grounding_rod))
+		else if(istype(A, /obj/machinery/power/energy_accumulator/grounding_rod))
 			closest_type = ROD
 			closest_atom = A
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3258,6 +3258,7 @@
 #include "code\modules\power\apc.dm"
 #include "code\modules\power\cable.dm"
 #include "code\modules\power\cell.dm"
+#include "code\modules\power\energy_accumulator.dm"
 #include "code\modules\power\floodlight.dm"
 #include "code\modules\power\generator.dm"
 #include "code\modules\power\gravitygenerator.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Merges a lot of common code between Tesla Coils and Radiation Collectors by making them subtypes of a new `/obj/machinery/power/energy_accumulator` type.
- Fixes bugs with Tesla Coil `delta_time` handling, which caused power generation smoothing to be half as smooth as it should have been.
- Adds constants where previously there were magic numbers.
- Uses existing constants where previously there were magic numbers.
- Rework existing constants to be defined in terms of joules rather than in tickrate dependent units.
- Adds `energy_to_joules` and `joules_to_energy` helpers so the calculations aren't inlined everywhere.
- Tesla Coils and Grounding Rods now get a readout of energy stored and power generated - or for Grounding Rods, the energy that would have been stored, and the power that could have been generated. The information and examine format follows the style of the readouts that we had with Radiation Collectors.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Brings SOUL to Tesla Coils and Grounding Rods

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
refactor: Radiation Collectors, Tesla Coils, and Grounding Rods are now subtypes of a common energy_accumulator type. This centralizes logic for smoothing energy release; converting between Joules, Watts, and internal energy units; and ensures that all such accumulators display and generate power along the same smoothing curve.
fix: Tesla Coils no longer generate power using half the smoothing that Radiation Collectors used. This was due to a mistake in handling delta_time.
code: Removed many magic numbers from power generation code.
qol: Tesla Coils will now display energy stored in Joules and power being produced in Watts, much like Radiation Collectors did.
qol: Grounding Rods will now display recent energy they've absorbed and the sustainable power that this energy could be producing. It should now be very obvious if you could use more Tesla Coils.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
