### PR TITLE
[MDB IGNORE] Adds directional prison intercoms

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5950,11 +5950,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "aSH" = (
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "aSI" = (
@@ -10685,6 +10681,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/item/radio/intercom/prison/directional/south,
 /turf/open/floor/iron,
 /area/security/brig)
 "bLo" = (
@@ -14827,6 +14824,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
 "cfq" = (
@@ -41214,11 +41212,7 @@
 /area/ai_monitored/command/storage/eva)
 "gwy" = (
 /obj/structure/chair/stool/directional/south,
-/obj/item/radio/intercom/directional/west{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "gwK" = (
@@ -48279,11 +48273,7 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
-/obj/item/radio/intercom/directional/west{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "itm" = (
@@ -52941,11 +52931,6 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/item/radio/intercom/directional/east{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /turf/open/floor/iron,
 /area/security/prison)
 "jRF" = (
@@ -53308,11 +53293,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/east{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "jZf" = (
@@ -55720,6 +55701,7 @@
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty,
 /obj/machinery/light/directional/south,
+/obj/item/radio/intercom/prison/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "kGC" = (
@@ -70277,11 +70259,7 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom/directional/east{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "oKw" = (
@@ -78650,11 +78628,7 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
-/obj/item/radio/intercom/directional/west{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "rhJ" = (
@@ -80287,6 +80261,7 @@
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/east,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -101547,11 +101522,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/east{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/grimy,
 /area/commons/dorms)
 "xYd" = (
@@ -101812,11 +101783,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/east{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "ycs" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -220,6 +220,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/radio/intercom/prison/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "abc" = (
@@ -949,6 +950,7 @@
 "afG" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "afH" = (
@@ -3187,6 +3189,7 @@
 "asD" = (
 /obj/structure/table,
 /obj/item/kitchen/fork/plastic,
+/obj/item/radio/intercom/prison/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "asE" = (
@@ -5094,13 +5097,9 @@
 /area/engineering/lobby)
 "aML" = (
 /obj/structure/cable,
-/obj/item/radio/intercom/directional/west{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/prison/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "aMN" = (
@@ -15570,15 +15569,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "dZz" = (
-/obj/item/radio/intercom/directional/east{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/item/radio/intercom/prison/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "dZH" = (
@@ -16556,11 +16551,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"eAF" = (
-/obj/machinery/light/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "eAJ" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -21678,11 +21668,7 @@
 "hfm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "hfu" = (
@@ -37445,11 +37431,7 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "pgn" = (
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "pgu" = (
@@ -45287,15 +45269,11 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "tkt" = (
-/obj/item/radio/intercom/directional/west{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/item/radio/intercom/prison/directional/west,
 /turf/open/floor/iron,
 /area/security/brig)
 "tkC" = (
@@ -50903,12 +50881,8 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "vZV" = (
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "wac" = (
@@ -78899,8 +78873,8 @@ alZ
 apz
 aqI
 acd
-acd
-eAF
+fRx
+aaq
 frj
 abz
 xPb
@@ -81199,7 +81173,7 @@ gQb
 bBM
 boP
 aai
-aaw
+pgn
 aap
 abs
 aoG

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -11681,12 +11681,8 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
 "Vd" = (
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/mine/laborcamp)
 "Ve" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -23615,6 +23615,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
+/obj/item/radio/intercom/prison/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "cwO" = (
@@ -23655,6 +23656,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
+/obj/item/radio/intercom/prison/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "cwS" = (
@@ -23686,6 +23688,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
+/obj/item/radio/intercom/prison/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "cxa" = (
@@ -37680,6 +37683,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/insectguts,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "het" = (
@@ -40876,11 +40880,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
@@ -40934,6 +40933,12 @@
 /obj/structure/bedsheetbin,
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
+/area/security/prison)
+"irG" = (
+/obj/machinery/plate_press,
+/obj/machinery/light/small/directional/south,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plating,
 /area/security/prison)
 "isi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54830,6 +54835,11 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"nyX" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/item/radio/intercom/prison/directional/south,
+/turf/open/floor/iron/white,
+/area/security/prison)
 "nzm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -54902,12 +54912,8 @@
 /area/ai_monitored/turret_protected/aisat/atmos)
 "nAW" = (
 /obj/structure/bookcase/random,
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/machinery/light/small/directional/north,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/grimy,
 /area/security/prison)
 "nAY" = (
@@ -64819,12 +64825,8 @@
 	pixel_x = 9;
 	pixel_y = 3
 	},
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "rhk" = (
@@ -65279,6 +65281,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
+/obj/item/radio/intercom/prison/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "rnV" = (
@@ -79380,6 +79383,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"wLJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/security/prison)
 "wLR" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "command maintenance";
@@ -91124,7 +91133,7 @@ anu
 ivj
 qJs
 aav
-kLr
+wLJ
 xFp
 xFp
 aau
@@ -92416,7 +92425,7 @@ oub
 chR
 qKa
 doP
-eXt
+irG
 aav
 aeU
 aeU
@@ -95759,7 +95768,7 @@ ycs
 cjD
 cjD
 cjD
-vAM
+nyX
 aav
 cmU
 cmU

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3599,15 +3599,11 @@
 "aEN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "aET" = (
@@ -21119,14 +21115,9 @@
 /area/service/chapel/office)
 "fpQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+	dir = 8
 	},
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
-/obj/structure/cable,
+/obj/item/radio/intercom/prison/directional/west,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "fpU" = (
@@ -32078,11 +32069,7 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "jpf" = (
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "jpn" = (
@@ -49224,11 +49211,7 @@
 /area/science/lab)
 "ptL" = (
 /obj/structure/chair/stool/directional/north,
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "ptZ" = (
@@ -51658,11 +51641,7 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "qkz" = (
@@ -57249,11 +57228,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "sof" = (
@@ -71449,6 +71424,7 @@
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/plating,
 /area/security/prison)
 "xsT" = (
@@ -94609,7 +94585,7 @@ wvy
 abe
 abe
 abe
-fpQ
+aby
 xvO
 agH
 afJ
@@ -94865,7 +94841,7 @@ pna
 ber
 pna
 pna
-pna
+fpQ
 tSU
 hbm
 cBe

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -659,10 +659,7 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "aeC" = (
-/obj/item/radio/intercom/directional/north{
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "aeF" = (
@@ -754,10 +751,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north{
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "afq" = (
@@ -2469,10 +2463,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/red/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/item/radio/intercom/directional/west{
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/west,
 /turf/open/floor/iron,
 /area/security/brig)
 "apk" = (
@@ -2498,10 +2489,7 @@
 	dir = 6;
 	network = list("ss13","Security")
 	},
-/obj/item/radio/intercom/directional/east{
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "app" = (
@@ -2671,10 +2659,7 @@
 	dir = 1;
 	network = list("ss13","Security")
 	},
-/obj/item/radio/intercom/directional/south{
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/security/brig)
 "aqe" = (
@@ -13012,11 +12997,8 @@
 	c_tag = "Security - Prison Garden";
 	network = list("ss13","Security","prison")
 	},
-/obj/item/radio/intercom/directional/north{
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/machinery/duct,
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "cYt" = (
@@ -17659,10 +17641,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/north{
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
 "eIm" = (
@@ -25718,16 +25697,13 @@
 /area/medical/virology)
 "hHU" = (
 /obj/structure/chair,
-/obj/item/radio/intercom/directional/north{
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "hHZ" = (
@@ -27448,6 +27424,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/item/radio/intercom/prison/directional/south,
 /turf/open/floor/iron,
 /area/security/prison/rec)
 "iqJ" = (
@@ -29052,13 +29029,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/west{
-	desc = "A station intercom. It looks like it has been modified to not broadcast.";
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
+/obj/item/radio/intercom/prison/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/work)
 "iQD" = (
@@ -29856,10 +29829,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/item/radio/intercom/directional/south{
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/south,
 /turf/open/floor/iron,
 /area/security/prison/workout)
 "jjN" = (
@@ -40425,10 +40395,7 @@
 	c_tag = "Security - Prison Commons";
 	network = list("ss13","Security","prison")
 	},
-/obj/item/radio/intercom/directional/north{
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison/rec)
 "ntZ" = (
@@ -51134,10 +51101,7 @@
 	dir = 1;
 	network = list("ss13","Security")
 	},
-/obj/item/radio/intercom/directional/south{
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/security/brig)
 "ryJ" = (
@@ -52062,14 +52026,11 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/east{
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/security/checkpoint/science)
 "rSW" = (
@@ -62263,10 +62224,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/south{
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/security/brig)
 "vNv" = (
@@ -62710,10 +62668,7 @@
 	dir = 1
 	},
 /obj/item/reagent_containers/food/drinks/drinkingglass,
-/obj/item/radio/intercom/directional/north{
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison/mess)
 "vWW" = (
@@ -65995,10 +65950,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north{
-	name = "prison intercom";
-	prison_radio = 1
-	},
+/obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/security/prison/mess)
 "xej" = (
@@ -68784,15 +68736,12 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/north{
-	name = "prison intercom";
-	prison_radio = 1
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/corner,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "ydp" = (

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -11,6 +11,11 @@
 /obj/item/radio/intercom/unscrewed
 	unscrewed = TRUE
 
+/obj/item/radio/intercom/prison
+	name = "prison intercom"
+	desc = "A station intercom. It looks like it has been modified to not broadcast."
+	prison_radio = TRUE
+
 /obj/item/radio/intercom/Initialize(mapload, ndir, building)
 	. = ..()
 	if(building)
@@ -157,4 +162,16 @@
 	pixel_x = 28
 
 /obj/item/radio/intercom/directional/west
+	pixel_x = -28
+
+/obj/item/radio/intercom/prison/directional/north
+	pixel_y = 22
+
+/obj/item/radio/intercom/prison/directional/south
+	pixel_y = -28
+
+/obj/item/radio/intercom/prison/directional/east
+	pixel_x = 28
+
+/obj/item/radio/intercom/prison/directional/west
 	pixel_x = -28


### PR DESCRIPTION
## About The Pull Request

Every single prison intercom was varedited, this makes for non standardizes varedits in terms of name, offset and description. This puts it all together and then some.
I also added some more intercoms, mostly to Kilo, because it was really lacking.

## Why It's Good For The Game

It's easier to add them when you don't have to varedit each one, especially when they see use on every single map.

## Changelog

:cl:
qol: All prison intercoms on all maps have been standardized!
fix: Delta's dormitories intercoms can now actually be spoken through, as it is no longer a prison intercom.
/:cl: