### PR TITLE
Fixes a runtime when wiping memories

### DIFF
--- a/code/__HELPERS/memory_helpers.dm
+++ b/code/__HELPERS/memory_helpers.dm
@@ -103,4 +103,4 @@
 
 ///small helper to clean out memories
 /datum/mind/proc/wipe_memory()
-	QDEL_LIST(memories)
+	QDEL_LIST_ASSOC_VAL(memories)


### PR DESCRIPTION
## About The Pull Request

Small one line fix to stop runtiming whenever wipe_memory is called (like when changelings absorb someone).

I made this because I failed the objective to absorb a changeling when I absorbed one, and for some reason I havent failed it with these changes, so this might possibly be the fix?

## Why It's Good For The Game

Small runtime fix

## Changelog

I'm not sure if this is the direct fix to the 'absorb a changeling' objective, so I won't put a changelog in case it isn't.