### PR TITLE
Adds Chameleon Armor to the uplink

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -526,6 +526,13 @@
 	new /obj/item/radio/headset/chameleon(src)
 	new /obj/item/stamp/chameleon(src)
 	new /obj/item/pda/chameleon(src)
+	
+/obj/item/storage/box/syndie_kit/chameleonarmor
+	name = "chameleon armor kit"
+	
+/obj/item/storage/box/syndie_kit/chameleonarmor/PopulateContents()
+	new /obj/item/clothing/head/chameleon/armored(src)
+	new /obj/item/clothing/suit/chameleon/armored(src)
 
 //5*(2*4) = 5*8 = 45, 45 damage if you hit one person with all 5 stars.
 //Not counting the damage it will do while embedded (2*4 = 8, at 15% chance)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -431,6 +431,9 @@
 /obj/item/clothing/suit/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+	
+/obj/item/clothing/suit/chameleon/armored
+	armor = list(MELEE = 40, BULLET = 50, LASER = 30, ENERGY = 40, BOMB = 35, BIO = 100, RAD = 50, FIRE = 50, ACID = 90, WOUND = 25)
 
 /obj/item/clothing/glasses/chameleon
 	name = "Optical Meson Scanner"
@@ -531,6 +534,9 @@
 	togglehatmask_action.UpdateButtonIcon()
 	var/datum/action/item_action/chameleon/drone/randomise/randomise_action = new(src)
 	randomise_action.UpdateButtonIcon()
+	
+/obj/item/clothing/head/chameleon/armored
+	armor = list(MELEE = 40, BULLET = 50, LASER = 30, ENERGY = 40, BOMB = 35, BIO = 100, RAD = 50, FIRE = 50, ACID = 90, WOUND = 25)
 
 /obj/item/clothing/mask/chameleon
 	name = "gas mask"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1191,6 +1191,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/storage/box/syndie_kit/chameleon
 	cost = 2
 	purchasable_from = ~UPLINK_NUKE_OPS //clown ops are allowed to buy this kit, since it's basically a costume
+	
+/datum/uplink_item/stealthy_tools/chameleonarmor
+	name = "Chameleon Armor"
+	desc = "A unique vest and helmet possessing advanced Syndicate composite nanofibre and chameleon technology, providing the same protection as a \
+			full blood red hardsuit without any of the lacking subtleties. Now your hazard vest is ballistic! This product is not spaceproof."
+	item = /obj/item/storage/box/syndie_kit/chameleonarmor
+	cost = 8
+	purchasable_from = ~UPLINK_NUKE_OPS
 
 /datum/uplink_item/stealthy_tools/chameleon_proj
 	name = "Chameleon Projector"


### PR DESCRIPTION
### About The Pull Request
Ever been lacking in armor as a tater tot? Wished you could be a strong boy against security without being blatantly obvious? Behold the brand new _chameleon armor!_ This vest and helmet sport chameleon appearance-changing tech but also protect as much as a blood red hardsuit does, with all the subtlety you love. It costs the same as the Hardsuit (**8 telecrystals**), and trades off the space protection granted by it for the chameleon ability to appear as whatever the hell you want it to.

### Why It's Good For The Game
Similarly expensive protection but with the caveat of being extra stelthy and not spaceproof.

### Changelog
🆑
add: chameleon armor kit
/🆑