### PR TITLE
Exchanges the drone in-game-code law enforcement for clumsy and pacifistic traits.

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -599,9 +599,6 @@ GLOBAL_LIST_EMPTY(PDAs)
 						playsound(src, 'sound/machines/terminal_success.ogg', 15, TRUE)
 			if("Drone Access")
 				var/mob/living/simple_animal/drone/drone_user = U
-				if(isdrone(U) && drone_user.shy)
-					to_chat(U, span_warning("Your laws prevent this action."))
-					return
 				var/new_state = text2num(href_list["drone_blacklist"])
 				GLOB.drone_machine_blacklist_enabled = new_state
 				if(!silent)

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -37,8 +37,6 @@
 /obj/effect/mob_spawn/drone/allow_spawn(mob/user)
 	var/client/user_client = user.client
 	var/mob/living/simple_animal/drone/drone_type = mob_type
-	if(!initial(drone_type.shy) || isnull(user_client) || !CONFIG_GET(flag/use_exp_restrictions_other))
-		return ..()
 	var/required_role = CONFIG_GET(string/drone_required_role)
 	var/required_playtime = CONFIG_GET(number/drone_role_playtime) * 60
 	if(CONFIG_GET(flag/use_exp_restrictions_admin_bypass) && check_rights_for(user.client, R_ADMIN))

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -29,7 +29,6 @@
 	default_storage = /obj/item/uplink
 	default_hatmask = /obj/item/clothing/head/helmet/space/hardsuit/syndi
 	hacked = TRUE
-	shy = FALSE
 	flavortext = null
 
 /mob/living/simple_animal/drone/syndrone/Initialize(mapload)
@@ -103,7 +102,6 @@
 
 /mob/living/simple_animal/drone/classic
 	name = "classic drone shell"
-	shy = FALSE
 	default_storage = /obj/item/storage/backpack/duffelbag/drone
 
 /obj/effect/mob_spawn/drone/derelict
@@ -135,7 +133,6 @@
 	"<span class='notice'>     - Interacting with non-drone players outside KS13, dead or alive.</span>\n"+\
 	"<span class='warning'>These rules are at admin discretion and will be heavily enforced.</span>\n"+\
 	"<span class='warning'><u>If you do not have the regular drone laws, follow your laws to the best of your ability.</u></span>"
-	shy = FALSE
 
 /mob/living/simple_animal/drone/derelict/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -152,7 +152,6 @@
 		to_chat(src, laws)
 		to_chat(src, "<i>Your onboard antivirus has initiated lockdown. Motor servos are impaired, ventilation access is denied, and your display reports that you are hacked to all nearby.</i>")
 		hacked = TRUE
-		set_shy(FALSE)
 		mind.special_role = "hacked drone"
 		REMOVE_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 		speed = 1 //gotta go slow
@@ -168,7 +167,6 @@
 		to_chat(src, laws)
 		to_chat(src, "<i>Having been restored, your onboard antivirus reports the all-clear and you are able to perform all actions again.</i>")
 		hacked = FALSE
-		set_shy(initial(shy))
 		mind.special_role = null
 		ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 		speed = initial(speed)
@@ -188,7 +186,6 @@
  */
 /mob/living/simple_animal/drone/proc/liberate()
 	laws = "1. You are a Free Drone."
-	set_shy(FALSE)
 	to_chat(src, laws)
 
 /**

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -136,7 +136,6 @@
 	name = "Bardrone"
 	desc = "A barkeeping drone, a robot built to tend bars."
 	hacked = TRUE
-	shy = FALSE
 	laws = "1. Serve drinks.\n\
 		2. Talk to patrons.\n\
 		3. Don't get messed up in their affairs."


### PR DESCRIPTION
## About The Pull Request
Tired of not being able to fix a mess an suicide bomber makes, due to prints of their dna around? Can't open the door of local robotocists workshop because they overlooked you coming to be, or left a corpse in the middle of the room? Trapped down an transdimensional ladder because of a corpse laying directly under it? Fix this issues and more by updating your drone hardware, featuring eased down law enforcement system, and a proper smart in-build system to ensure your peacefulness. 

## Why It's Good For The Game
Gives a reason to actually make, and play as drones made on the station, while sill limiting their offensive capabilities.


## Changelog
:cl:
expansion: Drones will now have peaceful and clumsy traits.
del: Removed code responsible for enforcing law 1 of drones, as well as most of the blacklists, save for the machine interaction.
code: While this PR mostly deletes the code, maintained leftovers shall it ever be reverted, or if someone wanted it to affect other  sentient mob/ghost role in the future.
/:cl:

