### PR TITLE
Fixes emissive appearances of vending machines being removed when the wire panel is opened/closed

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -432,7 +432,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		return TRUE
 	if(anchored)
 		default_deconstruction_screwdriver(user, icon_state, icon_state, I)
-		cut_overlays()
+		cut_overlay(panel_type)
 		if(panel_open)
 			add_overlay(panel_type)
 		updateUsrDialog()

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -262,12 +262,10 @@
 
 /obj/machinery/vending/update_overlays()
 	. = ..()
-	if(!light_mask)
-		return
-	if(!(machine_stat & BROKEN) && powered())
-		. += emissive_appearance(icon, light_mask)
 	if(panel_open)
 		. += panel_type
+	if(light_mask && !(machine_stat & BROKEN) && powered())
+		. += emissive_appearance(icon, light_mask)
 
 /obj/machinery/vending/atom_break(damage_flag)
 	. = ..()

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -266,6 +266,8 @@
 		return
 	if(!(machine_stat & BROKEN) && powered())
 		. += emissive_appearance(icon, light_mask)
+	if(panel_open)
+		. += panel_type
 
 /obj/machinery/vending/atom_break(damage_flag)
 	. = ..()
@@ -432,9 +434,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		return TRUE
 	if(anchored)
 		default_deconstruction_screwdriver(user, icon_state, icon_state, I)
-		cut_overlay(panel_type)
-		if(panel_open)
-			add_overlay(panel_type)
+		update_appearance()
 		updateUsrDialog()
 	else
 		to_chat(user, span_warning("You must first secure [src]."))


### PR DESCRIPTION
## About The Pull Request
Replaces a `cut_overlays()` call with `cut_overlay(panel_type)` EDIT: moved the panel overlay to the `update_overlays` proc

## Why It's Good For The Game
Fixing bad code.

## Changelog

:cl:
fix: Fixed the emissive appearances (basically what you can see even in complete darkness) and possibly other overlays of vending machines being removed when the wire panel is opened/closed.
/:cl:
