### PR TITLE
Atmospheric tanks explosions are only possible using a TTV

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -44,11 +44,13 @@
 			if(!user.transferItemToLoc(item, src))
 				return
 			tank_one = item
+			tank_one.can_explode = TRUE
 			to_chat(user, span_notice("You attach the tank to the transfer valve."))
 		else if(!tank_two)
 			if(!user.transferItemToLoc(item, src))
 				return
 			tank_two = item
+			tank_two.can_explode = TRUE
 			to_chat(user, span_notice("You attach the tank to the transfer valve."))
 
 		update_appearance()
@@ -244,6 +246,7 @@
 				split_gases()
 				valve_open = FALSE
 				tank_one.forceMove(drop_location())
+				tank_one.can_explode = FALSE
 				tank_one = null
 				. = TRUE
 		if("tanktwo")
@@ -251,6 +254,7 @@
 				split_gases()
 				valve_open = FALSE
 				tank_two.forceMove(drop_location())
+				tank_two.can_explode = FALSE
 				tank_two = null
 				. = TRUE
 		if("toggle")

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -38,6 +38,8 @@
 	var/tank_holder_icon_state = "holder_generic"
 	///Used by process() to track if there's a reason to process each tick
 	var/excited = TRUE
+	///Only TTVs are allowed to go boom
+	var/can_explode = FALSE
 
 /obj/item/tank/ui_action_click(mob/user)
 	toggle_internals(user)
@@ -306,7 +308,7 @@
 
 /// Handles rupturing and fragmenting
 /obj/item/tank/atom_destruction(damage_flag)
-	if(!air_contents)
+	if(!air_contents || !can_explode)
 		return ..()
 
 	/// Handle fragmentation


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Singletanks explosives (the ones made by filling up a tank with hot gases and waiting a bit until they explode, not the signaler ones) are heavily unbalanced as the explosion power is far too great compared to the effort required to create one. 
This PR disables basic tanks from exploding unless they are part of the TTV assembly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Everyone complains about how easy these are to make and spam, with a destructive power not comparable to the effort required. There is no way to balance this without gutting toxins, this is the best compromise.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Only TTVs are allowed to explode, basic tanks will just rupture and release all their gases.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
