### PR TITLE
Lets Player-Controlled Monkeys Make Noise When Using *Screech

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -109,7 +109,7 @@
 	var/dchatmsg = "<b>[user]</b> [msg]"
 
 	var/tmp_sound = get_sound(user)
-	if(tmp_sound && (!only_forced_audio || !intentional) && !TIMER_COOLDOWN_CHECK(user, type))
+	if(tmp_sound && should_play_sound(user, intentional) && !TIMER_COOLDOWN_CHECK(user, type))
 		TIMER_COOLDOWN_START(user, type, audio_cooldown)
 		playsound(user, tmp_sound, 50, vary)
 
@@ -261,6 +261,20 @@
 		var/mob/living/sender = user
 		if(HAS_TRAIT(sender, TRAIT_EMOTEMUTE))
 			return FALSE
+
+/**
+ * Check to see if the user should play a sound when performing the emote.
+ *
+ * Arguments:
+ * * user - Person that is doing the emote.
+ * * intentional - Bool that says whether the emote was forced (FALSE) or not (TRUE).
+ *
+ * Returns a bool about whether or not the user should play a sound when performing the emote.
+ */
+/datum/emote/proc/should_play_sound(mob/user, intentional = FALSE)
+	if(!only_forced_audio || !intentional)
+		return FALSE
+	return TRUE
 
 /**
 * Allows the intrepid coder to send a basic emote

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -272,7 +272,7 @@
  * Returns a bool about whether or not the user should play a sound when performing the emote.
  */
 /datum/emote/proc/should_play_sound(mob/user, intentional = FALSE)
-	if(!only_forced_audio || !intentional)
+	if(only_forced_audio && intentional)
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -86,7 +86,13 @@
 	key_third_person = "screeches"
 	message = "screeches."
 	emote_type = EMOTE_AUDIBLE
+	only_forced_audio = FALSE
 	vary = FALSE
+
+/datum/emote/living/carbon/human/scream/screech/can_run_emote(mob/user, status_check = TRUE, intentional)
+	if(!ismonkey(user) && intentional)
+		return FALSE
+	return ..()
 
 /datum/emote/living/carbon/human/pale
 	key = "pale"

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -86,13 +86,12 @@
 	key_third_person = "screeches"
 	message = "screeches."
 	emote_type = EMOTE_AUDIBLE
-	only_forced_audio = FALSE
 	vary = FALSE
 
-/datum/emote/living/carbon/human/scream/screech/can_run_emote(mob/user, status_check = TRUE, intentional)
+/datum/emote/living/carbon/human/scream/screech/should_play_sound(mob/user, intentional)
 	if(!ismonkey(user) && intentional)
 		return FALSE
-	return ..()
+	return TRUE
 
 /datum/emote/living/carbon/human/pale
 	key = "pale"

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -89,9 +89,9 @@
 	vary = FALSE
 
 /datum/emote/living/carbon/human/scream/screech/should_play_sound(mob/user, intentional)
-	if(!ismonkey(user) && intentional)
-		return FALSE
-	return TRUE
+	if(ismonkey(user))
+		return TRUE
+	return ..()
 
 /datum/emote/living/carbon/human/pale
 	key = "pale"


### PR DESCRIPTION
## About The Pull Request

This PR lets player-controlled monkeys make screeching noises using *screech.

Under the hood, this PR also adds a new proc to emotes called, should_play_sound.  What this does by default is the same check run_emote used to do with only_forced_audio, but now that it's in a proc you can override it if you want to.  Though, let's be real here, this is only going to get used for this PR because the only reason you'd want to bypass that check is if you're doing something for monkeys.  The amount of extremely specific circumstances which even warranted something like this could only stem from some stupid monkey/alien specific crap anyway, BUT JUST IN CASE YOU NEED IT, here it is.

## Why It's Good For The Game

Considering all the screeching AI monkeys do, it's a big shame that currently player monkeys can't do similar.  Considering that monkeys are valid salad and that AI monkeys already screech a lot anyway, I don't think letting players get in on the fun is a bad idea.  If need be, we can just tune up the sound cooldown on *screech but I don't think it's really that abusable to begin with.

## Changelog
:cl:
expansion: Player monkeys make a screeching noise when using the *screech emote.
/:cl: