### PR TITLE
Roulette wheels now say instead of magically cause text to appear

### DIFF
--- a/code/game/machinery/roulette_machine.dm
+++ b/code/game/machinery/roulette_machine.dm
@@ -126,7 +126,7 @@
 		if(my_card)
 			var/obj/item/card/id/player_card = W
 			if(player_card.registered_account.account_balance < chosen_bet_amount) //Does the player have enough funds
-				audible_message(span_warning("You do not have the funds to play! Lower your bet or get more money."))
+				say("You do not have the funds to play! Lower your bet or get more money.")
 				playsound(src, 'sound/machines/buzz-two.ogg', 30, TRUE)
 				return FALSE
 			if(!chosen_bet_amount || isnull(chosen_bet_type))
@@ -223,14 +223,14 @@
 	var/color = numbers["[rolled_number]"] //Weird syntax, but dict uses strings.
 	var/result = "[rolled_number] [color]" //e.g. 31 black
 
-	audible_message(span_notice("The result is: [result]"))
+	say("The result is: [result]")
 
 	playing = FALSE
 	update_icon(ALL, potential_payout, color, rolled_number, is_winner)
 	handle_color_light(color)
 
 	if(!is_winner)
-		audible_message(span_warning("You lost! Better luck next time"))
+		say("You lost! Better luck next time")
 		playsound(src, 'sound/machines/synth_no.ogg', 50)
 		return FALSE
 
@@ -238,7 +238,7 @@
 	var/account_balance = my_card?.registered_account?.account_balance
 	potential_payout = (account_balance >= potential_payout) ? potential_payout : account_balance
 
-	audible_message(span_notice("You have won [potential_payout] credits! Congratulations!"))
+	say("You have won [potential_payout] credits! Congratulations!")
 	playsound(src, 'sound/machines/synth_yes.ogg', 50)
 
 	dispense_prize(potential_payout)
@@ -343,7 +343,7 @@
 /obj/machinery/roulette/proc/check_bartender_funds(payout)
 	if(my_card.registered_account.account_balance >= payout)
 		return TRUE //We got the betting amount
-	audible_message(span_warning("The bank account of [my_card.registered_account.account_holder] does not have enough funds to pay out the potential prize, contact them to fill up their account or lower your bet!"))
+	say("The bank account of [my_card.registered_account.account_holder] does not have enough funds to pay out the potential prize, contact them to fill up their account or lower your bet!")
 	playsound(src, 'sound/machines/buzz-two.ogg', 30, TRUE)
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Small change, makes roulette wheels say their actions, rather than magically have text appear.
This also means it will now show up on runechat.

## Why It's Good For The Game

It's a visible message to everyone, but talks like it's directed at one person, so this should be a say instead of random text that appears on everyone's screen. Makes more sense & it can use runechat now, which is nice.

## Changelog

:cl:
qol: Roulette Wheels now say their actions, rather than have it magically appear in the chat box of everyone nearby.
/:cl: