### PR TITLE
Fixes a minor mapping mistake on Icebox station

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -53799,8 +53799,6 @@
 /area/security/warden)
 "yac" = (
 /obj/structure/cable/multilayer/multiz,
-/obj/structure/cable/multilayer/multiz,
-/obj/structure/cable/multilayer/multiz,
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plating/snowed/icemoon,
 /area/maintenance/port/aft)


### PR DESCRIPTION
## About The Pull Request

Fixes 3 multi z layer cable hubs being on the same turf in port quarter maintenance, everywhere else in maps there's only 1 on a turf

## Changelog

No front-facing changes
