### PR TITLE
Places regular/advanced mops in the same category on the lathes.

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -17,7 +17,7 @@
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 1000)
 	build_path = /obj/item/mop
-	category = list("initial","Tools","Tool Designs")
+	category = list("initial", "Equipment", "Tools", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
 /datum/design/broom

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -345,7 +345,7 @@
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 2500, /datum/material/glass = 200)
 	build_path = /obj/item/mop/advanced
-	category = list("Equipment")
+	category = list("Equipment", "Tools", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
 /datum/design/normtrash


### PR DESCRIPTION

## About The Pull Request

This places mops and advanced mops in both the equipment and tools categories when searched and used within the autolathe and protolathe. In truth, it's unclear if it should be equipment over being a tool, and there's no cost in placing it under both, so I have placed both designs in either category. 

## Why It's Good For The Game

Fixes #62210. Makes finding either design easier in the long run within fabrication UI.

## Changelog

:cl:
fix: Regular/Advanced mops are now in the same categories of the auto/protolathe.
/:cl:
