### PR TITLE
Pressure Tank: Fix many runtimes, consistency

### DIFF
--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -322,13 +322,13 @@
 	var/datum/gas_mixture/airmix = current_location.return_air()
 
 	var/time_taken = 4 SECONDS
-	var/unsafe = 0
+	var/unsafe = FALSE
 
 	var/internal_pressure = air_contents.return_pressure() - airmix.return_pressure()
 	if(internal_pressure > 2 * ONE_ATMOSPHERE)
 		time_taken *= 2
 		to_chat(user, span_warning("The tank seems to be pressurized, are you sure this is a good idea?"))
-		unsafe = 1
+		unsafe = TRUE
 
 	if(!tool.use_tool(src, user, time_taken, volume =  60))
 		return
@@ -346,15 +346,15 @@
 		return
 	var/obj/structure/tank_frame/frame = new(location)
 	frame.construction_state = TANK_PLATING_UNSECURED
-	for(var/datum/material/mat as anything in custom_materials)
+	for(var/datum/material/material as anything in custom_materials)
 		if (frame.material_end_product)
 			// If something looks fishy, you get nothing
-			message_admins("The [src] had multiple materials set. Unless you were messing around with VV, yell at a coder")
+			message_admins("\The [src] had multiple materials set. Unless you were messing around with VV, yell at a coder")
 			frame.material_end_product = null
 			frame.construction_state = TANK_FRAME
 			break
 		else
-			frame.material_end_product = mat
+			frame.material_end_product = material
 	frame.update_appearance()
 
 ///////////////////////////////////////////////////////////////////
@@ -499,7 +499,7 @@
 /obj/structure/tank_frame/proc/add_plating(mob/living/user, obj/item/stack/stack)
 	. = FALSE
 	if(!stack.material_type)
-		to_chat(user, span_notice("You're not sure how to use this material to make a tank..."))
+		balloon_alert(user, "invalid material!")
 	var/datum/material/stack_mat = GET_MATERIAL_REF(stack.material_type)
 	if(!(MAT_CATEGORY_RIGID in stack_mat.categories))
 		to_chat(user, span_notice("This material doesn't seem rigid enough to hold the shape of a tank..."))

--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -1,3 +1,5 @@
+#define TANK_PLATING_SHEETS 20
+
 /obj/machinery/atmospherics/components/tank
 	icon = 'icons/obj/atmospherics/stationary_canisters.dmi'
 	icon_state = "smooth"
@@ -10,7 +12,7 @@
 	density = TRUE
 	layer = ABOVE_WINDOW_LAYER
 
-	custom_materials = list(/datum/material/iron = 20000) // plasteel is not a material to prevent two bugs: one where the default pressure is 1.5 times higher as plasteel's material modifier is added, and a second one where the tank names could be "plasteel plasteel" tanks
+	custom_materials = list(/datum/material/iron = TANK_PLATING_SHEETS * MINERAL_MATERIAL_AMOUNT) // plasteel is not a material to prevent two bugs: one where the default pressure is 1.5 times higher as plasteel's material modifier is added, and a second one where the tank names could be "plasteel plasteel" tanks
 	material_flags = MATERIAL_EFFECTS | MATERIAL_GREYSCALE | MATERIAL_ADD_PREFIX | MATERIAL_AFFECT_STATISTICS
 
 	pipe_flags = PIPING_ONE_PER_TURF
@@ -320,25 +322,39 @@
 	var/datum/gas_mixture/airmix = current_location.return_air()
 
 	var/time_taken = 4 SECONDS
+	var/unsafe = 0
 
-	if(air_contents.return_pressure() > airmix.return_pressure())
+	var/internal_pressure = air_contents.return_pressure() - airmix.return_pressure()
+	if(internal_pressure > 2 * ONE_ATMOSPHERE)
 		time_taken *= 2
 		to_chat(user, span_warning("The tank seems to be pressurized, are you sure this is a good idea?"))
+		unsafe = 1
 
 	if(!tool.use_tool(src, user, time_taken, volume =  60))
 		return
 
+	if(unsafe)
+		unsafe_pressure_release(user, internal_pressure)
 	deconstruct(disassembled=TRUE)
 	to_chat(user, span_notice("You finish cutting open the sealed gas tank, revealing the innards."))
 
 /obj/machinery/atmospherics/components/tank/deconstruct(disassembled)
 	var/turf/location = drop_location()
 	. = ..()
+	location.assume_air(air_contents)
 	if(!disassembled)
 		return
 	var/obj/structure/tank_frame/frame = new(location)
 	frame.construction_state = TANK_PLATING_UNSECURED
-	frame.material_end_product = custom_materials[2].type
+	for(var/datum/material/mat as anything in custom_materials)
+		if (frame.material_end_product)
+			// If something looks fishy, you get nothing
+			message_admins("The [src] had multiple materials set. Unless you were messing around with VV, yell at a coder")
+			frame.material_end_product = null
+			frame.construction_state = TANK_FRAME
+			break
+		else
+			frame.material_end_product = mat
 	frame.update_appearance()
 
 ///////////////////////////////////////////////////////////////////
@@ -423,7 +439,7 @@
 	icon_state = "frame"
 	anchored = FALSE
 	density = TRUE
-	custom_materials = list(/datum/material/alloy/plasteel = 4000)
+	custom_materials = list(/datum/material/alloy/plasteel = 4 * MINERAL_MATERIAL_AMOUNT)
 	var/construction_state = TANK_FRAME
 	var/datum/material/material_end_product
 
@@ -449,7 +465,7 @@
 /obj/structure/tank_frame/deconstruct(disassembled)
 	if(disassembled)
 		for(var/datum/material/mat as anything in custom_materials)
-			new mat.sheet_type(drop_location())
+			new mat.sheet_type(drop_location(), custom_materials[mat] / MINERAL_MATERIAL_AMOUNT)
 	return ..()
 
 /obj/structure/tank_frame/update_icon(updates)
@@ -482,6 +498,8 @@
 
 /obj/structure/tank_frame/proc/add_plating(mob/living/user, obj/item/stack/stack)
 	. = FALSE
+	if(!stack.material_type)
+		to_chat(user, span_notice("You're not sure how to use this material to make a tank..."))
 	var/datum/material/stack_mat = GET_MATERIAL_REF(stack.material_type)
 	if(!(MAT_CATEGORY_RIGID in stack_mat.categories))
 		to_chat(user, span_notice("This material doesn't seem rigid enough to hold the shape of a tank..."))
@@ -491,18 +509,18 @@
 	to_chat(user, span_notice("You begin adding [stack] to [src]..."))
 	if(!stack.use_tool(src, user, 3 SECONDS))
 		return
-	if(!stack.use(20))
+	if(!stack.use(TANK_PLATING_SHEETS))
 		var/amount_more
-		switch(stack.amount)
+		switch(100 * stack.amount / TANK_PLATING_SHEETS)
 			if(0) // Wat?
 				amount_more = "any at all"
-			if(1 to 4)
+			if(1 to 25)
 				amount_more = "a lot more"
-			if(5 to 9)
+			if(26 to 50)
 				amount_more = "about four times as much"
-			if(10 to 15)
+			if(51 to 75)
 				amount_more = "about twice as much"
-			if(16 to 20)
+			if(76 to 100)
 				amount_more = "just a bit more"
 			else
 				amount_more = "an indeterminate amount more"
@@ -523,7 +541,7 @@
 	if(!tool.use_tool(src, user, 2 SECONDS))
 		return
 	construction_state = TANK_FRAME
-	new material_end_product.sheet_type(drop_location(), 20)
+	new material_end_product.sheet_type(drop_location(), TANK_PLATING_SHEETS)
 	material_end_product = null
 	update_appearance()
 
@@ -545,9 +563,10 @@
 	if(!isturf(build_location))
 		return
 	var/obj/machinery/atmospherics/components/tank/new_tank = new(build_location)
-	var/list/new_custom_materials = list()
-	new_custom_materials[material_end_product] = 20000
+	var/list/new_custom_materials = list((material_end_product) = TANK_PLATING_SHEETS * MINERAL_MATERIAL_AMOUNT)
 	new_tank.set_custom_materials(new_custom_materials)
 	new_tank.on_construction(new_tank.pipe_color, new_tank.piping_layer)
 	to_chat(user, span_notice("[new_tank] has been sealed and is ready to accept gases."))
 	qdel(src)
+
+#undef TANK_PLATING_SHEETS


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


Use `MINERAL_MATERIAL_AMOUNT`, add and use `TANK_PLATING_SHEETS` in place of magic numbers everywhere.

If you get a spooky warning about the tank being pressurized as you slice it open with a welding tool, you actually get consequences. These consequences (and the new conditions for it) are consistent with the checks in `atmosmachinery.dm`.

Don't try to use an array index of 2 on the `custom_materials` associative list which is meant to hold a single entry. If `custom_materials` ends up with multiple materials somehow, produce a frame with nothing rather than a plated frame.

Properly pass the amount of a material to create when dropping.

Don't try to use a stackable item which doesn't have a `material_type`.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Pressure Tanks are a total mess

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Pressure Tanks will now refuse to accept materials without a specific material type during construction.
fix: Pressure Tanks will now drop the correct amount of materials during deconstruction.
fix: Pressure Tanks will now send you flying if you continue to slice open a sufficiently pressurized tank despite the warning, rather than doing nothing.
fix: Pressure Tanks will release their gas contents when destroyed, rather than voiding them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
