### PR TITLE
Fixes space heaters working forever without draining cell charge.

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -81,7 +81,7 @@
 			on = FALSE
 		return PROCESS_KILL
 
-	if(!cell || cell.charge <= 0)
+	if(!cell || cell.charge <= 1)
 		on = FALSE
 		update_appearance()
 		return PROCESS_KILL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Just this small fix, they had a check to not drain cell charge if the consumption would be less than 1, likely to prevent them running dry too fast by constantly trying to slightly change the room's temperature.
This could result in them sitting under 1 charge and above 0, so they wouldn't consume charge or turn off, basically free and infinite heating/cooling. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I like when atmospherics work as intended.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Guillaume Prata
fix: Space Heaters won't change temperature without draining it's cell charge anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
