### PR TITLE
De-hardcodes accessory dmi files

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -162,7 +162,7 @@
 		to_chat(user, span_notice("You attach [accessory] to [src]."))
 
 	var/accessory_color = attached_accessory.icon_state
-	accessory_overlay = mutable_appearance('icons/mob/clothing/accessories.dmi', "[accessory_color]")
+	accessory_overlay = mutable_appearance(attached_accessory.worn_icon, "[accessory_color]")
 	accessory_overlay.alpha = attached_accessory.alpha
 	accessory_overlay.color = attached_accessory.color
 

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -2,6 +2,7 @@
 	name = "Accessory"
 	desc = "Something has gone wrong!"
 	icon = 'icons/obj/clothing/accessories.dmi'
+	worn_icon = 'icons/mob/clothing/accessories.dmi'
 	icon_state = "plasma"
 	inhand_icon_state = "" //no inhands
 	slot_flags = 0


### PR DESCRIPTION
## About The Pull Request

Moves accessory's .dmi file to be the jumpsuit's pinning proc, to the accessory's worn_icon.

## Why It's Good For The Game

Small QoL for downstreams who want to add their own accessories.

## Changelog

Not needed.