### PR TITLE
Custom burgers are placed above the mob layer.

### DIFF
--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -432,6 +432,7 @@
 /obj/item/food/burger/empty
 	name = "burger"
 	icon_state = "custburg"
+	layer = ABOVE_MOB_LAYER
 	tastes = list("bun")
 	foodtypes = GRAIN
 	desc = "A crazy, custom burger made by a mad cook."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a line to the custom burger code that places it above the mob layer.

## Why It's Good For The Game

When cooks find out that you can make custom burgers, the natural course of action is to immediately make a burger as big as humanly possible. The problem with that is since custom burgers are on the same layer as the rest of the food items, extremely tall burgers have this weird perspective issue where mobs will walk over it instead of around it.

![fucked up burger](https://user-images.githubusercontent.com/63932673/140658734-d84dd7c9-3f44-457c-8981-a4e7e16a70a7.JPG)

Having custom burgers be placed above the mob layer should fix this.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Toastgoats
fix: Custom burgers are now placed above the mob layer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
