### PR TITLE
Make ghost poly lose godmode upon gaining sentience

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -1000,6 +1000,9 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 /mob/living/simple_animal/parrot/poly/ghost/sentience_act()
 	..()
 	status_flags &= ~GODMODE
+	ADD_TRAIT(src, TRAIT_RESISTLOWPRESSURE, ROUNDSTART_TRAIT)
+	ADD_TRAIT(src, TRAIT_RESISTCOLD, ROUNDSTART_TRAIT)
+	ADD_TRAIT(src, TRAIT_NOBREATH, ROUNDSTART_TRAIT)
 
 /mob/living/simple_animal/parrot/poly/ghost/proc/Possess(mob/living/carbon/human/H)
 	if(!ishuman(H))

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -997,6 +997,10 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 			Possess(parrot_interest)
 	..()
 
+/mob/living/simple_animal/parrot/poly/ghost/sentience_act()
+	..()
+	status_flags &= ~GODMODE
+
 /mob/living/simple_animal/parrot/poly/ghost/proc/Possess(mob/living/carbon/human/H)
 	if(!ishuman(H))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Make the poly ghost simplemob lose its GODMODE status flag upon gaining sentience
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #62465
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Ghost polys no longer retain godmode status upon gaining sentience.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
