### PR TITLE
Lavaland external access fixes

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -545,7 +545,7 @@
 	},
 /obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock";
-	req_access_txt = "54"
+	req_access_txt = "48"
 	},
 /turf/open/floor/iron,
 /area/mine/eva)
@@ -3152,7 +3152,7 @@
 "sH" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock";
-	req_access_txt = "54"
+	req_access = null
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
@@ -3396,7 +3396,7 @@
 "zn" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock";
-	req_access_txt = "54";
+	req_access = null;
 	space_dir = 2
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -4483,8 +4483,7 @@
 	},
 /obj/machinery/door/airlock/external/glass{
 	name = "Mining External Airlock";
-	req_access_txt = "54";
-	space_dir = 4
+	req_access_txt = "48"
 	},
 /turf/open/floor/iron,
 /area/mine/eva)


### PR DESCRIPTION
Fixes #62268

:cl:
fix: Emergency inlet access on the mining station eastern-most airlocks has been removed.
fix: Fixed mining station east airlocks requiring external airlock access instead of mining access.
fix: Removed access requirements from southern mining station public external airlocks.
/:cl: