### PR TITLE
Fixes for Icebox science remap

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -6649,11 +6649,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"bga" = (
-/obj/machinery/destructive_scanner,
-/obj/effect/turf_decal/stripes/end,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "bgc" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
@@ -100524,7 +100519,7 @@ tut
 tut
 hof
 pXx
-bga
+aYV
 mGd
 aYV
 bfX

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -18732,11 +18732,11 @@
 	freq = 1400;
 	location = "Research Division"
 	},
-/obj/structure/plasticflaps,
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/plasticflaps/opaque,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "fIw" = (
@@ -20198,7 +20198,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/light/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34317,13 +34316,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
 "nFk" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "9;12;47"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "nFn" = (
@@ -51382,6 +51381,7 @@
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "woa" = (


### PR DESCRIPTION
## About The Pull Request

- Light on door has been moved.
- Opaque flaps instead of translucent
- scientists can get out of maintenance into departures
- Extra decon analyzer is kill

Insert NO GBP here

## Why It's Good For The Game

Just a few fixes from the science remap!

## Changelog

:cl: Melbert
fix: Icebox science: You can no longer peer into the science break room from maintenance, the loose light fixture has been relocated to a wall, and scientists can escape their own maintenance. Also the extra deconstructive analyzer was killed.
/:cl:
