### PR TITLE
Prevent the rare documentation generation failure

### DIFF
--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -7,6 +7,7 @@ jobs:
   generate_documentation:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: ubuntu-20.04
+    concurrency: gen-docs
     steps:
       - uses: actions/checkout@v2
       - name: Setup cache


### PR DESCRIPTION
Limit to one documentation generation job at a time.