### PR TITLE
AtmoZphere (tablet program) will show the tile's temperature as both °C and K now.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -27,7 +27,8 @@
 		var/pressure = environment.return_pressure()
 		var/total_moles = environment.total_moles()
 		data["AirPressure"] = round(pressure,0.1)
-		data["AirTemp"] = round(environment.temperature-T0C)
+		data["AirTempC"] = round(environment.temperature-T0C)
+		data["AirTempK"] = round(environment.temperature)
 		if (total_moles)
 			for(var/id in env_gases)
 				var/gas_level = env_gases[id][MOLES]/total_moles
@@ -36,7 +37,8 @@
 		data["AirData"] = airlist
 	else
 		data["AirPressure"] = 0
-		data["AirTemp"] = 0
+		data["AirTempC"] = 0
+		data["AirTempK"] = 0
 		data["AirData"] = list(list())
 	return data
 

--- a/tgui/packages/tgui/interfaces/NtosAtmos.js
+++ b/tgui/packages/tgui/interfaces/NtosAtmos.js
@@ -9,7 +9,8 @@ import { NtosWindow } from '../layouts';
 export const NtosAtmos = (props, context) => {
   const { act, data } = useBackend(context);
   const {
-    AirTemp,
+    AirTempC,
+    AirTempK,	
     AirPressure,
   } = data;
   const gases = flow([
@@ -25,7 +26,7 @@ export const NtosAtmos = (props, context) => {
         <Section>
           <LabeledList>
             <LabeledList.Item label="Temperature">
-              {AirTemp}°C
+              {AirTempC}°C | {AirTempK}K
             </LabeledList.Item>
             <LabeledList.Item label="Pressure">
               {AirPressure} kPa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
AtmoZphere would only display the temperature as °C and that value is kinda pointless for atmos techs so I'm changing that.

![kelvin](https://user-images.githubusercontent.com/55374212/139936126-ef8db23a-4a4d-41d2-aba5-171974e23309.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Today I found a cute way to use this program to make my life easier, then realized why nobody uses this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Guillaume Prata
qol: AtmoZphere (tablet program) will show the tile's temperature as both °C and K now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
