### PR TITLE
Fixes capitalisation error in hypernoblium crystal usage

### DIFF
--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer_items.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer_items.dm
@@ -18,7 +18,7 @@
 	if(worn_item.min_cold_protection_temperature == SPACE_SUIT_MIN_TEMP_PROTECT && worn_item.clothing_flags & STOPSPRESSUREDAMAGE)
 		to_chat(user, span_warning("[worn_item] is already pressure-resistant!"))
 		return
-	to_chat(user, span_notice("You see how the [worn_item] changes color, its now pressure proof."))
+	to_chat(user, span_notice("You see how the [worn_item] changes color, it's now pressure proof."))
 	worn_item.name = "pressure-resistant [worn_item.name]"
 	worn_item.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 	worn_item.add_atom_colour("#00fff7", FIXED_COLOUR_PRIORITY)

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer_items.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer_items.dm
@@ -1,6 +1,6 @@
 /obj/item/hypernoblium_crystal
 	name = "Hypernoblium Crystal"
-	desc = "crystalized oxygen and hypernoblium stored in a bottle to pressureproof your clothes."
+	desc = "Crystalized oxygen and hypernoblium stored in a bottle to pressureproof your clothes."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "potblue"
 	var/uses = 2
@@ -18,7 +18,7 @@
 	if(worn_item.min_cold_protection_temperature == SPACE_SUIT_MIN_TEMP_PROTECT && worn_item.clothing_flags & STOPSPRESSUREDAMAGE)
 		to_chat(user, span_warning("[worn_item] is already pressure-resistant!"))
 		return
-	to_chat(user, span_notice("you see how the [worn_item] changes color, its now pressure proof."))
+	to_chat(user, span_notice("You see how the [worn_item] changes color, its now pressure proof."))
 	worn_item.name = "pressure-resistant [worn_item.name]"
 	worn_item.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 	worn_item.add_atom_colour("#00fff7", FIXED_COLOUR_PRIORITY)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes two capitalisation errors in hypernoblium crystal usage messages.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better looking messages (also this was in the game for ~ 2 months and nobody noticed it because almost nobody messes with the crystalliser)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
spellcheck: Fixed capitalisation errors in hypernoblium crystal usage messages.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
