### PR TITLE
SM: Randomly damage/heal on dusting a Clown

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1062,6 +1062,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		consumed_mob.dust(force = TRUE)
 		if(power_changes)
 			matter_power += 200
+		if(takes_damage && is_clown_job(consumed_mob.mind?.assigned_role))
+			damage += rand(-300, 300) // HONK
+			damage = max(damage, 0)
 	else if(consumed_object.flags_1 & SUPERMATTER_IGNORES_1)
 		return
 	else if(isobj(consumed_object))

--- a/strings/sillytips.txt
+++ b/strings/sillytips.txt
@@ -31,6 +31,7 @@ As the Lawyer, you are the last bastion of roleplay-focused jobs. Even the curat
 There are at least 11 ways to get through plastic flaps. How many can you name?
 FEED ME A STRAY CAT
 Did you know that tossing the clown into a singularity will either increase or decrease its size by a large amount?
+Did you know that tossing the clown into the supermatter engine can destabilize or fix it massively?
 Most items have names longer than "soap".
 Demoman takes skill.
 Ask and you shall receive.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When the SM dusts a true Clown (HoP assignment doesn't count), it randomly takes from -300 to 300 damage.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We can't bring back lord singulo, but we can bring back some fragments of its soul

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: When all else fails, dusting a Clown can alter the Supermatter's containment field. It might make the situation better. It might not. Who knows, HONK
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
