### PR TITLE
You can unpack bibles into new altars of the gods

### DIFF
--- a/code/_globalvars/religion.dm
+++ b/code/_globalvars/religion.dm
@@ -8,6 +8,9 @@ GLOBAL_VAR(bible_name)
 GLOBAL_VAR(bible_icon_state)
 GLOBAL_VAR(bible_inhand_icon_state)
 
+//altar
+GLOBAL_LIST_EMPTY(chaplain_altars)
+
 //gear
 GLOBAL_VAR(holy_weapon_type)
 GLOBAL_VAR(holy_armor_type)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -43,6 +43,14 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	var/deity_name = "Christ"
 	force_string = "holy"
 
+/obj/item/storage/book/bible/examine(mob/user)
+	. = ..()
+	if(user?.mind?.holy_role)
+		if(GLOB.chaplain_altars.len)
+			. += span_notice("[src] has an expansion pack to replace any broken Altar.")
+		else
+			. += span_notice("[src] can be unpacked by hitting the floor of a holy area with it.")
+
 /obj/item/storage/book/bible/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/anti_magic, FALSE, TRUE)
@@ -109,6 +117,16 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 		return FALSE
 	return TRUE
 
+/obj/item/storage/book/bible/proc/make_new_altar(atom/bible_smacked, mob/user)
+	var/new_altar_area = get_turf(bible_smacked)
+
+	to_chat(user, span_warning("You begin unpacking [src]'s Altar expansion pack."))
+	if(!do_after(user, 15 SECONDS, new_altar_area))
+		to_chat(user, span_warning("You quickly put away [src]'s Altar expansion pack."))
+		return
+	new /obj/structure/altar_of_gods(new_altar_area)
+	qdel(src)
+
 /obj/item/storage/book/bible/proc/bless(mob/living/L, mob/living/user)
 	if(GLOB.religious_sect)
 		return GLOB.religious_sect.sect_bless(L,user)
@@ -133,7 +151,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 		to_chat(H, span_boldnotice("May the power of [deity_name] compel you to be healed!"))
 		playsound(src.loc, "punch", 25, TRUE, -1)
 		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
-	return 1
+	return TRUE
 
 /obj/item/storage/book/bible/attack(mob/living/M, mob/living/carbon/human/user, heal_mode = TRUE)
 
@@ -144,45 +162,41 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	if (HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 		to_chat(user, span_danger("[src] slips out of your hand and hits your head."))
 		user.take_bodypart_damage(10)
-		user.Unconscious(400)
+		user.Unconscious(40 SECONDS)
 		return
 
-	var/chaplain = 0
-	if(user.mind && (user.mind.holy_role))
-		chaplain = 1
-
-	if(!chaplain)
+	if (!user.mind && !user.mind.holy_role)
 		to_chat(user, span_danger("The book sizzles in your hands."))
-		user.take_bodypart_damage(0,10)
+		user.take_bodypart_damage(0, 10)
 		return
 
 	if (!heal_mode)
 		return ..()
 
-	var/smack = TRUE
-
-	if (M.stat != DEAD)
-		if(chaplain && user == M)
-			to_chat(user, span_warning("You can't heal yourself!"))
-			return
-
-		if(prob(60) && bless(M, user))
-			smack = FALSE
-		else if(iscarbon(M))
-			var/mob/living/carbon/C = M
-			if(!istype(C.head, /obj/item/clothing/head/helmet))
-				C.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5, 60)
-				to_chat(C, span_danger("You feel dumber."))
-
-		if(smack)
-			M.visible_message(span_danger("[user] beats [M] over the head with [src]!"), \
-					span_userdanger("[user] beats [M] over the head with [src]!"))
-			playsound(src.loc, "punch", 25, TRUE, -1)
-			log_combat(user, M, "attacked", src)
-
-	else
+	if (M.stat == DEAD)
 		M.visible_message(span_danger("[user] smacks [M]'s lifeless corpse with [src]."))
 		playsound(src.loc, "punch", 25, TRUE, -1)
+		return
+
+	if(user == M)
+		to_chat(user, span_warning("You can't heal yourself!"))
+		return
+
+	var/smack = TRUE
+
+	if(prob(60) && bless(M, user))
+		smack = FALSE
+	else if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		if(!istype(C.head, /obj/item/clothing/head/helmet))
+			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5, 60)
+			to_chat(C, span_danger("You feel dumber."))
+
+	if(smack)
+		M.visible_message(span_danger("[user] beats [M] over the head with [src]!"), \
+				span_userdanger("[user] beats [M] over the head with [src]!"))
+		playsound(src.loc, "punch", 25, TRUE, -1)
+		log_combat(user, M, "attacked", src)
 
 /obj/item/storage/book/bible/afterattack(atom/bible_smacked, mob/user, proximity)
 	. = ..()
@@ -191,10 +205,15 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	if(SEND_SIGNAL(bible_smacked, COMSIG_BIBLE_SMACKED, user, proximity) & COMSIG_END_BIBLE_CHAIN)
 		return
 	if(isfloorturf(bible_smacked))
-		to_chat(user, span_notice("You hit the floor with the bible."))
 		if(user.mind && (user.mind.holy_role))
-			for(var/obj/effect/rune/R in orange(2,user))
-				R.invisibility = 0
+			var/area/current_area = get_area(bible_smacked)
+			if(!GLOB.chaplain_altars.len && istype(current_area, /area/service/chapel))
+				make_new_altar(bible_smacked, user)
+				return
+			for(var/obj/effect/rune/nearby_runes in orange(2,user))
+				nearby_runes.invisibility = 0
+		to_chat(user, span_notice("You hit the floor with the bible."))
+
 	if(user?.mind?.holy_role)
 		if(bible_smacked.reagents && bible_smacked.reagents.has_reagent(/datum/reagent/water)) // blesses all the water in the holder
 			to_chat(user, span_notice("You bless [bible_smacked]."))
@@ -212,6 +231,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			B.name = name
 			B.icon_state = icon_state
 			B.inhand_icon_state = inhand_icon_state
+	
 	if(istype(bible_smacked, /obj/item/cult_bastard) && !IS_CULTIST(user))
 		var/obj/item/cult_bastard/sword = bible_smacked
 		to_chat(user, span_notice("You begin to exorcise [sword]."))

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -165,7 +165,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 		user.Unconscious(40 SECONDS)
 		return
 
-	if (!user.mind && !user.mind.holy_role)
+	if (!user.mind || !user.mind.holy_role)
 		to_chat(user, span_danger("The book sizzles in your hands."))
 		user.take_bodypart_damage(0, 10)
 		return
@@ -231,7 +231,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			B.name = name
 			B.icon_state = icon_state
 			B.inhand_icon_state = inhand_icon_state
-	
+
 	if(istype(bible_smacked, /obj/item/cult_bastard) && !IS_CULTIST(user))
 		var/obj/item/cult_bastard/sword = bible_smacked
 		to_chat(user, span_notice("You begin to exorcise [sword]."))

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -120,9 +120,8 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 /obj/item/storage/book/bible/proc/make_new_altar(atom/bible_smacked, mob/user)
 	var/new_altar_area = get_turf(bible_smacked)
 
-	to_chat(user, span_warning("You begin unpacking [src]'s Altar expansion pack."))
+	balloon_alert(user, "unpacking bible...")
 	if(!do_after(user, 15 SECONDS, new_altar_area))
-		to_chat(user, span_warning("You quickly put away [src]'s Altar expansion pack."))
 		return
 	new /obj/structure/altar_of_gods(new_altar_area)
 	qdel(src)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -120,7 +120,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 /obj/item/storage/book/bible/proc/make_new_altar(atom/bible_smacked, mob/user)
 	var/new_altar_area = get_turf(bible_smacked)
 
-	balloon_alert(user, "unpacking [src]...")
+	balloon_alert(user, "unpacking bible...")
 	if(!do_after(user, 15 SECONDS, new_altar_area))
 		return
 	new /obj/structure/altar_of_gods(new_altar_area)

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -120,7 +120,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 /obj/item/storage/book/bible/proc/make_new_altar(atom/bible_smacked, mob/user)
 	var/new_altar_area = get_turf(bible_smacked)
 
-	balloon_alert(user, "unpacking bible...")
+	balloon_alert(user, "unpacking [src]...")
 	if(!do_after(user, 15 SECONDS, new_altar_area))
 		return
 	new /obj/structure/altar_of_gods(new_altar_area)

--- a/code/modules/religion/religion_structures.dm
+++ b/code/modules/religion/religion_structures.dm
@@ -15,11 +15,16 @@
 /obj/structure/altar_of_gods/Initialize(mapload)
 	. = ..()
 	reflect_sect_in_icons()
+	GLOB.chaplain_altars += src
 	AddElement(/datum/element/climbable)
 
 /obj/structure/altar_of_gods/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/religious_tool, ALL, FALSE, CALLBACK(src, .proc/reflect_sect_in_icons))
+
+/obj/structure/altar_of_gods/Destroy()
+	GLOB.chaplain_altars -= src
+	return ..()
 
 /obj/structure/altar_of_gods/update_overlays()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

There's a problem of people breaking altar of the gods, just to fuck over the Chaplain's entire round.
I was thinking of making this by using a bible on the table instead, but that just feels weird since you would expect it to just place it on the table instead of make a new altar.

If you have any questions on how this is possible, [refer to this video](https://www.youtube.com/watch?v=AivZSC9J3Rs)

(Other code changes are because I tried to make it easier to read so I can go through it better)

## Why It's Good For The Game

Chaplains can replace their altar of the gods so it being destroyed won't mean their round is ruined.

## Changelog

:cl:
qol: Chaplains can now replace their Altar of the Gods by hitting the Chapel floor with a Bible.
/:cl: