### PR TITLE
Bank machine's process will immediately stop processing if its unpowered/broken.

### DIFF
--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -42,25 +42,27 @@
 
 /obj/machinery/computer/bank_machine/process(delta_time)
 	..()
-	if(siphoning)
-		if (machine_stat & (BROKEN|NOPOWER))
-			say("Insufficient power. Halting siphon.")
-			end_syphon()
-		var/siphon_am = 100 * delta_time
-		var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-		if(!D.has_money(siphon_am))
-			say("Cargo budget depleted. Halting siphon.")
-			end_syphon()
-			return
+	if(!siphoning)
+		return
+	if (machine_stat & (BROKEN|NOPOWER))
+		say("Insufficient power. Halting siphon.")
+		end_syphon()
+		return
+	var/siphon_am = 100 * delta_time
+	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
+	if(!D.has_money(siphon_am))
+		say("Cargo budget depleted. Halting siphon.")
+		end_syphon()
+		return
 
-		playsound(src, 'sound/items/poster_being_created.ogg', 100, TRUE)
-		syphoning_credits += siphon_am
-		D.adjust_money(-siphon_am)
-		if(next_warning < world.time && prob(15))
-			var/area/A = get_area(loc)
-			var/message = "Unauthorized credit withdrawal underway in [initial(A.name)]!!"
-			radio.talk_into(src, message, radio_channel)
-			next_warning = world.time + minimum_time_between_warnings
+	playsound(src, 'sound/items/poster_being_created.ogg', 100, TRUE)
+	syphoning_credits += siphon_am
+	D.adjust_money(-siphon_am)
+	if(next_warning < world.time && prob(15))
+		var/area/A = get_area(loc)
+		var/message = "Unauthorized credit withdrawal underway in [initial(A.name)]!!"
+		radio.talk_into(src, message, radio_channel)
+		next_warning = world.time + minimum_time_between_warnings
 
 /obj/machinery/computer/bank_machine/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION
## About The Pull Request

It already returns if the bank machine has no money, I don't see why it would continue if its broken/unpowered.
Also, to be honest, I only made this to make process early return if it isn't siphoning.

## Why It's Good For The Game

Small bug fix.

## Changelog

:cl:
fix: Bank machines will now immediately stop withdrawing funds if the machine is broken or unpowered.
/:cl: