### PR TITLE
Being extremely drunk can make you clumsy

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -706,6 +706,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define DRONE_SHY_TRAIT "drone_shy"
 /// Pacifism trait given by stabilized light pink extracts.
 #define STABILIZED_LIGHT_PINK_TRAIT "stabilized_light_pink"
+/// Trait given by being stupid drunk
+#define DRUNK_TRAIT "drunk_trait"
 
 /**
 * Trait granted by [/mob/living/carbon/Initialize] and


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR starts adding a chance each tick to gain TRAIT_CLUMSY once you've reached the level of drunkness that causes your eyes to blur, and getting even drunker than that only raises the chances per tick of gaining the trait. Once you have it, you can only get rid of it by sobering up, though it is possible if you're extremely drunk to *think* you've sobered up, without actually doing so.

The numbers I used here are total placeholders and subject to change. It shouldn't be something that happens constantly when you have one drink, but you should be able to try triggering it on purpose to perform funny bar shenanigans if you pace yourself right.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Extremely drunk people really shouldn't be trusted with dangerous things like firearms and flashlights. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Ryll/Shaps
expansion: Being extremely drunk now has a chance to grant you the clumsy trait until you sober up, Once your drinking buddy appears to have jerky movements when examined, you should consider relieving them of any dangerous firearms or flashlights, for the greater good.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
