### PR TITLE
Fixes a one character typo I made at some point

### DIFF
--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -296,7 +296,7 @@
 
 /// Traits for plants that can be activated to turn into a mob.
 /datum/plant_gene/trait/mob_transformation
-	name = "Dormat Ferocity"
+	name = "Dormant Ferocity"
 	trait_ids = ATTACK_SELF_ID
 	/// Whether mobs spawned by this trait are dangerous or not.
 	var/dangerous = FALSE


### PR DESCRIPTION
## About The Pull Request

Dormat -> Dormant for the plant trait `Dormant Ferocity`

## Why It's Good For The Game

Seriously how did no one, not even me, notice this until now

## Changelog

:cl: Melbert
spellcheck: Dormat -> Dormant
/:cl:
