### PR TITLE
Give Atmospherics Technician some mail options.

### DIFF
--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -32,7 +32,6 @@
 		/obj/item/grenade/gas_crystal/proto_nitrate_crystal = 10,
 		/obj/item/grenade/gas_crystal/healium_crystal = 10,
 		/obj/item/grenade/gas_crystal/nitrous_oxide_crystal = 5,
-		/obj/item/fireaxe = 1
 	)
 
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -26,6 +26,15 @@
 
 	family_heirlooms = list(/obj/item/lighter, /obj/item/lighter/greyscale, /obj/item/storage/box/matches)
 
+	mail_goodies = list(
+		/obj/item/rpd_upgrade/unwrench = 30,
+		/obj/item/grenade/gas_crystal/crystal_foam = 10,
+		/obj/item/grenade/gas_crystal/proto_nitrate_crystal = 10,
+		/obj/item/grenade/gas_crystal/healium_crystal = 10,
+		/obj/item/grenade/gas_crystal/nitrous_oxide_crystal = 5,
+		/obj/item/fireaxe = 1
+	)
+
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS
 	rpg_title = "Aeromancer"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Right now Atmos Techs (Curators and Miners too) don't have mail options, which results in all your mail being cash.
This both makes the economy hella pointless to Atmos Techs and makes receiving mail just boring.
So I gave them a few things that they can get IC already but I rarely see any Atmos Tech print/produce, mostly to push these tools to be used more often, incentive by exposure I suppose...
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The crystal grenades are quite efficient for station maintenance but rarely made.
They are also fun to use, so maybe now when people scream that medbay got bombed they will leave their HFR bunker just for the satisfaction of throwing crystal grenades at medbay to patch the holes and refill the air.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Guillaume Prata
expansion: Atmospherics Technicians can receive some useful things from their mail now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
