### PR TITLE
Fix machines breaking on Initialize

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -257,9 +257,6 @@
 			smoothing_flags |= SMOOTH_OBJ
 		SET_BITFLAG_LIST(canSmoothWith)
 
-	// apply materials properly from the default custom_materials value
-	set_custom_materials(custom_materials)
-
 	if(uses_integrity)
 		if (islist(armor))
 			armor = getArmor(arglist(armor))
@@ -268,6 +265,12 @@
 		else if (!istype(armor, /datum/armor))
 			stack_trace("Invalid type [armor.type] found in .armor during /atom Initialize()")
 		atom_integrity = max_integrity
+
+	// apply materials properly from the default custom_materials value
+	// This MUST come after atom_integrity is set above, as if old materials get removed,
+	// atom_integrity is checked against max_integrity and can BREAK the atom.
+	// The integrity to max_integrity ratio is still preserved.
+	set_custom_materials(custom_materials)
 
 	ComponentInitialize()
 	InitializeAIController()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -57,15 +57,7 @@
 	return ..()
 
 /obj/Initialize(mapload)
-	//if (islist(armor))
-	//	armor = getArmor(arglist(armor))
-	//else if (!armor)
-	//	armor = getArmor()
-	//else if (!istype(armor, /datum/armor))
-	//	stack_trace("Invalid type [armor.type] found in .armor during /obj Initialize()")
-	//atom_integrity = max_integrity
-
-	. = ..() //Do this after, else mat datums is mad.
+	. = ..()
 
 	if (set_obj_flags)
 		var/flagslist = splittext(set_obj_flags,";")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Machines were breaking on initialization, both when constructed and on map load. This affected at least `/obj/machinery/atmospherics/components/tank`, and possibly more.

In PR #61183, current health initialization was moved from before `set_custom_materials`, as `/obj/Initialize` expressly set integrity before calling the parent initialize.

This was hinted at by the comment `// Do this after, else mat datums is mad.` but could have been more explicit.

This moves the integrity initialization back to before mat datum handling, and makes a more explicit warning against moving integrity initialization after mat datums.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

bug bad fix good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Objects which use custom materials and break above 0 integrity no longer spawn broken.
code: Made a comment which warned against breaking this sort of thing more explicit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
