### PR TITLE
Vertical alignment for tgui button content

### DIFF
--- a/tgui/docs/component-reference.md
+++ b/tgui/docs/component-reference.md
@@ -229,6 +229,10 @@ the baseline alignment.
 over the button.
 - `children: any` - Content to render inside the button.
 - `onClick: function` - Called when element is clicked.
+- `verticalAlign: string` - Align content vertically.
+  - `top` - align content to the ceiling of the button box.
+  - `center` - align content on the center of the button box.
+  - `bottom` - align content on the ground of the button box.
 
 ### `Button.Checkbox`
 

--- a/tgui/docs/component-reference.md
+++ b/tgui/docs/component-reference.md
@@ -231,7 +231,7 @@ over the button.
 - `onClick: function` - Called when element is clicked.
 - `verticalAlign: string` - Align content vertically.
   - `top` - align content to the ceiling of the button box.
-  - `center` - align content on the center of the button box.
+  - `middle` - align content on the middle of the button box.
   - `bottom` - align content on the ground of the button box.
 
 ### `Button.Checkbox`

--- a/tgui/packages/tgui/components/Button.js
+++ b/tgui/packages/tgui/components/Button.js
@@ -35,6 +35,7 @@ export const Button = props => {
     children,
     onclick,
     onClick,
+	verticalAlign,
     ...rest
   } = props;
   const hasContent = !!(content || children);
@@ -94,22 +95,28 @@ export const Button = props => {
         }
       }}
       {...computeBoxProps(rest)}>
-      {(icon && iconPosition !== 'right') && (
-        <Icon
-          name={icon}
-          color={iconColor}
-          rotation={iconRotation}
-          spin={iconSpin} />
-      )}
-      {content}
-      {children}
-      {(icon && iconPosition === 'right') && (
-        <Icon
-          name={icon}
-          color={iconColor}
-          rotation={iconRotation}
-          spin={iconSpin} />
-      )}
+      <div className={(verticalAlign && typeof verticalAlign == "string")
+      ? "Button--align--" + verticalAlign
+      : undefined}>
+        <div>
+          {(icon && iconPosition !== 'right') && (
+              <Icon
+              name={icon}
+              color={iconColor}
+              rotation={iconRotation}
+              spin={iconSpin} />
+          )}
+          {content}
+          {children}
+          {(icon && iconPosition === 'right') && (
+              <Icon
+              name={icon}
+              color={iconColor}
+              rotation={iconRotation}
+              spin={iconSpin} />
+          )}
+        </div>
+      </div>
     </div>
   );
 

--- a/tgui/packages/tgui/components/Button.js
+++ b/tgui/packages/tgui/components/Button.js
@@ -96,7 +96,7 @@ export const Button = props => {
         }
       }}
       {...computeBoxProps(rest)}>
-      <div className={fluid && 'Button--content--fluid'}>
+      <div className={fluid && 'Button__content--fluid'}>
         {icon && iconPosition !== 'right' && (
           <Icon
             name={icon}

--- a/tgui/packages/tgui/components/Button.js
+++ b/tgui/packages/tgui/components/Button.js
@@ -35,7 +35,7 @@ export const Button = props => {
     children,
     onclick,
     onClick,
-	verticalAlign,
+    verticalAlign,
     ...rest
   } = props;
   const hasContent = !!(content || children);

--- a/tgui/packages/tgui/components/Button.js
+++ b/tgui/packages/tgui/components/Button.js
@@ -95,25 +95,30 @@ export const Button = props => {
         }
       }}
       {...computeBoxProps(rest)}>
-      <div className={(verticalAlign && typeof verticalAlign == "string")
-      ? "Button--align--" + verticalAlign
-      : undefined}>
+      <div
+        className={
+          verticalAlign && typeof verticalAlign === 'string'
+            ? 'Button--align--' + verticalAlign
+            : undefined
+        }>
         <div>
-          {(icon && iconPosition !== 'right') && (
-              <Icon
+          {icon && iconPosition !== 'right' && (
+            <Icon
               name={icon}
               color={iconColor}
               rotation={iconRotation}
-              spin={iconSpin} />
+              spin={iconSpin}
+            />
           )}
           {content}
           {children}
-          {(icon && iconPosition === 'right') && (
-              <Icon
+          {icon && iconPosition === 'right' && (
+            <Icon
               name={icon}
               color={iconColor}
               rotation={iconRotation}
-              spin={iconSpin} />
+              spin={iconSpin}
+            />
           )}
         </div>
       </div>

--- a/tgui/packages/tgui/components/Button.js
+++ b/tgui/packages/tgui/components/Button.js
@@ -68,6 +68,7 @@ export const Button = props => {
         circular && 'Button--circular',
         compact && 'Button--compact',
         iconPosition && 'Button--iconPosition--' + iconPosition,
+        verticalAlign && 'Button--verticalAlign--' + verticalAlign,
         (color && typeof color === 'string')
           ? 'Button--color--' + color
           : 'Button--color--default',
@@ -95,32 +96,25 @@ export const Button = props => {
         }
       }}
       {...computeBoxProps(rest)}>
-      <div
-        className={
-          verticalAlign && typeof verticalAlign === 'string'
-            ? 'Button--align--' + verticalAlign
-            : undefined
-        }>
-        <div>
-          {icon && iconPosition !== 'right' && (
-            <Icon
-              name={icon}
-              color={iconColor}
-              rotation={iconRotation}
-              spin={iconSpin}
-            />
-          )}
-          {content}
-          {children}
-          {icon && iconPosition === 'right' && (
-            <Icon
-              name={icon}
-              color={iconColor}
-              rotation={iconRotation}
-              spin={iconSpin}
-            />
-          )}
-        </div>
+      <div className={fluid && 'Button--content--fluid'}>
+        {icon && iconPosition !== 'right' && (
+          <Icon
+            name={icon}
+            color={iconColor}
+            rotation={iconRotation}
+            spin={iconSpin}
+          />
+        )}
+        {content}
+        {children}
+        {icon && iconPosition === 'right' && (
+          <Icon
+            name={icon}
+            color={iconColor}
+            rotation={iconRotation}
+            spin={iconSpin}
+          />
+        )}
       </div>
     </div>
   );

--- a/tgui/packages/tgui/styles/components/Button.scss
+++ b/tgui/packages/tgui/styles/components/Button.scss
@@ -141,7 +141,7 @@ $bg-map: colors.$bg-map !default;
   align-items: flex-start;
 }
 
-.Button--verticalAlign--center {
+.Button--verticalAlign--middle {
   align-items: center;
 }
 

--- a/tgui/packages/tgui/styles/components/Button.scss
+++ b/tgui/packages/tgui/styles/components/Button.scss
@@ -134,3 +134,27 @@ $bg-map: colors.$bg-map !default;
 .Button--selected {
   @include button-color($color-selected);
 }
+
+.Button--align-top{
+	display: flex;
+	justify-content: center;
+	flex-direction: flex-start;
+	height:100%;
+	width:100%
+}
+
+.Button--align--center{
+	display: flex;
+	justify-content: center;
+	flex-direction: column;
+	height:100%;
+	width:100%
+}
+
+.Button--align--bottom{
+	display: flex;
+	justify-content: flex-end;
+	flex-direction: column;
+	height:100%;
+	width:100%;
+}

--- a/tgui/packages/tgui/styles/components/Button.scss
+++ b/tgui/packages/tgui/styles/components/Button.scss
@@ -45,6 +45,7 @@ $bg-map: colors.$bg-map !default;
 .Button {
   position: relative;
   display: inline-block;
+  display: inline-flex;
   line-height: 1.667em;
   padding: 0 0.5em;
   margin-right: base.em(2px);
@@ -90,6 +91,7 @@ $bg-map: colors.$bg-map !default;
 
 .Button--fluid {
   display: block;
+  display: flex;
   margin-left: 0;
   margin-right: 0;
 }
@@ -135,26 +137,18 @@ $bg-map: colors.$bg-map !default;
   @include button-color($color-selected);
 }
 
-.Button--align-top{
-	display: flex;
-	justify-content: center;
-	flex-direction: flex-start;
-	height:100%;
-	width:100%
+.Button--verticalAlign--top{
+	align-items: flex-start;
 }
 
-.Button--align--center{
-	display: flex;
-	justify-content: center;
-	flex-direction: column;
-	height:100%;
-	width:100%
+.Button--verticalAlign--center{
+	align-items: center;
 }
 
-.Button--align--bottom{
-	display: flex;
-	justify-content: flex-end;
-	flex-direction: column;
-	height:100%;
-	width:100%;
+.Button--verticalAlign--bottom{
+	align-items: flex-end;
+}
+
+.Button--content--fluid{
+	flex: 1;
 }

--- a/tgui/packages/tgui/styles/components/Button.scss
+++ b/tgui/packages/tgui/styles/components/Button.scss
@@ -137,18 +137,18 @@ $bg-map: colors.$bg-map !default;
   @include button-color($color-selected);
 }
 
-.Button--verticalAlign--top{
-	align-items: flex-start;
+.Button--verticalAlign--top {
+  align-items: flex-start;
 }
 
-.Button--verticalAlign--center{
-	align-items: center;
+.Button--verticalAlign--center {
+  align-items: center;
 }
 
-.Button--verticalAlign--bottom{
-	align-items: flex-end;
+.Button--verticalAlign--bottom {
+  align-items: flex-end;
 }
 
-.Button--content--fluid{
-	flex: 1;
+.Button__content--fluid {
+  flex: 1;
 }


### PR DESCRIPTION
## About The Pull Request
Adds a `verticalAlign` prop for buttons that will wrap the content and icons in it in a flexbox and center/flex-end them. Made this an optional prop so it doesn't break browsers with bricked flexboxes.

## Why It's Good For The Game
UI feature

## Changelog
not player facing