### PR TITLE
RPD device separation and tooltips

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -20,23 +20,25 @@ GLOBAL_LIST_INIT(atmos_pipe_recipes, list(
 		new /datum/pipe_info/pipe("Bridge Pipe", /obj/machinery/atmospherics/pipe/bridge_pipe, TRUE),
 		new /datum/pipe_info/pipe("Multi-Deck Adapter", /obj/machinery/atmospherics/pipe/multiz, FALSE),
 	),
-	"Devices" = list(
+	"Basic Devices" = list(
 		new /datum/pipe_info/pipe("Connector", /obj/machinery/atmospherics/components/unary/portables_connector, TRUE),
 		new /datum/pipe_info/pipe("Gas Pump", /obj/machinery/atmospherics/components/binary/pump, TRUE),
-		new /datum/pipe_info/pipe("Volume Pump", /obj/machinery/atmospherics/components/binary/volume_pump, TRUE),
 		new /datum/pipe_info/pipe("Gas Filter", /obj/machinery/atmospherics/components/trinary/filter, TRUE),
 		new /datum/pipe_info/pipe("Gas Mixer", /obj/machinery/atmospherics/components/trinary/mixer, TRUE),
-		new /datum/pipe_info/pipe("Passive Gate", /obj/machinery/atmospherics/components/binary/passive_gate, TRUE),
 		new /datum/pipe_info/pipe("Injector", /obj/machinery/atmospherics/components/unary/outlet_injector, TRUE),
 		new /datum/pipe_info/pipe("Scrubber", /obj/machinery/atmospherics/components/unary/vent_scrubber, TRUE),
 		new /datum/pipe_info/pipe("Unary Vent", /obj/machinery/atmospherics/components/unary/vent_pump, TRUE),
 		new /datum/pipe_info/pipe("Passive Vent", /obj/machinery/atmospherics/components/unary/passive_vent, TRUE),
 		new /datum/pipe_info/pipe("Manual Valve", /obj/machinery/atmospherics/components/binary/valve, TRUE),
+		new /datum/pipe_info/meter("Meter"),
+	),
+	"Advanced Devices" = list(
+		new /datum/pipe_info/pipe("Volume Pump", /obj/machinery/atmospherics/components/binary/volume_pump, TRUE),
 		new /datum/pipe_info/pipe("Digital Valve", /obj/machinery/atmospherics/components/binary/valve/digital, TRUE),
+		new /datum/pipe_info/pipe("Passive Gate", /obj/machinery/atmospherics/components/binary/passive_gate, TRUE),
 		new /datum/pipe_info/pipe("Pressure Valve", /obj/machinery/atmospherics/components/binary/pressure_valve, TRUE),
 		new /datum/pipe_info/pipe("Temperature Gate", /obj/machinery/atmospherics/components/binary/temperature_gate, TRUE),
 		new /datum/pipe_info/pipe("Temperature Pump", /obj/machinery/atmospherics/components/binary/temperature_pump, TRUE),
-		new /datum/pipe_info/meter("Meter"),
 	),
 	"Heat Exchange" = list(
 		new /datum/pipe_info/pipe("Pipe", /obj/machinery/atmospherics/pipe/heat_exchanging/simple, FALSE),
@@ -84,6 +86,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/id = -1
 	var/dirtype = PIPE_BENDABLE
 	var/all_layers
+	var/RPD_tooltip
 
 /datum/pipe_info/proc/Render(dispenser)
 	var/dat = "<li><a href='?src=[REF(dispenser)]&[Params()]'>[name]</a></li>"
@@ -145,6 +148,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	icon_state = initial(path.pipe_state)
 	var/obj/item/pipe/c = initial(path.construction_type)
 	dirtype = initial(c.RPD_type)
+	RPD_tooltip = initial(path.RPD_tooltip)
 
 /datum/pipe_info/pipe/Params()
 	return "makepipe=[id]&type=[dirtype]"
@@ -155,6 +159,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 /datum/pipe_info/meter/New(label)
 	name = label
+	RPD_tooltip = initial(path.RPD_tooltip)
 
 /datum/pipe_info/meter/Params()
 	return "makemeter=[id]&type=[dirtype]"
@@ -361,7 +366,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 		var/list/r = list()
 		for(var/i in 1 to cat.len)
 			var/datum/pipe_info/info = cat[i]
-			r += list(list("pipe_name" = info.name, "pipe_index" = i, "selected" = (info == recipe), "all_layers" = info.all_layers))
+			r += list(list("pipe_name" = info.name, "pipe_index" = i, "selected" = (info == recipe), "all_layers" = info.all_layers, "RPD_tooltip" = info.RPD_tooltip))
 		data["categories"] += list(list("cat_name" = c, "recipes" = r))
 
 	var/list/init_directions = list("north" = FALSE, "south" = FALSE, "east" = FALSE, "west" = FALSE)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/id = -1
 	var/dirtype = PIPE_BENDABLE
 	var/all_layers
-	var/RPD_tooltip
+	var/rpd_tooltip
 
 /datum/pipe_info/proc/Render(dispenser)
 	var/dat = "<li><a href='?src=[REF(dispenser)]&[Params()]'>[name]</a></li>"
@@ -148,7 +148,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	icon_state = initial(path.pipe_state)
 	var/obj/item/pipe/c = initial(path.construction_type)
 	dirtype = initial(c.RPD_type)
-	RPD_tooltip = initial(path.RPD_tooltip)
+	rpd_tooltip = initial(path.rpd_tooltip)
 
 /datum/pipe_info/pipe/Params()
 	return "makepipe=[id]&type=[dirtype]"
@@ -159,7 +159,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 /datum/pipe_info/meter/New(label)
 	name = label
-	RPD_tooltip = "Place on top of a pipe to easily read the pressure/temperature of its contents."
+	rpd_tooltip = "Place on top of a pipe to easily read the pressure/temperature of its contents."
 
 /datum/pipe_info/meter/Params()
 	return "makemeter=[id]&type=[dirtype]"
@@ -366,7 +366,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 		var/list/r = list()
 		for(var/i in 1 to cat.len)
 			var/datum/pipe_info/info = cat[i]
-			r += list(list("pipe_name" = info.name, "pipe_index" = i, "selected" = (info == recipe), "all_layers" = info.all_layers, "RPD_tooltip" = info.RPD_tooltip))
+			r += list(list("pipe_name" = info.name, "pipe_index" = i, "selected" = (info == recipe), "all_layers" = info.all_layers, "rpd_tooltip" = info.rpd_tooltip))
 		data["categories"] += list(list("cat_name" = c, "recipes" = r))
 
 	var/list/init_directions = list("north" = FALSE, "south" = FALSE, "east" = FALSE, "west" = FALSE)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -159,7 +159,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 /datum/pipe_info/meter/New(label)
 	name = label
-	RPD_tooltip = initial(path.RPD_tooltip)
+	RPD_tooltip = "Place on top of a pipe to easily read the pressure/temperature of its contents."
 
 /datum/pipe_info/meter/Params()
 	return "makemeter=[id]&type=[dirtype]"

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -59,7 +59,7 @@
 	var/vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE
 
 	///Message in the RPD UI tooltips
-	var/RPD_tooltip = "If you see this, tell a c*der about it."
+	var/rpd_tooltip = "If you see this, tell a c*der about it."
 
 /obj/machinery/atmospherics/LateInitialize()
 	. = ..()

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -58,6 +58,9 @@
 	///The bitflag that's being checked on ventcrawling. Default is to allow ventcrawling and seeing pipes.
 	var/vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE
 
+	///Message in the RPD UI tooltips
+	var/RPD_tooltip = "If you see this, tell a c*der about it."
+
 /obj/machinery/atmospherics/LateInitialize()
 	. = ..()
 	update_name()

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -17,7 +17,7 @@ Passive gate is similar to the regular pump except:
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "passivegate"
 
-	RPD_tooltip = "A one-way air valve that does not require power. Passes gas when the output pressure is lower than the target pressure."
+	RPD_tooltip = "A one-way air valve that does not require power. Passes gas when the input pressure is higher than the output and the output pressure is lower than the designated value."
 
 	///Set the target pressure the component should arrive to
 	var/target_pressure = ONE_ATMOSPHERE

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -17,7 +17,7 @@ Passive gate is similar to the regular pump except:
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "passivegate"
 
-	RPD_tooltip = "A one-way air valve that does not require power. Passes gas when the input pressure is higher than the output and the output pressure is lower than the designated value."
+	rpd_tooltip = "A one-way air valve that does not require power. Passes gas when the input pressure is higher than the output and the output pressure is lower than the designated value."
 
 	///Set the target pressure the component should arrive to
 	var/target_pressure = ONE_ATMOSPHERE

--- a/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/passive_gate.dm
@@ -16,6 +16,9 @@ Passive gate is similar to the regular pump except:
 	interaction_flags_machine = INTERACT_MACHINE_OFFLINE | INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_SET_MACHINE
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "passivegate"
+
+	RPD_tooltip = "A one-way air valve that does not require power. Passes gas when the output pressure is lower than the target pressure."
+
 	///Set the target pressure the component should arrive to
 	var/target_pressure = ONE_ATMOSPHERE
 	///Variable for radio frequency

--- a/code/modules/atmospherics/machinery/components/binary_devices/pressure_valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pressure_valve.dm
@@ -6,6 +6,9 @@
 	shift_underlay_only = FALSE
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "pvalve"
+
+	RPD_tooltip = "A one way valve that allows gases through only if the input pressure is higher than the set target."
+
 	///Amount of pressure needed before the valve for it to open
 	var/target_pressure = ONE_ATMOSPHERE
 	///Frequency for radio signaling

--- a/code/modules/atmospherics/machinery/components/binary_devices/pressure_valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pressure_valve.dm
@@ -7,7 +7,7 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "pvalve"
 
-	RPD_tooltip = "A one way valve that allows gases through only if the input pressure is higher than the set target."
+	rpd_tooltip = "A one way valve that allows gases through only if the input pressure is higher than the set target."
 
 	///Amount of pressure needed before the valve for it to open
 	var/target_pressure = ONE_ATMOSPHERE

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -19,6 +19,9 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "pump"
 	vent_movement = NONE
+
+	RPD_tooltip = "Pressure based pump that moves gases from one pipenet to another."
+
 	///Pressure that the pump will reach when on
 	var/target_pressure = ONE_ATMOSPHERE
 	///Frequency for radio signaling

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -20,7 +20,7 @@
 	pipe_state = "pump"
 	vent_movement = NONE
 
-	RPD_tooltip = "Pressure based pump that moves gases from one pipenet to another."
+	rpd_tooltip = "Pressure based pump that moves gases from one pipenet to another."
 
 	///Pressure that the pump will reach when on
 	var/target_pressure = ONE_ATMOSPHERE

--- a/code/modules/atmospherics/machinery/components/binary_devices/temperature_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/temperature_gate.dm
@@ -7,7 +7,7 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "tgate"
 
-	RPD_tooltip = "Pumps gases if their temperature is lower than the set temperature. The setting can be inverted with a multitool."
+	rpd_tooltip = "Pumps gases if their temperature is lower than the set temperature. The setting can be inverted with a multitool."
 
 	///If the temperature of the mix before the gate is lower than this, the gas will flow (if inverted, if the temperature of the mix before the gate is higher than this)
 	var/target_temperature = T0C

--- a/code/modules/atmospherics/machinery/components/binary_devices/temperature_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/temperature_gate.dm
@@ -7,7 +7,7 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "tgate"
 
-	RPD_tooltip = "Pumps gases if their temperature is lower than the set temperature. The setting can be inverted."
+	RPD_tooltip = "Pumps gases if their temperature is lower than the set temperature. The setting can be inverted with a multitool."
 
 	///If the temperature of the mix before the gate is lower than this, the gas will flow (if inverted, if the temperature of the mix before the gate is higher than this)
 	var/target_temperature = T0C

--- a/code/modules/atmospherics/machinery/components/binary_devices/temperature_gate.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/temperature_gate.dm
@@ -6,6 +6,9 @@
 	shift_underlay_only = FALSE
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "tgate"
+
+	RPD_tooltip = "Pumps gases if their temperature is lower than the set temperature. The setting can be inverted."
+
 	///If the temperature of the mix before the gate is lower than this, the gas will flow (if inverted, if the temperature of the mix before the gate is higher than this)
 	var/target_temperature = T0C
 	///Minimum allowed temperature

--- a/code/modules/atmospherics/machinery/components/binary_devices/temperature_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/temperature_pump.dm
@@ -7,6 +7,9 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "tpump"
 	vent_movement = NONE
+
+	RPD_tooltip = "A pump that moves only heat from an hotter source to a colder target."
+
 	///Percent of the heat delta to transfer
 	var/heat_transfer_rate = 0
 	///Maximum allowed transfer percentage

--- a/code/modules/atmospherics/machinery/components/binary_devices/temperature_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/temperature_pump.dm
@@ -8,7 +8,7 @@
 	pipe_state = "tpump"
 	vent_movement = NONE
 
-	RPD_tooltip = "A pump that moves only heat from an hotter source to a colder target."
+	rpd_tooltip = "A pump that moves only heat from an hotter source to a colder target."
 
 	///Percent of the heat delta to transfer
 	var/heat_transfer_rate = 0

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -16,7 +16,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	pipe_state = "mvalve"
 	custom_reconcilation = TRUE
 
-	RPD_tooltip = "A pipe with a valve that can be used to disable flow of gas through it."
+	rpd_tooltip = "A pipe with a valve that can be used to disable flow of gas through it."
 
 	///Type of valve (manual or digital), used to set the icon of the component in update_icon_nopipes()
 	var/valve_type = MANUAL_VALVE
@@ -85,7 +85,7 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 
 	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OFFLINE | INTERACT_MACHINE_OPEN | INTERACT_MACHINE_OPEN_SILICON
 
-	RPD_tooltip = "A digital version of the manual valve. Can be controlled by silicons from distance."
+	rpd_tooltip = "A digital version of the manual valve. Can be controlled by silicons from distance."
 
 /obj/machinery/atmospherics/components/binary/valve/digital/Initialize(mapload)
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -15,6 +15,9 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	construction_type = /obj/item/pipe/binary
 	pipe_state = "mvalve"
 	custom_reconcilation = TRUE
+
+	RPD_tooltip = "A pipe with a valve that can be used to disable flow of gas through it."
+
 	///Type of valve (manual or digital), used to set the icon of the component in update_icon_nopipes()
 	var/valve_type = MANUAL_VALVE
 	///Bool to stop interactions while the opening/closing animation is going
@@ -81,6 +84,8 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	pipe_state = "dvalve"
 
 	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OFFLINE | INTERACT_MACHINE_OPEN | INTERACT_MACHINE_OPEN_SILICON
+
+	RPD_tooltip = "A digital version of the manual valve. Can be controlled by silicons from distance."
 
 /obj/machinery/atmospherics/components/binary/valve/digital/Initialize(mapload)
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -20,7 +20,7 @@
 	pipe_state = "volumepump"
 	vent_movement = NONE
 
-	RPD_tooltip = "A version of the pressure pump that trades output control for improved gas flow, moves gases based on volume up to ~9000 kPa"
+	rpd_tooltip = "A version of the pressure pump that trades output control for improved gas flow, moves gases based on volume up to ~9000 kPa"
 
 	///Transfer rate of the component in L/s
 	var/transfer_rate = MAX_TRANSFER_RATE

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -19,6 +19,9 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "volumepump"
 	vent_movement = NONE
+
+	RPD_tooltip = "A stronger version of the pressure pump, moves gases based on volume up to ~9000 kPa"
+
 	///Transfer rate of the component in L/s
 	var/transfer_rate = MAX_TRANSFER_RATE
 	///Check if the component has been overclocked

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -20,7 +20,7 @@
 	pipe_state = "volumepump"
 	vent_movement = NONE
 
-	RPD_tooltip = "A stronger version of the pressure pump, moves gases based on volume up to ~9000 kPa"
+	RPD_tooltip = "A version of the pressure pump that trades output control for improved gas flow, moves gases based on volume up to ~9000 kPa"
 
 	///Transfer rate of the component in L/s
 	var/transfer_rate = MAX_TRANSFER_RATE

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -9,7 +9,7 @@
 	construction_type = /obj/item/pipe/trinary/flippable
 	pipe_state = "filter"
 
-	RPD_tooltip = "Has one input and two outputs. Choose the gases to be moved to the lateral output."
+	rpd_tooltip = "Has one input and two outputs. Choose the gases to be moved to the lateral output."
 
 	///Rate of transfer of the gases to the outputs
 	var/transfer_rate = MAX_TRANSFER_RATE

--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -9,6 +9,8 @@
 	construction_type = /obj/item/pipe/trinary/flippable
 	pipe_state = "filter"
 
+	RPD_tooltip = "Has one input and two outputs. Choose the gases to be moved to the lateral output."
+
 	///Rate of transfer of the gases to the outputs
 	var/transfer_rate = MAX_TRANSFER_RATE
 	///What gases are we filtering, by typepath

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -9,7 +9,7 @@
 	construction_type = /obj/item/pipe/trinary/flippable
 	pipe_state = "mixer"
 
-	RPD_tooltip = "Has two input ports and one output. Choose the ratio between the two inputs to output."
+	rpd_tooltip = "Has two input ports and one output. Choose the ratio between the two inputs to output."
 
 	///Output pressure target
 	var/target_pressure = ONE_ATMOSPHERE

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -9,6 +9,8 @@
 	construction_type = /obj/item/pipe/trinary/flippable
 	pipe_state = "mixer"
 
+	RPD_tooltip = "Has two input ports and one output. Choose the ratio between the two inputs to output."
+
 	///Output pressure target
 	var/target_pressure = ONE_ATMOSPHERE
 	///Ratio between the node 1 and 2, determines the amount of gas transfered, sums up to 1

--- a/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
@@ -13,6 +13,8 @@
 	var/datum/weakref/partner_ref = null
 	var/update_cycle
 
+	RPD_tooltip = "Place two of these facing each other to equalize the temperature between the two pipenets."
+
 	pipe_state = "heunary"
 
 /obj/machinery/atmospherics/components/unary/heat_exchanger/layer2

--- a/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/heat_exchanger.dm
@@ -13,7 +13,7 @@
 	var/datum/weakref/partner_ref = null
 	var/update_cycle
 
-	RPD_tooltip = "Place two of these facing each other to equalize the temperature between the two pipenets."
+	rpd_tooltip = "Place two of these facing each other to equalize the temperature between the two pipenets."
 
 	pipe_state = "heunary"
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -12,7 +12,7 @@
 	pipe_state = "injector"
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF //really helpful in building gas chambers for xenomorphs
 
-	RPD_tooltip = "Pressurize the atmosphere forcefully, only able to control the flow of the gases."
+	rpd_tooltip = "Pressurize the atmosphere forcefully, only able to control the flow of the gases."
 
 	///Variable used for radio frequency injection
 	var/injecting = FALSE

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -12,6 +12,8 @@
 	pipe_state = "injector"
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF //really helpful in building gas chambers for xenomorphs
 
+	RPD_tooltip = "Pressurize the atmosphere forcefully, only able to control the flow of the gases."
+
 	///Variable used for radio frequency injection
 	var/injecting = FALSE
 	///Rate of operation of the device

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -12,6 +12,8 @@
 	pipe_state = "pvent"
 	vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE | VENTCRAWL_ENTRANCE_ALLOWED
 
+	RPD_tooltip = "Acts like an open valve between the pipenet and the environment."
+
 /obj/machinery/atmospherics/components/unary/passive_vent/update_icon_nopipes()
 	cut_overlays()
 	if(showpipe)

--- a/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/passive_vent.dm
@@ -12,7 +12,7 @@
 	pipe_state = "pvent"
 	vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE | VENTCRAWL_ENTRANCE_ALLOWED
 
-	RPD_tooltip = "Acts like an open valve between the pipenet and the environment."
+	rpd_tooltip = "Acts like an open valve between the pipenet and the environment."
 
 /obj/machinery/atmospherics/components/unary/passive_vent/update_icon_nopipes()
 	cut_overlays()

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -15,6 +15,8 @@
 	pipe_state = "connector"
 	custom_reconcilation = TRUE
 
+	RPD_tooltip = "Connector port to be used with canisters/portable pumps/portable scrubbers."
+
 	///Reference to the connected device
 	var/obj/machinery/portable_atmospherics/connected_device
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/portables_connector.dm
@@ -15,7 +15,7 @@
 	pipe_state = "connector"
 	custom_reconcilation = TRUE
 
-	RPD_tooltip = "Connector port to be used with canisters/portable pumps/portable scrubbers."
+	rpd_tooltip = "Connector port to be used with canisters/portable pumps/portable scrubbers."
 
 	///Reference to the connected device
 	var/obj/machinery/portable_atmospherics/connected_device

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -20,6 +20,8 @@
 	pipe_state = "uvent"
 	vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE | VENTCRAWL_ENTRANCE_ALLOWED
 
+	RPD_tooltip = "Vent pump that can be programmed to reach a set pressure in the environment or the inside of its pipe."
+
 	///Direction of pumping the gas (RELEASING or SIPHONING)
 	var/pump_direction = RELEASING
 	///Should we check internal pressure, external pressure, both or none? (EXT_BOUND, INT_BOUND, NO_BOUND)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -20,7 +20,7 @@
 	pipe_state = "uvent"
 	vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE | VENTCRAWL_ENTRANCE_ALLOWED
 
-	RPD_tooltip = "Vent pump that can be programmed to reach a set pressure in the environment or the inside of its pipe."
+	rpd_tooltip = "Vent pump that can be programmed to reach a set pressure in the environment or the inside of its pipe."
 
 	///Direction of pumping the gas (RELEASING or SIPHONING)
 	var/pump_direction = RELEASING

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -17,7 +17,7 @@
 	pipe_state = "scrubber"
 	vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE | VENTCRAWL_ENTRANCE_ALLOWED
 
-	RPD_tooltip = "Scrubber programmable to selectively filter gases."
+	rpd_tooltip = "Scrubber programmable to selectively filter gases."
 
 	///The mode of the scrubber (SCRUBBING or SIPHONING)
 	var/scrubbing = SCRUBBING //0 = siphoning, 1 = scrubbing

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -17,6 +17,8 @@
 	pipe_state = "scrubber"
 	vent_movement = VENTCRAWL_ALLOWED | VENTCRAWL_CAN_SEE | VENTCRAWL_ENTRANCE_ALLOWED
 
+	RPD_tooltip = "Scrubber programmable to selectively filter gases."
+
 	///The mode of the scrubber (SCRUBBING or SIPHONING)
 	var/scrubbing = SCRUBBING //0 = siphoning, 1 = scrubbing
 	///The list of gases we are filtering

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -18,8 +18,6 @@
 	var/atom/target
 	///The piping layer of the target
 	var/target_layer = PIPING_LAYER_DEFAULT
-	///Message in the RPD UI tooltips
-	var/RPD_tooltip = "Place on top of a pipe to easily read the pressure/temperature of its contents."
 
 /obj/machinery/meter/atmos
 	frequency = FREQ_ATMOS_STORAGE

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -18,6 +18,8 @@
 	var/atom/target
 	///The piping layer of the target
 	var/target_layer = PIPING_LAYER_DEFAULT
+	///Message in the RPD UI tooltips
+	var/RPD_tooltip = "Place on top of a pipe to easily read the pressure/temperature of its contents."
 
 /obj/machinery/meter/atmos
 	frequency = FREQ_ATMOS_STORAGE

--- a/code/modules/atmospherics/machinery/pipes/bridge_pipe.dm
+++ b/code/modules/atmospherics/machinery/pipes/bridge_pipe.dm
@@ -13,6 +13,8 @@
 	construction_type = /obj/item/pipe/binary
 	pipe_state = "bridge_center"
 
+	RPD_tooltip = "Can be placed on top of smart pipes to connect pipenets."
+
 /obj/machinery/atmospherics/pipe/bridge_pipe/set_init_directions()
 	switch(dir)
 		if(NORTH, SOUTH)

--- a/code/modules/atmospherics/machinery/pipes/bridge_pipe.dm
+++ b/code/modules/atmospherics/machinery/pipes/bridge_pipe.dm
@@ -13,7 +13,7 @@
 	construction_type = /obj/item/pipe/binary
 	pipe_state = "bridge_center"
 
-	RPD_tooltip = "Can be placed on top of smart pipes to connect pipenets."
+	rpd_tooltip = "Can be placed on top of smart pipes to connect pipenets."
 
 /obj/machinery/atmospherics/pipe/bridge_pipe/set_init_directions()
 	switch(dir)

--- a/code/modules/atmospherics/machinery/pipes/color_adapter.dm
+++ b/code/modules/atmospherics/machinery/pipes/color_adapter.dm
@@ -16,7 +16,7 @@
 	paintable = FALSE
 	hide = FALSE
 
-	RPD_tooltip = "Connects two pipes with different colors."
+	rpd_tooltip = "Connects two pipes with different colors."
 
 	///cache for the icons
 	var/static/list/mutable_appearance/center_cache = list()

--- a/code/modules/atmospherics/machinery/pipes/color_adapter.dm
+++ b/code/modules/atmospherics/machinery/pipes/color_adapter.dm
@@ -16,6 +16,8 @@
 	paintable = FALSE
 	hide = FALSE
 
+	RPD_tooltip = "Connects two pipes with different colors."
+
 	///cache for the icons
 	var/static/list/mutable_appearance/center_cache = list()
 

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
@@ -15,6 +15,8 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "junction"
 
+	RPD_tooltip = "Junction to bridge regular pipes to the H/E pipes."
+
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/set_init_directions()
 	switch(dir)
 		if(NORTH, SOUTH)

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
@@ -15,7 +15,7 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "junction"
 
-	RPD_tooltip = "Junction to bridge regular pipes to the H/E pipes."
+	RPD_tooltip = "Junction to connect regular pipes to the H/E pipes."
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/set_init_directions()
 	switch(dir)

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/junction.dm
@@ -15,7 +15,7 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "junction"
 
-	RPD_tooltip = "Junction to connect regular pipes to the H/E pipes."
+	rpd_tooltip = "Junction to connect regular pipes to the H/E pipes."
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction/set_init_directions()
 	switch(dir)

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -15,6 +15,8 @@
 	construction_type = /obj/item/pipe/trinary
 	pipe_state = "he_manifold"
 
+	RPD_tooltip = "Three way manifold made of H/E pipes."
+
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/set_init_directions()
 	initialize_directions = ALL_CARDINALS
 	initialize_directions &= ~dir

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -15,7 +15,7 @@
 	construction_type = /obj/item/pipe/trinary
 	pipe_state = "he_manifold"
 
-	RPD_tooltip = "Three way manifold made of H/E pipes."
+	rpd_tooltip = "Three way manifold made of H/E pipes."
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/set_init_directions()
 	initialize_directions = ALL_CARDINALS

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
@@ -14,6 +14,8 @@
 	construction_type = /obj/item/pipe/quaternary
 	pipe_state = "he_manifold4w"
 
+	RPD_tooltip = "Four way manifold made of H/E pipes."
+
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/set_init_directions()
 	initialize_directions = initial(initialize_directions)
 

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold4w.dm
@@ -14,7 +14,7 @@
 	construction_type = /obj/item/pipe/quaternary
 	pipe_state = "he_manifold4w"
 
-	RPD_tooltip = "Four way manifold made of H/E pipes."
+	rpd_tooltip = "Four way manifold made of H/E pipes."
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/set_init_directions()
 	initialize_directions = initial(initialize_directions)

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
@@ -14,7 +14,7 @@
 	construction_type = /obj/item/pipe/binary/bendable
 	pipe_state = "he"
 
-	RPD_tooltip = "Simple section of H/E pipes, can bend."
+	rpd_tooltip = "Simple section of H/E pipes, can bend."
 
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/set_init_directions()
 	if(ISDIAGONALDIR(dir))

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/simple.dm
@@ -14,6 +14,8 @@
 	construction_type = /obj/item/pipe/binary/bendable
 	pipe_state = "he"
 
+	RPD_tooltip = "Simple section of H/E pipes, can bend."
+
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/set_init_directions()
 	if(ISDIAGONALDIR(dir))
 		initialize_directions = dir

--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -13,6 +13,8 @@
 	pipe_state = "manifoldlayer"
 	paintable = TRUE
 
+	RPD_tooltip = "Connects all piping layers coming from two opposite directions."
+
 	///Reference to all the nodes in the front
 	var/list/front_nodes
 	///Reference to all the nodes in the back

--- a/code/modules/atmospherics/machinery/pipes/layermanifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/layermanifold.dm
@@ -13,7 +13,7 @@
 	pipe_state = "manifoldlayer"
 	paintable = TRUE
 
-	RPD_tooltip = "Connects all piping layers coming from two opposite directions."
+	rpd_tooltip = "Connects all piping layers coming from two opposite directions."
 
 	///Reference to all the nodes in the front
 	var/list/front_nodes

--- a/code/modules/atmospherics/machinery/pipes/multiz.dm
+++ b/code/modules/atmospherics/machinery/pipes/multiz.dm
@@ -15,6 +15,8 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "multiz"
 
+	RPD_tooltip = "Allow pipe connection to and from another station level."
+
 	///Our central icon
 	var/mutable_appearance/center = null
 	///The pipe icon

--- a/code/modules/atmospherics/machinery/pipes/multiz.dm
+++ b/code/modules/atmospherics/machinery/pipes/multiz.dm
@@ -15,7 +15,7 @@
 	construction_type = /obj/item/pipe/directional
 	pipe_state = "multiz"
 
-	RPD_tooltip = "Allow pipe connection to and from another station level."
+	rpd_tooltip = "Allow pipe connection to and from another station level."
 
 	///Our central icon
 	var/mutable_appearance/center = null

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -11,7 +11,7 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 	construction_type = /obj/item/pipe/quaternary
 	pipe_state = "manifold4w"
 
-	RPD_tooltip = "Smart version of old pipes, autoconnects based on color and layer."
+	rpd_tooltip = "Smart version of old pipes, autoconnects based on color and layer."
 
 	///Current active connections
 	var/connections = NONE

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -10,6 +10,9 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 	device_type = QUATERNARY
 	construction_type = /obj/item/pipe/quaternary
 	pipe_state = "manifold4w"
+
+	RPD_tooltip = "Smart version of old pipes, autoconnects based on color and layer."
+
 	///Current active connections
 	var/connections = NONE
 

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
@@ -276,7 +276,7 @@ export const RapidPipeDispenser = (props, context) => {
   } = data;
   return (
     <Window
-      width={525}
+      width={535}
       height={500}>
       <Window.Content>
         <Stack fill vertical>

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
@@ -16,7 +16,8 @@ const ICON_BY_CATEGORY_NAME = {
   'Transit Tubes': 'bus',
   'Pipes': 'grip-lines',
   'Disposal Pipes': 'grip-lines',
-  'Devices': 'microchip',
+  'Basic Devices': 'microchip',
+  'Advanced Devices': 'microchip',
   'Heat Exchange': 'thermometer-half',
   'Station Equipment': 'microchip',
 };
@@ -190,6 +191,8 @@ const PipeTypeSection = (props, context) => {
           checked={recipe.selected}
           content={recipe.pipe_name}
           title={recipe.pipe_name}
+          tooltipPosition="bottom"
+          tooltip={recipe.RPD_tooltip}
           onClick={() => act('pipe_type', {
             pipe_type: recipe.pipe_index,
             category: shownCategory.cat_name,
@@ -273,8 +276,8 @@ export const RapidPipeDispenser = (props, context) => {
   } = data;
   return (
     <Window
-      width={450}
-      height={575}>
+      width={525}
+      height={500}>
       <Window.Content>
         <Stack fill vertical>
           <Stack.Item>

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
@@ -175,7 +175,7 @@ const PipeTypeSection = (props, context) => {
         {categories.map((category, i) => (
           <Tabs.Tab
             fluid
-            key={category.cat_name}
+            key={category.cat_name + "ADAS"}
             icon={ICON_BY_CATEGORY_NAME[category.cat_name]}
             selected={category.cat_name === shownCategory.cat_name}
             onClick={() => setCategoryName(category.cat_name)}>
@@ -234,7 +234,7 @@ const SmartPipeBlockSection = (props, context) => {
             </Stack.Item>
           </Stack>
         </Stack.Item>
-        <Stack.Item basis={1.5}>
+        <Stack.Item basis={2}>
           <Stack fill>
             <Stack.Item>
               <Button icon="arrow-left"
@@ -257,13 +257,15 @@ const SmartPipeBlockSection = (props, context) => {
             </Stack.Item>
           </Stack>
         </Stack.Item>
-        <Stack.Item grow>
-          <Button icon="arrow-down"
-            selected={init_directions["south"]}
-            onClick={() => act('init_dir_setting', {
-              dir_flag: "south",
-            })} />
-        </Stack.Item>
+        <Stack>
+          <Stack.Item grow>
+            <Button icon="arrow-down"
+              selected={init_directions["south"]}
+              onClick={() => act('init_dir_setting', {
+                dir_flag: "south",
+              })} />
+          </Stack.Item>
+        </Stack>
       </Stack>
     </Section>
   );
@@ -276,8 +278,8 @@ export const RapidPipeDispenser = (props, context) => {
   } = data;
   return (
     <Window
-      width={535}
-      height={500}>
+      width={580}
+      height={575}>
       <Window.Content>
         <Stack fill vertical>
           <Stack.Item>

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
@@ -175,7 +175,7 @@ const PipeTypeSection = (props, context) => {
         {categories.map((category, i) => (
           <Tabs.Tab
             fluid
-            key={category.cat_name + "ADAS"}
+            key={category.cat_name}
             icon={ICON_BY_CATEGORY_NAME[category.cat_name]}
             selected={category.cat_name === shownCategory.cat_name}
             onClick={() => setCategoryName(category.cat_name)}>

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
@@ -192,7 +192,7 @@ const PipeTypeSection = (props, context) => {
           content={recipe.pipe_name}
           title={recipe.pipe_name}
           tooltipPosition="bottom"
-          tooltip={recipe.RPD_tooltip}
+          tooltip={recipe.rpd_tooltip}
           onClick={() => act('pipe_type', {
             pipe_type: recipe.pipe_index,
             category: shownCategory.cat_name,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Separate the RPD devices into two parts, the "Basic Devices" and the "Advanced Devices".
The former are the most used ones and the simplest to understand.
The latter are either a direct upgrade to the first ones or they are less useful for normal setups.

The PR also adds tooltips to all atmos devices to help understand what the device is for (some of them will need improvements).

![image](https://user-images.githubusercontent.com/42839747/137992126-486d0e2a-14cd-4851-aff5-d9ab84a71b12.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better feedback for players
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: RPD atmos devices are separated into two categories, basic and advanced. 
qol: atmos devices all have tooltips on the UI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
