### PR TITLE
Basic drone fuel can now be purchased from cargo.

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2525,6 +2525,13 @@
 	contains = list(/obj/item/exodrone)
 	crate_name = "exodrone crate"
 
+/datum/supply_pack/misc/exploration_fuel
+	name = "Drone Fuel Pellet"
+	desc = "A fresh tank of exoploration drone fuel."
+	cost = CARGO_CRATE_VALUE * 3
+	contains = list(/obj/item/fuel_pellet)
+	crate_name = "exodrone fuel crate"
+
 /datum/supply_pack/misc/paper
 	name = "Bureaucracy Crate"
 	desc = "High stacks of papers on your desk Are a big problem - make it Pea-sized with these bureaucratic supplies! Contains six pens, some camera film, hand labeler supplies, a paper bin, a carbon paper bin, three folders, a laser pointer, two clipboards and two stamps."//that was too forced

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2527,7 +2527,7 @@
 
 /datum/supply_pack/misc/exploration_fuel
 	name = "Drone Fuel Pellet"
-	desc = "A fresh tank of exoploration drone fuel."
+	desc = "A fresh tank of exploration drone fuel."
 	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/fuel_pellet)
 	crate_name = "exodrone fuel crate"


### PR DESCRIPTION

## About The Pull Request

This PR adds purchasable drone fuel within cargo. Advanced fuels are still specific to Atmos, but should you not have the assistance of atmospherics, you now have basic drone fuel that can be purchased and serve as a new purchasable from cargo.

## Why It's Good For The Game

Adds economy integration to a feature within cargo, internal moneysink and makes exploration drones more accessible by giving them a way to purchase more fuel as opposed to breaking into atmos or begging atmos, granted, atmos will be able to make FAR more effective fuel by comparison, which still leaves open room for cooperation.

## Changelog

:cl:
expansion: Cargo can now purchase individual tanks of exodrone fuel for around 3 crates worth of credits.
/:cl:
