### PR TITLE
Nerfs singletanks (again)

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -45,10 +45,21 @@
 #define TANK_LEAK_PRESSURE (30.*ONE_ATMOSPHERE)
 /// The internal pressure in kPa at which a handheld gas tank almost immediately ruptures.
 #define TANK_RUPTURE_PRESSURE (35.*ONE_ATMOSPHERE)
+// Tank explosions
+/// The base power of tank explosions. All of the below scaling constants are relative to this.
+#define TANK_FRAGMENT_POWER_BASE ((20**2)/2)
 /// The internal pressure in kPa at which an gas tank that breaks will cause an explosion.
-#define TANK_FRAGMENT_PRESSURE (40.*ONE_ATMOSPHERE)
-/// Range scaling constant for tank explosions. Calibrated so that a TTV assembled using two 70L tanks will hit the maxcap at at least 160atm.
-#define TANK_FRAGMENT_SCALE (84.*ONE_ATMOSPHERE)
+#define TANK_FRAGMENT_PRESSURE_THRESHOLD (40.*ONE_ATMOSPHERE)
+/// The excess tank pressure required for the pressure power multiplier to be 1.
+#define TANK_FRAGMENT_PRESSURE_SCALE (120.*ONE_ATMOSPHERE)
+/// The exponent that the scaled excess tank pressure is scaled to to get the power multiplier.
+#define TANK_FRAGMENT_PRESSURE_EXP 1
+/// The tank volume required for the volume power multiplier to be 1.
+#define TANK_FRAGMENT_VOLUME_SCALE (70 * 2)
+/// The exponent that the scaled tank volume is raised to to get the power multiplier.
+#define TANK_FRAGMENT_VOLUME_EXP 1
+/// The equation used to get tank fragmentation explosion power. As of writing this it is scaled to maxcap at 140L and 160kPa.
+#define TANK_FRAGMENT_POWER(BASE_POWER, PRESSURE, VOLUME) ((BASE_POWER) * ((((PRESSURE) - (TANK_FRAGMENT_PRESSURE_THRESHOLD)) / (TANK_FRAGMENT_PRESSURE_SCALE))**(TANK_FRAGMENT_PRESSURE_EXP)) * (((VOLUME) / (TANK_FRAGMENT_VOLUME_SCALE))**(TANK_FRAGMENT_VOLUME_EXP)))
 
 //MULTIPIPES
 //IF YOU EVER CHANGE THESE CHANGE SPRITES TO MATCH.

--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -50,11 +50,11 @@
 #define TANK_FRAGMENT_POWER_BASE ((20**2)/2)
 /// The internal pressure in kPa at which an gas tank that breaks will cause an explosion.
 #define TANK_FRAGMENT_PRESSURE_THRESHOLD (40.*ONE_ATMOSPHERE)
-/// The excess tank pressure required for the pressure power multiplier to be 1.
+/// The excess tank pressure required for the pressure power multiplier to be 1. (Assuming [TANK_FRAGMENT_PRESSURE_EXP] != 0)
 #define TANK_FRAGMENT_PRESSURE_SCALE (120.*ONE_ATMOSPHERE)
 /// The exponent that the scaled excess tank pressure is scaled to to get the power multiplier.
 #define TANK_FRAGMENT_PRESSURE_EXP 1
-/// The tank volume required for the volume power multiplier to be 1.
+/// The tank volume required for the volume power multiplier to be 1. (Assuming [TANK_FRAGMENT_VOLUME_EXP] != 0)
 #define TANK_FRAGMENT_VOLUME_SCALE (70 * 2)
 /// The exponent that the scaled tank volume is raised to to get the power multiplier.
 #define TANK_FRAGMENT_VOLUME_EXP 1

--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -57,7 +57,7 @@
 /// The tank volume required for the volume power multiplier to be 1. (Assuming [TANK_FRAGMENT_VOLUME_EXP] != 0)
 #define TANK_FRAGMENT_VOLUME_SCALE (70 * 2)
 /// The exponent that the scaled tank volume is raised to to get the power multiplier.
-#define TANK_FRAGMENT_VOLUME_EXP 1
+#define TANK_FRAGMENT_VOLUME_EXP 13.2170489136 // By Mothblocks request, this divides the explosion range of large (70L) singletanks by a factor of 69*sqrt(2).
 /// The equation used to get tank fragmentation explosion power. As of writing this it is scaled to maxcap at 140L and 160kPa.
 #define TANK_FRAGMENT_POWER(BASE_POWER, PRESSURE, VOLUME) ((BASE_POWER) * ((((PRESSURE) - (TANK_FRAGMENT_PRESSURE_THRESHOLD)) / (TANK_FRAGMENT_PRESSURE_SCALE))**(TANK_FRAGMENT_PRESSURE_EXP)) * (((VOLUME) / (TANK_FRAGMENT_VOLUME_SCALE))**(TANK_FRAGMENT_VOLUME_EXP)))
 

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -166,7 +166,7 @@
 		"minReleasePressure" = round(TANK_MIN_RELEASE_PRESSURE),
 		"maxReleasePressure" = round(TANK_MAX_RELEASE_PRESSURE),
 		"leakPressure" = round(TANK_LEAK_PRESSURE),
-		"fragmentPressure" = round(TANK_FRAGMENT_PRESSURE)
+		"fragmentPressure" = round(TANK_FRAGMENT_PRESSURE_THRESHOLD)
 	)
 
 /obj/item/tank/ui_data(mob/user)
@@ -311,7 +311,7 @@
 
 	/// Handle fragmentation
 	var/pressure = air_contents.return_pressure()
-	if(pressure > TANK_FRAGMENT_PRESSURE)
+	if(pressure > TANK_FRAGMENT_PRESSURE_THRESHOLD)
 		if(!istype(loc, /obj/item/transfer_valve))
 			log_bomber(get_mob_by_key(fingerprintslast), "was last key to touch", src, "which ruptured explosively")
 		//Give the gas a chance to build up more pressure through reacting

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -319,7 +319,7 @@
 		pressure = air_contents.return_pressure()
 
 		// As of writing this this is calibrated to maxcap at 140L and 160atm.
-		var/power = (air_contents.volume * (pressure - TANK_FRAGMENT_PRESSURE)) / TANK_FRAGMENT_SCALE
+		var/power = TANK_FRAGMENT_POWER(TANK_FRAGMENT_POWER_BASE, pressure, air_contents.volume)
 		dyn_explosion(src, power, flash_range = 1.5, ignorecap = FALSE)
 	return ..()
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -589,7 +589,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 		"maxReleasePressure" = round(can_max_release_pressure),
 		"pressureLimit" = round(pressure_limit),
 		"holdingTankLeakPressure" = round(TANK_LEAK_PRESSURE),
-		"holdingTankFragPressure" = round(TANK_FRAGMENT_PRESSURE)
+		"holdingTankFragPressure" = round(TANK_FRAGMENT_PRESSURE_THRESHOLD)
 	)
 
 /obj/machinery/portable_atmospherics/canister/ui_data()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Rewrites the equation used to calculate overpressurized tank explosion power to be more human-readable.
- Adds defines to allow for tank explosion range scaling to scale based on volume and pressure independently.
- Toxins shouldn't notice any changes since everything is balanced around TTV values remaining the same.
- Reduces the explosion range of 70L singletanks by a factor of `69` at Hugbug's request. (Open to discussion)

The new tank explosion scaling is
```
(BASE_POWER * (((PRESSURE - TANK_FRAGMENT_PRESSURE_THRESHOLD) / TANK_FRAGMENT_PRESSURE_SCALE)**TANK_FRAGMENT_PRESSURE_EXP) * ((VOLUME / TANK_FRAGMENT_VOLUME_SCALE)**TANK_FRAGMENT_VOLUME_EXP))
```

The exponents control how heavily the explosion power depends on the tank pressure and volume respectively. An exponent of 1 means it scales linearly. An exponent of 0 means that it ignores that factor. Anything positive and less than 1 makes it more effective at lower values and anything greater than 1 makes it less effective at lower values.

The scaling is set to preserve the current behavior of TTVs at the moment.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Makes it easier to rebalance singletanks without taking the nuclear option (#62388)
- Nerfs singletanks to prevent the above nuclear option.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: The explosive power of fragmenting gas tanks is even more dependent on volume. (No net change to the ordnance gameloop)
code: Tank explosion scaling is now both easier to read and easier to rebalance. Feel free to bikeshed to your hearts content.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
