### PR TITLE
Removes Detomatix PDA cartridge

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1162,10 +1162,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 
 	if(T)
 		T.hotspot_expose(700,125)
-		if(istype(cartridge, /obj/item/cartridge/virus/syndicate))
-			explosion(src, devastation_range = -1, heavy_impact_range = 1, light_impact_range = 3, flash_range = 4)
-		else
-			explosion(src, devastation_range = -1, heavy_impact_range = -1, light_impact_range = 2, flash_range = 3)
+		explosion(src, devastation_range = -1, heavy_impact_range = -1, light_impact_range = 2, flash_range = 3)
 	qdel(src)
 	return
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -109,7 +109,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		. += span_notice("Ctrl-click to remove [inserted_item].") //traitor pens are disguised so we're fine naming them on examine
 
 	if((!isnull(cartridge)))
-		. += span_notice("Ctrl+Shift-click to remove the cartridge.") //won't name cart on examine in case it's Detomatix
+		. += span_notice("Ctrl+Shift-click to remove the cartridge.") //won't name cart on examine in case it's a syndi cart.
 
 /obj/item/pda/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -178,7 +178,6 @@
 	greyscale_colors = "#927444#D6B328#6C3BA1"
 
 /obj/item/pda/syndicate
-	default_cartridge = /obj/item/cartridge/virus/syndicate
 	greyscale_colors = "#891417#80FF80"
 	name = "military PDA"
 	owner = "John Doe"

--- a/code/game/objects/items/devices/PDA/virus_cart.dm
+++ b/code/game/objects/items/devices/PDA/virus_cart.dm
@@ -51,33 +51,6 @@
 	else
 		to_chat(U, span_alert("PDA not found."))
 
-/obj/item/cartridge/virus/syndicate
-	name = "\improper Detomatix cartridge"
-	icon_state = "cart"
-	access = CART_REMOTE_DOOR
-	remote_door_id = "smindicate" //Make sure this matches the syndicate shuttle's shield/door id!! //don't ask about the name, testing.
-	charges = 4
-
-/obj/item/cartridge/virus/syndicate/send_virus(obj/item/pda/target, mob/living/U)
-	if(charges <= 0)
-		to_chat(U, span_notice("Out of charges."))
-		return
-	if(!isnull(target) && !target.toff)
-		charges--
-		var/difficulty = 0
-		if(target.cartridge)
-			difficulty += bit_count(target.cartridge.access&(CART_MEDICAL | CART_SECURITY | CART_ENGINE | CART_CLOWN | CART_JANITOR | CART_MANIFEST))
-			if(target.cartridge.access & CART_MANIFEST)
-				difficulty++ //if cartridge has manifest access it has extra snowflake difficulty
-		if(SEND_SIGNAL(target, COMSIG_PDA_CHECK_DETONATE) & COMPONENT_PDA_NO_DETONATE || prob(difficulty * 15))
-			U.show_message(span_danger("An error flashes on your [src]."), MSG_VISUAL)
-		else
-			log_bomber(U, "triggered a PDA explosion on", target, "[!is_special_character(U) ? "(TRIGGED BY NON-ANTAG)" : ""]")
-			U.show_message(span_notice("Success!"), MSG_VISUAL)
-			target.explode()
-	else
-		to_chat(U, span_alert("PDA not found."))
-
 /obj/item/cartridge/virus/frame
 	name = "\improper F.R.A.M.E. cartridge"
 	icon_state = "cart"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -128,7 +128,6 @@
 			/obj/item/storage/backpack/duffelbag/syndie/sabotage
 			new /obj/item/camera_bug(src)
 			new /obj/item/sbeacondrop/powersink(src)
-			new /obj/item/cartridge/virus/syndicate(src)
 			new /obj/item/storage/toolbox/syndicate(src)
 			new /obj/item/pizzabox/bomb(src)
 			new /obj/item/storage/box/syndie_kit/emp(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -986,15 +986,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 	purchasable_from = UPLINK_CLOWN_OPS
 
-/datum/uplink_item/explosives/detomatix
-	name = "Detomatix PDA Cartridge"
-	desc = "When inserted into a personal digital assistant, this cartridge gives you four opportunities to \
-			detonate PDAs of crewmembers who have their message feature enabled. \
-			The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer."
-	item = /obj/item/cartridge/virus/syndicate
-	cost = 6
-	restricted = TRUE
-
 /datum/uplink_item/explosives/emp
 	name = "EMP Grenades and Implanter Kit"
 	desc = "A box that contains five EMP grenades and an EMP implant with three uses. Useful to disrupt communications, \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the Detomatix PDA cart and any related code (that I know of).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
PDA bombs have no lead-in time, no warning, and thus no possible response. They often delimb, usually destroy the ID if it's in the PDA, and in general have little room for interesting interactions. C4 can be used creatively, and syndicate bombs have a loud beeping timer, but PDA is remote click-and-boom with little effort from the attacker. There is no reactionary for PDA bombs, and the only proactive approach is to shut off messaging, which is powergame-y and also discourages an alternate means of communication. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
del: Detomatix PDA cartridges, used for "PDA bombs", have been removed from the game.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

There's at least one plan to replace PDA bombs with something more fitting for the role the cartridge is supposed to play (sowing chaos within your target area), but there's not really a need for PDA bombs to stick around until the replacement is done.
