### PR TITLE
Removes useless variable from CAS - allows modularization by making the strings a variable

### DIFF
--- a/code/modules/games/cas.dm
+++ b/code/modules/games/cas.dm
@@ -18,7 +18,8 @@
 	var/card_face = "cas_white"
 	var/blanks = 25
 	var/decksize = 150
-	var/card_text_file = "strings/cas_white.txt"
+	///Holds both .txt files for white and black cards respectively. Takes both "cas_white" and "cas_black", strings must be passed through world.2filelist.
+	var/static/list/cards_against_space = list("cas_white" = world.file2list("strings/cas_white.txt"),"cas_black" = world.file2list("strings/cas_black.txt"))
 	var/list/allcards = list()
 
 /obj/item/toy/cards/deck/cas/black
@@ -29,10 +30,8 @@
 	card_face = "cas_black"
 	blanks = 0
 	decksize = 50
-	card_text_file = "strings/cas_black.txt"
 
 /obj/item/toy/cards/deck/cas/populate_deck()
-	var/static/list/cards_against_space = list("cas_white" = world.file2list("strings/cas_white.txt"),"cas_black" = world.file2list("strings/cas_black.txt"))
 	allcards = cards_against_space[card_face]
 	var/list/possiblecards = allcards.Copy()
 	if(possiblecards.len < decksize) // sanity check

--- a/code/modules/games/cas.dm
+++ b/code/modules/games/cas.dm
@@ -18,7 +18,7 @@
 	var/card_face = "cas_white"
 	var/blanks = 25
 	var/decksize = 150
-	///Holds both .txt files for white and black cards respectively. Takes both "cas_white" and "cas_black", strings must be passed through world.2filelist.
+	///Holds both .txt files for white and black cards respectively. Takes both "cas_white" and "cas_black", strings must be passed through world.file2list.
 	var/static/list/cards_against_space = list("cas_white" = world.file2list("strings/cas_white.txt"),"cas_black" = world.file2list("strings/cas_black.txt"))
 	var/list/allcards = list()
 


### PR DESCRIPTION
## About The Pull Request

This removes an useless variable from CAS, which pointed to the card's string. This was used nowhere but defined again on the black cards. This also moves a variable (which was on populate_deck()'s proc) to the card.

## Why It's Good For The Game

Variables that do nothing are bad. Also moving the variable holding the strings to the card allows subtypes without having to edit the whole proc, alongside making it seem all nicer and allowing documentation.

## Changelog

Not player facing.
