### PR TITLE
Makes the Roboticist tablet come pre-installed with BotKeeper and SiliConnect.

### DIFF
--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -45,7 +45,7 @@
 	uniform = /obj/item/clothing/under/rank/rnd/roboticist
 	suit = /obj/item/clothing/suit/toggle/labcoat/roboticist
 	backpack_contents = list(
-		/obj/item/modular_computer/tablet/preset/science = 1,
+		/obj/item/modular_computer/tablet/preset/robotics = 1,
 		)
 	belt = /obj/item/storage/belt/utility/full
 	ears = /obj/item/radio/headset/headset_sci

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -31,6 +31,18 @@
 	install_component(new /obj/item/computer_hardware/radio_card)
 	hard_drive.store_file(new /datum/computer_file/program/signaler)
 
+/obj/item/modular_computer/tablet/preset/robotics/Initialize(mapload)
+	. = ..()
+	var/obj/item/computer_hardware/hard_drive/small/hard_drive = new
+	install_component(new /obj/item/computer_hardware/processor_unit/small)
+	install_component(new /obj/item/computer_hardware/battery(src, /obj/item/stock_parts/cell/computer))
+	install_component(hard_drive)
+	install_component(new /obj/item/computer_hardware/card_slot)
+	install_component(new /obj/item/computer_hardware/network_card)
+	hard_drive.store_file(new /datum/computer_file/program/signaler)
+	hard_drive.store_file(new /datum/computer_file/program/borg_monitor)
+	hard_drive.store_file(new /datum/computer_file/program/robocontrol)
+
 /obj/item/modular_computer/tablet/preset/cargo/Initialize(mapload)
 	. = ..()
 	var/obj/item/computer_hardware/hard_drive/small/hard_drive = new

--- a/code/modules/modular_computers/computers/item/tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/tablet_presets.dm
@@ -39,7 +39,6 @@
 	install_component(hard_drive)
 	install_component(new /obj/item/computer_hardware/card_slot)
 	install_component(new /obj/item/computer_hardware/network_card)
-	hard_drive.store_file(new /datum/computer_file/program/signaler)
 	hard_drive.store_file(new /datum/computer_file/program/borg_monitor)
 	hard_drive.store_file(new /datum/computer_file/program/robocontrol)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Swaps the generic scientist tablet that Roboticists would usually get for one with robotics-related programs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A lot of new players don't understand how good tablets really are, tending to instead throw them away. It also reduces the time it would take to install these apps for a job that should have them by default.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: 
qol: Makes the roboticist tablet come pre installed with Botkeeper and SiliConnect.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
