### PR TITLE
Makes dash actions and Bluespace Prophecy trauma utilise teleport code instead of forced movement code.

### DIFF
--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -134,7 +134,7 @@
 
 		user.visible_message(span_warning("[user] [slip_in_message]."), null, null, null, user)
 
-		if(!do_teleport(src, destination_turf, no_effects = TRUE))
+		if(!do_teleport(user, destination_turf, no_effects = TRUE))
 			user.visible_message(span_warning("[user] [slip_out_message], ending up exactly where they left."), null, null, null, user)
 			return
 

--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -126,10 +126,18 @@
 		"slides out of a fold in spacetime")
 	to_chat(user, span_notice("You try to align with the bluespace stream..."))
 	if(do_after(user, 20, target = src))
-		new /obj/effect/temp_visual/bluespace_fissure(get_turf(src))
-		new /obj/effect/temp_visual/bluespace_fissure(get_turf(linked_to))
-		user.forceMove(get_turf(linked_to))
+		var/turf/source_turf = get_turf(src)
+		var/turf/destination_turf = get_turf(linked_to)
+
+		new /obj/effect/temp_visual/bluespace_fissure(source_turf)
+		new /obj/effect/temp_visual/bluespace_fissure(destination_turf)
+
 		user.visible_message(span_warning("[user] [slip_in_message]."), null, null, null, user)
+
+		if(!do_teleport(src, destination_turf, no_effects = TRUE))
+			user.visible_message(span_warning("[user] [slip_out_message], ending up exactly where they left."), null, null, null, user)
+			return
+
 		user.visible_message(span_warning("[user] [slip_out_message]."), span_notice("...and find your way to the other side."))
 
 /datum/brain_trauma/special/quantum_alignment

--- a/code/datums/dash_weapon.dm
+++ b/code/datums/dash_weapon.dm
@@ -30,19 +30,27 @@
 /datum/action/innate/dash/Activate()
 	dashing_item.attack_self(owner) //Used to toggle dash behavior in the dashing item
 
-/datum/action/innate/dash/proc/Teleport(mob/user, atom/target)
+/// Teleports user to target using do_teleport. Returns TRUE if teleport successful, FALSE otherwise.
+/datum/action/innate/dash/proc/teleport(mob/user, atom/target)
 	if(!IsAvailable())
-		return
+		return FALSE
+
 	var/turf/target_turf = get_turf(target)
 	if(target in view(user.client.view, user))
+		if(!do_teleport(user, target_turf, no_effects = TRUE))
+			user.balloon_alert(user, "dash blocked by location!")
+			return FALSE
+
 		var/obj/spot1 = new phaseout(get_turf(user), user.dir)
-		user.forceMove(target_turf)
 		playsound(target_turf, dash_sound, 25, TRUE)
 		var/obj/spot2 = new phasein(get_turf(user), user.dir)
 		spot1.Beam(spot2,beam_effect,time=2 SECONDS)
 		current_charges--
 		owner.update_action_buttons_icon()
 		addtimer(CALLBACK(src, .proc/charge), charge_rate)
+		return TRUE
+
+	return FALSE
 
 /datum/action/innate/dash/proc/charge()
 	current_charges = clamp(current_charges + 1, 0, max_charges)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -210,7 +210,7 @@
 /obj/item/cult_bastard/afterattack(atom/target, mob/user, proximity, click_parameters)
 	. = ..()
 	if(dash_toggled && !proximity)
-		jaunt.Teleport(user, target)
+		jaunt.teleport(user, target)
 		return
 	if(!proximity)
 		return

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -19,11 +19,11 @@
 /datum/action/innate/dash/hierophant/teleport(mob/user, atom/target)
 	var/dist = get_dist(user, target)
 	if(dist > HIEROPHANT_BLINK_RANGE)
-		user.bubble_message(user, "Blink destination out of range.")
+		user.balloon_alert(user, "Blink destination out of range.")
 		return
 	var/turf/target_turf = get_turf(target)
 	if(target_turf.is_blocked_turf_ignore_climbable())
-		user.bubble_message(user, "blink destination blocked.")
+		user.balloon_alert(user, "blink destination blocked.")
 		return
 	. = ..()
 	if(!current_charges)

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -23,7 +23,7 @@
 		return
 	var/turf/target_turf = get_turf(target)
 	if(target_turf.is_blocked_turf_ignore_climbable())
-		user.balloon_alert(user, "blink destination blocked.")
+		user.balloon_alert(user, "destination blocked!")
 		return
 	. = ..()
 	if(!current_charges)

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -19,7 +19,7 @@
 /datum/action/innate/dash/hierophant/teleport(mob/user, atom/target)
 	var/dist = get_dist(user, target)
 	if(dist > HIEROPHANT_BLINK_RANGE)
-		user.balloon_alert(user, "Blink destination out of range.")
+		user.balloon_alert(user, "destination out of range!")
 		return
 	var/turf/target_turf = get_turf(target)
 	if(target_turf.is_blocked_turf_ignore_climbable())

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -16,14 +16,14 @@
 	// It's a simple purple beam, works well enough for the purple hiero effects.
 	beam_effect = "plasmabeam"
 
-/datum/action/innate/dash/hierophant/Teleport(mob/user, atom/target)
+/datum/action/innate/dash/hierophant/teleport(mob/user, atom/target)
 	var/dist = get_dist(user, target)
 	if(dist > HIEROPHANT_BLINK_RANGE)
-		to_chat(user, span_hierophant_warning("Blink destination out of range."))
+		user.bubble_message(user, "Blink destination out of range.")
 		return
 	var/turf/target_turf = get_turf(target)
 	if(target_turf.is_blocked_turf_ignore_climbable())
-		to_chat(user, span_hierophant_warning("Blink destination blocked."))
+		user.bubble_message(user, "blink destination blocked.")
 		return
 	. = ..()
 	if(!current_charges)
@@ -117,7 +117,7 @@
 	if((target == beacon) && target.Adjacent(src))
 		return
 	if(blink_activated)
-		blink.Teleport(user, target)
+		blink.teleport(user, target)
 
 /obj/item/hierophant_club/update_icon_state()
 	icon_state = inhand_icon_state = "hierophant_club[blink_charged ? "_ready":""][(!QDELETED(beacon)) ? "":"_beacon"]"

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -45,7 +45,7 @@
 	var/list/modifiers = params2list(click_parameters)
 
 	if(LAZYACCESS(modifiers, RIGHT_CLICK) && !target.density)
-		jaunt.Teleport(user, target)
+		jaunt.teleport(user, target)
 
 /obj/item/energy_katana/pickup(mob/living/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does exactly what it says on the tin.

Dash actions such as ninja sword and hiero club now utilise bubble messages for feedback and do_teleport so they respect the various teleportation blocking flags we place on restricted/admin/weird areas.

Bluespace Prophecy teleportation also uses do_teleport for the same reasons.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Stops weird anomalies like people breaking out of places they shouldn't be allowed to and breaking in to places they shouldn't be allowed to. Protects areas on the CentCom z-level a bit better when players get sent there for whatever reasons.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Items with dash actions and the Bluespace Prophecy trauma now utilise proper teleportation code, disallowing teleportation to and from teleport restricted areas.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
