### PR TITLE
Adminwho and the status panel now shows when fellow admins are readied up in pre-game lobby

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -40,7 +40,7 @@ SUBSYSTEM_DEF(ticker)
 	/// Num of ready players, used for pregame stats on statpanel (only viewable by admins)
 	var/totalPlayersReady = 0
 	/// Num of ready admins, used for pregame stats on statpanel (only viewable by admins)
-	var/totalAdminsReady = 0
+	var/total_admins_ready = 0
 
 	var/queue_delay = 0
 	var/list/queued_players = list() //used for join queues when the server exceeds the hard population cap
@@ -161,12 +161,12 @@ SUBSYSTEM_DEF(ticker)
 				timeLeft = max(0,start_at - world.time)
 			totalPlayers = LAZYLEN(GLOB.new_player_list)
 			totalPlayersReady = 0
-			totalAdminsReady = 0
+			total_admins_ready = 0
 			for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
 				if(player.ready == PLAYER_READY_TO_PLAY)
 					++totalPlayersReady
 					if(player.client?.holder)
-						++totalAdminsReady
+						++total_admins_ready
 
 			if(start_immediately)
 				timeLeft = 0
@@ -533,7 +533,7 @@ SUBSYSTEM_DEF(ticker)
 
 	totalPlayers = SSticker.totalPlayers
 	totalPlayersReady = SSticker.totalPlayersReady
-	totalAdminsReady = SSticker.totalAdminsReady
+	total_admins_ready = SSticker.total_admins_ready
 
 	queue_delay = SSticker.queue_delay
 	queued_players = SSticker.queued_players

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -35,8 +35,12 @@ SUBSYSTEM_DEF(ticker)
 	var/gametime_offset = 432000 //Deciseconds to add to world.time for station time.
 	var/station_time_rate_multiplier = 12 //factor of station time progressal vs real time.
 
-	var/totalPlayers = 0 //used for pregame stats on statpanel
-	var/totalPlayersReady = 0 //used for pregame stats on statpanel
+	/// Num of players, used for pregame stats on statpanel
+	var/totalPlayers = 0
+	/// Num of ready players, used for pregame stats on statpanel (only viewable by admins)
+	var/totalPlayersReady = 0
+	/// Num of ready admins, used for pregame stats on statpanel (only viewable by admins)
+	var/totalAdminsReady = 0
 
 	var/queue_delay = 0
 	var/list/queued_players = list() //used for join queues when the server exceeds the hard population cap
@@ -157,10 +161,12 @@ SUBSYSTEM_DEF(ticker)
 				timeLeft = max(0,start_at - world.time)
 			totalPlayers = LAZYLEN(GLOB.new_player_list)
 			totalPlayersReady = 0
-			for(var/i in GLOB.new_player_list)
-				var/mob/dead/new_player/player = i
+			totalAdminsReady = 0
+			for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
 				if(player.ready == PLAYER_READY_TO_PLAY)
 					++totalPlayersReady
+					if(player.client?.holder)
+						++totalAdminsReady
 
 			if(start_immediately)
 				timeLeft = 0
@@ -527,6 +533,7 @@ SUBSYSTEM_DEF(ticker)
 
 	totalPlayers = SSticker.totalPlayers
 	totalPlayersReady = SSticker.totalPlayersReady
+	totalAdminsReady = SSticker.totalAdminsReady
 
 	queue_delay = SSticker.queue_delay
 	queued_players = SSticker.queued_players

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -83,7 +83,14 @@
 			if(isobserver(C.mob))
 				msg += " - Observing"
 			else if(isnewplayer(C.mob))
-				msg += " - Lobby"
+				if(SSticker.current_state <= GAME_STATE_PREGAME)
+					var/mob/dead/new_player/lobbied_admin = C.mob
+					if(lobbied_admin.ready == PLAYER_READY_TO_PLAY)
+						msg += " - Lobby (Readied)"
+					else
+						msg += " - Lobby (Not readied)"
+				else
+					msg += " - Lobby"
 			else
 				msg += " - Playing"
 

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -51,7 +51,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	. += "Players: [SSticker.totalPlayers]"
 	if(client.holder)
 		. += "Players Ready: [SSticker.totalPlayersReady]"
-		. += "Admins Ready: [SSticker.totalPlayersReady]"
+		. += "Admins Ready: [SSticker.totalPlayersReady] / [GLOB.admins.len]"
 
 /mob/dead/proc/server_hop()
 	set category = "OOC"

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -51,7 +51,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	. += "Players: [SSticker.totalPlayers]"
 	if(client.holder)
 		. += "Players Ready: [SSticker.totalPlayersReady]"
-		. += "Admins Ready: [SSticker.totalPlayersReady] / [GLOB.admins.len]"
+		. += "Admins Ready: [SSticker.total_admins_ready] / [GLOB.admins.len]"
 
 /mob/dead/proc/server_hop()
 	set category = "OOC"

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -51,6 +51,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	. += "Players: [SSticker.totalPlayers]"
 	if(client.holder)
 		. += "Players Ready: [SSticker.totalPlayersReady]"
+		. += "Admins Ready: [SSticker.totalPlayersReady]"
 
 /mob/dead/proc/server_hop()
 	set category = "OOC"


### PR DESCRIPTION
## About The Pull Request

- Using adminwho during the pregame lobby will now differentiate readied vs not readied admins in the lobby. 
![image](https://user-images.githubusercontent.com/51863163/140713476-1d22938c-1293-4545-8f15-9c1771b29afb.png)

- The status panel will now show a counter for how many admins currently readied up out of all non-deadminned admins.
![image](https://user-images.githubusercontent.com/51863163/140714889-08ac39d5-6f27-4311-978d-816a15e375a9.png)
![image](https://user-images.githubusercontent.com/51863163/140714874-25d632ca-733e-4f21-837a-62991f1091f3.png)

### This only shows up for players who are adminned!

## Why It's Good For The Game

Helps admins recognize at a glance how many of their fellow admins are planning on playing the round that's starting and how many may stick around to observe. Definitely not foolproof - admins may deadmin before readying up, or may be planning on late-joining the round. But I believe it can help.

## Changelog

:cl: Melbert
admin: Admins can now tell when other admins are readied up in the pre-game lobby. Check adminwho or view your stat panel.
/:cl:

