### PR TITLE
SM: Fix pressure bonus system

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -179,6 +179,25 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	///How much hallucination should we produce per unit of power?
 	var/hallucination_power = 0.1
 
+	///Pressure bonus constants
+
+	///These constants are used to derive the values in the pressure bonus equation from human-meaningful values
+	///If you're varediting these, call update_constants() to update the derived values
+
+	///What is the maximum multiplier reachable from having low pressure?
+	var/pressure_bonus_max_multiplier = 1.5
+	///At what environmental pressure, in kPa, should we start giving a pressure bonus?
+	var/pressure_bonus_max_pressure = 100
+	///How steeply angled is the pressure bonus curve? Higher values means more of the bonus is available at higher pressures.
+	///Note that very low values can keep the bonus very close to 1 until it's nearly a vaccuum. Higher values can introduce diminishing returns on lower pressure.
+	var/pressure_bonus_curve_angle = 1.8
+
+	///These values are calculated from the above in update_constants() and immediately overwritten
+	///These are here to 1) give you an idea of what to expect 2) provide a somewhat sane fallback if something breaks
+	var/pressure_bonus_derived_constant = 0.66
+	var/pressure_bonus_derived_steepness = 0.0001
+
+
 	///Our internal radio
 	var/obj/item/radio/radio
 	///The key our internal radio uses
@@ -253,6 +272,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	if (!moveable)
 		move_resist = MOVE_FORCE_OVERPOWERING // Avoid being moved by statues or other memes
 
+	update_constants()
+
 /obj/machinery/power/supermatter_crystal/Destroy()
 	investigate_log("has been destroyed.", INVESTIGATE_SUPERMATTER)
 	SSair.stop_processing_machine(src)
@@ -264,6 +285,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	if(psyOverlay)
 		QDEL_NULL(psyOverlay)
 	return ..()
+
+/obj/machinery/power/supermatter_crystal/proc/update_constants()
+	pressure_bonus_derived_steepness = (1 - 1 / pressure_bonus_max_multiplier) / (pressure_bonus_max_pressure ** pressure_bonus_curve_angle)
+	pressure_bonus_derived_constant = 1 / pressure_bonus_max_multiplier - pressure_bonus_derived_steepness
 
 /obj/machinery/power/supermatter_crystal/examine(mob/user)
 	. = ..()
@@ -652,7 +677,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			//(1 + (tritRad + pluoxDampen * bzDampen * o2Rad * plasmaRad / (10 - bzrads))) * freonbonus
 			playsound(src, 'sound/weapons/emitter2.ogg', 70, TRUE)
 			var/power_multiplier = max(0, (1 + (power_transmission_bonus / (10 - (gas_comp[/datum/gas/bz] * BZ_RADIOACTIVITY_MODIFIER)))) * freonbonus)// RadModBZ(500%)
-			var/pressure_multiplier = max((1 / ((env_pressure ** 1.5) + 5.5) * 0.01) + 0.8, 1)
+			var/pressure_multiplier = max((1 / ((env_pressure ** pressure_bonus_curve_angle) + 1) * pressure_bonus_derived_steepness) + pressure_bonus_derived_constant, 1)
 			var/co2_power_increase = max(gas_comp[/datum/gas/carbon_dioxide] * 2, 1)
 			supermatter_zap(
 				zapstart = src,

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -180,6 +180,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/hallucination_power = 0.1
 
 	///Pressure bonus constants
+	///If the SM is operating in sufficiently low pressure, increase power output.
+	///This needs both a small amount of gas and a strong cooling system to keep temperature low in a low heat capacity environment.
 
 	///These constants are used to derive the values in the pressure bonus equation from human-meaningful values
 	///If you're varediting these, call update_constants() to update the derived values

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -195,9 +195,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/pressure_bonus_curve_angle = 1.8
 
 	///These values are calculated from the above in update_constants() and immediately overwritten
-	///These are here to 1) give you an idea of what to expect 2) provide a somewhat sane fallback if something breaks
-	var/pressure_bonus_derived_constant = 0.63
-	var/pressure_bonus_derived_steepness = 0.0333
+	///The default values will always result in a no-op 1x modifier, in case something breaks.
+	var/pressure_bonus_derived_constant = 1
+	var/pressure_bonus_derived_steepness = 0
 
 
 	///Our internal radio

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -185,7 +185,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	///If you're varediting these, call update_constants() to update the derived values
 
 	///What is the maximum multiplier reachable from having low pressure?
-	var/pressure_bonus_max_multiplier = 1.5
+	var/pressure_bonus_max_multiplier = 0.5
 	///At what environmental pressure, in kPa, should we start giving a pressure bonus?
 	var/pressure_bonus_max_pressure = 100
 	///How steeply angled is the pressure bonus curve? Higher values means more of the bonus is available at higher pressures.
@@ -194,8 +194,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	///These values are calculated from the above in update_constants() and immediately overwritten
 	///These are here to 1) give you an idea of what to expect 2) provide a somewhat sane fallback if something breaks
-	var/pressure_bonus_derived_constant = 0.66
-	var/pressure_bonus_derived_steepness = 0.0001
+	var/pressure_bonus_derived_constant = 0.63
+	var/pressure_bonus_derived_steepness = 0.0333
 
 
 	///Our internal radio


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This brings the pressure bonus system in line with its original intentions:

> This is a multiplier meant to be used at low pressures. The lower the pressure the higher the multiplier. This is to encourage low pressure setups and so cold setups.
> At higher pressures (from around 100 kpa and up) it will max to 1

In practice, as pressure dropped, the multiplier remained at 1 until it dropped to 5.96kPa. It then very marginally increased until it reached x1.17 at 0kPa.

This introduces a system that solves the constants for the equation based on human readable parameters, and sets provisional parameters for it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #62124.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The SM now properly provides bonus power for operating in a low pressure environment. Make sure you can keep it cool enough, and remember, space or a vacuum won't work, but it will damage the SM!
code: Calculations relating to the SM pressure bonus are now derived from human readable parameters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
