### PR TITLE
Adds a hard limt to hfr fuel datums, moves antinob down to match it

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	var/fuel_consumption_multiplier = 1
 	///Multiplier for the gas production (min 0.01)
 	var/gas_production_multiplier = 1
-	///Max allowed temperature multiplier, scales the max temperature we can hit, See FUSION_MAXIMUM_TEMPERATURE (Maxed at 1, don't go getting any ideas)
+	///Max allowed temperature multiplier, scales the max temperature we can hit, see FUSION_MAXIMUM_TEMPERATURE (Maxed at 1, don't go getting any ideas)
 	var/temperature_change_multiplier = 1
 	///These are the main fuels, only 2 gases that are the ones being consumed by the fusion reaction (eg. H2 and trit)
 	var/requirements = list()

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	var/fuel_consumption_multiplier = 1
 	///Multiplier for the gas production (min 0.01)
 	var/gas_production_multiplier = 1
-	///Max allowed temperature multiplier, don't go overboard with this (mix 0.5, max 0.3)
+	///Max allowed temperature multiplier, scales the max temperature we can hit, See FUSION_MAXIMUM_TEMPERATURE (Maxed at 1, don't go getting any ideas)
 	var/temperature_change_multiplier = 1
 	///These are the main fuels, only 2 gases that are the ones being consumed by the fusion reaction (eg. H2 and trit)
 	var/requirements = list()
@@ -36,6 +36,10 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	var/secondary_products = list()
 	///Flags to decide what behaviour the meltdown will have depending on the fuel mix used
 	var/meltdown_flags = HYPERTORUS_FLAG_BASE_EXPLOSION
+
+/datum/hfr_fuel/New()
+	. = ..()
+	temperature_change_multiplier = min(temperature_change_multiplier, 1)
 
 /datum/hfr_fuel/plasma_oxy_fuel
 	id = "plasma_o2_fuel"
@@ -129,7 +133,7 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	energy_concentration_multiplier = 2
 	fuel_consumption_multiplier = 0.01
 	gas_production_multiplier = 3
-	temperature_change_multiplier = 1.2
+	temperature_change_multiplier = 1
 	requirements = list(/datum/gas/hypernoblium, /datum/gas/antinoblium)
 	primary_products = list(/datum/gas/helium)
 	secondary_products = list(/datum/gas/plasma, /datum/gas/oxygen, /datum/gas/nitrogen, /datum/gas/proto_nitrate, /datum/gas/stimulum, /datum/gas/miasma)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm serious about atmos's temp limit. I ain't going back to e32 land ever again.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

 Frankly this isn't really a huge change functionally, at those temps it barely batters. does somewhat lower the incentive to do the reaction, but ghil tells me there are other reasons so eh. Helps ward off the demons who keep waking me up at night

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: The nob + antinob hfr fuel type is now limited to 1e8 instead of 1e8 * 1.2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
