### PR TITLE
Fixes keeping Pheremone receptors when you don't have it anymore

### DIFF
--- a/code/modules/antagonists/changeling/fallen_changeling.dm
+++ b/code/modules/antagonists/changeling/fallen_changeling.dm
@@ -1,7 +1,7 @@
 ///a changeling that has lost their powers. does nothing, other than signify they suck
 /datum/antagonist/fallen_changeling
 	name = "Fallen Changeling"
-	roundend_category  = "changelings"
+	roundend_category = "changelings"
 	antagpanel_category = "Changeling"
 	job_rank = ROLE_CHANGELING
 	antag_moodlet = /datum/mood_event/fallen_changeling

--- a/code/modules/antagonists/changeling/powers/pheromone_receptors.dm
+++ b/code/modules/antagonists/changeling/powers/pheromone_receptors.dm
@@ -11,6 +11,13 @@
 	dna_cost = 2
 	var/receptors_active = FALSE
 
+/datum/action/changeling/pheromone_receptors/Remove(mob/living/carbon/user)
+	if(receptors_active)
+		var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
+		changeling.chem_recharge_slowdown -= 0.25
+		user.remove_status_effect(/datum/status_effect/agent_pinpointer/changeling)
+	..()
+
 /datum/action/changeling/pheromone_receptors/sting_action(mob/living/carbon/user)
 	..()
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)


### PR DESCRIPTION
## About The Pull Request

If you re-adapt with pheremone receptors, you actually keep it (and its recharge slowdown) forever, which sucks.

## Why It's Good For The Game

Bug fix

## Changelog

:cl:
fix: Changelings that re-adapt with pheremone receptors on, will have them forcefully removed.
/:cl: