### PR TITLE
Fixes halloween roundstart species

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -69,7 +69,7 @@ GLOBAL_VAR(command_name)
 	// Prefix
 	var/holiday_name = pick(SSevents.holidays)
 	if(holiday_name)
-		var/datum/holiday/holiday = SSevents.holidays[holiday_name]
+		var/datum/holiday/holiday = SSevents.get_holiday(holiday_name)
 		if(istype(holiday, /datum/holiday/friday_thirteenth))
 			random = 13
 		name = holiday.getStationPrefix()

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -33,13 +33,13 @@ SUBSYSTEM_DEF(communications)
 /**
  * Check if a mob can call an emergency meeting
  *
- * Should only really happen during april fools. 
+ * Should only really happen during april fools.
  * Checks to see that it's been at least 5 minutes since the last emergency meeting call.
  * Arguments:
  * * user - Mob who called the meeting
  */
 /datum/controller/subsystem/communications/proc/can_make_emergency_meeting(mob/living/user)
-	if(!(SSevents.holidays && SSevents.holidays[APRIL_FOOLS]))
+	if(!(SSevents.get_holiday(APRIL_FOOLS)))
 		return FALSE
 	else if(COOLDOWN_FINISHED(src, emergency_meeting_cooldown))
 		return TRUE
@@ -49,7 +49,7 @@ SUBSYSTEM_DEF(communications)
 /**
  * Call an emergency meeting
  *
- * Communications subsystem wrapper for the call_emergency_meeting world proc. 
+ * Communications subsystem wrapper for the call_emergency_meeting world proc.
  * Checks to make sure the proc can be called, and handles
  * relevant logging and timing. See that proc definition for more detail.
  * Arguments:

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -22,7 +22,6 @@ SUBSYSTEM_DEF(events)
 		control += E //add it to the list of all events (controls)
 	reschedule()
 	getHoliday()
-	GLOB.roundstart_races = generate_selectable_species()
 	return ..()
 
 
@@ -165,8 +164,8 @@ SUBSYSTEM_DEF(events)
 			var/DDD = time2text(time_in_timezone, "DDD") // get the current weekday
 
 			if(holiday.shouldCelebrate(DD, MM, YYYY, DDD))
-				holiday.celebrate()
 				LAZYSET(holidays, holiday.name, holiday)
+				holiday.celebrate()
 				delete_holiday = FALSE
 				break
 		if(delete_holiday)

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -22,6 +22,7 @@ SUBSYSTEM_DEF(events)
 		control += E //add it to the list of all events (controls)
 	reschedule()
 	getHoliday()
+	GLOB.roundstart_races = generate_selectable_species()
 	return ..()
 
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -269,7 +269,7 @@ SUBSYSTEM_DEF(ticker)
 	if(SSevents.holidays)
 		to_chat(world, span_notice("and..."))
 		for(var/holidayname in SSevents.holidays)
-			var/datum/holiday/holiday = SSevents.holidays[holidayname]
+			var/datum/holiday/holiday = SSevents.get_holiday(holidayname)
 			to_chat(world, "<h4>[holiday.greet()]</h4>")
 
 	PostSetup()

--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -223,17 +223,17 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	var/name_part1
 	var/name_part2
 
-	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+	if(SSevents.get_holiday(HALLOWEEN))
 		name_action = pick_list(ARCADE_FILE, "rpg_action_halloween")
 		name_part1 = pick_list(ARCADE_FILE, "rpg_adjective_halloween")
 		name_part2 = pick_list(ARCADE_FILE, "rpg_enemy_halloween")
 		weapons = strings(ARCADE_FILE, "rpg_weapon_halloween")
-	else if(SSevents.holidays && SSevents.holidays[CHRISTMAS])
+	else if(SSevents.get_holiday(CHRISTMAS))
 		name_action = pick_list(ARCADE_FILE, "rpg_action_xmas")
 		name_part1 = pick_list(ARCADE_FILE, "rpg_adjective_xmas")
 		name_part2 = pick_list(ARCADE_FILE, "rpg_enemy_xmas")
 		weapons = strings(ARCADE_FILE, "rpg_weapon_xmas")
-	else if(SSevents.holidays && SSevents.holidays[VALENTINES])
+	else if(SSevents.get_holiday(VALENTINES))
 		name_action = pick_list(ARCADE_FILE, "rpg_action_valentines")
 		name_part1 = pick_list(ARCADE_FILE, "rpg_adjective_valentines")
 		name_part2 = pick_list(ARCADE_FILE, "rpg_enemy_valentines")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -174,7 +174,7 @@
 				return
 			LAZYREMOVE(messages, LAZYACCESS(messages, message_index))
 		if ("emergency_meeting")
-			if(!(SSevents.holidays && SSevents.holidays[APRIL_FOOLS]))
+			if(!(SSevents.get_holiday(APRIL_FOOLS)))
 				return
 			if (!authenticated_as_silicon_or_captain(usr))
 				return
@@ -461,7 +461,7 @@
 				data["importantActionReady"] = COOLDOWN_FINISHED(src, important_action_cooldown)
 				data["shuttleCalled"] = FALSE
 				data["shuttleLastCalled"] = FALSE
-				data["aprilFools"] = SSevents.holidays && SSevents.holidays[APRIL_FOOLS]
+				data["aprilFools"] = SSevents.get_holiday(APRIL_FOOLS)
 				data["alertLevel"] = get_security_level()
 				data["authorizeName"] = authorize_name
 				data["canLogOut"] = !issilicon(user)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -83,7 +83,7 @@
 					var/mob/living/carbon/human/human = M
 					if(!(human.mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL|MOB_UNDEAD|MOB_SPIRIT)))
 						var/datum/species/species_to_transform = /datum/species/fly
-						if(SSevents.holidays && SSevents.holidays[MOTH_WEEK])
+						if(SSevents.get_holiday(MOTH_WEEK))
 							species_to_transform = /datum/species/moth
 						if(human.dna && human.dna.species.id != initial(species_to_transform.id))
 							to_chat(M, span_hear("You hear a buzzing in your ears."))

--- a/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
+++ b/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
@@ -7,16 +7,15 @@
 #define PRIDE_ALPHA 60
 
 /obj/effect/turf_decal/tile/Initialize(mapload)
-	if(SSevents.holidays)
-		if (SSevents.holidays[APRIL_FOOLS])
-			color = "#[random_short_color()]"
-		else if (SSevents.holidays[PRIDE_WEEK])
-			var/datum/holiday/pride_week/pride_week = SSevents.holidays[PRIDE_WEEK]
-			color = pride_week.get_floor_tile_color(src)
+	if (SSevents.get_holiday(APRIL_FOOLS))
+		color = "#[random_short_color()]"
+	else if (SSevents.get_holiday(PRIDE_WEEK))
+		var/datum/holiday/pride_week/pride_week = SSevents.get_holiday(PRIDE_WEEK)
+		color = pride_week.get_floor_tile_color(src)
 
-			// It looks garish at different alphas, and it's not possible to get a
-			// consistent color palette without this.
-			alpha = PRIDE_ALPHA
+		// It looks garish at different alphas, and it's not possible to get a
+		// consistent color palette without this.
+		alpha = PRIDE_ALPHA
 	return ..()
 
 #undef PRIDE_ALPHA
@@ -215,7 +214,7 @@
 	icon_state = "trimline_box"
 
 /obj/effect/turf_decal/trimline/Initialize(mapload)
-	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+	if(SSevents.get_holiday(APRIL_FOOLS))
 		color = "#[random_short_color()]"
 	. = ..()
 

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -651,7 +651,7 @@
 
 /obj/item/food/cookie/sugar/Initialize(mapload)
 	. = ..()
-	if(SSevents.holidays && SSevents.holidays[FESTIVE_SEASON])
+	if(SSevents.get_holiday(FESTIVE_SEASON))
 		var/shape = pick("tree", "bear", "santa", "stocking", "present", "cane")
 		desc = "A sugar cookie in the shape of a [shape]. I hope Santa likes it!"
 		icon_state = "sugarcookie_[shape]"

--- a/code/game/objects/items/implants/implant_mindshield.dm
+++ b/code/game/objects/items/implants/implant_mindshield.dm
@@ -28,7 +28,7 @@
 			qdel(src)
 			return TRUE
 		if(SEND_SIGNAL(target.mind, COMSIG_MINDSHIELD_IMPLANTED, user) & COMPONENT_MINDSHIELD_DECONVERTED)
-			if(prob(1) || SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+			if(prob(1) || SSevents.get_holiday(APRIL_FOOLS))
 				target.say("I'm out! I quit! Whose kidneys are these?", forced = "They're out! They quit! Whose kidneys do they have?")
 
 	ADD_TRAIT(target, TRAIT_MINDSHIELD, IMPLANT_TRAIT)

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -183,7 +183,7 @@
 	var/mineralChance = 13
 
 /turf/closed/mineral/random/Initialize(mapload)
-	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+	if(SSevents.get_holiday(APRIL_FOOLS))
 		mineralSpawnChanceList[/obj/item/stack/ore/bananium] = 3
 
 	mineralSpawnChanceList = typelist("mineralSpawnChanceList", mineralSpawnChanceList)

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -22,7 +22,7 @@
 	var/end_message = "."
 	var/rendered = begin_message + obj_message + end_message
 	deadchat_broadcast(rendered, "<b>[L]</b>", follow_target = L, turf_target = get_turf(L), message_type=DEADCHAT_ANNOUNCEMENT)
-	if(prob(1) || SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+	if(prob(1) || SSevents.get_holiday(APRIL_FOOLS))
 		L.say("You son of a bitch! I'm in.", forced = "That son of a bitch! They're in.")
 
 /datum/antagonist/brainwashed

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -272,7 +272,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		H.uncuff()
 		H.stuttering = 0
 		H.cultslurring = 0
-		if(prob(1) || SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+		if(prob(1) || SSevents.get_holiday(APRIL_FOOLS))
 			H.say("You son of a bitch! I'm in.", forced = "That son of a bitch! They're in.")
 	return TRUE
 

--- a/code/modules/antagonists/slaughter/slaughter.dm
+++ b/code/modules/antagonists/slaughter/slaughter.dm
@@ -208,7 +208,7 @@
 
 /mob/living/simple_animal/hostile/imp/slaughter/laughter/Initialize(mapload)
 	. = ..()
-	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+	if(SSevents.get_holiday(APRIL_FOOLS))
 		icon_state = "honkmon"
 
 /mob/living/simple_animal/hostile/imp/slaughter/laughter/Destroy()

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -305,7 +305,7 @@
 	//If this proc fires the mob must be a revhead
 	var/datum/antagonist/rev/head/converter = aggressor.mind.has_antag_datum(/datum/antagonist/rev/head)
 	if(converter.add_revolutionary(victim.mind))
-		if(prob(1) || SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+		if(prob(1) || SSevents.get_holiday(APRIL_FOOLS))
 			victim.say("You son of a bitch! I'm in.", forced = "That son of a bitch! They're in.")
 		times_used -- //Flashes less likely to burn out for headrevs when used for conversion
 	else

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -47,7 +47,7 @@
 		return FALSE
 	if(players_amt < min_players)
 		return FALSE
-	if(holidayID && (!SSevents.holidays || !SSevents.holidays[holidayID]))
+	if(holidayID && !SSevents.get_holiday(holidayID))
 		return FALSE
 	if(EMERGENCY_ESCAPED_OR_ENDGAMED)
 		return FALSE

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -51,9 +51,9 @@
 
 /obj/effect/spawner/xmastree/Initialize(mapload)
 	..()
-	if((CHRISTMAS in SSevents.holidays) && christmas_tree)
+	if(SSevents.get_holiday(CHRISTMAS) && christmas_tree)
 		new christmas_tree(get_turf(src))
-	else if((FESTIVE_SEASON in SSevents.holidays) && festive_tree)
+	else if(SSevents.get_holiday(FESTIVE_SEASON) && festive_tree)
 		new festive_tree(get_turf(src))
 
 	return INITIALIZE_HINT_QDEL

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -32,7 +32,7 @@
 		if("threatening")
 			wave_type = GLOB.meteors_threatening
 		if("catastrophic")
-			if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+			if(SSevents.get_holiday(HALLOWEEN))
 				wave_type = GLOB.meteorsSPOOKY
 			else
 				wave_type = GLOB.meteors_catastrophic

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -502,6 +502,10 @@
 	end_day = 2
 	end_month = NOVEMBER
 
+/datum/holiday/halloween/celebrate()
+	. = ..()
+	GLOB.roundstart_races = generate_selectable_species()
+
 /datum/holiday/halloween/greet()
 	return "Have a spooky Halloween!"
 

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -502,10 +502,6 @@
 	end_day = 2
 	end_month = NOVEMBER
 
-/datum/holiday/halloween/celebrate()
-	. = ..()
-	GLOB.roundstart_races = generate_selectable_species()
-
 /datum/holiday/halloween/greet()
 	return "Have a spooky Halloween!"
 

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -70,7 +70,7 @@
 
 /datum/outfit/job/hop/pre_equip(mob/living/carbon/human/H)
 	..()
-	if(locate(/datum/holiday/ianbirthday) in SSevents.holidays)
+	if(SSevents.get_holiday("Ian's Birthday"))
 		undershirt = /datum/sprite_accessory/undershirt/ian
 
 //only pet worth reviving

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -44,6 +44,6 @@
 
 /datum/outfit/job/janitor/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()
-	if(GARBAGEDAY in SSevents.holidays)
+	if(SSevents.get_holiday(GARBAGEDAY))
 		backpack_contents += /obj/item/gun/ballistic/revolver
 		r_pocket = /obj/item/ammo_box/a357

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -274,7 +274,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	var/balloon_clusters = 2
 
 /obj/effect/mapping_helpers/ianbirthday/LateInitialize()
-	if(locate(/datum/holiday/ianbirthday) in SSevents.holidays)
+	if(SSevents.get_holiday("Ian's Birthday"))
 		birthday()
 	qdel(src)
 
@@ -342,7 +342,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	icon_state = "iansnewyrshelper"
 
 /obj/effect/mapping_helpers/iannewyear/LateInitialize()
-	if(SSevents.holidays && SSevents.holidays[NEW_YEAR])
+	if(SSevents.get_holiday(NEW_YEAR))
 		fireworks()
 	qdel(src)
 

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -269,7 +269,7 @@
 /mob/living/carbon/human/get_blood_id()
 	if(HAS_TRAIT(src, TRAIT_HUSK))
 		return
-	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS] && is_clown_job(mind?.assigned_role))
+	if(SSevents.get_holiday(APRIL_FOOLS) && is_clown_job(mind?.assigned_role))
 		return /datum/reagent/colorful_reagent
 	if(dna.species.exotic_blood)
 		return dna.species.exotic_blood

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -24,7 +24,7 @@
 
 
 /datum/species/dullahan/check_roundstart_eligible()
-	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+	if(SSevents.get_holiday(HALLOWEEN))
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -783,7 +783,7 @@
 	..()
 
 /datum/species/golem/cloth/check_roundstart_eligible()
-	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+	if(SSevents.get_holiday(HALLOWEEN))
 		return TRUE
 	return ..()
 

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -107,6 +107,6 @@
 		return
 
 /datum/species/monkey/check_roundstart_eligible()
-	if(SSevents.holidays && SSevents.holidays[MONKEYDAY])
+	if(SSevents.get_holiday(MONKEYDAY))
 		return TRUE
 	return ..()

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -29,6 +29,6 @@
 			H.heal_overall_damage(0.5 * delta_time, 0.5 * delta_time, 0, BODYPART_ORGANIC)
 
 /datum/species/shadow/check_roundstart_eligible()
-	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+	if(SSevents.get_holiday(HALLOWEEN))
 		return TRUE
 	return ..()

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -43,7 +43,7 @@
 	C.set_safe_hunger_level()
 
 /datum/species/skeleton/check_roundstart_eligible()
-	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+	if(SSevents.get_holiday(HALLOWEEN))
 		return TRUE
 	return ..()
 

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -22,7 +22,7 @@
 	var/obj/effect/proc_holder/spell/targeted/shapeshift/bat/batform //attached to the datum itself to avoid cloning memes, and other duplicates
 
 /datum/species/vampire/check_roundstart_eligible()
-	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+	if(SSevents.get_holiday(HALLOWEEN))
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -37,7 +37,7 @@
 	bodytemp_cold_damage_limit = MINIMUM_TEMPERATURE_TO_MOVE // take damage below minimum movement temp
 
 /datum/species/zombie/check_roundstart_eligible()
-	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+	if(SSevents.get_holiday(HALLOWEEN))
 		return TRUE
 	return ..()
 

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -39,7 +39,7 @@
 
 /obj/item/paper_bin/proc/generate_paper()
 	var/obj/item/paper/paper = new papertype(src)
-	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
+	if(SSevents.get_holiday(APRIL_FOOLS))
 		if(prob(30))
 			paper.info = "<font face=\"[CRAYON_FONT]\" color=\"red\"><b>HONK HONK HONK HONK HONK HONK HONK<br>HOOOOOOOOOOOOOOOOOOOOOONK<br>APRIL FOOLS</b></font>"
 			paper.AddElement(/datum/element/honkspam)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Halloween roundstart species are bugged because the roundstart species list sometimes gets generated before ssevents initializes. This fixes that by letting holidays be fetched before ssevents initialization.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Hallowen is saved

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed halloween roundstart species not showing up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
