### PR TITLE
Cyborg non direct "combat" rebalance. Airlock seal buffed, borg RCD nerfed.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -598,7 +598,7 @@
 			. += "There's a [note.name] pinned to the front..."
 			. += note.examine(user)
 	if(seal)
-		. += "It's been braced with a pneumatic seal."
+		. += "It's been braced with a pneumatic airlock seal."
 	if(panel_open)
 		switch(security_level)
 			if(AIRLOCK_SECURITY_NONE)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -598,7 +598,7 @@
 			. += "There's a [note.name] pinned to the front..."
 			. += note.examine(user)
 	if(seal)
-		. += "It's been braced with a pneumatic airlock seal."
+		. += "It's been braced with \a [seal]."
 	if(panel_open)
 		switch(security_level)
 			if(AIRLOCK_SECURITY_NONE)

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -780,7 +780,6 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 /obj/item/construction/rcd/borg
 	no_ammo_message = "<span class='warning'>Insufficient charge.</span>"
 	desc = "A device used to rapidly build walls and floors."
-	canRturf = TRUE
 	banned_upgrades = RCD_UPGRADE_SILO_LINK
 	var/energyfactor = 72
 

--- a/code/game/objects/items/door_seal.dm
+++ b/code/game/objects/items/door_seal.dm
@@ -1,5 +1,5 @@
 /obj/item/door_seal
-	name = "pneumatic seal"
+	name = "pneumatic airlock seal"
 	desc = "A brace used to seal and reinforce an airlock. Useful for making areas inaccessible to those without opposable thumbs."
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "pneumatic_seal"
@@ -11,7 +11,7 @@
 	throwforce = 5
 	throw_speed = 2
 	throw_range = 1
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	custom_materials = list(/datum/material/iron=5000,/datum/material/plasma=500)
 	/// how long the seal takes to place on the door
 	var/seal_time = 3 SECONDS

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -325,14 +325,14 @@
 	category = list("Equipment")
 
 /datum/design/pneumatic_seal
-	name = "Pneumatic Seal"
-	desc = "A heavy brace used to seal doors. Useful for keeping out people without the dexterity to remove it."
+	name = "Pneumatic Airlock Seal"
+	desc = "A heavy brace used to seal airlocks. Useful for keeping out people without the dexterity to remove it."
 	id = "pneumatic_seal"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 20000, /datum/material/plasma = 10000)
 	build_path = /obj/item/door_seal
 	category = list("Equipment")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SCIENCE
 
 /////////////////////////////////////////
 ////////////Janitor Designs//////////////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lately, we had a few PRs and a lot of conversation around Borg combat, how it is binary and really dated compared to what we have for humans right now.
That is a giant can of worms that I don't want to touch, but there is another side of dealing with Rogue Silicons that is often ignored because it simply isn't viable enough to bother IMO and that is "environmental preparation" if you can call it that way...

To give a simple comparison, when Xenos are announced everyone goes around welding vents and airlocks to maint, it's my favorite part of dealing with Xenos as crew and they also suffer from a binary combat like Silicons do.

## Pneumatic Airlock Seal Buff
You know the thing? I bet you don't... it's this little fella here:
<details>
<summary>Pneumatic seal</summary>
<img src="https://user-images.githubusercontent.com/55374212/140608975-7ced5748-143e-4504-92c4-071b028cf97b.png" width="500">
</details>
If they are applied to an airlock, it will lock it until the seal is removed, and it can only be removed by humanoids.

You can print them on the Eng and Sec lathes, they are first tier tech and are expansive but IMO, the main reason that they are never used is that they are Bulky, if you want to seriously lock down an area against Silicons/Xenos/Simple mobs you either need to drag a crate with these or do multiple trips carrying by hand.

I changed them to be medium sized so you can reasonably put some in your bag and added them to the Science lathe, as Science should be IMO, the first dept to deal with rogue silicons/xeno mob spam.

## Engborg RCD nerf
Right now the Engborg is the best silicon to subvert by a far, unless you have some niche assassination plan that a Medborg might do better, not like the Engborg is bad at this anyway since they have the stun arm...

The issue outside of combat is that Engborgs can RCD down reinforced walls in 5 seconds and their roundstart cell allows them to do this 5 times which is more than enough to break in even on the AI sat, the area with multiple layers of Rwalls.

This also makes the Pneumatic seals stupidly useless, why would you lock down the Vault/Tcomms/Armory/whatever other sabotage the Silicons are doing if they can just RCD down the Rwalls faster than the protolathe can print 1 seal...

So now Engborgs can't deconstruct Rwalls with their RCD.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dealing with Silicons is really dated and right now boils to nuking them with the console/Ions/flash as you can't really stop them otherwise, we have a few tools and tricks to help like the seal or cutting AI + access wires on airlocks but no one bothers because the RCD exists on its current state.

On the other hand, Silicons thrive on non direct combat, sabotaging Tcomms, unlinking the Ore Silo to stop the crew's supply, cutting down power, etc, etc.

So with these, the crew has a way to deal with Silicons by limiting their mobility when they are working alone without making them weaker if they have a Human or a Malf AI helping them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
balance: Pneumatic airlocks seals are normal sized now and can be printed at the Science lathe.
balance: After dealing with another weekly subverted Engborg spacing the armory. CentCom's Robotics division decided to downgrade the Engborg RCD by removing it's Reinforced Wall deconstruction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
