### PR TITLE
Nerfs felipires and dullanids.

### DIFF
--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -36,7 +36,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	create_dna(src)
 	dna.initialize_dna(skip_index = TRUE)
 	dna.features["body_markings"] = "None"
-	dna.features["ears"] = "Cat"
+	dna.features["ears"] = "None"
 	dna.features["ethcolor"] = COLOR_WHITE
 	dna.features["frills"] = "None"
 	dna.features["horns"] = "None"
@@ -46,7 +46,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	dna.features["moth_wings"] = "Plain"
 	dna.features["snout"] = "Round"
 	dna.features["spines"] = "None"
-	dna.features["tail_human"] = "Cat"
+	dna.features["tail_human"] = "None"
 	dna.features["tail_lizard"] = "Smooth"
 
 //Inefficient pooling/caching way.

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -10,7 +10,7 @@
 		TRAIT_NOBREATH,
 	)
 	inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
-	mutant_bodyparts = list("tail_human" = "None", "ears" = "None", "wings" = "None")
+	mutant_bodyparts = list("wings" = "None")
 	use_skintones = TRUE
 	mutantbrain = /obj/item/organ/brain/dullahan
 	mutanteyes = /obj/item/organ/eyes/dullahan

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -10,7 +10,7 @@
 		TRAIT_NOBREATH,
 	)
 	inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
-	mutant_bodyparts = list("tail_human" = "None", "ears" = "None", "wings" = "None")
+	mutant_bodyparts = list("wings" = "None")
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | ERT_SPAWN
 	exotic_bloodtype = "U"
 	use_skintones = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/139354653-65c41810-394e-462a-b119-fceb80ce391f.png)
![image](https://user-images.githubusercontent.com/24975989/139354690-19efabd0-4c32-4465-bdb3-5f97b1a2113a.png)

Vampires and Dullahans have tail and ear mutant_parts defined but set to "None".

Because they're defined at all, the new prefs menu gives preference entries for them.

The /mob/living/carbon/human/dummy/consistent used to set these up has Cat ears and Cat tails defined in its DNA features.

Vampires and Dullahans inherit this dummy setting on the prefs menu, and thus can select cat ears and cat tails on the prefs menu.

Fixes /mob/living/carbon/human/dummy/consistent to not define cat ears and tails.
Fixes the Vampire and Dullahan species to define mutant bodyparts the same as humans, removing their ear and tail entries.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I hate fun.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Vampires and Dullahans can no longer select Cat ears and Cat tails. You monsters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
