### PR TITLE
Splits init profiles into a seperate log file

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -158,7 +158,7 @@
 #define INIT_ORDER_PATH -50
 #define INIT_ORDER_EXPLOSIONS -69
 #define INIT_ORDER_STATPANELS -98
-#define INIT_ORDER_DEMO -99  // o avoid a bunch of changes related to initialization being written, do this last
+#define INIT_ORDER_INIT_PROFILER -99 //Near the end, logs the costs of initialize
 #define INIT_ORDER_CHAT -100 //Should be last to ensure chat remains smooth during init.
 
 // Subsystem fire priority, from lowest to highest priority

--- a/code/controllers/subsystem/init_profiler.dm
+++ b/code/controllers/subsystem/init_profiler.dm
@@ -1,0 +1,25 @@
+#define INIT_PROFILE_NAME "init_profiler.json"
+
+///Subsystem exists so we can seperately log init time costs from the costs of general operation
+///Hopefully this makes sorting out what causes problems when easier
+SUBSYSTEM_DEF(init_profiler)
+	name = "Init Profiler"
+	init_order = INIT_ORDER_INIT_PROFILER
+	flags = SS_NO_FIRE
+
+/datum/controller/subsystem/init_profiler/Initialize()
+	if(CONFIG_GET(flag/auto_profile))
+		write_init_profile()
+	return ..()
+
+/datum/controller/subsystem/init_profiler/proc/write_init_profile()
+	var/current_profile_data = world.Profile(PROFILE_REFRESH, format = "json")
+	CHECK_TICK
+
+	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
+		stack_trace("Warning, profiling stopped manually before dump.")
+	var/prof_file = file("[GLOB.log_directory]/[INIT_PROFILE_NAME]")
+	if(fexists(prof_file))
+		fdel(prof_file)
+	WRITE_FILE(prof_file, current_profile_data)
+	world.Profile(PROFILE_CLEAR) //Now that we're written this data out, dump it. We don't want it getting mixed up with our current round data

--- a/config/config.txt
+++ b/config/config.txt
@@ -523,7 +523,7 @@ DEFAULT_VIEW_SQUARE 15x15
 
 
 ## Enable automatic profiling - Byond 513.1506 and newer only.
-AUTO_PROFILE
+#AUTO_PROFILE
 
 ## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
 ## More API details can be found here: https://centcom.melonmesa.com

--- a/config/config.txt
+++ b/config/config.txt
@@ -523,7 +523,7 @@ DEFAULT_VIEW_SQUARE 15x15
 
 
 ## Enable automatic profiling - Byond 513.1506 and newer only.
-#AUTO_PROFILE
+AUTO_PROFILE
 
 ## Uncomment to enable global ban DB using the provided URL. The API should expect to receive a ckey at the end of the URL.
 ## More API details can be found here: https://centcom.melonmesa.com

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -364,6 +364,7 @@
 #include "code\controllers\subsystem\icon_smooth.dm"
 #include "code\controllers\subsystem\id_access.dm"
 #include "code\controllers\subsystem\idlenpcpool.dm"
+#include "code\controllers\subsystem\init_profiler.dm"
 #include "code\controllers\subsystem\input.dm"
 #include "code\controllers\subsystem\ipintel.dm"
 #include "code\controllers\subsystem\job.dm"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Spits init profiles into their own file, so we can better track where pain points come from, both in round and post.
After all there's no point in knowing that sprite sheets generate 32 seconds of overtime during init if you
only care about inround, or vis versa.

## Why It's Good For The Game

I'm tired of people freaking out about blends that are only done during init, and I've noticed that the profiler is close to unusable at the moment because of how much init stuff is leaking in.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
server: Init profiles are now logged separately from standard ones, in init_profiler.json
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
