### PR TITLE
Adds art stuff to the library games vendor

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -194,7 +194,7 @@
 		SStgui.update_uis(src)
 
 /obj/item/canvas/nineteen_nineteen
-	name = "canvas(19x19)"
+	name = "canvas (19x19)"
 	icon_state = "19x19"
 	width = 19
 	height = 19
@@ -204,7 +204,7 @@
 	framed_offset_y = 9
 
 /obj/item/canvas/twentythree_nineteen
-	name = "canvas(23x19)"
+	name = "canvas (23x19)"
 	icon_state = "23x19"
 	width = 23
 	height = 19
@@ -214,7 +214,7 @@
 	framed_offset_y = 8
 
 /obj/item/canvas/twentythree_twentythree
-	name = "canvas(23x23)"
+	name = "canvas (23x23)"
 	icon_state = "23x23"
 	width = 23
 	height = 23

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -194,6 +194,7 @@
 		SStgui.update_uis(src)
 
 /obj/item/canvas/nineteen_nineteen
+	name = "canvas(19x19)"
 	icon_state = "19x19"
 	width = 19
 	height = 19
@@ -203,6 +204,7 @@
 	framed_offset_y = 9
 
 /obj/item/canvas/twentythree_nineteen
+	name = "canvas(23x19)"
 	icon_state = "23x19"
 	width = 23
 	height = 19
@@ -212,6 +214,7 @@
 	framed_offset_y = 8
 
 /obj/item/canvas/twentythree_twentythree
+	name = "canvas(23x23)"
 	icon_state = "23x23"
 	width = 23
 	height = 23
@@ -221,7 +224,7 @@
 	framed_offset_y = 6
 
 /obj/item/canvas/twentyfour_twentyfour
-	name = "ai universal standard canvas"
+	name = "canvas (AI Universal Standard)"
 	desc = "Besides being very large, the AI can accept these as a display from their internal database after you've hung it up."
 	icon_state = "24x24"
 	width = 24

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -4,6 +4,7 @@
 	product_ads = "Escape to a fantasy world!;Fuel your gambling addiction!;Ruin your friendships!;Roll for initiative!;Elves and dwarves!;Paranoid computers!;Totally not satanic!;Fun times forever!"
 	icon_state = "games"
 	products = list(
+		/obj/item/storage/crayons = 2,
 		/obj/item/toy/cards/deck = 5,
 		/obj/item/storage/dice = 10,
 		/obj/item/toy/cards/deck/cas = 3,
@@ -14,6 +15,9 @@
 		/obj/item/hourglass = 2,
 		/obj/item/instrument/piano_synth/headphones = 4,
 		/obj/item/camera = 3,
+		/obj/item/camera_film = 5,
+		/obj/item/chisel = 3,
+		/obj/item/stack/pipe_cleaner_coil/random = 10,
 		/obj/item/cardpack/series_one = 10,
 		/obj/item/cardpack/resin = 10,
 		/obj/item/storage/card_binder = 10,
@@ -24,6 +28,10 @@
 		/obj/item/skillchip/useless_adapter=5,
 		/obj/item/dyespray=3,
 		/obj/item/razor=3,
+		/obj/item/canvas/nineteen_nineteen = 5,
+		/obj/item/canvas/twentythree_nineteen = 5,
+		/obj/item/canvas/twentythree_twentythree = 5,
+		/obj/item/canvas/twentyfour_twentyfour = 5
 	)
 	contraband = list(
 		/obj/item/dice/fudge = 9,
@@ -31,6 +39,10 @@
 		/obj/item/instrument/musicalmoth=1
 	)
 	premium = list(
+		/obj/item/disk/holodisk = 5,
+		/obj/item/toy/crayon/spraycan  = 3,
+		/obj/item/rcl = 2,
+		/obj/item/airlock_painter = 1,
 		/obj/item/melee/skateboard/pro = 3,
 		/obj/item/clothing/shoes/wheelys/rollerskates= 3,
 		/obj/item/melee/skateboard/hoverboard = 1,

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -30,8 +30,7 @@
 		/obj/item/razor=3,
 		/obj/item/canvas/nineteen_nineteen = 5,
 		/obj/item/canvas/twentythree_nineteen = 5,
-		/obj/item/canvas/twentythree_twentythree = 5,
-		/obj/item/canvas/twentyfour_twentyfour = 5
+		/obj/item/canvas/twentythree_twentythree = 5
 	)
 	contraband = list(
 		/obj/item/dice/fudge = 9,
@@ -41,6 +40,7 @@
 	premium = list(
 		/obj/item/disk/holodisk = 5,
 		/obj/item/toy/crayon/spraycan  = 3,
+		/obj/item/canvas/twentyfour_twentyfour = 5,
 		/obj/item/rcl = 2,
 		/obj/item/airlock_painter = 1,
 		/obj/item/melee/skateboard/pro = 3,


### PR DESCRIPTION
## About The Pull Request

Adds a bunch of stuff to the games vendor in the library, mostly the art stuff you find in art storage(I think the only exception is holodisks and spraycans, which are premium items)

Renamed canvas so that their size can be distinguished in menus

## Why It's Good For The Game

Makes sure art supplies are always available on station even if there's no art storage room. Art is good, clean fun
:cl:
qol: Art supplies are now also available in the library vendor in case the art storage room is not present on station
/:cl: