### PR TITLE
Adds autoscrolling to scrollable TGUI sections (starting with NTOS Chat)

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -20,7 +20,7 @@
 	var/username
 	var/active_channel
 	var/list/channel_history = list()
-	var/operator_mode = FALSE // Channel operator mode
+	var/auto_scroll = TRUE // When true will force the scrollable chat to stick to the bottom
 	var/netadmin_mode = FALSE // Administrator mode (invisible to other users + bypasses passwords)
 	//A list of all the converstations we're a part of
 	var/list/datum/ntnet_conversation/conversations = list()
@@ -171,6 +171,9 @@
 			var/datum/computer_file/program/chatclient/pinged = locate(params["ref"]) in channel.active_clients + channel.offline_clients
 			channel.ping_user(src, pinged)
 			return TRUE
+		if("PRG_auto_scroll")
+			auto_scroll = !auto_scroll
+			return TRUE
 
 /datum/computer_file/program/chatclient/process_tick()
 	. = ..()
@@ -225,7 +228,7 @@
 				"id" = conv.id
 			)))
 	data["all_channels"] = all_channels
-
+	data["auto_scroll"] = auto_scroll
 	data["active_channel"] = active_channel
 	data["selfref"] = REF(src) //used to verify who is you, as usernames can be copied.
 	data["username"] = username

--- a/tgui/packages/tgui/components/Section.tsx
+++ b/tgui/packages/tgui/components/Section.tsx
@@ -46,7 +46,9 @@ export class Section extends Component<SectionProps> {
   }
 
   componentDidUpdate() {
-    if (this.props.autoScrolling && this.scrollableRef.current) {
+    if (this.scrollable
+      && this.props.autoScrolling
+      && this.scrollableRef.current) {
       this.scrollableRef.current
         .scrollTop = this.scrollableRef.current.scrollHeight;
     }

--- a/tgui/packages/tgui/components/Section.tsx
+++ b/tgui/packages/tgui/components/Section.tsx
@@ -16,6 +16,7 @@ interface SectionProps extends BoxProps {
   fill?: boolean;
   fitted?: boolean;
   scrollable?: boolean;
+  autoScrolling?: boolean;
   /** @deprecated This property no longer works, please remove it. */
   level?: boolean;
   /** @deprecated Please use `scrollable` property */
@@ -41,6 +42,13 @@ export class Section extends Component<SectionProps> {
   componentWillUnmount() {
     if (this.scrollable) {
       removeScrollableNode(this.scrollableRef.current);
+    }
+  }
+
+  componentDidUpdate() {
+    if (this.props.autoScrolling && this.scrollableRef.current) {
+      this.scrollableRef.current
+        .scrollTop = this.scrollableRef.current.scrollHeight;
     }
   }
 

--- a/tgui/packages/tgui/interfaces/NtosNetChat.js
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.js
@@ -66,6 +66,7 @@ export const NtosNetChat = (props, context) => {
     is_operator,
     strong,
     selfref,
+    auto_scroll,
     all_channels = [],
     clients = [],
     messages = [],
@@ -154,7 +155,7 @@ export const NtosNetChat = (props, context) => {
           <Stack.Item grow={5}>
             <Stack vertical fill>
               <Stack.Item grow>
-                <Section scrollable fill>
+                <Section scrollable autoScrolling={!!auto_scroll} fill>
                   {in_channel && (
                     authorized ? (
                       messages.map(message => (
@@ -255,6 +256,13 @@ export const NtosNetChat = (props, context) => {
                     </Section>
                   </Stack.Item>
                   <Section>
+                    <Stack.Item>
+                      <Button.Checkbox
+                        checked={auto_scroll}
+                        onClick={() => act('PRG_auto_scroll')}>
+                        Auto scroll chat
+                      </Button.Checkbox>
+                    </Stack.Item>
                     <Stack.Item mb="8px">
                       Settings for {title}:
                     </Stack.Item>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds some logic to `<Section scrollable>` for a new `autoScrolling` property that can be toggled on the fly to force components to scroll to the bottom after they are updated.

My first implementation uses a button that must be manually toggled in order to stop the autoscrolling fighting you on every update call so that you may scroll up. If I knew how to easily make that toggle switch automatically based on like scroll inputs or had infinite time to figure that out I would gladly have done so. I hope someone with more front-end/tgui knowledge will improve it later, but this is better than not having it as we do now IMHO.

Also I deleted the defunct `operator_mode` var so nobody else falls victim to it like I did thinking it actually does something.
 
## Why It's Good For The Game

QOL good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Added autoscrolling functionality to scrollable sections and implemented for NTOS Chat Clients.
code: Removed an unused var from the the NTOS Chat Client.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
