### PR TITLE
the PDA will no longer bother you with a 'you can't do this right now' message when closed while resting

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -462,7 +462,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/mob/living/U = usr
 	//Looking for master was kind of pointless since PDAs don't appear to have one.
 
-	if(usr.canUseTopic(src, BE_CLOSE, FALSE, NO_TK) && !href_list["close"])
+	if(!href_list["close"] && usr.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		add_fingerprint(U)
 		U.set_machine(src)
 


### PR DESCRIPTION
## About The Pull Request

When you close it while you're laying down, it will no longer give you the message "You can't do that right now!"

There really isn't much more to say, all it does is make it so the message doesn't show up if all you're doing is closing the interface.

## Why It's Good For The Game

because it's annoying

## Changelog

:cl:
qol: the PDA will no longer bother you with a message if all you're doing is closing the interface while laying down.
/:cl: