### PR TITLE
no more double/triple/etc prize for you after completing orion

### DIFF
--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -235,6 +235,8 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 				fuel = 60
 				settlers = list("Harry","Larry","Bob")
 		if("continue")
+			if (gameStatus == ORION_STATUS_START)
+				return
 			if(turns >= ORION_TRAIL_WINTURN)
 				win(gamer)
 				xp_gained += 34


### PR DESCRIPTION
## About The Pull Request

you used to be able to click the continue button at orion really fast, or some other thing like that, and it would spam continue at the server and give you lots of prizes

Fixes #59677

## Why It's Good For The Game

fix

## Changelog

:cl:
fix: orion can now no longer give you multiple prizes
/:cl: