### PR TITLE
Allow manual crafting of many atmos devices with the crafting menu

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -108,6 +108,7 @@
 #define CAT_ICE "Frozen"
 #define CAT_DRINK "Drinks"
 #define CAT_CHEMISTRY "Chemistry"
+#define CAT_ATMOSPHERIC "Atmospheric"
 
 //rcd modes
 #define RCD_FLOORWALL 0

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -44,6 +44,7 @@
 				),
 				CAT_DRINK = CAT_NONE,
 				CAT_CLOTHING = CAT_NONE,
+				CAT_ATMOSPHERIC = CAT_NONE,
 			)
 
 	var/cur_category = CAT_NONE

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -45,6 +45,14 @@
 /datum/crafting_recipe/proc/on_craft_completion(mob/user, atom/result)
 	return
 
+///Check if the pipe used for atmospheric device crafting is the proper one
+/datum/crafting_recipe/proc/atmos_pipe_check(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft \a [name] without a pipe fitting!"))
+	return FALSE
+
 /datum/crafting_recipe/improv_explosive
 	name = "IED"
 	result = /obj/item/grenade/iedcasing
@@ -1353,17 +1361,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/layer_adapter/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/layer_adapter/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/pipe/layer_manifold
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/color_adapter
@@ -1377,17 +1381,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/color_adapter/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/color_adapter/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/pipe/color_adapter
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/he_pipe
@@ -1401,17 +1401,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/he_pipe/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/he_pipe/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/he_junction
@@ -1425,17 +1421,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/he_junction/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/he_junction/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/pipe/heat_exchanging/junction
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/pressure_pump
@@ -1450,17 +1442,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/pressure_pump/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/pressure_pump/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/binary/pump
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/manual_valve
@@ -1474,17 +1462,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/manual_valve/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/manual_valve/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/binary/valve
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/vent
@@ -1499,17 +1483,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/vent/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/vent/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/unary/vent_pump
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/scrubber
@@ -1524,17 +1504,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/scrubber/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/scrubber/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/unary/vent_scrubber
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/filter
@@ -1549,17 +1525,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/filter/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/filter/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/trinary/filter
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/mixer
@@ -1574,17 +1546,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/mixer/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/mixer/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/trinary/mixer
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/connector
@@ -1598,17 +1566,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/connector/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/connector/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/unary/portables_connector
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/passive_vent
@@ -1622,17 +1586,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/passive_vent/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/passive_vent/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/unary/passive_vent
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/injector
@@ -1647,17 +1607,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/injector/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/injector/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/unary/outlet_injector
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 /datum/crafting_recipe/he_exchanger
@@ -1671,17 +1627,13 @@
 	category = CAT_ATMOSPHERIC
 
 /datum/crafting_recipe/he_exchanger/check_requirements(mob/user, list/collected_requirements)
-	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
-	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
-		return TRUE
-	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
-	return FALSE
+	return atmos_pipe_check(user, collected_requirements)
 
 /datum/crafting_recipe/he_exchanger/on_craft_completion(mob/user, atom/result)
 	var/obj/item/pipe/crafted_pipe = result
 	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/unary/heat_exchanger
 	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
-	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.setDir(user.dir)
 	crafted_pipe.update()
 
 #undef CRAFTING_MACHINERY_CONSUME

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -1326,5 +1326,363 @@
 	time = 40 SECONDS
 	category = CAT_MISC
 
+/datum/crafting_recipe/pipe
+	name = "Smart pipe fitting"
+	tool_behaviors = list(TOOL_WRENCH)
+	result = /obj/item/pipe/quaternary
+	reqs = list(/obj/item/stack/sheet/iron = 1)
+	time = 0.5 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/pipe/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/pipe/smart
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.p_init_dir = ALL_CARDINALS
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/layer_adapter
+	name = "Layer manifold fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/binary
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 1)
+	time = 1 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/layer_adapter/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/layer_adapter/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/pipe/layer_manifold
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/color_adapter
+	name = "Color adapter fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/binary
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 1)
+	time = 1 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/color_adapter/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/color_adapter/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/pipe/color_adapter
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/he_pipe
+	name = "H/E pipe fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/quaternary
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 1)
+	time = 1 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/he_pipe/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/he_pipe/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/he_junction
+	name = "H/E junction fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/directional
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 1)
+	time = 1 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/he_junction/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/he_junction/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/pipe/heat_exchanging/junction
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/pressure_pump
+	name = "Pressure pump fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/binary
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 5,
+		/obj/item/stack/cable_coil = 5)
+	time = 2 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/pressure_pump/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/pressure_pump/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/binary/pump
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/manual_valve
+	name = "Manual valve fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/binary
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 1)
+	time = 2 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/manual_valve/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/manual_valve/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/binary/valve
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/vent
+	name = "Vent pump fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/directional
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 5,
+		/obj/item/stack/cable_coil = 5)
+	time = 2 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/vent/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/vent/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/unary/vent_pump
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/scrubber
+	name = "Scrubber fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/directional
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 5,
+		/obj/item/stack/cable_coil = 5)
+	time = 2 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/scrubber/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/scrubber/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/unary/vent_scrubber
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/filter
+	name = "Filter fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/trinary/flippable
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 5,
+		/obj/item/stack/cable_coil = 5)
+	time = 2 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/filter/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/filter/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/trinary/filter
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/mixer
+	name = "Mixer fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/trinary/flippable
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 5,
+		/obj/item/stack/cable_coil = 5)
+	time = 2 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/mixer/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/mixer/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/trinary/mixer
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/connector
+	name = "Portable connector fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/directional
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 1)
+	time = 2 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/connector/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/connector/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/unary/portables_connector
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/passive_vent
+	name = "Passive vent fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/directional
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 1)
+	time = 2 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/passive_vent/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/passive_vent/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/unary/passive_vent
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/injector
+	name = "Outlet injector fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/directional
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 1,
+		/obj/item/stack/cable_coil = 5)
+	time = 2 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/injector/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/injector/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/unary/outlet_injector
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
+/datum/crafting_recipe/he_exchanger
+	name = "Heat exchanger fitting"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/item/pipe/directional
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/plasteel = 1)
+	time = 2 SECONDS
+	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/he_exchanger/check_requirements(mob/user, list/collected_requirements)
+	var/obj/item/pipe/required_pipe = collected_requirements[/obj/item/pipe][1]
+	if(ispath(required_pipe.pipe_type, /obj/machinery/atmospherics/pipe/smart))
+		return TRUE
+	to_chat(user, span_boldwarning("You can't craft a [name] without a pipe fitting!"))
+	return FALSE
+
+/datum/crafting_recipe/he_exchanger/on_craft_completion(mob/user, atom/result)
+	var/obj/item/pipe/crafted_pipe = result
+	crafted_pipe.pipe_type = /obj/machinery/atmospherics/components/unary/heat_exchanger
+	crafted_pipe.pipe_color = COLOR_VERY_LIGHT_GRAY
+	crafted_pipe.setDir(SOUTH)
+	crafted_pipe.update()
+
 #undef CRAFTING_MACHINERY_CONSUME
 #undef CRAFTING_MACHINERY_USE

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -303,7 +303,7 @@ Buildable meters
 	. = ..()
 	. += span_notice("The pipe layer is set to [piping_layer].")
 	. += span_notice("You can change the pipe layer by Alt-Clicking the device.")
-	. += span_notice("You can rotate the device by using it in hand.")
+	. += span_notice("You can rotate it by using it in hand.")
 
 /obj/item/pipe/AltClick(mob/user)
 	. = ..()

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -299,6 +299,27 @@ Buildable meters
 		C.blood_volume = 0
 	return(OXYLOSS|BRUTELOSS)
 
+/obj/item/pipe/examine(mob/user)
+	. = ..()
+	. += span_notice("The pipe layer is set to [piping_layer].")
+	. += span_notice("You can change the pipe layer by Alt-Clicking the device.")
+	. += span_notice("You can rotate the device by using it in hand.")
+
+/obj/item/pipe/AltClick(mob/user)
+	. = ..()
+	var/layer_to_set = (piping_layer >= PIPING_LAYER_MAX) ? PIPING_LAYER_MIN : (piping_layer + 1)
+	set_piping_layer(layer_to_set)
+	visible_message("You set the pipe layer to [piping_layer].")
+
+/obj/item/pipe/trinary/flippable/examine(mob/user)
+	. = ..()
+	. += span_notice("You can flip the device by Ctrl-Clicking it.")
+
+/obj/item/pipe/trinary/flippable/CtrlClick(mob/user)
+	. = ..()
+	do_a_flip()
+	visible_message("You flip the device.")
+
 /obj/item/pipe_meter
 	name = "meter"
 	desc = "A meter that can be wrenched on pipes, or attached to the floor with screws."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a way to manually create basic atmos components with the crafting menu
Not all of the RPD available devices can be crafted, just the most basic ones.
Those are: Pipes, Color adapter, Layer adapter, Portable connector, H/E pipe, H/E junction, Heat exchangers, pressure pump, manual valve, filter, mixer, vent, scrubber, outlet injector, passive vent.
The available devices ensure solid setups for all your needs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allow hand crafting of atmos devices
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: add the manual crafting of many atmos devices by the crafting menu
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
