### PR TITLE
liches can no longer embed phylactery grenades inside of indestructible structures

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -128,21 +128,20 @@
 
 /obj/item/spear/explosive/afterattack(atom/movable/AM, mob/user, proximity)
 	. = ..()
-	if(!proximity)
+	if(!proximity || !wielded || !istype(AM))
 		return
-	if(wielded && istype(AM))
-		if(AM.resistance_flags & INDESTRUCTIBLE) //due to the lich incident of 2021, embedding grenades inside of indestructible structures is forbidden
+	if(AM.resistance_flags & INDESTRUCTIBLE) //due to the lich incident of 2021, embedding grenades inside of indestructible structures is forbidden
+		return
+	if(ismob(AM))
+		var/mob/mob_target = AM
+		if(mob_target.status_flags & GODMODE) //no embedding grenade phylacteries inside of ghost poly either
 			return
-		if(ismob(AM))
-			var/mob/mob_target = AM
-			if(mob_target.status_flags & GODMODE) //no embedding grenade phylacteries inside of ghost poly either
-				return
-		if(iseffect(AM)) //no accidentally wasting your moment of glory on graffiti
-			return
-		user.say("[war_cry]", forced="spear warcry")
-		explosive.forceMove(AM)
-		explosive.detonate(lanced_by=user)
-		qdel(src)
+	if(iseffect(AM)) //and no accidentally wasting your moment of glory on graffiti
+		return
+	user.say("[war_cry]", forced="spear warcry")
+	explosive.forceMove(AM)
+	explosive.detonate(lanced_by=user)
+	qdel(src)
 
 //GREY TIDE
 /obj/item/spear/grey_tide

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -137,6 +137,8 @@
 			var/mob/mob_target = AM
 			if(mob_target.status_flags & GODMODE) //no embedding grenade phylacteries inside of ghost poly either
 				return
+		if(iseffect(AM)) //no accidentally wasting your moment of glory on graffiti
+			return
 		user.say("[war_cry]", forced="spear warcry")
 		explosive.forceMove(AM)
 		explosive.detonate(lanced_by=user)

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -130,7 +130,13 @@
 	. = ..()
 	if(!proximity)
 		return
-	if(wielded)
+	if(wielded && istype(AM))
+		if(AM.resistance_flags & INDESTRUCTIBLE) //due to the lich incident of 2021, embedding grenades inside of indestructible structures is forbidden
+			return
+		if(ismob(AM))
+			var/mob/mob_target = AM
+			if(mob_target.status_flags & GODMODE) //no embedding grenade phylacteries inside of ghost poly either
+				return
 		user.say("[war_cry]", forced="spear warcry")
 		explosive.forceMove(AM)
 		explosive.detonate(lanced_by=user)


### PR DESCRIPTION
## About The Pull Request

Explosive lances can no longer embed grenades inside of indestructible objects (including structures), immortal mobs, or effects (like graffiti).

## Why It's Good For The Game

<img width="346" alt="persistent lich ban" src="https://user-images.githubusercontent.com/42606352/139648306-e185f898-d80c-4f82-852f-76c18c6fbd08.PNG">

I would've patched this out after the round regardless, but hey, making this PR now will make me look better in the ban appeal.

Note that the trick mentioned in that ban reason doesn't actually make you "completely unkillable". You can still die just like anyone else can, but (in theory), unless the crew has a soulstone handy, it's nigh-impossible for them to keep you down for longer than around 3 minutes. It's the difference between having the godmode flag and having free respawns (with a 3 minute cooldown, which is long enough for the crew to red alert, call the shuttle, and reach the point of no return while you're dead).

## Changelog

:cl: ATHATH
fix: Liches (and mortals) can no longer use explosive lances to store grenade phylacteries inside of indestructible objects (including structures)), immortal mobs, or effects. As a side effect, you should no longer accidentally trigger your explosive lance on the wrong target by misclicking on a piece of graffiti during the heat of combat.
/:cl: