### PR TITLE
Breaking baseturf limits now directly spawns an error turf

### DIFF
--- a/code/__HELPERS/string_lists.dm
+++ b/code/__HELPERS/string_lists.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST_EMPTY(string_lists)
 	// return values
 	if(length(values) > 10)
 		stack_trace("The baseturfs list of [baseturf_holder] at [baseturf_holder.x], [baseturf_holder.y], [baseturf_holder.x] is [length(values)], it should never be this long, investigate. I've set baseturfs to a flashing wall as a visual queue")
+		baseturf_holder.ChangeTurf(/turf/closed/indestructible/baseturfs_ded, list(/turf/closed/indestructible/baseturfs_ded), flags = CHANGETURF_FORCEOP)
 		return string_list(list(/turf/closed/indestructible/baseturfs_ded)) //I want this reported god damn it
 	return string_list(values)
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes breaking the baseturf length limit spawn a baseturf warning tile as a replacement for the current tile.
Doesn't appear to cause infinite loops!

## Why It's Good For The Game

Hopefully this warns people of what's going on a bit better then just inserting it in the baseturfs
Here's an example error case I made by spawning ctf spawners

![image](https://user-images.githubusercontent.com/58055496/139191770-66018756-0214-4abd-b534-5626899d4789.png)
