### PR TITLE
You can now enter da vim once again

### DIFF
--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -33,7 +33,7 @@
 	return ..()
 
 /obj/vehicle/sealed/car/vim/mob_try_enter(mob/entering)
-	if(!isanimal(entering) || !isbasicmob(entering))
+	if(!isanimal(entering) && !isbasicmob(entering))
 		return FALSE
 	var/mob/living/animal_or_basic = entering
 	if(animal_or_basic.mob_size != MOB_SIZE_TINY)


### PR DESCRIPTION
## About The Pull Request

Small fix, it checks if you're either not a simple animal or not a simple mob, if you're not one of either, you can't enter.

## Why It's Good For The Game

Closes #62184

## Changelog

:cl:
fix: da vim can now be entered again.
/:cl: