### PR TITLE
Fixes a broken cable on metastation.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -41432,6 +41432,7 @@
 "mLm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "mLp" = (
@@ -93639,7 +93640,7 @@ tXK
 oTJ
 qgY
 vIC
-vIC
+bHj
 eql
 vIC
 rmd


### PR DESCRIPTION

## About The Pull Request

The recent changes to the metastation shuttle broke a single wire by arrivals that was previously there, resulting in arrivals losing power far more easily as an unintended change.

This adds one wire.

## Why It's Good For The Game

Fixes #62419. Prevents arrivals on meta to lose power in 5 minutes.

## Changelog

:cl:
fix: Metastation once again has power to arrivals.
/:cl:
