### PR TITLE
RPDs can't place transit tubes directly under dense objects.

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -611,6 +611,12 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 				if(isclosedturf(attack_target))
 					to_chat(user, span_warning("[src]'s error light flickers; there's something in the way!"))
 					return
+
+				var/turf/target_turf = get_turf(attack_target)
+				if(target_turf.is_blocked_turf(exclude_mobs = TRUE))
+					to_chat(user, span_warning("[src]'s error light flickers; there's something in the way!"))
+					return
+
 				to_chat(user, span_notice("You start building a transit tube..."))
 				playsound(get_turf(src), 'sound/machines/click.ogg', 50, TRUE)
 				if(do_after(user, transit_build_speed, target = attack_target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Right now you can directly place and wrench a transit tube under a few objects that are dense, this opens up a few issues, like you being able to bypass dense objects and get into places that you shouldn't with basically no effort as long as you have a RPD in your bag.
The main example of this is the brig cells, the bridge, the AI upload, the luxury area on the luxury shuttle, etc.
So a simple check was added to see if the turf has a dense object before placing a tube.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This PR #45609 was IMO one of the best balance changes in the game, before it access was a meme and you could get anywhere in a few seconds by just unwrenching windows.
With a RPD you can do the same, but the worse issue is that while it takes 1 second for you to place a tube under a reinforced window, you need to fully deconstruct the window to remove it.
While you fix 1 area that the clown turned into free access, they have build 5 more.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Guillaume Prata
balance: Due to budget cuts, the RPDs can't place transit tube under dense objects like windows anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
