### PR TITLE
Fixes NODROP guns dropping anyway when shooting yourself clumsily in the leg

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -276,7 +276,8 @@
 				var/shot_leg = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 				process_fire(user, user, FALSE, null, shot_leg)
 				SEND_SIGNAL(user, COMSIG_MOB_CLUMSY_SHOOT_FOOT)
-				user.dropItemToGround(src, TRUE)
+				if(!HAS_TRAIT(src, TRAIT_NODROP))
+					user.dropItemToGround(src, TRUE)
 				return TRUE
 
 /obj/item/gun/can_trigger_gun(mob/living/user)


### PR DESCRIPTION
## About The Pull Request
Fixes #62508
Apparently this was also an issue for the guns that were granted the nodrop trait from the anti-drop implant as well. 
## Why It's Good For The Game
Less cybernetic organs being spilt on the floor
## Changelog
:cl:
fix: fixed guns that are supposed to be undroppable (implant guns, guns when using an anti-drop implant) dropping anyway when you shoot yourself in the leg due to being Clumsy
/:cl:
