### PR TITLE
Adds two station traits: Ionic Stormfront and Radioactive Stormfront

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -248,3 +248,46 @@
 			new blood_type(get_turf(pick(orange(location, 2))))
 
 	new /obj/effect/decal/cleanable/blood/gibs/torso(last_location)
+
+// Abstract station trait used for station traits that modify a random event's weight or max occurrences.
+/datum/station_trait/random_event_weight_modifier
+	name = "Random Event Modifier"
+	report_message = "A random event has been modified this shift! Someone forgot to set this!"
+	show_in_report = TRUE
+	trait_flags = STATION_TRAIT_ABSTRACT
+	weight = 0
+
+	/// The path to the round_event_control that we modify.
+	var/event_control_path
+	/// Multiplier applied to the weight of the event.
+	var/weight_multiplier = 1
+	/// Flat modifier applied to the amount of max occurances the random event can have.
+	var/max_occurrences_modifier = 0
+
+/datum/station_trait/random_event_weight_modifier/on_round_start()
+	. = ..()
+	var/datum/round_event_control/modified_event = locate(event_control_path) in SSevents.control
+	if(!modified_event)
+		CRASH("[type] could not find a round event controller to modify on round start (likely has an invalid event_control_path set)!")
+
+	modified_event.weight *= weight_multiplier
+	modified_event.max_occurrences += max_occurrences_modifier
+
+/datum/station_trait/random_event_weight_modifier/ion_storms
+	name = "Ionic Stormfront"
+	report_message = "An ionic stormfront is passing over your station's system. Expect an increased likelihood of ion storms afflicting your station's silicon units."
+	trait_type = STATION_TRAIT_NEGATIVE
+	trait_flags = NONE
+	weight = 3
+	event_control_path = /datum/round_event_control/ion_storm
+	weight_multiplier = 2
+
+/datum/station_trait/random_event_weight_modifier/rad_storms
+	name = "Radiation Stormfront"
+	report_message = "A radioactive stormfront is passing through your station's system. Expect an increased likelihood of radiation storms passing over your station, as well the potential for multiple radiation storms to occur during your shift."
+	trait_type = STATION_TRAIT_NEGATIVE
+	trait_flags = NONE
+	weight = 2
+	event_control_path = /datum/round_event_control/radiation_storm
+	weight_multiplier = 1.5
+	max_occurrences_modifier = 2

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -249,7 +249,7 @@
 
 	new /obj/effect/decal/cleanable/blood/gibs/torso(last_location)
 
-// Abstract station trait used for station traits that modify a random event's weight or max occurrences.
+// Abstract station trait used for traits that modify a random event in some way (their weight or max occurrences).
 /datum/station_trait/random_event_weight_modifier
 	name = "Random Event Modifier"
 	report_message = "A random event has been modified this shift! Someone forgot to set this!"
@@ -261,7 +261,7 @@
 	var/event_control_path
 	/// Multiplier applied to the weight of the event.
 	var/weight_multiplier = 1
-	/// Flat modifier applied to the amount of max occurances the random event can have.
+	/// Flat modifier added to the amount of max occurances the random event can have.
 	var/max_occurrences_modifier = 0
 
 /datum/station_trait/random_event_weight_modifier/on_round_start()


### PR DESCRIPTION
## About The Pull Request

This PR adds two station traits. Ionic Stormfront and Radioactive Stormfront. 

- Ionic Stormfront doubles the weight of the ion storm event.
- Radioactive Stormfront slightly increases the weight of the radiation storm event (1.5x) and allows multiple radiation storms to occur during a round (+2 max occurrences). 

Both are relatively uncommon traits to roll.

## Why It's Good For The Game

Given a lot of random events are occurrences of "nature", (storms, anomalies, meteor showers, etc), I think it makes sense and has decent flavor that occasionally your station may experience certain events more often. 

Maybe the station is located in an anomalous region of space and anomalies are coming outta the walls. Maybe it's located in an asteroid belt and meteors pelt the exterior constantly. Who knows! For now, I went with two existing "weather" phenomenon that hit the station, rad and ion storms. Ion storms are usually funny and add variety to silicon players, and radiation storms are neat for antaggy potential but kinda uncommon.

## Changelog

:cl: Melbert
expansion: Two new station traits, Ionic Stormfront and Radiation Stormfront. They make ion storms and rad storms more common, respectively. 
/:cl:

