### PR TITLE
objectively terrible solution to the captain's gas mask scaring people with Greytider Phobia

### DIFF
--- a/code/_globalvars/traumas.dm
+++ b/code/_globalvars/traumas.dm
@@ -129,6 +129,7 @@ GLOBAL_LIST_INIT(phobia_objs, list(
 	"greytide" = (typecacheof(list(/obj/item/clothing/under/color/grey, /obj/item/melee/baton/security/cattleprod,
 		/obj/item/spear, /obj/item/toy/figure/assistant,
 		/obj/structure/statue/sandstone/assistant)) + typecacheof(list(/obj/item/clothing/mask/gas), ignore_root_path = FALSE, only_root_path = TRUE
+		// to match only specific items in this phobia and not subtypes, use an additional typecacheof w/ ignore_root_path set FALSE and only_root_patch set TRUE
 	)),
 
 	"lizards" = typecacheof(list(/obj/item/toy/plush/lizard_plushie, /obj/item/food/kebab/tail, /obj/item/organ/tail/lizard,

--- a/code/_globalvars/traumas.dm
+++ b/code/_globalvars/traumas.dm
@@ -127,8 +127,8 @@ GLOBAL_LIST_INIT(phobia_objs, list(
 	)),
 
 	"greytide" = (typecacheof(list(/obj/item/clothing/under/color/grey, /obj/item/melee/baton/security/cattleprod,
-		/obj/item/spear, /obj/item/toy/figure/assistant,
-		/obj/structure/statue/sandstone/assistant))+typecacheof(list(/obj/item/clothing/mask/gas), FALSE, TRUE)),
+		/obj/item/spear, /obj/item/toy/figure/assistant, /obj/structure/statue/sandstone/assistant)) +
+		typecacheof(list(/obj/item/clothing/mask/gas), ignore_root_path = FALSE, only_root_path = TRUE)),
 
 	"lizards" = typecacheof(list(/obj/item/toy/plush/lizard_plushie, /obj/item/food/kebab/tail, /obj/item/organ/tail/lizard,
 		/obj/item/reagent_containers/food/drinks/bottle/lizardwine, /obj/item/clothing/head/lizard, /obj/item/clothing/shoes/cowboy/lizard,

--- a/code/_globalvars/traumas.dm
+++ b/code/_globalvars/traumas.dm
@@ -127,8 +127,9 @@ GLOBAL_LIST_INIT(phobia_objs, list(
 	)),
 
 	"greytide" = (typecacheof(list(/obj/item/clothing/under/color/grey, /obj/item/melee/baton/security/cattleprod,
-		/obj/item/spear, /obj/item/toy/figure/assistant, /obj/structure/statue/sandstone/assistant)) +
-		typecacheof(list(/obj/item/clothing/mask/gas), ignore_root_path = FALSE, only_root_path = TRUE)),
+		/obj/item/spear, /obj/item/toy/figure/assistant,
+		/obj/structure/statue/sandstone/assistant)) + typecacheof(list(/obj/item/clothing/mask/gas), ignore_root_path = FALSE, only_root_path = TRUE
+	)),
 
 	"lizards" = typecacheof(list(/obj/item/toy/plush/lizard_plushie, /obj/item/food/kebab/tail, /obj/item/organ/tail/lizard,
 		/obj/item/reagent_containers/food/drinks/bottle/lizardwine, /obj/item/clothing/head/lizard, /obj/item/clothing/shoes/cowboy/lizard,

--- a/code/_globalvars/traumas.dm
+++ b/code/_globalvars/traumas.dm
@@ -126,10 +126,9 @@ GLOBAL_LIST_INIT(phobia_objs, list(
 		/obj/item/clothing/under/plasmaman/clown
 	)),
 
-	"greytide" = typecacheof(list(/obj/item/clothing/under/color/grey, /obj/item/melee/baton/security/cattleprod,
-		/obj/item/spear, /obj/item/clothing/mask/gas, /obj/item/toy/figure/assistant,
-		/obj/structure/statue/sandstone/assistant
-	)),
+	"greytide" = (typecacheof(list(/obj/item/clothing/under/color/grey, /obj/item/melee/baton/security/cattleprod,
+		/obj/item/spear, /obj/item/toy/figure/assistant,
+		/obj/structure/statue/sandstone/assistant))+typecacheof(list(/obj/item/clothing/mask/gas), FALSE, TRUE)),
 
 	"lizards" = typecacheof(list(/obj/item/toy/plush/lizard_plushie, /obj/item/food/kebab/tail, /obj/item/organ/tail/lizard,
 		/obj/item/reagent_containers/food/drinks/bottle/lizardwine, /obj/item/clothing/head/lizard, /obj/item/clothing/shoes/cowboy/lizard,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- PR'ed for Hacktoberfest (so if this passes muster I'd appreciate it being tagged with `hacktoberfest-accepted`)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
closes https://github.com/tgstation/tgstation/issues/62452
## Why It's Good For The Game

People that are scared of assistants now won't be scared of Security/The Captain
Previously: https://streamable.com/vdej9j
Fixed: https://streamable.com/s4pzf9

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Gas mask subtypes will no longer scare people with Greytider Phobia
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
