### PR TITLE
Makes the American sausage a sausage subtype & Advanced roasting stick fixes

### DIFF
--- a/code/datums/memory/memory.dm
+++ b/code/datums/memory/memory.dm
@@ -72,7 +72,7 @@
 		/mob/living/simple_animal/chick,
 		/mob/living/basic/cow/wisdom,
 		/obj/item/skub,
-		/obj/item/food/american_sausage
+		/obj/item/food/sausage/american
 	)
 
 	var/list/forewords = strings(MEMORY_FILE, story_type + "_forewords")

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -305,19 +305,21 @@
 	foodtypes = MEAT | BREAKFAST
 	food_flags = FOOD_FINGER_FOOD
 	eatverbs = list("bite","chew","nibble","deep throat","gobble","chomp")
-	var/roasted = FALSE
 	w_class = WEIGHT_CLASS_SMALL
 	burns_on_grill = TRUE
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/sausage/MakeProcessable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/salami, 6, 30)
-	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/american_sausage, 1, 30)
+	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/sausage/american, 1, 30)
 
-/obj/item/food/american_sausage
+/obj/item/food/sausage/american
 	name = "american sausage"
 	desc = "Snip."
 	icon_state = "american_sausage"
+
+/obj/item/food/sausage/american/MakeProcessable()
+	return
 
 /obj/item/food/salami
 	name = "salami"

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -395,6 +395,7 @@
 			to_chat(user, span_notice("You extend [src] towards [target]."))
 			playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, TRUE)
 			finish_roasting(user, target)
+			return
 		else
 			return
 		finish_roasting(user, target)
@@ -410,6 +411,7 @@
 	else
 		QDEL_NULL(beam)
 		playsound(src, 'sound/weapons/batonextend.ogg', 50, TRUE)
+		to_chat(user, span_notice("You put [src] away."))
 
 /obj/item/melee/cleric_mace
 	name = "cleric mace"

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -387,9 +387,6 @@
 	if (!extended)
 		return
 	if (is_type_in_typecache(target, ovens))
-		if (held_sausage?.roasted)
-			to_chat(user, span_warning("Your [held_sausage] has already been cooked!"))
-			return
 		if (istype(target, /obj/singularity) && get_dist(user, target) < 10)
 			to_chat(user, span_notice("You send [held_sausage] towards [target]."))
 			playsound(src, 'sound/items/rped.ogg', 50, TRUE)
@@ -397,21 +394,22 @@
 		else if (user.Adjacent(target))
 			to_chat(user, span_notice("You extend [src] towards [target]."))
 			playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, TRUE)
-		else
-			return
-		if(do_after(user, 100, target = user))
 			finish_roasting(user, target)
 		else
-			QDEL_NULL(beam)
-			playsound(src, 'sound/weapons/batonextend.ogg', 50, TRUE)
+			return
+		finish_roasting(user, target)
 
 /obj/item/melee/roastingstick/proc/finish_roasting(user, atom/target)
-	to_chat(user, span_notice("You finish roasting [held_sausage]."))
-	playsound(src,'sound/items/welder2.ogg',50,TRUE)
-	held_sausage.add_atom_colour(rgb(103,63,24), FIXED_COLOUR_PRIORITY)
-	held_sausage.name = "[target.name]-roasted [held_sausage.name]"
-	held_sausage.desc = "[held_sausage.desc] It has been cooked to perfection on \a [target]."
-	update_appearance()
+	if(do_after(user, 100, target = user))
+		to_chat(user, span_notice("You finish roasting [held_sausage]."))
+		playsound(src,'sound/items/welder2.ogg',50,TRUE)
+		held_sausage.add_atom_colour(rgb(103,63,24), FIXED_COLOUR_PRIORITY)
+		held_sausage.name = "[target.name]-roasted [held_sausage.name]"
+		held_sausage.desc = "[held_sausage.desc] It has been cooked to perfection on \a [target]."
+		update_appearance()
+	else
+		QDEL_NULL(beam)
+		playsound(src, 'sound/weapons/batonextend.ogg', 50, TRUE)
 
 /obj/item/melee/cleric_mace
 	name = "cleric mace"

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -62,6 +62,8 @@
 	if(used_item.get_temperature())
 		start_burning()
 	if(grill)
+		if(istype(used_item, /obj/item/melee/roastingstick))
+			return FALSE
 		if(!user.combat_mode && !(used_item.item_flags & ABSTRACT))
 			if(user.temporarilyRemoveItemFromInventory(used_item))
 				used_item.forceMove(get_turf(src))

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -970,7 +970,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	if(!istype(item) || (item.item_flags & ABSTRACT) || !istype(user))
 		return
 	if(istype(item, /obj/item/melee/roastingstick))
-		return ..()
+		return FALSE
 	if(istype(item, /obj/item/clothing/mask/cigarette))
 		var/obj/item/clothing/mask/cigarette/cig = item
 		var/clumsy = HAS_TRAIT(user, TRAIT_CLUMSY)


### PR DESCRIPTION
## About The Pull Request
Makes the American sausage a proper subtype of sausage, which makes it actually edible, apparently. It also makes it stick on the advanced roasting stick!
The advanced roasting stick will no longer try to grill itself over a bonfire with a griddle installed, allowing you to use the actual bonfire for your roasting needs.

There was actually a check that was supposed to limit the amount of times you could roast a sausage to a measly 1. It wasn't actually working. This PR removes that in favor of mad cooks creating these: 
![image](https://user-images.githubusercontent.com/75863639/137804501-d632d07f-007e-47cf-beea-0d59211dcfda.png)

## To-Do
- [x] make the roasting stick stop hitting the SM crystal when trying to roast. it doesnt _actually_ hit the crystal but it is very unnerving

## Why It's Good For The Game
A little bit more use for a very underused method of cooking a sausage. Recently, Icebox has had one added in the map shiftstart, go find it!
Makes it possible to use the same bonfire for both making a grilled sausage and roasting said sausage over said bonfire.

## Changelog
:cl:
fix: The american sausage has become edible AND roast-stick-friendly!
fix: Fixes advanced roasting stick griddling itself when used on a bonfire with a rod griddle built over it instead of using the bonfire to roast the sausage.
/:cl:
