### PR TITLE
Blind mobs can now smell what the oven is cooking. Plus punctuation.

### DIFF
--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -68,9 +68,9 @@
 	used_tray.AddToPlate(baked_result)
 
 	if(positive_result)
-		used_oven.visible_message(span_warning("You smell something great coming from [used_oven]"))
+		used_oven.visible_message(span_notice("You smell something great coming from [used_oven]."), blind_message = span_notice("You smell something great..."))
 	else
-		used_oven.visible_message(span_warning("You smell a burnt smell coming from [used_oven]"))
+		used_oven.visible_message(span_warning("You smell a burnt smell coming from [used_oven]."), blind_message = span_warning("You smell a burnt smell..."))
 	SEND_SIGNAL(parent, COMSIG_BAKE_COMPLETED, baked_result)
 	qdel(parent)
 


### PR DESCRIPTION
## About The Pull Request
Title. This will fix #62454. Also changing the spans class for positive results from warning to notice because it's not a negative thing.

## Why It's Good For The Game
Can you smell what the oven is cooking?

## Changelog

:cl:
fix: Fixed blind mobs not receiving messages for when a food item has finished baking ("You smell something great / a burnt smell...")
spellcheck: Added punctuation to the above messages.
/:cl: