### PR TITLE
Backup human names work again

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -420,6 +420,7 @@
 		player_client.prefs.safe_transfer_prefs_to(src, TRUE, is_antag)
 		if (require_human)
 			set_species(/datum/species/human)
+			apply_pref_name(/datum/preference/name/backup_human, player_client)
 		if(CONFIG_GET(flag/force_random_names))
 			var/species_type = player_client.prefs.read_preference(/datum/preference/choiced/species)
 			var/datum/species/species = new species_type


### PR DESCRIPTION
## About The Pull Request

~Apparently, during the prefs refactor, they removed the old code for assigning backup human names and forgot to put the corresponding new code in. This PR puts that new code in.~

Fixes #60795

## Why It's Good For The Game

No more mistakenly thinking there's nonhuman heads of staff.

## Changelog

:cl:
fix: Backup human names are once again respected when forcibly humanizing what would otherwise be a non-human head of staff.
/:cl:
