### PR TITLE
Prevents mindswaping into ghost poly

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -976,6 +976,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 	color = "#FFFFFF77"
 	speak_chance = 20
 	status_flags = GODMODE
+	sentience_type = SENTIENCE_BOSS //This is so players can't mindswap into ghost poly to become a literal god
 	incorporeal_move = INCORPOREAL_MOVE_BASIC
 	butcher_results = list(/obj/item/ectoplasm = 1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Closes https://github.com/tgstation/tgstation/issues/62465

Also makes ghost poly technically designated as a boss in the code as their sentience type, as far as I can tell this doesn't actually change anything other than the ability to make it sentient, but it also makes sense for a creature effectively incapable of death to be designated as a boss in the code.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As funny as it is, mindswapping (blood into a rainbow slime extract gives you a mindswap potion) into ghost poly, or otherwise making ghost poly sentient, is an exploit that should be patched. Ghost poly is as fast as a ghost, can move through walls, has godmode, and if you give it a fugu gland it can beat people up. It can also pick up things, such as the nuke disk, which would make nukeops rounds pretty unfair and unfun.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Aspiring xenobiologists and ambitious wizards can no longer mindswap into ghost poly or otherwise make them sentient in an attempt to gain godmode + ghost speed + the ability to go through walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
