### PR TITLE
Engineers can once again use the SM air alarm

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -36873,9 +36873,12 @@
 	dir = 8;
 	network = list("ss13","engine")
 	},
-/obj/machinery/airalarm/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/airalarm/engine{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "lcF" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6999,8 +6999,11 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/meter,
-/obj/machinery/airalarm/directional/south,
 /obj/structure/cable,
+/obj/machinery/airalarm/engine{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "aQw" = (


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Supermatter Chamber typically uses a specialized air alarm that starts unlocked, and can be locked/unlocked with `ACCESS_ENGINE` as well as `ACCESS_ATMOSPHERICS`.

However, tramstation and MetaStation both used the generic directional air alarm instead of the specialized `airalarm/engine`. Delta, IceBox, and Kilo all already used the `airalarm/engine` variant.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Engineers never setting up the SM isn't totally a meme

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: The SM air alarm on MetaStation and TramStation once again starts unlocked, and can also be locked and unlocked by Engineers instead of just Atmospherics Technicians. This matches the setup on Delta, IceBox, and Kilo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
