### PR TITLE
Fixes being able to shock people with wielded mjollnir as a pacifist.

### DIFF
--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -141,6 +141,8 @@
 
 /obj/item/mjollnir/attack(mob/living/M, mob/user)
 	..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		return
 	if(wielded)
 		shock(M)
 


### PR DESCRIPTION
## About The Pull Request

Fixes pacifists wielding mjollnir being able to shock people by adding a check in mjollnir's attack. Fixes #62232 .

## Why It's Good For The Game

Fixes pacifists wielding mjollnir being able to shock people. 

## Changelog
:cl:
fix: Fixes pacifists wielding mjollnir being able to shock people. 
/:cl:


