### PR TITLE
[READY] Inacusiate and Multiver (making them humanly possible to mix with purity 1)

### DIFF
--- a/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
+++ b/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
@@ -282,16 +282,15 @@
 	required_temp = 380
 	optimal_temp = 400
 	overheat_temp = 410
-	optimal_ph_min = 2.5
-	optimal_ph_max = 7
+	optimal_ph_min = 5
+	optimal_ph_max = 9.5
 	determin_ph_range = 4
-	temp_exponent_factor = 0.5
+	temp_exponent_factor = 0.1
 	ph_exponent_factor = 1
 	thermic_constant = 0
-	H_ion_release = 0
-	rate_up_lim = 25
+	H_ion_release = 0.015
+	rate_up_lim = 10
 	purity_min = 0.1 //Fire is our worry for now
-	reaction_flags = REACTION_REAL_TIME_SPLIT | REACTION_PH_VOL_CONSTANT
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_PLANT | REACTION_TAG_TOXIN
 
 //You get nothing! I'm serious about staying under the heating requirements!

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -59,17 +59,17 @@
 	mix_message = "The mixture sputters loudly and becomes a light grey color!"
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_ORGAN
 	//Fermichem vars
-	required_temp = 200
+	required_temp = 300
 	optimal_temp = 400
-	overheat_temp = 450
-	optimal_ph_min = 2
-	optimal_ph_max = 5
+	overheat_temp = 500
+	optimal_ph_min = 5
+	optimal_ph_max = 10
 	determin_ph_range = 10
-	temp_exponent_factor = 3
+	temp_exponent_factor = 0.35
 	ph_exponent_factor = 0.5
-	thermic_constant = 200
-	H_ion_release = 0.05
-	rate_up_lim = 50
+	thermic_constant = 20
+	H_ion_release = 1.5
+	rate_up_lim = 3
 	purity_min = 0.25
 
 ///Calls it over and over


### PR DESCRIPTION
[I screwed up with git, and accidentally closed the [previous PR](https://github.com/tgstation/tgstation/pull/62453) for this. I attached previous comments in the comment section below.]

## About The Pull Request

This PR tweaks the pH-related values of Inacusiate and Multiver to give players a fair chance to create pure Inacusiate or any other pure chemicals that require Multiver.

## Why It's Good For The Game

Currently the creation of pure Inacusiate is near humanly impossible.
Usually, in order to achieve pure chemicals, you have to be very precise about pH-values and temperature during their reactions. This involves diligent chemists cooling their reagents down to start the reaction at juuuust the threshold, in order to slow the reaction and control it.

### Inacusiate

**Issue 1:** 
1. Inacusiate requires water which freezes into Ice when cold (280°K and below)
2. The reaction starting temperature is 200 (when water is frozen)
3. The Ice melts at 280, setting the reaction off 80 over the threshold

**Issue 2:**
1. Inacusiate is exothermic
2. Combined with the temperature jumpstart, it quickly overheats

**Issue 3:**

1. It's maximum throughput limit is relatively high for a chemical that overheats this quickly
2. In practice, the reaction is over before you manage to blink twice, with little chance to do any adjustments

**I claim that (on any /tg/server) it is currently next to impossible to create pure Inacusiate. You can test this with any chem dispenser (not the debug dispenser) and while not in admin mode on e.g. a custom server**


**My solution**

I tweaked the fermichem values of Inacusiate to:

- Slow down the reaction
- Give a little bit more room for error
- Start at 300°K instead of 200°K
- Limit the throughput
- Retain difficulty in form of pH-boosting (so it's not too easy either)


### Multiver

While fixing Inacusiate, I noticed that even though I worked with seemingly perfect reagents, I still received purity values from all over the place. Ultimately I discovered that Multiver was the culprit. 

**Issue 1:**

1. Multiver's impurities are hidden at low values. Multiver with a purity of 0.75 will still show up as "Pure" in the HPLC.
2. Especially for inexperienced players, impurities in Multiver can be deceiving (since they are invisible).

**Issue 2:**

1. Multivers creation range is very narrow (380-409°K), but it reacts fast and with a high throughput.
2. Due to the endproducts own pH, the reaction overshoots the max pH-value quickly, and due to the high reaction speed, impurities build up quickly.

**Issue 3:**

1. Multiver has three precursor reactions (Oil, Ash, Table Salt) and is needed for 7 other chemicals.
2. Multiver becomes a bottleneck in the creation of pure chemicals due to Issues 1 and 2.

**My solution**

I tweaked the fermichem values of Multiver to:

- Slow down the reaction
- Give a little bit more room for error
- Limit the throughput
- Retain difficulty in form of pH-boosting (so it's not too easy either)

## What does it boil down to / Some examples

- When using pure(!) precursor reagents, Multiver and Inacusiate are now easier to make pure.
- 5u pure Ash + 5u pure Table salt will yield 10u pure Multiver at 400°K with no interference (Higher amounts require pH changes).
- 20u pure Ash + 20u pure Table salt will require about 5-8 drops of acidic buffer solution to become pure Multiver.
- Creating 10u Inacusiate from a lower temperature, warming up to 301°K, requires 4-5 drops of acidic buffer solution to become pure Inacusiate
- Pure Inacusiate (unrelated to the amount) has a bigger time window of dropping in buffer solution, with a realistic outcome of purity 1
- Creating 10u Inacusiate at room temperature (pure 5u of Multiver, Water, Carbon) without interference yields a purity of 0.92
- Creating 60 Inacusiate (30u of each reagent) and not caring about pH or temperature, will create 25% impurity

### Testing

If you want to test my values without downloading or compiling code, you can open any up-to-date custom server on your computer and (as Admin) edit the Global values in the MC-tab.
Search for "chemical_reactions_list", then "Inacusiate" or "Multiver" and edit the fermichem-vars according to my committed changes.

Important: The debug chem dispenser on runtime station only dispenses purity 1 chemicals.
Pre-set chemicals in chemistry at roundstart are always 0.75 purity.

I recommend you test from the bottom up, as if you were a normal player without admin rights on a normal station.

Should this PR go through, I will update the wiki accordingly.

## Changelog

:cl:
fix: Pure Inacusiate is now humanly possible to create
fix: Truly pure Multiver is much easier to achieve now
/:cl:
