### PR TITLE
Fixes microbomb implants blowing you up anyway on popup close & doubleclicking the action button

### DIFF
--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -40,7 +40,7 @@
 		popup = TRUE
 		var/response = tgui_alert(imp_in, "Are you sure you want to activate your [name]? This will cause you to explode!", "[name] Confirmation", list("Yes", "No"))
 		popup = FALSE
-		if(response == "No")
+		if(response == "No" || response == null)
 			return 0
 	heavy = round(heavy)
 	medium = round(medium)

--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -40,7 +40,7 @@
 		popup = TRUE
 		var/response = tgui_alert(imp_in, "Are you sure you want to activate your [name]? This will cause you to explode!", "[name] Confirmation", list("Yes", "No"))
 		popup = FALSE
-		if(response == "No" || response == null)
+		if(response != "Yes")
 			return 0
 	heavy = round(heavy)
 	medium = round(medium)

--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -36,11 +36,13 @@
 	. = ..()
 	if(!cause || !imp_in || active)
 		return 0
-	if(cause == "action_button" && !popup)
+	if(cause == "action_button")
+		if(popup)
+			return FALSE
 		popup = TRUE
 		var/response = tgui_alert(imp_in, "Are you sure you want to activate your [name]? This will cause you to explode!", "[name] Confirmation", list("Yes", "No"))
 		popup = FALSE
-		if(response == "No" || response == null)
+		if(response != "Yes")
 			return 0
 	heavy = round(heavy)
 	medium = round(medium)


### PR DESCRIPTION
## About The Pull Request
Title, this ~~probably~~ _indeed_ was a problem for the macrobomb as well. ~~didn't test.~~
doubleclicking the action button pointed out by @Ghommie
## Why It's Good For The Game
ided
## Changelog
:cl:
fix: fixes bomb implants blowing you up anyway when closing the window instead of pressing the "No" option
fix: fixes bomb implants blowing you up when clicking the action button while the confirmation popup is still up
/:cl: