### PR TITLE
Adds yawn propagation

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -52,6 +52,9 @@
 #define COOLDOWN_CIRCUIT_PATHFIND_DIF "circuit_pathfind_different"
 #define COOLDOWN_CIRCUIT_TARGET_INTERCEPT "circuit_target_intercept"
 
+// mob cooldowns
+#define COOLDOWN_YAWN_PROPAGATION "yawn_propagation_cooldown"
+
 //TIMER COOLDOWN MACROS
 
 #define COMSIG_CD_STOP(cd_index) "cooldown_[cd_index]"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -415,6 +415,8 @@
 #define EXAMINE_MORE_WINDOW 1 SECONDS
 /// If you examine another mob who's successfully examined you during this duration of time, you two try to make eye contact. Cute!
 #define EYE_CONTACT_WINDOW 2 SECONDS
+/// If you yawn while someone nearby has examined you within this time frame, it will force them to yawn as well. Tradecraft!
+#define YAWN_PROPAGATION_EXAMINE_WINDOW 2 SECONDS
 
 /// How far away you can be to make eye contact with someone while examining
 #define EYE_CONTACT_RANGE 5

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -346,6 +346,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 // Being close enough to the supermatter makes it heal at higher temperatures
 // and emit less heat. Present on /mob or /datum/mind
 #define TRAIT_SUPERMATTER_SOOTHER "supermatter_soother"
+/// User has recently yawned. Cheaty way to track if someone has yawned recently, whether they meant to or not, since emote cooldowns don't track unintentional emotes
+#define TRAIT_YAWNED_RECENTLY "yawned_recently"
 /*
 * Trait granted by various security jobs, and checked by [/obj/item/food/donut]
 * When present in the mob's mind, they will always love donuts.

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -346,8 +346,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 // Being close enough to the supermatter makes it heal at higher temperatures
 // and emit less heat. Present on /mob or /datum/mind
 #define TRAIT_SUPERMATTER_SOOTHER "supermatter_soother"
-/// User has recently yawned. Cheaty way to track if someone has yawned recently, whether they meant to or not, since emote cooldowns don't track unintentional emotes
-#define TRAIT_YAWNED_RECENTLY "yawned_recently"
 /*
 * Trait granted by various security jobs, and checked by [/obj/item/food/donut]
 * When present in the mob's mind, they will always love donuts.

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -414,11 +414,60 @@
 	key_third_person = "wsmiles"
 	message = "smiles weakly."
 
+/// The base chance for your yawn to propagate to someone else if they're on the same tile as you
+#define YAWN_PROPAGATE_CHANCE_BASE 60
+/// The base chance for your yawn to propagate to someone else if they're on the same tile as you
+#define YAWN_PROPAGATE_CHANCE_DECAY 10
+
 /datum/emote/living/yawn
 	key = "yawn"
 	key_third_person = "yawns"
 	message = "yawns."
 	emote_type = EMOTE_AUDIBLE
+	cooldown = 3 SECONDS
+
+/datum/emote/living/yawn/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	if(!. || !isliving(user))
+		return
+
+	if(!HAS_TRAIT(user, TRAIT_YAWNED_RECENTLY))
+		addtimer(CALLBACK(src, .proc/reset_yawn, user), cooldown * 3)
+		ADD_TRAIT(user, TRAIT_YAWNED_RECENTLY, TRAIT_GENERIC)
+
+	var/mob/living/carbon/carbon_user = user
+	if(istype(carbon_user) && ((carbon_user.wear_mask?.flags_inv & HIDEFACE) || carbon_user.head?.flags_inv & HIDEFACE))
+		return // if your face is obscured, skip propagation
+
+	var/propagation_distance = user.client ? 5 : 2 // mindless mobs are less able to spread yawns
+
+	for(var/mob/living/iter_living in view(user, propagation_distance))
+		if(IS_DEAD_OR_INCAP(iter_living) || HAS_TRAIT(iter_living, TRAIT_YAWNED_RECENTLY))
+			continue
+
+		var/dist_between = get_dist(user, iter_living)
+		var/recently_examined = FALSE // if you yawn just after someone looks at you, it forces them to yawn as well. Tradecraft!
+
+		if(iter_living.client)
+			var/examine_time = LAZYACCESS(iter_living.client?.recent_examines, user)
+			if(examine_time && (world.time - examine_time < YAWN_PROPAGATION_EXAMINE_WINDOW))
+				recently_examined = TRUE
+
+		if(!recently_examined && !prob(YAWN_PROPAGATE_CHANCE_BASE - (YAWN_PROPAGATE_CHANCE_DECAY * dist_between)))
+			continue
+
+		var/yawn_delay = rand(0.25 SECONDS, 0.75 SECONDS) * dist_between
+		addtimer(CALLBACK(src, .proc/propagate_yawn, iter_living), yawn_delay)
+
+/// This yawn has been triggered by someone else yawning specifically, likely after a delay. Check again if they don't have the yawned recently trait
+/datum/emote/living/yawn/proc/propagate_yawn(mob/user)
+	if(!istype(user) || HAS_TRAIT(user, TRAIT_YAWNED_RECENTLY))
+		return
+	user.emote("yawn")
+
+/// Simply remove the recently yawned trait
+/datum/emote/living/yawn/proc/reset_yawn(mob/user)
+	REMOVE_TRAIT(user, TRAIT_YAWNED_RECENTLY, TRAIT_GENERIC)
 
 /datum/emote/living/gurgle
 	key = "gurgle"

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -431,9 +431,8 @@
 	if(!. || !isliving(user))
 		return
 
-	if(!HAS_TRAIT(user, TRAIT_YAWNED_RECENTLY))
-		addtimer(CALLBACK(src, .proc/reset_yawn, user), cooldown * 3)
-		ADD_TRAIT(user, TRAIT_YAWNED_RECENTLY, TRAIT_GENERIC)
+	if(!TIMER_COOLDOWN_CHECK(user, COOLDOWN_YAWN_PROPAGATION))
+		TIMER_COOLDOWN_START(user, COOLDOWN_YAWN_PROPAGATION, cooldown * 3)
 
 	var/mob/living/carbon/carbon_user = user
 	if(istype(carbon_user) && ((carbon_user.wear_mask?.flags_inv & HIDEFACE) || carbon_user.head?.flags_inv & HIDEFACE))
@@ -442,7 +441,7 @@
 	var/propagation_distance = user.client ? 5 : 2 // mindless mobs are less able to spread yawns
 
 	for(var/mob/living/iter_living in view(user, propagation_distance))
-		if(IS_DEAD_OR_INCAP(iter_living) || HAS_TRAIT(iter_living, TRAIT_YAWNED_RECENTLY))
+		if(IS_DEAD_OR_INCAP(iter_living) || TIMER_COOLDOWN_CHECK(user, COOLDOWN_YAWN_PROPAGATION))
 			continue
 
 		var/dist_between = get_dist(user, iter_living)
@@ -461,13 +460,12 @@
 
 /// This yawn has been triggered by someone else yawning specifically, likely after a delay. Check again if they don't have the yawned recently trait
 /datum/emote/living/yawn/proc/propagate_yawn(mob/user)
-	if(!istype(user) || HAS_TRAIT(user, TRAIT_YAWNED_RECENTLY))
+	if(!istype(user) || TIMER_COOLDOWN_CHECK(user, COOLDOWN_YAWN_PROPAGATION))
 		return
 	user.emote("yawn")
 
-/// Simply remove the recently yawned trait
-/datum/emote/living/yawn/proc/reset_yawn(mob/user)
-	REMOVE_TRAIT(user, TRAIT_YAWNED_RECENTLY, TRAIT_GENERIC)
+#undef YAWN_PROPAGATE_CHANCE_BASE
+#undef YAWN_PROPAGATE_CHANCE_DECAY
 
 /datum/emote/living/gurgle
 	key = "gurgle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You ever see someone yawn and suddenly want to yawn yourself? Then maybe someone else nearby saw you yawn and yawned too? That's in the game now!

https://streamable.com/uyxbsz

Yawning can make nearby mobs yawn. Also, you can use the classic counter-intelligence method of yawning to check if someone is watching you. If they've examined you in the last 2 seconds and are nearby, they'll be forced to yawn (assuming their cooldown allows it).

The yawn emote now has a 3 second cooldown to perform manually, and you are unable to catch a contagious yawn for 9 seconds after your last one.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Buffs verisimilitude 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ryll/Shaps
add: Yawns can now propagate and cause other nearby mobs who see it to yawn as well.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
