### PR TITLE
Changes the organic slurry mechanics to contain the slurry within the rat.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -232,15 +232,10 @@
 		var/trans_amount = reagents.maximum_volume - reagents.total_volume * (4 / 3)
 		if(target_reagents.has_reagent(/datum/reagent/fuel) && target_reagents.trans_to(src, trans_amount))
 			to_chat(user, span_notice("You dip [src] into [target]."))
-			reagents.trans_to(target, reagents.total_volume)
 		else
 			to_chat(user, span_warning("That's a terrible idea."))
 	else
 		return ..()
-
-/obj/item/food/deadmouse/on_grind()
-	. = ..()
-	reagents.clear_reagents()
 
 /obj/item/food/deadmouse/moldy
 	name = "moldy dead mouse"


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR changes how organic slurry is produced by retaining the organic slurry inside the mouse that created it. 

What this means in practice is that each mouse can only produce about 37u organic slurry, instead of being able to turn every unit of welding fuel you can get you hands on into slurry.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
 Currently, due to the abundance of thousands of units of welding fuel in  maintenance and the trivial conversion to slurry, organic slurry is as abundant as welding fuel and thus not very interesting. 

By requring mouse corpses to produce large amounts of slurry, we introduce a mouse breeding element that fit well thematically into the gameplay loop of the current consumers of slurry; the maintenance sect and cytology.

The amount that can be obtained from a single mouse is still more than enough that is needed for ghetto toxins treatment, but won't be enough for the maintenance sect or gelatinous cube spam.

Also this implementation seems more intutive, as several people have pointed out that they thought it already worked like this. I myself thought it worked like this at the time when i assigned my cyto mobs organic slurry as a required reagent.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: The organic slurry is now retained inside the rat after it is dipped in welding fuel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
