### PR TITLE
stops aheal from deleting all restraints in target's inventory

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -828,10 +828,8 @@
 		suiciding = FALSE
 		regenerate_limbs()
 		regenerate_organs()
-		if(handcuffed)
-			qdel(handcuffed)
-		if(legcuffed)
-			qdel(legcuffed)
+		QDEL_NULL(handcuffed)
+		QDEL_NULL(legcuffed)
 		set_handcuffed(null)
 		update_handcuffed()
 	cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -828,9 +828,17 @@
 		suiciding = FALSE
 		regenerate_limbs()
 		regenerate_organs()
+		if(handcuffed)
+			var/obj/item/restraints/handcuffs = handcuffed
+			qdel(handcuffs)
+		if(legcuffed)
+			var/obj/item/restraints/legcuffs = legcuffed
+			qdel(legcuffs)
 		set_handcuffed(null)
-		for(var/obj/item/restraints/R in contents) //actually remove cuffs from inventory
-			qdel(R)
+		// duplicating code from /mob/living/carbon/resist_restraints()
+		// and /mob/living/carbon/proc/clear_cuffs(obj/item/I, cuff_break)
+		//for(var/obj/item/restraints/R in contents) //actually remove cuffs from inventory
+			//qdel(R)
 		update_handcuffed()
 	cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
 	..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -829,16 +829,10 @@
 		regenerate_limbs()
 		regenerate_organs()
 		if(handcuffed)
-			var/obj/item/restraints/handcuffs = handcuffed
-			qdel(handcuffs)
+			qdel(handcuffed)
 		if(legcuffed)
-			var/obj/item/restraints/legcuffs = legcuffed
-			qdel(legcuffs)
+			qdel(legcuffed)
 		set_handcuffed(null)
-		// duplicating code from /mob/living/carbon/resist_restraints()
-		// and /mob/living/carbon/proc/clear_cuffs(obj/item/I, cuff_break)
-		//for(var/obj/item/restraints/R in contents) //actually remove cuffs from inventory
-			//qdel(R)
 		update_handcuffed()
 	cure_all_traumas(TRAUMA_RESILIENCE_MAGIC)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- PR'ed for Hacktoberfest (so if this passes muster I'd appreciate it being tagged with `hacktoberfest-accepted`)



Closes https://github.com/tgstation/tgstation/issues/62459
![image](https://user-images.githubusercontent.com/82134074/139558039-eb95bfff-63a9-4158-a806-a5c1a8dfdbc5.png)



## Why It's Good For The Game
fixes a corner case with an often used admin command
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: admin heals no longer delete all restraints in target's inventory
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
