### PR TITLE
Spirit holding component won't let you awaken another spirit until it's done

### DIFF
--- a/code/datums/components/spirit_holding.dm
+++ b/code/datums/components/spirit_holding.dm
@@ -63,6 +63,7 @@
 		attempting_awakening = FALSE
 		return
 
+	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_SELF)
 	var/mob/dead/observer/chosen_spirit = pick(candidates)
 	bound_spirit = new(parent)
 	bound_spirit.ckey = chosen_spirit.ckey
@@ -78,7 +79,6 @@
 
 	//prevents awakening it again + new signals for a now-possessed item
 	attempting_awakening = FALSE
-	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_SELF)
 	RegisterSignal(parent, COMSIG_ATOM_RELAYMOVE, .proc/block_buckle_message)
 	RegisterSignal(parent, COMSIG_BIBLE_SMACKED, .proc/on_bible_smacked)
 

--- a/code/datums/components/spirit_holding.dm
+++ b/code/datums/components/spirit_holding.dm
@@ -63,7 +63,6 @@
 		attempting_awakening = FALSE
 		return
 
-	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_SELF)
 	var/mob/dead/observer/chosen_spirit = pick(candidates)
 	bound_spirit = new(parent)
 	bound_spirit.ckey = chosen_spirit.ckey
@@ -78,9 +77,10 @@
 		bound_spirit.fully_replace_character_name(null, "The spirit of [input]")
 
 	//prevents awakening it again + new signals for a now-possessed item
-	attempting_awakening = FALSE
+	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_SELF)
 	RegisterSignal(parent, COMSIG_ATOM_RELAYMOVE, .proc/block_buckle_message)
 	RegisterSignal(parent, COMSIG_BIBLE_SMACKED, .proc/on_bible_smacked)
+	attempting_awakening = FALSE
 
 ///signal fired from a mob moving inside the parent
 /datum/component/spirit_holding/proc/block_buckle_message(datum/source, mob/living/user, direction)

--- a/code/datums/components/spirit_holding.dm
+++ b/code/datums/components/spirit_holding.dm
@@ -63,6 +63,9 @@
 		attempting_awakening = FALSE
 		return
 
+	//Immediately unregister to prevent making a new spirit
+	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_SELF)
+	
 	var/mob/dead/observer/chosen_spirit = pick(candidates)
 	bound_spirit = new(parent)
 	bound_spirit.ckey = chosen_spirit.ckey
@@ -76,8 +79,7 @@
 		parent = input
 		bound_spirit.fully_replace_character_name(null, "The spirit of [input]")
 
-	//prevents awakening it again + new signals for a now-possessed item
-	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_SELF)
+	//Add new signals for parent and stop attempting to awaken
 	RegisterSignal(parent, COMSIG_ATOM_RELAYMOVE, .proc/block_buckle_message)
 	RegisterSignal(parent, COMSIG_BIBLE_SMACKED, .proc/on_bible_smacked)
 	attempting_awakening = FALSE

--- a/code/datums/components/spirit_holding.dm
+++ b/code/datums/components/spirit_holding.dm
@@ -57,7 +57,7 @@
 	attempting_awakening = TRUE
 	to_chat(awakener, span_notice("You attempt to wake the spirit of [parent]..."))
 
-	var/list/candidates = poll_ghost_candidates("Do you want to play as the spirit of [awakener.real_name]'s blade?", ROLE_PAI, FALSE, 100, POLL_IGNORE_POSSESSED_BLADE)
+	var/mob/dead/observer/candidates = poll_ghost_candidates("Do you want to play as the spirit of [awakener.real_name]'s blade?", ROLE_PAI, FALSE, 100, POLL_IGNORE_POSSESSED_BLADE)
 	if(!LAZYLEN(candidates))
 		to_chat(awakener, span_warning("[parent] is dormant. Maybe you can try again later."))
 		attempting_awakening = FALSE
@@ -65,7 +65,7 @@
 
 	//Immediately unregister to prevent making a new spirit
 	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_SELF)
-	
+
 	var/mob/dead/observer/chosen_spirit = pick(candidates)
 	bound_spirit = new(parent)
 	bound_spirit.ckey = chosen_spirit.ckey


### PR DESCRIPTION
## About The Pull Request

If you spam a spirit holding item, you can request a second spirit after getting the first
![image](https://user-images.githubusercontent.com/53777086/138728198-defdd6cc-7803-4717-bf49-aba1822b817a.png)

Which ends up causing
![image](https://user-images.githubusercontent.com/53777086/138728636-3be82fe8-7110-4575-b1fa-f62824cf07e3.png)

## Why It's Good For The Game

Every round where there's a Chaplain with a null rod, there ends up having some godmoded shade on station fucking with people. I'm not sure if this is the full fix, but hopefully this can fix something,

## Changelog

:cl:
fix: Godmoded shades should no longer spawn from posessed blades spawning spirits too fast.
/:cl: