### PR TITLE
Removes the mention of teeth in demon heart

### DIFF
--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -154,8 +154,8 @@
 /obj/item/organ/heart/demon/attack(mob/M, mob/living/carbon/user, obj/target)
 	if(M != user)
 		return ..()
-	user.visible_message(span_warning("[user] raises [src] to [user.p_their()] mouth and tears into it with [user.p_their()] teeth!"), \
-		span_danger("An unnatural hunger consumes you. You raise [src] your mouth and devour it!"))
+	user.visible_message(span_warning("[user] raises [src] to [user.p_their()] mouth and tears into it ferociously!"), \
+		span_danger("An unnatural hunger consumes you. You raise [src] and devour it!"))
 	playsound(user, 'sound/magic/demon_consume.ogg', 50, TRUE)
 	for(var/obj/effect/proc_holder/spell/knownspell in user.mind.spell_list)
 		if(knownspell.type == /obj/effect/proc_holder/spell/bloodcrawl)


### PR DESCRIPTION
## About The Pull Request

Removes the description of biting into the demon's heart with your teeth.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/53777086/137844038-d78c67ca-78b1-4c74-aa89-0a1e52ed7c4c.png)

## Changelog

:cl:
spellcheck: Demon hearts will no longer say you've bitten into it with teeth that may or may not exist.
/:cl: