### PR TITLE
implements pews needing a tool to be rotated

### DIFF
--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -76,9 +76,9 @@
 	if( . == FALSE )
 		return .
 
-	var/mob/living/LivingUser = user
-	if(istype(LivingUser))
-		var/obj/item/tool = LivingUser.get_active_held_item()
+	var/mob/living/living_user = user
+	if(istype(living_user))
+		var/obj/item/tool = living_user.get_active_held_item()
 		if(!tool || !tool.tool_behaviour || tool.tool_behaviour != TOOL_WRENCH)
 			to_chat(user, span_warning("You need to equip a wrench in your active slot to rotate the [name]"))
 			return FALSE

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -73,9 +73,8 @@
 
 /obj/structure/chair/pew/can_user_rotate(mob/user)
 	. = ..()
-	if( . == FALSE )
-		return .
-
+	if(!.)
+		return
 	var/mob/living/LivingUser = user
 	if(istype(LivingUser))
 		var/obj/item/tool = LivingUser.get_active_held_item()

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -74,13 +74,14 @@
 /obj/structure/chair/pew/can_user_rotate(mob/user)
 	. = ..()
 	if(!.)
-		return .
+		return
 
 	var/mob/living/living_user = user
 	if(istype(living_user))
 		var/obj/item/tool = living_user.get_active_held_item()
 		if(!tool || tool.tool_behaviour != TOOL_WRENCH)
 			to_chat(user, span_warning("You need to equip a wrench in your active slot to rotate the [name]"))
+			balloon_alert(user, "You need to equip a wrench in your active slot to rotate the [name]")
 			return FALSE
 		return TRUE
-	return .
+	return

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -84,4 +84,3 @@
 		to_chat(user, span_warning("You need to equip a wrench in your active slot to rotate the [name]"))
 		balloon_alert(user, "You need to equip a wrench in your active slot to rotate the [name]")
 		return FALSE
-	return TRUE

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -70,3 +70,17 @@
 /obj/structure/chair/pew/right/post_unbuckle_mob()
 	. = ..()
 	update_rightpewarmrest()
+
+/obj/structure/chair/pew/can_user_rotate(mob/user)
+	. = ..()
+	if( . == FALSE )
+		return .
+
+	var/mob/living/LivingUser = user
+	if(istype(LivingUser))
+		var/obj/item/tool = LivingUser.get_active_held_item()
+		if(!tool || !tool.tool_behaviour || tool.tool_behaviour != TOOL_WRENCH)
+			to_chat(user, span_warning("You need to equip a wrench in your active slot to rotate the [name]"))
+			return FALSE
+		return TRUE
+	return FALSE

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -77,11 +77,11 @@
 		return
 
 	var/mob/living/living_user = user
-	if(istype(living_user))
-		var/obj/item/tool = living_user.get_active_held_item()
-		if(!tool || tool.tool_behaviour != TOOL_WRENCH)
-			to_chat(user, span_warning("You need to equip a wrench in your active slot to rotate the [name]"))
-			balloon_alert(user, "You need to equip a wrench in your active slot to rotate the [name]")
-			return FALSE
-		return TRUE
-	return
+	if(!istype(living_user))
+		return
+	var/obj/item/tool = living_user.get_active_held_item()
+	if(!tool || tool.tool_behaviour != TOOL_WRENCH)
+		to_chat(user, span_warning("You need to equip a wrench in your active slot to rotate the [name]"))
+		balloon_alert(user, "You need to equip a wrench in your active slot to rotate the [name]")
+		return FALSE
+	return TRUE

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -81,6 +81,5 @@
 		return
 	var/obj/item/tool = living_user.get_active_held_item()
 	if(!tool || tool.tool_behaviour != TOOL_WRENCH)
-		to_chat(user, span_warning("You need to equip a wrench in your active slot to rotate the [name]"))
-		balloon_alert(user, "You need to equip a wrench in your active slot to rotate the [name]")
+		balloon_alert(user, "you need a wrench!")
 		return FALSE

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -78,7 +78,7 @@
 	var/mob/living/LivingUser = user
 	if(istype(LivingUser))
 		var/obj/item/tool = LivingUser.get_active_held_item()
-		if(!tool || !tool.tool_behaviour || tool.tool_behaviour != TOOL_WRENCH)
+		if(!tool || tool.tool_behaviour != TOOL_WRENCH)
 			to_chat(user, span_warning("You need to equip a wrench in your active slot to rotate the [name]"))
 			return FALSE
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- PR'ed for Hacktoberfest (so if this passes muster I'd appreciate it being tagged with `hacktoberfest-accepted`)
- Pews now require a wrench in hand to be rotated
closes https://github.com/tgstation/tgstation/issues/50136
![image](https://user-images.githubusercontent.com/82134074/138973425-5cfc91bf-7719-4011-8250-ca7c05d7a4c4.png)

## Why It's Good For The Game

This prevents people from easily messing up the chapel and publicly placed pews

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Wooden pews now require a wrench in hand to be rotated
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
