### PR TITLE
Tramstation: Map Sanitization

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -11173,10 +11173,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"bJv" = (
-/obj/effect/turf_decal/sand/plating,
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/mine/explored)
 "bJL" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -90964,8 +90960,8 @@ dhe
 dhe
 dhe
 dhe
-bJv
-bJv
+dhe
+dhe
 dhe
 oXC
 dhe
@@ -91221,8 +91217,8 @@ dhe
 dhe
 dhe
 dhe
-bJv
-bJv
+dhe
+dhe
 dhe
 dhe
 dhe


### PR DESCRIPTION

## About The Pull Request

When a wall is placed over a turf_decal in the editor, you can't see that turf_decal, which is unfortunate, because you WILL see the turf_decal over the wall in-game. 

## Why It's Good For The Game

The result never looks good. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Tramstation is now free from oddly decaled walls. 
/:cl:

I should really figure out the linter so we can just lint for these, but I don't know if it would Neuter the capabilities of Dream Maker or FastDMM2 users. 