### PR TITLE
quantum pads can teleport items and unbuckled people again

### DIFF
--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -177,7 +177,7 @@
 					if(isliving(ROI))
 						var/mob/living/L = ROI
 						//only TP living mobs buckled to non anchored items
-						if(!L.buckled || L.buckled.anchored)
+						if(L.buckled && L.buckled.anchored)
 							continue
 					//Don't TP ghosts
 					else if(isobserver(ROI))

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -180,7 +180,7 @@
 						if(!L.buckled || L.buckled.anchored)
 							continue
 					//Don't TP ghosts
-					else if(!isobserver(ROI))
+					else if(isobserver(ROI))
 						continue
 
 				do_teleport(ROI, get_turf(target_pad), no_effects = TRUE, channel = TELEPORT_CHANNEL_QUANTUM)


### PR DESCRIPTION
## About The Pull Request

Quantum pads can teleport unattended items again.

Quantum pads can teleport people who aren't buckled to something again.

Quantum pads can no longer involuntarily teleport ghosts, although ghosts can still click on a quantum pad to teleport to that quantum pad's destination pad.

Fixes https://github.com/tgstation/tgstation/issues/62634.

## Why It's Good For The Game

A code comment claims that ghosts are not supposed to be teleported by quantum pads. However, due to an error in the logic of the code for quantum pads, the check that is intended to keep ghosts from being (involuntarily) teleported by quantum pads currently actually makes it so that ONLY living creatures and ghosts can be teleported by pads, and not unattended items.

A similar bug caused living creatures who WEREN'T buckled to something to not be teleported by quantum pads. This error has been corrected.

## Changelog

:cl: ATHATH
fix: Quantum pads can teleport non-living things again.
fix: Quantum pads can teleport creatures who aren't buckled to something again. Creatures who are buckled to something unanchored can still be teleported by quantum pads, but creatures who are buckled to something anchored cannot.
fix: Quantum pads can no longer involuntarily teleport ghosts, although ghosts can still click on a quantum pad to teleport to that quantum pad's destination pad.
/:cl: