### PR TITLE
Stops the "You lack optic scanners, you get stunned" singularity proc from affecting blinded or dead mobs.

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -395,7 +395,7 @@
 
 /obj/singularity/proc/mezzer()
 	for(var/mob/living/carbon/stunned_mob in oviewers(8, src))
-		if(stunned_mob.stat == DEAD || is_blind(stunned_mob))
+		if(stunned_mob.stat == DEAD || stunned_mob.is_blind())
 			continue
 
 		if(ishuman(stunned_mob))

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -398,7 +398,7 @@
 		if(stunned_mob.stat == DEAD || stunned_mob.is_blind())
 			continue
 
-		if(ishuman(stunned_mob))
+		if(!ishuman(stunned_mob))
 			apply_stun(stunned_mob)
 			continue
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -395,10 +395,10 @@
 
 /obj/singularity/proc/mezzer()
 	for(var/mob/living/carbon/stunned_mob in oviewers(8, src))
-		if(isbrain(stunned_mob)) //Ignore brains
+		if(stunned_mob.stat == DEAD || is_blind(stunned_mob))
 			continue
 
-		if(stunned_mob.stat != CONSCIOUS || !ishuman(stunned_mob))
+		if(ishuman(stunned_mob))
 			apply_stun(stunned_mob)
 			continue
 


### PR DESCRIPTION
## About The Pull Request
See the title. It shouldn't affect them because they can't stare at the singularity. Also brains aren't carbon mobs.

## Why It's Good For The Game
This will fix #42117.

## Changelog

:cl:
fix: Stops the "You lack optic scanners, you get stunned" singularity event from affecting blinded or dead mobs.
/:cl:
