### PR TITLE
heavily EMPing suit sensors will now short them out instead of randomizing them

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -68,13 +68,18 @@
 		//make the sensor mode favor higher levels, except coords.
 		sensor_mode = pick(SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS, SENSOR_COORDS)
 
-/obj/item/clothing/under/emp_act()
+/obj/item/clothing/under/emp_act(severity)
 	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
 	if(has_sensor > NO_SENSORS)
-		sensor_mode = pick(SENSOR_OFF, SENSOR_OFF, SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS)
+		if(severity <= EMP_HEAVY)
+			sensor_mode = SENSOR_OFF
+		else
+			sensor_mode = min(sensor_mode, pick(SENSOR_OFF, SENSOR_OFF, SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS))
 		if(ismob(loc))
 			var/mob/M = loc
-			to_chat(M,span_warning("The sensors on the [src] change rapidly!"))
+			to_chat(M,span_warning("The sensors on the [src] shudder and buzz!"))
 
 /obj/item/clothing/under/visual_equipped(mob/user, slot)
 	..()

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -74,12 +74,20 @@
 		return
 	if(has_sensor > NO_SENSORS)
 		if(severity <= EMP_HEAVY)
-			sensor_mode = SENSOR_OFF
+			has_sensor = BROKEN_SENSORS
+			if(ismob(loc))
+				var/mob/M = loc
+				to_chat(M,span_warning("[src]'s sensors short out!"))
 		else
-			sensor_mode = min(sensor_mode, pick(SENSOR_OFF, SENSOR_OFF, SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS))
-		if(ismob(loc))
-			var/mob/M = loc
-			to_chat(M,span_warning("The sensors on the [src] shudder and buzz!"))
+			sensor_mode = pick(SENSOR_OFF, SENSOR_OFF, SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS)
+			if(ismob(loc))
+				var/mob/M = loc
+				to_chat(M,span_warning("The sensors on the [src] change rapidly!"))
+		if(ishuman(loc))
+			var/mob/living/carbon/human/ooman = loc
+			if(ooman.w_uniform == src)
+				ooman.update_suit_sensors()
+
 
 /obj/item/clothing/under/visual_equipped(mob/user, slot)
 	..()


### PR DESCRIPTION
## About The Pull Request

Heavily EMPing a jumpsuit or another piece of under clothing will now short out its suit sensors (as if they had shorted out from damage to the jumpsuit) instead of randomizing their setting. You can repair them with a cable coil as normal.

The sensor list will now be updated when your jumpsuit is EMP'd to reflect any possible changes in suit sensor status.

Under clothing will now respect the EMP_PROTECT_SELF flag.

## Why It's Good For The Game

This makes the primary counter to bloodthirsty paramedics not RNG-dependent.

## Changelog

:cl: ATHATH
balance: Heavily EMPing a jumpsuit or another piece of under clothing will now short out its suit sensors (as if they had shorted out from damage to the jumpsuit) instead of randomizing their setting. You can repair them with a cable coil as normal.
fix: The sensor list will now be updated when your jumpsuit is EMP'd to reflect any possible changes in suit sensor status.
fix: Under clothing will now respect the EMP_PROTECT_SELF flag.
/:cl:
