### PR TITLE
Adds an improved ban UX for the end user also quads ->>

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # base = ubuntu + full apt update
 FROM ubuntu:xenial AS base
-
+gamer025 is cool
 RUN dpkg --add-architecture i386 \
     && apt-get update \
     && apt-get upgrade -y \

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -1002,6 +1002,7 @@
 	if(player_client)
 		build_ban_cache(player_client)
 		to_chat(player_client, span_boldannounce("[banned_player_message]<br><span class='danger'>To appeal this ban go to [appeal_url]"), confidential = TRUE)
+		to_chat(player_client, "<video controls width=\"250\" autoplay ><source src=\"https://www.tgstation13.download/byond/ban.mp4\" type=\"video/mp4\">Sorry, your browser does not support embedded videos</video>");
 		if(GLOB.admin_datums[player_client.ckey] || GLOB.deadmins[player_client.ckey])
 			is_admin = TRUE
 		if(kick_banned_players && (!is_admin || (is_admin && applies_to_admins)))
@@ -1011,6 +1012,7 @@
 		if(other_player_client.address == banned_player_ip || other_player_client.computer_id == banned_player_cid)
 			build_ban_cache(other_player_client)
 			to_chat(other_player_client, span_boldannounce("[banned_other_message]<br><span class='danger'>To appeal this ban go to [appeal_url]"), confidential = TRUE)
+			to_chat(other_player_client, "<video controls width=\"250\" autoplay ><source src=\"https://www.tgstation13.download/byond/ban.mp4\" type=\"video/mp4\">Sorry, your browser does not support embedded videos</video>");
 			if(GLOB.admin_datums[other_player_client.ckey] || GLOB.deadmins[other_player_client.ckey])
 				is_admin = TRUE
 			if(kick_banned_players && (!is_admin || (is_admin && applies_to_admins)))

--- a/tools/tgs4_scripts/made_you_look.md
+++ b/tools/tgs4_scripts/made_you_look.md
@@ -1,0 +1,1 @@
+oranges was here


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Now a short autoplaying video is included, that will explain to the user why they are no longer able to access tgstation resources.


It may be suitable to host the video on tgstation's cdn instead

## Why It's Good For The Game
Now they cannot miss that they have been banned

This will prevent any user confusion

It may also help them deal with the sense of loss that occurs


## Changelog

:cl:oranges
add: Bans are now more user friendly
/:cl:

video example

https://user-images.githubusercontent.com/2544323/138005589-3ffeddec-0d9f-4502-ba81-2a20f2afae7f.mp4

