### PR TITLE
Basic ID cards with job trims can now hold higher level accesses to their own departments.

### DIFF
--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -355,8 +355,8 @@
 #define REGION_ACCESS_ALL_STATION COMMON_ACCESS + COMMAND_ACCESS + PRIVATE_COMMAND_ACCESS + CAPTAIN_ACCESS
 /// Name for the General region.
 #define REGION_GENERAL "General"
-/// Used to seed the accesses_by_region list in SSid_access. A list of general service accesses that are overseen by the HoP.
-#define REGION_ACCESS_GENERAL list( \
+/// Access that all members of service and other non-departmental jobs should be able to add to their standard ID cards, regardless of wildcard type.
+#define JOB_ACCESS_GENERAL list( \
 	ACCESS_KITCHEN, \
 	ACCESS_BAR, \
 	ACCESS_HYDROPONICS, \
@@ -367,10 +367,12 @@
 	ACCESS_THEATRE, \
 	ACCESS_LAWYER, \
 )
+/// Used to seed the accesses_by_region list in SSid_access. A list of general service accesses that are overseen by the HoP.
+#define REGION_ACCESS_GENERAL JOB_ACCESS_GENERAL
 /// Name for the Security region.
 #define REGION_SECURITY "Security"
-/// Used to seed the accesses_by_region list in SSid_access. A list of all security regional accesses that are overseen by the HoS.
-#define REGION_ACCESS_SECURITY list( \
+/// Access that all members of security should be able to add to their standard ID cards, regardless of wildcard type.
+#define JOB_ACCESS_SECURITY list( \
 	ACCESS_SEC_DOORS, \
 	ACCESS_WEAPONS, \
 	ACCESS_SECURITY, \
@@ -379,26 +381,28 @@
 	ACCESS_FORENSICS_LOCKERS, \
 	ACCESS_COURT, \
 	ACCESS_MECH_SECURITY, \
-	ACCESS_HOS, \
 )
+/// Used to seed the accesses_by_region list in SSid_access. A list of all security regional accesses that are overseen by the HoS.
+#define REGION_ACCESS_SECURITY (JOB_ACCESS_SECURITY + list(ACCESS_HOS))
 /// Name for the Medbay region.
 #define REGION_MEDBAY "Medbay"
-/// Used to seed the accesses_by_region list in SSid_access. A list of all medbay regional accesses that are overseen by the CMO.
-#define REGION_ACCESS_MEDBAY list( \
+/// Access that all members of medical should be able to add to their ID cards, regardless of wildcard type.
+#define JOB_ACCESS_MEDBAY list( \
 	ACCESS_MEDICAL, \
 	ACCESS_MORGUE, \
 	ACCESS_CHEMISTRY, \
 	ACCESS_VIROLOGY, \
 	ACCESS_SURGERY, \
 	ACCESS_MECH_MEDICAL, \
-	ACCESS_CMO, \
 	ACCESS_PHARMACY, \
 	ACCESS_PSYCHOLOGY, \
 )
+/// Used to seed the accesses_by_region list in SSid_access. A list of all medbay regional accesses that are overseen by the CMO.
+#define REGION_ACCESS_MEDBAY (JOB_ACCESS_MEDBAY + list(ACCESS_CMO))
 /// Name for the Research region.
 #define REGION_RESEARCH "Research"
-/// Used to seed the accesses_by_region list in SSid_access. A list of all research regional accesses that are overseen by the RD.
-#define REGION_ACCESS_RESEARCH list( \
+/// Access that all members of research/science should be able to add to their ID cards, regardless of wildcard type.
+#define JOB_ACCESS_RESEARCH list( \
 	ACCESS_RESEARCH, \
 	ACCESS_RND, \
 	ACCESS_ORDNANCE, \
@@ -407,14 +411,14 @@
 	ACCESS_ROBOTICS, \
 	ACCESS_XENOBIOLOGY, \
 	ACCESS_MECH_SCIENCE, \
-	ACCESS_MINISAT, \
-	ACCESS_RD, \
 	ACCESS_NETWORK, \
 )
+/// Used to seed the accesses_by_region list in SSid_access. A list of all research regional accesses that are overseen by the RD.
+#define REGION_ACCESS_RESEARCH (JOB_ACCESS_RESEARCH + list(ACCESS_MINISAT, ACCESS_RD))
 /// Name for the Engineering region.
 #define REGION_ENGINEERING "Engineering"
-/// Used to seed the accesses_by_region list in SSid_access. A list of all engineering regional accesses that are overseen by the CE.
-#define REGION_ACCESS_ENGINEERING list( \
+/// Access that all members of engineering should be able to add to their ID cards, regardless of wildcard type.
+#define JOB_ACCESS_ENGINEERING list( \
 	ACCESS_CONSTRUCTION, \
 	ACCESS_AUX_BASE, \
 	ACCESS_MAINT_TUNNELS, \
@@ -425,13 +429,13 @@
 	ACCESS_ATMOSPHERICS, \
 	ACCESS_MECH_ENGINE, \
 	ACCESS_TCOMSAT, \
-	ACCESS_MINISAT, \
-	ACCESS_CE, \
 )
+/// Used to seed the accesses_by_region list in SSid_access. A list of all engineering regional accesses that are overseen by the CE.
+#define REGION_ACCESS_ENGINEERING (JOB_ACCESS_ENGINEERING + list(ACCESS_MINISAT, ACCESS_CE))
 /// Name for the Supply region.
 #define REGION_SUPPLY "Supply"
-/// Used to seed the accesses_by_region list in SSid_access. A list of all cargo regional accesses that are overseen by the HoP.
-#define REGION_ACCESS_SUPPLY list( \
+/// Access that all members of supply should be able to add to their ID cards, regardless of wildcard type.
+#define JOB_ACCESS_SUPPLY list( \
 	ACCESS_MAILSORTING, \
 	ACCESS_MINING, \
 	ACCESS_MINING_STATION, \
@@ -441,6 +445,8 @@
 	ACCESS_QM, \
 	ACCESS_VAULT, \
 )
+/// Used to seed the accesses_by_region list in SSid_access. A list of all cargo regional accesses that are overseen by the HoP.
+#define REGION_ACCESS_SUPPLY JOB_ACCESS_SUPPLY
 /// Name for the Command region.
 #define REGION_COMMAND "Command"
 /// Used to seed the accesses_by_region list in SSid_access. A list of all command regional accesses that are overseen by the Captain.

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -12,5 +12,6 @@
 	/// Accesses that this trim unlocks on a card that require wildcard slots to apply. If a card cannot accept all a trim's wildcard accesses, the card is incompatible with the trim.
 	var/list/wildcard_access = list()
 
+/// Overridable proc. A list of wildcard accesses that this trim is overriding to force them to be considered ACCESS_FLAG_COMMON if applied to an ID card holding this trim.
 /datum/id_trim/proc/get_common_wildcard_overrides()
 	return list()

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -11,3 +11,6 @@
 	var/list/access = list()
 	/// Accesses that this trim unlocks on a card that require wildcard slots to apply. If a card cannot accept all a trim's wildcard accesses, the card is incompatible with the trim.
 	var/list/wildcard_access = list()
+
+/datum/id_trim/proc/get_common_wildcard_overrides()
+	return list()

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -23,6 +23,8 @@
 	var/list/template_access
 	/// The typepath to the job datum from the id_trim.
 	var/datum/job/job
+	/// List of job accesses that this trim overrides as common. If an access is in this list, it will always be added as a common wildcard to ID cards holding this trim.
+	var/list/common_access = list()
 
 /datum/id_trim/job/New()
 	if(isnull(job_changes))
@@ -48,6 +50,9 @@
 		minimal_wildcard_access |= access_changes["additional_minimal_wildcard_access"]
 
 	refresh_trim_access()
+
+/datum/id_trim/job/get_common_wildcard_overrides()
+	return common_access.Copy()
 
 /**
  * Goes through various non-map config settings and modifies the trim's access based on this.
@@ -83,6 +88,7 @@
 	config_job = "assistant"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/assistant
+	common_access = JOB_ACCESS_GENERAL
 
 /datum/id_trim/job/assistant/refresh_trim_access()
 	. = ..()
@@ -103,6 +109,7 @@
 	config_job = "atmospheric_technician"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CE, ACCESS_CHANGE_IDS)
 	job = /datum/job/atmospheric_technician
+	common_access = JOB_ACCESS_ENGINEERING
 
 /datum/id_trim/job/bartender
 	assignment = "Bartender"
@@ -112,6 +119,7 @@
 	config_job = "bartender"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/bartender
+	common_access = JOB_ACCESS_GENERAL
 
 /datum/id_trim/job/botanist
 	assignment = "Botanist"
@@ -121,6 +129,7 @@
 	config_job = "botanist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/botanist
+	common_access = JOB_ACCESS_GENERAL
 
 /datum/id_trim/job/captain
 	assignment = "Captain"
@@ -146,6 +155,7 @@
 	config_job = "cargo_technician"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/cargo_technician
+	common_access = JOB_ACCESS_SUPPLY
 
 /datum/id_trim/job/chaplain
 	assignment = "Chaplain"
@@ -155,6 +165,7 @@
 	config_job = "chaplain"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/chaplain
+	common_access = JOB_ACCESS_GENERAL
 
 /datum/id_trim/job/chemist
 	assignment = "Chemist"
@@ -164,6 +175,7 @@
 	config_job = "chemist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CMO, ACCESS_CHANGE_IDS)
 	job = /datum/job/chemist
+	common_access = JOB_ACCESS_MEDBAY
 
 /datum/id_trim/job/chief_engineer
 	assignment = "Chief Engineer"
@@ -177,6 +189,7 @@
 	config_job = "chief_engineer"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CHANGE_IDS)
 	job = /datum/job/chief_engineer
+	common_access = JOB_ACCESS_ENGINEERING
 
 /datum/id_trim/job/chief_medical_officer
 	assignment = "Chief Medical Officer"
@@ -190,6 +203,7 @@
 	config_job = "chief_medical_officer"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CHANGE_IDS)
 	job = /datum/job/chief_medical_officer
+	common_access = JOB_ACCESS_MEDBAY
 
 /datum/id_trim/job/clown
 	assignment = "Clown"
@@ -199,6 +213,7 @@
 	config_job = "clown"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/clown
+	common_access = JOB_ACCESS_GENERAL
 
 /datum/id_trim/job/cook
 	assignment = "Cook"
@@ -208,6 +223,7 @@
 	config_job = "cook"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/cook
+	common_access = JOB_ACCESS_GENERAL
 
 /datum/id_trim/job/curator
 	assignment = "Curator"
@@ -217,6 +233,7 @@
 	config_job = "curator"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/curator
+	common_access = JOB_ACCESS_GENERAL
 
 /datum/id_trim/job/detective
 	assignment = "Detective"
@@ -227,6 +244,7 @@
 	config_job = "detective"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOS, ACCESS_CHANGE_IDS)
 	job = /datum/job/detective
+	common_access = JOB_ACCESS_SECURITY
 
 /datum/id_trim/job/detective/refresh_trim_access()
 	. = ..()
@@ -246,6 +264,7 @@
 	config_job = "geneticist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_RD, ACCESS_CHANGE_IDS)
 	job = /datum/job/geneticist
+	common_access = JOB_ACCESS_RESEARCH
 
 /datum/id_trim/job/head_of_personnel
 	assignment = "Head of Personnel"
@@ -264,6 +283,10 @@
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CHANGE_IDS)
 	job = /datum/job/head_of_personnel
 
+/datum/id_trim/job/head_of_personnel/New()
+	common_access = JOB_ACCESS_GENERAL | JOB_ACCESS_SUPPLY
+	return ..()
+
 /datum/id_trim/job/head_of_security
 	assignment = "Head of Security"
 	trim_state = "trim_headofsecurity"
@@ -277,6 +300,7 @@
 	config_job = "head_of_security"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CHANGE_IDS)
 	job = /datum/job/head_of_security
+	common_access = JOB_ACCESS_SECURITY
 
 /datum/id_trim/job/head_of_security/refresh_trim_access()
 	. = ..()
@@ -296,6 +320,7 @@
 	config_job = "janitor"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/janitor
+	common_access = JOB_ACCESS_GENERAL
 
 /datum/id_trim/job/lawyer
 	assignment = "Lawyer"
@@ -305,6 +330,7 @@
 	config_job = "lawyer"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_HOS, ACCESS_CHANGE_IDS)
 	job = /datum/job/lawyer
+	common_access = JOB_ACCESS_GENERAL
 
 /datum/id_trim/job/medical_doctor
 	assignment = "Medical Doctor"
@@ -314,6 +340,7 @@
 	config_job = "medical_doctor"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CMO, ACCESS_CHANGE_IDS)
 	job = /datum/job/doctor
+	common_access = JOB_ACCESS_MEDBAY
 
 /datum/id_trim/job/mime
 	assignment = "Mime"
@@ -323,6 +350,7 @@
 	config_job = "mime"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/mime
+	common_access = JOB_ACCESS_GENERAL
 
 /datum/id_trim/job/paramedic
 	assignment = "Paramedic"
@@ -333,6 +361,7 @@
 	config_job = "paramedic"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CMO, ACCESS_CHANGE_IDS)
 	job = /datum/job/paramedic
+	common_access = JOB_ACCESS_MEDBAY
 
 /datum/id_trim/job/prisoner
 	assignment = "Prisoner"
@@ -377,6 +406,7 @@
 	config_job = "psychologist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CMO, ACCESS_CHANGE_IDS)
 	job = /datum/job/psychologist
+	common_access = JOB_ACCESS_GENERAL
 
 /datum/id_trim/job/quartermaster
 	assignment = "Quartermaster"
@@ -387,6 +417,7 @@
 	config_job = "quartermaster"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/quartermaster
+	common_access = JOB_ACCESS_SUPPLY
 
 /datum/id_trim/job/research_director
 	assignment = "Research Director"
@@ -402,6 +433,7 @@
 	config_job = "research_director"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CHANGE_IDS)
 	job = /datum/job/research_director
+	common_access = JOB_ACCESS_RESEARCH
 
 /datum/id_trim/job/roboticist
 	assignment = "Roboticist"
@@ -412,6 +444,7 @@
 	config_job = "roboticist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_RD, ACCESS_CHANGE_IDS)
 	job = /datum/job/roboticist
+	common_access = JOB_ACCESS_RESEARCH
 
 /datum/id_trim/job/scientist
 	assignment = "Scientist"
@@ -422,6 +455,7 @@
 	config_job = "scientist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_RD, ACCESS_CHANGE_IDS)
 	job = /datum/job/scientist
+	common_access = JOB_ACCESS_RESEARCH
 
 /// Sec officers have departmental variants. They each have their own trims with bonus departmental accesses.
 /datum/id_trim/job/security_officer
@@ -435,6 +469,7 @@
 	config_job = "security_officer"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOS, ACCESS_CHANGE_IDS)
 	job = /datum/job/security_officer
+	common_access = JOB_ACCESS_SECURITY
 
 /datum/id_trim/job/security_officer/refresh_trim_access()
 	. = ..()
@@ -477,6 +512,7 @@
 	config_job = "shaft_miner"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOP, ACCESS_CHANGE_IDS)
 	job = /datum/job/shaft_miner
+	common_access = JOB_ACCESS_SUPPLY
 
 /// ID card obtained from the mining Disney dollar points vending machine.
 /datum/id_trim/job/shaft_miner/spare
@@ -493,6 +529,7 @@
 	config_job = "station_engineer"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CE, ACCESS_CHANGE_IDS)
 	job = /datum/job/station_engineer
+	common_access = JOB_ACCESS_ENGINEERING
 
 /datum/id_trim/job/virologist
 	assignment = "Virologist"
@@ -502,6 +539,7 @@
 	config_job = "virologist"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_CMO, ACCESS_CHANGE_IDS)
 	job = /datum/job/virologist
+	common_access = JOB_ACCESS_MEDBAY
 
 /datum/id_trim/job/warden
 	assignment = "Warden"
@@ -512,6 +550,7 @@
 	config_job = "warden"
 	template_access = list(ACCESS_CAPTAIN, ACCESS_HOS, ACCESS_CHANGE_IDS)
 	job = /datum/job/warden
+	common_access = JOB_ACCESS_SECURITY
 
 /datum/id_trim/job/warden/refresh_trim_access()
 	. = ..()

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -174,8 +174,12 @@
 		return FALSE
 
 	var/wildcard_allocated
+	var/datum/id_trim/try_trim = ispath(trim) ? SSid_access.trim_singletons_by_path[trim] : trim
+
+	var/list/wildcard_overrides = try_trim?.get_common_wildcard_overrides()
+
 	for(var/wildcard in wildcard_list)
-		var/wildcard_flag = SSid_access.get_access_flag(wildcard)
+		var/wildcard_flag = (wildcard in wildcard_overrides) ? ACCESS_FLAG_COMMON : SSid_access.get_access_flag(wildcard)
 		wildcard_allocated = FALSE
 		for(var/flag_name in new_wildcard_limits)
 			var/limit_flags = SSid_access.wildcard_flags_by_wildcard[flag_name]
@@ -202,9 +206,13 @@
  */
 /obj/item/card/id/proc/add_wildcards(list/wildcard_list, try_wildcard = null, mode = ERROR_ON_FAIL)
 	var/wildcard_allocated
+
+	var/list/wildcard_overrides = trim?.get_common_wildcard_overrides()
+
 	// Iterate through each wildcard in our list. Get its access flag. Then iterate over wildcard slots and try to fit it in.
 	for(var/wildcard in wildcard_list)
-		var/wildcard_flag = SSid_access.get_access_flag(wildcard)
+		var/wildcard_flag = (wildcard in wildcard_overrides) ? ACCESS_FLAG_COMMON : SSid_access.get_access_flag(wildcard)
+
 		wildcard_allocated = FALSE
 		for(var/flag_name in wildcard_slots)
 			if(flag_name == WILDCARD_NAME_FORCED)

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -288,7 +288,6 @@
 
 	data["regions"] = regions
 
-
 	data["accessFlags"] = SSid_access.flags_by_access
 	data["wildcardFlags"] = SSid_access.wildcard_flags_by_wildcard
 	data["accessFlagNames"] = SSid_access.access_flag_string_by_flag
@@ -334,15 +333,18 @@
 		data["access_on_card"] = id_card.access
 		data["wildcardSlots"] = id_card.wildcard_slots
 		data["id_age"] = id_card.registered_age
+		data["commonFlag"] = ACCESS_FLAG_COMMON
 
 		if(id_card.trim)
 			var/datum/id_trim/card_trim = id_card.trim
 			data["hasTrim"] = TRUE
 			data["trimAssignment"] = card_trim.assignment ? card_trim.assignment : ""
 			data["trimAccess"] = card_trim.access ? card_trim.access : list()
+			data["trimCommonWildcardOverrides"] = card_trim.get_common_wildcard_overrides()
 		else
 			data["hasTrim"] = FALSE
 			data["trimAssignment"] = ""
 			data["trimAccess"] = list()
+			data["trimCommonWildcardOverrides"] = list()
 
 	return data

--- a/tgui/packages/tgui/interfaces/NtosCard.js
+++ b/tgui/packages/tgui/interfaces/NtosCard.js
@@ -30,7 +30,9 @@ export const NtosCardContent = (props, context) => {
     accessFlagNames,
     showBasic,
     templates = {},
-  } = data; 
+    commonFlag,
+    trimCommonWildcardOverrides = [],
+  } = data;
 
   if (!have_id_slot) {
     return (
@@ -43,6 +45,10 @@ export const NtosCardContent = (props, context) => {
   const [
     selectedTab,
   ] = useSharedState(context, "selectedTab", "login");
+
+  trimCommonWildcardOverrides.forEach(access => {
+    accessFlags[access] = commonFlag;
+  });
 
   return (
     <>

--- a/tgui/packages/tgui/interfaces/NtosCard.js
+++ b/tgui/packages/tgui/interfaces/NtosCard.js
@@ -3,6 +3,15 @@ import { Box, Button, Dropdown, Input, NoticeBox, NumberInput, Section, Stack, T
 import { NtosWindow } from '../layouts';
 import { AccessList } from './common/AccessList';
 
+const buildAccessFlags = (accessFlags, overrideAccess, commonFlag) => {
+  let finalAccessFlags = [...accessFlags];
+  for (const access of overrideAccess) {
+    finalAccessFlags[access] = commonFlag;
+  }
+
+  return finalAccessFlags;
+};
+
 export const NtosCard = (props, context) => {
   return (
     <NtosWindow
@@ -46,9 +55,12 @@ export const NtosCardContent = (props, context) => {
     selectedTab,
   ] = useSharedState(context, "selectedTab", "login");
 
-  trimCommonWildcardOverrides.forEach(access => {
-    accessFlags[access] = commonFlag;
-  });
+
+  const finalAccessFlags = buildAccessFlags(
+    accessFlags,
+    trimCommonWildcardOverrides,
+    commonFlag
+  );
 
   return (
     <>
@@ -89,7 +101,7 @@ export const NtosCardContent = (props, context) => {
                 wildcardFlags={wildcardFlags}
                 wildcardSlots={wildcardSlots}
                 trimAccess={trimAccess}
-                accessFlags={accessFlags}
+                accessFlags={finalAccessFlags}
                 accessFlagNames={accessFlagNames}
                 showBasic={!!showBasic}
                 extraButtons={


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

tl;dr - RD can now give out toxins access to genetics on skeleton and highpop, robo on highpop. CE can give station engineers atmos access on highpop. HoS can give sec officers and detectives armory access on skeleton and highpop.

Allows ID trims to override access wildcard flag types, enabling specific job trims to have access to accesses with higher level wildcard flags than before.

This allows certain command-restricted accesses such as toxins, armory or atmosphertics to be added to cards trimmed for members of that department despite the ordinary restrictions present.

For example, the CE can now give Station Engineers access to Atmospherics, the RD can give Geneticists access to Toxins and the HoS can give Sec Officers and the Det access to the Armory.

Geneticist has access to Toxins accesses as common...
![image](https://user-images.githubusercontent.com/24975989/138365390-fd0ba0b3-3d1e-4a86-913b-33f73f74986d.png)

But no access to Atmospherics or the Armory 
![image](https://user-images.githubusercontent.com/24975989/138365440-c951158b-3e66-469d-acc9-9580580a56b4.png)

While a detective has the ability to access the Armory
![image](https://user-images.githubusercontent.com/24975989/138366177-b11bf1f3-9b3e-4dc1-ae74-11abd8fdab91.png)
![image](https://user-images.githubusercontent.com/24975989/138369086-e2208d07-ee29-4c09-b482-1890eeb3dda5.png)

But no access to Toxins
![image](https://user-images.githubusercontent.com/24975989/138366200-5bac73b5-5e16-404b-919f-ca29a7d23423.png)

Or Atmospherics
![image](https://user-images.githubusercontent.com/24975989/138366216-b0de57ba-7a9e-42ad-851a-8a92ba05f4ad.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The headmins recently re-enabled the skeleton access config, which limits innate accesses on ID cards at higher populations.

ID trims were testmerged and my observations of this feature on live servers have been done with the config disabled.

Now there's more data and more player feedback, I am getting reports that Station Engineers couldn't be given Atmospherics access without a silver ID card in highpop.

This really made absolutely no sense and the CE should be able to give out atmospherics access to their departmental staff. The same holds true with the HoS and armory access or the RD and toxins access. It really is their lane.

I think this is a nice QoL tweak to address those lingering concerns with players not being able to get access to certain areas from their own departmental head.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Station Engineer trimmed ID cards can now be given Atmospherics access without needing to be Silver.
qol: Geneticist and Roboticist trimmed ID cards can now be given Ordnance (Toxins) accesses without needing to be Silver.
qol: Detective and Sec Officer trimmed ID cards can now be given Armory access without needing to be Silver.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
