### PR TITLE
Fixes sleeping carp wave kick dealing insane damage + wounds, fixes neckgrab throws not being harder

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -45,7 +45,7 @@
 					span_userdanger("You are kicked square in the chest by [A], sending you flying!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
 	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
 	var/atom/throw_target = get_edge_target_turf(D, A.dir)
-	D.throw_at(throw_target, 7, 14, A)
+	D.throw_at(throw_target, 7, 4, A)
 	D.apply_damage(15, A.get_attack_type(), BODY_ZONE_CHEST, wound_bonus = CANT_WOUND)
 	log_combat(A, D, "launchkicked (Sleeping Carp)")
 	return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -150,12 +150,15 @@
 
 	var/atom/movable/thrown_thing
 	var/obj/item/I = get_active_held_item()
+	var/neckgrab_throw = FALSE // we can't check for if it's a neckgrab throw when totaling up power_throw since we've already stopped pulling them by then, so get it early
 
 	if(!I)
 		if(pulling && isliving(pulling) && grab_state >= GRAB_AGGRESSIVE)
 			var/mob/living/throwable_mob = pulling
 			if(!throwable_mob.buckled)
 				thrown_thing = throwable_mob
+				if(grab_state >= GRAB_NECK)
+					neckgrab_throw = TRUE
 				stop_pulling()
 				if(HAS_TRAIT(src, TRAIT_PACIFISM))
 					to_chat(src, span_notice("You gently let go of [throwable_mob]."))
@@ -177,7 +180,7 @@
 			power_throw--
 		if(HAS_TRAIT(thrown_thing, TRAIT_DWARF))
 			power_throw++
-		if(pulling && grab_state >= GRAB_NECK)
+		if(neckgrab_throw)
 			power_throw++
 		visible_message(span_danger("[src] throws [thrown_thing][power_throw ? " really hard!" : "."]"), \
 						span_danger("You throw [thrown_thing][power_throw ? " really hard!" : "."]"))
@@ -842,7 +845,7 @@
 
 /mob/living/carbon/proc/can_defib()
 
-	
+
 	if (suiciding)
 		return DEFIB_FAIL_SUICIDE
 
@@ -874,10 +877,10 @@
 
 		if (BR.suicided || BR.brainmob?.suiciding)
 			return DEFIB_FAIL_NO_INTELLIGENCE
-	
+
 	if(key && key[1] == "@") // Adminghosts (#61870)
 		return DEFIB_NOGRAB_AGHOST
-	
+
 	return DEFIB_POSSIBLE
 
 /mob/living/carbon/harvest(mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Back when I made being thrown into walls/structures/whatever extra fast do extra damage to you in #55383, I missed out on the fact that the sleeping carp wave kick move apparently launches you at an insane 14 speed for some reason, compared to the standard throw's 2 speed. Thankfully, I had capped the amount of extra speed you can take damage from to 5, but even with this cap, this still meant being wave kicked into a wall (not even counting the 10-15 brute from the first punch) dealt 50 brute, with

15 damage from the kick itself, and 35 damage from the impact (10 base + 25 from the extra speed, *with* +25 wound bonus from the speed too). That 35 damage impact + 25 wound bonus gives you a whopping **38%** chance to suffer a critical bone break at full health. Here's a handy chart to show the percentage outcomes:
[![meta-chart.png](https://i.imgur.com/JVcBB16l.jpg)](https://i.imgur.com/JVcBB16.png)

I'm merciful and left in 2 points of extra speed, so you still deal 20 damage on the impact + 10 wound bonus. Since wound rolling scales exponentially with damage, going from 35 -> 20 damage is extremely significant, and brings the odds to this:
[![meta-chart (1).png](https://i.imgur.com/XPkYUNXl.jpg)](https://i.imgur.com/XPkYUNX.png)

I also realized while testing this that neckgrab throwing people doesn't actually throw them harder as originally intended, and fixed that, so throwing someone from a neckgrab deals a bit more damage. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
An infinitely repeatable 2 step attack combo should not be able to cause outright compound fractures

I'd count this as fixing an oversight that I just became aware of, but to sidestep the GBP question from maints, I'll mark it as balance in the CL
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Ryll/Shaps
balance: Being launched into a solid atom by Sleeping Carp's Wave Kick has been fixed to no longer deal far more damage and wounding power than originally intended, and can no longer cause outright compound fractures in healthy targets.
fix: Throwing someone you have in a neckgrab or are choking will now properly throw them harder than normal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
