### PR TITLE
Add codeowner assignment workflow

### DIFF
--- a/.github/workflows/codeowner_assignment.yml
+++ b/.github/workflows/codeowner_assignment.yml
@@ -1,11 +1,7 @@
-#Example worflow for Gamer025/CodeOwnersParser
-
 name: Codeowner Assignment
 
 # Controls when the workflow will run
-on:
-  pull_request:
-    branches: [ master ]
+on: pull_request
 
 jobs:
   assign-users:
@@ -16,6 +12,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
       - uses: actions/checkout@v2
 
+      #Parse the Codeowner file
       - name: CodeOwnersParser
         id: CodeOwnersParser
         uses: tgstation/CodeOwnersParser@v1

--- a/.github/workflows/codeowner_assignment.yml
+++ b/.github/workflows/codeowner_assignment.yml
@@ -1,0 +1,29 @@
+#Example worflow for Gamer025/CodeOwnersParser
+
+name: Codeowner Assignment
+
+# Controls when the workflow will run
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  assign-users:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
+      - uses: actions/checkout@v2
+
+      - name: CodeOwnersParser
+        id: CodeOwnersParser
+        uses: tgstation/CodeOwnersParser@v1
+
+      #Assign users
+      - name: Assign users
+        if: steps.CodeOwnersParser.outputs.owners != ''
+        uses: tgstation/AssignUser@v1
+        with:
+          separator: ' '
+          users: ${{ steps.CodeOwnersParser.outputs.owners }}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a workflow action that parses the codeowner file and assigns all users with modified files to the corresponding PR.
This allows assignment of users without giving them write access to the repository (they still need to be in a team).

Alternatively the action can be changed to instead post and edit a comment, which would allow for notification of users without them needing a team.
Closes #60740 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Codebase
Allows assignment of users without giving them write access to the codebase
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
