### PR TITLE
[s] Hotfix notes not belonging to players being shown to players

### DIFF
--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -651,7 +651,7 @@
 		WHERE type = :type
 		AND deleted = 0
 		AND (expire_timestamp > NOW() OR expire_timestamp IS NULL)
-		AND ((type != 'message' AND type != 'watchlist entry') OR targetckey = :targetckey)
+		AND (type = 'memo' OR targetckey = :targetckey)
 		[after_timestamp? "AND timestamp > :after_timestamp": ""]
 		[!show_secret? "AND secret = 0": ""]
 	"}, parameters)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
See title.
Other players will no longer see other player's notes when they connect to the server.
Memos will still be shown to admins.

Things that I have tested in the making of this PR:
- Notes of a player not being shown to other players definitely work
- Notes of a player being shown to a player definitely work.
- Memos are still shown to admins.

Closes #62348

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Fixes a critical bug with notes and bans

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixes notes and bans being shown to players on connect when the note or ban doesn't belong to them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
