### PR TITLE
Improves the visible message from burning limbs in plasma lava

### DIFF
--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -208,8 +208,9 @@
 		burn_human.emote("scream")
 		ADD_TRAIT(burn_limb, TRAIT_PLASMABURNT, src)
 		burn_human.update_body_parts()
-		burn_human.visible_message(span_warning("[burn_human] screams in pain as [burn_human.p_their()] [burn_limb] melts down to the bone!"), \
-			span_userdanger("You scream out in pain as your [burn_limb] melts down to the bone, leaving an eerie plasma-like glow where flesh used to be!"))
+		burn_human.emote("scream")
+		burn_human.visible_message(span_warning("[burn_human]'s [burn_limb.name] melts down to the bone!"), \
+			span_userdanger("You scream out in pain as your [burn_limb.name] melts down to the bone, leaving an eerie plasma-like glow where flesh used to be!"))
 	if(!plasma_parts.len && !robo_parts.len) //a person with no potential organic limbs left AND no robotic limbs, time to turn them into a plasmaman
 		burn_human.IgniteMob()
 		burn_human.set_species(/datum/species/plasmaman)


### PR DESCRIPTION
## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/62530

## Why It's Good For The Game
Corpses shouldn't be giving visible messages that say they're screaming.

## Changelog

:cl:
fix: Corpses will no longer scream when their limbs melt to the bone in icemoon's plasma lava
/:cl: