### PR TITLE
Fixes a few cargo exports problems.

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -24,7 +24,6 @@ Then the player gets the profit from selling his own wasted time.
 	var/list/exported_atoms = list() //names of atoms sold/deleted by export
 	var/list/total_amount = list() //export instance => total count of sold objects of its type, only exists if any were sold
 	var/list/total_value = list() //export instance => total value of sold objects
-	var/list/exported_atoms_ref = list() //if they're not deleted they go in here for use.
 
 // external_report works as "transaction" object, pass same one in if you're doing more than one export in single go
 /proc/export_item_and_contents(atom/movable/AM, apply_elastic = TRUE, delete_unsold = TRUE, dry_run=FALSE, datum/export_report/external_report)
@@ -40,25 +39,25 @@ Then the player gets the profit from selling his own wasted time.
 	if(!report) //If we don't have any longer transaction going on
 		report = new
 
-	// We go backwards, so it'll be innermost objects sold first
-	for(var/i in reverse_range(contents))
-		var/atom/movable/thing = i
-		var/sold = FALSE
+	// We go backwards, so it'll be innermost objects sold first. We also make sure nothing is accidentally delete before everything is sold.
+	var/list/to_delete = list()
+	for(var/atom/movable/thing as anything in reverse_range(contents))
 		if(QDELETED(thing))
 			continue
 
-		for(var/datum/export/E in GLOB.exports_list)
-			if(!E)
-				continue
-			if(E.applies_to(thing, apply_elastic))
-				sold = E.sell_object(thing, report, dry_run, apply_elastic, profit_ratio)
+		var/sold = FALSE
+		for(var/datum/export/export in GLOB.exports_list)
+			if(export.applies_to(thing, apply_elastic))
+				sold = export.sell_object(thing, report, dry_run, apply_elastic, profit_ratio)
 				report.exported_atoms += " [thing.name]"
-				if(!QDELETED(thing))
-					report.exported_atoms_ref += thing
 				break
 		if(!dry_run && (sold || delete_unsold))
 			if(ismob(thing))
 				thing.investigate_log("deleted through cargo export",INVESTIGATE_CARGO)
+			to_delete += thing
+
+	for(var/atom/movable/thing as anything in to_delete)
+		if(!QDELETED(thing))
 			qdel(thing)
 
 	return report

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -43,7 +43,7 @@ Then the player gets the profit from selling his own wasted time.
 	var/list/to_delete = list()
 	for(var/atom/movable/thing as anything in reverse_range(contents))
 		var/sold = FALSE
-		for(var/datum/export/export in GLOB.exports_list)
+		for(var/datum/export/export as anything in GLOB.exports_list)
 			if(export.applies_to(thing, apply_elastic))
 				sold = export.sell_object(thing, report, dry_run, apply_elastic, profit_ratio)
 				report.exported_atoms += " [thing.name]"

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -42,9 +42,6 @@ Then the player gets the profit from selling his own wasted time.
 	// We go backwards, so it'll be innermost objects sold first. We also make sure nothing is accidentally delete before everything is sold.
 	var/list/to_delete = list()
 	for(var/atom/movable/thing as anything in reverse_range(contents))
-		if(QDELETED(thing))
-			continue
-
 		var/sold = FALSE
 		for(var/datum/export/export in GLOB.exports_list)
 			if(export.applies_to(thing, apply_elastic))

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -213,7 +213,7 @@
 	. = ..()
 	if(!proximity)
 		return
-	var/datum/export_report/ex = export_item_and_contents(I, dry_run=TRUE)
+	var/datum/export_report/ex = export_item_and_contents(I, delete_unsold = selling, dry_run = !selling)
 	var/price = 0
 	for(var/x in ex.total_amount)
 		price += ex.total_value[x]
@@ -223,11 +223,6 @@
 		to_chat(user, span_notice("[selling ? "Sold" : "Getting the price of"] [I], value: <b>[true_price]</b> credits[I.contents.len ? " (exportable contents included)" : ""].[profit_scaling < 1 && selling ? "<b>[round(price-true_price)]</b> credit\s taken as processing fee\s." : ""]"))
 		if(selling)
 			new /obj/item/holochip(get_turf(user),true_price)
-			for(var/i in ex.exported_atoms_ref)
-				var/atom/movable/AM = i
-				if(QDELETED(AM))
-					continue
-				qdel(AM)
 	else
 		to_chat(user, span_warning("There is no export value for [I] or any items within it."))
 

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -220,7 +220,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		for(var/atom/movable/AM in shuttle_area)
 			if(iscameramob(AM))
 				continue
-			if(!AM.anchored || istype(AM, /obj/vehicle/sealed/mecha))
+			if(!AM.anchored)
 				export_item_and_contents(AM, export_categories , dry_run = FALSE, external_report = ex)
 
 	if(ex.exported_atoms)


### PR DESCRIPTION
## About The Pull Request
Cargo exports will now start deleting the thing and its contents only after everything has been sold and hopefully stop objects from being deleted before getting sold (no export datum actually deletes anything on `sell_object()`). This PR also removes a variable only used in one place (an admin only item created by ExcessiveUseOfCobblestone, who probably didn't know there's an argument that stops unsold items from getting deleted) and that may be source of harddels.

## Why It's Good For The Game
This will fix #62644, perhaps some harddels and other oddities.

## Changelog

:cl:
fix: Cargo exports will now start deleting items only after everything is sold. This will fix issues such as unachievable exports (like machine ones) and getting less credits than what export scanners says.
/:cl:
