### PR TITLE
External airlock access fixes [MDB IGNORE]

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
@@ -998,7 +998,7 @@
 "oF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "oM" = (
@@ -2631,7 +2631,7 @@
 /area/ruin/plasma_facility/commons)
 "Qh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron/smooth{
 	initial_gas_mix = "ICEMOON_ATMOS"

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_frozen_comms.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_frozen_comms.dmm
@@ -38,7 +38,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /turf/open/floor/iron/smooth{
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
@@ -377,7 +377,7 @@
 /area/ruin/powered/shuttle)
 "SK" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/iron/smooth{
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -312,7 +312,7 @@
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
 "gs" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/ruin/powered/beach)
 "gC" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -1000,7 +1000,7 @@
 /area/ruin/powered/clownplanet)
 "os" = (
 /obj/effect/mapping_helpers/no_lava,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/noslip,
 /area/ruin/powered/clownplanet)
 "pv" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -131,7 +131,7 @@
 /turf/open/floor/vault,
 /area/ruin/powered/seedvault)
 "av" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron/dark,
 /area/ruin/powered/seedvault)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1632,7 +1632,7 @@
 /turf/open/floor/iron,
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "gd" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	req_access_txt = "150"
 	},
 /obj/structure/fans/tiny,
@@ -1659,7 +1659,7 @@
 /area/ruin/unpowered/syndicate_lava_base/cargo)
 "gh" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	req_access_txt = "150"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -2240,7 +2240,7 @@
 	},
 /area/ruin/unpowered/syndicate_lava_base/virology)
 "hw" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	req_access_txt = "150"
 	},
 /obj/structure/fans/tiny,
@@ -2472,7 +2472,7 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "hX" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	req_access_txt = "150"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -2482,7 +2482,7 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "hY" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	req_access_txt = "150"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4233,7 +4233,7 @@
 /area/ruin/unpowered/syndicate_lava_base/main)
 "lT" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	req_access_txt = "150"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -4617,7 +4617,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/unpowered/syndicate_lava_base/telecomms)
 "mS" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	req_access_txt = "150"
 	},
 /obj/structure/fans/tiny,
@@ -5737,7 +5737,7 @@
 /turf/open/floor/wood,
 /area/ruin/unpowered/syndicate_lava_base/bar)
 "EZ" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	req_access_txt = "150"
 	},
 /obj/structure/fans/tiny,
@@ -5860,7 +5860,7 @@
 /area/ruin/unpowered/syndicate_lava_base/engineering)
 "St" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	req_access_txt = "150"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/_maps/RandomRuins/SpaceRuins/DJstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation.dmm
@@ -330,7 +330,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/djstation)
 "bi" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Ruskie DJ Station"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -344,7 +344,7 @@
 /turf/open/floor/plating/airless,
 /area/template_noop)
 "Co" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Ruskie DJ Station"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -57,7 +57,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/solar_control)
 "au" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "External Engineering"
 	},
 /obj/structure/cable,
@@ -99,13 +99,13 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge/ai_upload)
 "aL" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Air Bridge Access"
 	},
 /turf/open/floor/iron,
 /area/ruin/space/derelict/bridge/ai_upload)
 "aM" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Air Bridge Access"
 	},
 /turf/open/floor/plating,
@@ -145,7 +145,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/derelict/solar_control)
 "aV" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "External Engineering"
 	},
 /turf/open/floor/plating,
@@ -401,7 +401,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/bridge/ai_upload)
 "ca" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/iron,
 /area/ruin/space/derelict/solar_control)
 "cd" = (
@@ -1603,7 +1603,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/medical)
 "hB" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "External Engineering"
 	},
 /turf/open/floor/plating/airless,
@@ -2154,7 +2154,7 @@
 /turf/template_noop,
 /area/ruin/unpowered/no_grav)
 "jU" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Arrivals Docking Bay 1"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -2581,7 +2581,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/derelict/arrival)
 "lZ" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Escape Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -2966,7 +2966,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/se_solar)
 "nD" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Escape Airlock"
 	},
 /turf/open/floor/plating/airless,
@@ -3118,7 +3118,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/se_solar)
 "ok" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/derelict/se_solar)
@@ -3358,7 +3358,7 @@
 	},
 /area/ruin/space/derelict/bridge/ai_upload)
 "DE" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Escape Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -3505,7 +3505,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/primary/port)
 "Le" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Arrivals Docking Bay 1"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
@@ -64,7 +64,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/abandoned_tele)
 "p" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -127,7 +127,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/abandoned_tele)
 "O" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -312,7 +312,7 @@
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/abandonedzoo)
 "bG" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -455,7 +455,7 @@
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "lo" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -137,7 +137,7 @@
 /turf/closed/wall,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "aB" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
@@ -187,7 +187,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost)
 "aL" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost)
@@ -1640,14 +1640,14 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
 "uV" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost/powerstorage)
 "LB" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -364,7 +364,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter3)
 "gc" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter3)
@@ -558,7 +558,7 @@
 /area/shuttle/caravan/freighter2)
 "hs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating/airless,
 /area/shuttle/caravan/freighter2)
@@ -1235,7 +1235,7 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/unpowered)
 "vE" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -1243,7 +1243,7 @@
 /area/shuttle/caravan/freighter3)
 "GL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -277,7 +277,7 @@
 /turf/open/floor/plating,
 /area/awaymission/bmpship/fore)
 "bq" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/bmpship/fore)
 "bs" = (

--- a/_maps/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict2.dmm
@@ -9,7 +9,7 @@
 /turf/template_noop,
 /area/template_noop)
 "c" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/dinner_for_two)
 "d" = (

--- a/_maps/RandomRuins/SpaceRuins/derelict5.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict5.dmm
@@ -65,11 +65,11 @@
 /area/ruin/unpowered)
 "r" = (
 /obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered)
 "s" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -23,7 +23,7 @@
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ae" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Syndicate ship airlock";
 	req_one_access_txt = "150"
 	},
@@ -262,7 +262,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "aU" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Syndicate ship airlock";
 	req_one_access_txt = "150"
 	},
@@ -317,7 +317,7 @@
 /area/ruin/space/has_grav/powered/syndicate_forgotten_vault)
 "be" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Syndicate ship airlock";
 	req_one_access_txt = "150"
 	},
@@ -519,7 +519,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bF" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Syndicate ship airlock";
 	req_one_access_txt = "150"
 	},
@@ -565,7 +565,7 @@
 "bM" = (
 /obj/structure/cable,
 /obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Syndicate ship airlock";
 	req_one_access_txt = "150"
 	},

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -334,7 +334,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/gasthelizard)
 "V" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/gasthelizard)
@@ -342,7 +342,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/gasthelizard)
 "Z" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},

--- a/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -93,7 +93,7 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/space/has_grav/powered/authorship)
 "t" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/space/has_grav/powered/authorship)
 "u" = (

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -122,7 +122,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	id_tag = "syndie_listeningpost_external";
 	req_access_txt = "150"
 	},
@@ -142,7 +142,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	id_tag = "syndie_listeningpost_external";
 	req_access_txt = "150"
 	},

--- a/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mrow_thats_right.dmm
@@ -103,7 +103,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "au" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -893,19 +893,19 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/powered/cat_man)
 "Bl" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "RT" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered/cat_man)
 "Sl" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},

--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -817,7 +817,7 @@
 /turf/open/floor/plating/airless,
 /area/tcommsat/oldaisat)
 "cQ" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/tcommsat/oldaisat)
 "cR" = (

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -972,7 +972,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/comm)
 "cN" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -4260,7 +4260,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Engineering External Access"
 	},
 /turf/open/floor/plating,
@@ -6402,7 +6402,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Engineering External Access"
 	},
 /turf/open/floor/plating,
@@ -7115,7 +7115,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/ancientstation/betastorage)
 "RX" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/mining)

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -56,7 +56,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/onehalf/dorms_med)
 "aq" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/onehalf/drone_bay)

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -3287,7 +3287,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/power)
 "kJ" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -4262,7 +4262,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/power)
 "sN" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},

--- a/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -30,7 +30,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/turretedoutpost)
 "ai" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -357,7 +357,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/turretedoutpost)
 "Nu" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},

--- a/_maps/RandomZLevels/Academy.dmm
+++ b/_maps/RandomZLevels/Academy.dmm
@@ -981,7 +981,7 @@
 /area/awaymission/academy)
 "eA" = (
 /obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -214,7 +214,7 @@
 /turf/closed/wall,
 /area/awaymission/caves/bmp_asteroid/level_three)
 "aI" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
@@ -756,7 +756,7 @@
 	},
 /area/awaymission/caves/research)
 "cH" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
@@ -791,7 +791,7 @@
 	},
 /area/awaymission/caves/research)
 "cP" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
@@ -922,7 +922,7 @@
 	},
 /area/awaymission/caves/bmp_asteroid/level_two)
 "dh" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/caves/bmp_asteroid/level_two)
 "di" = (
@@ -1390,7 +1390,7 @@
 /turf/open/floor/plating,
 /area/awaymission/caves/listeningpost)
 "fi" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/caves/listeningpost)
 "fj" = (
@@ -1542,7 +1542,7 @@
 /turf/open/floor/iron,
 /area/awaymission/caves/bmp_asteroid)
 "fN" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/caves/bmp_asteroid)
 "fP" = (
@@ -1741,7 +1741,7 @@
 /turf/open/floor/iron,
 /area/awaymission/caves/bmp_asteroid)
 "gz" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Mess Hall"
 	},
 /turf/open/floor/plating,

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -1620,7 +1620,7 @@
 /area/awaymission/moonoutpost19/syndicate)
 "du" = (
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	density = 0;
 	icon_state = "open";
 	opacity = 0;
@@ -1775,7 +1775,7 @@
 /area/awaymission/moonoutpost19/main)
 "dI" = (
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	density = 0;
 	icon_state = "open";
 	opacity = 0;
@@ -5683,7 +5683,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/awaymission/moonoutpost19/arrivals)
 "mL" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -5693,7 +5693,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "mM" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -6423,7 +6423,7 @@
 	},
 /area/awaymission/moonoutpost19/main)
 "vV" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -6439,7 +6439,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "zZ" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
@@ -6545,7 +6545,7 @@
 	},
 /area/awaymission/moonoutpost19/arrivals)
 "Wf" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -30,7 +30,7 @@
 /turf/open/space,
 /area/awaymission/research/interior/engineering)
 "ai" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/engineering)
 "aj" = (
@@ -528,7 +528,7 @@
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/engineering)
 "bx" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
 "by" = (
@@ -5322,7 +5322,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/awaymission/research/exterior)
 "mu" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Escape Pod One"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -5491,7 +5491,7 @@
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/escapepods)
 "mO" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Escape Pod Two"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -5517,7 +5517,7 @@
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/escapepods)
 "mS" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Escape Pod Three"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -5578,7 +5578,7 @@
 /turf/open/floor/plating,
 /area/awaymission/research/interior/escapepods)
 "mZ" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Escape Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -5607,7 +5607,7 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/awaymission/research/interior/engineering)
 "pt" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Escape Pod Three"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -5728,7 +5728,7 @@
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior)
 "xG" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Escape Pod Two"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -5869,7 +5869,7 @@
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior)
 "TE" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Escape Pod One"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -5933,7 +5933,7 @@
 /turf/open/floor/iron,
 /area/awaymission/research/interior/dorm)
 "XE" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Escape Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -4535,7 +4535,7 @@
 	},
 /area/awaymission/snowdin/post/hydro)
 "lM" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	piping_layer = 4;
@@ -4546,7 +4546,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
 "lN" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
@@ -6218,14 +6218,14 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/secpost)
 "qr" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/barricade/wooden/crude,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post)
 "qs" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	piping_layer = 4;
 	pixel_x = 5;
@@ -6494,7 +6494,7 @@
 /turf/open/floor/iron,
 /area/awaymission/snowdin/post/engineering)
 "rc" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -6509,7 +6509,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/cavern2)
 "re" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -6645,7 +6645,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post)
 "rH" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/structure/barricade/wooden/crude/snow,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -7605,7 +7605,7 @@
 /turf/open/floor/plating/asteroid/snow/ice,
 /area/awaymission/snowdin/cave/cavern)
 "uZ" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -7613,7 +7613,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/cavern1)
 "vb" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -9005,7 +9005,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
 "zn" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
@@ -9178,7 +9178,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
 "zS" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -9368,7 +9368,7 @@
 /turf/open/floor/plating/asteroid/snow,
 /area/awaymission/snowdin/outside)
 "Av" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/minipost)
 "Aw" = (
@@ -9416,7 +9416,7 @@
 	},
 /area/awaymission/snowdin/outside)
 "AC" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -10474,7 +10474,7 @@
 	},
 /area/awaymission/snowdin/outside)
 "DG" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Ready Room";
 	req_access_txt = "150"
 	},
@@ -11330,7 +11330,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_main)
 "Gb" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_main)
@@ -13032,14 +13032,14 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
 "Lw" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/minipost)
 "Lx" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -13421,7 +13421,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
 "OF" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Ready Room";
 	req_access_txt = "150"
 	},
@@ -13548,7 +13548,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/awaymission/snowdin/post/broken_shuttle)
 "PR" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Ready Room";
 	req_access_txt = "150"
 	},
@@ -13847,7 +13847,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_dock)
 "SX" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -14089,7 +14089,7 @@
 /turf/open/floor/plating/snowed/cavern,
 /area/awaymission/snowdin/cave/cavern)
 "VW" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -14354,7 +14354,7 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/mining_main)
 "Yn" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},

--- a/_maps/RandomZLevels/spacebattle.dmm
+++ b/_maps/RandomZLevels/spacebattle.dmm
@@ -37,7 +37,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/spacebattle/syndicate2)
 "ak" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/syndicate2)
 "al" = (
@@ -117,7 +117,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/spacebattle/syndicate3)
 "aE" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/syndicate3)
 "aG" = (
@@ -207,7 +207,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/spacebattle/syndicate2)
 "bb" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/syndicate1)
 "bc" = (
@@ -339,7 +339,7 @@
 /turf/open/space,
 /area/awaymission/spacebattle/cruiser)
 "bJ" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "bK" = (
@@ -1243,7 +1243,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/awaymission/spacebattle/cruiser)
 "fl" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/syndicate4)
 "fm" = (
@@ -2060,7 +2060,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/spacebattle/syndicate7)
 "hU" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/syndicate7)
 "hV" = (
@@ -2238,7 +2238,7 @@
 /turf/closed/mineral/bananium,
 /area/space/nearstation)
 "iF" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "iG" = (
@@ -2278,7 +2278,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "iT" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/syndicate5)
 "iW" = (
@@ -2314,7 +2314,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/awaymission/spacebattle/syndicate6)
 "jf" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/awaymission/spacebattle/syndicate6)
 "ji" = (

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -2160,7 +2160,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -2174,7 +2174,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "eI" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -10620,7 +10620,7 @@
 /area/awaymission/undergroundoutpost45/research)
 "uw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -11005,7 +11005,7 @@
 	},
 /area/awaymission/undergroundoutpost45/research)
 "vk" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating{
 	heat_capacity = 1e+006
 	},
@@ -12499,7 +12499,7 @@
 /area/awaymission/undergroundoutpost45/mining)
 "xX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Mining External Airlock";
 	req_access_txt = "201"
 	},
@@ -12572,7 +12572,7 @@
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "yf" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Mining External Airlock";
 	req_access_txt = "201"
 	},

--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -1193,7 +1193,7 @@
 	},
 /area/awaymission/wildwest/gov)
 "fd" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -1545,7 +1545,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/awaymission/wildwest/mines)
 "gi" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -1704,12 +1704,12 @@
 /turf/open/floor/plating/ironsand,
 /area/awaymission/wildwest/mines)
 "pD" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
 /area/awaymission/wildwest/refine)
 "Gh" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -1720,14 +1720,14 @@
 /turf/open/floor/carpet,
 /area/awaymission/wildwest/mines)
 "Kh" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/awaymission/wildwest/refine)
 "RN" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},

--- a/_maps/map_files/Mafia/mafia_lavaland.dmm
+++ b/_maps/map_files/Mafia/mafia_lavaland.dmm
@@ -34,7 +34,7 @@
 	},
 /area/mafia)
 "j" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	max_integrity = 99999;
 	name = "Maintenance"
 	},

--- a/_maps/map_files/Mafia/mafia_snow.dmm
+++ b/_maps/map_files/Mafia/mafia_snow.dmm
@@ -100,7 +100,7 @@
 /turf/open/lava/plasma/mafia,
 /area/mafia)
 "x" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	max_integrity = 9999;
 	opacity = 0
 	},
@@ -122,7 +122,7 @@
 /turf/open/lava/plasma/mafia,
 /area/mafia)
 "A" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	max_integrity = 9999
 	},
 /obj/machinery/door/poddoor/preopen{

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -420,7 +420,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/external/glass{
 	name = "Labor Camp Shuttle Prisoner Airlock"
 	},
 /turf/open/floor/iron,
@@ -3152,10 +3152,9 @@
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "sH" = (
-/obj/machinery/door/airlock/external{
-	glass = 1;
+/obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock";
-	opacity = 0
+	req_access_txt = "54"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
@@ -3397,10 +3396,10 @@
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
 "zn" = (
-/obj/machinery/door/airlock/external{
-	glass = 1;
+/obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock";
-	opacity = 0
+	req_access_txt = "54";
+	space_dir = 2
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -3666,10 +3665,9 @@
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "FT" = (
-/obj/machinery/door/airlock/external{
-	glass = 1;
+/obj/machinery/door/airlock/external/glass{
 	name = "Labor Camp External Airlock";
-	opacity = 0
+	req_access = null
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -3755,10 +3753,9 @@
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "HV" = (
-/obj/machinery/door/airlock/external{
-	glass = 1;
+/obj/machinery/door/airlock/external/glass{
 	name = "Labor Camp External Airlock";
-	opacity = 0
+	req_access = null
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -4365,7 +4362,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external{
-	name = "Lavaland Shuttle Airlock"
+	name = "Lavaland Shuttle Airlock";
+	space_dir = 8
 	},
 /turf/open/floor/iron,
 /area/mine/living_quarters)
@@ -4475,7 +4473,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/external/glass{
 	name = "Labor Camp Shuttle Prisoner Airlock"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4485,11 +4483,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	glass = 1;
+/obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock";
-	opacity = 0;
-	req_access_txt = "54"
+	req_access_txt = "54";
+	space_dir = 4
 	},
 /turf/open/floor/iron,
 /area/mine/eva)
@@ -4497,10 +4494,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	glass = 1;
+/obj/machinery/door/airlock/external/glass{
 	name = "Mining Shuttle Airlock";
-	opacity = 0
+	space_dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -421,7 +421,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external/glass{
-	name = "Labor Camp Shuttle Prisoner Airlock"
+	name = "Labor Camp Shuttle Prisoner Airlock";
+	space_dir = 8
 	},
 /turf/open/floor/iron,
 /area/mine/laborcamp)
@@ -542,10 +543,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	glass = 1;
+/obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock";
-	opacity = 0;
 	req_access_txt = "54"
 	},
 /turf/open/floor/iron,
@@ -612,10 +611,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	glass = 1;
+/obj/machinery/door/airlock/external/glass{
 	name = "Mining Shuttle Airlock";
-	opacity = 0
+	space_dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,

--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -889,7 +889,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "dZ" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -1052,7 +1052,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/engineering/storage)
@@ -1227,7 +1227,7 @@
 /turf/open/floor/plating,
 /area/engineering/storage)
 "oh" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -1465,7 +1465,7 @@
 /turf/open/floor/plating,
 /area/construction)
 "CA" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -1587,7 +1587,7 @@
 /turf/open/floor/plating,
 /area/engineering/storage)
 "Kd" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -121,7 +121,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -903,7 +903,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "di" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Labor Camp Shuttle Airlock"
 	},
 /obj/structure/fans/tiny,
@@ -1256,7 +1256,7 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "ex" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Escape Pod One"
 	},
 /obj/structure/fans/tiny,
@@ -1370,7 +1370,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Supply Dock Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -1385,7 +1385,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Supply Dock Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -1444,7 +1444,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fb" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Departure Lounge Airlock"
 	},
 /obj/effect/turf_decal/delivery,
@@ -1563,7 +1563,7 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fs" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Transport Airlock"
 	},
 /obj/structure/fans/tiny,
@@ -1799,7 +1799,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "gc" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Auxiliary Airlock"
 	},
 /obj/structure/fans/tiny,
@@ -2113,7 +2113,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /turf/open/floor/plating,
 /area/medical/medbay)
 "qb" = (
@@ -2508,7 +2508,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /turf/open/floor/plating,
 /area/medical/medbay)
 "Rb" = (
@@ -2615,7 +2615,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/main)

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2348,7 +2348,7 @@
 /turf/open/floor/iron,
 /area/centcom/supply)
 "jr" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Supply Shuttle";
 	req_access_txt = "106"
 	},
@@ -6732,7 +6732,7 @@
 /turf/open/floor/wood/tile,
 /area/centcom/holding)
 "uJ" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	req_access_txt = "150"
 	},
 /turf/open/floor/plating,
@@ -7646,7 +7646,7 @@
 /turf/open/floor/wood/large,
 /area/centcom/holding)
 "xc" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Ferry Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -9647,14 +9647,14 @@
 /turf/open/floor/sepia,
 /area/centcom/holding)
 "Dq" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/centcom/control)
 "Dr" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -10095,7 +10095,7 @@
 /turf/closed/indestructible/riveted,
 /area/tdome/tdomeobserve)
 "Eq" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/tdome/tdomeobserve)
@@ -12832,7 +12832,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/admin)
 "Kj" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Backup Emergency Escape Shuttle"
 	},
 /obj/effect/turf_decal/delivery,
@@ -16284,7 +16284,7 @@
 /turf/open/floor/sepia,
 /area/centcom/holding)
 "Xy" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Ferry Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -810,7 +810,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bL" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Emergency Recovery Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -850,7 +850,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bR" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Emergency Recovery Airlock"
 	},
 /obj/effect/turf_decal/stripes/line,

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -6,7 +6,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/escape/luxury)
 "ac" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Economy-Class"
 	},
 /turf/open/floor/iron,

--- a/_maps/shuttles/emergency_medisim.dmm
+++ b/_maps/shuttles/emergency_medisim.dmm
@@ -53,7 +53,7 @@
 /area/shuttle/escape)
 "fa" = (
 /obj/machinery/door/airlock/external/ruin{
-	ruin{name = "Engine Maintenance Access"
+	name = "Engine Maintenance Access"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -582,7 +582,7 @@
 /area/shuttle/escape/simulation)
 "Aw" = (
 /obj/machinery/door/airlock/external/ruin{
-	ruin{name = "Engine Maintenance Access";
+	name = "Engine Maintenance Access";
 	req_access_txt = "19"
 	},
 /turf/open/floor/mineral/titanium/white,

--- a/_maps/shuttles/emergency_medisim.dmm
+++ b/_maps/shuttles/emergency_medisim.dmm
@@ -52,8 +52,8 @@
 /turf/template_noop,
 /area/shuttle/escape)
 "fa" = (
-/obj/machinery/door/airlock/external{
-	name = "Engine Maintenance Access"
+/obj/machinery/door/airlock/external/ruin{
+	ruin{name = "Engine Maintenance Access"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -581,8 +581,8 @@
 /turf/open/floor/wood,
 /area/shuttle/escape/simulation)
 "Aw" = (
-/obj/machinery/door/airlock/external{
-	name = "Engine Maintenance Access";
+/obj/machinery/door/airlock/external/ruin{
+	ruin{name = "Engine Maintenance Access";
 	req_access_txt = "19"
 	},
 /turf/open/floor/mineral/titanium/white,

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -335,7 +335,7 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "bf" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Emergency Recovery Airlock"
 	},
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/shuttles/emergency_monastery.dmm
+++ b/_maps/shuttles/emergency_monastery.dmm
@@ -354,7 +354,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "du" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
+ruin,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dF" = (
@@ -682,7 +683,8 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "hN" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
+ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -779,7 +781,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "iT" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
+ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -913,7 +916,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
+ruin,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "kq" = (
@@ -1002,7 +1006,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
+ruin,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "lj" = (
@@ -1397,7 +1402,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "qx" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
+ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -2235,8 +2241,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "zw" = (
-/obj/machinery/door/airlock/external{
-	name = "Pod Docking Bay"
+/obj/machinery/door/airlock/external/ruin{
+	ruin{name = "Pod Docking Bay"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -2513,7 +2519,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "DS" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
+ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -4088,8 +4095,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "UQ" = (
-/obj/machinery/door/airlock/external{
-	name = "Pod Docking Bay"
+/obj/machinery/door/airlock/external/ruin{
+	ruin{name = "Pod Docking Bay"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -4224,8 +4231,8 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Wh" = (
-/obj/machinery/door/airlock/external{
-	name = "Dock Access"
+/obj/machinery/door/airlock/external/ruin{
+	ruin{name = "Dock Access"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4

--- a/_maps/shuttles/emergency_monastery.dmm
+++ b/_maps/shuttles/emergency_monastery.dmm
@@ -355,7 +355,6 @@
 /area/shuttle/escape)
 "du" = (
 /obj/machinery/door/airlock/external/ruin,
-ruin,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "dF" = (
@@ -684,7 +683,6 @@ ruin,
 /area/shuttle/escape)
 "hN" = (
 /obj/machinery/door/airlock/external/ruin,
-ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -782,7 +780,6 @@ ruin,
 /area/shuttle/escape)
 "iT" = (
 /obj/machinery/door/airlock/external/ruin,
-ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -917,7 +914,6 @@ ruin,
 	dir = 8
 	},
 /obj/machinery/door/airlock/external/ruin,
-ruin,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "kq" = (
@@ -1007,7 +1003,6 @@ ruin,
 	dir = 4
 	},
 /obj/machinery/door/airlock/external/ruin,
-ruin,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "lj" = (
@@ -1403,7 +1398,6 @@ ruin,
 /area/shuttle/escape)
 "qx" = (
 /obj/machinery/door/airlock/external/ruin,
-ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -2242,7 +2236,7 @@ ruin,
 /area/shuttle/escape)
 "zw" = (
 /obj/machinery/door/airlock/external/ruin{
-	ruin{name = "Pod Docking Bay"
+	name = "Pod Docking Bay"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -2520,7 +2514,6 @@ ruin,
 /area/shuttle/escape)
 "DS" = (
 /obj/machinery/door/airlock/external/ruin,
-ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -4096,7 +4089,7 @@ ruin,
 /area/shuttle/escape)
 "UQ" = (
 /obj/machinery/door/airlock/external/ruin{
-	ruin{name = "Pod Docking Bay"
+	name = "Pod Docking Bay"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -4232,7 +4225,7 @@ ruin,
 /area/shuttle/escape)
 "Wh" = (
 /obj/machinery/door/airlock/external/ruin{
-	ruin{name = "Dock Access"
+	name = "Dock Access"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -936,7 +936,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "cd" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Emegency Shuttle External Airlock"
 	},
 /turf/open/floor/plating,
@@ -1027,7 +1027,7 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "cn" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "co" = (
@@ -1082,7 +1082,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "ct" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -2052,7 +2052,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "eo" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Emegency Shuttle External Airlock"
 	},
 /obj/docking_port/mobile/emergency{

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -135,8 +135,8 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "aL" = (
-/obj/machinery/door/airlock/external{
-	name = "Emergency Launch Catwalk";
+/obj/machinery/door/airlock/external/ruin{
+	ruin{name = "Emergency Launch Catwalk";
 	req_access_txt = "10"
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/emergency_supermatter.dmm
+++ b/_maps/shuttles/emergency_supermatter.dmm
@@ -136,7 +136,7 @@
 /area/shuttle/escape)
 "aL" = (
 /obj/machinery/door/airlock/external/ruin{
-	ruin{name = "Emergency Launch Catwalk";
+	name = "Emergency Launch Catwalk";
 	req_access_txt = "10"
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/ferry_fancy.dmm
+++ b/_maps/shuttles/ferry_fancy.dmm
@@ -10,7 +10,7 @@
 /turf/open/floor/plating,
 /area/shuttle/transport)
 "d" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/pod/dark,
 /area/shuttle/transport)
 "e" = (
@@ -94,7 +94,7 @@
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
 "r" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/pod/light,
 /area/shuttle/transport)
 

--- a/_maps/shuttles/hunter_bounty.dmm
+++ b/_maps/shuttles/hunter_bounty.dmm
@@ -7,7 +7,7 @@
 /area/shuttle/hunter)
 "c" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/shuttle/hunter)
 "d" = (
@@ -24,7 +24,7 @@
 /area/shuttle/hunter)
 "f" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/hunter)
@@ -51,7 +51,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /turf/open/floor/plating,
 /area/shuttle/hunter)
 "m" = (
@@ -189,7 +189,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/docking_port/stationary{
 	dwidth = 11;
 	height = 16;

--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -964,7 +964,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	id_tag = "infiltrator_portdoor";
 	name = "Infiltrator Port Airlock"
 	},

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -398,7 +398,7 @@
 /turf/open/floor/plating,
 /area/shuttle/syndicate/hallway)
 "aW" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Ready Room";
 	req_access_txt = "150"
 	},
@@ -455,7 +455,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/syndicate/eva)
 "ba" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "E.V.A. Gear Storage";
 	req_access_txt = "150"
 	},
@@ -472,7 +472,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/syndicate/eva)
 "bb" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	req_access_txt = "150"
 	},
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/shuttles/mining_kilo.dmm
+++ b/_maps/shuttles/mining_kilo.dmm
@@ -274,7 +274,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/mining/large)
 "I" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Mining Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -314,7 +314,7 @@
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
 "L" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "Mining Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/_maps/shuttles/mining_large.dmm
+++ b/_maps/shuttles/mining_large.dmm
@@ -399,8 +399,8 @@
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
 "D" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Shuttle External Airlock"
+/obj/machinery/door/airlock/external/ruin{
+	ruin{name = "Mining Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
@@ -438,8 +438,8 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/mining/large)
 "J" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Shuttle External Airlock"
+/obj/machinery/door/airlock/external/ruin{
+	ruin{name = "Mining Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1

--- a/_maps/shuttles/mining_large.dmm
+++ b/_maps/shuttles/mining_large.dmm
@@ -400,7 +400,7 @@
 /area/shuttle/mining/large)
 "D" = (
 /obj/machinery/door/airlock/external/ruin{
-	ruin{name = "Mining Shuttle External Airlock"
+	name = "Mining Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
@@ -439,7 +439,7 @@
 /area/shuttle/mining/large)
 "J" = (
 /obj/machinery/door/airlock/external/ruin{
-	ruin{name = "Mining Shuttle External Airlock"
+	name = "Mining Shuttle External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -342,7 +342,7 @@
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "aF" = (
-/obj/machinery/door/airlock/external/glass{
+/obj/machinery/door/airlock/external/glass/ruin{
 	id_tag = "pirateportexternal"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
@@ -375,7 +375,7 @@
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "aJ" = (
-/obj/machinery/door/airlock/external/glass{
+/obj/machinery/door/airlock/external/glass/ruin{
 	id_tag = "pirateportexternal"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
@@ -791,7 +791,7 @@
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "bZ" = (
-/obj/machinery/door/airlock/external/glass{
+/obj/machinery/door/airlock/external/glass/ruin{
 	id_tag = "piratestarboardexternal"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
@@ -801,7 +801,7 @@
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "ce" = (
-/obj/machinery/door/airlock/external/glass{
+/obj/machinery/door/airlock/external/glass/ruin{
 	id_tag = "piratestarboardexternal"
 	},
 /obj/effect/mapping_helpers/airlock/locked,

--- a/_maps/shuttles/pirate_silverscale.dmm
+++ b/_maps/shuttles/pirate_silverscale.dmm
@@ -46,7 +46,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "de" = (
-/obj/machinery/door/airlock/external/glass{
+/obj/machinery/door/airlock/external/glass/ruin{
 	id_tag = "pirateportexternal"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -131,7 +131,7 @@
 /turf/template_noop,
 /area/template_noop)
 "jm" = (
-/obj/machinery/door/airlock/external/glass{
+/obj/machinery/door/airlock/external/glass/ruin{
 	id_tag = "piratestarboardexternal"
 	},
 /obj/docking_port/stationary{
@@ -250,7 +250,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "nY" = (
-/obj/machinery/door/airlock/external/glass{
+/obj/machinery/door/airlock/external/glass/ruin{
 	id_tag = "pirateportexternal"
 	},
 /turf/open/floor/pod/dark,
@@ -385,7 +385,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "zQ" = (
-/obj/machinery/door/airlock/external/glass{
+/obj/machinery/door/airlock/external/glass/ruin{
 	id_tag = "piratestarboardexternal"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{

--- a/_maps/shuttles/ruin_caravan_victim.dmm
+++ b/_maps/shuttles/ruin_caravan_victim.dmm
@@ -366,7 +366,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	id_tag = "caravantrade1_bolt"
 	},
 /turf/open/floor/plating,
@@ -999,7 +999,7 @@
 "VD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	id_tag = "caravantrade1_bolt"
 	},
 /obj/docking_port/mobile{

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -646,7 +646,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	id_tag = "caravanpirate_bolt_starboard"
 	},
 /turf/open/floor/plating,
@@ -821,7 +821,7 @@
 "Jb" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	id_tag = "caravanpirate_bolt_port"
 	},
 /obj/docking_port/mobile{
@@ -855,7 +855,7 @@
 "Ku" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	id_tag = "caravanpirate_bolt_starboard"
 	},
 /turf/open/floor/plating,
@@ -914,7 +914,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	id_tag = "caravanpirate_bolt_port"
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -13,7 +13,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
 "ae" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/docking_port/mobile{
 	callTime = 250;
@@ -123,7 +123,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/crew)
 "ap" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -731,7 +731,7 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "bm" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -854,7 +854,7 @@
 /turf/open/floor/iron,
 /area/shuttle/abandoned/bridge)
 "by" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
@@ -1146,7 +1146,7 @@
 /turf/open/floor/iron,
 /area/shuttle/abandoned/bridge)
 "cc" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -1842,7 +1842,7 @@
 	},
 /area/shuttle/abandoned/medbay)
 "do" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -1887,7 +1887,7 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned/medbay)
 "dt" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},

--- a/_maps/shuttles/whiteship_delta.dmm
+++ b/_maps/shuttles/whiteship_delta.dmm
@@ -15,7 +15,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/abandoned/crew)
 "ad" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/docking_port/mobile{
 	callTime = 250;
@@ -275,7 +275,7 @@
 /turf/open/floor/wood,
 /area/shuttle/abandoned/crew)
 "aG" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -310,7 +310,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/external/glass{
+/obj/machinery/door/airlock/external/glass/ruin{
 	name = "E.V.A Access"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -419,7 +419,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/external/glass{
+/obj/machinery/door/airlock/external/glass/ruin{
 	name = "E.V.A Access"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1661,7 +1661,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external/glass{
+/obj/machinery/door/airlock/external/glass/ruin{
 	name = "E.V.A Access"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1677,7 +1677,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/external/glass{
+/obj/machinery/door/airlock/external/glass/ruin{
 	name = "E.V.A Access"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -1848,7 +1848,7 @@
 /turf/open/floor/iron,
 /area/shuttle/abandoned/medbay)
 "dI" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -2058,7 +2058,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/cargo)
 "eb" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},

--- a/_maps/shuttles/whiteship_donut.dmm
+++ b/_maps/shuttles/whiteship_donut.dmm
@@ -10,7 +10,7 @@
 /area/shuttle/abandoned)
 "ad" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/docking_port/mobile{
 	dir = 2;
 	dwidth = 8;

--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -22,7 +22,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "NTMS-037 Port Airlock"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -114,7 +114,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "NTMS-037 Port Airlock"
 	},
 /turf/open/floor/mineral/plastitanium,
@@ -211,7 +211,7 @@
 /area/shuttle/abandoned/cargo)
 "as" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "External Freight Airlock"
 	},
 /obj/effect/decal/cleanable/greenglow,
@@ -239,7 +239,7 @@
 /area/shuttle/abandoned/engine)
 "ax" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	id_tag = "ntms_exterior";
 	name = "NTMS-037 Mining Airlock"
 	},
@@ -266,7 +266,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 10
 	},
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "NTMS-037 Mining Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -476,7 +476,7 @@
 /area/shuttle/abandoned/engine)
 "aR" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	id_tag = "ntms_exterior";
 	name = "NTMS-037 Mining Airlock"
 	},
@@ -498,7 +498,7 @@
 "aT" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/door/airlock/external{
+/obj/machinery/door/airlock/external/ruin{
 	name = "NTMS-037 Mining Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/_maps/shuttles/whiteship_meta.dmm
+++ b/_maps/shuttles/whiteship_meta.dmm
@@ -30,7 +30,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/abandoned/crew)
 "ah" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/docking_port/mobile{
 	callTime = 250;
@@ -346,7 +346,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/crew)
 "aI" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -439,7 +439,7 @@
 /area/shuttle/abandoned/engine)
 "aQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -508,7 +508,7 @@
 "aV" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
@@ -1316,7 +1316,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/bridge)
 "ch" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -1332,7 +1332,7 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)
 "cj" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -2081,7 +2081,7 @@
 /area/shuttle/abandoned/engine)
 "dt" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
@@ -2108,7 +2108,7 @@
 "dw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
@@ -2345,7 +2345,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/abandoned/bar)
 "dP" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -2542,7 +2542,7 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned/cargo)
 "ej" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},

--- a/_maps/shuttles/whiteship_tram.dmm
+++ b/_maps/shuttles/whiteship_tram.dmm
@@ -11,7 +11,7 @@
 /area/shuttle/abandoned/engine)
 "ad" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/docking_port/mobile{
 	dir = 2;
 	dwidth = 6;
@@ -70,7 +70,7 @@
 /area/shuttle/abandoned/engine)
 "an" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/shuttle/abandoned/engine)

--- a/_maps/templates/medium_shuttle1.dmm
+++ b/_maps/templates/medium_shuttle1.dmm
@@ -24,7 +24,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/ruin/powered/shuttle/medium_1)
 "h" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /turf/open/floor/plating,
 /area/ruin/powered/shuttle/medium_1)
 "i" = (

--- a/_maps/templates/medium_shuttle2.dmm
+++ b/_maps/templates/medium_shuttle2.dmm
@@ -36,7 +36,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/powered/shuttle/medium_2)
 "l" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /turf/open/floor/plating,
 /area/ruin/powered/shuttle/medium_2)
 "m" = (

--- a/_maps/templates/medium_shuttle3.dmm
+++ b/_maps/templates/medium_shuttle3.dmm
@@ -21,7 +21,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/ruin/powered/shuttle/medium_3)
 "j" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass/ruin,
 /turf/open/floor/plating,
 /area/ruin/powered/shuttle/medium_3)
 "k" = (

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -385,6 +385,7 @@
 
 	return ..()
 
+/// Access free external airlock
 /obj/machinery/door/airlock/external/ruin
 	req_access = null
 
@@ -392,6 +393,7 @@
 	opacity = FALSE
 	glass = TRUE
 
+/// Access free external glass airlock
 /obj/machinery/door/airlock/external/glass/ruin
 	req_access = null
 

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -346,6 +346,13 @@
 	/// Whether or not the airlock can be opened without access from a certain direction while powered, or with bare hands from any direction while unpowered OR pressurized.
 	var/space_dir = null
 
+/obj/machinery/door/airlock/external/Initialize(mapload, ...)
+	// default setting is for mapping only, let overrides work
+	if(!mapload || req_access_txt || req_one_access_txt)
+		req_access = null
+
+	return ..()
+
 /obj/machinery/door/airlock/external/LateInitialize()
 	. = ..()
 	if(space_dir)
@@ -378,9 +385,15 @@
 
 	return ..()
 
+/obj/machinery/door/airlock/external/ruin
+	req_access = null
+
 /obj/machinery/door/airlock/external/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/external/glass/ruin
+	req_access = null
 
 //////////////////////////////////
 /*


### PR DESCRIPTION
Missed from #62161 

- Fixes lavaland airlock accesses
- Fixes needing ACCESS_EXTERNAL_AIRLOCK for ruin airlocks