### PR TITLE
Removes 2 unused vars from replay days

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -93,10 +93,6 @@
 
 	var/list/alternate_appearances
 
-
-	/// Last appearance of the atom for demo saving purposes
-	var/image/demo_last_appearance
-
 	///Light systems, both shouldn't be active at the same time.
 	var/light_system = STATIC_LIGHT
 	///Range of the light in tiles. Zero means no light.

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -61,9 +61,6 @@
 
 	var/zfalling = FALSE
 
-	///Last location of the atom for demo recording purposes
-	var/atom/demo_last_loc
-
 	/// Either FALSE, [EMISSIVE_BLOCK_GENERIC], or [EMISSIVE_BLOCK_UNIQUE]
 	var/blocks_emissive = FALSE
 	///Internal holder for emissive blocker object, do not use directly use blocks_emissive


### PR DESCRIPTION
## About The Pull Request

Removes two vars used in replays / demos that don't belong anymore

## Why It's Good For The Game

These are on `/atom` and `/atom/movable`, wow

## Changelog

No player facing changes
