### PR TITLE
SM Chamber Air Alarms and Areas consistency

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -28619,6 +28619,10 @@
 	dir = 1;
 	name = "Gas to Filter"
 	},
+/obj/machinery/airalarm/engine{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -49793,7 +49793,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/engine,
-/area/engineering/supermatter)
+/area/engineering/supermatter/room)
 "lDK" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -23017,6 +23017,9 @@
 	dir = 4;
 	name = "Gas to Chamber"
 	},
+/obj/machinery/airalarm/engine{
+	pixel_y = 23
+	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "fUR" = (
@@ -36890,10 +36893,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/airalarm/engine{
-	dir = 8;
-	pixel_x = 24
-	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "lcF" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -36895,7 +36895,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/engine,
-/area/engineering/supermatter)
+/area/engineering/supermatter/room)
 "lcF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6999,10 +6999,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/meter,
 /obj/structure/cable,
-/obj/machinery/airalarm/engine{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "aQw" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7004,7 +7004,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/engine,
-/area/engineering/supermatter)
+/area/engineering/supermatter/room)
 "aQw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Meta, Kilo and Tram have a supermatter chamber `/area` outside of the supermatter chamber, to link the alarm hanging on the wall behind it to the SM Chamber. This changes this area to be consistent with the rest of the room, adds air alarms to the antechamber if they weren't present previously, and removes any air alarm immediately outside of the antechamber to avoid confusion.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

...well, it might not be:

> (18:29:10) <Saal> I would ask that this isn't done, since this is typically one of the first areas to become unsafe during a delamination event

I've updated this PR to be consistent anyway, but this probably needs discussion

<details>
<summary>old reasoning</summary>
I can't unsee it

![ss13-stray-chamber](https://user-images.githubusercontent.com/14355175/139179447-310c487e-28a5-44ca-803c-898f6a4e8a9a.png)
</details>

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: SM Chamber Air Alarms are now always inside the antechamber. The SM Room no longer has one tile magically being considered part of the SM Chamber, where applicable. This affects KiloStation, MetaStation, and TramStation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
