### PR TITLE
Fix random names breaking preferences

### DIFF
--- a/code/modules/admin/verbs/anonymousnames.dm
+++ b/code/modules/admin/verbs/anonymousnames.dm
@@ -129,7 +129,8 @@ GLOBAL_DATUM(current_anonymous_theme, /datum/anonymous_theme)
  * * target - mob for preferences and gender
  */
 /datum/anonymous_theme/proc/anonymous_name(mob/target)
-	var/species_type = target.client.prefs.read_preference(/datum/preference/choiced/species)
+	var/datum/client_interface/client = GET_CLIENT(target)
+	var/species_type = client.prefs.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type
 	return species.random_name(target.gender,1)
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -401,12 +401,12 @@
 	var/require_human = CONFIG_GET(flag/enforce_human_authority) && (job.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
 
 	if(fully_randomize)
-		if(require_human)
-			player_client.prefs.randomise_appearance_prefs(~RANDOMIZE_SPECIES)
-		else
-			player_client.prefs.randomise_appearance_prefs()
-
 		player_client.prefs.apply_prefs_to(src)
+
+		if(require_human)
+			randomize_human_appearance(~RANDOMIZE_SPECIES)
+		else
+			randomize_human_appearance()
 
 		if (require_human)
 			set_species(/datum/species/human)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -249,4 +249,4 @@
 			continue
 
 		if (preference.is_randomizable())
-			preferences.write_preference(preference, preference.create_random_value(preferences))
+			preference.apply_to_human(src, preference.create_random_value(preferences))

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -44,6 +44,7 @@
 #define TRAIT_SOURCE_UNIT_TESTS "unit_tests"
 
 #include "anchored_mobs.dm"
+#include "anonymous_themes.dm"
 #include "bespoke_id.dm"
 #include "binary_insert.dm"
 #include "bloody_footprints.dm"

--- a/code/modules/unit_tests/anonymous_themes.dm
+++ b/code/modules/unit_tests/anonymous_themes.dm
@@ -1,0 +1,23 @@
+/// Ensure that anonymous themes works without changing your preferences
+TEST_FOCUS(/datum/unit_test/anonymous_themes)
+
+/datum/unit_test/anonymous_themes/Run()
+	GLOB.current_anonymous_theme = new /datum/anonymous_theme
+
+	var/mob/living/carbon/human/human = allocate(/mob/living/carbon/human)
+
+	var/datum/client_interface/client = new
+	human.mock_client = client
+
+	client.prefs = new
+
+	client.prefs.write_preference(GLOB.preference_entries[/datum/preference/name/real_name], "Prefs Biddle")
+
+	human.apply_prefs_job(client, SSjob.GetJobType(/datum/job/assistant))
+
+	TEST_ASSERT_NOTEQUAL(human.real_name, "Prefs Biddle", "apply_prefs_job didn't randomize human name with an anonymous theme")
+	TEST_ASSERT_EQUAL(client.prefs.read_preference(/datum/preference/name/real_name), "Prefs Biddle", "Anonymous theme overrode original prefs")
+
+/datum/unit_test/anonymous_themes/Destroy()
+	QDEL_NULL(GLOB.current_anonymous_theme)
+	return ..()

--- a/code/modules/unit_tests/anonymous_themes.dm
+++ b/code/modules/unit_tests/anonymous_themes.dm
@@ -1,5 +1,5 @@
 /// Ensure that anonymous themes works without changing your preferences
-TEST_FOCUS(/datum/unit_test/anonymous_themes)
+/datum/unit_test/anonymous_themes
 
 /datum/unit_test/anonymous_themes/Run()
 	GLOB.current_anonymous_theme = new /datum/anonymous_theme


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The randomization (specifically from the random names secret) overrode your preferences, this fixes that.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Random names (such as from the secrets panel) will no longer override your preferences.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
