### PR TITLE
Adds new Insect Habitat Icebox Ruin.

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_bughabitat.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_bughabitat.dmm
@@ -9,29 +9,29 @@
 	dir = 4
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "aR" = (
 /obj/item/reagent_containers/syringe/syriniver,
 /obj/effect/turf_decal/siding/wideplating/dark/corner,
 /obj/effect/turf_decal/tile/dark/anticorner,
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "bu" = (
 /obj/effect/spawner/random/food_or_drink/snack,
 /mob/living/basic/cockroach,
 /turf/open/floor/grass/snow/basalt/safe,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "bQ" = (
 /obj/effect/turf_decal/siding/wideplating/light{
 	color = "#236F26";
 	dir = 8
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "cK" = (
 /mob/living/simple_animal/ant,
 /turf/open/floor/grass,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "eM" = (
 /obj/structure/chair/pew/right{
 	dir = 8
@@ -41,7 +41,7 @@
 	},
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "eN" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/biogenerator,
@@ -51,15 +51,15 @@
 	dir = 5
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "fI" = (
 /obj/effect/decal/remains/human,
 /obj/item/clipboard,
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "fO" = (
 /turf/open/floor/grass/snow,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "fP" = (
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
 	dir = 1
@@ -68,11 +68,11 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "hk" = (
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/grass/snow,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "hy" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/toggle/labcoat,
@@ -80,7 +80,7 @@
 /obj/structure/cable,
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "hM" = (
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
 	dir = 4
@@ -89,16 +89,16 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "ih" = (
 /obj/structure/window/reinforced/tinted/fulltile,
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "kv" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/item/shovel,
 /turf/open/floor/grass/snow,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "lj" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/spawner/east,
@@ -108,15 +108,15 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "lE" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "lG" = (
 /obj/machinery/space_heater,
 /turf/open/floor/carpet/neon/simple/lime,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "ma" = (
 /obj/structure/statue/snow/snowman,
 /turf/open/floor/grass/snow,
@@ -125,7 +125,7 @@
 /obj/machinery/light/warm/directional/west,
 /obj/structure/tank_holder/oxygen,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "of" = (
 /obj/structure/sink{
 	dir = 4
@@ -135,60 +135,60 @@
 	dir = 8
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "ot" = (
 /mob/living/basic/cockroach,
 /obj/item/seeds/soya,
 /turf/open/floor/grass/snow/basalt/safe,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "oZ" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "qV" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/item/wallframe/camera,
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/grass,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "ri" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/spawner/random/food_or_drink/snack,
 /turf/open/floor/grass,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "rE" = (
 /obj/effect/spawner/random/structure/chair_flipped,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "sl" = (
 /obj/machinery/light/warm/directional/east,
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "sr" = (
 /obj/machinery/plumbing/growing_vat,
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "st" = (
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "tI" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "uB" = (
 /mob/living/simple_animal/butterfly,
 /obj/structure/chair/pew/left{
 	dir = 8
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "va" = (
 /obj/item/book/manual/wiki/cytology,
 /obj/structure/table,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "wC" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -196,25 +196,25 @@
 	color = "#236F26"
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "wL" = (
 /obj/effect/turf_decal/siding/wideplating/light{
 	color = "#236F26";
 	dir = 10
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "xq" = (
 /mob/living/simple_animal/butterfly,
 /obj/effect/turf_decal/siding/wideplating/light{
 	color = "#236F26"
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "yz" = (
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "yC" = (
 /obj/machinery/door/window/eastleft,
 /obj/effect/turf_decal/siding/wideplating/light{
@@ -222,7 +222,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "zJ" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/siding/wideplating/light{
@@ -230,33 +230,33 @@
 	dir = 1
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "AL" = (
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Bs" = (
 /turf/closed/wall/ice,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "BK" = (
 /obj/structure/table/rolling,
 /obj/item/petri_dish/random,
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Cb" = (
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Cv" = (
 /obj/machinery/light/warm/directional/east,
 /obj/structure/closet,
 /obj/item/food/cheese,
 /obj/item/stack/rods/ten,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Du" = (
 /obj/machinery/door/airlock/public,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Ea" = (
 /obj/machinery/door/window/northright,
 /obj/effect/turf_decal/siding/wideplating/light{
@@ -264,7 +264,7 @@
 	dir = 1
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Fq" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable,
@@ -272,33 +272,33 @@
 	color = "#236F26"
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Ft" = (
 /turf/open/floor/grass,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Gg" = (
 /obj/item/trash/shrimp_chips,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "HA" = (
 /turf/closed/wall,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "HU" = (
 /obj/machinery/light/warm/directional/east,
 /obj/item/clothing/suit/hooded/wintercoat/hydro,
 /turf/open/floor/carpet/neon/simple/lime,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "IX" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Jr" = (
 /obj/machinery/door/airlock/public{
 	dir = 4
 	},
 /obj/structure/barricade/wooden/crude,
 /turf/closed/mineral/random/snow,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Kc" = (
 /obj/structure/table,
 /obj/machinery/light_switch/directional/south,
@@ -307,16 +307,16 @@
 	color = "#236F26"
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Kq" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/carpet/neon/simple/lime,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Ku" = (
 /obj/structure/table,
 /obj/item/construction/plumbing/research,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Ly" = (
 /obj/structure/table,
 /obj/item/stack/ducts/fifty{
@@ -324,11 +324,11 @@
 	},
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Nv" = (
 /obj/item/reagent_containers/syringe,
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Ou" = (
 /obj/structure/toilet{
 	dir = 8
@@ -337,7 +337,7 @@
 /obj/item/plunger,
 /mob/living/simple_animal/mouse,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Pt" = (
 /obj/machinery/light/warm/directional/west,
 /obj/machinery/door/window/northright,
@@ -346,7 +346,7 @@
 	dir = 9
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Qd" = (
 /turf/open/floor/grass/snow,
 /area/icemoon/surface)
@@ -358,26 +358,26 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "QV" = (
 /obj/structure/table,
 /obj/structure/windoor_assembly{
 	dir = 4
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "RJ" = (
 /obj/structure/window/reinforced/spawner/east,
 /mob/living/basic/cockroach,
 /turf/open/floor/grass/snow/basalt/safe,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "RR" = (
 /turf/open/floor/carpet/neon/simple/lime,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Tn" = (
 /obj/item/coin/silver,
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Tp" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/effect/turf_decal/siding/wideplating/light{
@@ -385,33 +385,33 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Tr" = (
 /obj/item/pen/fountain,
 /turf/open/floor/iron,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "VM" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "VQ" = (
 /obj/item/coin/silver,
 /obj/item/reagent_containers/syringe,
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "Xn" = (
 /turf/closed/mineral/random/snow,
 /area/icemoon/surface)
 "Xt" = (
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/grass/snow/basalt/safe,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 "ZT" = (
 /obj/effect/spawner/structure/window/hollow/directional{
 	dir = 4
 	},
 /turf/open/floor/plastic,
-/area/ruin/unpowered/bughabitat)
+/area/ruin/bughabitat)
 
 (1,1,1) = {"
 Xn

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_bughabitat.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_bughabitat.dmm
@@ -1,0 +1,703 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"as" = (
+/obj/machinery/door/airlock/public,
+/turf/closed/mineral/random/snow,
+/area/icemoon/surface)
+"ax" = (
+/obj/effect/turf_decal/stripes/white/line{
+	color = "#236F26";
+	dir = 4
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"aR" = (
+/obj/item/reagent_containers/syringe/syriniver,
+/obj/effect/turf_decal/siding/wideplating/dark/corner,
+/obj/effect/turf_decal/tile/dark/anticorner,
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"bu" = (
+/obj/effect/spawner/random/food_or_drink/snack,
+/mob/living/basic/cockroach,
+/turf/open/floor/grass/snow/basalt/safe,
+/area/ruin/unpowered/bughabitat)
+"bQ" = (
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26";
+	dir = 8
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"cK" = (
+/mob/living/simple_animal/ant,
+/turf/open/floor/grass,
+/area/ruin/unpowered/bughabitat)
+"eM" = (
+/obj/structure/chair/pew/right{
+	dir = 8
+	},
+/obj/item/bedsheet{
+	pixel_y = 13
+	},
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"eN" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/biogenerator,
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26";
+	dir = 5
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"fI" = (
+/obj/effect/decal/remains/human,
+/obj/item/clipboard,
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"fO" = (
+/turf/open/floor/grass/snow,
+/area/ruin/unpowered/bughabitat)
+"fP" = (
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"hk" = (
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/grass/snow,
+/area/ruin/unpowered/bughabitat)
+"hy" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/toggle/labcoat,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"hM" = (
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"ih" = (
+/obj/structure/window/reinforced/tinted/fulltile,
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"kv" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/item/shovel,
+/turf/open/floor/grass/snow,
+/area/ruin/unpowered/bughabitat)
+"lj" = (
+/obj/structure/cable,
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26";
+	dir = 6
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"lE" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"lG" = (
+/obj/machinery/space_heater,
+/turf/open/floor/carpet/neon/simple/lime,
+/area/ruin/unpowered/bughabitat)
+"ma" = (
+/obj/structure/statue/snow/snowman,
+/turf/open/floor/grass/snow,
+/area/icemoon/surface)
+"mM" = (
+/obj/machinery/light/warm/directional/west,
+/obj/structure/tank_holder/oxygen,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"of" = (
+/obj/structure/sink{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26";
+	dir = 8
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"ot" = (
+/mob/living/basic/cockroach,
+/obj/item/seeds/soya,
+/turf/open/floor/grass/snow/basalt/safe,
+/area/ruin/unpowered/bughabitat)
+"oZ" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"qV" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/item/wallframe/camera,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/grass,
+/area/ruin/unpowered/bughabitat)
+"ri" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/spawner/random/food_or_drink/snack,
+/turf/open/floor/grass,
+/area/ruin/unpowered/bughabitat)
+"rE" = (
+/obj/effect/spawner/random/structure/chair_flipped,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"sl" = (
+/obj/machinery/light/warm/directional/east,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"sr" = (
+/obj/machinery/plumbing/growing_vat,
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"st" = (
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"tI" = (
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"uB" = (
+/mob/living/simple_animal/butterfly,
+/obj/structure/chair/pew/left{
+	dir = 8
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"va" = (
+/obj/item/book/manual/wiki/cytology,
+/obj/structure/table,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"wC" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26"
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"wL" = (
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26";
+	dir = 10
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"xq" = (
+/mob/living/simple_animal/butterfly,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26"
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"yz" = (
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"yC" = (
+/obj/machinery/door/window/eastleft,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26";
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"zJ" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26";
+	dir = 1
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"AL" = (
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"Bs" = (
+/turf/closed/wall/ice,
+/area/ruin/unpowered/bughabitat)
+"BK" = (
+/obj/structure/table/rolling,
+/obj/item/petri_dish/random,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Cb" = (
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Cv" = (
+/obj/machinery/light/warm/directional/east,
+/obj/structure/closet,
+/obj/item/food/cheese,
+/obj/item/stack/rods/ten,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Du" = (
+/obj/machinery/door/airlock/public,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Ea" = (
+/obj/machinery/door/window/northright,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26";
+	dir = 1
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Fq" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26"
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Ft" = (
+/turf/open/floor/grass,
+/area/ruin/unpowered/bughabitat)
+"Gg" = (
+/obj/item/trash/shrimp_chips,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"HA" = (
+/turf/closed/wall,
+/area/ruin/unpowered/bughabitat)
+"HU" = (
+/obj/machinery/light/warm/directional/east,
+/obj/item/clothing/suit/hooded/wintercoat/hydro,
+/turf/open/floor/carpet/neon/simple/lime,
+/area/ruin/unpowered/bughabitat)
+"IX" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Jr" = (
+/obj/machinery/door/airlock/public{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/crude,
+/turf/closed/mineral/random/snow,
+/area/ruin/unpowered/bughabitat)
+"Kc" = (
+/obj/structure/table,
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/cell_charger,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26"
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Kq" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/carpet/neon/simple/lime,
+/area/ruin/unpowered/bughabitat)
+"Ku" = (
+/obj/structure/table,
+/obj/item/construction/plumbing/research,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Ly" = (
+/obj/structure/table,
+/obj/item/stack/ducts/fifty{
+	amount = 23
+	},
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Nv" = (
+/obj/item/reagent_containers/syringe,
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"Ou" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small/blacklight,
+/obj/item/plunger,
+/mob/living/simple_animal/mouse,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Pt" = (
+/obj/machinery/light/warm/directional/west,
+/obj/machinery/door/window/northright,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26";
+	dir = 9
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Qd" = (
+/turf/open/floor/grass/snow,
+/area/icemoon/surface)
+"Qp" = (
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"QV" = (
+/obj/structure/table,
+/obj/structure/windoor_assembly{
+	dir = 4
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"RJ" = (
+/obj/structure/window/reinforced/spawner/east,
+/mob/living/basic/cockroach,
+/turf/open/floor/grass/snow/basalt/safe,
+/area/ruin/unpowered/bughabitat)
+"RR" = (
+/turf/open/floor/carpet/neon/simple/lime,
+/area/ruin/unpowered/bughabitat)
+"Tn" = (
+/obj/item/coin/silver,
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"Tp" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/turf_decal/siding/wideplating/light{
+	color = "#236F26";
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"Tr" = (
+/obj/item/pen/fountain,
+/turf/open/floor/iron,
+/area/ruin/unpowered/bughabitat)
+"VM" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"VQ" = (
+/obj/item/coin/silver,
+/obj/item/reagent_containers/syringe,
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+"Xn" = (
+/turf/closed/mineral/random/snow,
+/area/icemoon/surface)
+"Xt" = (
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/grass/snow/basalt/safe,
+/area/ruin/unpowered/bughabitat)
+"ZT" = (
+/obj/effect/spawner/structure/window/hollow/directional{
+	dir = 4
+	},
+/turf/open/floor/plastic,
+/area/ruin/unpowered/bughabitat)
+
+(1,1,1) = {"
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+"}
+(2,1,1) = {"
+Xn
+Qd
+Xn
+Xn
+Xn
+Xn
+Xn
+Qd
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+"}
+(3,1,1) = {"
+Xn
+Qd
+Bs
+HA
+HA
+HA
+Bs
+ih
+Bs
+HA
+Bs
+HA
+HA
+HA
+Qd
+Xn
+"}
+(4,1,1) = {"
+Xn
+Xn
+HA
+bu
+ot
+Pt
+of
+bQ
+wL
+Du
+Cb
+rE
+Gg
+HA
+Qd
+Xn
+"}
+(5,1,1) = {"
+Xn
+Qd
+HA
+RJ
+Xt
+zJ
+AL
+AL
+Kc
+HA
+ZT
+QV
+ZT
+Bs
+Xn
+Xn
+"}
+(6,1,1) = {"
+Xn
+Qd
+Bs
+cK
+Ft
+Ea
+aR
+hM
+wC
+HA
+RR
+RR
+lG
+Bs
+Xn
+Xn
+"}
+(7,1,1) = {"
+Xn
+Xn
+HA
+qV
+ri
+zJ
+Qp
+fP
+xq
+Du
+HU
+Kq
+Xn
+as
+Xn
+Xn
+"}
+(8,1,1) = {"
+Xn
+Xn
+HA
+fO
+fO
+Ea
+oZ
+Tn
+Fq
+HA
+HA
+HA
+Bs
+Bs
+Qd
+Xn
+"}
+(9,1,1) = {"
+Xn
+Qd
+HA
+hk
+kv
+eN
+Tp
+yC
+lj
+hy
+mM
+IX
+VM
+Bs
+ma
+Xn
+"}
+(10,1,1) = {"
+Xn
+Qd
+Bs
+va
+Ly
+Ku
+sr
+AL
+Nv
+oZ
+AL
+lE
+st
+HA
+Qd
+Xn
+"}
+(11,1,1) = {"
+Xn
+Qd
+HA
+Cb
+Tr
+sl
+fI
+AL
+AL
+AL
+VQ
+HA
+yz
+HA
+Qd
+Xn
+"}
+(12,1,1) = {"
+Xn
+Qd
+HA
+Bs
+HA
+HA
+Cb
+AL
+AL
+AL
+tI
+HA
+Ou
+Bs
+Xn
+Xn
+"}
+(13,1,1) = {"
+Xn
+Qd
+Qd
+Qd
+Qd
+Bs
+BK
+uB
+eM
+ax
+Cv
+HA
+HA
+HA
+Qd
+Xn
+"}
+(14,1,1) = {"
+Xn
+Xn
+Qd
+Qd
+Qd
+HA
+HA
+Bs
+Bs
+Jr
+Bs
+Bs
+Qd
+Qd
+Qd
+Xn
+"}
+(15,1,1) = {"
+Xn
+Xn
+Qd
+Qd
+Qd
+Qd
+Xn
+Xn
+Xn
+Xn
+Xn
+Qd
+Qd
+Qd
+Qd
+Xn
+"}
+(16,1,1) = {"
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+Xn
+"}

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -44,6 +44,12 @@
 	description = "This homestead was once host to a happy homesteading family. It's now host to hungry bears."
 	suffix = "icemoon_underground_abandoned_homestead.dmm"
 
+/datum/map_template/ruin/icemoon/entemology
+	name = "Insect Research Station"
+	id = "bug_habitat"
+	description = "An independently funded research outpost, long abandoned. Their mission, to boldly go where no insect life would ever live, ever, and look for bugs."
+	suffix = "icemoon_surface_bughabitat.dmm"
+
 // above and below ground together
 
 /datum/map_template/ruin/icemoon/mining_site

--- a/code/game/area/areas/ruins/icemoon.dm
+++ b/code/game/area/areas/ruins/icemoon.dm
@@ -36,7 +36,7 @@
 	mood_bonus = -5
 	mood_message = "<span class='brown'>I feel like I am being watched...</span>\n"
 
-/area/ruin/unpowered/bughabitat
+/area/ruin/bughabitat
 	name = "\improper Entemology Outreach Center"
 	icon_state = "dk_yellow"
 	mood_bonus = 1

--- a/code/game/area/areas/ruins/icemoon.dm
+++ b/code/game/area/areas/ruins/icemoon.dm
@@ -35,3 +35,9 @@
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 	mood_bonus = -5
 	mood_message = "<span class='brown'>I feel like I am being watched...</span>\n"
+
+/area/ruin/unpowered/bughabitat
+	name = "\improper Entemology Outreach Center"
+	icon_state = "dk_yellow"
+	mood_bonus = 1
+	mood_message = "<span class='nicegreen'>This place seems strangely serene.</span>\n"


### PR DESCRIPTION

## About The Pull Request

This adds a new upper level icebox ruin, which serves as the remains of a previous attempt at research on the ice planet.

Their goal?

The search for new insectoid life.

Nobody told them it'd be this cold, however.
![image](https://user-images.githubusercontent.com/41715314/137645358-8e3ccd83-efa6-4220-9254-68f77823cf49.png)

## Why It's Good For The Game

populates the surface of icebox with a different style of building, as the building comes with a deceptive challenge: the building has been caved in with ice and low temperatures, so retaking the building to be usable for crew or resting purposes requires handling the low ice turfs created by breaking into the building.

Additionally, gives stragglers looking around the map a ghetto, intermediate way to interact with cytology.

## Changelog

:cl:
add: A new frosted over building has been unearthed in the wastes of icebox.
/:cl:
