### PR TITLE
Fixes invalid turfs on icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -6998,7 +6998,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plating/catwalk_floor,
+/turf/open/floor/catwalk_floor,
 /area/maintenance/department/chapel)
 "Cu" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -7032,7 +7032,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating/catwalk_floor,
+/turf/open/floor/catwalk_floor,
 /area/maintenance/department/chapel)
 "Cx" = (
 /obj/structure/rack,
@@ -8781,7 +8781,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating/catwalk_floor,
+/turf/open/floor/catwalk_floor,
 /area/maintenance/department/chapel)
 "IV" = (
 /obj/machinery/door/airlock{


### PR DESCRIPTION
## About The Pull Request

The catwalk repathing missed some turfs from lower icebox

## Why It's Good For The Game

Chapel maint no longer space!

## Changelog

:cl: Melbert
fix: Icebox chapel maint is no longer spaced, literally
/:cl:
