### PR TITLE
Fix RWall smoothing

### DIFF
--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -200,8 +200,10 @@
 
 /turf/closed/wall/r_wall/update_icon(updates=ALL)
 	. = ..()
-	if(!(updates & UPDATE_SMOOTHING) || (d_state != INTACT))
+	if(d_state != INTACT)
 		smoothing_flags = NONE
+		return
+	if (!(updates & UPDATE_SMOOTHING))
 		return
 	smoothing_flags = SMOOTH_BITMASK
 	QUEUE_SMOOTH_NEIGHBORS(src)

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -87,6 +87,7 @@
 		ChangeTurf(decon_type, flags = CHANGETURF_INHERIT_AIR)
 	else
 		ScrapeAway()
+	QUEUE_SMOOTH_NEIGHBORS(src)
 
 /turf/closed/wall/proc/break_wall()
 	new sheet_type(src, sheet_amount)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reinforced wall smoothing was broken in daec500/#59140. Reinforced walls would update with `~UPDATE_SMOOTHING` after smoothing was complete, causing their `smoothing_flags` to become `NONE`.

This effectively meant that all reinforced walls would smooth exactly once, and any further updates, such as building a new reinforced wall next to an existing one, would fail to update the existing wall.

By keeping distinct the case where the reinforced wall is no longer intact, and so should no longer cause smoothing, and the case where no `UPDATE_SMOOTHING` is provided so the update should early return, we can avoid overwriting `smoothing_flags` unnecessarily.

As a bonus, make nearby walls re-smooth when we break, too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #62186.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Reinforced walls will now properly re-smooth when nearby reinforced walls are created or destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
