### PR TITLE
Gives paramedics external airlock access in lowpop

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -327,7 +327,7 @@
 /datum/id_trim/job/paramedic
 	assignment = "Paramedic"
 	trim_state = "trim_paramedic"
-	extra_access = list(ACCESS_SURGERY)
+	extra_access = list(ACCESS_SURGERY, ACCESS_EXTERNAL_AIRLOCKS)
 	minimal_access = list(ACCESS_AUX_BASE, ACCESS_CARGO, ACCESS_CONSTRUCTION, ACCESS_ENGINE, ACCESS_EVA, ACCESS_HYDROPONICS,
 					ACCESS_MAINT_TUNNELS, ACCESS_MECH_MEDICAL, ACCESS_MEDICAL, ACCESS_MINERAL_STOREROOM, ACCESS_MORGUE, ACCESS_RESEARCH)
 	config_job = "paramedic"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Grants paramedics external airlock access on lowpop. Originally suggested by https://github.com/tgstation/tgstation/pull/62161#issuecomment-945008272

## Why It's Good For The Game

It's in the job description. Paramedics should be able to make those daring space jumps to save the ones who got spaced. Restricted to lowpop because those sort of risks should be taken by the appropriate crewmates when fully staffed.

## Changelog

🆑 
balance: Paramedics now receive external airlock access in lowpop.
/:cl: