### PR TITLE
Prevents chaplains from choosing 30 force null rods (oh god)

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -155,7 +155,7 @@
 	if(!GLOB.holy_weapon_type && istype(src, /obj/item/nullrod))
 		var/list/rods = list()
 		for(var/obj/item/nullrod/nullrod_type as anything in typesof(/obj/item/nullrod))
-			if(!chaplain_spawnable)
+			if(!initial(nullrod_type.chaplain_spawnable))
 				continue
 			rods[nullrod_type] = initial(nullrod_type.menu_description)
 		AddComponent(/datum/component/subtype_picker, rods, CALLBACK(src, .proc/on_holy_weapon_picked))


### PR DESCRIPTION
## About The Pull Request

Chaplains can no longer choose 30 force admin only null rods

## Why It's Good For The Game

Chaplains shouldn't be able to get 30 force weapons

## Changelog

:cl: Melbert
fix: Chaplains can no longer select admin only null rods.
/:cl:
