### PR TITLE
Adds 2 new signals, adds pre/postattack_secondary signals to circuit signal handler presets (+a proccall component fix)

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -1331,8 +1331,10 @@
 	#define COMPONENT_SECONDARY_CALL_NORMAL_ATTACK_CHAIN (1<<2)
 /// From base of [/obj/item/proc/attack_secondary()]: (atom/target, mob/user, params)
 #define COMSIG_ITEM_ATTACK_SECONDARY "item_pre_attack_secondary"
-///from base of obj/item/afterattack(): (atom/target, mob/user, params)
+///from base of obj/item/afterattack(): (atom/target, mob/user, proximity_flag, click_parameters)
 #define COMSIG_ITEM_AFTERATTACK "item_afterattack"
+///from base of obj/item/afterattack_secondary(): (atom/target, mob/user, proximity_flag, click_parameters)
+#define COMSIG_ITEM_AFTERATTACK_SECONDARY "item_afterattack_secondary"
 ///from base of obj/item/attack_qdeleted(): (atom/target, mob/user, params)
 #define COMSIG_ITEM_ATTACK_QDELETED "item_attack_qdeleted"
 ///from base of atom/attack_hand(): (mob/user, modifiers)
@@ -1341,7 +1343,9 @@
 #define COMSIG_MOB_ITEM_ATTACK "mob_item_attack"
 ///from base of obj/item/afterattack(): (atom/target, mob/user, proximity_flag, click_parameters)
 #define COMSIG_MOB_ITEM_AFTERATTACK "mob_item_afterattack"
-///from base of obj/item/attack_qdeleted(): (atom/target, mob/user, proxiumity_flag, click_parameters)
+///from base of obj/item/afterattack_secondary(): (atom/target, mob/user, proximity_flag, click_parameters)
+#define COMSIG_MOB_ITEM_AFTERATTACK_SECONDARY "mob_item_afterattack_secondary"
+///from base of obj/item/attack_qdeleted(): (atom/target, mob/user, proximity_flag, click_parameters)
 #define COMSIG_MOB_ITEM_ATTACK_QDELETED "mob_item_attack_qdeleted"
 ///from base of mob/RangedAttack(): (atom/A, modifiers)
 #define COMSIG_MOB_ATTACK_RANGED "mob_attack_ranged"

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -657,3 +657,25 @@
 		if(condition.Invoke(i))
 			. |= i
 
+///Returns a list with all weakrefs resolved
+/proc/recursive_list_resolve(list/list_to_resolve)
+	. = list()
+	for(var/element in list_to_resolve)
+		if(istext(element))
+			. += element
+			var/possible_assoc_value = list_to_resolve[element]
+			if(possible_assoc_value)
+				.[element] = recursive_list_resolve_element(possible_assoc_value)
+		else
+			. += list(recursive_list_resolve_element(element))
+
+///Helper for /proc/recursive_list_resolve
+/proc/recursive_list_resolve_element(element)
+	if(islist(element))
+		var/list/inner_list = element
+		return recursive_list_resolve(inner_list)
+	else if(isweakref(element))
+		var/datum/weakref/ref = element
+		return ref.resolve()
+	else
+		return element

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -292,6 +292,15 @@
  * * click_parameters - is the params string from byond [/atom/proc/Click] code, see that documentation.
  */
 /obj/item/proc/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
+	var/signal_result = SEND_SIGNAL(src, COMSIG_ITEM_AFTERATTACK_SECONDARY, target, user, proximity_flag, click_parameters)
+	SEND_SIGNAL(user, COMSIG_MOB_ITEM_AFTERATTACK, target, user, proximity_flag, click_parameters)
+
+	if(signal_result & COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	if(signal_result & COMPONENT_SECONDARY_CONTINUE_ATTACK_CHAIN)
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
+
 	return SECONDARY_ATTACK_CALL_NORMAL
 
 /// Called if the target gets deleted by our attack

--- a/code/modules/wiremod/components/admin/proccall.dm
+++ b/code/modules/wiremod/components/admin/proccall.dm
@@ -63,7 +63,6 @@
 
 	var/to_invoke = proc_name.value
 	var/list/params = arguments.value || list()
-	var/list/resolved_params = list()
 
 	if(!to_invoke)
 		return
@@ -71,14 +70,7 @@
 	if(called_on != GLOBAL_PROC && !hascall(called_on, to_invoke))
 		return
 
-	for(var/param in params)
-		if(isweakref(param))
-			var/datum/weakref/ref = param
-			resolved_params += list(ref.resolve())
-		else
-			resolved_params += list(param)
-
-	INVOKE_ASYNC(src, .proc/do_proccall, called_on, to_invoke, resolved_params)
+	INVOKE_ASYNC(src, .proc/do_proccall, called_on, to_invoke, recursive_list_resolve(params))
 
 /obj/item/circuit_component/proccall/proc/do_proccall(called_on, to_invoke, params)
 	var/result = HandleUserlessProcCall(parent.get_creator(), called_on, to_invoke, params)

--- a/code/modules/wiremod/components/admin/proccall.dm
+++ b/code/modules/wiremod/components/admin/proccall.dm
@@ -62,7 +62,8 @@
 		return
 
 	var/to_invoke = proc_name.value
-	var/params = arguments.value || list()
+	var/list/params = arguments.value || list()
+	var/list/resolved_params = list()
 
 	if(!to_invoke)
 		return
@@ -70,7 +71,14 @@
 	if(called_on != GLOBAL_PROC && !hascall(called_on, to_invoke))
 		return
 
-	INVOKE_ASYNC(src, .proc/do_proccall, called_on, to_invoke, params)
+	for(var/param in params)
+		if(isweakref(param))
+			var/datum/weakref/ref = param
+			resolved_params += list(ref.resolve())
+		else
+			resolved_params += list(param)
+
+	INVOKE_ASYNC(src, .proc/do_proccall, called_on, to_invoke, resolved_params)
 
 /obj/item/circuit_component/proccall/proc/do_proccall(called_on, to_invoke, params)
 	var/result = HandleUserlessProcCall(parent.get_creator(), called_on, to_invoke, params)

--- a/code/modules/wiremod/components/admin/setvar.dm
+++ b/code/modules/wiremod/components/admin/setvar.dm
@@ -29,4 +29,9 @@
 	if(!var_name || !object)
 		return
 
-	object.vv_edit_var(var_name, new_value.value)
+	var/resolved_new_value = new_value.value
+	if(islist(resolved_new_value))
+		var/list/to_resolve = resolved_new_value
+		resolved_new_value = recursive_list_resolve(to_resolve)
+
+	object.vv_edit_var(var_name, resolved_new_value)

--- a/code/modules/wiremod/components/admin/signal_handler/signal_list.dm
+++ b/code/modules/wiremod/components/admin/signal_handler/signal_list.dm
@@ -18,6 +18,8 @@ GLOBAL_LIST_INIT(integrated_circuit_signal_ids, generate_circuit_signal_list())
 
 /proc/generate_circuit_signal_list()
 	var/cancel_attack = circuit_signal_response("Cancel Attack", COMPONENT_CANCEL_ATTACK_CHAIN)
+	var/secondary_cancel_attack = circuit_signal_response("Cancel Attack", COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN)
+	var/secondary_continue_attack = circuit_signal_response("Continue Attack", COMPONENT_SECONDARY_CONTINUE_ATTACK_CHAIN)
 	var/target = circuit_signal_param("Target", PORT_TYPE_ATOM)
 	var/user = circuit_signal_param("User", PORT_TYPE_ATOM)
 	var/item = circuit_signal_param("Item", PORT_TYPE_ATOM)
@@ -37,7 +39,9 @@ GLOBAL_LIST_INIT(integrated_circuit_signal_ids, generate_circuit_signal_list())
 		COMSIG_ITEM_ATTACK = list(cancel_attack, target, user),
 		COMSIG_ITEM_PRE_ATTACK = list(cancel_attack, target, user),
 		COMSIG_ITEM_AFTERATTACK = list(cancel_attack, target, user),
-		COMSIG_ITEM_ATTACK_SECONDARY = list(circuit_signal_response("Cancel Attack", COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN), target, user),
+		COMSIG_ITEM_ATTACK_SECONDARY = list(secondary_cancel_attack, secondary_continue_attack, target, user),
+		COMSIG_ITEM_PRE_ATTACK_SECONDARY = list(secondary_cancel_attack, secondary_continue_attack, target, user),
+		COMSIG_ITEM_AFTERATTACK_SECONDARY = list(secondary_cancel_attack, secondary_continue_attack, target, user),
 		COMSIG_ITEM_ATTACK_SELF = list(cancel_attack, user),
 		COMSIG_ITEM_ATTACK_SELF_SECONDARY = list(cancel_attack, user),
 	)

--- a/code/modules/wiremod/components/admin/spawn.dm
+++ b/code/modules/wiremod/components/admin/spawn.dm
@@ -38,8 +38,10 @@
 	if(!params)
 		params = list()
 
-	params.Insert(1, spawn_at.value)
+	var/list/resolved_params = recursive_list_resolve(params)
 
-	var/atom/spawned = new typepath(arglist(params))
+	resolved_params.Insert(1, spawn_at.value)
+
+	var/atom/spawned = new typepath(arglist(resolved_params))
 	spawned.datum_flags |= DF_VAR_EDITED
 	spawned_atom.set_output(spawned)


### PR DESCRIPTION
## About The Pull Request
- Adds `COMSIG_ITEM_AFTERATTACK_SECONDARY` and `COMSIG_MOB_ITEM_AFTERATTACK_SECONDARY` signals, which are both called by `item/proc/afterattack_secondary`.
- Adds `COMSIG_ITEM_PRE_ATTACK_SECONDARY` and `COMSIG_ITEM_AFTERATTACK_SECONDARY` to the list of circuit signal handler presets.
- The proc call, set var, and spawn atom components will resolve any weakrefs passed to them in their parameter port, seeing as the list literal component now converts datums into weakrefs.

## Why It's Good For The Game

Adds some more options to admin circuits, while also fixing an issue that popped up.

## Changelog

:cl:
fix: The proc call, set var, and spawn atom circuit components will properly resolve any weakrefs passed to them through their list ports.
admin: The signal handler circuit component has two new presets, item_pre_attack_secondary and item_afterattack_secondary.
/:cl:
