### PR TITLE
Removes the qol tag from the changelog template as qol is no longer supported by the changelog renderer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,6 @@ add: Added new mechanics or gameplay changes
 add: Added more things
 expansion: Expands content of an existing feature
 del: Removed old things
-qol: made something easier to use
 balance: rebalanced something
 fix: fixed a few things
 soundadd: added a new sound thingy


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

Bad looking changelog entries are bad, the qol entries end up on the same line as the previous entry and it looks terrible.

I think some more of these tags got discontinued as well, QoL is just the most recent one I've seen fail on live.

