### PR TITLE
Adds The Secret Brainwashing Technique-Chip

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -397,6 +397,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_KNOW_CYBORG_WIRES "know_cyborg_wires"
 #define TRAIT_KNOW_ENGI_WIRES "know_engi_wires"
 #define TRAIT_ENTRAILS_READER "entrails_reader"
+/// this skillchip trait lets you wash brains in washing machines to heal them
 #define TRAIT_BRAINWASHING "brainwashing"
 
 ///Movement type traits for movables. See elements/movetype_handler.dm

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -397,6 +397,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_KNOW_CYBORG_WIRES "know_cyborg_wires"
 #define TRAIT_KNOW_ENGI_WIRES "know_engi_wires"
 #define TRAIT_ENTRAILS_READER "entrails_reader"
+#define TRAIT_BRAINWASHING "brainwashing"
 
 ///Movement type traits for movables. See elements/movetype_handler.dm
 #define TRAIT_MOVE_GROUND "move_ground"

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -320,6 +320,7 @@ GLOBAL_LIST_INIT(rarity_loot, list(//rare: really good items
 		/obj/item/book/granter/crafting_recipe/pipegun_prime = 1,
 		/obj/item/book/granter/crafting_recipe/trash_cannon = 1,
 		/obj/item/tattoo_kit = 1,
+		/obj/item/skillchip/brainwashing = 1,
 		) = 1,
 
 ))

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -180,6 +180,8 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		AM.wash(CLEAN_WASH)
 		AM.machine_wash(src)
 
+	//if we had the ability to brainwash, remove that now
+	REMOVE_TRAIT(src, TRAIT_BRAINWASHING, SKILLCHIP_TRAIT)
 	busy = FALSE
 	if(color_source)
 		qdel(color_source)
@@ -362,6 +364,8 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		to_chat(user, span_warning("[src] must be cleaned up first!"))
 		return SECONDARY_ATTACK_CONTINUE_CHAIN
 	busy = TRUE
+	if(HAS_TRAIT(user, TRAIT_BRAINWASHING))
+		ADD_TRAIT(src, TRAIT_BRAINWASHING, SKILLCHIP_TRAIT)
 	update_appearance()
 	addtimer(CALLBACK(src, .proc/wash_cycle), 20 SECONDS)
 	START_PROCESSING(SSfastprocess, src)

--- a/code/modules/library/skill_learning/skillchip.dm
+++ b/code/modules/library/skill_learning/skillchip.dm
@@ -433,3 +433,21 @@
 	skill_icon = "lungs"
 	activate_message = "<span class='notice'>You feel that you know a lot about interpreting organs.</span>"
 	deactivate_message = "<span class='notice'>Knowledge of liver damage, heart strain and lung scars fades from your mind.</span>"
+
+/obj/item/skillchip/brainwashing
+	name = "suspicious skillchip"
+	auto_traits = list(TRAIT_BRAINWASHING)
+	skill_name = "Brainwashing"
+	skill_description = "WARNING: The integrity of this chip is compromised. Please discard this skillchip."
+	skill_icon = "soap"
+	activate_message = span_notice("...But all at once it comes to you... something involving putting a brain in a washing machine?")
+	deactivate_message = span_warning("All knowledge of the secret brainwashing technique is GONE.")
+
+/obj/item/skillchip/brainwashing/examine(mob/user)
+	. = ..()
+	. += span_warning("It seems to have been corroded over time, putting this in your head may not be the best idea...")
+
+/obj/item/skillchip/brainwashing/on_activate(mob/living/carbon/user, silent = FALSE)
+	to_chat(user, span_danger("You get a pounding headache as the chip sends corrupt memories into your head!"))
+	user.adjustOrganLoss(ORGAN_SLOT_BRAIN, 20)
+	. = ..()

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -307,8 +307,7 @@
 		setOrganDamage(0)
 		cure_all_traumas(TRAUMA_RESILIENCE_SURGERY)
 	else
-		qdel(src)
-		new /obj/effect/gibspawner/generic(brainwasher.loc)
+		setOrganDamage(BRAIN_DAMAGE_DEATH)
 
 /obj/item/organ/brain/alien
 	name = "alien brain"

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -301,6 +301,15 @@
 	// Any skillchips has been transferred over, time to empty the list.
 	LAZYCLEARLIST(skillchips)
 
+/obj/item/organ/brain/machine_wash(obj/machinery/washing_machine/brainwasher)
+	. = ..()
+	if(HAS_TRAIT(brainwasher, TRAIT_BRAINWASHING))
+		setOrganDamage(0)
+		cure_all_traumas(TRAUMA_RESILIENCE_SURGERY)
+	else
+		qdel(src)
+		new /obj/effect/gibspawner/generic(brainwasher.loc)
+
 /obj/item/organ/brain/alien
 	name = "alien brain"
 	desc = "We barely understand the brains of terrestial animals. Who knows what we may find in the brain of such an advanced species?"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a skillchip found in maint that lets you put brains in washing machines, and scrub em back into good health. Brains now get maximum damage if put in a washing machine OTHERWISE.

VERY heavily inspired by this video:
https://www.youtube.com/watch?v=88po7PY14E8

## Why It's Good For The Game

stupid, fun, innocent round gimmick you can find in maint. Guys, do you realize how fun this misc pool is specifically?

I mean this isn't really fully related but the misc item pool in the rare maint loot is the best random pool of items in the game. Each one is amazing.
![image](https://user-images.githubusercontent.com/40974010/138542808-cf68bf6a-f05b-45fd-9898-c3edf155337e.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added a rare skillchip to maint.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
