### PR TITLE
Fixes changelings not being able to absorb people they've DNA stung before

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -248,9 +248,9 @@
  * Arguments:
  * * target - Who we're trying to absorb
  * * verbose - If TRUE, print a message to the changeling about why we can't absorb, if we can't
- * * override_nontrue_absorb - Set to TRUE for true absoprtions, which lets them override non-true absorptions, AKA DNA stings
+ * * is_true_absorb - Set to TRUE for true absoprtions, which lets them override non-true absorptions, AKA DNA stings
  */
-/datum/antagonist/changeling/proc/can_absorb_dna(mob/living/carbon/human/target, verbose = TRUE, override_nontrue_absorb = FALSE)
+/datum/antagonist/changeling/proc/can_absorb_dna(mob/living/carbon/human/target, verbose = TRUE, is_true_absorb = FALSE)
 	var/mob/living/carbon/user = owner.current
 	if(!istype(user))
 		return
@@ -262,40 +262,7 @@
 			return
 	if(!target)
 		return
-	if(NO_DNA_COPY in target.dna.species.species_traits)
-		if(verbose)
-			to_chat(user, span_warning("[target] is not compatible with our biology."))
-		return
-	if(HAS_TRAIT(target, TRAIT_BADDNA))
-		if(verbose)
-			to_chat(user, span_warning("DNA of [target] is ruined beyond usability!"))
-		return
-	if(HAS_TRAIT(target, TRAIT_HUSK))
-		if(verbose)
-			to_chat(user, span_warning("[target]'s body is ruined beyond usability!"))
-		return
-	if(!ishuman(target))
-		if(verbose)
-			to_chat(user, span_warning("We could gain no benefit from absorbing a lesser creature."))
-		return
-	if(has_dna(target.dna))
-		// in order for it to be possible to true absorb a body we already DNA stung, we have to be able to override DNA sting profiles
-		var/abort_absorb = TRUE
-		if(override_nontrue_absorb)
-			for(var/datum/changelingprofile/iter_profile in stored_profiles)
-				if(iter_profile.dna.is_same_as(target.dna) && !iter_profile.true_absorb)
-					abort_absorb = FALSE // the profile we have on this guy was only a DNA sting, so an absorption still goes through
-					break
-
-		if(abort_absorb)
-			if(verbose)
-				to_chat(user, span_warning("We already have this DNA in storage!"))
-			return
-	if(!target.has_dna())
-		if(verbose)
-			to_chat(user, span_warning("[target] is not compatible with our biology."))
-		return
-	return TRUE
+	return target.can_be_absorbed(src, verbose, is_true_absorb)
 
 
 /datum/antagonist/changeling/proc/create_profile(mob/living/carbon/human/H, protect = 0, true_absorb = FALSE)

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -25,7 +25,7 @@
 
 	var/mob/living/carbon/target = owner.pulling
 	var/datum/antagonist/changeling/changeling = owner.mind.has_antag_datum(/datum/antagonist/changeling)
-	return changeling.can_absorb_dna(target, override_nontrue_absorb = TRUE)
+	return changeling.can_absorb_dna(target, is_true_absorb = TRUE)
 
 /datum/action/changeling/absorb_dna/sting_action(mob/owner)
 	var/datum/antagonist/changeling/changeling = owner.mind.has_antag_datum(/datum/antagonist/changeling)

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -43,7 +43,6 @@
 	var/credit_absorb = TRUE // we get credit if we absorb a corpse we don't have DNA from, or if it's a corpse that's only been DNA stung previously
 
 	for(var/datum/changelingprofile/iter_profile as anything in changeling.stored_profiles)
-		credit_absorb = FALSE
 		if(iter_profile.dna.is_same_as(target.dna))
 			is_existing_profile = TRUE
 			credit_absorb = !iter_profile.true_absorb // we only get credit for the absorb if the existing DNA isn't already a true absorb

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1009,6 +1009,39 @@
 	if(mind.assigned_role.title in SSjob.name_occupations)
 		.[mind.assigned_role.title] = minutes
 
+/mob/living/carbon/human/can_be_absorbed(datum/antagonist/changeling/absorbing_changeling, verbose = TRUE, is_true_absorb = FALSE)
+	var/mob/changeling_mob = absorbing_changeling?.owner?.current
+
+	if(!istype(dna) || (NO_DNA_COPY in dna.species.species_traits))
+		if(verbose)
+			to_chat(changeling_mob, span_warning("[src] is not compatible with our biology."))
+		return
+
+	if(HAS_TRAIT(src, TRAIT_BADDNA))
+		if(verbose)
+			to_chat(changeling_mob, span_warning("DNA of [src] is ruined beyond usability!"))
+		return
+
+	if(HAS_TRAIT(src, TRAIT_HUSK))
+		if(verbose)
+			to_chat(changeling_mob, span_warning("[src]'s body is ruined beyond usability!"))
+		return
+
+	if(absorbing_changeling.has_dna(dna)) // changeling already absorbed this DNA
+		var/abort_absorb = TRUE // only way we don't abort is if it wasn't a true absorb before but this is a true absorb
+		if(is_true_absorb)
+			for(var/datum/changelingprofile/iter_profile in absorbing_changeling.stored_profiles)
+				if(iter_profile.dna.is_same_as(dna) && !iter_profile.true_absorb)
+					abort_absorb = FALSE // the profile we have on this guy was only a DNA sting, so an absorption still goes through
+					break
+
+		if(abort_absorb)
+			if(verbose)
+				to_chat(changeling_mob, span_warning("We already have this DNA in storage!"))
+			return
+
+	return TRUE
+
 /mob/living/carbon/human/monkeybrain
 	ai_controller = /datum/ai_controller/monkey
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2176,3 +2176,20 @@
 			span_userdanger("You're thrown violently into [lattice], smashing through it and punching straight through!"))
 		apply_damage(rand(5,10), BRUTE, BODY_ZONE_CHEST)
 		lattice.deconstruct(FALSE)
+
+/**
+ * Used to see if this specific mob is kosher to be absorbed by a changeling. Only really matters for humans
+ *
+ * Returns TRUE if the various absorb conditions are met on the mob (namely, it has valid DNA that the changeling does not have).
+ * Called by [/datum/antagonist/changeling/proc/can_absorb_dna], after said proc verifies that the changeling has the space for it
+ *
+ * Arguments:
+ * * absorbing_changeling - The changeling datum for the changeling succ'ing us
+ * * verbose - If TRUE, give the absorbing changeling a message for why they can't absorb us, if that's the case
+ * * is_true_absorb - If TRUE, that means it's not just a DNA sting, and can override DNA profiles gained by DNA stings (in case you sting someone you actually need to absorb)
+ */
+/mob/living/proc/can_be_absorbed(datum/antagonist/changeling/absorbing_changeling, verbose = TRUE, is_true_absorb = FALSE)
+	var/mob/changeling_mob = absorbing_changeling?.owner?.current
+	if(verbose)
+		to_chat(changeling_mob, span_warning("We could gain no benefit from absorbing a lesser creature."))
+	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently, if you're a ling and DNA sting someone, then later decide you want to fully absorb them, you're unable to do so because you already have their DNA stored. This is problematic if you DNA sting your absorption target, or another changeling who you want to absorb for the goodies you get from that.

This PR makes it so DNA sting changelingprofiles no longer block true absorptions. Instead, true absorbing someone you've already DNA stung simply marks the existing profile as truly stung so you can't succ it again, and gives you the credit and any possible goodies that  go along with it.

Mind changeling code is like super ancient and this initial draft may have bugs or side effects. Point out any possible issues in the reviews, p l s

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency, and if a ling actually wants to commit to doing a full succ when DNA sting is 99.99% of the time infinitely safer and less dangerous than absorptions, who are we to hardstop them from their dreams?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Ryll/Shaps
fix: Changelings can now fully absorb the bodies of people they previously DNA stung. It still only counts one body, but at least you're no longer doomed to redtext because you DNA stung your absorption target first by accident.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
