### PR TITLE
Fix runtime when editing bans introduced by untrustworthy code ocelot.

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -219,6 +219,7 @@
 		<input type='hidden' name='oldreason' value='[reason]'>
 		<input type='hidden' name='page' value='[page]'>
 		<input type='hidden' name='adminkey' value='[admin_key]'>
+		<input type='hidden' name='role' value='[role]'>
 		<br>
 		When ticked, edits here will also affect bans created with matching ckey, IP, CID and time. Use this to edit all role bans which were made at the same time.
 		"}
@@ -434,6 +435,7 @@
 			changes += list("Reason" = "[href_list["oldreason"]]<br>to<br>[reason]")
 		if(!changes.len)
 			error_state += "No changes were detected."
+		roles_to_ban += href_list["role"]
 	else
 		severity = href_list["radioseverity"]
 		if(!severity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/138606188-1ab3f47d-628d-4bb8-b4a7-138d173af538.png)

In #62122 I modified the logic for editing bans to allow edited server bans to re-apply fully including kicking matching players off the server if a ban's IP or CID was edited. As part of this, I made some procs more generic. When editing a ban, no role was previously set.

Now when editing bans, the banned role ("Server" or the specific role banned) is now passed through the hrefs and picked up/parsed appropriately, fixing the runtime and restoring expected functionality.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Code ocelot bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
admin: The terrible code ocelot haunting the editing ban panel has been banished. Editing bans now actually works again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
