### PR TITLE
(Tries) to remove long timer singlecaps

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -414,13 +414,14 @@
 	requirements = list(
 		/datum/gas/oxygen = MINIMUM_MOLE_COUNT,
 		/datum/gas/nitryl = MINIMUM_MOLE_COUNT,
-		"MAX_TEMP" = 600
+		"MAX_TEMP" = T0C + 70 //Pretty warm, explicitly not fire temps. Time bombs are cool, but not that cool. If it makes you feel any better it's close
 	)
 
 /datum/gas_reaction/nitryl_decomposition/react(datum/gas_mixture/air)
 	var/list/cached_gases = air.gases
 	var/temperature = air.temperature
 	var/old_heat_capacity = air.heat_capacity()
+	//This reaction is agressively slow. like, a tenth of a mole per fire slow. Keep that in mind
 	var/heat_efficency = min(temperature / (FIRE_MINIMUM_TEMPERATURE_TO_EXIST * 8), cached_gases[/datum/gas/nitryl][MOLES])
 	var/energy_produced = heat_efficency * NITRYL_DECOMPOSITION_ENERGY
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ok. Let's talk yeah?

This pr changes the temperature limit on nitryl. Lowers it from 600k to roughly 340k
So I assume you're familiar with singletank/cap bombs (Fuck you assembly people)
Idea is basically the same as a ttv, except it's not a ttv, so you've got no control

It's a product of a cursed problem around explosion code that I'm willing to harbor
We want two things. TTVs that work off pressure, in a semi realistic way, and tanks that explode when you fuck up your ttv
Only makes sense that the tanks should have at least the same base logic as the ttv right? That's kind of the issue
I'm not willing to compromise on any of those three points, so things are the way they are

Ok now that we're all on the same page. You remember that bit I said about no control?
Nitryl has a decomposition reaction. Exists so you can't plumb the station with the stuff, etc etc
Takes nitryl, which is "canonically" 1 nitrogen 2 oxygen, decomposes it into 02, and heat

Aggressively soulful reaction right? Really slow, so it's not an instant thing, but it does go through

Anyway. So let's say we take a ttv mix, trit + plasma, and take advantage of some parts of that reaction.
1: It takes a small amount of o2 and a large amount of no2, and returns you a large amount of o2 over a long period of time
2: It's exothermic. So we're slowly ramping up the temperature of our mix. Very very slowly mind

I'm sure you can figure out the problem here. Giving people what amounts to fuses, which at this scale is a problem
It honestly does kind of hurt to try and remove this, because frankly if I played this game I'd be telling people about it whenever I got the chance (Consider what I just did "that")

Thing is it allows for levels of nuke that are not workable. It's a concept I've been aware of for a while, but I A: didn't realize how stronk it was, and B: didn't think it was well known enough
People are using it a lot, and god it's stronk

Please consider this a by-proxy salt pr, since again, I don't play
Oh and to be clear, I won't do prs like this anytime someone uses something strong. That's why servers have admins. I've got sanity limits though, and this crossed those

## Why it's Bad For The Game
![image](https://user-images.githubusercontent.com/58055496/139192235-a7e58003-f3e9-4073-aa34-ac3fdd0438b7.png)

Closes #62388 (I'd close it myself but that feels wrong for some reason) (Jesus I can't type can I eh?)
Relieves? #62391 (Might still be needed, but not as aggressively. Fuck you mothblocks, it's ok temporal you don't need to scale the slope by 69, don't need to stress bout it *muffled laughter*)

## Logchain
:cl:
fix: You're (hopefully) no longer able to make timed singlecaps using nitryl. I really liked this one honestly, it's got an aggressive amount of heart and soul
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
