### PR TITLE
Restaurant for Icebox and Delta

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3835,20 +3835,8 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "azD" = (
-/obj/structure/chair/stool/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/grass,
 /area/service/bar/atrium)
 "azH" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -7550,18 +7538,10 @@
 /turf/open/space,
 /area/space/nearstation)
 "bkO" = (
-/obj/structure/chair/stool/directional/west,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/sofa/left{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "bla" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9364,18 +9344,9 @@
 /area/maintenance/port/aft)
 "bBg" = (
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/red,
 /area/service/bar/atrium)
 "bBi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9538,18 +9509,7 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "bDy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "bDN" = (
 /obj/structure/closet/crate/freezer/blood,
@@ -10228,6 +10188,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"bIx" = (
+/obj/effect/turf_decal/siding/brown,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/service/bar/atrium)
 "bIC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -15309,20 +15276,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "chH" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/siding/brown{
 	dir = 8
 	},
-/obj/item/clothing/mask/cigarette/pipe,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/brown/corner,
+/turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "chK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16364,18 +16325,13 @@
 	dir = 4;
 	name = "service camera"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/siding/brown{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
+/turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "coe" = (
 /turf/closed/wall,
@@ -22280,6 +22236,13 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/port)
+"dbX" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/bar/atrium)
 "dcb" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
@@ -36647,20 +36610,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "faY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/door/window{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "fbe" = (
 /obj/effect/turf_decal/tile/green{
@@ -37286,11 +37239,8 @@
 "fjP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchencounter";
-	name = "Kitchen Counter Shutters"
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "fjU" = (
@@ -37554,19 +37504,13 @@
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
 "fpi" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/siding/brown{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "fpn" = (
 /obj/structure/table/wood,
@@ -37699,19 +37643,12 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "fqN" = (
-/obj/structure/chair/stool/directional/east,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "fqO" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -38624,29 +38561,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/service/janitor)
-"fGm" = (
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -8
-	},
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/item/clothing/head/fedora,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/bar/atrium)
 "fGt" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -39942,21 +39856,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"gbz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/iron,
-/area/service/bar/atrium)
 "gbB" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -40215,6 +40114,21 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"ghQ" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/candle/infinite{
+	layer = 4;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	layer = 5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/bar/atrium)
 "ghU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -40727,20 +40641,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"gpk" = (
-/obj/structure/chair/stool/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/service/bar/atrium)
 "gpr" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -42076,18 +41976,15 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "gJj" = (
-/obj/structure/chair/stool/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/siding/brown{
+	pixel_y = -5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck{
+	pixel_x = -1;
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/carpet/red,
 /area/service/bar/atrium)
 "gJq" = (
 /obj/machinery/light/small/directional/south,
@@ -42685,6 +42582,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/solars/starboard/aft)
+"gTE" = (
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/brown/corner,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/parquet,
+/area/service/bar/atrium)
 "gTH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -47159,19 +47067,19 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "idl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/chair/stool/bar/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/royalblack,
+/area/service/bar/atrium)
+"idq" = (
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "idv" = (
 /obj/structure/urinal/directional/north,
@@ -47600,18 +47508,8 @@
 /turf/open/floor/iron,
 /area/maintenance/port)
 "ije" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/chair/stool/directional/east,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/grass,
 /area/service/bar/atrium)
 "ijt" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -50489,20 +50387,8 @@
 /turf/open/floor/iron/grimy,
 /area/service/lawoffice)
 "jfD" = (
-/obj/structure/table/wood,
-/obj/item/food/cheesiehonkers,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/chair/sofa/left,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "jfV" = (
 /obj/structure/cable,
@@ -51383,6 +51269,7 @@
 	pixel_y = 3
 	},
 /obj/item/lighter,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "jvh" = (
@@ -52108,6 +51995,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
+"jFW" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/bar/atrium)
 "jGf" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap,
@@ -52668,18 +52565,9 @@
 /turf/open/floor/iron,
 /area/service/lawoffice)
 "jOV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/red,
 /area/service/bar/atrium)
 "jOW" = (
 /obj/structure/sign/warning/nosmoking,
@@ -53033,24 +52921,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"jTr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchencounter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/service/kitchen)
 "jTx" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera{
@@ -54504,6 +54374,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"koU" = (
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
+/area/service/bar/atrium)
 "kpk" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop,
@@ -54862,20 +54739,9 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "ktL" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/orangejuice,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/chair/sofa,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "ktT" = (
 /obj/machinery/requests_console/directional/west{
@@ -55738,19 +55604,8 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "kGJ" = (
-/obj/structure/chair/stool/directional/west,
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/structure/hedge,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "kGM" = (
 /obj/machinery/computer/upload/ai{
@@ -56166,21 +56021,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/research)
-"kOD" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/service/bar/atrium)
 "kOP" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/delivery,
@@ -56314,22 +56154,15 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "kQE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "kQF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -57925,21 +57758,15 @@
 /turf/closed/wall,
 /area/engineering/supermatter/room)
 "lmM" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 7
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -7
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "lmX" = (
 /obj/structure/cable,
@@ -58200,20 +58027,16 @@
 /area/commons/fitness/recreation)
 "lqZ" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/siding/brown,
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/structure/window{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/firealarm/directional/east,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "lra" = (
 /obj/effect/decal/cleanable/dirt,
@@ -59281,21 +59104,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"lHa" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/soda_cans/cola,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/service/bar/atrium)
 "lHe" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/tile/neutral{
@@ -62545,6 +62353,15 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"mDm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/brown,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/parquet,
+/area/service/bar/atrium)
 "mDs" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -62841,6 +62658,14 @@
 "mIc" = (
 /turf/open/space/basic,
 /area/space/nearstation)
+"mIi" = (
+/obj/effect/turf_decal/siding/brown,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/parquet,
+/area/service/bar/atrium)
 "mIq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/janitor,
@@ -64149,17 +63974,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"nbw" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchencounter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/structure/displaycase/forsale/kitchen,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/service/kitchen)
 "nbH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -65455,19 +65269,16 @@
 /area/service/library)
 "nqP" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/airalarm/directional/east,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "nqQ" = (
 /obj/effect/turf_decal/tile/red,
@@ -66720,19 +66531,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "nLa" = (
-/obj/structure/table/wood,
-/obj/item/paicard,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/sofa/right{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "nLn" = (
 /obj/effect/turf_decal/delivery,
@@ -68203,17 +68005,8 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
 "ofO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "ogh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -68904,18 +68697,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "opE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/flora/junglebush,
+/turf/open/floor/grass,
 /area/service/bar/atrium)
 "opF" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -72205,19 +71988,15 @@
 /area/hallway/primary/central/aft)
 "pqt" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/siding/brown/corner,
+/obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/siding/white/corner{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "pqH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -73529,6 +73308,11 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"pNf" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/turf/open/floor/carpet/royalblack,
+/area/service/bar/atrium)
 "pNm" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -73922,6 +73706,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"pRo" = (
+/obj/effect/turf_decal/siding/brown{
+	pixel_y = -5
+	},
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/service/bar/atrium)
 "pRv" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
@@ -76692,19 +76485,11 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "qFk" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/coffee,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/sofa{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "qFn" = (
 /obj/structure/cable,
@@ -77764,19 +77549,13 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "qUo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/siding/brown{
+	pixel_y = -5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/red,
 /area/service/bar/atrium)
 "qUy" = (
 /obj/effect/turf_decal/tile/brown,
@@ -78591,19 +78370,8 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/command/nuke_storage)
 "rgO" = (
-/obj/structure/chair/stool/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/chair/sofa/right,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "rgQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -78891,22 +78659,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"rmi" = (
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/service/bar/atrium)
 "rmm" = (
 /obj/structure/table_frame/wood,
 /obj/item/crowbar/red,
@@ -79710,6 +79462,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"rBQ" = (
+/obj/effect/turf_decal/siding/brown,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/service/bar/atrium)
 "rBV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/toilet{
@@ -79895,6 +79655,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"rEh" = (
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/parquet,
+/area/service/bar/atrium)
 "rEu" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -80898,6 +80668,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/break_room)
+"rTG" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/parquet,
+/area/service/bar/atrium)
 "rTO" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -81755,18 +81534,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "shu" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "shw" = (
 /obj/structure/cable,
@@ -82630,19 +82401,9 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "stu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/red,
 /area/service/bar/atrium)
 "stP" = (
 /obj/machinery/door/firedoor,
@@ -84242,18 +84003,11 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "sRg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/siding/brown{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "sRM" = (
 /obj/machinery/camera{
@@ -84774,18 +84528,10 @@
 	},
 /area/commons/dorms)
 "taj" = (
-/obj/structure/chair/stool/bar/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
 "tak" = (
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -85809,6 +85555,14 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
+"tsE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/service/bar/atrium)
 "tsI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -85937,21 +85691,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
-"tuq" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/bar/atrium)
 "tuR" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
@@ -86345,19 +86084,11 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "tBr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/brown{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "tBs" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -87131,30 +86862,9 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "tLs" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/royalblack,
 /area/service/bar/atrium)
-"tLx" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchencounter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/service/kitchen)
 "tLy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -89471,6 +89181,12 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
+"uuH" = (
+/obj/structure/table/rolling{
+	name = "a la carte"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/bar/atrium)
 "uuS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -90157,22 +89873,6 @@
 "uEO" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/ce)
-"uEX" = (
-/obj/structure/table/wood,
-/obj/item/food/chips,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/bar/atrium)
 "uFk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -92115,6 +91815,16 @@
 	heat_capacity = 1e+006
 	},
 /area/commons/dorms)
+"viM" = (
+/obj/effect/turf_decal/siding/brown,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/service/bar/atrium)
 "vje" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -92461,6 +92171,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/gravity_generator)
+"voS" = (
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/brown/corner,
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/service/bar/atrium)
 "voU" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
@@ -95637,22 +95357,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/cargo/warehouse)
-"wmQ" = (
-/obj/structure/table/wood,
-/obj/item/storage/dice,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/service/bar/atrium)
 "wnk" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/turf_decal/tile/neutral{
@@ -98897,19 +98601,13 @@
 /turf/open/space,
 /area/engineering/atmos)
 "xiX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/item/radio/intercom/directional/east,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "xiY" = (
 /obj/item/kirbyplants/random,
@@ -99414,19 +99112,14 @@
 /turf/open/floor/iron/grimy,
 /area/service/library/abandoned)
 "xrc" = (
-/obj/structure/chair/stool/bar/directional/north,
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/siding/brown{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "xrd" = (
 /obj/effect/spawner/random/vending/colavend,
@@ -102178,21 +101871,6 @@
 "yhJ" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"yhN" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/service/bar)
 "yhU" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder{
@@ -139100,13 +138778,13 @@ tIm
 guN
 stu
 pqt
-ofO
-ofO
-ofO
-ofO
-ofO
-bDy
-ofO
+idq
+idq
+idq
+rEh
+idq
+idq
+idq
 cnV
 sRg
 qhd
@@ -139356,17 +139034,17 @@ kbd
 hXi
 jvd
 jOV
-ofO
+mIi
 qUo
+kGJ
 rgO
-rgO
-bDy
+dbX
 bkO
 kGJ
-ofO
+taj
 tLs
 taj
-jTr
+kEi
 uIn
 reI
 gXp
@@ -139613,17 +139291,17 @@ mre
 vsR
 wEH
 jOV
-bDy
+bIx
 gJj
-wmQ
+kGJ
 ktL
-ofO
+jFW
 qFk
-uEX
-gpk
+kGJ
+ghQ
 ofO
-taj
-nbw
+ghQ
+gRl
 reI
 tyZ
 fGQ
@@ -139869,18 +139547,18 @@ kUs
 pOo
 mvD
 bSd
-gbz
-ofO
-gJj
-fGm
+jOV
+bIx
+pRo
+kGJ
 jfD
-ofO
+dbX
 nLa
-kOD
-gpk
+kGJ
+idl
 bDy
 idl
-fjP
+kEi
 gXp
 hKw
 oJz
@@ -140125,17 +139803,17 @@ alf
 ude
 mre
 unM
-yhN
+wEH
 jOV
-ofO
-gJj
-lHa
-rmi
-bDy
+gTE
+fpi
+fpi
+fpi
+xrc
 chH
 fpi
-gpk
-ofO
+xrc
+voS
 xrc
 fjP
 reI
@@ -140384,17 +140062,17 @@ niH
 krF
 wEH
 bBg
-ofO
-tuq
+koU
+opE
 ije
 azD
 opE
-fqN
+mDm
 fqN
 faY
-bDy
-taj
-tLx
+viM
+uuH
+kEi
 uIn
 reI
 uIn
@@ -140642,12 +140320,12 @@ kJm
 tep
 xiX
 nqP
-shu
-shu
+rTG
+tsE
 kQE
 tBr
-shu
-shu
+rBQ
+pNf
 shu
 lqZ
 lmM
@@ -140900,11 +140578,11 @@ iKP
 ncV
 ncV
 uZJ
-uZJ
+ncV
 jQq
+ncV
 vih
-vih
-uZJ
+ncV
 uZJ
 ncV
 ncV

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2763,16 +2763,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"aoU" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "aoV" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron,
@@ -8096,16 +8086,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
-"bvC" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "bvE" = (
 /turf/open/floor/iron/white/side{
 	dir = 6
@@ -10153,11 +10133,10 @@
 	},
 /area/maintenance/port/aft)
 "bTv" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/white{
-	dir = 6
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "bTx" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -10221,15 +10200,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bUz" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "bUI" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -11850,14 +11820,8 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "csK" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "csN" = (
 /obj/structure/transit_tube/horizontal,
@@ -13557,12 +13521,9 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "cSu" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/brown/corner,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "cSv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -13902,7 +13863,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "dbO" = (
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "dbR" = (
 /obj/structure/sign/warning/securearea{
@@ -14083,22 +14045,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
-"dfC" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "dfM" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "dgj" = (
-/obj/effect/turf_decal/tile/red/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/large,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "dgN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -14525,9 +14481,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dtd" = (
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "dtk" = (
 /obj/machinery/airalarm/directional/north,
@@ -14623,30 +14583,22 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dwV" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/table,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/turf/open/floor/iron/large,
+/obj/structure/hedge/opaque,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "dxn" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/large,
+/obj/structure/table/wood/fancy,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "dxt" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -15275,16 +15227,8 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "dRa" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/restaurant_portal/restaurant,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "dRb" = (
 /obj/structure/cable,
@@ -15783,8 +15727,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/cook,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "eex" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -17942,11 +17886,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"fqr" = (
-/obj/structure/table,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/smooth_large,
-/area/service/kitchen/diner)
 "fqF" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -19492,10 +19431,13 @@
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
 "gdy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/brown{
 	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "gdK" = (
 /turf/open/floor/plating{
@@ -19663,14 +19605,21 @@
 /turf/closed/wall,
 /area/engineering/main)
 "gjg" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/white{
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/paper_bin,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
+"gjs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/brown{
 	dir = 8
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "gjy" = (
 /obj/structure/table,
@@ -19801,14 +19750,8 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/locker)
 "gmp" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 10
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/chair/sofa,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "gmx" = (
 /obj/structure/table,
@@ -21134,11 +21077,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "gXv" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/large,
+/obj/structure/table/wood/fancy,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "gXy" = (
 /obj/machinery/door/airlock/security/glass{
@@ -21521,8 +21464,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "hge" = (
-/obj/effect/turf_decal/tile/red/full,
-/turf/open/floor/iron/large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "hgg" = (
 /obj/structure/cable,
@@ -21838,6 +21786,15 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/maintenance/starboard/fore)
+"hru" = (
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/service/kitchen/diner)
 "hrF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -21890,11 +21847,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"hsd" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/table,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "hsh" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -23087,17 +23039,8 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ids" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/large,
+/obj/structure/chair/wood,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "idw" = (
 /obj/effect/turf_decal/tile/blue,
@@ -24471,17 +24414,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"iLq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
 "iLK" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -24593,14 +24525,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
-"iNZ" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "iOA" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
@@ -24915,6 +24839,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"iWP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/silver,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "iWV" = (
 /turf/closed/wall,
 /area/command/heads_quarters/hop)
@@ -25547,19 +25478,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
-"jnv" = (
-/obj/structure/table,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/service/kitchen/diner)
 "jnK" = (
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
@@ -27781,12 +27699,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"kAh" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "kAE" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
@@ -28511,11 +28423,11 @@
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
 "kQS" = (
-/obj/machinery/restaurant_portal/restaurant,
-/obj/effect/turf_decal/siding/white{
-	dir = 10
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "kRh" = (
 /obj/structure/chair/stool/directional/south,
@@ -28802,9 +28714,8 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "lcz" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white/corner,
-/turf/open/floor/iron/large,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "lcE" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -28854,6 +28765,16 @@
 	},
 /turf/open/floor/engine,
 /area/science/genetics)
+"lek" = (
+/obj/structure/table/wood/fancy/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "len" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -29732,9 +29653,13 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "lDF" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "lDW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -29925,18 +29850,23 @@
 /turf/open/floor/iron,
 /area/medical/medbay/aft)
 "lIw" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Service-Diner";
 	dir = 4
 	},
-/turf/open/floor/iron/large,
+/obj/structure/table/wood/fancy/red,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "lIT" = (
 /obj/machinery/camera{
@@ -31314,10 +31244,10 @@
 /turf/open/floor/iron,
 /area/construction)
 "mtr" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "mtA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -31381,6 +31311,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"mvY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "mwH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -31410,11 +31349,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"mxk" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "mxo" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white/side{
@@ -31997,6 +31931,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"mKh" = (
+/obj/structure/hedge/opaque,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
+/area/service/kitchen/diner)
 "mKO" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/chair/stool/directional/north,
@@ -32116,14 +32055,12 @@
 /turf/open/floor/carpet/blue,
 /area/medical/psychology)
 "mNo" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Canteen"
+/obj/effect/turf_decal/tile/red/half{
+	dir = 4
 	},
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
-/area/service/kitchen/diner)
+/obj/machinery/door/airlock/silver,
+/turf/open/floor/carpet/black,
+/area/hallway/secondary/service)
 "mNK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32661,8 +32598,14 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay)
 "nbH" = (
-/obj/structure/chair,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown,
+/obj/structure/aquarium,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/box/aquarium_props,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "nbK" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -34088,19 +34031,12 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "nPr" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 10
+	},
+/obj/structure/table/rolling,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "nPx" = (
 /obj/item/cigbutt,
@@ -34490,11 +34426,11 @@
 	},
 /area/maintenance/aft)
 "nXe" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/table/wood/fancy/red,
+/obj/item/candle/infinite{
+	pixel_y = 7
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "nXm" = (
 /obj/machinery/firealarm/directional/south,
@@ -34750,14 +34686,6 @@
 /obj/structure/industrial_lift,
 /turf/open/openspace,
 /area/commons/storage/mining)
-"oep" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "oeE" = (
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/circuit,
@@ -34957,18 +34885,6 @@
 "ojf" = (
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
-"ojl" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Canteen"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_half{
-	dir = 1
-	},
-/area/service/kitchen/diner)
 "ojo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -35526,15 +35442,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/engineering/break_room)
-"oAV" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/smooth_large,
-/area/service/kitchen/diner)
 "oAY" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line{
@@ -37239,10 +37146,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "psp" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "pss" = (
 /obj/machinery/door/airlock/external{
@@ -38242,13 +38147,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"pUI" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "pUM" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 24
@@ -38272,16 +38170,18 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
 "pVj" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
-/turf/open/floor/iron/large,
+/obj/effect/turf_decal/siding/brown,
+/obj/structure/aquarium,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/box/aquarium_props,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "pVH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -39093,13 +38993,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qqX" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red/full,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "qra" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -40633,14 +40526,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/port/fore)
-"rpY" = (
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/turf_decal/siding/white{
-	dir = 5
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/smooth_large,
-/area/service/kitchen/diner)
 "rqn" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40803,7 +40688,6 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "rtZ" = (
-/obj/structure/table,
 /obj/machinery/airalarm/kitchen_cold_room{
 	dir = 4;
 	pixel_x = -24
@@ -41050,23 +40934,9 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "rzN" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
-"rzP" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "rAg" = (
 /obj/structure/closet,
@@ -41423,10 +41293,9 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "rHc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "rHn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42003,14 +41872,10 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "rYk" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/hedge/opaque,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "rYA" = (
 /obj/structure/disposalpipe/segment,
@@ -43004,16 +42869,8 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "stA" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/large,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "stJ" = (
 /obj/structure/cable/multilayer/multiz,
@@ -43250,15 +43107,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"sAt" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/holopad,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "sAw" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -43872,8 +43720,19 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "sRN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/table/wood/fancy/red,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -7;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "sSi" = (
 /turf/open/floor/plating,
@@ -44854,16 +44713,16 @@
 /turf/open/floor/plating,
 /area/commons/storage/emergency/port)
 "trH" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 7
 	},
-/obj/effect/turf_decal/siding/white{
-	dir = 5
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -7
 	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "trV" = (
 /obj/effect/turf_decal/siding/white,
@@ -45264,13 +45123,6 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"tEB" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "tEH" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/red/line{
@@ -45346,8 +45198,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "tHa" = (
 /turf/open/floor/engine,
@@ -47373,12 +47227,10 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "uCM" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 4
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/large,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "uDd" = (
 /obj/effect/turf_decal/stripes/line{
@@ -47792,8 +47644,11 @@
 /turf/open/floor/carpet,
 /area/command/meeting_room)
 "uQl" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/brown/corner,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "uQt" = (
 /obj/machinery/holopad,
@@ -48285,11 +48140,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/aft)
 "vgc" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/siding/white{
-	dir = 8
+/obj/structure/chair/sofa{
+	dir = 1
 	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "vgs" = (
 /obj/structure/ladder{
@@ -48378,10 +48232,16 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "vjE" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/red/full,
-/obj/item/clothing/head/fedora,
-/turf/open/floor/iron/large,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "vjL" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -49181,14 +49041,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"vHs" = (
-/obj/machinery/door/airlock/freezer{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/freezer,
-/area/service/kitchen/coldroom)
 "vHw" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Equipment Room";
@@ -49269,14 +49121,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"vJD" = (
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/iron/large,
-/area/service/kitchen/diner)
 "vJL" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -50288,18 +50132,13 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "wks" = (
-/obj/structure/table,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/door/window/eastleft,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "wky" = (
 /obj/structure/table,
@@ -51313,11 +51152,7 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "wPy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "wPH" = (
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -52573,9 +52408,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "xwa" = (
-/obj/structure/table,
-/obj/item/clothing/mask/cigarette/cigar,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/hedge/opaque,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "xwi" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -52731,16 +52565,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"xyB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/public/glass{
-	name = "Canteen"
-	},
-/turf/open/floor/iron,
-/area/service/kitchen/diner)
 "xyE" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/hidden,
@@ -52866,12 +52690,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"xCO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/service/kitchen/diner)
 "xCR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -53736,14 +53554,9 @@
 /turf/open/floor/wood,
 /area/maintenance/aft)
 "xYT" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 6
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "xZm" = (
 /obj/effect/turf_decal/stripes/line,
@@ -90888,7 +90701,7 @@ xBq
 cVb
 ils
 ils
-ojl
+mNo
 mNo
 fmt
 cAy
@@ -91148,13 +90961,13 @@ gjg
 csK
 mtr
 pVj
-jnv
+xwa
 lIw
 vgc
 dwV
 gmp
 sRN
-cAG
+ils
 aYV
 aYV
 oOF
@@ -91403,15 +91216,15 @@ cVb
 wks
 vjE
 wPy
-mxk
+mtr
 nbH
-hsd
-nXe
-dfC
 xwa
-vJD
-sRN
-cAG
+nXe
+vgc
+xwa
+gmp
+lek
+ils
 aYV
 aYV
 oOF
@@ -91662,12 +91475,12 @@ psp
 cSu
 gdy
 lDF
-dbO
+hru
 hge
 uQl
-tEB
 dtd
-ils
+dtd
+gjs
 ils
 bcq
 bcq
@@ -91915,14 +91728,14 @@ oFM
 xLr
 cVb
 dRa
-qqX
 wPy
-kAh
+mKh
+mvY
 eet
-sAt
+mvY
 tGT
 dgj
-rHc
+mvY
 rzN
 kQS
 ils
@@ -92172,17 +91985,17 @@ nAQ
 xZF
 cVb
 nPr
-fqr
-pUI
-xCO
+wPy
+mKh
+gXv
 lcz
-rzP
+gXv
 uCM
 dbO
 gXv
 rHc
 dxn
-xyB
+ils
 jdM
 jdM
 oOF
@@ -92429,17 +92242,17 @@ qBm
 vNE
 cVb
 trH
-bvC
+wPy
 rYk
-oep
-xYT
-ils
-rpY
-iNZ
-oAV
-bUz
 bTv
-sRN
+xYT
+bTv
+uCM
+dbO
+bTv
+rzN
+bTv
+ils
 aYV
 mju
 oOF
@@ -92688,14 +92501,14 @@ sEf
 sEf
 sEf
 sEf
-vHs
+sEf
 sEf
 sEf
 fxo
 vaJ
-iLq
-vaJ
-aoU
+mjA
+iWP
+mjA
 mjA
 ect
 iaK

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1228,14 +1228,11 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "ahY" = (
+/obj/structure/chair/sofa/left{
+	dir = 4
+	},
 /obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
-/obj/structure/table/rolling{
-	name = "a la carte"
-	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "aia" = (
 /obj/structure/bookcase{
@@ -8578,11 +8575,14 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "biW" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/brown/corner,
-/turf/open/floor/wood/parquet,
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "bjv" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -8638,13 +8638,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bkS" = (
-/obj/effect/turf_decal/siding/brown{
+/obj/structure/railing{
 	dir = 8
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-06"
-	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "bkY" = (
 /turf/closed/wall/r_wall,
@@ -12350,6 +12347,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
+"cPk" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/diner)
 "cPs" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -13024,19 +13025,11 @@
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cZa" = (
-/obj/structure/table/wood/fancy,
-/obj/item/candle/infinite{
-	pixel_y = 7
+/obj/structure/chair/sofa/corner{
+	dir = 1
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -7;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -7;
-	pixel_y = 14
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "cZd" = (
 /obj/structure/lattice,
@@ -13147,9 +13140,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"dbD" = (
-/turf/open/floor/carpet/royalblack,
-/area/service/kitchen/diner)
 "dbG" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -13433,9 +13423,10 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
+/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "dhe" = (
 /turf/closed/mineral/random/stationside/asteroid/porus,
@@ -13652,8 +13643,10 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
 "dlB" = (
-/obj/structure/chair/sofa,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "dlD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -16135,13 +16128,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"egJ" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/carpet/royalblack,
-/area/service/kitchen/diner)
 "egQ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -16832,6 +16818,16 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"etd" = (
+/obj/structure/chair/sofa/corner{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/diner)
 "etj" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -17889,8 +17885,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "eOQ" = (
-/obj/structure/hedge,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/glass,
 /area/service/kitchen/diner)
 "eOT" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -17997,6 +17995,11 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"eRC" = (
+/obj/structure/chair/sofa/corner,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/diner)
 "eRF" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -18409,10 +18412,10 @@
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/brown/corner{
+/obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "eYw" = (
 /obj/structure/chair/stool/directional/east,
@@ -19164,7 +19167,7 @@
 /turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "for" = (
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "fos" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -19368,15 +19371,12 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "frk" = (
-/obj/structure/window{
+/obj/structure/railing,
+/obj/structure/chair/sofa/left{
 	dir = 1
 	},
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/effect/turf_decal/siding/brown{
-	dir = 9
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "frr" = (
 /obj/effect/turf_decal/sand,
@@ -20190,10 +20190,7 @@
 "fEd" = (
 /obj/effect/turf_decal/siding/thinplating/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/brown{
-	dir = 8
-	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "fEy" = (
 /obj/machinery/door/airlock/external{
@@ -20632,7 +20629,8 @@
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 1
 	},
-/turf/open/floor/wood/parquet,
+/obj/structure/railing/corner,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "fNC" = (
 /obj/structure/table,
@@ -20673,7 +20671,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 5
 	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "fOe" = (
 /obj/machinery/computer/secure_data,
@@ -22324,10 +22322,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/brown{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "gta" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -22372,10 +22367,11 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "gul" = (
+/obj/structure/chair,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
 	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "gun" = (
 /obj/machinery/light/small/directional/north,
@@ -23257,8 +23253,11 @@
 /area/science/server)
 "gLI" = (
 /obj/machinery/newscaster/directional/west,
-/obj/structure/chair/sofa,
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "gLJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23752,15 +23751,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"gVa" = (
-/obj/effect/turf_decal/siding/brown/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
-/area/service/kitchen/diner)
 "gVh" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Telecomms Relay Access";
@@ -24678,7 +24668,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "hmt" = (
 /obj/item/chair,
@@ -24802,10 +24792,12 @@
 /area/science/research)
 "hpU" = (
 /obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/siding/brown,
-/turf/open/floor/wood/parquet,
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "hqc" = (
 /obj/effect/turf_decal/stripes{
@@ -25083,8 +25075,10 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "huz" = (
-/obj/structure/hedge/opaque,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/chair/sofa{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "huU" = (
 /obj/structure/chair/comfy/brown,
@@ -26057,6 +26051,10 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"hPr" = (
+/obj/structure/chair,
+/turf/open/floor/glass,
+/area/service/kitchen/diner)
 "hPx" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -26470,6 +26468,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"hYr" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/service/kitchen/diner)
 "hYA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27426,12 +27431,7 @@
 /turf/open/floor/iron,
 /area/science/research)
 "irR" = (
-/obj/structure/aquarium,
-/obj/item/storage/box/aquarium_props,
-/obj/item/storage/fish_case/random,
-/obj/item/storage/fish_case/random,
-/obj/item/storage/fish_case/random,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/glass,
 /area/service/kitchen/diner)
 "irY" = (
 /obj/effect/turf_decal/tile/bar,
@@ -32809,13 +32809,6 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
-"kps" = (
-/obj/structure/table/wood/fancy/red,
-/obj/item/candle/infinite{
-	pixel_y = 7
-	},
-/turf/open/floor/carpet/royalblack,
-/area/service/kitchen/diner)
 "kpF" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -35524,14 +35517,6 @@
 "lvw" = (
 /turf/closed/wall,
 /area/mine/explored)
-"lwb" = (
-/obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/effect/turf_decal/siding/brown{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/service/kitchen/diner)
 "lwr" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/machinery/airalarm/directional/south,
@@ -36111,8 +36096,12 @@
 /turf/open/floor/plating,
 /area/commons/vacant_room/office)
 "lIJ" = (
-/obj/effect/turf_decal/siding/brown,
-/turf/open/floor/wood/parquet,
+/obj/structure/railing,
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "lIK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -36361,7 +36350,7 @@
 /area/hallway/secondary/exit)
 "lNh" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/glass,
 /area/service/kitchen/diner)
 "lNy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37175,14 +37164,16 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "meK" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "mfg" = (
 /obj/effect/turf_decal/stripes/line,
@@ -38596,17 +38587,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"mLb" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = 7
-	},
-/obj/item/reagent_containers/food/drinks/bottle/wine,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = -7
-	},
-/turf/open/floor/carpet/royalblack,
-/area/service/kitchen/diner)
 "mLc" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control";
@@ -38839,10 +38819,11 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "mPV" = (
+/obj/structure/chair,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 6
 	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "mPX" = (
 /obj/effect/turf_decal/siding/wood{
@@ -40036,6 +40017,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"noL" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/diner)
 "noO" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
@@ -41152,6 +41137,14 @@
 /obj/item/relic,
 /turf/open/floor/plating,
 /area/mine/explored)
+"nLg" = (
+/obj/structure/chair/sofa/left,
+/obj/effect/landmark/start/hangover,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/diner)
 "nLj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/event_spawn,
@@ -41223,11 +41216,12 @@
 /turf/open/floor/iron,
 /area/security/office)
 "nMb" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
+/obj/structure/chair/sofa/right{
+	dir = 8
 	},
-/turf/open/floor/wood/parquet,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "nMl" = (
 /obj/machinery/meter{
@@ -41812,7 +41806,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 9
 	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "nVQ" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
@@ -42318,6 +42312,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"ogX" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/machinery/navbeacon/wayfinding/kitchen,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/diner)
 "ohj" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
@@ -45533,12 +45534,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
-"psL" = (
-/obj/structure/noticeboard{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/service/kitchen)
 "psZ" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -47366,6 +47361,10 @@
 	},
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
+"qae" = (
+/obj/machinery/restaurant_portal/restaurant,
+/turf/open/floor/glass,
+/area/service/kitchen/diner)
 "qaY" = (
 /obj/structure/industrial_lift{
 	id = "publicElevator"
@@ -47461,6 +47460,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/maint)
+"qcY" = (
+/obj/structure/chair/sofa{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/diner)
 "qdd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48232,8 +48237,7 @@
 	dir = 6;
 	network = list("ss13","Service")
 	},
-/obj/structure/chair/sofa,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "qrK" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -48621,15 +48625,13 @@
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "qEv" = (
+/obj/item/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Service - Kitchen Diner South";
 	dir = 5;
 	network = list("ss13","Service")
 	},
-/obj/structure/chair/sofa{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "qEz" = (
 /obj/structure/table/optable,
@@ -49138,12 +49140,13 @@
 /turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "qNL" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/door/window/northleft,
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
+/obj/structure/railing,
+/obj/structure/chair/sofa/corner{
+	dir = 8
 	},
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/light/directional/east,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "qNW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50489,6 +50492,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"rpR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/diner)
 "rqf" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
@@ -50819,14 +50828,11 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "rym" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/structure/chair/sofa/left{
+	dir = 1
 	},
-/obj/item/candle/infinite{
-	pixel_y = 7
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "ryt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -51030,10 +51036,10 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "rCT" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-06"
+/obj/structure/railing{
+	dir = 4
 	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "rDl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -51807,14 +51813,15 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "rTe" = (
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchencounter";
+	name = "Kitchen Counter Shutters"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "rTo" = (
@@ -52159,13 +52166,13 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "rYY" = (
-/obj/structure/table/reinforced,
+/obj/machinery/smartfridge/food,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchencounter";
 	name = "Kitchen Counter Shutters"
 	},
-/turf/closed/wall,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "rZl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -54043,10 +54050,8 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/brown{
-	dir = 8
-	},
-/turf/open/floor/wood/parquet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "sNq" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -54177,16 +54182,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"sPV" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/brown{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
-/area/service/kitchen/diner)
 "sPW" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/camera{
@@ -54868,6 +54863,14 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/iron,
 /area/maintenance/port/central)
+"tbF" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/diner)
 "tbQ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -55730,10 +55733,8 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "tqq" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/table,
+/turf/open/floor/glass,
 /area/service/kitchen/diner)
 "tqs" = (
 /obj/structure/chair,
@@ -57810,6 +57811,16 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"ucr" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen/diner)
 "ucR" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58839,16 +58850,6 @@
 	},
 /turf/open/floor/plating,
 /area/service/kitchen)
-"uwU" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/brown{
-	dir = 8
-	},
-/turf/open/floor/wood/parquet,
-/area/service/kitchen/diner)
 "uxd" = (
 /obj/machinery/ore_silo,
 /obj/effect/turf_decal/bot_white/right,
@@ -58904,19 +58905,11 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "uxR" = (
-/obj/structure/table/wood/fancy,
-/obj/item/candle/infinite{
-	pixel_y = 7
+/obj/structure/chair/sofa/corner{
+	dir = 8
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 7;
-	pixel_y = 14
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "uxU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59179,10 +59172,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "uDS" = (
-/obj/structure/chair/sofa{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "uDV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -59596,9 +59589,8 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/restaurant_portal/restaurant,
-/obj/effect/turf_decal/siding/brown,
-/turf/open/floor/wood/parquet,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "uLa" = (
 /obj/machinery/door/airlock/hatch{
@@ -59609,12 +59601,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
-"uLq" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/service/kitchen/diner)
 "uLy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62153,9 +62139,11 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
+/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/thinplating/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "vRU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -62713,10 +62701,8 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/brown{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "wcv" = (
 /turf/closed/wall/r_wall,
@@ -62838,9 +62824,13 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "weK" = (
+/obj/structure/chair/sofa/corner{
+	dir = 1
+	},
+/obj/structure/railing,
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/brown,
-/turf/open/floor/wood/parquet,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "weT" = (
 /obj/machinery/modular_computer/console/preset/command{
@@ -64115,11 +64105,9 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
+/obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/brown/corner{
-	dir = 8
-	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "wBW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -66039,14 +66027,10 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "xlh" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/structure/chair/sofa/right{
+	dir = 1
 	},
-/obj/item/candle/infinite{
-	pixel_y = 7
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "xll" = (
 /obj/structure/table,
@@ -66635,15 +66619,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "xwL" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/food/drinks/bottle/wine,
-/obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_x = 7
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/openspace,
 /area/service/kitchen/diner)
 "xwN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -66859,13 +66835,8 @@
 /turf/open/floor/iron/smooth,
 /area/maintenance/tram/right)
 "xzW" = (
-/obj/effect/turf_decal/siding/brown/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
+/obj/structure/table,
+/turf/open/floor/iron/cafeteria,
 /area/service/kitchen/diner)
 "xAh" = (
 /obj/effect/turf_decal/trimline/white/line{
@@ -165019,9 +164990,9 @@ svc
 rGD
 wJP
 wJP
-wJP
-wJP
-wJP
+hYr
+oLn
+oLn
 wJP
 wJP
 bcn
@@ -165273,10 +165244,10 @@ aGY
 baI
 aGY
 aGY
-wJP
+aGY
 wJP
 gLI
-cZa
+etd
 huz
 cZa
 qEv
@@ -165533,14 +165504,14 @@ cQg
 aGY
 uKU
 dlB
-xlh
-huz
+nLg
+ucr
 xlh
 uDS
 ahY
 weK
 xwL
-wJP
+xwL
 wWx
 avO
 axj
@@ -165790,14 +165761,14 @@ nxn
 abq
 wBV
 fEd
-uwU
-uwU
-uwU
+sNi
+sNi
+sNi
 sNi
 xzW
 lIJ
-mLb
-wJP
+xwL
+xwL
 wgv
 avQ
 avn
@@ -166047,10 +166018,10 @@ xHa
 abq
 vRk
 mPV
-dbD
-dbD
-dbD
-dbD
+tqq
+eOQ
+irR
+irR
 fOc
 eXF
 bkS
@@ -166303,10 +166274,10 @@ iio
 nxn
 abq
 dhb
-eOQ
-tqq
-dbD
-dbD
+irR
+irR
+irR
+hPr
 tqq
 eOQ
 hmq
@@ -166559,14 +166530,14 @@ bHJ
 xkd
 xHa
 rYY
-dhb
+tbF
 irR
-kps
-dbD
+irR
+qae
 lNh
-kps
 irR
-hmq
+irR
+ogX
 for
 rRU
 avK
@@ -166815,13 +166786,13 @@ ajQ
 aqp
 cIA
 nxn
-rYY
+abq
 dhb
-eOQ
-uLq
-dbD
-dbD
-uLq
+irR
+irR
+irR
+hPr
+tqq
 eOQ
 hmq
 for
@@ -167072,13 +167043,13 @@ bUO
 cpO
 oqy
 gSy
-psL
+abq
 meK
 gul
-dbD
-dbD
-dbD
-dbD
+tqq
+eOQ
+irR
+irR
 nVE
 fNu
 rCT
@@ -167332,14 +167303,14 @@ wYT
 rTe
 biW
 gsW
-sPV
-sPV
-sPV
 wbZ
-gVa
+wbZ
+wbZ
+wbZ
+xzW
 frk
-lwb
-wJP
+xwL
+xwL
 aOk
 avW
 avn
@@ -167588,15 +167559,15 @@ ptl
 sur
 aGY
 hpU
-dlB
+for
+cPk
+ucr
 rym
-huz
-rym
-uDS
+rpR
 nMb
 qNL
-egJ
-wJP
+xwL
+xwL
 wgv
 sLw
 axr
@@ -167843,13 +167814,13 @@ aGY
 uwP
 aGY
 aGY
-wJP
+aGY
 wJP
 qrC
+eRC
+qcY
 uxR
-huz
-uxR
-uDS
+noL
 wJP
 wJP
 wJP
@@ -168103,9 +168074,9 @@ tGh
 lmk
 wJP
 wJP
-wJP
-wJP
-wJP
+oLn
+oLn
+oLn
 wJP
 wJP
 nxe

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1228,11 +1228,14 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "ahY" = (
-/obj/structure/chair/sofa/left{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/structure/table/rolling{
+	name = "a la carte"
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "aia" = (
 /obj/structure/bookcase{
@@ -8575,14 +8578,11 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "biW" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/structure/chair/stool/bar/directional/south,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown/corner,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "bjv" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -8638,10 +8638,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bkS" = (
-/obj/structure/railing{
+/obj/effect/turf_decal/siding/brown{
 	dir = 8
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "bkY" = (
 /turf/closed/wall/r_wall,
@@ -12347,10 +12350,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
-"cPk" = (
-/obj/structure/chair/sofa/right,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "cPs" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -13025,11 +13024,19 @@
 /turf/open/floor/iron/grimy,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cZa" = (
-/obj/structure/chair/sofa/corner{
-	dir = 1
+/obj/structure/table/wood/fancy,
+/obj/item/candle/infinite{
+	pixel_y = 7
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "cZd" = (
 /obj/structure/lattice,
@@ -13140,6 +13147,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"dbD" = (
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "dbG" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -13423,10 +13433,9 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/thinplating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "dhe" = (
 /turf/closed/mineral/random/stationside/asteroid/porus,
@@ -13643,10 +13652,8 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
 "dlB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/sofa,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "dlD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -16128,6 +16135,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"egJ" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "egQ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -16818,16 +16832,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"etd" = (
-/obj/structure/chair/sofa/corner{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "etj" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -17885,10 +17889,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "eOQ" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/glass,
+/obj/structure/hedge,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "eOT" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -17995,11 +17997,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"eRC" = (
-/obj/structure/chair/sofa/corner,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "eRF" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -18412,10 +18409,10 @@
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
 	},
-/obj/structure/railing/corner{
+/obj/effect/turf_decal/siding/brown/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "eYw" = (
 /obj/structure/chair/stool/directional/east,
@@ -19167,7 +19164,7 @@
 /turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "for" = (
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "fos" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -19371,12 +19368,15 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "frk" = (
-/obj/structure/railing,
-/obj/structure/chair/sofa/left{
+/obj/structure/window{
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/effect/turf_decal/siding/brown{
+	dir = 9
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "frr" = (
 /obj/effect/turf_decal/sand,
@@ -20190,7 +20190,10 @@
 "fEd" = (
 /obj/effect/turf_decal/siding/thinplating/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "fEy" = (
 /obj/machinery/door/airlock/external{
@@ -20629,8 +20632,7 @@
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 1
 	},
-/obj/structure/railing/corner,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "fNC" = (
 /obj/structure/table,
@@ -20671,7 +20673,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 5
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "fOe" = (
 /obj/machinery/computer/secure_data,
@@ -22322,7 +22324,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "gta" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -22367,11 +22372,10 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
 "gul" = (
-/obj/structure/chair,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "gun" = (
 /obj/machinery/light/small/directional/north,
@@ -23253,11 +23257,8 @@
 /area/science/server)
 "gLI" = (
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/sofa,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "gLJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23751,6 +23752,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"gVa" = (
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/service/kitchen/diner)
 "gVh" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Telecomms Relay Access";
@@ -24668,7 +24678,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "hmt" = (
 /obj/item/chair,
@@ -24792,12 +24802,10 @@
 /area/science/research)
 "hpU" = (
 /obj/machinery/power/apc/auto_name/north,
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 1
-	},
-/obj/machinery/light/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "hqc" = (
 /obj/effect/turf_decal/stripes{
@@ -25075,10 +25083,8 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "huz" = (
-/obj/structure/chair/sofa{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/hedge/opaque,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "huU" = (
 /obj/structure/chair/comfy/brown,
@@ -26051,10 +26057,6 @@
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
-"hPr" = (
-/obj/structure/chair,
-/turf/open/floor/glass,
-/area/service/kitchen/diner)
 "hPx" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -26468,13 +26470,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"hYr" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/service/kitchen/diner)
 "hYA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27431,7 +27426,12 @@
 /turf/open/floor/iron,
 /area/science/research)
 "irR" = (
-/turf/open/floor/glass,
+/obj/structure/aquarium,
+/obj/item/storage/box/aquarium_props,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/fish_case/random,
+/obj/item/storage/fish_case/random,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "irY" = (
 /obj/effect/turf_decal/tile/bar,
@@ -32809,6 +32809,13 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
+"kps" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "kpF" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -35517,6 +35524,14 @@
 "lvw" = (
 /turf/closed/wall,
 /area/mine/explored)
+"lwb" = (
+/obj/structure/table/wood,
+/obj/item/clipboard,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "lwr" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/machinery/airalarm/directional/south,
@@ -36096,12 +36111,8 @@
 /turf/open/floor/plating,
 /area/commons/vacant_room/office)
 "lIJ" = (
-/obj/structure/railing,
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "lIK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -36350,7 +36361,7 @@
 /area/hallway/secondary/exit)
 "lNh" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/glass,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "lNy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37164,16 +37175,14 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "meK" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "mfg" = (
 /obj/effect/turf_decal/stripes/line,
@@ -38587,6 +38596,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"mLb" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -7
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "mLc" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control";
@@ -38819,11 +38839,10 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "mPV" = (
-/obj/structure/chair,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 6
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "mPX" = (
 /obj/effect/turf_decal/siding/wood{
@@ -40017,10 +40036,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"noL" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "noO" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
@@ -41137,14 +41152,6 @@
 /obj/item/relic,
 /turf/open/floor/plating,
 /area/mine/explored)
-"nLg" = (
-/obj/structure/chair/sofa/left,
-/obj/effect/landmark/start/hangover,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "nLj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/event_spawn,
@@ -41216,12 +41223,11 @@
 /turf/open/floor/iron,
 /area/security/office)
 "nMb" = (
-/obj/structure/chair/sofa/right{
-	dir = 8
-	},
 /obj/item/radio/intercom/directional/east,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "nMl" = (
 /obj/machinery/meter{
@@ -41806,7 +41812,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 9
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "nVQ" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
@@ -42312,13 +42318,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"ogX" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/machinery/navbeacon/wayfinding/kitchen,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "ohj" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
@@ -45534,6 +45533,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/hallway/primary/tram/left)
+"psL" = (
+/obj/structure/noticeboard{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/service/kitchen)
 "psZ" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -47361,10 +47366,6 @@
 	},
 /turf/open/floor/plating/asteroid/airless,
 /area/mine/explored)
-"qae" = (
-/obj/machinery/restaurant_portal/restaurant,
-/turf/open/floor/glass,
-/area/service/kitchen/diner)
 "qaY" = (
 /obj/structure/industrial_lift{
 	id = "publicElevator"
@@ -47460,12 +47461,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/maint)
-"qcY" = (
-/obj/structure/chair/sofa{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "qdd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48237,7 +48232,8 @@
 	dir = 6;
 	network = list("ss13","Service")
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/sofa,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "qrK" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -48625,13 +48621,15 @@
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "qEv" = (
-/obj/item/kirbyplants/random,
 /obj/machinery/camera{
 	c_tag = "Service - Kitchen Diner South";
 	dir = 5;
 	network = list("ss13","Service")
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/structure/chair/sofa{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "qEz" = (
 /obj/structure/table/optable,
@@ -49140,13 +49138,12 @@
 /turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
 "qNL" = (
-/obj/structure/railing,
-/obj/structure/chair/sofa/corner{
-	dir = 8
-	},
 /obj/machinery/light/directional/east,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/door/window/northleft,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "qNW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50492,12 +50489,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"rpR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "rqf" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
@@ -50828,11 +50819,14 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "rym" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
+/obj/structure/table/wood/fancy,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/cafeteria,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "ryt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -51036,10 +51030,10 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "rCT" = (
-/obj/structure/railing{
-	dir = 4
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "rDl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -51813,15 +51807,14 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "rTe" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchencounter";
-	name = "Kitchen Counter Shutters"
-	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen";
+	req_access_txt = "28"
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "rTo" = (
@@ -52166,13 +52159,13 @@
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
 "rYY" = (
-/obj/machinery/smartfridge/food,
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchencounter";
 	name = "Kitchen Counter Shutters"
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/closed/wall,
 /area/service/kitchen)
 "rZl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -54050,8 +54043,10 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "sNq" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -54182,6 +54177,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"sPV" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/service/kitchen/diner)
 "sPW" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/camera{
@@ -54863,14 +54868,6 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/iron,
 /area/maintenance/port/central)
-"tbF" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "tbQ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -55733,8 +55730,10 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "tqq" = (
-/obj/structure/table,
-/turf/open/floor/glass,
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "tqs" = (
 /obj/structure/chair,
@@ -57811,16 +57810,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"ucr" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen/diner)
 "ucR" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58850,6 +58839,16 @@
 	},
 /turf/open/floor/plating,
 /area/service/kitchen)
+"uwU" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/service/kitchen/diner)
 "uxd" = (
 /obj/machinery/ore_silo,
 /obj/effect/turf_decal/bot_white/right,
@@ -58905,11 +58904,19 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "uxR" = (
-/obj/structure/chair/sofa/corner{
-	dir = 8
+/obj/structure/table/wood/fancy,
+/obj/item/candle/infinite{
+	pixel_y = 7
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 7;
+	pixel_y = 14
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "uxU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59172,10 +59179,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "uDS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/structure/chair/sofa{
+	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "uDV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -59589,8 +59596,9 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/restaurant_portal/restaurant,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "uLa" = (
 /obj/machinery/door/airlock/hatch{
@@ -59601,6 +59609,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/radshelter/civil)
+"uLq" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/service/kitchen/diner)
 "uLy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62139,11 +62153,9 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/siding/thinplating/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "vRU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -62701,8 +62713,10 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "wcv" = (
 /turf/closed/wall/r_wall,
@@ -62824,13 +62838,9 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "weK" = (
-/obj/structure/chair/sofa/corner{
-	dir = 1
-	},
-/obj/structure/railing,
 /obj/machinery/light/directional/west,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown,
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "weT" = (
 /obj/machinery/modular_computer/console/preset/command{
@@ -64105,9 +64115,11 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/structure/chair/stool/bar/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "wBW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -66027,10 +66039,14 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "xlh" = (
-/obj/structure/chair/sofa/right{
-	dir = 1
+/obj/structure/table/wood/fancy,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/item/candle/infinite{
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "xll" = (
 /obj/structure/table,
@@ -66619,7 +66635,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "xwL" = (
-/turf/open/openspace,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/food/drinks/bottle/wine,
+/obj/item/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 7
+	},
+/turf/open/floor/carpet/royalblack,
 /area/service/kitchen/diner)
 "xwN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -66835,8 +66859,13 @@
 /turf/open/floor/iron/smooth,
 /area/maintenance/tram/right)
 "xzW" = (
-/obj/structure/table,
-/turf/open/floor/iron/cafeteria,
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
 /area/service/kitchen/diner)
 "xAh" = (
 /obj/effect/turf_decal/trimline/white/line{
@@ -164990,9 +165019,9 @@ svc
 rGD
 wJP
 wJP
-hYr
-oLn
-oLn
+wJP
+wJP
+wJP
 wJP
 wJP
 bcn
@@ -165244,10 +165273,10 @@ aGY
 baI
 aGY
 aGY
-aGY
+wJP
 wJP
 gLI
-etd
+cZa
 huz
 cZa
 qEv
@@ -165504,14 +165533,14 @@ cQg
 aGY
 uKU
 dlB
-nLg
-ucr
+xlh
+huz
 xlh
 uDS
 ahY
 weK
 xwL
-xwL
+wJP
 wWx
 avO
 axj
@@ -165761,14 +165790,14 @@ nxn
 abq
 wBV
 fEd
-sNi
-sNi
-sNi
+uwU
+uwU
+uwU
 sNi
 xzW
 lIJ
-xwL
-xwL
+mLb
+wJP
 wgv
 avQ
 avn
@@ -166018,10 +166047,10 @@ xHa
 abq
 vRk
 mPV
-tqq
-eOQ
-irR
-irR
+dbD
+dbD
+dbD
+dbD
 fOc
 eXF
 bkS
@@ -166274,10 +166303,10 @@ iio
 nxn
 abq
 dhb
-irR
-irR
-irR
-hPr
+eOQ
+tqq
+dbD
+dbD
 tqq
 eOQ
 hmq
@@ -166530,14 +166559,14 @@ bHJ
 xkd
 xHa
 rYY
-tbF
+dhb
 irR
-irR
-qae
+kps
+dbD
 lNh
+kps
 irR
-irR
-ogX
+hmq
 for
 rRU
 avK
@@ -166786,13 +166815,13 @@ ajQ
 aqp
 cIA
 nxn
-abq
+rYY
 dhb
-irR
-irR
-irR
-hPr
-tqq
+eOQ
+uLq
+dbD
+dbD
+uLq
 eOQ
 hmq
 for
@@ -167043,13 +167072,13 @@ bUO
 cpO
 oqy
 gSy
-abq
+psL
 meK
 gul
-tqq
-eOQ
-irR
-irR
+dbD
+dbD
+dbD
+dbD
 nVE
 fNu
 rCT
@@ -167303,14 +167332,14 @@ wYT
 rTe
 biW
 gsW
+sPV
+sPV
+sPV
 wbZ
-wbZ
-wbZ
-wbZ
-xzW
+gVa
 frk
-xwL
-xwL
+lwb
+wJP
 aOk
 avW
 avn
@@ -167559,15 +167588,15 @@ ptl
 sur
 aGY
 hpU
-for
-cPk
-ucr
+dlB
 rym
-rpR
+huz
+rym
+uDS
 nMb
 qNL
-xwL
-xwL
+egJ
+wJP
 wgv
 sLw
 axr
@@ -167814,13 +167843,13 @@ aGY
 uwP
 aGY
 aGY
-aGY
+wJP
 wJP
 qrC
-eRC
-qcY
 uxR
-noL
+huz
+uxR
+uDS
 wJP
 wJP
 wJP
@@ -168074,9 +168103,9 @@ tGh
 lmk
 wJP
 wJP
-oLn
-oLn
-oLn
+wJP
+wJP
+wJP
 wJP
 wJP
 nxe


### PR DESCRIPTION
## About The Pull Request

Replaces the existing dining areas on Icebox and Delta with a new restaurant. This is a draft because it's incomplete.

## Why It's Good For The Game

The intended flow of this is for customers to come in, be seated by a server - either the chef or a hired assistant, who will write down their order and give it to the chef on a piece of paper, to be pinned to the bulletin board for the chef to keep track of tickets. While the food cooks, customers can sit and chat all they like. The server will make sure that everyone is happy and has what they need, as well as serving drinks from the bar, creating cooperation between the two halves of the bar. There is also a rolling table to offer customers à la carte desserts, drinks, or to generally make moving large amounts of food around easier. All of this provides more opportunity for RP.

## Changelog

:cl:
add: Replaces the existing dining areas on Icebox and Delta with a new restaurant.
/:cl:

## Delta
### No planned changes.
![image](https://user-images.githubusercontent.com/58074918/138471340-d31cf212-288c-43c1-b09a-38751c09d96d.png)


## Icemoon
### Planned changes - removal of roundstart fish, changes to airlocks, and add side entrance. Theme change to izakaya.
![image](https://user-images.githubusercontent.com/58074918/138472358-9013cf40-17b6-44fc-bae9-ca1772a4e96d.png)