### PR TITLE
Makes the scream emote sound use a species proc rather than being a long list

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -56,30 +56,10 @@
 /datum/emote/living/carbon/human/scream/get_sound(mob/living/user)
 	if(!ishuman(user))
 		return
-	var/mob/living/carbon/human/H = user
-	if(H.mind?.miming)
+	var/mob/living/carbon/human/human = user
+	if(human.mind?.miming)
 		return
-	if(ishumanbasic(H) || isfelinid(H))
-		if(user.gender == FEMALE)
-			return pick('sound/voice/human/femalescream_1.ogg', 'sound/voice/human/femalescream_2.ogg', 'sound/voice/human/femalescream_3.ogg', 'sound/voice/human/femalescream_4.ogg', 'sound/voice/human/femalescream_5.ogg')
-		else
-			if(prob(1))
-				return 'sound/voice/human/wilhelm_scream.ogg'
-			return pick('sound/voice/human/malescream_1.ogg', 'sound/voice/human/malescream_2.ogg', 'sound/voice/human/malescream_3.ogg', 'sound/voice/human/malescream_4.ogg', 'sound/voice/human/malescream_5.ogg', 'sound/voice/human/malescream_6.ogg')
-	else if(ismoth(H))
-		return 'sound/voice/moth/scream_moth.ogg'
-	else if(islizard(H))
-		return pick('sound/voice/lizard/lizard_scream_1.ogg', 'sound/voice/lizard/lizard_scream_2.ogg', 'sound/voice/lizard/lizard_scream_3.ogg')
-	else if(isethereal(H))
-		return pick('sound/voice/ethereal/ethereal_scream_1.ogg', 'sound/voice/ethereal/ethereal_scream_2.ogg', 'sound/voice/ethereal/ethereal_scream_3.ogg')
-	else if(ismonkey(user)) //If its a monkey, override it.
-		return pick('sound/creatures/monkey/monkey_screech_1.ogg',
-					'sound/creatures/monkey/monkey_screech_2.ogg',
-					'sound/creatures/monkey/monkey_screech_3.ogg',
-					'sound/creatures/monkey/monkey_screech_4.ogg',
-					'sound/creatures/monkey/monkey_screech_5.ogg',
-					'sound/creatures/monkey/monkey_screech_6.ogg',
-					'sound/creatures/monkey/monkey_screech_7.ogg')
+	return human.dna.species.get_scream_sound(human)
 
 /datum/emote/living/carbon/human/scream/screech //If a human tries to screech it'll just scream.
 	key = "screech"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2128,3 +2128,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /// This should create a CONSISTENT result, so the icons don't randomly change.
 /datum/species/proc/prepare_human_for_preview(mob/living/carbon/human/human)
 	return
+
+/// Returns the species's scream sound.
+/datum/species/proc/get_scream_sound(mob/living/carbon/human/human)
+	return

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -147,3 +147,8 @@
 	features += "feature_ethcolor"
 
 	return features
+
+/datum/species/ethereal/get_scream_sound(mob/living/carbon/human/ethereal)
+	return pick('sound/voice/ethereal/ethereal_scream_1.ogg',
+				'sound/voice/ethereal/ethereal_scream_2.ogg',
+				'sound/voice/ethereal/ethereal_scream_3.ogg')

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -20,3 +20,19 @@
 	human.hairstyle = "Business Hair"
 	human.hair_color = "#bb9966" // brown
 	human.update_hair()
+
+/datum/species/human/get_scream_sound(mob/living/carbon/human/human)
+	if(human.gender == MALE)
+		if(prob(1))
+			return 'sound/voice/human/wilhelm_scream.ogg'
+		return pick('sound/voice/human/malescream_1.ogg',
+					'sound/voice/human/malescream_2.ogg',
+					'sound/voice/human/malescream_3.ogg',
+					'sound/voice/human/malescream_4.ogg',
+					'sound/voice/human/malescream_5.ogg',
+					'sound/voice/human/malescream_6.ogg')
+	return pick('sound/voice/human/femalescream_1.ogg',
+				'sound/voice/human/femalescream_2.ogg',
+				'sound/voice/human/femalescream_3.ogg',
+				'sound/voice/human/femalescream_4.ogg',
+				'sound/voice/human/femalescream_5.ogg')

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -115,6 +115,11 @@
 	mutant_bodyparts["tail_lizard"] = tail
 	human_mob.update_body()
 
+/datum/species/lizard/get_scream_sound(mob/living/carbon/human/lizard)
+	return pick('sound/voice/lizard/lizard_scream_1.ogg',
+				'sound/voice/lizard/lizard_scream_2.ogg',
+				'sound/voice/lizard/lizard_scream_3.ogg')
+
 /*
 Lizard subspecies: ASHWALKERS
 */

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -104,3 +104,12 @@
 	if(SSevents.holidays && SSevents.holidays[MONKEYDAY])
 		return TRUE
 	return ..()
+
+/datum/species/monkey/get_scream_sound(mob/living/carbon/human/monkey)
+		return pick('sound/creatures/monkey/monkey_screech_1.ogg',
+					'sound/creatures/monkey/monkey_screech_2.ogg',
+					'sound/creatures/monkey/monkey_screech_3.ogg',
+					'sound/creatures/monkey/monkey_screech_4.ogg',
+					'sound/creatures/monkey/monkey_screech_5.ogg',
+					'sound/creatures/monkey/monkey_screech_6.ogg',
+					'sound/creatures/monkey/monkey_screech_7.ogg')

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -63,3 +63,6 @@
 	human_mob.dna.features["wings"] = wings
 	human_mob.dna.features["moth_wings"] = wings
 	human_mob.update_body()
+
+/datum/species/moth/get_scream_sound(mob/living/carbon/human/human)
+	return 'sound/voice/moth/scream_moth.ogg'


### PR DESCRIPTION
## About The Pull Request

Currently, the scream emote takes its sounds from a LONG else if statement that includes each species that has a scream emote. With this pull request, species will now have a proc that will return the scream sound. This changes no functionality at all.

## Why It's Good For The Game

idk something tells me that it's good

## Changelog

Not player-facing.