### PR TITLE
Fix runtime on physical experiments' unregister_events() running on null

### DIFF
--- a/code/modules/experisci/experiment/types/physical_experiment.dm
+++ b/code/modules/experisci/experiment/types/physical_experiment.dm
@@ -13,7 +13,8 @@
 	return completed
 
 /datum/experiment/physical/perform_experiment_actions(datum/component/experiment_handler/experiment_handler, atom/target)
-	unregister_events()
+	if(currently_scanned_atom)
+		unregister_events()
 	currently_scanned_atom = target
 	linked_experiment_handler = experiment_handler
 	if(register_events())


### PR DESCRIPTION
## About The Pull Request
the unregister_events() proc is used to stop listening for a signal from a previously scanned atom for experiment purposes. if the experi-scanner wasn't used for scanning atoms for physical experiments previously, it would cause a runtime, trying to unregister a signal from a non-existant atom.
## Why It's Good For The Game
one less runtime to care about
the fact that we have only one available physical experiment for this to runtime is sad
## Changelog
:cl:
fix: fixed a runtime in physical experiments trying to unregister a signal from a non-existant atom
/:cl: