### PR TITLE
Make the CMO spawn with "infection resistant" shoes like everyone at medbay.

### DIFF
--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -56,7 +56,7 @@
 	l_pocket = /obj/item/pinpointer/crew
 	ears = /obj/item/radio/headset/heads/cmo
 	uniform = /obj/item/clothing/under/rank/medical/chief_medical_officer
-	shoes = /obj/item/clothing/shoes/sneakers/brown
+	shoes = /obj/item/clothing/shoes/sneakers/blue
 	suit = /obj/item/clothing/suit/toggle/labcoat/cmo
 	l_hand = /obj/item/storage/firstaid/medical
 	suit_store = /obj/item/flashlight/pen/paramedic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Everyone at medbay spawn with either the white or blue shoes, both have some resistance against infections blood.
The CMO, on the other hand starts with the brown one, which has none and makes stepping on any infected blood pool be an instant infection.
Just change them to spawn with blue shoes, following the same logic of this PR: #58652
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Right now the smartest thing to do when you spawn as CMO is to cut the gauze you start with into cloth and then making a pair of white shoes so you don't get 100% of the diseases that medbay has to deal with.
This is both repetitive and just punishes new CMOs that weren't told about this trick, as no one else on their department has to deal with the issue...

![CMO](https://user-images.githubusercontent.com/55374212/138443666-1e734f7a-fbbd-46cc-8e61-f4aabfe52878.png)
Image comparing the CMO outfit with the blue shoes as requested.
The Hardsuit hide the shoes to be clear.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Guillaume Prata
qol: CMOs will now spawn with blue shoes (Paramedic) that protect them from contracting diseases from any blood pool they step in, just like everyone else at medbay already does.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
