### PR TITLE
Adds more roundstart food places to Tramstation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -267,6 +267,16 @@
 "abW" = (
 /turf/closed/wall,
 /area/service/lawoffice)
+"aca" = (
+/obj/structure/table/glass,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "acb" = (
 /obj/structure/ladder,
 /turf/open/floor/iron/dark,
@@ -1898,24 +1908,13 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "alB" = (
-/obj/structure/closet/secure_closet/chief_medical,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
+/obj/structure/chair/sofa/left{
+	dir = 8
 	},
-/obj/item/screwdriver,
-/obj/item/cartridge/medical{
-	pixel_x = 3
+/turf/open/floor/iron/cafeteria{
+	dir = 5
 	},
-/obj/item/cartridge/medical{
-	pixel_x = -3
-	},
-/obj/item/cartridge/chemistry{
-	pixel_y = 6
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/keycard_auth/directional/east,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
+/area/medical/break_room)
 "alD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -3374,6 +3373,10 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/item/paper{
+	info = "buy more donk pockets";
+	name = "To-Do List"
+	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "atG" = (
@@ -3626,13 +3629,12 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/entry)
 "auO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
+/area/medical/break_room)
 "auU" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/openspace,
@@ -6247,16 +6249,12 @@
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "aIQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/vending/cigarette,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
+/area/medical/break_room)
 "aIR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -7856,13 +7854,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aYp" = (
-/obj/structure/bed/dogbed/runtime,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/south,
-/mob/living/simple_animal/pet/cat/runtime,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "aYq" = (
@@ -8564,10 +8562,6 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
-"biL" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
 "biN" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10186,17 +10180,16 @@
 /turf/closed/wall,
 /area/cargo/qm)
 "bSY" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/structure/chair/sofa/right{
+	dir = 8
 	},
-/obj/machinery/requests_console/directional/east{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer's Requests Console"
+/obj/structure/sign/poster/official/help_others{
+	pixel_x = 32
 	},
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
+/turf/open/floor/iron/cafeteria{
+	dir = 5
+	},
+/area/medical/break_room)
 "bTb" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -11191,21 +11184,12 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "crT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/light/directional/south,
-/obj/machinery/camera{
-	c_tag = "Medical - Chief Medical Officer's Office";
-	dir = 1;
-	network = list("ss13","medbay")
+/obj/structure/table/glass,
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/iron/cafeteria{
+	dir = 5
 	},
-/obj/machinery/button/door/directional/south{
-	id = "cmoprivacy";
-	name = "CMO Privacy Shutters";
-	req_access_txt = "40"
-	},
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
+/area/medical/break_room)
 "csa" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/item/clothing/mask/breath,
@@ -11658,6 +11642,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"cBI" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "cBY" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -12108,6 +12101,10 @@
 	dir = 5
 	},
 /area/science/breakroom)
+"cLd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/command/heads_quarters/cmo)
 "cLf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13301,6 +13298,16 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
+"deq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchencounter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "der" = (
 /turf/closed/wall/r_wall,
 /area/science/research)
@@ -13786,6 +13793,13 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/science/research)
+"dos" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/cafeteria{
+	dir = 5
+	},
+/area/command/heads_quarters/rd)
 "dot" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 4"
@@ -13838,10 +13852,20 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dqb" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/maintenance/department/security)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/closet{
+	name = "Evidence Closet 1"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "dqx" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -14032,7 +14056,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "dtn" = (
 /obj/structure/bed,
@@ -14093,6 +14117,23 @@
 /obj/structure/cable,
 /turf/open/floor/plating/catwalk_floor,
 /area/maintenance/tram/mid)
+"dus" = (
+/obj/structure/closet/secure_closet/chief_medical,
+/obj/item/screwdriver,
+/obj/item/cartridge/medical{
+	pixel_x = 3
+	},
+/obj/item/cartridge/medical{
+	pixel_x = -3
+	},
+/obj/item/cartridge/chemistry{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "duv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14864,15 +14905,14 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "dKr" = (
-/obj/structure/chair/office/light,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
+/area/medical/break_room)
 "dKz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16214,6 +16254,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/bar)
+"eiC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "eiE" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -16881,12 +16928,15 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "etY" = (
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/effect/landmark/start/chief_medical_officer,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
+/turf/open/floor/iron/cafeteria{
+	dir = 5
+	},
+/area/medical/break_room)
 "eue" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -16948,7 +16998,7 @@
 "euW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "eve" = (
 /obj/machinery/shower{
@@ -18939,11 +18989,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
-"fiT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "fjc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -19155,7 +19200,7 @@
 	req_one_access_txt = "12;5;28"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "fof" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19691,7 +19736,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "fwC" = (
-/obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -19709,6 +19753,7 @@
 	c_tag = "Arrivals - Central Hall";
 	dir = 5
 	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/entry)
 "fwL" = (
@@ -20203,8 +20248,9 @@
 /area/commons/lounge)
 "fEG" = (
 /obj/structure/window/reinforced,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 1
+	},
 /turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
@@ -20306,11 +20352,11 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "fGs" = (
-/obj/machinery/computer/crew{
-	dir = 4
-	},
+/obj/structure/bed/dogbed/runtime,
+/mob/living/simple_animal/pet/cat/runtime,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
@@ -20549,6 +20595,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison)
+"fMc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/filingcabinet/security{
+	pixel_x = 4
+	},
+/obj/item/storage/secure/safe/directional/east,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "fMi" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -20908,6 +20967,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/item/clipboard,
+/obj/item/paper/monitorkey,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "fSd" = (
@@ -21696,7 +21757,7 @@
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/spawner/random/entertainment/drugs,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "ghE" = (
 /obj/machinery/light/small/directional/north,
@@ -22690,7 +22751,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "gCu" = (
 /obj/machinery/disposal/delivery_chute{
@@ -23541,11 +23602,18 @@
 /turf/open/floor/iron,
 /area/hallway/primary/tram/right)
 "gRW" = (
-/obj/structure/girder,
-/obj/structure/grille,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/maintenance/department/security)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/closet{
+	name = "Evidence Closet 1"
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "gSe" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -24282,6 +24350,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"hgj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "hgr" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -24460,6 +24535,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"hko" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "hks" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -25694,6 +25780,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"hIB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria{
+	dir = 5
+	},
+/area/medical/break_room)
 "hIG" = (
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -25861,7 +25958,7 @@
 "hKW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "hLp" = (
 /obj/effect/turf_decal/delivery,
@@ -27214,6 +27311,15 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/service/theater)
+"inM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "inR" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -27666,13 +27772,12 @@
 /area/security/brig)
 "iwt" = (
 /obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/folder/blue,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/neck/stethoscope,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
+/obj/machinery/microwave,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/cafeteria{
+	dir = 5
+	},
+/area/medical/break_room)
 "iwP" = (
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -29190,7 +29295,7 @@
 	req_one_access_txt = "5;28"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "iVI" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -30385,12 +30490,23 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "jyn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "cmoprivacy";
-	name = "privacy shutter"
+/obj/machinery/door/airlock/command{
+	name = "Chief Medical Officer";
+	req_access = null;
+	req_access_txt = "40"
 	},
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "jys" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -30660,6 +30776,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"jCN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "jDb" = (
 /obj/structure/table,
 /obj/item/paper/pamphlet/radstorm,
@@ -30710,6 +30833,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"jDK" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "jDM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31488,6 +31622,7 @@
 /obj/structure/table,
 /obj/item/assembly/flash/handheld,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/security/office)
 "jSE" = (
@@ -32805,6 +32940,17 @@
 	},
 /turf/open/openspace,
 /area/hallway/primary/tram/center)
+"kpw" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "kpF" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -33238,6 +33384,15 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"kzw" = (
+/obj/structure/table/glass,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/computer/security/telescreen/cmo,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "kzB" = (
 /obj/structure/sign/warning/radiation/rad_area{
 	dir = 1;
@@ -33353,12 +33508,20 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "kBV" = (
-/obj/machinery/computer/med_data{
+/obj/machinery/requests_console/directional/east{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer's Requests Console"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
+/obj/machinery/suit_storage_unit/cmo,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
 "kCh" = (
@@ -33386,6 +33549,10 @@
 /obj/effect/turf_decal/trimline/green/corner,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"kDe" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "kDu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35383,6 +35550,8 @@
 	dir = 8;
 	network = list("ss13","medbay")
 	},
+/obj/item/stack/sheet/cardboard,
+/obj/item/food/donkpocket/pizza,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "ltC" = (
@@ -35653,16 +35822,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/maint)
-"lzH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
 "lAa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36034,30 +36193,25 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "lHJ" = (
-/obj/machinery/door/airlock/command{
-	name = "Chief Medical Officer";
-	req_access = null;
-	req_access_txt = "40"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
+/obj/structure/window/reinforced/tinted/fulltile,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/medical/break_room)
 "lHL" = (
 /obj/item/crowbar/large,
 /obj/structure/rack,
 /obj/item/flashlight,
 /turf/open/floor/iron/dark,
 /area/engineering/supermatter/room)
+"lIc" = (
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "lId" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -37190,12 +37344,10 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "mfD" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/paper/monitorkey,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/modular_computer/console/preset/id,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "mfX" = (
@@ -37286,6 +37438,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/prison/mess)
+"mii" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "mim" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37555,6 +37713,8 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
+/obj/structure/table/glass,
+/obj/machinery/microwave,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "mnD" = (
@@ -37603,18 +37763,13 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "mpB" = (
-/obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/storage/secure/briefcase{
-	pixel_x = 3;
-	pixel_y = 5
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
+/turf/open/floor/iron/cafeteria{
+	dir = 5
 	},
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
+/area/medical/break_room)
 "mpT" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -38736,6 +38891,15 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"mOv" = (
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/right)
 "mOA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39067,7 +39231,7 @@
 "mUL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/assembly/mousetrap/armed,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "mUX" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -39160,6 +39324,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
+"mWo" = (
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "mWs" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -39372,6 +39539,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/security/office)
 "mZQ" = (
@@ -39440,7 +39608,7 @@
 "naC" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "naF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -39590,6 +39758,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"ncE" = (
+/turf/closed/wall/r_wall,
+/area/medical/storage)
 "ncI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron/white,
@@ -41241,6 +41412,14 @@
 /obj/structure/reagent_dispensers/peppertank/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
+"nMD" = (
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "nMG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42919,6 +43098,16 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter)
+"osX" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "otb" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
@@ -43375,6 +43564,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/catwalk_floor,
 /area/hallway/primary/tram/left)
+"oBr" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "oBs" = (
 /obj/effect/turf_decal/siding/thinplating,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -43510,6 +43705,16 @@
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"oEw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "oEz" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -45668,6 +45873,8 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
+/obj/structure/table/glass,
+/obj/item/storage/box/donkpockets/donkpocketspicy,
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "pwt" = (
@@ -46080,6 +46287,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"pCD" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "pCN" = (
 /obj/structure/fluff/tram_rail/anchor,
 /turf/open/openspace,
@@ -46956,6 +47172,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"pRp" = (
+/obj/machinery/door/airlock/medical{
+	name = "Break Room";
+	req_access_txt = "5"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/cafeteria{
+	dir = 5
+	},
+/area/medical/break_room)
 "pRt" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -47038,11 +47268,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
-"pSQ" = (
-/obj/item/assembly/mousetrap/armed,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/maintenance/department/security)
 "pSS" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -47100,8 +47325,8 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "pTN" = (
-/obj/machinery/computer/secure_data,
 /obj/machinery/newscaster/security_unit/directional/north,
+/obj/machinery/modular_computer/console/preset/id,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/hos)
 "pTP" = (
@@ -47432,6 +47657,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/security/prison/safe)
+"qcw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "qcA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -47467,6 +47701,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"qdh" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "qdu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -48287,6 +48531,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/tram/mid)
+"qtJ" = (
+/obj/machinery/computer/med_data{
+	dir = 4
+	},
+/obj/machinery/keycard_auth/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "qtK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -50015,6 +50269,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"rgi" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "rgk" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -50727,6 +50987,17 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/plating,
 /area/maintenance/tram/right)
+"rwB" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/left)
 "rwK" = (
 /obj/machinery/computer/message_monitor{
 	dir = 1
@@ -51526,7 +51797,7 @@
 "rNY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/crowbar,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "rOb" = (
 /obj/structure/closet/crate,
@@ -51903,6 +52174,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/library)
+"rUv" = (
+/obj/effect/turf_decal/trimline/yellow/warning,
+/obj/structure/railing,
+/obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw{
+	dir = 1
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "rUD" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
@@ -52544,15 +52824,14 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "sgi" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Security Maintenance";
-	req_access_txt = "1"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating/catwalk_floor,
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_one_access_txt = "1;4"
+	},
+/turf/open/floor/iron/dark,
 /area/security/office)
 "shw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53204,9 +53483,16 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "sva" = (
-/obj/machinery/suit_storage_unit/cmo,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
@@ -54159,6 +54445,12 @@
 /obj/item/banner/cargo/mundane,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"sPO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "sPP" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -54598,10 +54890,15 @@
 /turf/open/floor/iron/smooth,
 /area/maintenance/port/aft)
 "sWU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/wrench,
-/turf/open/floor/iron/smooth,
-/area/maintenance/department/security)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/closet{
+	name = "Evidence Closet 1"
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "sXa" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -55466,13 +55763,15 @@
 "tmv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	name = "sorting disposal pipe (Medical)";
+	sortType = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "tmw" = (
@@ -56272,20 +56571,11 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "tBe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/cafeteria{
 	dir = 5
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
+/area/medical/break_room)
 "tBr" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two";
@@ -56538,7 +56828,7 @@
 "tFt" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "tFu" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -56790,14 +57080,15 @@
 /turf/open/floor/iron/smooth,
 /area/maintenance/central)
 "tKi" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/item/clipboard,
-/obj/machinery/computer/security/telescreen/cmo,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/cafeteria{
+	dir = 5
+	},
+/area/medical/break_room)
 "tKy" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -57920,12 +58211,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/office)
-"ufz" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/vending/wallmed/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/cmo)
 "ufF" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Quartermaster";
@@ -59803,16 +60088,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
-"uPw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "uPQ" = (
 /obj/structure/table,
 /obj/item/radio/intercom/directional/east{
@@ -60750,11 +61025,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
-"voF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "voW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -61124,6 +61394,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/tram/center)
+"vwk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "vxi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61203,7 +61482,7 @@
 "vzm" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "vzr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -61278,6 +61557,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"vAB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "vAW" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -61943,10 +62227,17 @@
 /turf/open/floor/iron,
 /area/security/checkpoint)
 "vNf" = (
-/obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/maintenance/department/security)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/closet{
+	name = "Evidence Closet 1"
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "vNg" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -62783,6 +63074,17 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"weh" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera{
+	c_tag = "Medical - Chief Medical Officer's Office";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "wei" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63076,6 +63378,23 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"wlc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet{
+	name = "Evidence Closet 1"
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "wld" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/exit)
@@ -63183,6 +63502,13 @@
 /obj/machinery/recharger,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"wnQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "woj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -63347,6 +63673,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating/catwalk_floor,
 /area/maintenance/central)
+"wqA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "interro-court"
+	},
+/obj/structure/cable,
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_one_access_txt = "1;4"
+	},
+/turf/open/floor/plating/catwalk_floor,
+/area/security/office)
 "wqL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
@@ -63547,6 +63886,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"wup" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/arrow_ccw,
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron,
+/area/hallway/primary/tram/center)
 "wux" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
 	dir = 8
@@ -63957,7 +64307,7 @@
 "wyP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "wyR" = (
 /obj/structure/cable/multilayer/multiz,
@@ -64061,13 +64411,12 @@
 "wBy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8;
+	name = "sorting disposal pipe (CMO's Office)";
+	sortType = 10
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wBA" = (
@@ -65157,10 +65506,6 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"wWF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "wWJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -66524,11 +66869,6 @@
 "xvh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	name = "sorting disposal pipe (Medical)";
-	sortType = 9
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -66882,6 +67222,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"xAM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/cmo)
 "xAZ" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67956,7 +68303,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/four,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/maintenance/department/medical)
 "xWu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -155236,7 +155583,7 @@ vUA
 azB
 qbg
 axX
-aBy
+rwB
 pPM
 aFj
 aJV
@@ -157286,7 +157633,7 @@ lCs
 lCs
 jfn
 avc
-awT
+lIc
 axX
 vUA
 azB
@@ -160076,9 +160423,9 @@ ksf
 mGs
 xKB
 bcm
-uyA
-bKx
-pSQ
+sPO
+wlc
+sWU
 sWU
 xNY
 xNY
@@ -160333,12 +160680,12 @@ bcm
 hKu
 bcm
 bcm
-uyA
-uyA
-uyA
-uyA
-uyA
-sCm
+jCN
+wnQ
+hgj
+sPO
+sPO
+wqA
 wHc
 wei
 aqT
@@ -160590,11 +160937,11 @@ aRN
 xXs
 aRN
 bcm
-bKx
+fMc
 dqb
 gRW
 vNf
-kaL
+bcm
 aFF
 bdJ
 kjY
@@ -160846,12 +161193,12 @@ dhe
 aBM
 aBM
 aBM
-kaL
-kaL
-kaL
-kaL
-kaL
-kaL
+bcm
+bcm
+bcm
+bcm
+bcm
+bcm
 aFF
 aFF
 wZv
@@ -163231,11 +163578,11 @@ lnE
 kGh
 xxq
 snA
-dhe
-dhe
-dhe
-dhe
-dhe
+eIq
+eIq
+eIq
+eIq
+eIq
 dhe
 dhe
 dhe
@@ -163487,12 +163834,12 @@ dFW
 qVt
 xpj
 lwr
-snA
-dhe
-dhe
-dhe
-dhe
-dhe
+ncE
+qtJ
+osX
+cBI
+dus
+eIq
 dhe
 dhe
 dhe
@@ -163744,11 +164091,11 @@ nEg
 bxX
 ozN
 aIK
-snA
-dhe
-dhe
-dhe
-dhe
+ncE
+oBr
+rgi
+mWo
+nMD
 qLi
 qLi
 qLi
@@ -164001,11 +164348,11 @@ fwO
 fqI
 eZx
 sFG
-snA
-dhe
-dhe
-dhe
-dhe
+ncE
+kzw
+nUt
+aca
+weh
 qLi
 xlH
 qto
@@ -164258,11 +164605,11 @@ vHS
 aTC
 fed
 snA
-snA
-dhe
-dhe
-dhe
-dhe
+ncE
+xAM
+qdh
+vAB
+eiC
 qLi
 lgb
 mVs
@@ -164511,16 +164858,16 @@ akY
 dFl
 dFl
 dFl
-twk
+pCD
 tmv
+qcw
 mKP
-nbz
-eIq
-eIq
-eIq
-eIq
-eIq
-eIq
+cLd
+oBr
+mii
+mWo
+kDe
+qLi
 lgb
 mVs
 mVs
@@ -164768,16 +165115,16 @@ tpn
 tpn
 tpn
 tpn
-tpn
+inM
 xvh
 wBy
-mKP
+jDK
 jyn
 sva
 kBV
 fGs
 aYp
-eIq
+qLi
 lgb
 mVs
 mVs
@@ -165029,12 +165376,12 @@ qIq
 ioz
 cvc
 xCV
-jyn
-lzH
-biL
-biL
-ufz
 eIq
+eIq
+eIq
+eIq
+eIq
+qLi
 lgb
 mVs
 mVs
@@ -165285,13 +165632,13 @@ uht
 aJd
 qIq
 kev
-uPw
+xCV
 lHJ
 tBe
 mpB
 iwt
 crT
-eIq
+qLi
 hHw
 mVs
 mXp
@@ -165516,7 +165863,7 @@ bWo
 hdO
 cdx
 mph
-aBR
+wup
 ggq
 aFf
 nbz
@@ -165541,14 +165888,14 @@ elV
 uht
 uht
 pTk
-cvc
-xCV
-jyn
+vwk
+kpw
+pRp
 dKr
-nUt
+hIB
 etY
 auO
-eIq
+qLi
 lgb
 mVs
 kvO
@@ -165800,12 +166147,12 @@ uht
 tlz
 cvc
 xCV
-jyn
+lHJ
 aIQ
 tKi
 bSY
 alB
-eIq
+qLi
 lgb
 mVs
 eyR
@@ -166057,12 +166404,12 @@ uht
 uDV
 cvc
 xCV
-eIq
-eIq
-eIq
-eIq
-eIq
-eIq
+qLi
+qLi
+qLi
+qLi
+qLi
+qLi
 lgb
 mVs
 eyR
@@ -167039,7 +167386,7 @@ bUO
 cpO
 oqy
 gSy
-abq
+deq
 meK
 gul
 tqq
@@ -167566,7 +167913,7 @@ xwL
 xwL
 wgv
 sLw
-axr
+rUv
 lIu
 bWo
 qLb
@@ -168861,7 +169208,7 @@ avn
 avn
 aaI
 lbM
-wWF
+gaa
 lbM
 irj
 cMw
@@ -169118,7 +169465,7 @@ avn
 ghE
 ujw
 lbM
-wWF
+gaa
 iVt
 wZq
 cAF
@@ -169386,7 +169733,7 @@ irj
 eVQ
 uMO
 arO
-bNo
+oEw
 aeA
 aeT
 lbM
@@ -169632,7 +169979,7 @@ avn
 avn
 giY
 lbM
-wWF
+gaa
 lbM
 uyN
 pJm
@@ -169889,7 +170236,7 @@ avn
 qhE
 ujw
 lbM
-wWF
+gaa
 lbM
 iTC
 mIG
@@ -170146,7 +170493,7 @@ avn
 avn
 ujZ
 lbM
-wWF
+gaa
 lbM
 irj
 uqs
@@ -170403,7 +170750,7 @@ ayd
 jpW
 aRN
 lbM
-wWF
+gaa
 lbM
 lbM
 lbM
@@ -170412,9 +170759,9 @@ eVQ
 irj
 muI
 lbM
-wWF
-wWF
-fiT
+gaa
+gaa
+pxX
 ebJ
 sbZ
 sbZ
@@ -170660,22 +171007,22 @@ ayd
 jpW
 aRN
 lbM
-wWF
-wWF
+gaa
+gaa
 vzm
-wWF
+gaa
 lbM
 rkb
 irj
 irj
 lbM
-wWF
+gaa
 lbM
 lbM
 cst
 lbM
 lbM
-voF
+eOU
 hce
 siX
 wao
@@ -170920,19 +171267,19 @@ lbM
 lbM
 lbM
 lbM
-wWF
+gaa
 lbM
 uZV
 vni
 eJo
 lbM
-wWF
+gaa
 lbM
 hKW
 rXH
 mgW
 lbM
-wWF
+gaa
 hce
 mtB
 btO
@@ -171177,13 +171524,13 @@ aBM
 aBM
 dhe
 lbM
-wWF
+gaa
 lbM
 lbM
 lbM
 lbM
 lbM
-wWF
+gaa
 lbM
 ghn
 euW
@@ -171435,12 +171782,12 @@ aBM
 aBM
 lbM
 tFt
-voF
-wWF
-wWF
-wWF
+eOU
+gaa
+gaa
+gaa
 dtc
-wWF
+gaa
 lbM
 lbM
 lbM
@@ -171705,9 +172052,9 @@ dhe
 lbM
 wyP
 jOR
-wWF
+gaa
 mUL
-wWF
+gaa
 kOx
 lbM
 hce
@@ -175796,7 +176143,7 @@ omi
 aAQ
 ujT
 ayt
-aCs
+hko
 aEd
 raJ
 bJd
@@ -177360,7 +177707,7 @@ jrL
 fBa
 iVS
 lev
-lev
+dos
 lev
 dcy
 fBa
@@ -177846,7 +178193,7 @@ xtb
 xtb
 aun
 rLa
-axM
+mOv
 ayt
 omi
 aAQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a couple more snack vendors in public-access areas and gives each department some roundstart basic food as typically seen in other maps (donuts for sec, donk pockets in break rooms, ect).
Security now has an evidence room to the right of their main brig room.
Medical now has a small break room beside the CMO's office.
The most far-left and far-right docks of the central wing have some public-access snack/cigarette vendors to encourage people to leave their departments when the junk food in their department runs out.

## Why It's Good For The Game

Gives slightly more reasonable access to junkfood on the map, something that was lacking. Also gives some department members a reason to leave their department more and visit other wings for basic shit.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: MMMiracles
add: Tramstation now has stocked the various departments with either a basic break room or basic starter food to give a growing crew what they need to stay healthy.
add: Some extra public-access vendors for junkfood and cigarettes have been added to the public halls of Tramstation.
add: Security now has an evidence room to store confiscated things.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

![image](https://user-images.githubusercontent.com/9276171/138378583-5667aff7-204e-43a4-a549-bbf03174fa90.png)

