### PR TITLE
Fixes? NumberInputs taking their text color from their border

### DIFF
--- a/tgui/packages/tgui/styles/components/NumberInput.scss
+++ b/tgui/packages/tgui/styles/components/NumberInput.scss
@@ -19,7 +19,7 @@ $border-radius: Input.$border-radius !default;
   border: base.em(1px) solid $border-color;
   border: base.em(1px) solid rgba($border-color, 0.75);
   border-radius: $border-radius;
-  color: $border-color;
+  color: $text-color;
   background-color: $background-color;
   padding: 0 base.em(4px);
   margin-right: base.em(2px);


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes NumberInput components take their "color" from $text-color instead of $border-color

## Why It's Good For The Game

I noticed this was causing NumberInput to have its text color changed when you changed its border. I'm not 100% on if this is intended or not, but it strikes me as kinda weird. All three of these inputs are styled the same
![image](https://user-images.githubusercontent.com/58055496/139527279-8460f848-a426-4982-b9ba-299d3f93adda.png)
I'm essentially monkey see monkey doing this by looking at Input.scss. I've tested it, and it works, just not in a good place to switch branches right now

