### PR TITLE
Includes `adminobserverooc` span in the OOC selector for chat

### DIFF
--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -82,7 +82,7 @@ export const MESSAGE_TYPES = [
     type: MESSAGE_TYPE_OOC,
     name: 'OOC',
     description: 'The bluewall of global OOC messages',
-    selector: '.ooc, .adminooc, .oocplain',
+    selector: '.ooc, .adminooc, .adminobserverooc, .oocplain',
   },
   {
     type: MESSAGE_TYPE_ADMINPM,


### PR DESCRIPTION
## About The Pull Request

This PR puts `adminobserverooc` span into the OOC selectors, allowing messages sent with `adminobserverooc` span be filtered to / from chat tabs with OOC enabled / disabled..

## Why It's Good For The Game

`adminobserverooc` is the default OOC span for admin ranks that are do not have `R_ADMIN`, and it's annoying to have their OOC messages not filter into the correct chat tabs.
![image](https://user-images.githubusercontent.com/51863163/138568627-4a27df2e-93fc-4c7f-b133-816621a63515.png)

## Changelog

:cl: Melbert
fix: The OOC messages of people with minor admin ranks now respect OOC filters in chat tabs
/:cl:
