### PR TITLE
Makes the "Ian's Adventure" station trait more interesting by making the dog deadchat controllable plus extra lives.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -267,6 +267,9 @@
 ///from base of [/datum/controller/subsystem/materials/proc/InitializeMaterial]: (/datum/material)
 #define COMSIG_MATERIALS_INIT_MAT "SSmaterials_init_mat"
 
+///from base of [/datum/component/multiple_lives/proc/respawn]: (mob/respawned_mob, gibbed, lives_left)
+#define COMSIG_ON_MULTIPLE_LIVES_RESPAWN "on_multiple_lives_respawn"
+
 ///from base of [/datum/reagents/proc/add_reagent] - Sent before the reagent is added: (reagenttype, amount, reagtemp, data, no_react)
 #define COMSIG_REAGENTS_PRE_ADD_REAGENT "reagents_pre_add_reagent"
 	/// Prevents the reagent from being added.
@@ -297,6 +300,7 @@
 #define COMSIG_REAGENTS_EXPOSE_TURF "reagents_expose_turf"
 ///from base of [/datum/component/personal_crafting/proc/del_reqs]: ()
 #define COMSIG_REAGENTS_CRAFTING_PING "reagents_crafting_ping"
+
 
 // Lighting:
 ///from base of [atom/proc/set_light]: (l_range, l_power, l_color, l_on)

--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -1,5 +1,9 @@
-#define DEMOCRACY_MODE "democracy"
-#define ANARCHY_MODE "anarchy"
+///Will execute a single command after the cooldown based on player votes.
+#define DEMOCRACY_MODE (1<<0)
+///Allows each player to do a single command every cooldown.
+#define ANARCHY_MODE (1<<1)
+///Mutes the democracy mode messages send to orbiters at the end of each cycle. Useful for when the cooldown is so low it'd get spammy.
+#define MUTE_DEMOCRACY_MESSAGES (1<<2)
 
 /**
  * Deadchat Plays Things - The Componenting
@@ -18,7 +22,7 @@
 	var/list/ckey_to_cooldown = list()
 	/// List of everything orbitting this component's parent.
 	var/orbiters = list()
-	/// Either DEMOCRACY_MODE which will execute a single command after the cooldown based on player votes, or ANARCHY_MODE which allows each player to do a single command every cooldown.
+	/// A bitfield containing the mode which this component uses (DEMOCRACY_MODE or ANARCHY_MODE) and other settings)
 	var/deadchat_mode
 	/// In DEMOCRACY_MODE, this is how long players have to vote on an input. In ANARCHY_MODE, this is how long between inputs for each unique player.
 	var/input_cooldown
@@ -37,7 +41,9 @@
 	inputs = _inputs
 	input_cooldown = _input_cooldown
 	on_removal = _on_removal
-	if(deadchat_mode == DEMOCRACY_MODE)
+	if(deadchat_mode & DEMOCRACY_MODE)
+		if(deadchat_mode & ANARCHY_MODE) // Choose one, please.
+			stack_trace("deadchat_control component added to [parent.type] with both democracy and anarchy modes enabled.")
 		timerid = addtimer(CALLBACK(src, .proc/democracy_loop), input_cooldown, TIMER_STOPPABLE | TIMER_LOOP)
 	notify_ghosts("[parent] is now deadchat controllable!", source = parent, action = NOTIFY_ORBIT, header="Something Interesting!")
 
@@ -56,7 +62,7 @@
 	if(!inputs[message])
 		return
 
-	if(deadchat_mode == ANARCHY_MODE)
+	if(deadchat_mode & ANARCHY_MODE)
 		var/cooldown = ckey_to_cooldown[source.ckey] - world.time
 		if(cooldown > 0)
 			to_chat(source, span_warning("Your deadchat control inputs are still on cooldown for another [cooldown * 0.1] seconds."))
@@ -66,22 +72,23 @@
 		to_chat(source, span_notice("\"[message]\" input accepted. You are now on cooldown for [input_cooldown * 0.1] seconds."))
 		return MOB_DEADSAY_SIGNAL_INTERCEPT
 
-	if(deadchat_mode == DEMOCRACY_MODE)
+	if(deadchat_mode & DEMOCRACY_MODE)
 		ckey_to_cooldown[source.ckey] = message
 		to_chat(source, span_notice("You have voted for \"[message]\"."))
 		return MOB_DEADSAY_SIGNAL_INTERCEPT
 
 /datum/component/deadchat_control/proc/democracy_loop()
-	if(QDELETED(parent) || deadchat_mode != DEMOCRACY_MODE)
+	if(QDELETED(parent) || !(deadchat_mode & DEMOCRACY_MODE))
 		deltimer(timerid)
 		return
 	var/result = count_democracy_votes()
 	if(!isnull(result))
 		inputs[result].Invoke()
-		var/message = "<span class='deadsay italics bold'>[parent] has done action [result]!<br>New vote started. It will end in [input_cooldown * 0.1] seconds.</span>"
-		for(var/M in orbiters)
-			to_chat(M, message)
-	else
+		if(!(deadchat_mode & MUTE_DEMOCRACY_MESSAGES))
+			var/message = "<span class='deadsay italics bold'>[parent] has done action [result]!<br>New vote started. It will end in [input_cooldown * 0.1] seconds.</span>"
+			for(var/M in orbiters)
+				to_chat(M, message)
+	else if(!(deadchat_mode & MUTE_DEMOCRACY_MESSAGES))
 		var/message = "<span class='deadsay italics bold'>No votes were cast this cycle.</span>"
 		for(var/M in orbiters)
 			to_chat(M, message)
@@ -160,11 +167,11 @@
 	if(!isobserver(user))
 		return
 
-	examine_list += span_notice("[A.p_theyre(TRUE)] currently under deadchat control using the [deadchat_mode] ruleset!")
+	examine_list += span_notice("[A.p_theyre(TRUE)] currently under deadchat control using the [(deadchat_mode & DEMOCRACY_MODE) ? "democracy" : "anarchy"] ruleset!")
 
-	if(deadchat_mode == DEMOCRACY_MODE)
+	if(deadchat_mode & DEMOCRACY_MODE)
 		examine_list += span_notice("Type a command into chat to vote on an action. This happens once every [input_cooldown * 0.1] seconds.")
-	else if(deadchat_mode == ANARCHY_MODE)
+	else if(deadchat_mode & ANARCHY_MODE)
 		examine_list += span_notice("Type a command into chat to perform. You may do this once every [input_cooldown * 0.1] seconds.")
 
 	var/extended_examine = "<span class='notice'>Command list:"

--- a/code/datums/components/multiple_lives.dm
+++ b/code/datums/components/multiple_lives.dm
@@ -1,0 +1,43 @@
+/**
+ * A simple component that spawns a mob of the same type and transfers itself to it when parent dies.
+ * For more complex behaviors, use the COMSIG_ON_MULTIPLE_LIVES_RESPAWN comsig.
+ */
+/datum/component/multiple_lives
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	/// The number of respawns the living mob has left.
+	var/lives_left
+
+/datum/component/multiple_lives/Initialize(lives_left)
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	src.lives_left = lives_left
+
+/datum/component/multiple_lives/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_LIVING_DEATH, .proc/respawn)
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)
+
+/datum/component/multiple_lives/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_LIVING_DEATH, COMSIG_PARENT_EXAMINE))
+
+/datum/component/multiple_lives/proc/respawn(mob/living/source, gibbed)
+	SIGNAL_HANDLER
+	if(source.suiciding) //Freed from this mortail coil.
+		qdel(src)
+		return
+	var/mob/living/respawned_mob = new source.type (source.drop_location())
+	source.mind?.transfer_to(respawned_mob)
+	lives_left--
+	if(lives_left <= 0)
+		qdel(src)
+	else
+		respawned_mob.TakeComponent(src)
+	SEND_SIGNAL(source, COMSIG_ON_MULTIPLE_LIVES_RESPAWN, respawned_mob, gibbed, lives_left)
+
+/datum/component/multiple_lives/proc/on_examine(mob/living/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+	if(isobserver(user) || source == user)
+		examine_list += "[source.p_theyve(TRUE)] [lives_left] extra lives left."
+
+/datum/component/multiple_lives/InheritComponent(datum/component/multiple_lives/new_comp , lives_left)
+	src.lives_left += new_comp ? new_comp.lives_left : lives_left

--- a/code/datums/components/multiple_lives.dm
+++ b/code/datums/components/multiple_lives.dm
@@ -3,6 +3,7 @@
  * For more complex behaviors, use the COMSIG_ON_MULTIPLE_LIVES_RESPAWN comsig.
  */
 /datum/component/multiple_lives
+	can_transfer = TRUE
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 	/// The number of respawns the living mob has left.
 	var/lives_left
@@ -30,8 +31,7 @@
 	lives_left--
 	if(lives_left <= 0)
 		qdel(src)
-	else
-		respawned_mob.TakeComponent(src)
+	source.TransferComponents(respawned_mob)
 	SEND_SIGNAL(source, COMSIG_ON_MULTIPLE_LIVES_RESPAWN, respawned_mob, gibbed, lives_left)
 
 /datum/component/multiple_lives/proc/on_examine(mob/living/source, mob/user, list/examine_list)
@@ -41,3 +41,7 @@
 
 /datum/component/multiple_lives/InheritComponent(datum/component/multiple_lives/new_comp , lives_left)
 	src.lives_left += new_comp ? new_comp.lives_left : lives_left
+
+/datum/component/multiple_lives/PostTransfer()
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -36,6 +36,12 @@
 		if(!(istype(dog, /mob/living/simple_animal/pet/dog/corgi/ian) || istype(dog, /mob/living/simple_animal/pet/dog/corgi/puppy/ian)))
 			continue
 
+		// Makes this station trait more interesting. Ian probably won't go anywhere without a little external help.
+		// Also gives him a couple extra lives to survive eventual tiders.
+		dog.deadchat_plays(DEMOCRACY_MODE|MUTE_DEMOCRACY_MESSAGES, 3 SECONDS)
+		dog.AddComponent(/datum/component/multiple_lives, 2)
+		RegisterSignal(dog, COMSIG_ON_MULTIPLE_LIVES_RESPAWN, .proc/do_corgi_respawn)
+
 		// The extended safety checks at time of writing are about chasms and lava
 		// if there are any chasms and lava on stations in the future, woah
 		var/turf/current_turf = get_turf(dog)
@@ -46,6 +52,36 @@
 		dog.forceMove(adventure_turf)
 		do_smoke(location=adventure_turf)
 
+/// Moves the new dog somewhere safe, equips it with the old one's inventory and makes it deadchat_playable.
+/datum/station_trait/ian_adventure/proc/do_corgi_respawn(mob/living/simple_animal/pet/dog/corgi/old_dog, mob/living/simple_animal/pet/dog/corgi/new_dog, gibbed, lives_left)
+	SIGNAL_HANDLER
+
+	var/turf/current_turf = get_turf(new_dog)
+	var/turf/adventure_turf = find_safe_turf(extended_safety_checks = TRUE, dense_atoms = FALSE)
+
+	do_smoke(location=current_turf)
+	new_dog.forceMove(adventure_turf)
+	do_smoke(location=adventure_turf)
+
+	if(old_dog.inventory_back)
+		var/obj/item/old_dog_back = old_dog.inventory_back
+		old_dog.inventory_back = null
+		old_dog_back.forceMove(new_dog)
+		new_dog.inventory_back = old_dog_back
+
+	if(old_dog.inventory_head)
+		var/obj/item/old_dog_hat = old_dog.inventory_head
+		old_dog.inventory_head = null
+		new_dog.place_on_head(old_dog_hat)
+
+	new_dog.update_corgi_fluff()
+	new_dog.regenerate_icons()
+	new_dog.deadchat_plays(DEMOCRACY_MODE|MUTE_DEMOCRACY_MESSAGES, 3 SECONDS)
+	if(lives_left)
+		RegisterSignal(new_dog, COMSIG_ON_MULTIPLE_LIVES_RESPAWN, .proc/do_corgi_respawn)
+
+	if(!gibbed) //The old dog will now disappear so we won't have more than one Ian at a time.
+		qdel(old_dog)
 
 /datum/station_trait/glitched_pdas
 	name = "PDA glitch"

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -69,6 +69,48 @@
 		inventory_back = null
 	return ..()
 
+/mob/living/simple_animal/pet/dog/corgi/deadchat_plays(mode = ANARCHY_MODE, cooldown = 12 SECONDS)
+	. = AddComponent(/datum/component/deadchat_control/cardinal_movement, mode, list(
+		"speak" = CALLBACK(src, .proc/handle_automated_speech, TRUE),
+		"wear_hat" = CALLBACK(src, .proc/find_new_hat),
+		"drop_hat" = CALLBACK(src, .proc/drop_hat),
+		"spin" = CALLBACK(src, /mob.proc/emote, "spin")), cooldown, CALLBACK(src, .proc/stop_deadchat_plays))
+
+	if(. == COMPONENT_INCOMPATIBLE)
+		return
+
+	stop_automated_movement = TRUE
+
+///Deadchat plays command that picks a new hat for Ian.
+/mob/living/simple_animal/pet/dog/corgi/proc/find_new_hat()
+	if(!isturf(loc))
+		return
+	var/list/possible_headwear = list()
+	for(var/obj/item/item in loc)
+		if(ispath(item.dog_fashion, /datum/dog_fashion/head))
+			possible_headwear += item
+	if(!length(possible_headwear))
+		for(var/obj/item/item in orange(1))
+			if(ispath(item.dog_fashion, /datum/dog_fashion/head) && CanReach(item))
+				possible_headwear += item
+	if(!length(possible_headwear))
+		return
+	if(inventory_head)
+		inventory_head.forceMove(drop_location())
+		inventory_head = null
+	place_on_head(pick(possible_headwear))
+	visible_message(span_notice("[src] puts [inventory_head] on [p_their()] own head, somehow."))
+
+///Deadchat plays command that drops the current hat off Ian.
+/mob/living/simple_animal/pet/dog/corgi/proc/drop_hat()
+	if(!inventory_head)
+		return
+	visible_message(span_notice("[src] vigorously shakes [p_their()] head, dropping [inventory_head] to the ground."))
+	inventory_head.forceMove(drop_location())
+	inventory_head = null
+	update_corgi_fluff()
+	regenerate_icons()
+
 /mob/living/simple_animal/pet/dog/corgi/handle_atom_del(atom/A)
 	if(A == inventory_head)
 		inventory_head = null
@@ -79,7 +121,6 @@
 		update_corgi_fluff()
 		regenerate_icons()
 	return ..()
-
 
 /mob/living/simple_animal/pet/dog/pug
 	name = "\improper pug"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -612,6 +612,7 @@
 #include "code\datums\components\mirage_border.dm"
 #include "code\datums\components\mirv.dm"
 #include "code\datums\components\mood.dm"
+#include "code\datums\components\multiple_lives.dm"
 #include "code\datums\components\ntnet_interface.dm"
 #include "code\datums\components\omen.dm"
 #include "code\datums\components\orbiter.dm"


### PR DESCRIPTION
## About The Pull Request
Makes the "Ian Adventure" station trait more interesting by giving him deadchat control (democracy mode, 3 seconds cooldown on inputs) and a couple extra lives* to survive early round tiding. 

*Basically, a new component that respawns the critter when he dies. The component itself is simple enough, but it sends a signal each respawn to allow other datums to expand this behavior how they want. I've contemplated adding a signal that can stop death, dusting and gibbing instead of respawning the mob at first but because `death()`, `dust()` and `gib()` were made with the assertion that the mob is always going to die I've quickly realized it'd require a refactor that's way too big and out of scope.

The deadchat control of corgis only include commands to change and drop hats, "speak" (random lines from the speak list of the mob) and spin (other than cardinal movement) for now. I'd have loved to add more complex commands (like, argumented) that can potentially be relayed to the AI controller, but I guess that'll have to wait until the thing gets refactored a little.

## Why It's Good For The Game
"Ian's Adventure" is a really bland station trait at the moment. All it does is move Ian somewhere else at the start of the round. Even by the station traits standard of being small things this is insignificant, and also pretty bad considering Ian is not actually going on an adventure since he lacks the initiative to do anything being an npc dog.
This PR aims to breath fresh air into this station trait and push it toward a slighty more engaging direction, though it relies on observers to work, while still being a small """"cute"""" station trait.

## Changelog

:cl:
expansion: The "Ian's Adventure" station trait now makes Ian deadchat controllable and gives him a couple extra lives (to survive early round tiding)
/:cl:
