### PR TITLE
Washing machines can now shrink old t-shirts.

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -234,12 +234,12 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	qdel(src)
 
 /mob/living/simple_animal/pet/machine_wash(obj/machinery/washing_machine/washer)
-	Washer.bloody_mess = TRUE
+	washer.bloody_mess = TRUE
 	gib()
 
 /obj/item/machine_wash(obj/machinery/washing_machine/washer)
-	if(Washer.color_source)
-		dye_item(Washer.color_source.dye_color)
+	if(washer.color_source)
+		dye_item(washer.color_source.dye_color)
 
 /obj/item/clothing/under/dye_item(dye_color, dye_key)
 	. = ..()
@@ -256,7 +256,7 @@ GLOBAL_LIST_INIT(dye_registry, list(
 
 /obj/item/clothing/head/mob_holder/machine_wash(obj/machinery/washing_machine/washer)
 	..()
-	held_mob.machine_wash(Washer)
+	held_mob.machine_wash(washer)
 
 /obj/item/clothing/shoes/sneakers/machine_wash(obj/machinery/washing_machine/washer)
 	if(chained)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -222,24 +222,24 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	return target_type //successfully "appearance copy" dyed something; returns the target type as a hacky way of extending
 
 //what happens to this object when washed inside a washing machine
-/atom/movable/proc/machine_wash(obj/machinery/washing_machine/WM)
+/atom/movable/proc/machine_wash(obj/machinery/washing_machine/Washer)
 	return
 
-/obj/item/stack/sheet/hairlesshide/machine_wash(obj/machinery/washing_machine/WM)
+/obj/item/stack/sheet/hairlesshide/machine_wash(obj/machinery/washing_machine/Washer)
 	new /obj/item/stack/sheet/wethide(drop_location(), amount)
 	qdel(src)
 
-/obj/item/clothing/suit/hooded/ian_costume/machine_wash(obj/machinery/washing_machine/WM)
+/obj/item/clothing/suit/hooded/ian_costume/machine_wash(obj/machinery/washing_machine/Washer)
 	new /obj/item/food/meat/slab/corgi(loc)
 	qdel(src)
 
-/mob/living/simple_animal/pet/machine_wash(obj/machinery/washing_machine/WM)
-	WM.bloody_mess = TRUE
+/mob/living/simple_animal/pet/machine_wash(obj/machinery/washing_machine/Washer)
+	Washer.bloody_mess = TRUE
 	gib()
 
-/obj/item/machine_wash(obj/machinery/washing_machine/WM)
-	if(WM.color_source)
-		dye_item(WM.color_source.dye_color)
+/obj/item/machine_wash(obj/machinery/washing_machine/Washer)
+	if(Washer.color_source)
+		dye_item(Washer.color_source.dye_color)
 
 /obj/item/clothing/under/dye_item(dye_color, dye_key)
 	. = ..()
@@ -249,16 +249,16 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		if(!can_adjust && adjusted) //we deadjust the uniform if it's now unadjustable
 			toggle_jumpsuit_adjust()
 
-/obj/item/clothing/under/machine_wash(obj/machinery/washing_machine/WM)
+/obj/item/clothing/under/machine_wash(obj/machinery/washing_machine/Washer)
 	freshly_laundered = TRUE
 	addtimer(VARSET_CALLBACK(src, freshly_laundered, FALSE), 5 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE)
 	..()
 
-/obj/item/clothing/head/mob_holder/machine_wash(obj/machinery/washing_machine/WM)
+/obj/item/clothing/head/mob_holder/machine_wash(obj/machinery/washing_machine/Washer)
 	..()
 	held_mob.machine_wash(WM)
 
-/obj/item/clothing/shoes/sneakers/machine_wash(obj/machinery/washing_machine/WM)
+/obj/item/clothing/shoes/sneakers/machine_wash(obj/machinery/washing_machine/Washer)
 	if(chained)
 		chained = FALSE
 		slowdown = SHOES_SLOWDOWN

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -256,7 +256,7 @@ GLOBAL_LIST_INIT(dye_registry, list(
 
 /obj/item/clothing/head/mob_holder/machine_wash(obj/machinery/washing_machine/Washer)
 	..()
-	held_mob.machine_wash(WM)
+	held_mob.machine_wash(Washer)
 
 /obj/item/clothing/shoes/sneakers/machine_wash(obj/machinery/washing_machine/Washer)
 	if(chained)

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -222,22 +222,22 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	return target_type //successfully "appearance copy" dyed something; returns the target type as a hacky way of extending
 
 //what happens to this object when washed inside a washing machine
-/atom/movable/proc/machine_wash(obj/machinery/washing_machine/Washer)
+/atom/movable/proc/machine_wash(obj/machinery/washing_machine/washer)
 	return
 
-/obj/item/stack/sheet/hairlesshide/machine_wash(obj/machinery/washing_machine/Washer)
+/obj/item/stack/sheet/hairlesshide/machine_wash(obj/machinery/washing_machine/washer)
 	new /obj/item/stack/sheet/wethide(drop_location(), amount)
 	qdel(src)
 
-/obj/item/clothing/suit/hooded/ian_costume/machine_wash(obj/machinery/washing_machine/Washer)
+/obj/item/clothing/suit/hooded/ian_costume/machine_wash(obj/machinery/washing_machine/washer)
 	new /obj/item/food/meat/slab/corgi(loc)
 	qdel(src)
 
-/mob/living/simple_animal/pet/machine_wash(obj/machinery/washing_machine/Washer)
+/mob/living/simple_animal/pet/machine_wash(obj/machinery/washing_machine/washer)
 	Washer.bloody_mess = TRUE
 	gib()
 
-/obj/item/machine_wash(obj/machinery/washing_machine/Washer)
+/obj/item/machine_wash(obj/machinery/washing_machine/washer)
 	if(Washer.color_source)
 		dye_item(Washer.color_source.dye_color)
 
@@ -249,16 +249,16 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		if(!can_adjust && adjusted) //we deadjust the uniform if it's now unadjustable
 			toggle_jumpsuit_adjust()
 
-/obj/item/clothing/under/machine_wash(obj/machinery/washing_machine/Washer)
+/obj/item/clothing/under/machine_wash(obj/machinery/washing_machine/washer)
 	freshly_laundered = TRUE
 	addtimer(VARSET_CALLBACK(src, freshly_laundered, FALSE), 5 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE)
 	..()
 
-/obj/item/clothing/head/mob_holder/machine_wash(obj/machinery/washing_machine/Washer)
+/obj/item/clothing/head/mob_holder/machine_wash(obj/machinery/washing_machine/washer)
 	..()
 	held_mob.machine_wash(Washer)
 
-/obj/item/clothing/shoes/sneakers/machine_wash(obj/machinery/washing_machine/Washer)
+/obj/item/clothing/shoes/sneakers/machine_wash(obj/machinery/washing_machine/washer)
 	if(chained)
 		chained = FALSE
 		slowdown = SHOES_SLOWDOWN

--- a/code/modules/clothing/suits/shirt.dm
+++ b/code/modules/clothing/suits/shirt.dm
@@ -11,10 +11,10 @@
 	. = ..()
 	if(wash_count <= 5)
 		transform *= TRANSFORM_USING_VARIABLE(0.8, 1)
-		Washer.visible_message(span_notice("\the [src] appears to have shrunk down after a long machine washing."))
+		washer.visible_message(span_notice("\the [src] appears to have shrunk down after a long machine washing."))
 		wash_count += 1
 	else
-		Washer.visible_message(span_notice("\the [src] appears to have imploded due to repeat washing. Tiny strands of energy from the wash-dimension linger."))
+		washer.visible_message(span_notice("\the [src] appears to have imploded due to repeat washing. Tiny strands of energy from the wash-dimension linger."))
 		qdel(src)
 
 /obj/item/clothing/suit/nerdshirt

--- a/code/modules/clothing/suits/shirt.dm
+++ b/code/modules/clothing/suits/shirt.dm
@@ -11,10 +11,10 @@
 	. = ..()
 	if(wash_count <= 5)
 		transform *= TRANSFORM_USING_VARIABLE(0.8, 1)
-		washer.balloon_alert_to_viewers("\the [src] appears to have shrunk down after a long machine washing.")
+		washer.balloon_alert_to_viewers("\the [src] appears to have shrunken after being washed.")
 		wash_count += 1
 	else
-		washer.balloon_alert_to_viewers("\the [src] appears to have imploded due to repeat washing. Tiny strands of energy from the wash-dimension linger.")
+		washer.balloon_alert_to_viewers("\the [src] implodes due to repeated washing.")
 		qdel(src)
 
 /obj/item/clothing/suit/nerdshirt

--- a/code/modules/clothing/suits/shirt.dm
+++ b/code/modules/clothing/suits/shirt.dm
@@ -11,10 +11,10 @@
 	. = ..()
 	if(wash_count <= 5)
 		transform *= TRANSFORM_USING_VARIABLE(0.8, 1)
-		washer.visible_message(span_notice("\the [src] appears to have shrunk down after a long machine washing."))
+		washer.balloon_alert_to_viewers("\the [src] appears to have shrunk down after a long machine washing.")
 		wash_count += 1
 	else
-		washer.visible_message(span_notice("\the [src] appears to have imploded due to repeat washing. Tiny strands of energy from the wash-dimension linger."))
+		washer.balloon_alert_to_viewers("\the [src] appears to have imploded due to repeat washing. Tiny strands of energy from the wash-dimension linger.")
 		qdel(src)
 
 /obj/item/clothing/suit/nerdshirt

--- a/code/modules/clothing/suits/shirt.dm
+++ b/code/modules/clothing/suits/shirt.dm
@@ -4,14 +4,17 @@
 	icon_state = "ianshirt"
 	inhand_icon_state = "ianshirt"
 	species_exception = list(/datum/species/golem)
+	///How many times has this shirt been washed? (In an ideal world this is just the determinant of the transform matrix.)
+	var/wash_count = 0
 
 /obj/item/clothing/suit/ianshirt/machine_wash(obj/machinery/washing_machine/WM)
 	. = ..()
 	if(wash_count <= 5)
-		transform *= TRANSFORM_USING_VARIABLE(0.8)
-		visible_message(span_notice("\the [src] appears to have shrunk down after a long machine washing."))
+		transform *= TRANSFORM_USING_VARIABLE(0.8, 1)
+		WM.visible_message(span_notice("\the [src] appears to have shrunk down after a long machine washing."))
+		wash_count += 1
 	else
-		visible_message(span_notice("\the [src] appears to have imploded due to repeat washing. Tiny strands of energy from the wash-dimension linger."))
+		WM.visible_message(span_notice("\the [src] appears to have imploded due to repeat washing. Tiny strands of energy from the wash-dimension linger."))
 		qdel(src)
 
 /obj/item/clothing/suit/nerdshirt

--- a/code/modules/clothing/suits/shirt.dm
+++ b/code/modules/clothing/suits/shirt.dm
@@ -7,7 +7,7 @@
 	///How many times has this shirt been washed? (In an ideal world this is just the determinant of the transform matrix.)
 	var/wash_count = 0
 
-/obj/item/clothing/suit/ianshirt/machine_wash(obj/machinery/washing_machine/Washer)
+/obj/item/clothing/suit/ianshirt/machine_wash(obj/machinery/washing_machine/washer)
 	. = ..()
 	if(wash_count <= 5)
 		transform *= TRANSFORM_USING_VARIABLE(0.8, 1)

--- a/code/modules/clothing/suits/shirt.dm
+++ b/code/modules/clothing/suits/shirt.dm
@@ -5,6 +5,15 @@
 	inhand_icon_state = "ianshirt"
 	species_exception = list(/datum/species/golem)
 
+/obj/item/clothing/suit/ianshirt/machine_wash(obj/machinery/washing_machine/WM)
+	. = ..()
+	if(wash_count <= 5)
+		transform *= TRANSFORM_USING_VARIABLE(0.8)
+		visible_message(span_notice("\the [src] appears to have shrunk down after a long machine washing."))
+	else
+		visible_message(span_notice("\the [src] appears to have imploded due to repeat washing. Tiny strands of energy from the wash-dimension linger."))
+		qdel(src)
+
 /obj/item/clothing/suit/nerdshirt
 	name = "gamer shirt"
 	desc = "A baggy shirt with vintage game character Phanic the Weasel. Why would anyone wear this?"

--- a/code/modules/clothing/suits/shirt.dm
+++ b/code/modules/clothing/suits/shirt.dm
@@ -7,14 +7,14 @@
 	///How many times has this shirt been washed? (In an ideal world this is just the determinant of the transform matrix.)
 	var/wash_count = 0
 
-/obj/item/clothing/suit/ianshirt/machine_wash(obj/machinery/washing_machine/WM)
+/obj/item/clothing/suit/ianshirt/machine_wash(obj/machinery/washing_machine/Washer)
 	. = ..()
 	if(wash_count <= 5)
 		transform *= TRANSFORM_USING_VARIABLE(0.8, 1)
-		WM.visible_message(span_notice("\the [src] appears to have shrunk down after a long machine washing."))
+		Washer.visible_message(span_notice("\the [src] appears to have shrunk down after a long machine washing."))
 		wash_count += 1
 	else
-		WM.visible_message(span_notice("\the [src] appears to have imploded due to repeat washing. Tiny strands of energy from the wash-dimension linger."))
+		Washer.visible_message(span_notice("\the [src] appears to have imploded due to repeat washing. Tiny strands of energy from the wash-dimension linger."))
 		qdel(src)
 
 /obj/item/clothing/suit/nerdshirt


### PR DESCRIPTION

## About The Pull Request

![image](https://user-images.githubusercontent.com/41715314/138544272-96cb7168-9a12-4f16-8c34-1cf0860d1f92.png)
Worn T-shirts, found in maintenance are now susceptible to shrinkage after repeated washing machine washings.
Too many machine washes can cause the shirts to shrink to the point that they simply disappear to the laundry dimension, as does real clothes in real life.

## Why It's Good For The Game

Fun little hidden interaction with laundry machines due to my having noticed that laundry machines exist in the code still.

## Changelog

:cl:
expansion: Laundry machines can shrink particularly old, worn t-shirts. Remember kids, hand wash only.
/:cl:
