### PR TITLE
Double bedsheets have the correct worn sprites.

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -293,93 +293,123 @@ LINEN BINS
 /obj/item/bedsheet/double
 	icon_state = "double_sheetwhite"
 	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
+	worn_icon_state = "sheetwhite"
 
 /obj/item/bedsheet/blue/double
 	icon_state = "double_sheetblue"
+	worn_icon_state = "sheetblue"
 
 /obj/item/bedsheet/green/double
 	icon_state = "double_sheetgreen"
+	worn_icon_state = "sheetgreen"
 
 /obj/item/bedsheet/grey/double
 	icon_state = "double_sheetgrey"
+	worn_icon_state = "sheetgrey"
 
 /obj/item/bedsheet/orange/double
 	icon_state = "double_sheetorange"
+	worn_icon_state = "sheetorange"
 
 /obj/item/bedsheet/purple/double
 	icon_state = "double_sheetpurple"
+	worn_icon_state = "sheetpurple"
 
 /obj/item/bedsheet/patriot/double
 	icon_state = "double_sheetUSA"
+	worn_icon_state = "sheetUSA"
 
 /obj/item/bedsheet/rainbow/double
 	icon_state = "double_sheetrainbow"
+	worn_icon_state = "sheetrainbow"
 
 /obj/item/bedsheet/red/double
 	icon_state = "double_sheetred"
+	worn_icon_state = "sheetred"
 
 /obj/item/bedsheet/yellow/double
 	icon_state = "double_sheetyellow"
+	worn_icon_state = "sheetyellow"
 
 /obj/item/bedsheet/mime/double
 	icon_state = "double_sheetmime"
+	worn_icon_state = "sheetmime"
 
 /obj/item/bedsheet/clown/double
 	icon_state = "double_sheetclown"
+	worn_icon_state = "sheetclown"
 
 /obj/item/bedsheet/captain/double
 	icon_state = "double_sheetcaptain"
+	worn_icon_state = "sheetcaptain"
 
 /obj/item/bedsheet/rd/double
 	icon_state = "double_sheetrd"
+	worn_icon_state = "sheetrd"
 
 /obj/item/bedsheet/medical/double
 	icon_state = "double_sheetmedical"
+	worn_icon_state = "sheetmedical"
 
 /obj/item/bedsheet/cmo/double
 	icon_state = "double_sheetcmo"
+	worn_icon_state = "sheetcmo"
 
 /obj/item/bedsheet/hos/double
 	icon_state = "double_sheethos"
+	worn_icon_state = "sheethos"
 
 /obj/item/bedsheet/hop/double
 	icon_state = "double_sheethop"
+	worn_icon_state = "sheethop"
 
 /obj/item/bedsheet/ce/double
 	icon_state = "double_sheetce"
+	worn_icon_state = "sheetce"
 
 /obj/item/bedsheet/qm/double
 	icon_state = "double_sheetqm"
+	worn_icon_state = "sheetqm"
 
 /obj/item/bedsheet/chaplain/double
 	icon_state = "double_sheetchap"
+	worn_icon_state = "sheetchap"
 
 /obj/item/bedsheet/brown/double
 	icon_state = "double_sheetbrown"
+	worn_icon_state = "sheetbrown"
 
 /obj/item/bedsheet/black/double
 	icon_state = "double_sheetblack"
+	worn_icon_state = "sheetblack"
 
 /obj/item/bedsheet/centcom/double
 	icon_state = "double_sheetcentcom"
+	worn_icon_state = "sheetcentcom"
 
 /obj/item/bedsheet/syndie/double
 	icon_state = "double_sheetsyndie"
+	worn_icon_state = "sheetsyndie"
 
 /obj/item/bedsheet/cult/double
 	icon_state = "double_sheetcult"
+	worn_icon_state = "sheetcult"
 
 /obj/item/bedsheet/wiz/double
 	icon_state = "double_sheetwiz"
+	worn_icon_state = "sheetwiz"
 
 /obj/item/bedsheet/nanotrasen/double
 	icon_state = "double_sheetNT"
+	worn_icon_state = "sheetNT"
 
 /obj/item/bedsheet/ian/double
 	icon_state = "double_sheetian"
+	worn_icon_state = "sheetian"
 
 /obj/item/bedsheet/cosmos/double
 	icon_state = "double_sheetcosmos"
+	worn_icon_state = "sheetcosmos"
 
 /obj/item/bedsheet/random/double
 	icon_state = "random_bedsheet"


### PR DESCRIPTION
## About The Pull Request

Double Bedsheets have a new icon_state, but in doing so, break their worn_icon_states, as their worn_icon_state was set by the icon_state.

This manually sets their worn icons in order to avoid funny broken sprites.

## Why It's Good For The Game

Fixes situations like this:
![image](https://user-images.githubusercontent.com/41715314/138970711-a9d34f39-0972-4515-9100-a496b92f041a.png)
AKA fixes #62378.

## Changelog

:cl:
fix: Double Bedsheets now properly show the bedsheet sprites.
/:cl:
