### PR TITLE
SDQL spells can have their admin messages suppressed (+a small ui fix)

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -210,9 +210,10 @@
 			to_chat(usr, results[I], confidential = TRUE)
 	SSblackbox.record_feedback("nested tally", "SDQL query", 1, list(ckey, query_text))
 
-/world/proc/SDQL2_query(query_text, log_entry1, log_entry2)
+/world/proc/SDQL2_query(query_text, log_entry1, log_entry2, silent = FALSE)
 	var/query_log = "executed SDQL query(s): \"[query_text]\"."
-	message_admins("[log_entry1] [query_log]")
+	if(!silent)
+		message_admins("[log_entry1] [query_log]")
 	query_log = "[log_entry2] [query_log]"
 	log_game(query_log)
 	NOTICE(query_log)

--- a/code/modules/admin/verbs/SDQL2/SDQL_spells/executor_component.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_spells/executor_component.dm
@@ -1,6 +1,7 @@
 /datum/component/sdql_executor
 	var/query = "CALL visible_message(\"<span class='warning'>The spell fizzles!</span>\") ON * IN TARGETS"
 	var/giver //The ckey of the user that gave this spell
+	var/suppress_message_admins
 	var/list/scratchpad = list() //Use this to store vars in between queries and casts.
 	var/list/saved_overrides = list()
 
@@ -35,7 +36,7 @@
 	if(!usr) //We need to set AdminProcCaller manually because it won't be set automatically by WrapAdminProcCall if usr is null
 		GLOB.AdminProcCaller = "SDQL_SPELL_OF_[user.ckey]"
 	GLOB.AdminProcCallCount++
-	world.SDQL2_query(query_text, "[key_name(user, TRUE)] (via an SDQL spell given by [giver])", "[key_name(user)] (via an SDQL spell given by [giver])")
+	world.SDQL2_query(query_text, "[key_name(user, TRUE)] (via an SDQL spell given by [giver])", "[key_name(user)] (via an SDQL spell given by [giver])", silent = suppress_message_admins)
 	GLOB.AdminProcCallCount--
 	GLOB.AdminProcCaller = null
 

--- a/code/modules/admin/verbs/SDQL2/SDQL_spells/spell_edit_menu.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_spells/spell_edit_menu.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_INIT_TYPED(sdql_spells, /obj/effect/proc_holder/spell, list())
 	var/mob/living/target_mob
 	var/obj/effect/proc_holder/spell/target_spell
 	var/spell_type
-	var/list/saved_vars = list("query" = "")
+	var/list/saved_vars = list("query" = "", "suppress_message_admins" = FALSE)
 	var/list/list_vars = list()
 	var/list/parse_result = null
 	var/alert
@@ -199,6 +199,8 @@ GLOBAL_LIST_INIT_TYPED(sdql_spells, /obj/effect/proc_holder/spell, list())
 			"query_self" = "TARGETS is null.",
 			"query_targeted" = "TARGETS is replaced with a list containing a reference(s) to the targeted mob(s).",
 			"query_targeted_touch" = "TARGETS is replaced with a list containing a reference to the atom hit with the touch attack.",
+			"suppress_message_admins" = "If this is true, the spell will not print out its query to admins' chat panels.\n\
+				The query will still be output to the game log.",
 			"charge_type" = "How the spell's charge works. This affects how charge_max is used.\n\
 				When set to \"recharge\", charge_max is the time in deciseconds between casts of the spell.\n\
 				When set to \"charges\", the user can only use the spell a number of times equal to charge_max.\n\
@@ -269,6 +271,7 @@ GLOBAL_LIST_INIT_TYPED(sdql_spells, /obj/effect/proc_holder/spell, list())
 	if(!executor)
 		CRASH("[sample]'s SDQL executor component went missing!")
 	saved_vars["query"] = executor.query
+	saved_vars["suppress_message_admins"] = executor.suppress_message_admins
 	load_list_var(executor.scratchpad, "scratchpad")
 	for(var/V in sample.vars&editable_spell_vars)
 		if(islist(sample.vars[V]))
@@ -486,6 +489,12 @@ GLOBAL_LIST_INIT_TYPED(sdql_spells, /obj/effect/proc_holder/spell, list())
 				continue
 			result_vars[V] = temp_vars[V]
 			continue
+		if(V == "suppress_message_admins")
+			if(!isnum(temp_vars[V]))
+				parse_errors += "The value of \"suppress_message_admins\" must be a number"
+				continue
+			result_vars[V] = !!temp_vars[V]
+			continue
 		if(!(V in editable_spell_vars))
 			parse_errors += "\"[V]\" is not an editable variable"
 			continue
@@ -567,7 +576,7 @@ GLOBAL_LIST_INIT_TYPED(sdql_spells, /obj/effect/proc_holder/spell, list())
 				if(!(temp_list_vars[V][W]["flags"] & LIST_VAR_FLAGS_NAMED))
 					parse_errors += "[V]/[W] did not have the LIST_VAR_FLAGS_NAMED flag set; it has been set"
 					temp_list_vars[V][W]["flags"] |= LIST_VAR_FLAGS_NAMED
-				if(temp_list_vars & ~(LIST_VAR_FLAGS_NAMED | LIST_VAR_FLAGS_TYPED))
+				if(temp_list_vars[V][W]["flags"] & ~(LIST_VAR_FLAGS_NAMED | LIST_VAR_FLAGS_TYPED))
 					parse_errors += "[V]/[W] has unused bit flags set; they have been unset"
 					temp_list_vars[V][W]["flags"] &= LIST_VAR_FLAGS_NAMED | LIST_VAR_FLAGS_TYPED
 				if(!(temp_list_vars[V][W]["flags"] & LIST_VAR_FLAGS_TYPED))
@@ -903,6 +912,8 @@ GLOBAL_LIST_INIT_TYPED(sdql_spells, /obj/effect/proc_holder/spell, list())
 	for(var/V in saved_vars+list_vars)
 		if(V == "query")
 			executor.vv_edit_var("query", saved_vars["query"])
+		else if(V == "suppress_message_admins")
+			executor.vv_edit_var("suppress_message_admins", saved_vars["suppress_message_admins"])
 		else if(V == "scratchpad")
 			var/list/new_scratchpad = generate_list_var("scratchpad")
 			if(new_scratchpad)

--- a/tgui/packages/tgui/interfaces/SDQLSpellMenu.js
+++ b/tgui/packages/tgui/interfaces/SDQLSpellMenu.js
@@ -16,6 +16,12 @@ const typevars = (type) => {
     { name: 'name', type: 'string', options: null, default_value: '' },
     { name: 'desc', type: 'string', options: null, default_value: '' },
     { name: 'query', type: 'string', options: null, default_value: '' },
+    {
+      name: 'suppress_message_admins',
+      type: 'bool',
+      options: null,
+      default_value: false,
+    },
     { name: 'action_icon', type: 'string', options: null, default_value: '' },
     {
       name: 'action_icon_state',
@@ -825,11 +831,11 @@ const SDQLSpellParseErrorModal = (props, context) => {
   const multiple_errors = parse_errors.length > 1;
   return (
     <Modal>
-      <Stack vertical>
+      <Stack fill vertical>
         <Stack.Item>
           Parse error{multiple_errors ? "s" : ""} occured while loading from file.
         </Stack.Item>
-        <Stack.Item grow>
+        <Stack.Item>
           <Section scrollable maxWidth="600px" maxHeight="200px">
             {parse_errors.map((error, i) => {
               return (
@@ -852,7 +858,7 @@ const SDQLSpellParseErrorModal = (props, context) => {
                 Some data could be correctly parsed. Click below to view.
               </Box>
             </Stack.Item>
-            <Stack.Item grow>
+            <Stack.Item>
               <Collapsible title="Parsed Data">
                 <Section scrollable maxWidth="600px" maxHeight="200px">
                   <LabeledList>


### PR DESCRIPTION
## About The Pull Request

Adds a `suppress_message_admins` var to SDQL spells, which makes the query not appear in chat, while still writing it to the game log.

## Why It's Good For The Game

Melbert was complaining about how an SDQL spell he gave someone flooded the admins' chats with 5 lines of text every time it was cast.

## Changelog

:cl:
admin: Added a "suppress_message_admins" variable to SDQL spells, which prevents the spell's query from getting output to all admins' chat panels. The query will still be written to the game log.
fix: The SDQL spell parse error modal grows properly.
/:cl:
