### PR TITLE
Makes maps be able to load correctly again

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -26,6 +26,9 @@ require only minor tweaks.
 
 #define SPACERUIN_MAP_EDGE_PAD 15
 
+/// Path for the next_map.json file, if someone, for some messed up reason, wants to change it.
+#define PATH_TO_NEXT_MAP_JSON "data/next_map.json"
+
 /// Special map path value for custom adminloaded stations.
 #define CUSTOM_MAP_PATH "custom"
 

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -48,7 +48,7 @@
 								// 2 for preloading absolutely everything;
 
 #ifdef LOWMEMORYMODE
-#define FORCE_MAP "_maps/runtimestation.json"
+#define FORCE_MAP "runtimestation"
 #endif
 
 //Update this whenever you need to take advantage of more recent byond features

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -296,7 +296,7 @@ Used by the AI doomsday and the self-destruct nuke.
 	if(config.map_path == CUSTOM_MAP_PATH)
 		fdel("_maps/custom/[config.map_file]")
 		// And as the file is now removed set the next map to default.
-		next_map_config = load_map_config(force_default_map = TRUE)
+		next_map_config = load_default_map_config()
 
 GLOBAL_LIST_EMPTY(the_station_areas)
 
@@ -384,7 +384,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 
 /datum/controller/subsystem/mapping/proc/changemap(datum/map_config/VM)
 	if(!VM.MakeNextMap())
-		next_map_config = load_map_config(force_default_map = TRUE)
+		next_map_config = load_default_map_config()
 		message_admins("Failed to set new map with next_map.json for [VM.map_name]! Using default as backup!")
 		return
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -63,7 +63,7 @@ SUBSYSTEM_DEF(mapping)
 		var/old_config = config
 		config = global.config.defaultmap
 		if(!config || config.defaulted)
-			to_chat(world, span_boldannounce("Unable to load next or default map config, defaulting to Meta Station"))
+			to_chat(world, span_boldannounce("Unable to load next or default map config, defaulting to Meta Station."))
 			config = old_config
 	initialize_biomes()
 	loadWorld()
@@ -296,7 +296,7 @@ Used by the AI doomsday and the self-destruct nuke.
 	if(config.map_path == CUSTOM_MAP_PATH)
 		fdel("_maps/custom/[config.map_file]")
 		// And as the file is now removed set the next map to default.
-		next_map_config = load_map_config(default_to_box = TRUE)
+		next_map_config = load_map_config(force_default_map = TRUE)
 
 GLOBAL_LIST_EMPTY(the_station_areas)
 
@@ -384,7 +384,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 
 /datum/controller/subsystem/mapping/proc/changemap(datum/map_config/VM)
 	if(!VM.MakeNextMap())
-		next_map_config = load_map_config(default_to_box = TRUE)
+		next_map_config = load_map_config(force_default_map = TRUE)
 		message_admins("Failed to set new map with next_map.json for [VM.map_name]! Using default as backup!")
 		return
 

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -35,29 +35,31 @@
 	var/job_changes = list()
 
 /**
+ * Proc that simply loads the default map config, which should always be functional.
+ */
+/proc/load_default_map_config()
+	return new var/datum/map_config/config
+
+
+/**
  * Proc handling the loading of map configs. Will return the default map config (see above) if the loading of said confile fails for any reason whatsoever, so we always have a working map for the server to run.
  * Arguments:
  * * filename - Name of the config file for the map we want to load.
- * * force_default_map - Do we forcefully load the default map?
- * * delete_after - Boolean to delete the map config after loading it (I don't know why you would, I suggest not setting it to TRUE if you don't want to mess up the config of your server(s)).
  * * error_if_missing - Bool that says whether failing to load the config for the map will be logged in log_world or not as it's passed to LoadConfig().
  *
  * Returns the config for the map to load.
  */
-/proc/load_map_config(filename = null, force_default_map, delete_after, error_if_missing = TRUE)
+/proc/load_map_config(filename = null, error_if_missing = TRUE)
+	var/datum/map_config/config = load_default_map_config()
 	if(filename) // If none is specified, then go to look for next_map.json, for map rotation purposes.
 		filename = "_maps/[filename].json"
 	else
 		filename = PATH_TO_NEXT_MAP_JSON
-	var/datum/map_config/config = new
-	if (force_default_map)
-		return config
 	if (!config.LoadConfig(filename, error_if_missing))
 		qdel(config)
-		config = new /datum/map_config  // Fall back to Box
-	else if (delete_after)
-		fdel(filename)
+		return load_default_map_config()
 	return config
+
 
 #define CHECK_EXISTS(X) if(!istext(json[X])) { log_world("[##X] missing from json!"); return; }
 

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -34,13 +34,23 @@
 	/// Dictionary of job sub-typepath to template changes dictionary
 	var/job_changes = list()
 
-/proc/load_map_config(filename = "next_map", default_to_box, delete_after, error_if_missing = TRUE)
-	if(filename == "next_map") // Since they don't share the same path, you gotta handle them differently...
-		filename = "data/[filename].json"
-	else
+/**
+ * Proc handling the loading of map configs. Will return the default map config (see above) if the loading of said confile fails for any reason whatsoever, so we always have a working map for the server to run.
+ * Arguments:
+ * * filename - Name of the config file for the map we want to load.
+ * * force_default_map - Do we forcefully load the default map?
+ * * delete_after - Boolean to delete the map config after loading it (I don't know why you would, I suggest not setting it to TRUE if you don't want to mess up the config of your server(s)).
+ * * error_if_missing - Bool that says whether failing to load the config for the map will be logged in log_world or not as it's passed to LoadConfig().
+ *
+ * Returns the config for the map to load.
+ */
+/proc/load_map_config(filename = null, force_default_map, delete_after, error_if_missing = TRUE)
+	if(filename) // If none is specified, then go to look for next_map.json, for map rotation purposes.
 		filename = "_maps/[filename].json"
+	else
+		filename = PATH_TO_NEXT_MAP_JSON
 	var/datum/map_config/config = new
-	if (default_to_box)
+	if (force_default_map)
 		return config
 	if (!config.LoadConfig(filename, error_if_missing))
 		qdel(config)
@@ -50,6 +60,7 @@
 	return config
 
 #define CHECK_EXISTS(X) if(!istext(json[X])) { log_world("[##X] missing from json!"); return; }
+
 /datum/map_config/proc/LoadConfig(filename, error_if_missing)
 	if(!fexists(filename))
 		if(error_if_missing)

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -38,13 +38,13 @@
  * Proc that simply loads the default map config, which should always be functional.
  */
 /proc/load_default_map_config()
-	return new var/datum/map_config/config
+	return new /datum/map_config
 
 
 /**
  * Proc handling the loading of map configs. Will return the default map config (see above) if the loading of said confile fails for any reason whatsoever, so we always have a working map for the server to run.
  * Arguments:
- * * filename - Name of the config file for the map we want to load.
+ * * filename - Name of the config file for the map we want to load. The .json file extension is added during the proc, so do not specify filenames with the extension.
  * * error_if_missing - Bool that says whether failing to load the config for the map will be logged in log_world or not as it's passed to LoadConfig().
  *
  * Returns the config for the map to load.

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -42,7 +42,7 @@
 
 
 /**
- * Proc handling the loading of map configs. Will return the default map config (see above) if the loading of said confile fails for any reason whatsoever, so we always have a working map for the server to run.
+ * Proc handling the loading of map configs. Will return the default map config using [/proc/load_default_map_config] if the loading of said file fails for any reason whatsoever, so we always have a working map for the server to run.
  * Arguments:
  * * filename - Name of the config file for the map we want to load. The .json file extension is added during the proc, so do not specify filenames with the extension.
  * * error_if_missing - Bool that says whether failing to load the config for the map will be logged in log_world or not as it's passed to LoadConfig().

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -34,8 +34,11 @@
 	/// Dictionary of job sub-typepath to template changes dictionary
 	var/job_changes = list()
 
-/proc/load_map_config(filename = "next_map.json", default_to_box, delete_after, error_if_missing = TRUE)
-	filename = "data/[filename].json"
+/proc/load_map_config(filename = "next_map", default_to_box, delete_after, error_if_missing = TRUE)
+	if(filename == "next_map") // Since they don't share the same path, you gotta handle them differently...
+		filename = "data/[filename].json"
+	else
+		filename = "_maps/[filename].json"
 	var/datum/map_config/config = new
 	if (default_to_box)
 		return config

--- a/code/modules/admin/verbs/maprotation.dm
+++ b/code/modules/admin/verbs/maprotation.dm
@@ -82,7 +82,7 @@
 
 		VM.map_path = CUSTOM_MAP_PATH
 		VM.map_file = "[map_file]"
-		VM.config_filename = "data/next_map.json"
+		VM.config_filename = PATH_TO_NEXT_MAP_JSON
 		var/json_value = list(
 			"version" = MAP_CURRENT_VERSION,
 			"map_name" = VM.map_name,
@@ -92,9 +92,9 @@
 		)
 
 		// If the file isn't removed text2file will just append.
-		if(fexists("data/next_map.json"))
-			fdel("data/next_map.json")
-		text2file(json_encode(json_value), "data/next_map.json")
+		if(fexists(PATH_TO_NEXT_MAP_JSON))
+			fdel(PATH_TO_NEXT_MAP_JSON)
+		text2file(json_encode(json_value), PATH_TO_NEXT_MAP_JSON)
 
 		if(SSmapping.changemap(VM))
 			message_admins("[key_name_admin(usr)] has changed the map to [VM.map_name]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So, clearly, the person that did that refactor to fix some security issues didn't know how maps are loaded.
As such, at the end of every round, the next map would get written to `data/next_map.json`, and the next round, the game would try and load `_maps/next_map.json.json`. I got a feeling they didn't test their PR too much.

This PR fixes a bunch of the code for `load_map_config()`, documenting it better and removing a deprecated (I hope) parameter that was also a security concern along the way, while also making another proc for just loading the default map config, which is supposed to always be functional.

Props to Timberpoes for the review and the suggestions to clean the code and make it better when I was making this.

And, yes, I tested it, and it works.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There's only so many times people will enjoy playing on the same map every single round. Oh, and it also messes with downstreams, so it's doubly important.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: GoldenAlpharex, with some oversight from Timberpoes
fix: Maps will now correctly be loaded at the start of a round. Hurray!
code: Improved the code for loading map configs and made it more documented, while also removing a way to delete config files while I was at it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
