### PR TITLE
Move refactor

### DIFF
--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -15,4 +15,5 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 /// Not very readable but it works
 #define DELAY_TO_GLIDE_SIZE(delay) (clamp(((32 / max((delay) / world.tick_lag, 1)) * GLOB.glide_size_multiplier), MIN_GLIDE_SIZE, MAX_GLIDE_SIZE))
 
-#define BUMP_MOVE_DEALT_WITH (1<<1)
+#define TURF_CAN_ENTER (1<<0)
+#define TURF_ENTER_ALREADY_MOVED (1<<1)

--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -14,3 +14,5 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 /// The whole result is then clamped to within the range above.
 /// Not very readable but it works
 #define DELAY_TO_GLIDE_SIZE(delay) (clamp(((32 / max((delay) / world.tick_lag, 1)) * GLOB.glide_size_multiplier), MIN_GLIDE_SIZE, MAX_GLIDE_SIZE))
+
+#define BUMP_MOVE_DEALT_WITH (1<<1)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -411,10 +411,6 @@
 				return
 	
 	else if(!loc.Exit(src, direction))
-		if(can_pass_diagonally)
-			loc = get_step(loc, can_pass_diagonally)
-			if(set_dir_on_move)
-				setDir(can_pass_diagonally)
 		return
 	
 	var/atom/oldloc

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -427,7 +427,7 @@
 		loc.Exited(src, can_pass_diagonally)
 		get_step(loc, can_pass_diagonally).Entered(src, loc, null)
 		Moved(loc, can_pass_diagonally)
-		if(set_dir_on_move)
+		if(set_dir_on_move) //We want to set the direction to be the one of the "second" diagonal move, aka not can_pass_diagonally
 			setDir(direction &~ can_pass_diagonally)
 	
 	else if(set_dir_on_move)
@@ -465,9 +465,9 @@
 		var/enter_return_value = newloc.Enter(src)
 		if(!(enter_return_value & TURF_CAN_ENTER) || (SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE))
 			if(can_pass_diagonally && !(enter_return_value & TURF_ENTER_ALREADY_MOVED))
-				loc = get_step(loc, can_pass_diagonally)
-				if(set_dir_on_move)
-					setDir(can_pass_diagonally)
+				loc = get_step(loc, can_pass_diagonally)//We failed to finish our diagonal move. We actually move the loc now to properly finish the first move
+				if(set_dir_on_move) 					//we didn't do it earlier because it allows to push/shuffle diagonally
+					setDir(can_pass_diagonally)			//We also set the dir correctly so it doesn't look weird
 			return
 	
 	oldloc = loc

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -385,7 +385,7 @@
 	if(!direction)
 		direction = get_dir(src, newloc)
 
-	var/can_pass_diagonally = FALSE
+	var/can_pass_diagonally = 0
 	if ((direction & (direction - 1))) //Check if the first part of the diagonal move is possible
 		if(direction & NORTH)
 			can_pass_diagonally = get_step(loc, NORTH)?.Enter(src) ? NORTH : 0

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -376,6 +376,29 @@
 	loc = new_loc
 	Moved(old_loc)
 
+#define BENCHMARK_LOOP while(world.timeofday < end_time)
+#define BENCHMARK_RESET iterations = 0; end_time = world.timeofday + duration
+#define BENCHMARK_MESSAGE(message) message_admins("[message] got [iterations] iterations in 1 seconds!"); BENCHMARK_RESET
+
+/atom/movable/proc/benchmark()
+	var/iterations = 0
+	var/duration = 1 SECONDS
+	var/end_time = world.timeofday + duration
+
+	BENCHMARK_LOOP
+		Move(get_step(src, NORTH), NORTH)
+		Move(get_step(src, SOUTH), SOUTH)
+		iterations++
+
+	BENCHMARK_MESSAGE("cardinal move")
+
+	BENCHMARK_LOOP
+		Move(get_step(src, NORTHEAST), NORTHEAST)
+		Move(get_step(src, SOUTHWEST), SOUTHWEST)
+		iterations++
+
+	BENCHMARK_MESSAGE("diag move")
+
 #define SET_CARDINAL_DIR(set_dir_on_move, direction, can_pass_diagonally)\
 if(set_dir_on_move){setDir(direction &~ can_pass_diagonally)}
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -373,29 +373,6 @@
 	loc = new_loc
 	Moved(old_loc)
 
-#define BENCHMARK_LOOP while(world.timeofday < end_time)
-#define BENCHMARK_RESET iterations = 0; end_time = world.timeofday + duration
-#define BENCHMARK_MESSAGE(message) message_admins("[message] got [iterations] iterations in 30 seconds!"); BENCHMARK_RESET
-
-/atom/movable/proc/benchmark()
-	var/iterations = 0
-	var/duration = 30 SECONDS
-	var/end_time = world.timeofday + duration
-
-	BENCHMARK_LOOP
-		Move(get_step(src, NORTH), NORTH)
-		Move(get_step(src, SOUTH), SOUTH)
-		iterations++
-
-	BENCHMARK_MESSAGE("cardinal move")
-
-	BENCHMARK_LOOP
-		Move(get_step(src, NORTHEAST), NORTHEAST)
-		Move(get_step(src, SOUTHWEST), SOUTHWEST)
-		iterations++
-
-	BENCHMARK_MESSAGE("diag move")
-
 /atom/movable/Move(atom/newloc, direction, glide_size_override)
 	var/atom/movable/pullee = pulling
 	if(!moving_from_pull)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -480,7 +480,7 @@
 
 	last_move = direction
 
-	if(LAZYLEN(buckled_mobs) && !handle_buckled_mob_movement(loc, direction)) //movement failed due to buckled mob(s)
+	if(has_buckled_mobs() && !handle_buckled_mob_movement(loc, direction)) //movement failed due to buckled mob(s)
 		return FALSE
 	return TRUE
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -394,17 +394,18 @@ if(set_dir_on_move){setDir(direction &~ can_pass_diagonally)}
 		moving_diagonally = TRUE
 		if(set_dir_on_move)
 			setDir(direction) //We first set the direction to prevent going through dir sensible object
-		if(direction & NORTH)
-			can_pass_diagonally = get_step(loc, NORTH)?.Enter(src) ? NORTH : NONE
-		if(!can_pass_diagonally && (direction & EAST))
-			can_pass_diagonally = get_step(loc, EAST)?.Enter(src) ? EAST : NONE
-		if(!can_pass_diagonally && (direction & WEST))
-			can_pass_diagonally = get_step(loc, WEST)?.Enter(src) ? WEST : NONE
-		if(!can_pass_diagonally && (direction & SOUTH))
-			can_pass_diagonally = get_step(loc, SOUTH)?.Enter(src) ? SOUTH : NONE
-		moving_diagonally = FALSE
-		if(!can_pass_diagonally)
+		if((direction & NORTH) && get_step(loc, NORTH)?.Enter(src))
+			can_pass_diagonally = NORTH
+		else if((direction & EAST) && get_step(loc, EAST)?.Enter(src))
+			can_pass_diagonally =  EAST
+		else if((direction & WEST) && get_step(loc, WEST)?.Enter(src))
+			can_pass_diagonally = WEST
+		else if((direction & SOUTH) && get_step(loc, SOUTH)?.Enter(src))
+			can_pass_diagonally = SOUTH
+		else
+			moving_diagonally = FALSE
 			return
+		moving_diagonally = FALSE
 
 	var/is_multi_tile_object = bound_width > 32 || bound_height > 32
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -454,10 +454,7 @@ if(set_dir_on_move){setDir(direction &~ can_pass_diagonally)}
 				)
 		) // If this is a multi-tile object then we need to predict the new locs and check if they allow our entrance.
 		for(var/atom/entering_loc as anything in new_locs)
-			if(!entering_loc.Enter(src))
-				SET_CARDINAL_DIR(set_dir_on_move, direction, can_pass_diagonally)
-				return
-			if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, entering_loc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
+			if(!entering_loc.Enter(src) || SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, entering_loc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
 				SET_CARDINAL_DIR(set_dir_on_move, direction, can_pass_diagonally)
 				return
 	else
@@ -481,7 +478,7 @@ if(set_dir_on_move){setDir(direction &~ can_pass_diagonally)}
 	else // Else there's just one loc to be exited.
 		oldloc.Exited(src, direction)
 
-	if(!loc || (loc == oldloc && oldloc != newloc))
+	if(!loc || loc == oldloc)
 		last_move = 0
 		return
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -417,13 +417,14 @@ if(set_dir_on_move){setDir(direction &~ can_pass_diagonally)}
 		moving_diagonally = TRUE
 		if(set_dir_on_move)
 			setDir(direction) //We first set the direction to prevent going through dir sensible object
-		if((direction & NORTH) && get_step(loc, NORTH)?.Enter(src))
+		if((direction & NORTH) && get_step(loc, NORTH)?.Enter(src) && get_step(loc, NORTH).Exit(src, direction & ~NORTH))
 			can_pass_diagonally = NORTH
-		else if((direction & EAST) && get_step(loc, EAST)?.Enter(src))
+		else if((direction & EAST) && get_step(loc, EAST)?.Enter(src) && get_step(loc, EAST).Exit(src, direction & ~EAST))
 			can_pass_diagonally =  EAST
-		else if((direction & WEST) && get_step(loc, WEST)?.Enter(src))
+		else if((direction & WEST) && get_step(loc, WEST)?.Enter(src) && get_step(loc, WEST).Exit(src, direction & ~WEST))
 			can_pass_diagonally = WEST
-		else if((direction & SOUTH) && get_step(loc, SOUTH)?.Enter(src))
+		else if((direction & SOUTH) && get_step(loc, SOUTH)?.Enter(src) && get_step(loc, SOUTH).Exit(src, direction & ~SOUTH))
+			can_pass_diagonally = SOUTH
 			can_pass_diagonally = SOUTH
 		else
 			moving_diagonally = FALSE
@@ -459,8 +460,8 @@ if(set_dir_on_move){setDir(direction &~ can_pass_diagonally)}
 				return
 	else
 		var/enter_return_value = newloc.Enter(src)
-		if((enter_return_value != TRUE) || (SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE))
-			if(can_pass_diagonally && !(enter_return_value & BUMP_MOVE_DEALT_WITH))
+		if(!(enter_return_value & TURF_CAN_ENTER) || (SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE))
+			if(can_pass_diagonally && !(enter_return_value & TURF_ENTER_ALREADY_MOVED))
 				Move(get_step(loc, can_pass_diagonally), can_pass_diagonally)
 				return
 			SET_CARDINAL_DIR(set_dir_on_move, direction, can_pass_diagonally)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -34,7 +34,6 @@
 	var/pass_flags = NONE
 	/// If false makes [CanPass][/atom/proc/CanPass] call [CanPassThrough][/atom/movable/proc/CanPassThrough] on this type instead of using default behaviour
 	var/generic_canpass = TRUE
-	var/moving_diagonally = 0 //0: not doing a diagonal move. 1 and 2: doing the first/second step of the diagonal move
 	var/atom/movable/moving_from_pull //attempt to resume grab after moving instead of before.
 	var/list/client_mobs_in_contents // This contains all the client mobs within this container
 	var/datum/forced_movement/force_moving = null //handled soley by forced_movement.dm
@@ -352,7 +351,7 @@
 		if(pulling.anchored || pulling.move_resist > move_force)
 			stop_pulling()
 			return
-	if(pulledby && moving_diagonally != FIRST_DIAG_STEP && get_dist(src, pulledby) > 1) //separated from our puller and not in the middle of a diagonal move.
+	if(pulledby && get_dist(src, pulledby) > 1) //separated from our puller and not in the middle of a diagonal move.
 		pulledby.stop_pulling()
 
 
@@ -386,7 +385,7 @@
 		direction = get_dir(src, newloc)
 
 	var/can_pass_diagonally = 0
-	if ((direction & (direction - 1))) //Check if the first part of the diagonal move is possible
+	if (direction & (direction - 1)) //Check if the first part of the diagonal move is possible
 		if(direction & NORTH)
 			can_pass_diagonally = get_step(loc, NORTH)?.Enter(src) ? NORTH : 0
 		if(!can_pass_diagonally && (direction & EAST))
@@ -658,8 +657,6 @@
 		var/area/old_area = get_area(oldloc)
 		var/area/destarea = get_area(destination)
 		var/movement_dir = get_dir(src, destination)
-
-		moving_diagonally = 0
 
 		loc = destination
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -384,16 +384,16 @@
 	if(!direction)
 		direction = get_dir(src, newloc)
 
-	var/can_pass_diagonally = 0
+	var/can_pass_diagonally = NONE
 	if (direction & (direction - 1)) //Check if the first part of the diagonal move is possible
 		if(direction & NORTH)
-			can_pass_diagonally = get_step(loc, NORTH)?.Enter(src) ? NORTH : 0
+			can_pass_diagonally = get_step(loc, NORTH)?.Enter(src) ? NORTH : NONE
 		if(!can_pass_diagonally && (direction & EAST))
-			can_pass_diagonally = get_step(loc, EAST)?.Enter(src) ? EAST : 0
+			can_pass_diagonally = get_step(loc, EAST)?.Enter(src) ? EAST : NONE
 		if(!can_pass_diagonally && (direction & WEST))
-			can_pass_diagonally = get_step(loc, WEST)?.Enter(src) ? WEST : 0
+			can_pass_diagonally = get_step(loc, WEST)?.Enter(src) ? WEST : NONE
 		if(!can_pass_diagonally && (direction & SOUTH))
-			can_pass_diagonally = get_step(loc, SOUTH)?.Enter(src) ? SOUTH : 0
+			can_pass_diagonally = get_step(loc, SOUTH)?.Enter(src) ? SOUTH : NONE
 		if(!can_pass_diagonally)
 			return
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -474,7 +474,7 @@
 			//puller and pullee more than one tile away or in diagonal position and whatever the pullee is pulling isn't already moving from a pull as it'll most likely result in an infinite loop a la ouroborus.
 			if(!pulling.pulling?.moving_from_pull && (get_dist(src, pulling) > 1 || (pull_dir - 1) & pull_dir))
 				pulling.moving_from_pull = src
-				pulling.Move(oldloc, get_dir(pulling, oldloc)) //the pullee tries to reach our previous position
+				pulling.Move(oldloc, get_dir(pulling, oldloc), glide_size) //the pullee tries to reach our previous position
 				pulling.moving_from_pull = null
 			check_pulling()
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -386,6 +386,8 @@
 
 	var/can_pass_diagonally = NONE
 	if (direction & (direction - 1)) //Check if the first part of the diagonal move is possible
+		if(set_dir_on_move)
+			setDir(direction) //We first set the direction to prevent going through dir sensible object
 		if(direction & NORTH)
 			can_pass_diagonally = get_step(loc, NORTH)?.Enter(src) ? NORTH : NONE
 		if(!can_pass_diagonally && (direction & EAST))
@@ -398,7 +400,7 @@
 			return
 
 	if(set_dir_on_move)
-		setDir(direction &~ can_pass_diagonally)
+		setDir(direction &~ can_pass_diagonally) //We don't want to have a diagonal direction, so we take the direction of our last hypothetical cardinal move
 
 	var/is_multi_tile_object = bound_width > 32 || bound_height > 32
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -377,7 +377,6 @@
 
 /atom/movable/Move(atom/newloc, direction, glide_size_override)
 	var/atom/movable/pullee = pulling
-	var/turf/old_turf = loc
 	if(!moving_from_pull)
 		check_pulling()
 	if(!loc || !newloc || loc == newloc)
@@ -475,7 +474,7 @@
 			//puller and pullee more than one tile away or in diagonal position and whatever the pullee is pulling isn't already moving from a pull as it'll most likely result in an infinite loop a la ouroborus.
 			if(!pulling.pulling?.moving_from_pull && (get_dist(src, pulling) > 1 || (pull_dir - 1) & pull_dir))
 				pulling.moving_from_pull = src
-				pulling.Move(old_turf, get_dir(pulling, old_turf)) //the pullee tries to reach our previous position
+				pulling.Move(oldloc, get_dir(pulling, oldloc)) //the pullee tries to reach our previous position
 				pulling.moving_from_pull = null
 			check_pulling()
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -426,7 +426,7 @@
 		for(var/atom/entering_loc as anything in new_locs)
 			if(!entering_loc.Enter(src))
 				return
-			if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, entering_loc))
+			if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, entering_loc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
 				return
 	else if(!newloc.Enter(src) || (SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE))
 		if(can_pass_diagonally) //We cannot get to our final destination, but we can move a little
@@ -472,8 +472,8 @@
 			stop_pulling()
 		else
 			var/pull_dir = get_dir(src, pulling)
-			//puller and pullee more than one tile away or in diagonal position
-			if(get_dist(src, pulling) > 1 || (moving_diagonally != SECOND_DIAG_STEP && ((pull_dir - 1) & pull_dir)))
+			//puller and pullee more than one tile away or in diagonal position and whatever the pullee is pulling isn't already moving from a pull as it'll most likely result in an infinite loop a la ouroborus.
+			if(!pulling.pulling?.moving_from_pull && (get_dist(src, pulling) > 1 || (pull_dir - 1) & pull_dir))
 				pulling.moving_from_pull = src
 				pulling.Move(old_turf, get_dir(pulling, old_turf)) //the pullee tries to reach our previous position
 				pulling.moving_from_pull = null

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -428,10 +428,12 @@
 				return
 			if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, entering_loc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
 				return
-	else if(!newloc.Enter(src) || (SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE))
-		if(can_pass_diagonally) //We cannot get to our final destination, but we can move a little
+	else
+		var/enter_return_value = newloc.Enter(src)
+		if(!enter_return_value || (SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE))
+			return
+		else if((enter_return_value & BUMP_MOVE_DEALT_WITH) && can_pass_diagonally) //We cannot get to our final destination, but we can move a little
 			Move(get_step(loc, can_pass_diagonally), can_pass_diagonally)
-		return
 
 	var/atom/oldloc = loc
 	move_stacks++

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -398,7 +398,7 @@
 			return
 
 	if(set_dir_on_move)
-		setDir(direction)
+		setDir(direction &~ can_pass_diagonally)
 
 	var/is_multi_tile_object = bound_width > 32 || bound_height > 32
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -438,11 +438,12 @@ if(set_dir_on_move){setDir(direction &~ can_pass_diagonally)}
 				return
 	else
 		var/enter_return_value = newloc.Enter(src)
-		if(!enter_return_value || (SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE))
+		if((enter_return_value != TRUE) || (SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE))
+			if(can_pass_diagonally && !(enter_return_value & BUMP_MOVE_DEALT_WITH))
+				Move(get_step(loc, can_pass_diagonally), can_pass_diagonally)
+				return
 			SET_CARDINAL_DIR(set_dir_on_move, direction, can_pass_diagonally)
 			return
-		else if((enter_return_value & BUMP_MOVE_DEALT_WITH) && can_pass_diagonally) //We cannot get to our final destination, but we can move a little
-			Move(get_step(loc, can_pass_diagonally), can_pass_diagonally)
 
 	SET_CARDINAL_DIR(set_dir_on_move, direction, can_pass_diagonally)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -425,7 +425,6 @@ if(set_dir_on_move){setDir(direction &~ can_pass_diagonally)}
 			can_pass_diagonally = WEST
 		else if((direction & SOUTH) && get_step(loc, SOUTH)?.Enter(src) && get_step(loc, SOUTH).Exit(src, direction & ~SOUTH))
 			can_pass_diagonally = SOUTH
-			can_pass_diagonally = SOUTH
 		else
 			moving_diagonally = FALSE
 			return

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -272,7 +272,7 @@
 
 /obj/machinery/door/firedoor/border_only/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	if(!(border_dir == dir)) //Make sure looking at appropriate border
+	if(!(border_dir & dir)) //Make sure looking at appropriate border
 		return TRUE
 
 /obj/machinery/door/firedoor/border_only/proc/on_exit(datum/source, atom/movable/leaving, direction)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -282,7 +282,7 @@
 	if(leaving == src)
 		return // Let's not block ourselves.
 
-	if(direction == dir && density)
+	if((direction & dir) && density)
 		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -149,7 +149,7 @@
 	if((pass_flags_self & leaving.pass_flags) || ((pass_flags_self & LETPASSTHROW) && leaving.throwing))
 		return
 
-	if(direction == dir && density)
+	if((direction & dir) && density)
 		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -116,7 +116,7 @@
 	if(.)
 		return
 
-	if(border_dir == dir)
+	if(border_dir & dir)
 		return FALSE
 
 	if(istype(mover, /obj/structure/window))

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -18,6 +18,7 @@ Buildable meters
 	icon_state = "simple"
 	inhand_icon_state = "buildpipe"
 	w_class = WEIGHT_CLASS_NORMAL
+	set_dir_on_move = FALSE
 	///Piping layer that we are going to be on
 	var/piping_layer = PIPING_LAYER_DEFAULT
 	///Type of pipe-object made, selected from the RPD
@@ -113,11 +114,6 @@ Buildable meters
 /obj/item/pipe/trinary/flippable/do_a_flip()
 	setDir(turn(dir, flipped ? 45 : -45))
 	flipped = !flipped
-
-/obj/item/pipe/Move()
-	var/old_dir = dir
-	..()
-	setDir(old_dir) //pipes changing direction when moved is just annoying and buggy
 
 // Convert dir of fitting into dir of built component
 /obj/item/pipe/proc/fixed_dir()

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -84,11 +84,11 @@
 /obj/structure/lattice/catwalk/deconstruction_hints(mob/user)
 	return span_notice("The supporting rods look like they could be <b>cut</b>.")
 
-/obj/structure/lattice/catwalk/Move()
+/obj/structure/lattice/catwalk/Moved(atom/OldLoc, Dir)
+	. = ..()
 	var/turf/T = loc
 	for(var/obj/structure/cable/C in T)
 		C.deconstruct()
-	..()
 
 /obj/structure/lattice/catwalk/deconstruct()
 	var/turf/T = loc

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -86,7 +86,7 @@
 	if (leaving.pass_flags & pass_flags_self)
 		return
 
-	if (direction == dir && density)
+	if ((direction & dir) && density)
 		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -58,7 +58,7 @@
 /obj/structure/windoor_assembly/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
 
-	if(border_dir == dir)
+	if(border_dir & dir)
 		return
 
 	if(istype(mover, /obj/structure/window))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -112,7 +112,7 @@
 	if(fulltile)
 		return FALSE
 
-	if(border_dir == dir)
+	if(border_dir & dir)
 		return FALSE
 
 	if(istype(mover, /obj/structure/window))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -139,7 +139,7 @@
 	if (fulltile)
 		return
 
-	if(direction == dir && density)
+	if((direction & dir) && density)
 		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -228,7 +228,6 @@
 				C.accident(I)
 
 		var/olddir = C.dir
-		C.moving_diagonally = 0 //If this was part of diagonal move slipping will stop it.
 		if(!(lube & SLIDE_ICE))
 			C.Knockdown(knockdown_amount)
 			C.Paralyze(paralyze_amount)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -350,8 +350,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	if(!canPassSelf) //Even if mover is unstoppable they need to bump us.
 		firstbump = src
 	if(firstbump)
-		mover.Bump(firstbump)
-		return (mover.movement_type & PHASING)
+		return (mover.Bump(firstbump)) | (mover.movement_type & PHASING)
 	return TRUE
 
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -350,7 +350,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	if(!canPassSelf) //Even if mover is unstoppable they need to bump us.
 		firstbump = src
 	if(firstbump)
-		return (mover.Bump(firstbump) & BUMP_MOVE_DEALT_WITH) | (mover.movement_type & PHASING)
+		return (mover.Bump(firstbump) & TURF_ENTER_ALREADY_MOVED) | (mover.movement_type & PHASING)
 	return TRUE
 
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -350,7 +350,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	if(!canPassSelf) //Even if mover is unstoppable they need to bump us.
 		firstbump = src
 	if(firstbump)
-		return (mover.Bump(firstbump)) | (mover.movement_type & PHASING)
+		return (mover.Bump(firstbump) & BUMP_MOVE_DEALT_WITH) | (mover.movement_type & PHASING)
 	return TRUE
 
 

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -84,10 +84,9 @@
 	update_appearance()
 	return TRUE
 
-/obj/machinery/portable_atmospherics/Move()
+/obj/machinery/portable_atmospherics/Moved(atom/OldLoc, Dir)
 	. = ..()
-	if(.)
-		disconnect()
+	disconnect()
 
 /**
  * Allow the portable machine to be disconnected from the connector

--- a/code/modules/awaymissions/away_props.dm
+++ b/code/modules/awaymissions/away_props.dm
@@ -8,7 +8,7 @@
 
 /obj/effect/oneway/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	return . && (REVERSE_DIR(border_dir) == dir || get_turf(mover) == get_turf(src))
+	return . && (REVERSE_DIR(border_dir) & dir || get_turf(mover) == get_turf(src))
 
 
 /obj/effect/wind

--- a/code/modules/meteors/meteors.dm
+++ b/code/modules/meteors/meteors.dm
@@ -108,14 +108,15 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 		qdel(src)
 		return FALSE
 
-	. = ..() //process movement...
+	return ..()
 
-	if(.)//.. if did move, ram the turf we get in
-		var/turf/T = get_turf(loc)
-		ram_turf(T)
+/obj/effect/meteor/Moved()
+	. = ..()
+	var/turf/T = get_turf(loc)
+	ram_turf(T)
 
-		if(prob(10) && !isspaceturf(T))//randomly takes a 'hit' from ramming
-			get_hit()
+	if(prob(10) && !isspaceturf(T))//randomly takes a 'hit' from ramming
+		get_hit()
 
 /obj/effect/meteor/Destroy()
 	if (timerid)
@@ -343,10 +344,9 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	meteordrop = list(/obj/item/stack/ore/plasma)
 	threat = 50
 
-/obj/effect/meteor/tunguska/Move()
+/obj/effect/meteor/tunguska/Moved(atom/OldLoc, Dir)
 	. = ..()
-	if(.)
-		new /obj/effect/temp_visual/revenant(get_turf(src))
+	new /obj/effect/temp_visual/revenant(get_turf(src))
 
 /obj/effect/meteor/tunguska/meteor_effect()
 	..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -61,7 +61,7 @@
 	if(ismob(A))
 		var/mob/M = A
 		if(MobBump(M))
-			return
+			return BUMP_MOVE_DEALT_WITH
 	if(isobj(A))
 		var/obj/O = A
 		if(ObjBump(O))
@@ -69,7 +69,7 @@
 	if(ismovable(A))
 		var/atom/movable/AM = A
 		if(PushAM(AM, move_force))
-			return
+			return BUMP_MOVE_DEALT_WITH
 
 /mob/living/Bumped(atom/movable/AM)
 	..()
@@ -114,6 +114,9 @@
 					if(!(world.time % 5))
 						to_chat(src, span_warning("[L] is restraining [P], you cannot push past."))
 					return TRUE
+
+	if(dir & (dir - 1)) //no mob swap during diagonal moves.
+		return
 
 	if(!M.buckled && !M.has_buckled_mobs())
 		var/mob_swap = FALSE
@@ -207,6 +210,8 @@
 //Called when we want to push an atom/movable
 /mob/living/proc/PushAM(atom/movable/AM, force = move_force)
 	if(now_pushing)
+		return TRUE
+	if(dir & (dir - 1)) // No pushing in diagonal move
 		return TRUE
 	if(!client && (mob_size < MOB_SIZE_SMALL))
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -115,7 +115,7 @@
 						to_chat(src, span_warning("[L] is restraining [P], you cannot push past."))
 					return TRUE
 
-	if(dir & (dir - 1)) //no mob swap during diagonal moves.
+	if(moving_diagonally) //no mob swap during diagonal moves.
 		return
 
 	if(!M.buckled && !M.has_buckled_mobs())
@@ -211,8 +211,8 @@
 /mob/living/proc/PushAM(atom/movable/AM, force = move_force)
 	if(now_pushing)
 		return TRUE
-	if(dir & (dir - 1)) // No pushing in diagonal move
-		return TRUE
+	if(moving_diagonally) // No pushing in diagonal move
+		return
 	if(!client && (mob_size < MOB_SIZE_SMALL))
 		return
 	now_pushing = TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -210,7 +210,7 @@
 //Called when we want to push an atom/movable
 /mob/living/proc/PushAM(atom/movable/AM, force = move_force)
 	if(now_pushing)
-		return TRUE
+		return
 	if(moving_diagonally) // No pushing in diagonal move
 		return
 	if(!client && (mob_size < MOB_SIZE_SMALL))
@@ -263,6 +263,7 @@
 	if(current_dir)
 		AM.setDir(current_dir)
 	now_pushing = FALSE
+	return TRUE
 
 /mob/living/start_pulling(atom/movable/AM, state, force = pull_force, supress_message = FALSE)
 	if(!AM || !src)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -61,7 +61,7 @@
 	if(ismob(A))
 		var/mob/M = A
 		if(MobBump(M))
-			return BUMP_MOVE_DEALT_WITH
+			return TURF_ENTER_ALREADY_MOVED
 	if(isobj(A))
 		var/obj/O = A
 		if(ObjBump(O))
@@ -69,7 +69,7 @@
 	if(ismovable(A))
 		var/atom/movable/AM = A
 		if(PushAM(AM, move_force))
-			return BUMP_MOVE_DEALT_WITH
+			return TURF_ENTER_ALREADY_MOVED
 
 /mob/living/Bumped(atom/movable/AM)
 	..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -115,9 +115,6 @@
 						to_chat(src, span_warning("[L] is restraining [P], you cannot push past."))
 					return TRUE
 
-	if(moving_diagonally)//no mob swap during diagonal moves.
-		return TRUE
-
 	if(!M.buckled && !M.has_buckled_mobs())
 		var/mob_swap = FALSE
 		var/too_strong = (M.move_resist > move_force) //can't swap with immovable objects unless they help us
@@ -210,8 +207,6 @@
 //Called when we want to push an atom/movable
 /mob/living/proc/PushAM(atom/movable/AM, force = move_force)
 	if(now_pushing)
-		return TRUE
-	if(moving_diagonally)// no pushing during diagonal moves.
 		return TRUE
 	if(!client && (mob_size < MOB_SIZE_SMALL))
 		return
@@ -800,7 +795,7 @@
 
 	. = ..()
 
-	if(pulledby && moving_diagonally != FIRST_DIAG_STEP && get_dist(src, pulledby) > 1 && (pulledby != moving_from_pull))//separated from our puller and not in the middle of a diagonal move.
+	if(pulledby && get_dist(src, pulledby) > 1 && (pulledby != moving_from_pull))//separated from our puller and not in the middle of a diagonal move.
 		pulledby.stop_pulling()
 	else
 		if(isliving(pulledby))

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -1,4 +1,4 @@
-/mob/living/Moved()
+/mob/living/Moved(atom/OldLoc, Dir)
 	. = ..()
 	update_turf_movespeed(loc)
 

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -530,10 +530,10 @@
 
 /mob/living/simple_animal/bot/mulebot/Moved(atom/OldLoc, Dir)
 	. = ..()
-	if(bloodiness) //Bloodiness is added on run_voer
-		var/obj/effect/decal/cleanable/blood/tracks/B = new(oldLoc)
+	if(bloodiness) //Bloodiness is added on run_over
+		var/obj/effect/decal/cleanable/blood/tracks/B = new(OldLoc)
 		B.add_blood_DNA(return_blood_DNA())
-		B.setDir(direct)
+		B.setDir(Dir)
 		bloodiness--
 
 	for(var/mob/living/carbon/human/future_pancake in loc)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -528,20 +528,13 @@
 		pathset = 1 //Indicates the AI's custom path is initialized.
 		start()
 
-/mob/living/simple_animal/bot/mulebot/Move(atom/newloc, direct) //handle leaving bloody tracks. can't be done via Moved() since that can end up putting the tracks somewhere BEFORE we get bloody.
-	if(!bloodiness) //important to check this first since Bump() is called in the Move() -> Entered() chain
-		return ..()
-	var/atom/oldLoc = loc
+/mob/living/simple_animal/bot/mulebot/Moved(atom/OldLoc, Dir)
 	. = ..()
-	if(!last_move || isspaceturf(oldLoc)) //if we didn't sucessfully move, or if our old location was a spaceturf.
-		return
-	var/obj/effect/decal/cleanable/blood/tracks/B = new(oldLoc)
-	B.add_blood_DNA(return_blood_DNA())
-	B.setDir(direct)
-	bloodiness--
-
-/mob/living/simple_animal/bot/mulebot/Moved()
-	. = ..()
+	if(bloodiness) //Bloodiness is added on run_voer
+		var/obj/effect/decal/cleanable/blood/tracks/B = new(oldLoc)
+		B.add_blood_DNA(return_blood_DNA())
+		B.setDir(direct)
+		bloodiness--
 
 	for(var/mob/living/carbon/human/future_pancake in loc)
 		run_over(future_pancake)

--- a/code/modules/mob/living/simple_animal/guardian/types/charger.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/charger.dm
@@ -39,10 +39,10 @@
 /mob/living/simple_animal/hostile/guardian/charger/proc/charging_end()
 	charging = 0
 
-/mob/living/simple_animal/hostile/guardian/charger/Move()
-	if(charging)
-		new /obj/effect/temp_visual/decoy/fading(loc,src)
+/mob/living/simple_animal/hostile/guardian/charger/Moved(atom/OldLoc, Dir)
 	. = ..()
+	if(charging)
+		new /obj/effect/temp_visual/decoy/fading(OldLoc ,src)
 
 /mob/living/simple_animal/hostile/guardian/charger/snapback()
 	if(!charging)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -451,7 +451,7 @@
 
 
 /mob/living/simple_animal/hostile/Move(atom/newloc, dir , step_x , step_y)
-	if(dodging && approaching_target && prob(dodge_prob) && moving_diagonally == 0 && isturf(loc) && isturf(newloc))
+	if(dodging && approaching_target && prob(dodge_prob) && isturf(loc) && isturf(newloc))
 		return dodge(newloc,dir)
 	else
 		return ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -475,7 +475,7 @@ Difficulty: Hard
 	if(charging)
 		new /obj/effect/temp_visual/decoy/fading(loc,src)
 		DestroySurroundings()
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Moved(atom/OldLoc, Dir, Forced = FALSE)
 	if(Dir)

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -9,7 +9,7 @@
 		M.adjust_fire_stacks(fire_stacks)
 		M.IgniteMob()
 
-/obj/projectile/bullet/incendiary/Move()
+/obj/projectile/bullet/incendiary/Moved(atom/OldLoc, Dir)
 	. = ..()
 	var/turf/location = get_turf(src)
 	if(location)

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -10,6 +10,7 @@
 	density = FALSE
 	pressure_resistance = 5*ONE_ATMOSPHERE
 	max_integrity = 200
+	set_dir_on_move = FALSE
 	var/obj/pipe_type = /obj/structure/disposalpipe/segment
 	var/pipename
 
@@ -40,11 +41,6 @@
 	update_appearance()
 
 	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
-
-/obj/structure/disposalconstruct/Move()
-	var/old_dir = dir
-	..()
-	setDir(old_dir) //pipes changing direction when moved is just annoying and buggy
 
 /obj/structure/disposalconstruct/update_icon_state()
 	if(ispath(pipe_type, /obj/machinery/disposal/bin))

--- a/code/modules/ruins/lavalandruin_code/puzzle.dm
+++ b/code/modules/ruins/lavalandruin_code/puzzle.dm
@@ -206,8 +206,8 @@
 	var/icon/puzzle_icon
 
 /obj/structure/puzzle_element/Move(nloc, dir)
-	if(!isturf(nloc) || moving_diagonally || get_dist(get_step(src,dir),get_turf(source)) > 1)
-		return 0
+	if(!isturf(nloc) || dir & (dir - 1) || get_dist(get_step(src, dir),get_turf(source)) > 1)
+		return FALSE
 	else
 		return ..()
 

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -76,7 +76,7 @@
 	if(leaving == src)
 		return // Let's not block ourselves.
 
-	if (direction == dir && density)
+	if ((direction & dir) && density)
 		leaving.Bump(src)
 		return COMPONENT_ATOM_BLOCK_EXIT
 

--- a/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/ruins/objects_and_mobs/necropolis_gate.dm
@@ -64,7 +64,7 @@
 
 /obj/structure/necropolis_gate/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	if(border_dir != dir)
+	if(!(border_dir & dir))
 		return TRUE
 
 /obj/structure/necropolis_gate/proc/on_exit(datum/source, atom/movable/leaving, direction)

--- a/code/modules/swarmers/swarmer.dm
+++ b/code/modules/swarmers/swarmer.dm
@@ -85,8 +85,7 @@
 	. = ..()
 	if(!LAZYLEN(dronelist))
 		return
-	for(var/d in dronelist)
-		var/mob/living/simple_animal/hostile/drone = d
+	for(var/mob/living/simple_animal/hostile/drone as anything in dronelist)
 		if(!drone.target && !HAS_TRAIT(drone, TRAIT_IMMOBILIZED) && isturf(drone.loc))
 			step_to(drone, src)
 

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -147,8 +147,7 @@
 			remove_controller_actions_by_flag(controller, i)
 	return TRUE
 
-/obj/vehicle/Move(newloc, dir)
+/obj/vehicle/Moved(atom/OldLoc, Dir)
 	. = ..()
-	if(trailer && .)
-		var/dir_to_move = get_dir(trailer.loc, newloc)
-		step(trailer, dir_to_move)
+	if(trailer)
+		trailer.Move(Oldloc, Dir)

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -150,4 +150,4 @@
 /obj/vehicle/Moved(atom/OldLoc, Dir)
 	. = ..()
 	if(trailer)
-		trailer.Move(Oldloc, Dir)
+		trailer.Move(OldLoc, Dir)

--- a/code/modules/vehicles/mecha/working/working.dm
+++ b/code/modules/vehicles/mecha/working/working.dm
@@ -8,10 +8,9 @@
 	QDEL_NULL(box)
 	return ..()
 
-/obj/vehicle/sealed/mecha/working/Move()
+/obj/vehicle/sealed/mecha/working/Moved(atom/OldLoc, Dir)
 	. = ..()
-	if(.)
-		collect_ore()
+	collect_ore()
 
 /**
  * Handles collecting ore.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Make move an inline proc, no longer 5 proc call for a single diagonal movement.

Tested so far:
 - You cannot phase between two walls while moving diagonally
 - You cannot phase between two mobs if you weren't able to bump/shuffle either
 - You cannot phase throught baricades or windows (true this time)
 - Pulling seems to have normal behaviour
 - Push seems to have normal behaviour (you can now push diagonally as a bonus)
 - Shuffling seems to have normal behaviour (You can now shuffle diagonally as a bonus)
 - Slipping seems to work normally
 - Projectiles works normally
 - Space walking seems to be normal
 - Throwing works normally

Benchmark (the time is a lie, it's for 30 seconds)

Old code 
![image](https://user-images.githubusercontent.com/25491240/142231399-8d59e13d-359f-4496-b897-e75fd0ad6ea7.png)

New code: 
![image](https://user-images.githubusercontent.com/25491240/142231440-47adf710-458f-4267-8962-2a97ac8d1f26.png)

So according to this benchmark (conditions are roughly similar, called this at the same moment on the same map at the same place on a carbon human, for 30 secs), this is a 14% perf increase for cardinal moves and a 23% for diagonal move

Here's the benchmark code used :
![image](https://user-images.githubusercontent.com/25491240/140577065-60bd5b7c-5d1b-4e2d-b1cd-dc6a196348f7.png)

Probably a change of behaviour in how the after image for bubble gum works. (Only once per diag move rahter than twice)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Probably better perf, as we are proc calling less. I'll get profile data from tgmc if this passes review process.

Also cool diag move : 

https://user-images.githubusercontent.com/25491240/141023940-615bfc62-2072-453c-bccc-b9811182c060.mp4

Move() is the most expensive non yielding code on tg and tgmc, even the slightest perf increase can help.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Probably better performance with the Move() proc. 14% perf increase for cardinal moves and 23% for diagonal move
qol: You can shuffle/push diagonally
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
