### PR TITLE
Tweaks obsession to allow better interaction

### DIFF
--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -74,9 +74,11 @@
 	if(!viewing)
 		return
 	if(prob(25)) // 25% chances to be nervous and stutter.
-		owner.stuttering = max(3, owner.stuttering)
 		if(prob(50)) // 12.5% chance (previous check taken into account) of doing something suspicious.
 			addtimer(CALLBACK(src, .proc/on_failed_social_interaction), rand(1, 3) SECONDS)
+		else if(owner.stuttering == 0)
+			to_chat(owner, span_warning("Being near [obsession] makes you nervous and you begin to stutter..."))
+		owner.stuttering = max(3, owner.stuttering)
 
 /datum/brain_trauma/special/obsessed/proc/on_hug(mob/living/hugger, mob/living/hugged)
 	SIGNAL_HANDLER

--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -73,37 +73,34 @@
 /datum/brain_trauma/special/obsessed/handle_speech(datum/source, list/speech_args)
 	if(!viewing)
 		return
-	var/datum/component/mood/mood = owner.GetComponent(/datum/component/mood)
-	if(mood && mood.sanity >= SANITY_GREAT && social_interaction())
-		speech_args[SPEECH_MESSAGE] = ""
+	if(prob(25)) // 25% chances to be nervous and stutter.
+		owner.stuttering = max(3, owner.stuttering)
+		if(prob(50)) // 12.5% chance (previous check taken into account) of doing something suspicious.
+			addtimer(CALLBACK(src, .proc/on_failed_social_interaction), rand(1, 3) SECONDS)
 
 /datum/brain_trauma/special/obsessed/proc/on_hug(mob/living/hugger, mob/living/hugged)
 	SIGNAL_HANDLER
 	if(hugged == obsession)
 		obsession_hug_count++
 
-/datum/brain_trauma/special/obsessed/proc/social_interaction()
-	var/fail = FALSE //whether you can finish a sentence while doing it
-	owner.stuttering = max(3, owner.stuttering)
-	owner.blur_eyes(10)
-	switch(rand(1,4))
-		if(1)
+/datum/brain_trauma/special/obsessed/proc/on_failed_social_interaction()
+	if(QDELETED(owner) || owner.stat >= UNCONSCIOUS)
+		return
+	switch(rand(1, 100)) 
+		if(1 to 40)
+			INVOKE_ASYNC(owner, /mob.proc/emote, pick("blink", "blink_r"))
+			owner.blur_eyes(10)
+			to_chat(owner, span_userdanger("You sweat profusely and have a hard time focusing..."))
+		if(41 to 80)
+			INVOKE_ASYNC(owner, /mob.proc/emote, "pale")
 			shake_camera(owner, 15, 1)
-			owner.vomit()
-			fail = TRUE
-		if(2)
+			owner.adjustStaminaLoss(70)
+			to_chat(owner, span_userdanger("You feel your heart lurching in your chest..."))
+		if(81 to 100)
 			INVOKE_ASYNC(owner, /mob.proc/emote, "cough")
 			owner.dizziness += 10
-			fail = TRUE
-		if(3)
-			to_chat(owner, span_userdanger("You feel your heart lurching in your chest..."))
-			owner.Stun(20)
-			shake_camera(owner, 15, 1)
-		if(4)
-			to_chat(owner, span_warning("You faint."))
-			owner.Unconscious(80)
-			fail = TRUE
-	return fail
+			owner.adjust_disgust(5)
+			to_chat(owner, span_userdanger("You gag and swallow a bit of bile..."))
 
 // if the creep examines first, then the obsession examines them, have a 50% chance to possibly blow their cover. wearing a mask avoids this risk
 /datum/brain_trauma/special/obsessed/proc/stare(datum/source, mob/living/examining_mob, triggering_examiner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Previous behavior: If you had a good mood you'd vomit, cough, get stunned or faint, most of the time the message not going through, if you were viewing your obsession target. You had to leave their side and lower your mood before you'd be able to talk near them again.

Current behavior: Mood doesn't determine your nervousness near your target. You have a low chance (25%) of stuttering near them, and a lower chance (12.5%) of acting suspiciously, be it coughing, blinking or going pale, with slight penalties, but none as harsh as before.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I was playing today and became obsessed. Started by stealing the family heirloom of my target, then took their co-worker for a chat in maint and killed them, and when I went to have my grand finale and kidnapped my target, well, I couldn't interact with them. If I spoke I'd pass out and whatnot, and the message wouldn't go through. So I had to silently kill them before doing my great monologue. This PR aims to allow for interactions between the obsessed and their target.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Obsessed have a low chance of stuttering and displaying shifty behavior near their targets, instead of vomiting or passing out if on good mood. This is to better allow verbal interactions between obsessed and obsession target, while keeping them shifty and creepy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
