### PR TITLE
Revert "Locker based combat, evolved. (#60000)"

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -684,9 +684,6 @@
 #define COMSIG_CARBON_HUGGED "carbon_hugged"
 ///When a carbon mob is headpatted, this is called on the carbon that is headpatted. (mob/living/headpatter)
 #define COMSIG_CARBON_HEADPAT "carbon_headpatted"
-///When a carbon mob is disarmed, this is called on objects that have unique behavior when the target is shoved into it (obj/structure/table, obj/machinery/disposal/bin)
-#define COMSIG_CARBON_DISARM_COLLIDE "carbon_disarm_collision"
-	#define COMSIG_CARBON_SHOVE_HANDLED (1<<0)
 
 ///When a carbon slips. Called on /turf/open/handle_slip()
 #define COMSIG_ON_CARBON_SLIP "carbon_slip"

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -74,7 +74,6 @@
 	. = ..()
 	update_appearance()
 	PopulateContents()
-	RegisterSignal(src, COMSIG_CARBON_DISARM_COLLIDE, .proc/locker_carbon)
 
 //USE THIS TO FILL IT, NOT INITIALIZE OR NEW
 /obj/structure/closet/proc/PopulateContents()
@@ -327,9 +326,7 @@
 /obj/structure/closet/proc/after_close(mob/living/user)
 	return
 
-/**
- * Toggles a closet open or closed, to the opposite state. Does not respect locked or welded states, however.
- */
+
 /obj/structure/closet/proc/toggle(mob/living/user)
 	if(opened)
 		return close(user)
@@ -678,20 +675,5 @@
 
 /obj/structure/closet/return_temperature()
 	return
-
-/obj/structure/closet/proc/locker_carbon(obj/structure/closet/closet, mob/living/carbon/shover, mob/living/carbon/target)
-	SIGNAL_HANDLER
-	if(opened)
-		target.forceMove(src)
-	if(!(locked || welded))
-		toggle()
-	update_icon()
-	target.visible_message(span_danger("[shover.name] shoves [target.name] into \the [src]!"),
-		span_userdanger("You're shoved into \the [src] by [target.name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)
-	to_chat(src, span_danger("You shove [target.name] into \the [src]!"))
-	log_combat(src, target, "shoved", "into [src] (locker/crate)")
-	if(locked || welded)
-		return
-	return COMSIG_CARBON_SHOVE_HANDLED
 
 #undef LOCKER_FULL

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -41,7 +41,6 @@
 	if(_buildstack)
 		buildstack = _buildstack
 	AddElement(/datum/element/climbable)
-	RegisterSignal(src, COMSIG_CARBON_DISARM_COLLIDE, .proc/table_carbon)
 
 /obj/structure/table/examine(mob/user)
 	. = ..()
@@ -259,15 +258,6 @@
 			return TRUE
 	return FALSE
 
-/obj/structure/table/proc/table_carbon(obj/structure/table/the_table, mob/living/carbon/shover, mob/living/carbon/target)
-	SIGNAL_HANDLER
-	target.Knockdown(SHOVE_KNOCKDOWN_TABLE)
-	target.visible_message(span_danger("[shover.name] shoves [target.name] onto \the [the_table]!"),
-		span_userdanger("You're shoved onto \the [the_table] by [shover.name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)
-	to_chat(shover, span_danger("You shove [target.name] onto \the [the_table]!"))
-	target.throw_at(src, 1, 1, null, FALSE) //1 speed throws with no spin are basically just forcemoves with a hard collision check
-	log_combat(src, target, "shoved", "onto [the_table] (table)")
-	return COMSIG_CARBON_SHOVE_HANDLED
 
 /obj/structure/table/greyscale
 	icon = 'icons/obj/smooth_structures/table_greyscale.dmi'

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -8,8 +8,6 @@
 	ADD_TRAIT(src, TRAIT_AGEUSIA, NO_TONGUE_TRAIT)
 
 	GLOB.carbon_list += src
-	RegisterSignal(src, COMSIG_LIVING_DEATH, .proc/attach_rot)
-	RegisterSignal(src, COMSIG_CARBON_DISARM_COLLIDE, .proc/disarm_collision)
 
 /mob/living/carbon/Destroy()
 	//This must be done first, so the mob ghosts correctly before DNA etc is nulled
@@ -1293,14 +1291,3 @@
 /mob/living/carbon/proc/attach_rot()
 	if(mob_biotypes & (MOB_ORGANIC|MOB_UNDEAD))
 		AddComponent(/datum/component/rot, 6 MINUTES, 10 MINUTES, 1)
-
-/mob/living/carbon/proc/disarm_collision(mob/living/carbon/collateral, mob/living/carbon/shover, mob/living/carbon/target)
-	SIGNAL_HANDLER
-	target.Knockdown(SHOVE_KNOCKDOWN_HUMAN)
-	if(!collateral.is_shove_knockdown_blocked())
-		collateral.Knockdown(SHOVE_KNOCKDOWN_COLLATERAL)
-	target.visible_message(span_danger("[shover] shoves [target.name] into [collateral.name]!"),
-		span_userdanger("You're shoved into [collateral.name] by [shover]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)
-	to_chat(src, span_danger("You shove [target.name] into [collateral.name]!"))
-	log_combat(src, target, "shoved", "into [collateral.name]")
-	return COMSIG_CARBON_SHOVE_HANDLED

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -258,16 +258,10 @@
 	var/shove_dir = get_dir(loc, target_oldturf)
 	var/turf/target_shove_turf = get_step(target.loc, shove_dir)
 	var/mob/living/carbon/target_collateral_carbon
+	var/obj/structure/table/target_table
+	var/obj/machinery/disposal/bin/target_disposal_bin
 	var/shove_blocked = FALSE //Used to check if a shove is blocked so that if it is knockdown logic can be applied
-	var/handled = FALSE
-	for(var/atom/movable/every_single_thing_but_target as anything in target_shove_turf.contents - target)
-		if(SEND_SIGNAL(every_single_thing_but_target, COMSIG_CARBON_DISARM_COLLIDE, src, target) & COMSIG_CARBON_SHOVE_HANDLED)
-			handled = TRUE
-			break
-		if(!handled)
-			SEND_SIGNAL(target, COMSIG_CARBON_DISARM_COLLIDE, src, target)
-	if(handled)
-		return //We are using an object's disarm collision reaction instead of base disarm reactions.
+
 	//Thank you based whoneedsspace
 	target_collateral_carbon = locate(/mob/living/carbon) in target_shove_turf.contents
 
@@ -280,6 +274,8 @@
 	else
 		target.Move(target_shove_turf, shove_dir)
 		if(get_turf(target) == target_oldturf)
+			target_table = locate(/obj/structure/table) in target_shove_turf.contents
+			target_disposal_bin = locate(/obj/machinery/disposal/bin) in target_shove_turf.contents
 			shove_blocked = TRUE
 
 	if(target.IsKnockdown() && !target.IsParalyzed())
@@ -303,12 +299,34 @@
 					if(obj_content.flags_1 & ON_BORDER_1 && obj_content.dir == turn(shove_dir, 180) && obj_content.density)
 						directional_blocked = TRUE
 						break
-		if((!target_collateral_carbon) || directional_blocked)
+		if((!target_table && !target_collateral_carbon && !target_disposal_bin) || directional_blocked)
 			target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
 			target.visible_message(span_danger("[name] shoves [target.name], knocking [target.p_them()] down!"),
 							span_userdanger("You're knocked down from a shove by [name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)
 			to_chat(src, span_danger("You shove [target.name], knocking [target.p_them()] down!"))
 			log_combat(src, target, "shoved", "knocking them down")
+		else if(target_table)
+			target.Knockdown(SHOVE_KNOCKDOWN_TABLE)
+			target.visible_message(span_danger("[name] shoves [target.name] onto \the [target_table]!"),
+							span_userdanger("You're shoved onto \the [target_table] by [name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)
+			to_chat(src, span_danger("You shove [target.name] onto \the [target_table]!"))
+			target.throw_at(target_table, 1, 1, null, FALSE) //1 speed throws with no spin are basically just forcemoves with a hard collision check
+			log_combat(src, target, "shoved", "onto [target_table] (table)")
+		else if(target_collateral_carbon)
+			target.Knockdown(SHOVE_KNOCKDOWN_HUMAN)
+			if(!target_collateral_carbon.is_shove_knockdown_blocked())
+				target_collateral_carbon.Knockdown(SHOVE_KNOCKDOWN_COLLATERAL)
+			target.visible_message(span_danger("[name] shoves [target.name] into [target_collateral_carbon.name]!"),
+				span_userdanger("You're shoved into [target_collateral_carbon.name] by [name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)
+			to_chat(src, span_danger("You shove [target.name] into [target_collateral_carbon.name]!"))
+			log_combat(src, target, "shoved", "into [target_collateral_carbon.name]")
+		else if(target_disposal_bin)
+			target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
+			target.forceMove(target_disposal_bin)
+			target.visible_message(span_danger("[name] shoves [target.name] into \the [target_disposal_bin]!"),
+							span_userdanger("You're shoved into \the [target_disposal_bin] by [name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)
+			to_chat(src, span_danger("You shove [target.name] into \the [target_disposal_bin]!"))
+			log_combat(src, target, "shoved", "into [target_disposal_bin] (disposal bin)")
 	else
 		target.visible_message(span_danger("[name] shoves [target.name]!"),
 						span_userdanger("You're shoved by [name]!"), span_hear("You hear aggressive shuffling!"), COMBAT_MESSAGE_RANGE, src)

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -41,7 +41,6 @@
 	//gas.volume = 1.05 * CELLSTANDARD
 	update_appearance()
 	RegisterSignal(src, COMSIG_RAT_INTERACT, .proc/on_rat_rummage)
-	RegisterSignal(src, COMSIG_CARBON_DISARM_COLLIDE, .proc/trash_carbon)
 
 	return INITIALIZE_HINT_LATELOAD //we need turfs to have air
 
@@ -527,12 +526,3 @@
 
 	INVOKE_ASYNC(src, /obj/machinery/disposal/.proc/rat_rummage, king)
 
-/obj/machinery/disposal/proc/trash_carbon(obj/machinery/disposal/binny, mob/living/carbon/shover, mob/living/carbon/target)
-	SIGNAL_HANDLER
-	target.Knockdown(SHOVE_KNOCKDOWN_SOLID)
-	target.forceMove(binny)
-	target.visible_message(span_danger("[shover.name] shoves [target.name] into \the [binny]!"),
-		span_userdanger("You're shoved into \the [binny] by [target.name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, binny)
-	to_chat(binny, span_danger("You shove [target.name] into \the [binny]!"))
-	log_combat(binny, target, "shoved", "into [binny] (disposal bin)")
-	return COMSIG_CARBON_SHOVE_HANDLED


### PR DESCRIPTION
Reverts tgstation/tgstation#60000

# Why this is good for the game

Long story short, there's a series of underlying bugs involved with the signal based approach to disarm code that was taken.
Fixes #62555.

One such example of this issue:

> Multiple things register the same signal.
> So a single shove executes all code paths.
> Even when something returns COMSIG_STOP_THIS_I_HANDLED_IT
> The signal is still send to all listeners.
>  So all possible results of shoving happen, and simultaneously.
> Quantum shoving.
> You'll shove someone and they'll get pushed back, knocked into themselves and fall over and shoved onto a table. ~Timberpoes

So, unless someone can magically rewrite this in a way that doesn't impose the same difficulties with signal based combat code, it should most certainly be reverted for now until a more concrete solution is reached.

# Changelog
🆑
fix: Locker combat has been shelved for now
/🆑