### PR TITLE
Fixes numeric prefs not working with TGUI dropdowns that might return a string instead of a number

### DIFF
--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -498,6 +498,8 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 	abstract_type = /datum/preference/numeric
 
 /datum/preference/numeric/deserialize(input, datum/preferences/preferences)
+	if(istext(input)) // Sometimes TGUI will return a string instead of a number, so we take that into account.
+		input = text2num(input) // Worst case, it's null, it'll just use create_default_value()
 	return sanitize_float(input, minimum, maximum, step, create_default_value())
 
 /datum/preference/numeric/serialize(input)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So, I noticed that I was no longer able to change the pixel scaling pref anymore. I was curious, so I investigated, turns out it kept on being reset to 0 because TGUI was sending it back as a string, rather than as a number, due to how the pref menu's dropdowns were made. Since I thought it would be better and safer to simply add a check for text values being inputed to numeric preferences, that's what I did. If there's somehow no numeric character at the start of that string, it'll return null, which doesn't change the behavior of the `sanitize_float()` proc, which is to return `create_default_value()`'s return value if the input isn't a number.

Closes https://github.com/tgstation/tgstation/issues/61535
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You can now change your game's pixel scaling method again. It also future-proofs it, with a simple check that will ensure that, if it's a number, even if it's put as a string, it's still going to work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: GoldenAlpharex
fix: Fixed certain preferences being reset to their default values when trying to change them, due to the dropdown menu of options changing numbers into text and due to that not being supported by numeric preferences. AKA, changing pixel scaling method will work again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
