### PR TITLE
Shooting specific wizard staffs as a non-wizard or non-magician now backfires in different ways.

### DIFF
--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -254,6 +254,11 @@
 	spooky_scaries |= M
 	to_chat(M, "[span_userdanger("You have been revived by ")]<B>[user.real_name]!</B>")
 	to_chat(M, span_userdanger("[user.p_theyre(TRUE)] your master now, assist [user.p_them()] even if it costs you your new life!"))
+	var/datum/antagonist/wizard/antag_datum = user.mind.has_antag_datum(/datum/antagonist/wizard)
+	if(antag_datum)
+		if(!antag_datum.wiz_team)
+			antag_datum.create_wiz_team()
+		M.mind.add_antag_datum(/datum/antagonist/wizard_minion, antag_datum.wiz_team)
 
 	equip_roman_skeleton(M)
 

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -19,6 +19,49 @@
 	var/wiz_age = WIZARD_AGE_MIN /* Wizards by nature cannot be too young. */
 	show_to_ghosts = TRUE
 
+/datum/antagonist/wizard_minion
+	name = "Wizard Minion"
+	antagpanel_category = "Wizard"
+	antag_hud_type = ANTAG_HUD_WIZ
+	antag_hud_name = "apprentice"
+	show_in_roundend = FALSE
+	show_name_in_check_antagonists = TRUE
+	/// The wizard team this wizard minion is part of.
+	var/datum/team/wizard/wiz_team
+
+/datum/antagonist/wizard_minion/create_team(datum/team/wizard/new_team)
+	if(!new_team)
+		return
+	if(!istype(new_team))
+		stack_trace("Wrong team type passed to [type] initialization.")
+	wiz_team = new_team
+
+/datum/antagonist/wizard_minion/apply_innate_effects(mob/living/mob_override)
+	var/mob/living/current_mob = mob_override || owner.current
+	add_antag_hud(antag_hud_type, antag_hud_name, current_mob)
+	current_mob.faction |= ROLE_WIZARD
+
+/datum/antagonist/wizard_minion/remove_innate_effects(mob/living/mob_override)
+	var/mob/living/last_mob = mob_override || owner.current
+	remove_antag_hud(antag_hud_type, last_mob)
+	last_mob.faction -= ROLE_WIZARD
+
+/datum/antagonist/wizard_minion/on_gain()
+	create_objectives()
+	return ..()
+
+/datum/antagonist/wizard_minion/proc/create_objectives()
+	if(!wiz_team)
+		return
+	var/datum/objective/custom/custom_objective = new()
+	custom_objective.owner = owner
+	custom_objective.name = "Serve [wiz_team.master_wizard?.owner]"
+	custom_objective.explanation_text = "Serve [wiz_team.master_wizard?.owner]"
+	objectives += custom_objective
+
+/datum/antagonist/wizard_minion/get_team()
+	return wiz_team
+
 /datum/antagonist/wizard/on_gain()
 	equip_wizard()
 	if(give_objectives)
@@ -305,7 +348,7 @@
 	parts += "<span class='header'>Wizards/witches of [master_wizard.owner.name] team were:</span>"
 	parts += master_wizard.roundend_report()
 	parts += " "
-	parts += "<span class='header'>[master_wizard.owner.name] apprentices were:</span>"
+	parts += "<span class='header'>[master_wizard.owner.name] apprentices and minions were:</span>"
 	parts += printplayerlist(members - master_wizard.owner)
 
 	return "<div class='panel redborder'>[parts.Join("<br>")]</div>"

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -519,6 +519,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	var/allowmultiple = FALSE
 	var/allowling = TRUE
 	var/allowguardian = FALSE
+	var/datum/antagonist/antag_datum_to_give
 
 /obj/item/guardiancreator/attack_self(mob/living/user)
 	if(isguardian(user) && !allowguardian)
@@ -620,6 +621,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 						/mob/living/proc/guardian_recall, \
 						/mob/living/proc/guardian_reset))
 	G?.client.init_verbs()
+	return G
 
 /obj/item/guardiancreator/choose
 	random = FALSE
@@ -630,6 +632,18 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 /obj/item/guardiancreator/choose/wizard
 	possible_guardians = list("Assassin", "Chaos", "Charger", "Dextrous", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Gravitokinetic")
 	allowmultiple = TRUE
+
+/obj/item/guardiancreator/choose/wizard/spawn_guardian(mob/living/user, mob/dead/candidate)
+	. = ..()
+	var/mob/guardian = .
+	if(!guardian)
+		return
+
+	var/datum/antagonist/wizard/antag_datum = user.mind.has_antag_datum(/datum/antagonist/wizard)
+	if(antag_datum)
+		if(!antag_datum.wiz_team)
+			antag_datum.create_wiz_team()
+		guardian.mind.add_antag_datum(/datum/antagonist/wizard_minion, antag_datum.wiz_team)
 
 /obj/item/guardiancreator/tech
 	name = "holoparasite injector"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -246,7 +246,7 @@
 		shoot_with_empty_chamber(user)
 		return
 
-	if(check_botched(user))
+	if(check_botched(user, target))
 		return
 
 	var/obj/item/bodypart/other_hand = user.has_hand_for_held_index(user.get_inactive_hand_index()) //returns non-disabled inactive hands
@@ -268,13 +268,13 @@
 
 	return process_fire(target, user, TRUE, params, null, bonus_spread)
 
-/obj/item/gun/proc/check_botched(mob/living/user, params)
+/obj/item/gun/proc/check_botched(mob/living/user, atom/target)
 	if(clumsy_check)
 		if(istype(user))
 			if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(40))
 				to_chat(user, span_userdanger("You shoot yourself in the foot with [src]!"))
 				var/shot_leg = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-				process_fire(user, user, FALSE, params, shot_leg)
+				process_fire(user, user, FALSE, null, shot_leg)
 				SEND_SIGNAL(user, COMSIG_MOB_CLUMSY_SHOOT_FOOT)
 				user.dropItemToGround(src, TRUE)
 				return TRUE

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -103,7 +103,7 @@
 
 /obj/item/gun/magic/staff/chaos/on_intruder_use(mob/living/user)
 	if(user.anti_magic_check(TRUE, FALSE, FALSE)) // Don't let people with antimagic use the staff of chaos.
-		return TRUE
+		return FALSE
 
 	if(prob(95)) // You have a 5% chance of hitting yourself when using the staff of chaos.
 		return TRUE

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -7,6 +7,16 @@
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	item_flags = NEEDS_PERMIT | NO_MAT_REDEMPTION
 
+/obj/item/gun/magic/staff/check_botched(mob/living/user, params)
+	if(!user?.mind?.has_antag_datum(/datum/antagonist/wizard) && !user.mind.has_antag_datum(/datum/antagonist/survivalist/magic))
+		return !on_intruder_use(user)
+	return ..()
+
+/// Called when someone who isn't a wizard or magician uses this staff.
+/// Return TRUE to allow usage.
+/obj/item/gun/magic/staff/proc/on_intruder_use(mob/living/user)
+	return TRUE
+
 /obj/item/gun/magic/staff/change
 	name = "staff of change"
 	desc = "An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself."
@@ -15,6 +25,12 @@
 	icon_state = "staffofchange"
 	inhand_icon_state = "staffofchange"
 	school = SCHOOL_TRANSMUTATION
+
+/obj/item/gun/magic/staff/change/on_intruder_use(mob/living/user)
+	balloon_alert(user, ".. wabbajack")
+	user.dropItemToGround(src, TRUE)
+	process_fire(user, user, FALSE)
+	return FALSE
 
 /obj/item/gun/magic/staff/animate
 	name = "staff of animation"
@@ -33,6 +49,12 @@
 	icon_state = "staffofhealing"
 	inhand_icon_state = "staffofhealing"
 	school = SCHOOL_RESTORATION
+
+/obj/item/gun/magic/staff/healing/on_intruder_use(mob/living/user)
+	balloon_alert(user, "bzzzt!")
+	user.dropItemToGround(src, TRUE)
+	lightningbolt(user)
+	return FALSE
 
 /obj/item/gun/magic/staff/healing/handle_suicide() //Stops people trying to commit suicide to heal themselves
 	return
@@ -57,6 +79,12 @@
 /obj/item/gun/magic/staff/chaos/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	chambered.projectile_type = pick(allowed_projectile_types)
 	. = ..()
+
+/obj/item/gun/magic/staff/chaos/on_intruder_use(mob/living/user)
+	balloon_alert(user, "chaos")
+	user.dropItemToGround(src, TRUE)
+	process_fire(user, user, FALSE)
+	return FALSE
 
 /obj/item/gun/magic/staff/door
 	name = "staff of door creation"
@@ -97,6 +125,10 @@
 	sharpness = SHARP_EDGED
 	max_charges = 4
 	school = SCHOOL_EVOCATION
+
+// Spellblade is just a melee weapon to non-wizards
+/obj/item/gun/magic/staff/spellblade/on_intruder_use(mob/living/user)
+	return FALSE
 
 /obj/item/gun/magic/staff/spellblade/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -44,7 +44,7 @@
 	if(QDELETED(user) || loc != user || choice != "Yes" || user.incapacitated() || using_client != user.client)
 		return
 	user.dropItemToGround(src, TRUE)
-	var/randomize = pick("monkey","slime","humanoid","animal")
+	var/randomize = pick("monkey","humanoid","animal")
 	var/mob/new_body = user.wabbajack(randomize)
 	balloon_alert(new_body, "wabbajack, wabbajack!")
 

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -37,10 +37,16 @@
 	allow_intruder_use = TRUE
 
 /obj/item/gun/magic/staff/change/on_intruder_use(mob/living/user)
-	user.dropItemToGround(src, TRUE)
-	var/mob/new_body = user.wabbajack("animal")
-	balloon_alert(new_body, "wabbajack, wabbajack!")
+	tgui_alert_async(user, "Are you sure you want to use this? It will be used on yourself!", "Warning!", buttons = list("Yes", "No"), callback = CALLBACK(src, .proc/on_tgui_submit, user, user.client))
 	return FALSE
+
+/obj/item/gun/magic/staff/change/proc/on_tgui_submit(mob/living/user, client/using_client, choice)
+	if(QDELETED(user) || loc != user || choice != "Yes" || user.incapacitated() || using_client != user.client)
+		return
+	user.dropItemToGround(src, TRUE)
+	var/randomize = pick("monkey","slime","humanoid","animal")
+	var/mob/new_body = user.wabbajack(randomize)
+	balloon_alert(new_body, "wabbajack, wabbajack!")
 
 /obj/item/gun/magic/staff/animate
 	name = "staff of animation"

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -102,6 +102,9 @@
 	. = ..()
 
 /obj/item/gun/magic/staff/chaos/on_intruder_use(mob/living/user)
+	if(user.anti_magic_check(TRUE, FALSE, FALSE)) // Don't let people with antimagic use the staff of chaos.
+		return TRUE
+
 	if(prob(95)) // You have a 5% chance of hitting yourself when using the staff of chaos.
 		return TRUE
 	balloon_alert(user, "chaos!")

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -29,7 +29,7 @@
 /obj/item/gun/magic/staff/change/on_intruder_use(mob/living/user)
 	user.dropItemToGround(src, TRUE)
 	var/mob/new_body = user.wabbajack("animal")
-	balloon_alert(new_body, ".. wabbajack")
+	balloon_alert(new_body, "wabbajack, wabbajack!")
 	return FALSE
 
 /obj/item/gun/magic/staff/animate
@@ -51,7 +51,6 @@
 	school = SCHOOL_RESTORATION
 
 /obj/item/gun/magic/staff/healing/on_intruder_use(mob/living/user)
-	balloon_alert(user, "bzzzt!")
 	user.dropItemToGround(src, TRUE)
 	lightningbolt(user)
 	return FALSE
@@ -81,7 +80,7 @@
 	. = ..()
 
 /obj/item/gun/magic/staff/chaos/on_intruder_use(mob/living/user)
-	balloon_alert(user, "chaos")
+	balloon_alert(user, "chaos!")
 	user.dropItemToGround(src, TRUE)
 	process_fire(user, user, FALSE)
 	return FALSE

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -103,6 +103,7 @@
 
 /obj/item/gun/magic/staff/chaos/on_intruder_use(mob/living/user)
 	if(user.anti_magic_check(TRUE, FALSE, FALSE)) // Don't let people with antimagic use the staff of chaos.
+		balloon_alert(user, "the staff refuses to fire!")
 		return FALSE
 
 	if(prob(95)) // You have a 5% chance of hitting yourself when using the staff of chaos.

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -27,9 +27,9 @@
 	school = SCHOOL_TRANSMUTATION
 
 /obj/item/gun/magic/staff/change/on_intruder_use(mob/living/user)
-	balloon_alert(user, ".. wabbajack")
 	user.dropItemToGround(src, TRUE)
-	process_fire(user, user, FALSE)
+	var/mob/new_body = user.wabbajack("animal")
+	balloon_alert(new_body, ".. wabbajack")
 	return FALSE
 
 /obj/item/gun/magic/staff/animate

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -6,9 +6,16 @@
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	item_flags = NEEDS_PERMIT | NO_MAT_REDEMPTION
+	var/allow_intruder_use = FALSE
+
 
 /obj/item/gun/magic/staff/check_botched(mob/living/user, params)
-	if(!user?.mind?.has_antag_datum(/datum/antagonist/wizard) && !user.mind.has_antag_datum(/datum/antagonist/survivalist/magic))
+	if(allow_intruder_use)
+		return ..()
+
+	if(!user?.mind?.has_antag_datum(/datum/antagonist/wizard) \
+		&& !user.mind.has_antag_datum(/datum/antagonist/survivalist/magic) \
+		&& !user.mind.has_antag_datum(/datum/antagonist/wizard_minion))
 		return !on_intruder_use(user)
 	return ..()
 
@@ -25,6 +32,9 @@
 	icon_state = "staffofchange"
 	inhand_icon_state = "staffofchange"
 	school = SCHOOL_TRANSMUTATION
+
+/obj/item/gun/magic/staff/change/unrestricted
+	allow_intruder_use = TRUE
 
 /obj/item/gun/magic/staff/change/on_intruder_use(mob/living/user)
 	user.dropItemToGround(src, TRUE)
@@ -49,6 +59,9 @@
 	icon_state = "staffofhealing"
 	inhand_icon_state = "staffofhealing"
 	school = SCHOOL_RESTORATION
+
+/obj/item/gun/magic/staff/healing/unrestricted
+	allow_intruder_use = TRUE
 
 /obj/item/gun/magic/staff/healing/on_intruder_use(mob/living/user)
 	user.dropItemToGround(src, TRUE)
@@ -75,11 +88,16 @@
 	/obj/projectile/magic/bounty, /obj/projectile/magic/antimagic, /obj/projectile/magic/fetch, /obj/projectile/magic/sapping,
 	/obj/projectile/magic/necropotence, /obj/projectile/magic, /obj/projectile/temp/chill, /obj/projectile/magic/wipe)
 
+/obj/item/gun/magic/staff/chaos/unrestricted
+	allow_intruder_use = TRUE
+
 /obj/item/gun/magic/staff/chaos/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	chambered.projectile_type = pick(allowed_projectile_types)
 	. = ..()
 
 /obj/item/gun/magic/staff/chaos/on_intruder_use(mob/living/user)
+	if(prob(95)) // You have a 5% chance of hitting yourself when using the staff of chaos.
+		return TRUE
 	balloon_alert(user, "chaos!")
 	user.dropItemToGround(src, TRUE)
 	process_fire(user, user, FALSE)
@@ -124,10 +142,6 @@
 	sharpness = SHARP_EDGED
 	max_charges = 4
 	school = SCHOOL_EVOCATION
-
-// Spellblade is just a melee weapon to non-wizards
-/obj/item/gun/magic/staff/spellblade/on_intruder_use(mob/living/user)
-	return FALSE
 
 /obj/item/gun/magic/staff/spellblade/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
If you try using the staff of change, the staff of chaos, the spellblade or the staff of healing as a crewmember, then it'll backfire.
People who can use the staff normally: Apprentices, Wizards, Amateur Magician (from Summon Magic event)

Backfiring is different depending on the staff, each effect is listed below and happens when you try firing the staff.
Staff of change - Wabbajacks the imposter, although they can't become a xeno or a borg.
Staff of chaos - 5% chance to fire the staff at the imposter using it.
Staff of healing - Acts as a medibeam gun to the imposter.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Crew getting access to the Staff of Change tends to end in a lot of people becoming xenomorphs or syndicate borgs. It forces the round into a turn for the worse for all antags as xenomorphs have hardstuns, syndicate borgs have emag, greatly improved healing chemicals and powerful weaponary.
Crew getting access to the Staff of Healing results in death being irrelevant. Killing people is no longer a viable tactic as an antagonist because anyone killed, no matter how damaged their body is, can be instantly healed with this staff.
Crew getting access to the Staff of Chaos is like crew getting access to the staff of change and the staff of healing at the same time, only more unpredictable. It's better if they can't reliably use it to get the spells they want as chaos is implied in the name, it becomes russian roulette trying to get the correct bolt as you can also get shot by a bolt of death, instantly killing you.

This is a better alternative to outright removing the staffs or making them usable only by wizards as it gives a quirky use to trying to use them as a crewmember. Maybe not the staff of healing, but fuck the staff of healing.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: If you try using the staff of change, the staff of chaos or the staff of healing as a crewmember, then it'll backfire. The Staff of change wabbajacks the user, like the pool of change; this means you can't become a xenomorph or a syndicate borg. The Staff of chaos has a 5% chance of firing the bolt directly at the user using it. The Staff of healing now behaves like a medibeam gun to non-wizards trying to use it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
