### PR TITLE
Allows pAI's to print photographs for 10 ram

### DIFF
--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -13,15 +13,15 @@
 															"digital messenger" = 5,
 															"atmosphere sensor" = 5,
 															"photography module" = 5,
+															"camera zoom" = 10,
+															"printer module" = 10,
 															"remote signaler" = 10,
 															"medical records" = 10,
 															"security records" = 10,
-															"camera zoom" = 10,
 															"host scan" = 10,
 															"medical HUD" = 20,
 															"security HUD" = 20,
 															"loudness booster" = 20,
-															"printer module" = 20,
 															"newscaster" = 20,
 															"door jack" = 25,
 															"encryption keys" = 25,
@@ -581,6 +581,5 @@
 	dat += "Messages: <hr> [aiPDA.tnote]"
 	return dat
 
-// Bootleg Printer "Software"
 /mob/living/silicon/pai/proc/softwarePrinter()
 	aicamera.paiprint(usr)

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -21,10 +21,11 @@
 															"medical HUD" = 20,
 															"security HUD" = 20,
 															"loudness booster" = 20,
+															"printer module" = 20,
 															"newscaster" = 20,
-															"internal gps" = 35,
 															"door jack" = 25,
 															"encryption keys" = 25,
+															"internal gps" = 35,
 															"universal translator" = 35
 															)
 
@@ -70,7 +71,8 @@
 				left_part = softwareDoor()
 			if("hostscan")
 				left_part = softwareHostScan()
-
+			if("printer module")
+				left_part = softwarePrinter()
 
 	//usr << browse_rsc('windowbak.png') // This has been moved to the mob's Login() proc
 
@@ -271,6 +273,10 @@
 					internal_gps = new(src)
 				internal_gps.attack_self(src)
 
+			if("printermodule")
+				aicamera.paiprint(usr)
+
+
 		paiInterface()
 
 // MENUS
@@ -305,6 +311,8 @@
 			dat += "<a href='byond://?src=[REF(src)];software=loudness;sub=0'>Loudness Booster</a> <br>"
 		if(s == "internal gps")
 			dat += "<a href='byond://?src=[REF(src)];software=internalgps;sub=0'>Internal GPS</a> <br>"
+		if(s == "printer module")
+			dat += "<a href='byond://?src=[REF(src)];software=printermodule;sub=0'>Printer Module</a> <br>"
 
 	dat += "<br>"
 
@@ -572,3 +580,7 @@
 	dat += "<br><br>"
 	dat += "Messages: <hr> [aiPDA.tnote]"
 	return dat
+
+// Bootleg Printer "Software"
+/mob/living/silicon/pai/proc/softwarePrinter()
+	aicamera.paiprint(usr)

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -222,9 +222,10 @@
 /obj/item/camera/proc/printpicture(mob/user, datum/picture/picture) //Normal camera proc for creating photos
 	var/obj/item/photo/p = new(get_turf(src), picture)
 	if(in_range(src, user)) //needed because of TK
-		user.put_in_hands(p)
-		pictures_left--
-		to_chat(user, span_notice("[pictures_left] photos left."))
+		if(!ispAI(user))
+			user.put_in_hands(p)
+			pictures_left--
+			to_chat(user, span_notice("[pictures_left] photos left."))
 		var/customise = "No"
 		if(can_customise)
 			customise = tgui_alert(user, "Do you want to customize the photo?", "Customization", list("Yes", "No"))

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -98,4 +98,4 @@
 		return
 	printpicture(user,selection)
 	visible_message(span_notice("A picture appears on top of the chassis of [paimob.name]!"))
-	to_chat(usr, span_notice("You print a photograph."))
+	to_chat(user, span_notice("You print a photograph."))

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -87,8 +87,7 @@
 	p.pixel_x = p.base_pixel_x + rand(-10, 10)
 	p.pixel_y = p.base_pixel_y + rand(-10, 10)
 	C.toner -= printcost  //All fun allowed.
-	visible_message(span_notice("[C.name] spits out a photograph from a narrow slot on its chassis."))
-	to_chat(usr, span_notice("You print a photograph."))
+	user.visible_message(span_notice("[C.name] spits out a photograph from a narrow slot on its chassis."),span_notice("You print a photograph."))
 
 /obj/item/camera/siliconcam/proc/paiprint(mob/user)
 	var/mob/living/silicon/pai/paimob = loc
@@ -97,5 +96,4 @@
 		to_chat(user, span_warning("Invalid Image."))
 		return
 	printpicture(user,selection)
-	visible_message(span_notice("A picture appears on top of the chassis of [paimob.name]!"))
-	to_chat(user, span_notice("You print a photograph."))
+	user.visible_message(span_notice("A picture appears on top of the chassis of [paimob.name]!"),span_notice("You print a photograph."))

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -91,11 +91,11 @@
 	to_chat(usr, span_notice("You print a photograph."))
 
 /obj/item/camera/siliconcam/proc/paiprint(mob/user)
-	var/mob/living/silicon/pai/C = loc
+	var/mob/living/silicon/pai/paimob = loc
 	var/datum/picture/selection = selectpicture(user)
 	if(!istype(selection))
 		to_chat(user, span_warning("Invalid Image."))
 		return
 	printpicture(user,selection)
-	visible_message(span_notice("A picture appears on top of the chassis of [C.name]!"))
+	visible_message(span_notice("A picture appears on top of the chassis of [paimob.name]!"))
 	to_chat(usr, span_notice("You print a photograph."))

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -96,8 +96,6 @@
 	if(!istype(selection))
 		to_chat(user, span_warning("Invalid Image."))
 		return
-	var/obj/item/photo/p = new /obj/item/photo(C.loc, selection)
-	p.pixel_x = p.base_pixel_x + rand(-10, 10)
-	p.pixel_y = p.base_pixel_y + rand(-10, 10)
-	visible_message(span_notice("[C.name] spits out a photograph from a very tiny slit on its chassis."))
+	printpicture(user,selection)
+	visible_message(span_notice("A picture appears on top of the chassis of [C.name]!"))
 	to_chat(usr, span_notice("You print a photograph."))

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -89,3 +89,15 @@
 	C.toner -= printcost  //All fun allowed.
 	visible_message(span_notice("[C.name] spits out a photograph from a narrow slot on its chassis."))
 	to_chat(usr, span_notice("You print a photograph."))
+
+/obj/item/camera/siliconcam/proc/paiprint(mob/user)
+	var/mob/living/silicon/pai/C = loc
+	var/datum/picture/selection = selectpicture(user)
+	if(!istype(selection))
+		to_chat(user, span_warning("Invalid Image."))
+		return
+	var/obj/item/photo/p = new /obj/item/photo(C.loc, selection)
+	p.pixel_x = p.base_pixel_x + rand(-10, 10)
+	p.pixel_y = p.base_pixel_y + rand(-10, 10)
+	visible_message(span_notice("[C.name] spits out a photograph from a very tiny slit on its chassis."))
+	to_chat(usr, span_notice("You print a photograph."))


### PR DESCRIPTION
Also moves the "Internal GPS' down by its 35 ram brother.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Allows PAI to access a newly inbuilt bluespace printer at the cost of some processing power being diverted to mine for cryptocurrency.
## Why It's Good For The Game
Pai's are perfect travel buddies, but its a shame they cant print out their memories to share with their master. Well now they can! Simply take a picture, select the "Printer" button, and (optionally select an image if multiple are available) Presto! Instant picture. No toner required, its ported directly from an automatic nanotransen printer! Of course, some ram is actually being used for crypto mining for pure NT profit, but who cares? Pictures!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Pai Printer Module
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
