### PR TITLE
Pacifists can now fire circuit guns

### DIFF
--- a/code/modules/wiremod/shell/gun.dm
+++ b/code/modules/wiremod/shell/gun.dm
@@ -18,6 +18,7 @@
 
 /obj/item/ammo_casing/energy/wiremod_gun
 	projectile_type = /obj/projectile/energy/wiremod_gun
+	harmful = FALSE
 	select_name = "circuit"
 	fire_sound = 'sound/weapons/blaster.ogg'
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the 'harmful' var to wiregun casing so pacifists can fire the circuit gun.

## Why It's Good For The Game

Pacifists can use non-lethal weapons and the circuit gun seems pretty non-lethal.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: MMMiracles
fix: Pacifists can now fire the circuit gun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Fixes #62152