### PR TITLE
Fixes string_list procs when used with filepaths.

### DIFF
--- a/code/__HELPERS/_string_lists.dm
+++ b/code/__HELPERS/_string_lists.dm
@@ -7,39 +7,39 @@ GLOBAL_LIST(string_cache)
 GLOBAL_VAR(string_filename_current_key)
 
 
-/proc/strings_replacement(filename, key)
-	filename = SANITIZE_FILENAME(filename)
-	load_strings_file(filename)
+/proc/strings_replacement(filepath, key)
+	filepath = sanitize_filepath(filepath)
+	load_strings_file(filepath)
 
-	if((filename in GLOB.string_cache) && (key in GLOB.string_cache[filename]))
-		var/response = pick(GLOB.string_cache[filename][key])
+	if((filepath in GLOB.string_cache) && (key in GLOB.string_cache[filepath]))
+		var/response = pick(GLOB.string_cache[filepath][key])
 		var/regex/r = regex("@pick\\((\\D+?)\\)", "g")
 		response = r.Replace(response, /proc/strings_subkey_lookup)
 		return response
 	else
-		CRASH("strings list not found: [STRING_DIRECTORY]/[filename], index=[key]")
+		CRASH("strings list not found: [STRING_DIRECTORY]/[filepath], index=[key]")
 
-/proc/strings(filename as text, key as text)
-	filename = SANITIZE_FILENAME(filename)
-	load_strings_file(filename)
-	if((filename in GLOB.string_cache) && (key in GLOB.string_cache[filename]))
-		return GLOB.string_cache[filename][key]
+/proc/strings(filepath as text, key as text)
+	filepath = sanitize_filepath(filepath)
+	load_strings_file(filepath)
+	if((filepath in GLOB.string_cache) && (key in GLOB.string_cache[filepath]))
+		return GLOB.string_cache[filepath][key]
 	else
-		CRASH("strings list not found: [STRING_DIRECTORY]/[filename], index=[key]")
+		CRASH("strings list not found: [STRING_DIRECTORY]/[filepath], index=[key]")
 
 /proc/strings_subkey_lookup(match, group1)
 	return pick_list(GLOB.string_filename_current_key, group1)
 
-/proc/load_strings_file(filename)
-	filename = SANITIZE_FILENAME(filename) // in case we're called directly
-	GLOB.string_filename_current_key = filename
-	if(filename in GLOB.string_cache)
+/proc/load_strings_file(filepath)
+	filepath = sanitize_filepath(filepath) // in case we're called directly
+	GLOB.string_filename_current_key = filepath
+	if(filepath in GLOB.string_cache)
 		return //no work to do
 
 	if(!GLOB.string_cache)
 		GLOB.string_cache = new
 
-	if(fexists("[STRING_DIRECTORY]/[filename]"))
-		GLOB.string_cache[filename] = json_load("[STRING_DIRECTORY]/[filename]")
+	if(fexists("[STRING_DIRECTORY]/[filepath]"))
+		GLOB.string_cache[filepath] = json_load("[STRING_DIRECTORY]/[filepath]")
 	else
-		CRASH("file not found: [STRING_DIRECTORY]/[filename]")
+		CRASH("file not found: [STRING_DIRECTORY]/[filepath]")

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -95,3 +95,12 @@ GLOBAL_VAR_INIT(fileaccess_timer, 0)
 	fcopy(file, filename)
 	. = md5filepath(filename)
 	fdel(filename)
+
+/// Sanitizes the name of each node in the path.
+/proc/sanitize_filepath(path)
+	. = ""
+	var/list/all_nodes = splittext(path, "/")
+	for(var/node in all_nodes)
+		if(.)
+			. += "/" // Add the delimiter before each successive node.
+		. += SANITIZE_FILENAME(node)

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -107,8 +107,9 @@ GLOBAL_VAR_INIT(fileaccess_timer, 0)
  *
  * If you use SANITIZE_FILENAME to sanitize a file path things will break.
  */
-/proc/sanitize_filepath(path, delimiter = "/")
+/proc/sanitize_filepath(path)
 	. = ""
+	var/delimiter = "/" //Very much intentionally hardcoded
 	var/list/all_nodes = splittext(path, delimiter)
 	for(var/node in all_nodes)
 		if(.)

--- a/code/__HELPERS/files.dm
+++ b/code/__HELPERS/files.dm
@@ -96,11 +96,21 @@ GLOBAL_VAR_INIT(fileaccess_timer, 0)
 	. = md5filepath(filename)
 	fdel(filename)
 
-/// Sanitizes the name of each node in the path.
-/proc/sanitize_filepath(path)
+/**
+ * Sanitizes the name of each node in the path.
+ *
+ * Im case you are wondering when to use this proc and when to use SANITIZE_FILENAME,
+ *
+ * You use SANITIZE_FILENAME to sanitize the name of a file [e.g. example.txt]
+ *
+ * You use sanitize_filepath sanitize the path of a file [e.g. root/node/example.txt]
+ *
+ * If you use SANITIZE_FILENAME to sanitize a file path things will break.
+ */
+/proc/sanitize_filepath(path, delimiter = "/")
 	. = ""
-	var/list/all_nodes = splittext(path, "/")
+	var/list/all_nodes = splittext(path, delimiter)
 	for(var/node in all_nodes)
 		if(.)
-			. += "/" // Add the delimiter before each successive node.
+			. += delimiter // Add the delimiter before each successive node.
 		. += SANITIZE_FILENAME(node)


### PR DESCRIPTION
## About The Pull Request
I have been trying to load Tram station to show Lemon the smoother tram for a few hours now only to find out someone broke things big time.
I'm adding a `sanitize_filepath` proc to fix the flunky.

EDIT for those ignorant about the issue: Someone has recently modified the procs in the string_list file so they'd sanitize filenames, as a security precaution. Unfortunately, it turns out these procs are also used with filepaths as argument, which use the `/` as a delimiter between nodes.
Because the `SANITIZE_FILENAME` macro also purges delimiters (it's supposed to be used on filenames, not paths), this meant file paths were not being loaded correctly. Basically, it has broken map rotation, tcg and wound strings. At least the server hasn't been updated yet.

## Why It's Good For The Game
I don't like runtimes and game-breaking issues. Please speedmerge (unless CI fails).

## Changelog
N/A, just give this a high/critical priority label for the good boy points.