### PR TITLE
You can't type with boxing gloves on.

### DIFF
--- a/code/modules/clothing/gloves/boxing.dm
+++ b/code/modules/clothing/gloves/boxing.dm
@@ -5,6 +5,7 @@
 	inhand_icon_state = "boxing"
 	equip_delay_other = 60
 	species_exception = list(/datum/species/golem) // now you too can be a golem boxing champion
+	clothing_traits = list(TRAIT_CHUNKYFINGERS)
 
 /obj/item/clothing/gloves/boxing/green
 	icon_state = "boxinggreen"


### PR DESCRIPTION
## About The Pull Request

You can no longer type with boxing gloves on.

## Why It's Good For The Game

Improves the immersion of people wearing boxing gloves.
I don't see any fingers; do _you_ see any fingers?

## Changelog

:cl:
fix: Fixes a grave oversight of being able to type with boxing gloves on.
/:cl:

