### PR TITLE
Allows basic mobs to be sentience potioned & simple access component

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -546,7 +546,7 @@
 #define COMSIG_MOB_TRIED_ACCESS "tried_access"
 	#define ACCESS_ALLOWED (1<<0)
 	#define ACCESS_DISALLOWED (1<<1)
-	#define SOURCE_INCOMPATIBLE (1<<2)
+	#define LOCKED_ATOM_INCOMPATIBLE (1<<2)
 
 ///from base of mob/anti_magic_check(): (mob/user, magic, holy, tinfoil, chargecost, self, protection_sources)
 #define COMSIG_MOB_RECEIVE_MAGIC "mob_receive_magic"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -542,8 +542,12 @@
 /// From base of /client/Move()
 #define COMSIG_MOB_CLIENT_MOVED "mob_client_moved"
 
-///from base of obj/allowed(mob/M): (/obj) returns bool, if TRUE the mob has id access to the obj
-#define COMSIG_MOB_ALLOWED "mob_allowed"
+///from base of obj/allowed(mob/M): (/obj) returns MOB_ALLOWED if mob has id access to the obj
+#define COMSIG_MOB_TRIED_ACCESS "tried_access"
+	#define ACCESS_ALLOWED (1<<0)
+	#define ACCESS_DISALLOWED (1<<1)
+	#define SOURCE_INCOMPATIBLE (1<<2)
+
 ///from base of mob/anti_magic_check(): (mob/user, magic, holy, tinfoil, chargecost, self, protection_sources)
 #define COMSIG_MOB_RECEIVE_MAGIC "mob_receive_magic"
 	#define COMPONENT_BLOCK_MAGIC (1<<0)

--- a/code/datums/components/simple_access.dm
+++ b/code/datums/components/simple_access.dm
@@ -19,7 +19,7 @@
 /datum/component/simple_access/proc/on_tried_access(datum/source, atom/locked_thing)
 	SIGNAL_HANDLER
 	if(!isobj(locked_thing))
-		return SOURCE_INCOMPATIBLE
+		return LOCKED_ATOM_INCOMPATIBLE
 	var/obj/locked_object = locked_thing
 	if(locked_object.check_access_list(access))
 		return ACCESS_ALLOWED

--- a/code/datums/components/simple_access.dm
+++ b/code/datums/components/simple_access.dm
@@ -1,18 +1,31 @@
+///This component allows us to give a mob access without giving them an ID card.
 /datum/component/simple_access
+	///list of accesses we are allowed to access via this component
 	var/list/access
 
-/datum/component/simple_access/Initialize(list/new_access)
+/datum/component/simple_access/Initialize(list/new_access, atom/donor_atom)
+	. = ..()
 	if(!ismob(parent))
 		return COMPONENT_INCOMPATIBLE
 	access = new_access
 	RegisterSignal(parent, COMSIG_MOB_TRIED_ACCESS, .proc/on_tried_access)
+	if(!donor_atom)
+		return
+	if(istype(donor_atom, /obj/item/organ))
+		RegisterSignal(donor_atom, COMSIG_ORGAN_REMOVED, .proc/on_donor_removed)
+	else if(istype(donor_atom, /obj/item/implant))
+		RegisterSignal(donor_atom, COMSIG_IMPLANT_REMOVED, .proc/on_donor_removed)
 
-/datum/component/simple_access/proc/on_tried_access(datum/source)
+/datum/component/simple_access/proc/on_tried_access(datum/source, atom/locked_thing)
 	SIGNAL_HANDLER
-	if(!isobj(source))
+	if(!isobj(locked_thing))
 		return SOURCE_INCOMPATIBLE
-	var/obj/locked_thing = source
-	if(locked_thing.check_access_list(access))
+	var/obj/locked_object = locked_thing
+	if(locked_object.check_access_list(access))
 		return ACCESS_ALLOWED
 	else
 		return ACCESS_DISALLOWED
+
+/datum/component/simple_access/proc/on_donor_removed(datum/source)
+	SIGNAL_HANDLER
+	qdel(src)

--- a/code/datums/components/simple_access.dm
+++ b/code/datums/components/simple_access.dm
@@ -1,0 +1,18 @@
+/datum/component/simple_access
+	var/list/access
+
+/datum/component/simple_access/Initialize(list/new_access)
+	if(!ismob(parent))
+		return COMPONENT_INCOMPATIBLE
+	access = new_access
+	RegisterSignal(parent, COMSIG_MOB_TRIED_ACCESS, .proc/on_tried_access)
+
+/datum/component/simple_access/proc/on_tried_access(datum/source)
+	SIGNAL_HANDLER
+	if(!isobj(source))
+		return SOURCE_INCOMPATIBLE
+	var/obj/locked_thing = source
+	if(locked_thing.check_access_list(access))
+		return ACCESS_ALLOWED
+	else
+		return ACCESS_DISALLOWED

--- a/code/modules/antagonists/abductor/equipment/glands/access.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/access.dm
@@ -9,12 +9,4 @@
 
 /obj/item/organ/heart/gland/access/activate()
 	to_chat(owner, span_notice("You feel like a VIP for some reason."))
-	RegisterSignal(owner, COMSIG_MOB_ALLOWED, .proc/free_access)
-
-/obj/item/organ/heart/gland/access/proc/free_access(datum/source, obj/O)
-	SIGNAL_HANDLER
-	return TRUE
-
-/obj/item/organ/heart/gland/access/Remove(mob/living/carbon/M, special = 0)
-	UnregisterSignal(owner, COMSIG_MOB_ALLOWED)
-	..()
+	owner.AddComponent(/datum/component/simple_access, SSid_access.get_region_access_list(list(REGION_ALL_GLOBAL)), src)

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -14,7 +14,7 @@
 		//Access can't stop the abuse
 		return TRUE
 	//If the mob has the simple_access component with the requried access, we let them in.
-	else if(SEND_SIGNAL(accessor, COMSIG_MOB_TRIED_ACCESS) & ACCESS_ALLOWED)
+	else if(SEND_SIGNAL(accessor, COMSIG_MOB_TRIED_ACCESS, src) & ACCESS_ALLOWED)
 		return TRUE
 	//If the mob is holding a valid ID, we let them in. get_active_held_item() is on the mob level, so no need to copypasta everywhere.
 	else if(check_access(accessor.get_active_held_item()))

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -13,21 +13,21 @@
 	if(isAdminGhostAI(accessor))
 		//Access can't stop the abuse
 		return TRUE
-	else if(istype(accessor) && SEND_SIGNAL(accessor, COMSIG_MOB_ALLOWED, src))
+	//If the mob has the simple_access component with the requried access, we let them in.
+	else if(SEND_SIGNAL(accessor, COMSIG_MOB_TRIED_ACCESS) & ACCESS_ALLOWED)
 		return TRUE
+	//If the mob is holding a valid ID, we let them in. get_active_held_item() is on the mob level, so no need to copypasta everywhere.
+	else if(check_access(accessor.get_active_held_item()))
+		return TRUE
+	//if they are wearing a card that has access, that works
 	else if(ishuman(accessor))
 		var/mob/living/carbon/human/human_accessor = accessor
-		//if they are holding or wearing a card that has access, that works
-		if(check_access(human_accessor.get_active_held_item()) || src.check_access(human_accessor.wear_id))
+		if(check_access(human_accessor.wear_id))
 			return TRUE
-	else if(isalienadult(accessor))
-		var/mob/living/carbon/george = accessor
-		//they can only hold things :(
-		if(check_access(george.get_active_held_item()))
-			return TRUE
+	//if they have a hacky abstract animal ID with the required access, let them in i guess...
 	else if(isanimal(accessor))
 		var/mob/living/simple_animal/animal = accessor
-		if(check_access(animal.get_active_held_item()) || check_access(animal.access_card))
+		if(check_access(animal.access_card))
 			return TRUE
 	return FALSE
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -741,13 +741,7 @@
 /obj/item/slimepotion/slime/sentience/nuclear/after_success(mob/living/user, mob/living/smart_mob)
 	var/obj/item/implant/radio/syndicate/imp = new(src)
 	imp.implant(smart_mob, user)
-
-	// Ugly as sin. Simble mob accesses are for another time.
-	if(isanimal(smart_mob))
-		var/mob/living/simple_animal/smart_animal = smart_mob
-		smart_animal.access_card = new /obj/item/card/id/advanced/chameleon(smart_animal)
-		SSid_access.apply_trim_to_card(smart_animal, /datum/id_trim/chameleon)
-		ADD_TRAIT(smart_animal.access_card, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
+	smart_mob.AddComponent(/datum/component/simple_access, list(ACCESS_SYNDICATE, ACCESS_MAINT_TUNNELS))
 
 /obj/item/slimepotion/transference
 	name = "consciousness transference potion"

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -686,58 +686,68 @@
 	var/being_used = FALSE
 	var/sentience_type = SENTIENCE_ORGANIC
 
-/obj/item/slimepotion/slime/sentience/attack(mob/living/M, mob/user)
-	if(being_used || !ismob(M))
+/obj/item/slimepotion/slime/sentience/attack(mob/living/dumb_mob, mob/user)
+	if(being_used || !ismob(dumb_mob))
 		return
-	if(!isanimal(M) || M.ckey) //only works on animals that aren't player controlled
-		to_chat(user, span_warning("[M] is already too intelligent for this to work!"))
+	if((!isanimal(dumb_mob) && !isbasicmob(dumb_mob)) || dumb_mob.ckey) //only works on animals that aren't player controlled
+		to_chat(user, span_warning("[dumb_mob] is already too intelligent for this to work!"))
 		return
-	if(M.stat)
-		to_chat(user, span_warning("[M] is dead!"))
+	if(dumb_mob.stat)
+		to_chat(user, span_warning("[dumb_mob] is dead!"))
 		return
-	var/mob/living/simple_animal/SM = M
-	if(SM.sentience_type != sentience_type)
-		to_chat(user, span_warning("[src] won't work on [SM]."))
-		return
+	if(isanimal(dumb_mob))
+		var/mob/living/simple_animal/dumb_animal = dumb_mob
+		if(dumb_animal.sentience_type != sentience_type)
+			to_chat(user, span_warning("[src] won't work on [dumb_animal]."))
+			return
+	else if(isbasicmob(dumb_mob)) //duplicate shit code until all simple animasls are made into basic mobs. sentience_type is not on living, but it duplicated  on basic and animal
+		var/mob/living/basic/basic_dumb_bitch = dumb_mob
+		if(basic_dumb_bitch.sentience_type != sentience_type)
+			to_chat(user, span_warning("[src] won't work on [basic_dumb_bitch]."))
+			return
 
-	to_chat(user, span_notice("You offer [src] to [SM]..."))
+	to_chat(user, span_notice("You offer [src] to [dumb_mob]..."))
 	being_used = TRUE
 
-	var/list/candidates = poll_candidates_for_mob("Do you want to play as [SM.name]?", ROLE_SENTIENCE, ROLE_SENTIENCE, 5 SECONDS, SM, POLL_IGNORE_SENTIENCE_POTION) // see poll_ignore.dm
+	var/list/candidates = poll_candidates_for_mob("Do you want to play as [dumb_mob.name]?", ROLE_SENTIENCE, ROLE_SENTIENCE, 5 SECONDS, dumb_mob, POLL_IGNORE_SENTIENCE_POTION) // see poll_ignore.dm
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
-		SM.key = C.key
-		SM.mind.enslave_mind_to_creator(user)
-		SEND_SIGNAL(SM, COMSIG_SIMPLEMOB_SENTIENCEPOTION, user)
-		SM.sentience_act()
-		to_chat(SM, span_warning("All at once it makes sense: you know what you are and who you are! Self awareness is yours!"))
-		to_chat(SM, span_userdanger("You are grateful to be self aware and owe [user.real_name] a great debt. Serve [user.real_name], and assist [user.p_them()] in completing [user.p_their()] goals at any cost."))
-		if(SM.flags_1 & HOLOGRAM_1) //Check to see if it's a holodeck creature
-			to_chat(SM, span_userdanger("You also become depressingly aware that you are not a real creature, but instead a holoform. Your existence is limited to the parameters of the holodeck."))
-		to_chat(user, span_notice("[SM] accepts [src] and suddenly becomes attentive and aware. It worked!"))
-		SM.copy_languages(user)
-		after_success(user, SM)
+		dumb_mob.key = C.key
+		dumb_mob.mind.enslave_mind_to_creator(user)
+		SEND_SIGNAL(dumb_mob, COMSIG_SIMPLEMOB_SENTIENCEPOTION, user)
+		if(isanimal(dumb_mob))
+			var/mob/living/simple_animal/smart_animal = dumb_mob
+			smart_animal.sentience_act()
+		to_chat(dumb_mob, span_warning("All at once it makes sense: you know what you are and who you are! Self awareness is yours!"))
+		to_chat(dumb_mob, span_userdanger("You are grateful to be self aware and owe [user.real_name] a great debt. Serve [user.real_name], and assist [user.p_them()] in completing [user.p_their()] goals at any cost."))
+		if(dumb_mob.flags_1 & HOLOGRAM_1) //Check to see if it's a holodeck creature
+			to_chat(dumb_mob, span_userdanger("You also become depressingly aware that you are not a real creature, but instead a holoform. Your existence is limited to the parameters of the holodeck."))
+		to_chat(user, span_notice("[dumb_mob] accepts [src] and suddenly becomes attentive and aware. It worked!"))
+		dumb_mob.copy_languages(user)
+		after_success(user, dumb_mob)
 		qdel(src)
 	else
-		to_chat(user, span_notice("[SM] looks interested for a moment, but then looks back down. Maybe you should try again later."))
+		to_chat(user, span_notice("[dumb_mob] looks interested for a moment, but then looks back down. Maybe you should try again later."))
 		being_used = FALSE
 		..()
 
-/obj/item/slimepotion/slime/sentience/proc/after_success(mob/living/user, mob/living/simple_animal/SM)
+/obj/item/slimepotion/slime/sentience/proc/after_success(mob/living/user, mob/living/smart_mob)
 	return
 
 /obj/item/slimepotion/slime/sentience/nuclear
 	name = "syndicate intelligence potion"
 	desc = "A miraculous chemical mix that grants human like intelligence to living beings. It has been modified with Syndicate technology to also grant an internal radio implant to the target and authenticate with identification systems."
 
-/obj/item/slimepotion/slime/sentience/nuclear/after_success(mob/living/user, mob/living/simple_animal/SM)
+/obj/item/slimepotion/slime/sentience/nuclear/after_success(mob/living/user, mob/living/smart_mob)
 	var/obj/item/implant/radio/syndicate/imp = new(src)
-	imp.implant(SM, user)
+	imp.implant(smart_mob, user)
 
 	// Ugly as sin. Simble mob accesses are for another time.
-	SM.access_card = new /obj/item/card/id/advanced/chameleon(SM)
-	SSid_access.apply_trim_to_card(SM, /datum/id_trim/chameleon)
-	ADD_TRAIT(SM.access_card, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
+	if(isanimal(smart_mob))
+		var/mob/living/simple_animal/smart_animal = smart_mob
+		smart_animal.access_card = new /obj/item/card/id/advanced/chameleon(smart_animal)
+		SSid_access.apply_trim_to_card(smart_animal, /datum/id_trim/chameleon)
+		ADD_TRAIT(smart_animal.access_card, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
 
 /obj/item/slimepotion/transference
 	name = "consciousness transference potion"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -627,6 +627,7 @@
 #include "code\datums\components\shrink.dm"
 #include "code\datums\components\shy.dm"
 #include "code\datums\components\shy_in_room.dm"
+#include "code\datums\components\simple_access.dm"
 #include "code\datums\components\singularity.dm"
 #include "code\datums\components\sitcomlaughter.dm"
 #include "code\datums\components\sizzle.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR makes it possible to sentience potion basic mobs.

Because the syndicate sentientience potion also added an abstract ID to the mob, and basic mobs did not support this, i've created a new component that holds this access.

The abductor all access gland has been refactored to use this component.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If basic mobs are going to replace simple_animals, they need to support one of the biggest features that interacts with simple_animals, sentience granters such as the sentience potion.

Currently, there are some basic mobs that would be fun sentience targets, moonicorns and hauberoaches come to mind and going forward, as i add more cytology mobs, i'd rather make them basic mobs than make them simple_animals which should be considered a deprecated type.
 
The new component also allows coders to grant access not tied to an ID card, but that can optionally be tied to an organ or implant.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Cows, roaches and their subtypes can be sentienced again.
refactor: refactored syndicate sentience potion and abductor all access gland to use the new simple_access component.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
