### PR TITLE
Replaces a portion of C-style for loops with the more commonplace for loops, which are faster.

### DIFF
--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -151,7 +151,7 @@
 /obj/item/storage/secure/briefcase/syndie/PopulateContents()
 	..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	for(var/i = 0, i < STR.max_items - 2, i++)
+	for(var/iteration in 1 to STR.max_items - 2)
 		new /obj/item/stack/spacecash/c1000(src)
 
 

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -151,7 +151,7 @@
 /obj/item/storage/secure/briefcase/syndie/PopulateContents()
 	..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	for(var/iteration in 1 to STR.max_items - 2)
+	for(var/i in 1 to STR.max_items - 2)
 		new /obj/item/stack/spacecash/c1000(src)
 
 

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -316,7 +316,7 @@
 		var/obj/effect/resin_container/A = new (get_turf(src))
 		log_game("[key_name(user)] used Resin Launcher at [AREACOORD(user)].")
 		playsound(src,'sound/items/syringeproj.ogg',40,TRUE)
-		for(var/iteration in 1 to 5)
+		for(var/i in 1 to 5)
 			step_towards(A, target)
 			sleep(2)
 		A.Smoke()

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -316,7 +316,7 @@
 		var/obj/effect/resin_container/A = new (get_turf(src))
 		log_game("[key_name(user)] used Resin Launcher at [AREACOORD(user)].")
 		playsound(src,'sound/items/syringeproj.ogg',40,TRUE)
-		for(var/a=0, a<5, a++)
+		for(var/iteration in 1 to 5)
 			step_towards(A, target)
 			sleep(2)
 		A.Smoke()

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -36,7 +36,7 @@
 
 /obj/structure/closet/secure_closet/freezer/kitchen/PopulateContents()
 	..()
-	for(var/iteration in 1 to 3)
+	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/food/condiment/flour(src)
 	new /obj/item/reagent_containers/food/condiment/rice(src)
 	new /obj/item/reagent_containers/food/condiment/sugar(src)
@@ -48,10 +48,10 @@
 
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance/PopulateContents()
 	..()
-	for(var/iteration in 1 to 5)
+	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/food/condiment/milk(src)
 		new /obj/item/reagent_containers/food/condiment/soymilk(src)
-	for(var/iteration in 1 to 2)
+	for(var/i in 1 to 2)
 		new /obj/item/storage/fancy/egg_box(src)
 
 /obj/structure/closet/secure_closet/freezer/kitchen/mining
@@ -63,7 +63,7 @@
 
 /obj/structure/closet/secure_closet/freezer/meat/PopulateContents()
 	..()
-	for(var/iteration in 1 to 4)
+	for(var/i in 1 to 4)
 		new /obj/item/food/meat/slab/monkey(src)
 
 /obj/structure/closet/secure_closet/freezer/meat/open
@@ -84,10 +84,10 @@
 
 /obj/structure/closet/secure_closet/freezer/fridge/PopulateContents()
 	..()
-	for(var/iteration in 1 to 5)
+	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/food/condiment/milk(src)
 		new /obj/item/reagent_containers/food/condiment/soymilk(src)
-	for(var/iteration in 1 to 2)
+	for(var/i in 1 to 2)
 		new /obj/item/storage/fancy/egg_box(src)
 
 /obj/structure/closet/secure_closet/freezer/fridge/open
@@ -101,11 +101,11 @@
 
 /obj/structure/closet/secure_closet/freezer/money/PopulateContents()
 	..()
-	for(var/iteration in 1 to 3)
+	for(var/i in 1 to 3)
 		new /obj/item/stack/spacecash/c1000(src)
-	for(var/iteration in 1 to 5)
+	for(var/i in 1 to 5)
 		new /obj/item/stack/spacecash/c500(src)
-	for(var/iteration in 1 to 6)
+	for(var/i in 1 to 6)
 		new /obj/item/stack/spacecash/c200(src)
 
 /obj/structure/closet/secure_closet/freezer/cream_pie

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -36,7 +36,7 @@
 
 /obj/structure/closet/secure_closet/freezer/kitchen/PopulateContents()
 	..()
-	for(var/i = 0, i < 3, i++)
+	for(var/iteration in 1 to 3)
 		new /obj/item/reagent_containers/food/condiment/flour(src)
 	new /obj/item/reagent_containers/food/condiment/rice(src)
 	new /obj/item/reagent_containers/food/condiment/sugar(src)
@@ -48,11 +48,10 @@
 
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance/PopulateContents()
 	..()
-	for(var/i = 0, i < 5, i++)
+	for(var/iteration in 1 to 5)
 		new /obj/item/reagent_containers/food/condiment/milk(src)
-	for(var/i = 0, i < 5, i++)
 		new /obj/item/reagent_containers/food/condiment/soymilk(src)
-	for(var/i = 0, i < 2, i++)
+	for(var/iteration in 1 to 2)
 		new /obj/item/storage/fancy/egg_box(src)
 
 /obj/structure/closet/secure_closet/freezer/kitchen/mining
@@ -64,7 +63,7 @@
 
 /obj/structure/closet/secure_closet/freezer/meat/PopulateContents()
 	..()
-	for(var/i = 0, i < 4, i++)
+	for(var/iteration in 1 to 4)
 		new /obj/item/food/meat/slab/monkey(src)
 
 /obj/structure/closet/secure_closet/freezer/meat/open
@@ -85,11 +84,10 @@
 
 /obj/structure/closet/secure_closet/freezer/fridge/PopulateContents()
 	..()
-	for(var/i = 0, i < 5, i++)
+	for(var/iteration in 1 to 5)
 		new /obj/item/reagent_containers/food/condiment/milk(src)
-	for(var/i = 0, i < 5, i++)
 		new /obj/item/reagent_containers/food/condiment/soymilk(src)
-	for(var/i = 0, i < 2, i++)
+	for(var/iteration in 1 to 2)
 		new /obj/item/storage/fancy/egg_box(src)
 
 /obj/structure/closet/secure_closet/freezer/fridge/open
@@ -103,11 +101,11 @@
 
 /obj/structure/closet/secure_closet/freezer/money/PopulateContents()
 	..()
-	for(var/i = 0, i < 3, i++)
+	for(var/iteration in 1 to 3)
 		new /obj/item/stack/spacecash/c1000(src)
-	for(var/i = 0, i < 5, i++)
+	for(var/iteration in 1 to 5)
 		new /obj/item/stack/spacecash/c500(src)
-	for(var/i = 0, i < 6, i++)
+	for(var/iteration in 1 to 6)
 		new /obj/item/stack/spacecash/c200(src)
 
 /obj/structure/closet/secure_closet/freezer/cream_pie

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -117,7 +117,7 @@
 	/obj/item/stack/sheet/mineral/wood
 	)
 
-	for(var/i = 0, i<2, i++)
+	for(var/iteration in 1 to 2)
 		for(var/res in resources)
 			var/obj/item/stack/R = res
 			new res(src, initial(R.max_amount))

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -117,7 +117,7 @@
 	/obj/item/stack/sheet/mineral/wood
 	)
 
-	for(var/iteration in 1 to 2)
+	for(var/i in 1 to 2)
 		for(var/res in resources)
 			var/obj/item/stack/R = res
 			new res(src, initial(R.max_amount))

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -983,8 +983,9 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 /proc/SDQL_testout(list/query_tree, indent = 0)
 	var/static/whitespace = "&nbsp;&nbsp;&nbsp; "
 	var/spaces = ""
-	for(var/s = 0, s < indent, s++)
-		spaces += whitespace
+	if(indent > 0)
+		for(var/iteration in 1 to indent)
+			spaces += whitespace
 
 	for(var/item in query_tree)
 		if(istype(item, /list))

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -984,7 +984,7 @@ GLOBAL_DATUM_INIT(sdql2_vv_statobj, /obj/effect/statclick/sdql2_vv_all, new(null
 	var/static/whitespace = "&nbsp;&nbsp;&nbsp; "
 	var/spaces = ""
 	if(indent > 0)
-		for(var/iteration in 1 to indent)
+		for(var/i in 1 to indent)
 			spaces += whitespace
 
 	for(var/item in query_tree)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -714,8 +714,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 					surname_found = i
 					break
 			//forenames
-			for(var/iteration in 1 to surname_found-1)
-				var/word = ckey(L[iteration])
+			for(var/i in 1 to surname_found-1)
+				var/word = ckey(L[i])
 				if(word)
 					forenames[word] = M
 			//ckeys

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -714,8 +714,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 					surname_found = i
 					break
 			//forenames
-			for(var/i=1, i<surname_found, i++)
-				var/word = ckey(L[i])
+			for(var/var/iteration in 1 to surname_found-1)
+				var/word = ckey(L[iteration])
 				if(word)
 					forenames[word] = M
 			//ckeys

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -714,7 +714,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 					surname_found = i
 					break
 			//forenames
-			for(var/var/iteration in 1 to surname_found-1)
+			for(var/iteration in 1 to surname_found-1)
 				var/word = ckey(L[iteration])
 				if(word)
 					forenames[word] = M

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -759,7 +759,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 		I.play_tool_sound(src)
 		if(I.use_tool(src, user, 30))
 			playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
-			for(var/iteration in 0 to framestackamount)
+			for(var/i in 0 to framestackamount)
 				new framestack(get_turf(src))
 			qdel(src)
 			return

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -759,7 +759,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 		I.play_tool_sound(src)
 		if(I.use_tool(src, user, 30))
 			playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
-			for(var/i = 1, i <= framestackamount, i++)
+			for(var/iteration in 0 to framestackamount)
 				new framestack(get_turf(src))
 			qdel(src)
 			return

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -18,9 +18,9 @@
 	gland_types = shuffle(gland_types)
 	gland_colors = new/list(gland_types.len)
 	amounts = new/list(gland_types.len)
-	for(var/i=1,i<=gland_types.len,i++)
-		gland_colors[i] = random_color()
-		amounts[i] = rand(1,5)
+	for(var/iteration in 1 to gland_types.len)
+		gland_colors[iteration] = random_color()
+		amounts[iteration] = rand(1,5)
 
 /obj/machinery/abductor/gland_dispenser/ui_status(mob/user)
 	if(!isabductor(user) && !isobserver(user))
@@ -39,7 +39,7 @@
 /obj/machinery/abductor/gland_dispenser/ui_data(mob/user)
 	var/list/data = list()
 	data["glands"] = list()
-	for(var/gland_number=1,gland_number<=gland_colors.len,gland_number++)
+	for(var/gland_number in 1 to gland_colors.len)
 		var/list/gland_information = list(
 			"color" = gland_colors[gland_number],
 			"amount" = amounts[gland_number],
@@ -65,9 +65,9 @@
 	if(istype(W, /obj/item/organ/heart/gland))
 		if(!user.transferItemToLoc(W, src))
 			return
-		for(var/i=1,i<=gland_colors.len,i++)
-			if(gland_types[i] == W.type)
-				amounts[i]++
+		for(var/iteration in 1 to gland_colors.len)
+			if(gland_types[iteration] == W.type)
+				amounts[iteration]++
 	else
 		return ..()
 

--- a/code/modules/antagonists/abductor/machinery/dispenser.dm
+++ b/code/modules/antagonists/abductor/machinery/dispenser.dm
@@ -18,9 +18,9 @@
 	gland_types = shuffle(gland_types)
 	gland_colors = new/list(gland_types.len)
 	amounts = new/list(gland_types.len)
-	for(var/iteration in 1 to gland_types.len)
-		gland_colors[iteration] = random_color()
-		amounts[iteration] = rand(1,5)
+	for(var/i in 1 to gland_types.len)
+		gland_colors[i] = random_color()
+		amounts[i] = rand(1,5)
 
 /obj/machinery/abductor/gland_dispenser/ui_status(mob/user)
 	if(!isabductor(user) && !isobserver(user))
@@ -65,9 +65,9 @@
 	if(istype(W, /obj/item/organ/heart/gland))
 		if(!user.transferItemToLoc(W, src))
 			return
-		for(var/iteration in 1 to gland_colors.len)
-			if(gland_types[iteration] == W.type)
-				amounts[iteration]++
+		for(var/i in 1 to gland_colors.len)
+			if(gland_types[i] == W.type)
+				amounts[i]++
 	else
 		return ..()
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -413,7 +413,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/fire_cascade/proc/fire_cascade(atom/centre,max_range)
 	playsound(get_turf(centre), 'sound/items/welder.ogg', 75, TRUE)
 	var/_range = 1
-	for(var/iteration in 0 to max_range)
+	for(var/i in 0 to max_range)
 		for(var/turf/T in spiral_range_turfs(_range,centre))
 			new /obj/effect/hotspot(T)
 			T.hotspot_expose(700,50,1)

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -413,7 +413,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/fire_cascade/proc/fire_cascade(atom/centre,max_range)
 	playsound(get_turf(centre), 'sound/items/welder.ogg', 75, TRUE)
 	var/_range = 1
-	for(var/i = 0, i <= max_range,i++)
+	for(var/iteration in 0 to max_range)
 		for(var/turf/T in spiral_range_turfs(_range,centre))
 			new /obj/effect/hotspot(T)
 			T.hotspot_expose(700,50,1)

--- a/code/modules/antagonists/gang/handler.dm
+++ b/code/modules/antagonists/gang/handler.dm
@@ -161,7 +161,7 @@ GLOBAL_VAR(families_override_theme)
 			log_game("[gangbanger] was not a human, and thus has lost their gangster role.")
 			replacement_gangsters++
 	if(replacement_gangsters)
-		for(var/j = 0, j < replacement_gangsters, j++)
+		for(var/iteration in 1 to replacement_gangsters)
 			if(!antag_candidates.len)
 				log_game("Unable to find more replacement gangsters. Not all of the gangs will spawn.")
 				break

--- a/code/modules/antagonists/gang/handler.dm
+++ b/code/modules/antagonists/gang/handler.dm
@@ -161,7 +161,7 @@ GLOBAL_VAR(families_override_theme)
 			log_game("[gangbanger] was not a human, and thus has lost their gangster role.")
 			replacement_gangsters++
 	if(replacement_gangsters)
-		for(var/iteration in 1 to replacement_gangsters)
+		for(var/j in 1 to replacement_gangsters)
 			if(!antag_candidates.len)
 				log_game("Unable to find more replacement gangsters. Not all of the gangs will spawn.")
 				break

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -77,8 +77,8 @@
 		start_index = assigned_contracts.len + 1
 
 	// Generate contracts, and find the lowest paying.
-	for(var/index in 1 to to_generate.len)
-		var/datum/syndicate_contract/contract_to_add = new(owner, assigned_targets, to_generate[index])
+	for(var/i in 1 to to_generate.len)
+		var/datum/syndicate_contract/contract_to_add = new(owner, assigned_targets, to_generate[i])
 		var/contract_payout_total = contract_to_add.contract.payout + contract_to_add.contract.payout_bonus
 
 		assigned_targets.Add(contract_to_add.contract.target)

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -77,8 +77,8 @@
 		start_index = assigned_contracts.len + 1
 
 	// Generate contracts, and find the lowest paying.
-	for (var/i = 1; i <= to_generate.len; i++)
-		var/datum/syndicate_contract/contract_to_add = new(owner, assigned_targets, to_generate[i])
+	for(var/index in 1 to to_generate.len)
+		var/datum/syndicate_contract/contract_to_add = new(owner, assigned_targets, to_generate[index])
 		var/contract_payout_total = contract_to_add.contract.payout + contract_to_add.contract.payout_bonus
 
 		assigned_targets.Add(contract_to_add.contract.target)

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -35,7 +35,7 @@
 		return BRUTELOSS
 	else//didnt realize this suicide act existed (was in miscellaneous.dm) and didnt want to remove it, so made it a 50/50 chance. Why not!
 		user.visible_message(span_suicide("[user] is bashing [user.p_their()] own head in with [src]! Ain't that a kick in the head?"))
-		for(var/i = 0, i < 3, i++)
+		for(var/iteration in 1 to 3)
 			sleep(3)
 			playsound(user, 'sound/weapons/genhit2.ogg', 50, TRUE)
 		return(BRUTELOSS)

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -35,7 +35,7 @@
 		return BRUTELOSS
 	else//didnt realize this suicide act existed (was in miscellaneous.dm) and didnt want to remove it, so made it a 50/50 chance. Why not!
 		user.visible_message(span_suicide("[user] is bashing [user.p_their()] own head in with [src]! Ain't that a kick in the head?"))
-		for(var/iteration in 1 to 3)
+		for(var/i in 1 to 3)
 			sleep(3)
 			playsound(user, 'sound/weapons/genhit2.ogg', 50, TRUE)
 		return(BRUTELOSS)

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -18,7 +18,7 @@
 /datum/round_event/electrical_storm/start()
 	var/list/epicentreList = list()
 
-	for(var/i=1, i <= lightsoutAmount, i++)
+	for(var/iteration in 1 to lightsoutAmount)
 		var/turf/T = find_safe_turf()
 		if(istype(T))
 			epicentreList += T

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -18,7 +18,7 @@
 /datum/round_event/electrical_storm/start()
 	var/list/epicentreList = list()
 
-	for(var/iteration in 1 to lightsoutAmount)
+	for(var/i in 1 to lightsoutAmount)
 		var/turf/T = find_safe_turf()
 		if(istype(T))
 			epicentreList += T

--- a/code/modules/events/fake_virus.dm
+++ b/code/modules/events/fake_virus.dm
@@ -14,7 +14,7 @@
 	//first we do hard status effect victims
 	var/defacto_min = min(3, LAZYLEN(fake_virus_victims))
 	if(defacto_min)// event will hit 1-3 people by default, but will do 1-2 or just 1 if only those many candidates are available
-		for(var/iteration in 1 to rand(1,defacto_min))
+		for(var/i in 1 to rand(1,defacto_min))
 			var/mob/living/carbon/human/hypochondriac = pick(fake_virus_victims)
 			hypochondriac.apply_status_effect(STATUS_EFFECT_FAKE_VIRUS)
 			fake_virus_victims -= hypochondriac
@@ -23,7 +23,7 @@
 	//then we do light one-message victims who simply cough or whatever once (have to repeat the process since the last operation modified our candidates list)
 	defacto_min = min(5, LAZYLEN(fake_virus_victims))
 	if(defacto_min)
-		for(var/iteration in 1 to rand(1,defacto_min))
+		for(var/i in 1 to rand(1,defacto_min))
 			var/mob/living/carbon/human/onecoughman = pick(fake_virus_victims)
 			if(prob(25))//1/4 odds to get a spooky message instead of coughing out loud
 				addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, onecoughman, span_warning("[pick("Your head hurts.", "Your head pounds.")]")), rand(30,150))

--- a/code/modules/events/fake_virus.dm
+++ b/code/modules/events/fake_virus.dm
@@ -14,7 +14,7 @@
 	//first we do hard status effect victims
 	var/defacto_min = min(3, LAZYLEN(fake_virus_victims))
 	if(defacto_min)// event will hit 1-3 people by default, but will do 1-2 or just 1 if only those many candidates are available
-		for(var/i=1; i<=rand(1,defacto_min); i++)
+		for(var/iteration in 1 to rand(1,defacto_min))
 			var/mob/living/carbon/human/hypochondriac = pick(fake_virus_victims)
 			hypochondriac.apply_status_effect(STATUS_EFFECT_FAKE_VIRUS)
 			fake_virus_victims -= hypochondriac
@@ -23,7 +23,7 @@
 	//then we do light one-message victims who simply cough or whatever once (have to repeat the process since the last operation modified our candidates list)
 	defacto_min = min(5, LAZYLEN(fake_virus_victims))
 	if(defacto_min)
-		for(var/i=1; i<=rand(1,defacto_min); i++)
+		for(var/iteration in 1 to rand(1,defacto_min))
 			var/mob/living/carbon/human/onecoughman = pick(fake_virus_victims)
 			if(prob(25))//1/4 odds to get a spooky message instead of coughing out loud
 				addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, onecoughman, span_warning("[pick("Your head hurts.", "Your head pounds.")]")), rand(30,150))

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -165,7 +165,7 @@
 			if(ANTIDOTE_NEEDED)
 				var/obj/effect/mob_spawn/human/corpse/assistant/infected_assistant = pick(/obj/effect/mob_spawn/human/corpse/assistant/beesease_infection, /obj/effect/mob_spawn/human/corpse/assistant/brainrot_infection, /obj/effect/mob_spawn/human/corpse/assistant/spanishflu_infection)
 				var/turf/T
-				for(var/iteration in 1 to 10)
+				for(var/i in 1 to 10)
 					if(prob(15))
 						shuttle_spawns.Add(/obj/item/reagent_containers/glass/bottle)
 					else if(prob(15))

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -165,7 +165,7 @@
 			if(ANTIDOTE_NEEDED)
 				var/obj/effect/mob_spawn/human/corpse/assistant/infected_assistant = pick(/obj/effect/mob_spawn/human/corpse/assistant/beesease_infection, /obj/effect/mob_spawn/human/corpse/assistant/brainrot_infection, /obj/effect/mob_spawn/human/corpse/assistant/spanishflu_infection)
 				var/turf/T
-				for(var/i=0, i<10, i++)
+				for(var/iteration in 1 to 10)
 					if(prob(15))
 						shuttle_spawns.Add(/obj/item/reagent_containers/glass/bottle)
 					else if(prob(15))

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_EMPTY(all_wormholes) // So we can pick wormholes to teleport to
 		if(is_station_level(T.z))
 			pick_turfs += T
 
-	for(var/iteration in 1 to number_of_wormholes)
+	for(var/i in 1 to number_of_wormholes)
 		var/turf/T = pick(pick_turfs)
 		wormholes += new /obj/effect/portal/wormhole(T, 0, null, FALSE)
 

--- a/code/modules/events/wormholes.dm
+++ b/code/modules/events/wormholes.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_EMPTY(all_wormholes) // So we can pick wormholes to teleport to
 		if(is_station_level(T.z))
 			pick_turfs += T
 
-	for(var/i = 1, i <= number_of_wormholes, i++)
+	for(var/iteration in 1 to number_of_wormholes)
 		var/turf/T = pick(pick_turfs)
 		wormholes += new /obj/effect/portal/wormhole(T, 0, null, FALSE)
 

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -25,7 +25,7 @@
 
 /datum/chemical_reaction/food/tofu/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/food/tofu(location)
 	return
 
@@ -43,7 +43,7 @@
 
 /datum/chemical_reaction/food/chocolate_bar/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/food/chocolatebar(location)
 	return
 
@@ -54,7 +54,7 @@
 
 /datum/chemical_reaction/food/chocolate_bar2/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/food/chocolatebar(location)
 	return
 
@@ -64,7 +64,7 @@
 
 /datum/chemical_reaction/food/chocolate_bar3/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/food/chocolatebar(location)
 	return
 
@@ -99,7 +99,7 @@
 
 /datum/chemical_reaction/food/cheesewheel/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/food/cheese/wheel(location)
 
 /datum/chemical_reaction/food/synthmeat
@@ -109,7 +109,7 @@
 
 /datum/chemical_reaction/food/synthmeat/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/food/meat/slab/synthmeat(location)
 
 /datum/chemical_reaction/food/hot_ramen
@@ -139,7 +139,7 @@
 
 /datum/chemical_reaction/food/dough/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/food/dough(location)
 
 /datum/chemical_reaction/food/cakebatter
@@ -149,7 +149,7 @@
 
 /datum/chemical_reaction/food/cakebatter/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/food/cakebatter(location)
 
 /datum/chemical_reaction/food/cakebatter/vegan

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -25,7 +25,7 @@
 
 /datum/chemical_reaction/food/tofu/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/food/tofu(location)
 	return
 
@@ -43,7 +43,7 @@
 
 /datum/chemical_reaction/food/chocolate_bar/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/food/chocolatebar(location)
 	return
 
@@ -54,7 +54,7 @@
 
 /datum/chemical_reaction/food/chocolate_bar2/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/food/chocolatebar(location)
 	return
 
@@ -64,7 +64,7 @@
 
 /datum/chemical_reaction/food/chocolate_bar3/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/food/chocolatebar(location)
 	return
 
@@ -99,7 +99,7 @@
 
 /datum/chemical_reaction/food/cheesewheel/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/food/cheese/wheel(location)
 
 /datum/chemical_reaction/food/synthmeat
@@ -109,7 +109,7 @@
 
 /datum/chemical_reaction/food/synthmeat/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/food/meat/slab/synthmeat(location)
 
 /datum/chemical_reaction/food/hot_ramen
@@ -139,7 +139,7 @@
 
 /datum/chemical_reaction/food/dough/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/food/dough(location)
 
 /datum/chemical_reaction/food/cakebatter
@@ -149,7 +149,7 @@
 
 /datum/chemical_reaction/food/cakebatter/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/food/cakebatter(location)
 
 /datum/chemical_reaction/food/cakebatter/vegan

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -171,7 +171,7 @@
 		if(prob(getYield() * 20))
 			seed_count++
 		var/output_loc = parent.Adjacent(user) ? user.loc : parent.loc //needed for TK
-		for(var/iteration in 1 to seed_count)
+		for(var/i  in 1 to seed_count)
 			var/obj/item/seeds/replicapod/harvestseeds = src.Copy()
 			result.Add(harvestseeds)
 			harvestseeds.forceMove(output_loc)

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -171,7 +171,7 @@
 		if(prob(getYield() * 20))
 			seed_count++
 		var/output_loc = parent.Adjacent(user) ? user.loc : parent.loc //needed for TK
-		for(var/i=0,i<seed_count,i++)
+		for(var/iteration in 1 to seed_count)
 			var/obj/item/seeds/replicapod/harvestseeds = src.Copy()
 			result.Add(harvestseeds)
 			harvestseeds.forceMove(output_loc)

--- a/code/modules/mapping/space_management/space_transition.dm
+++ b/code/modules/mapping/space_management/space_transition.dm
@@ -68,10 +68,10 @@
 	var/list/point_grid[conf_set_len*2+1][conf_set_len*2+1]
 	var/list/grid = list()
 	var/datum/space_transition_point/P
-	for(var/i = 1, i<=conf_set_len*2+1, i++)
-		for(var/j = 1, j<=conf_set_len*2+1, j++)
-			P = new/datum/space_transition_point(i,j, point_grid)
-			point_grid[i][j] = P
+	for(var/iteration_x in 1 to conf_set_len*2+1)
+		for(var/iteration_y in 1 to conf_set_len*2+1)
+			P = new/datum/space_transition_point(iteration_x, iteration_y, point_grid)
+			point_grid[iteration_x][iteration_y] = P
 			grid.Add(P)
 	for(var/datum/space_transition_point/pnt in grid)
 		pnt.set_neigbours(point_grid)
@@ -125,7 +125,7 @@
 				S.destination_x = x_pos_transition[side] == 1 ? S.x : x_pos_transition[side]
 				S.destination_y = y_pos_transition[side] == 1 ? S.y : y_pos_transition[side]
 				S.destination_z = zdestination
-				
+
 				// Mirage border code
 				var/mirage_dir
 				if(S.x == 1 + TRANSITIONEDGE)

--- a/code/modules/mapping/space_management/space_transition.dm
+++ b/code/modules/mapping/space_management/space_transition.dm
@@ -68,10 +68,10 @@
 	var/list/point_grid[conf_set_len*2+1][conf_set_len*2+1]
 	var/list/grid = list()
 	var/datum/space_transition_point/P
-	for(var/iteration_x in 1 to conf_set_len*2+1)
-		for(var/iteration_y in 1 to conf_set_len*2+1)
-			P = new/datum/space_transition_point(iteration_x, iteration_y, point_grid)
-			point_grid[iteration_x][iteration_y] = P
+	for(var/x in 1 to conf_set_len*2+1)
+		for(var/y in 1 to conf_set_len*2+1)
+			P = new/datum/space_transition_point(x, y, point_grid)
+			point_grid[x][y] = P
 			grid.Add(P)
 	for(var/datum/space_transition_point/pnt in grid)
 		pnt.set_neigbours(point_grid)

--- a/code/modules/meteors/meteors.dm
+++ b/code/modules/meteors/meteors.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 ///////////////////////////////
 
 /proc/spawn_meteors(number = 10, list/meteortypes)
-	for(var/i = 0; i < number; i++)
+	for(var/iteration in 1 to number)
 		spawn_meteor(meteortypes)
 
 /proc/spawn_meteor(list/meteortypes)

--- a/code/modules/meteors/meteors.dm
+++ b/code/modules/meteors/meteors.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 ///////////////////////////////
 
 /proc/spawn_meteors(number = 10, list/meteortypes)
-	for(var/iteration in 1 to number)
+	for(var/i in 1 to number)
 		spawn_meteor(meteortypes)
 
 /proc/spawn_meteor(list/meteortypes)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -20,7 +20,7 @@
 	. = ..()
 	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
 	code = ""
-	for(var/i = 0, i < codelen, i++)
+	for(var/iteration in 1 to codelen)
 		var/dig = pick(digits)
 		code += dig
 		digits -= dig  //there are never matching digits in the answer

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -20,7 +20,7 @@
 	. = ..()
 	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
 	code = ""
-	for(var/iteration in 1 to codelen)
+	for(var/i in 1 to codelen)
 		var/dig = pick(digits)
 		code += dig
 		digits -= dig  //there are never matching digits in the answer

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -375,7 +375,7 @@
 		if(31 to 60) //Throw object in facing direction
 			var/turf/target = get_turf(loc)
 			var/range = rand(2,I.throw_range)
-			for(var/i = 1; i < range; i++)
+			for(var/iteration in 1 to range-1)
 				var/turf/new_turf = get_step(target, dir)
 				target = new_turf
 				if(new_turf.density)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -375,7 +375,7 @@
 		if(31 to 60) //Throw object in facing direction
 			var/turf/target = get_turf(loc)
 			var/range = rand(2,I.throw_range)
-			for(var/iteration in 1 to range-1)
+			for(var/i in 1 to range-1)
 				var/turf/new_turf = get_step(target, dir)
 				target = new_turf
 				if(new_turf.density)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -414,7 +414,7 @@
 	H.visible_message(span_danger("[H] turns into a pile of sand!"))
 	for(var/obj/item/W in H)
 		H.dropItemToGround(W)
-	for(var/iteration in 1 to rand(3,5))
+	for(var/i in 1 to rand(3,5))
 		new /obj/item/stack/ore/glass(get_turf(H))
 	qdel(H)
 
@@ -446,7 +446,7 @@
 	H.visible_message(span_danger("[H] shatters!"))
 	for(var/obj/item/W in H)
 		H.dropItemToGround(W)
-	for(var/iteration in 1 to rand(3,5))
+	for(var/i in 1 to rand(3,5))
 		new /obj/item/shard(get_turf(H))
 	qdel(H)
 
@@ -1210,7 +1210,7 @@
 	H.visible_message(span_danger("[H] turns into a pile of snow!"))
 	for(var/obj/item/W in H)
 		H.dropItemToGround(W)
-	for(var/iteration in 1 to rand(3,5))
+	for(var/i in 1 to rand(3,5))
 		new /obj/item/stack/sheet/mineral/snow(get_turf(H))
 	new /obj/item/food/grown/carrot(get_turf(H))
 	qdel(H)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -414,7 +414,7 @@
 	H.visible_message(span_danger("[H] turns into a pile of sand!"))
 	for(var/obj/item/W in H)
 		H.dropItemToGround(W)
-	for(var/i=1, i <= rand(3,5), i++)
+	for(var/iteration in 1 to rand(3,5))
 		new /obj/item/stack/ore/glass(get_turf(H))
 	qdel(H)
 
@@ -446,7 +446,7 @@
 	H.visible_message(span_danger("[H] shatters!"))
 	for(var/obj/item/W in H)
 		H.dropItemToGround(W)
-	for(var/i=1, i <= rand(3,5), i++)
+	for(var/iteration in 1 to rand(3,5))
 		new /obj/item/shard(get_turf(H))
 	qdel(H)
 
@@ -1210,7 +1210,7 @@
 	H.visible_message(span_danger("[H] turns into a pile of snow!"))
 	for(var/obj/item/W in H)
 		H.dropItemToGround(W)
-	for(var/i=1, i <= rand(3,5), i++)
+	for(var/iteration in 1 to rand(3,5))
 		new /obj/item/stack/sheet/mineral/snow(get_turf(H))
 	new /obj/item/food/grown/carrot(get_turf(H))
 	qdel(H)

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -41,13 +41,13 @@
 	var/temp
 	if (master)
 		laws.ion.len = master.ion.len
-		for (var/index = 1, index <= master.ion.len, index++)
+		for (var/index in 1 to master.ion.len)
 			temp = master.ion[index]
 			if (length(temp) > 0)
 				laws.ion[index] = temp
 
 		laws.hacked.len = master.hacked.len
-		for (var/index = 1, index <= master.hacked.len, index++)
+		for (var/index in 1 to master.hacked.len)
 			temp = master.hacked[index]
 			if (length(temp) > 0)
 				laws.hacked[index] = temp
@@ -59,13 +59,13 @@
 		laws.zeroth = temp
 
 		laws.inherent.len = master.inherent.len
-		for (var/index = 1, index <= master.inherent.len, index++)
+		for (var/index in 1 to master.inherent.len)
 			temp = master.inherent[index]
 			if (length(temp) > 0)
 				laws.inherent[index] = temp
 
 		laws.supplied.len = master.supplied.len
-		for (var/index = 1, index <= master.supplied.len, index++)
+		for (var/index in 1 to master.supplied.len)
 			temp = master.supplied[index]
 			if (length(temp) > 0)
 				laws.supplied[index] = temp

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -253,7 +253,7 @@
 			lawcheck[1] = "No" //Given Law 0's usual nature, it defaults to NOT getting reported. --NeoFite
 		list += {"<A href='byond://?src=[REF(src)];lawc=0'>[lawcheck[1]] 0:</A> <font color='#ff0000'><b>[laws.zeroth]</b></font><BR>"}
 
-	for (var/index = 1, index <= laws.hacked.len, index++)
+	for (var/index in 1 to laws.hacked.len)
 		var/law = laws.hacked[index]
 		if (length(law) > 0)
 			if (!hackedcheck[index])
@@ -261,7 +261,7 @@
 			list += {"<A href='byond://?src=[REF(src)];lawh=[index]'>[hackedcheck[index]] [ion_num()]:</A> <font color='#660000'>[law]</font><BR>"}
 			hackedcheck.len += 1
 
-	for (var/index = 1, index <= laws.ion.len, index++)
+	for (var/index in 1 to laws.ion.len)
 		var/law = laws.ion[index]
 
 		if (length(law) > 0)
@@ -271,7 +271,7 @@
 			ioncheck.len += 1
 
 	var/number = 1
-	for (var/index = 1, index <= laws.inherent.len, index++)
+	for (var/index in 1 to laws.inherent.len)
 		var/law = laws.inherent[index]
 
 		if (length(law) > 0)
@@ -282,7 +282,7 @@
 			list += {"<A href='byond://?src=[REF(src)];lawc=[number]'>[lawcheck[number+1]] [number]:</A> [law]<BR>"}
 			number++
 
-	for (var/index = 1, index <= laws.supplied.len, index++)
+	for (var/index in 1 to laws.supplied.len)
 		var/law = laws.supplied[index]
 		if (length(law) > 0)
 			lawcheck.len += 1

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -531,8 +531,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 	var/step_count = move_speed ? move_speed : base_speed //If a value is passed into move_speed, use that instead of the default speed var.
 
 	if(step_count >= 1 && tries < BOT_STEP_MAX_RETRIES)
-		for(var/step_number = 0, step_number < step_count,step_number++)
-			addtimer(CALLBACK(src, .proc/bot_step), BOT_STEP_DELAY*step_number)
+		for(var/step_number in 1 to step_count)
+			addtimer(CALLBACK(src, .proc/bot_step), BOT_STEP_DELAY*(step_number-1))
 	else
 		return FALSE
 	return TRUE

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -177,7 +177,7 @@
 			var/new_powerlevel = round(powerlevel / 4)
 			var/turf/drop_loc = drop_location()
 
-			for(var/i=1,i<=4,i++)
+			for(var/iteration in 1 to 4)
 				var/child_colour
 				if(mutation_chance >= 100)
 					child_colour = "rainbow"
@@ -190,7 +190,7 @@
 				if(ckey)
 					M.set_nutrition(new_nutrition) //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
 				M.powerlevel = new_powerlevel
-				if(i != 1)
+				if(iteration != 1)
 					step_away(M,src)
 				M.set_friends(Friends)
 				babies += M

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -177,7 +177,7 @@
 			var/new_powerlevel = round(powerlevel / 4)
 			var/turf/drop_loc = drop_location()
 
-			for(var/iteration in 1 to 4)
+			for(var/i in 1 to 4)
 				var/child_colour
 				if(mutation_chance >= 100)
 					child_colour = "rainbow"
@@ -190,7 +190,7 @@
 				if(ckey)
 					M.set_nutrition(new_nutrition) //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
 				M.powerlevel = new_powerlevel
-				if(iteration != 1)
+				if(i != 1)
 					step_away(M,src)
 				M.set_friends(Friends)
 				babies += M

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -222,7 +222,7 @@
 	if(reproduce)
 		var/number = pick(14;2,3,4) //reproduce (has a small chance of producing 3 or 4 offspring)
 		var/list/babies = list()
-		for(var/i=1,i<=number,i++)
+		for(var/iteration in 1 to number)
 			var/mob/living/simple_animal/slime/M = new/mob/living/simple_animal/slime(loc)
 			M.set_nutrition(round(nutrition/number))
 			step_away(M,src)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -222,7 +222,7 @@
 	if(reproduce)
 		var/number = pick(14;2,3,4) //reproduce (has a small chance of producing 3 or 4 offspring)
 		var/list/babies = list()
-		for(var/iteration in 1 to number)
+		for(var/i in 1 to number)
 			var/mob/living/simple_animal/slime/M = new/mob/living/simple_animal/slime(loc)
 			M.set_nutrition(round(nutrition/number))
 			step_away(M,src)

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -406,7 +406,7 @@
 		return
 	flickering = TRUE
 	if(on && status == LIGHT_OK)
-		for(var/iteration in 1 to amount)
+		for(var/i in 1 to amount)
 			if(status != LIGHT_OK)
 				break
 			on = !on

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -406,7 +406,7 @@
 		return
 	flickering = TRUE
 	if(on && status == LIGHT_OK)
-		for(var/i = 0; i < amount; i++)
+		for(var/iteration in 1 to amount)
 			if(status != LIGHT_OK)
 				break
 			on = !on

--- a/code/modules/procedural_mapping/mapGenerator.dm
+++ b/code/modules/procedural_mapping/mapGenerator.dm
@@ -69,13 +69,13 @@
 	if(bigZ % 2 == 0)
 		offByOneOffset = 0
 
-	for(var/i = lilZ, i <= bigZ+offByOneOffset, i++)
+	for(var/iteration in lilZ to bigZ+offByOneOffset)
 		var/theRadius = radius
-		if(i != sphereMagic)
-			theRadius = max(radius/max((2*abs(sphereMagic-i)),1),1)
+		if(iteration != sphereMagic)
+			theRadius = max(radius/max((2*abs(sphereMagic-iteration)),1),1)
 
 
-		map |= circle_range(locate(centerX,centerY,i),theRadius)
+		map |= circle_range(locate(centerX,centerY,iteration),theRadius)
 
 
 	return map

--- a/code/modules/procedural_mapping/mapGenerator.dm
+++ b/code/modules/procedural_mapping/mapGenerator.dm
@@ -69,13 +69,13 @@
 	if(bigZ % 2 == 0)
 		offByOneOffset = 0
 
-	for(var/iteration in lilZ to bigZ+offByOneOffset)
+	for(var/i in lilZ to bigZ+offByOneOffset)
 		var/theRadius = radius
-		if(iteration != sphereMagic)
-			theRadius = max(radius/max((2*abs(sphereMagic-iteration)),1),1)
+		if(i != sphereMagic)
+			theRadius = max(radius/max((2*abs(sphereMagic-i)),1),1)
 
 
-		map |= circle_range(locate(centerX,centerY,iteration),theRadius)
+		map |= circle_range(locate(centerX,centerY,i),theRadius)
 
 
 	return map

--- a/code/modules/procedural_mapping/mapGenerators/cellular.dm
+++ b/code/modules/procedural_mapping/mapGenerators/cellular.dm
@@ -75,7 +75,7 @@
 					value += edge_value
 					continue
 			value += old_state[n_x][n_y]
-	value -= old_state[y][y]
+	value -= old_state[x][y]
 
 	if(value in b_rule)
 		return 1

--- a/code/modules/procedural_mapping/mapGenerators/cellular.dm
+++ b/code/modules/procedural_mapping/mapGenerators/cellular.dm
@@ -30,10 +30,10 @@
 
 /datum/map_generator/ca/proc/initialize()
 	old_state = new/list(width)
-	for(var/i = 1,i<=width,i++)
-		old_state[i] = new/list(height)
-		for(var/j = 1,j<=height,j++)
-			old_state[i][j] = rand(0,1)
+	for(var/iteration_x in 1 to width)
+		old_state[iteration_x] = new/list(height)
+		for(var/iteration_y in 1 to height)
+			old_state[iteration_x][iteration_y] = rand(0,1)
 
 	current_state = old_state.Copy()
 
@@ -42,25 +42,25 @@
 	//Maybe some less basic implemetation later, but this is just simple admin tool
 	initialize()
 
-	for(var/generation = 0,generation<iterations,generation++)
-		for(var/i = 1,i<=width,i++)
-			for(var/j = 1,j<=height,j++)
-				current_state[i][j] = apply_rule(i,j)
+	for(var/generation in 1 to iterations)
+		for(var/iteration_x in 1 to width)
+			for(var/iteration_y in 1 to height)
+				current_state[iteration_x][iteration_y] = apply_rule(iteration_x, iteration_y)
 		//copy state over
 		old_state = current_state.Copy()
 
-	for(var/i=1,i<=width,i++)
-		for(var/j=1,j<=height,j++)
-			var/turf/T = locate(start.x+i-1,start.y+j-1,start.z)
+	for(var/iteration_x in 1 to width)
+		for(var/iteration_y in 1 to height)
+			var/turf/T = locate(start.x+iteration_x-1,start.y+iteration_y-1,start.z)
 			if(T)
-				T.ChangeTurf(type_map[current_state[i][j]+1])
+				T.ChangeTurf(type_map[current_state[iteration_x][iteration_y]+1])
 
-/datum/map_generator/ca/proc/apply_rule(i,j)
+/datum/map_generator/ca/proc/apply_rule(index_x, index_y)
 	var/value = 0
-	for(var/dx=-1,dx<=1,dx++)
-		for(var/dy=-1,dy<=1,dy++)
-			var/n_x = i+dx
-			var/n_y = j+dy
+	for(var/dist_x in -1 to 1)
+		for(var/dist_y in -1 to 1)
+			var/n_x = index_x+dist_x
+			var/n_y = index_y+dist_y
 			if(n_x < 1 || n_x > width || n_y <1 || n_y > height)
 				if(loop_edges)
 					if(n_x < 1)
@@ -75,12 +75,12 @@
 					value += edge_value
 					continue
 			value += old_state[n_x][n_y]
-	value -= old_state[i][j]
+	value -= old_state[index_y][index_y]
 
 	if(value in b_rule)
 		return 1
 	if(value in s_rule)
-		return old_state[i][j]
+		return old_state[index_x][index_y]
 	return 0
 
 /datum/map_generator/ca/caves

--- a/code/modules/procedural_mapping/mapGenerators/cellular.dm
+++ b/code/modules/procedural_mapping/mapGenerators/cellular.dm
@@ -30,10 +30,10 @@
 
 /datum/map_generator/ca/proc/initialize()
 	old_state = new/list(width)
-	for(var/iteration_x in 1 to width)
-		old_state[iteration_x] = new/list(height)
-		for(var/iteration_y in 1 to height)
-			old_state[iteration_x][iteration_y] = rand(0,1)
+	for(var/x in 1 to width)
+		old_state[x] = new/list(height)
+		for(var/y in 1 to height)
+			old_state[x][y] = rand(0,1)
 
 	current_state = old_state.Copy()
 
@@ -43,24 +43,24 @@
 	initialize()
 
 	for(var/generation in 1 to iterations)
-		for(var/iteration_x in 1 to width)
-			for(var/iteration_y in 1 to height)
-				current_state[iteration_x][iteration_y] = apply_rule(iteration_x, iteration_y)
+		for(var/x in 1 to width)
+			for(var/y in 1 to height)
+				current_state[x][y] = apply_rule(x, y)
 		//copy state over
 		old_state = current_state.Copy()
 
-	for(var/iteration_x in 1 to width)
-		for(var/iteration_y in 1 to height)
-			var/turf/T = locate(start.x+iteration_x-1,start.y+iteration_y-1,start.z)
+	for(var/x in 1 to width)
+		for(var/y in 1 to height)
+			var/turf/T = locate(start.x+x-1,start.y+y-1,start.z)
 			if(T)
-				T.ChangeTurf(type_map[current_state[iteration_x][iteration_y]+1])
+				T.ChangeTurf(type_map[current_state[x][y]+1])
 
-/datum/map_generator/ca/proc/apply_rule(index_x, index_y)
+/datum/map_generator/ca/proc/apply_rule(x, y)
 	var/value = 0
 	for(var/dist_x in -1 to 1)
 		for(var/dist_y in -1 to 1)
-			var/n_x = index_x+dist_x
-			var/n_y = index_y+dist_y
+			var/n_x = x+dist_x
+			var/n_y = y+dist_y
 			if(n_x < 1 || n_x > width || n_y <1 || n_y > height)
 				if(loop_edges)
 					if(n_x < 1)
@@ -75,12 +75,12 @@
 					value += edge_value
 					continue
 			value += old_state[n_x][n_y]
-	value -= old_state[index_y][index_y]
+	value -= old_state[y][y]
 
 	if(value in b_rule)
 		return 1
 	if(value in s_rule)
-		return old_state[index_x][index_y]
+		return old_state[x][y]
 	return 0
 
 /datum/map_generator/ca/caves

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -75,7 +75,7 @@
 		stack_trace("Tried loading unsupported ammocasing type [load_type] into ammo box [type].")
 		return
 
-	for(var/i = max(1, stored_ammo.len), i <= max_ammo, i++)
+	for(var/iteration in max(1, stored_ammo.len) to max_ammo)
 		stored_ammo += new round_check(src)
 	update_ammo_count()
 

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -75,7 +75,7 @@
 		stack_trace("Tried loading unsupported ammocasing type [load_type] into ammo box [type].")
 		return
 
-	for(var/iteration in max(1, stored_ammo.len) to max_ammo)
+	for(var/i in max(1, stored_ammo.len) to max_ammo)
 		stored_ammo += new round_check(src)
 	update_ammo_count()
 

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -55,7 +55,7 @@
 	if(!load_type)
 		load_type = ammo_type
 
-	for(var/iteration in 1 to max_ammo)
+	for(var/i in 1 to max_ammo)
 		if(!give_round(new load_type(src)))
 			break
 	update_appearance()

--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -55,7 +55,7 @@
 	if(!load_type)
 		load_type = ammo_type
 
-	for(var/i = 1, i <= max_ammo, i++)
+	for(var/iteration in 1 to max_ammo)
 		if(!give_round(new load_type(src)))
 			break
 	update_appearance()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -98,10 +98,10 @@
 
 /obj/item/gun/energy/proc/update_ammo_types()
 	var/obj/item/ammo_casing/energy/shot
-	for (var/i = 1, i <= ammo_type.len, i++)
-		var/shottype = ammo_type[i]
+	for (var/index in 1 to ammo_type.len)
+		var/shottype = ammo_type[index]
 		shot = new shottype(src)
-		ammo_type[i] = shot
+		ammo_type[index] = shot
 	shot = ammo_type[select]
 	fire_sound = shot.fire_sound
 	fire_delay = shot.delay

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -98,10 +98,10 @@
 
 /obj/item/gun/energy/proc/update_ammo_types()
 	var/obj/item/ammo_casing/energy/shot
-	for (var/index in 1 to ammo_type.len)
-		var/shottype = ammo_type[index]
+	for (var/i in 1 to ammo_type.len)
+		var/shottype = ammo_type[i]
 		shot = new shottype(src)
-		ammo_type[index] = shot
+		ammo_type[i] = shot
 	shot = ammo_type[select]
 	fire_sound = shot.fire_sound
 	fire_delay = shot.delay

--- a/code/modules/reagents/chem_splash.dm
+++ b/code/modules/reagents/chem_splash.dm
@@ -37,9 +37,9 @@
 		var/list/viewable = view(affected_range, epicenter)
 
 		var/list/accessible = list(epicenter)
-		for(var/iteration in 1 to affected_range)
+		for(var/i in 1 to affected_range)
 			var/list/turflist = list()
-			for(var/turf/T in (orange(iteration, epicenter) - orange(iteration-1, epicenter)))
+			for(var/turf/T in (orange(i, epicenter) - orange(i-1, epicenter)))
 				turflist |= T
 			for(var/turf/T in turflist)
 				if(!(get_dir(T,epicenter) in GLOB.cardinals) && (abs(T.x - epicenter.x) == abs(T.y - epicenter.y) ))

--- a/code/modules/reagents/chem_splash.dm
+++ b/code/modules/reagents/chem_splash.dm
@@ -37,9 +37,9 @@
 		var/list/viewable = view(affected_range, epicenter)
 
 		var/list/accessible = list(epicenter)
-		for(var/i=1; i<=affected_range; i++)
+		for(var/iteration in 1 to affected_range)
 			var/list/turflist = list()
-			for(var/turf/T in (orange(i, epicenter) - orange(i-1, epicenter)))
+			for(var/turf/T in (orange(iteration, epicenter) - orange(iteration-1, epicenter)))
 				turflist |= T
 			for(var/turf/T in turflist)
 				if(!(get_dir(T,epicenter) in GLOB.cardinals) && (abs(T.x - epicenter.x) == abs(T.y - epicenter.y) ))

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -362,8 +362,8 @@
 				if(STRB)
 					drop_threshold = STRB.max_items - bottle.contents.len
 					target_loc = bottle
-			for(var/i = 0; i < amount; i++)
-				if(i < drop_threshold)
+			for(var/iteration in 1 to amount)
+				if(iteration-1 < drop_threshold)
 					P = new/obj/item/reagent_containers/pill(target_loc)
 				else
 					P = new/obj/item/reagent_containers/pill(drop_location())
@@ -379,7 +379,7 @@
 			return TRUE
 		if(item_type == "patch")
 			var/obj/item/reagent_containers/pill/patch/P
-			for(var/i = 0; i < amount; i++)
+			for(var/iteration in 1 to amount)
 				P = new/obj/item/reagent_containers/pill/patch(drop_location())
 				P.name = trim("[name] patch")
 				adjust_item_drop_location(P)
@@ -387,7 +387,7 @@
 			return TRUE
 		if(item_type == "bottle")
 			var/obj/item/reagent_containers/glass/bottle/P
-			for(var/i = 0; i < amount; i++)
+			for(var/iteration in 1 to amount)
 				P = new/obj/item/reagent_containers/glass/bottle(drop_location())
 				P.name = trim("[name] bottle")
 				adjust_item_drop_location(P)
@@ -395,7 +395,7 @@
 			return TRUE
 		if(item_type == "condimentPack")
 			var/obj/item/reagent_containers/food/condiment/pack/P
-			for(var/i = 0; i < amount; i++)
+			for(var/iteration in 1 to amount)
 				P = new/obj/item/reagent_containers/food/condiment/pack(drop_location())
 				P.originalname = name
 				P.name = trim("[name] pack")
@@ -404,7 +404,7 @@
 			return TRUE
 		if(item_type == "condimentBottle")
 			var/obj/item/reagent_containers/food/condiment/P
-			for(var/i = 0; i < amount; i++)
+			for(var/iteration in 1 to amount)
 				P = new/obj/item/reagent_containers/food/condiment(drop_location())
 				if (style)
 					apply_condi_style(P, style)

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -362,8 +362,8 @@
 				if(STRB)
 					drop_threshold = STRB.max_items - bottle.contents.len
 					target_loc = bottle
-			for(var/iteration in 1 to amount)
-				if(iteration-1 < drop_threshold)
+			for(var/i in 1 to amount)
+				if(i-1 < drop_threshold)
 					P = new/obj/item/reagent_containers/pill(target_loc)
 				else
 					P = new/obj/item/reagent_containers/pill(drop_location())
@@ -379,7 +379,7 @@
 			return TRUE
 		if(item_type == "patch")
 			var/obj/item/reagent_containers/pill/patch/P
-			for(var/iteration in 1 to amount)
+			for(var/i in 1 to amount)
 				P = new/obj/item/reagent_containers/pill/patch(drop_location())
 				P.name = trim("[name] patch")
 				adjust_item_drop_location(P)
@@ -387,7 +387,7 @@
 			return TRUE
 		if(item_type == "bottle")
 			var/obj/item/reagent_containers/glass/bottle/P
-			for(var/iteration in 1 to amount)
+			for(var/i in 1 to amount)
 				P = new/obj/item/reagent_containers/glass/bottle(drop_location())
 				P.name = trim("[name] bottle")
 				adjust_item_drop_location(P)
@@ -395,7 +395,7 @@
 			return TRUE
 		if(item_type == "condimentPack")
 			var/obj/item/reagent_containers/food/condiment/pack/P
-			for(var/iteration in 1 to amount)
+			for(var/i in 1 to amount)
 				P = new/obj/item/reagent_containers/food/condiment/pack(drop_location())
 				P.originalname = name
 				P.name = trim("[name] pack")
@@ -404,7 +404,7 @@
 			return TRUE
 		if(item_type == "condimentBottle")
 			var/obj/item/reagent_containers/food/condiment/P
-			for(var/iteration in 1 to amount)
+			for(var/i in 1 to amount)
 				P = new/obj/item/reagent_containers/food/condiment(drop_location())
 				if (style)
 					apply_condi_style(P, style)

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -258,7 +258,7 @@
 				spawned_mob = new mob_class(get_turf(holder.my_atom))//Spawn our specific mob_class
 			spawned_mob.faction |= mob_faction
 			if(prob(50))
-				for(var/iteration in 1 to rand(1, 3))
+				for(var/j in 1 to rand(1, 3))
 					step(spawned_mob, pick(NORTH,SOUTH,EAST,WEST))
 
 /**

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -258,7 +258,7 @@
 				spawned_mob = new mob_class(get_turf(holder.my_atom))//Spawn our specific mob_class
 			spawned_mob.faction |= mob_faction
 			if(prob(50))
-				for(var/j = 1, j <= rand(1, 3), j++)
+				for(var/iteration in 1 to rand(1, 3))
 					step(spawned_mob, pick(NORTH,SOUTH,EAST,WEST))
 
 /**

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -128,7 +128,7 @@
 
 /datum/chemical_reaction/moon_rock/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		var/obj/item/food/drug/moon_rock/new_rock = new(location)
 		new_rock.pixel_x = rand(-6, 6)
 		new_rock.pixel_y = rand(-6, 6)

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -128,7 +128,7 @@
 
 /datum/chemical_reaction/moon_rock/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		var/obj/item/food/drug/moon_rock/new_rock = new(location)
 		new_rock.pixel_x = rand(-6, 6)
 		new_rock.pixel_y = rand(-6, 6)
@@ -140,7 +140,7 @@
 
 /datum/chemical_reaction/blastoff_ampoule/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration = 1, iteration <= created_volume, iteration++)
+	for(var/iteration in 1 to created_volume)
 		var/obj/item/reagent_containers/glass/blastoff_ampoule/new_ampoule = new(location)
 		new_ampoule.pixel_x = rand(-6, 6)
 		new_ampoule.pixel_y = rand(-6, 6)
@@ -152,7 +152,7 @@
 
 /datum/chemical_reaction/saturnx_glob/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration = 1, iteration <= created_volume, iteration++)
+	for(var/iteration in 1 to created_volume)
 		var/obj/item/food/drug/saturnx/new_glob = new(location)
 		new_glob.pixel_x = rand(-6, 6)
 		new_glob.pixel_y = rand(-6, 6)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -350,7 +350,7 @@
 
 /datum/chemical_reaction/medicine/medsuture/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/stack/medical/suture/medicated(location)
 
 /datum/chemical_reaction/medicine/medmesh
@@ -359,7 +359,7 @@
 
 /datum/chemical_reaction/medicine/medmesh/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/stack/medical/mesh/advanced(location)
 
 /datum/chemical_reaction/medicine/poultice

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -350,7 +350,7 @@
 
 /datum/chemical_reaction/medicine/medsuture/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/stack/medical/suture/medicated(location)
 
 /datum/chemical_reaction/medicine/medmesh
@@ -359,7 +359,7 @@
 
 /datum/chemical_reaction/medicine/medmesh/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/stack/medical/mesh/advanced(location)
 
 /datum/chemical_reaction/medicine/poultice

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -53,7 +53,7 @@
 
 /datum/chemical_reaction/plasma_solidification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/stack/sheet/mineral/plasma(location)
 
 /datum/chemical_reaction/gold_solidification
@@ -64,7 +64,7 @@
 
 /datum/chemical_reaction/gold_solidification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/stack/sheet/mineral/gold(location)
 
 /datum/chemical_reaction/uranium_solidification
@@ -75,7 +75,7 @@
 
 /datum/chemical_reaction/uranium_solidification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/stack/sheet/mineral/uranium(location)
 
 /datum/chemical_reaction/capsaicincondensation
@@ -92,7 +92,7 @@
 
 /datum/chemical_reaction/soapification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/soap/homemade(location)
 
 /datum/chemical_reaction/omegasoapification
@@ -106,7 +106,7 @@
 
 /datum/chemical_reaction/omegasoapification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/soap/omega(location)
 
 /datum/chemical_reaction/candlefication
@@ -118,7 +118,7 @@
 
 /datum/chemical_reaction/candlefication/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/candle(location)
 
 /datum/chemical_reaction/meatification
@@ -129,7 +129,7 @@
 
 /datum/chemical_reaction/meatification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in 1 to created_volume)
+	for(var/i in 1 to created_volume)
 		new /obj/item/food/meat/slab/meatproduct(location)
 	return
 
@@ -559,7 +559,7 @@
 
 /datum/chemical_reaction/corgium/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in rand(1, created_volume) to created_volume) // More lulz.
+	for(var/i in rand(1, created_volume) to created_volume) // More lulz.
 		new /mob/living/simple_animal/pet/dog/corgi(location)
 	..()
 
@@ -598,7 +598,7 @@
 
 /datum/chemical_reaction/butterflium/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/iteration in rand(1, created_volume) to created_volume)
+	for(var/i in rand(1, created_volume) to created_volume)
 		new /mob/living/simple_animal/butterfly(location)
 	..()
 //scream powder

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -53,7 +53,7 @@
 
 /datum/chemical_reaction/plasma_solidification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/stack/sheet/mineral/plasma(location)
 
 /datum/chemical_reaction/gold_solidification
@@ -64,7 +64,7 @@
 
 /datum/chemical_reaction/gold_solidification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/stack/sheet/mineral/gold(location)
 
 /datum/chemical_reaction/uranium_solidification
@@ -75,7 +75,7 @@
 
 /datum/chemical_reaction/uranium_solidification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/stack/sheet/mineral/uranium(location)
 
 /datum/chemical_reaction/capsaicincondensation
@@ -92,7 +92,7 @@
 
 /datum/chemical_reaction/soapification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/soap/homemade(location)
 
 /datum/chemical_reaction/omegasoapification
@@ -106,7 +106,7 @@
 
 /datum/chemical_reaction/omegasoapification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/soap/omega(location)
 
 /datum/chemical_reaction/candlefication
@@ -118,7 +118,7 @@
 
 /datum/chemical_reaction/candlefication/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/candle(location)
 
 /datum/chemical_reaction/meatification
@@ -129,7 +129,7 @@
 
 /datum/chemical_reaction/meatification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/iteration in 1 to created_volume)
 		new /obj/item/food/meat/slab/meatproduct(location)
 	return
 
@@ -559,7 +559,7 @@
 
 /datum/chemical_reaction/corgium/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = rand(1, created_volume), i <= created_volume, i++) // More lulz.
+	for(var/iteration in rand(1, created_volume) to created_volume) // More lulz.
 		new /mob/living/simple_animal/pet/dog/corgi(location)
 	..()
 
@@ -598,7 +598,7 @@
 
 /datum/chemical_reaction/butterflium/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = rand(1, created_volume), i <= created_volume, i++)
+	for(var/iteration in rand(1, created_volume) to created_volume)
 		new /mob/living/simple_animal/butterfly(location)
 	..()
 //scream powder

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -359,10 +359,10 @@
 	var/turf/T2 = get_step(T,turn(direction, -90))
 	var/list/the_targets = list(T,T1,T2)
 
-	for(var/i=1, i<=3, i++) // intialize sprays
+	for(var/iteration in 1 to 3) // intialize sprays
 		if(reagents.total_volume < 1)
 			return
-		..(the_targets[i], user)
+		..(the_targets[iteration], user)
 
 /obj/item/reagent_containers/spray/chemsprayer/bioterror
 	list_reagents = list(/datum/reagent/toxin/sodium_thiopental = 100, /datum/reagent/toxin/coniine = 100, /datum/reagent/toxin/venom = 100, /datum/reagent/consumable/condensedcapsaicin = 100, /datum/reagent/toxin/initropidril = 100, /datum/reagent/toxin/polonium = 100)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -359,10 +359,10 @@
 	var/turf/T2 = get_step(T,turn(direction, -90))
 	var/list/the_targets = list(T,T1,T2)
 
-	for(var/iteration in 1 to 3) // intialize sprays
+	for(var/i in 1 to 3) // intialize sprays
 		if(reagents.total_volume < 1)
 			return
-		..(the_targets[iteration], user)
+		..(the_targets[i], user)
 
 /obj/item/reagent_containers/spray/chemsprayer/bioterror
 	list_reagents = list(/datum/reagent/toxin/sodium_thiopental = 100, /datum/reagent/toxin/coniine = 100, /datum/reagent/toxin/venom = 100, /datum/reagent/consumable/condensedcapsaicin = 100, /datum/reagent/toxin/initropidril = 100, /datum/reagent/toxin/polonium = 100)

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -137,7 +137,7 @@ Burning extracts:
 	var/list/turfs = list()
 	for(var/turf/open/T in range(1,get_turf(user)))
 		turfs += T
-	for(var/iteration in 1 to amount)
+	for(var/i in 1 to amount)
 		var/path = get_random_food()
 		var/obj/item/O = new path(pick(turfs))
 		O.reagents.add_reagent(/datum/reagent/toxin/slimejelly,5) //Oh god it burns
@@ -250,7 +250,7 @@ Burning extracts:
 		var/mob/living/spawned_mob = create_random_mob(get_turf(user), HOSTILE_SPAWN)
 		spawned_mob.faction |= "[REF(user)]"
 		if(prob(50))
-			for(var/iteration in 1 to rand(1, 3))
+			for(var/j in 1 to rand(1, 3))
 				step(spawned_mob, pick(NORTH,SOUTH,EAST,WEST))
 	..()
 

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -137,7 +137,7 @@ Burning extracts:
 	var/list/turfs = list()
 	for(var/turf/open/T in range(1,get_turf(user)))
 		turfs += T
-	for(var/i = 0, i < amount, i++)
+	for(var/iteration in 1 to amount)
 		var/path = get_random_food()
 		var/obj/item/O = new path(pick(turfs))
 		O.reagents.add_reagent(/datum/reagent/toxin/slimejelly,5) //Oh god it burns
@@ -250,7 +250,7 @@ Burning extracts:
 		var/mob/living/spawned_mob = create_random_mob(get_turf(user), HOSTILE_SPAWN)
 		spawned_mob.faction |= "[REF(user)]"
 		if(prob(50))
-			for(var/j = 1, j <= rand(1, 3), j++)
+			for(var/iteration in 1 to rand(1, 3))
 				step(spawned_mob, pick(NORTH,SOUTH,EAST,WEST))
 	..()
 

--- a/code/modules/research/xenobiology/crossbreeding/industrial.dm
+++ b/code/modules/research/xenobiology/crossbreeding/industrial.dm
@@ -42,7 +42,7 @@ Industrial extracts:
 	if(plasmaabsorbed >= plasmarequired)
 		playsound(src, 'sound/effects/attackblob.ogg', 50, TRUE)
 		plasmaabsorbed -= plasmarequired
-		for(var/iteration in 1 to itemamount)
+		for(var/i in 1 to itemamount)
 			do_after_spawn(new itempath(get_turf(src)))
 	else if(IsWorking)
 		playsound(src, 'sound/effects/bubbles.ogg', 5, TRUE)

--- a/code/modules/research/xenobiology/crossbreeding/industrial.dm
+++ b/code/modules/research/xenobiology/crossbreeding/industrial.dm
@@ -42,7 +42,7 @@ Industrial extracts:
 	if(plasmaabsorbed >= plasmarequired)
 		playsound(src, 'sound/effects/attackblob.ogg', 50, TRUE)
 		plasmaabsorbed -= plasmarequired
-		for(var/i = 0, i < itemamount, i++)
+		for(var/iteration in 1 to itemamount)
 			do_after_spawn(new itempath(get_turf(src)))
 	else if(IsWorking)
 		playsound(src, 'sound/effects/bubbles.ogg', 5, TRUE)

--- a/code/modules/research/xenobiology/crossbreeding/selfsustaining.dm
+++ b/code/modules/research/xenobiology/crossbreeding/selfsustaining.dm
@@ -18,7 +18,7 @@ Self-sustaining extracts:
 /obj/item/slimecross/selfsustaining/Initialize(mapload)
 	..()
 	visible_message(span_warning("The [src] shudders, and splits into four smaller extracts."))
-	for(var/i = 0, i < 4, i++)
+	for(var/iteration in 1 to 4)
 		var/obj/item/autoslime/A = new /obj/item/autoslime(src.loc)
 		var/obj/item/slime_extract/X = new extract_type(A)
 		A.extract = X

--- a/code/modules/research/xenobiology/crossbreeding/selfsustaining.dm
+++ b/code/modules/research/xenobiology/crossbreeding/selfsustaining.dm
@@ -18,7 +18,7 @@ Self-sustaining extracts:
 /obj/item/slimecross/selfsustaining/Initialize(mapload)
 	..()
 	visible_message(span_warning("The [src] shudders, and splits into four smaller extracts."))
-	for(var/iteration in 1 to 4)
+	for(var/i in 1 to 4)
 		var/obj/item/autoslime/A = new /obj/item/autoslime(src.loc)
 		var/obj/item/slime_extract/X = new extract_type(A)
 		A.extract = X

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -120,11 +120,11 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		var/datum/turf_reservation/roomReservation = SSmapping.RequestBlockReservation(hotelRoomTemp.width, hotelRoomTemp.height)
 		hotelRoomTempEmpty.load(locate(roomReservation.bottom_left_coords[1], roomReservation.bottom_left_coords[2], roomReservation.bottom_left_coords[3]))
 		var/turfNumber = 1
-		for(var/i=0, i<hotelRoomTemp.width, i++)
-			for(var/j=0, j<hotelRoomTemp.height, j++)
+		for(var/iteration_x in 0 to hotelRoomTemp.width-1)
+			for(var/iteration_y in 0 to hotelRoomTemp.height-1)
 				for(var/atom/movable/A in storedRooms["[roomNumber]"][turfNumber])
 					if(istype(A.loc, /obj/item/abstracthotelstorage))//Don't want to recall something thats been moved
-						A.forceMove(locate(roomReservation.bottom_left_coords[1] + i, roomReservation.bottom_left_coords[2] + j, roomReservation.bottom_left_coords[3]))
+						A.forceMove(locate(roomReservation.bottom_left_coords[1] + iteration_x, roomReservation.bottom_left_coords[2] + iteration_y, roomReservation.bottom_left_coords[3]))
 				turfNumber++
 		for(var/obj/item/abstracthotelstorage/S in storageTurf)
 			if((S.roomNumber == roomNumber) && (S.parentSphere == src))
@@ -165,9 +165,9 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	if(activeRooms.len)
 		for(var/x in activeRooms)
 			var/datum/turf_reservation/room = activeRooms[x]
-			for(var/i=0, i<hotelRoomTemp.width, i++)
-				for(var/j=0, j<hotelRoomTemp.height, j++)
-					for(var/atom/movable/A in locate(room.bottom_left_coords[1] + i, room.bottom_left_coords[2] + j, room.bottom_left_coords[3]))
+			for(var/iteration_x in 0 to hotelRoomTemp.width-1)
+				for(var/iteration_y in 0 to hotelRoomTemp.height-1)
+					for(var/atom/movable/A in locate(room.bottom_left_coords[1] + iteration_x, room.bottom_left_coords[2] + iteration_y, room.bottom_left_coords[3]))
 						if(ismob(A))
 							var/mob/M = A
 							if(M.mind)
@@ -417,10 +417,10 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	storageObj.roomNumber = roomnumber
 	storageObj.parentSphere = parentSphere
 	storageObj.name = "Room [roomnumber] Storage"
-	for(var/i=0, i<parentSphere.hotelRoomTemp.width, i++)
-		for(var/j=0, j<parentSphere.hotelRoomTemp.height, j++)
+	for(var/iteration_x in 0 to parentSphere.hotelRoomTemp.width-1)
+		for(var/iteration_y in 0 to parentSphere.hotelRoomTemp.height-1)
 			var/list/turfContents = list()
-			for(var/atom/movable/A in locate(reservation.bottom_left_coords[1] + i, reservation.bottom_left_coords[2] + j, reservation.bottom_left_coords[3]))
+			for(var/atom/movable/A in locate(reservation.bottom_left_coords[1] + iteration_x, reservation.bottom_left_coords[2] + iteration_y, reservation.bottom_left_coords[3]))
 				if(ismob(A) && !isliving(A))
 					continue //Don't want to store ghosts
 				turfContents += A

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -120,11 +120,11 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		var/datum/turf_reservation/roomReservation = SSmapping.RequestBlockReservation(hotelRoomTemp.width, hotelRoomTemp.height)
 		hotelRoomTempEmpty.load(locate(roomReservation.bottom_left_coords[1], roomReservation.bottom_left_coords[2], roomReservation.bottom_left_coords[3]))
 		var/turfNumber = 1
-		for(var/iteration_x in 0 to hotelRoomTemp.width-1)
-			for(var/iteration_y in 0 to hotelRoomTemp.height-1)
+		for(var/x in 0 to hotelRoomTemp.width-1)
+			for(var/y in 0 to hotelRoomTemp.height-1)
 				for(var/atom/movable/A in storedRooms["[roomNumber]"][turfNumber])
 					if(istype(A.loc, /obj/item/abstracthotelstorage))//Don't want to recall something thats been moved
-						A.forceMove(locate(roomReservation.bottom_left_coords[1] + iteration_x, roomReservation.bottom_left_coords[2] + iteration_y, roomReservation.bottom_left_coords[3]))
+						A.forceMove(locate(roomReservation.bottom_left_coords[1] + x, roomReservation.bottom_left_coords[2] + y, roomReservation.bottom_left_coords[3]))
 				turfNumber++
 		for(var/obj/item/abstracthotelstorage/S in storageTurf)
 			if((S.roomNumber == roomNumber) && (S.parentSphere == src))
@@ -165,9 +165,9 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	if(activeRooms.len)
 		for(var/x in activeRooms)
 			var/datum/turf_reservation/room = activeRooms[x]
-			for(var/iteration_x in 0 to hotelRoomTemp.width-1)
-				for(var/iteration_y in 0 to hotelRoomTemp.height-1)
-					for(var/atom/movable/A in locate(room.bottom_left_coords[1] + iteration_x, room.bottom_left_coords[2] + iteration_y, room.bottom_left_coords[3]))
+			for(var/i in 0 to hotelRoomTemp.width-1)
+				for(var/j in 0 to hotelRoomTemp.height-1)
+					for(var/atom/movable/A in locate(room.bottom_left_coords[1] + i, room.bottom_left_coords[2] + j, room.bottom_left_coords[3]))
 						if(ismob(A))
 							var/mob/M = A
 							if(M.mind)
@@ -417,10 +417,10 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	storageObj.roomNumber = roomnumber
 	storageObj.parentSphere = parentSphere
 	storageObj.name = "Room [roomnumber] Storage"
-	for(var/iteration_x in 0 to parentSphere.hotelRoomTemp.width-1)
-		for(var/iteration_y in 0 to parentSphere.hotelRoomTemp.height-1)
+	for(var/x in 0 to parentSphere.hotelRoomTemp.width-1)
+		for(var/y in 0 to parentSphere.hotelRoomTemp.height-1)
 			var/list/turfContents = list()
-			for(var/atom/movable/A in locate(reservation.bottom_left_coords[1] + iteration_x, reservation.bottom_left_coords[2] + iteration_y, reservation.bottom_left_coords[3]))
+			for(var/atom/movable/A in locate(reservation.bottom_left_coords[1] + x, reservation.bottom_left_coords[2] + y, reservation.bottom_left_coords[3]))
 				if(ismob(A) && !isliving(A))
 					continue //Don't want to store ghosts
 				turfContents += A

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -475,7 +475,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 				if(!can_target(target, user, TRUE))
 					continue
 				possible_targets += target
-			for(var/iteration in 1 to max_targets)
+			for(var/i in 1 to max_targets)
 				if(!possible_targets.len)
 					break
 				if(target_ignore_prev)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -475,7 +475,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 				if(!can_target(target, user, TRUE))
 					continue
 				possible_targets += target
-			for(var/i=1,i<=max_targets,i++)
+			for(var/iteration in 1 to max_targets)
 				if(!possible_targets.len)
 					break
 				if(target_ignore_prev)

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -23,7 +23,7 @@
 		if(T.density && !summon_ignore_density)
 			targets -= T
 
-	for(var/i=0,i<summon_amt,i++)
+	for(var/iteration in 1 to summon_amt)
 		if(!targets.len)
 			break
 		var/summoned_object_type = pick(summon_type)

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -23,7 +23,7 @@
 		if(T.density && !summon_ignore_density)
 			targets -= T
 
-	for(var/iteration in 1 to summon_amt)
+	for(var/i in 1 to summon_amt)
 		if(!targets.len)
 			break
 		var/summoned_object_type = pick(summon_type)

--- a/code/modules/spells/spell_types/projectile.dm
+++ b/code/modules/spells/spell_types/projectile.dm
@@ -122,7 +122,7 @@
 
 /obj/effect/proc_holder/spell/targeted/projectile/dumbfire/choose_targets(mob/user = usr)
 	var/turf/T = get_turf(user)
-	for(var/i = 1; i < range; i++)
+	for(var/iteration in 1 to range-1)
 		var/turf/new_turf = get_step(T, user.dir)
 		if(new_turf.density)
 			break

--- a/code/modules/spells/spell_types/projectile.dm
+++ b/code/modules/spells/spell_types/projectile.dm
@@ -122,7 +122,7 @@
 
 /obj/effect/proc_holder/spell/targeted/projectile/dumbfire/choose_targets(mob/user = usr)
 	var/turf/T = get_turf(user)
-	for(var/iteration in 1 to range-1)
+	for(var/i in 1 to range-1)
 		var/turf/new_turf = get_step(T, user.dir)
 		if(new_turf.density)
 			break

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -568,7 +568,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 							span_userdanger("You are pinned down by [src]!"))
 					if(3) // glass candy
 						crit_rebate = 50
-						for(var/iteration in 1 to num_shards)
+						for(var/i in 1 to num_shards)
 							var/obj/item/shard/shard = new /obj/item/shard(get_turf(C))
 							shard.embedding = list(embed_chance = 100, ignore_throwspeed_threshold = TRUE, impact_pain_mult=1, pain_chance=5)
 							shard.updateEmbedding()

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -568,7 +568,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 							span_userdanger("You are pinned down by [src]!"))
 					if(3) // glass candy
 						crit_rebate = 50
-						for(var/i = 0, i < num_shards, i++)
+						for(var/iteration in 1 to num_shards)
 							var/obj/item/shard/shard = new /obj/item/shard(get_turf(C))
 							shard.embedding = list(embed_chance = 100, ignore_throwspeed_threshold = TRUE, impact_pain_mult=1, pain_chance=5)
 							shard.updateEmbedding()


### PR DESCRIPTION
## About The Pull Request
See title. Basically it replaces some instances of `for(var/i=value,value<=foo,value++)` with `for(var/i in 1 to value)`. In many cases, the `i` loop counter (also called `j` in nested loops, which are used for grids and mapping mostly) has been renamed in accordance with the contribution guidelines.
This doesn't cover every for loop in the code of course; for loops that don't use the less than (or equal to) operation as condition were excluded, like those that have an advancement that isn't an increment operation or that can modify one of the variables used in the condition in the performed statement (for example, when the condition is `iteration<=list.len` but new entries may be added or removed as it loops, increasing/decreasing the number of loops as a result). Many of the loops that qualify for this have also been skipped for the time being to make reviewing and the merging process easier. They may be included in a different PR.


## Why It's Good For The Game
These latter traditional for loops are faster and more user-friendly. Thanks to KylerAce for the for loops benchmark:
![h](https://cdn.discordapp.com/attachments/326831214667235328/906591418552844308/Screenshot_1495.png)

## Changelog
N/A. Code Improvement.