### PR TITLE
the gluttony ruin is no longer radioactive

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
@@ -80,7 +80,7 @@
 /turf/closed/indestructible/riveted/uranium,
 /area/ruin/powered/gluttony)
 "S" = (
-/obj/machinery/door/airlock/uranium,
+/obj/machinery/door/airlock/uranium/safe,
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/iron/freezer,
 /area/ruin/powered/gluttony)

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -197,10 +197,10 @@
 	assemblytype = /obj/structure/door_assembly/door_assembly_uranium
 	var/last_event = 0
 	//Is this airlock actually radioactive?
-	var/safe = FALSE
+	var/actually_radioactive = TRUE
 
 /obj/machinery/door/airlock/uranium/process()
-	if(!safe && world.time > last_event+20)
+	if(actually_radioactive && world.time > last_event+20)
 		if(prob(50))
 			radiate()
 		last_event = world.time
@@ -220,10 +220,10 @@
 	glass = TRUE
 
 /obj/machinery/door/airlock/uranium/safe
-	safe = TRUE
+	actually_radioactive = FALSE
 
 /obj/machinery/door/airlock/uranium/glass/safe
-	safe = TRUE
+	actually_radioactive = FALSE
 
 /obj/machinery/door/airlock/plasma
 	name = "plasma airlock"

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -196,9 +196,11 @@
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_uranium
 	var/last_event = 0
+	//Is this airlock actually radioactive?
+	var/safe = FALSE
 
 /obj/machinery/door/airlock/uranium/process()
-	if(world.time > last_event+20)
+	if(!safe && world.time > last_event+20)
 		if(prob(50))
 			radiate()
 		last_event = world.time
@@ -216,6 +218,12 @@
 /obj/machinery/door/airlock/uranium/glass
 	opacity = FALSE
 	glass = TRUE
+
+/obj/machinery/door/airlock/uranium/safe
+	safe = TRUE
+
+/obj/machinery/door/airlock/uranium/glass/safe
+	safe = TRUE
 
 /obj/machinery/door/airlock/plasma
 	name = "plasma airlock"


### PR DESCRIPTION
## About The Pull Request

Fixes half of https://github.com/tgstation/tgstation/issues/62691.

The uranium doors of the gluttony ruin are now a non-radioactive subtype, so the ruin's contents won't all be glowing green by the time you get there as a miner.

As it turns out, the gluttony ruin's indestructible uranium walls already weren't radioactive, so I didn't have to change anything about them.

## Why It's Good For The Game

The gluttony ruin's theme is overeating, not a slow, painful death via radiation. You'll also be expected to stay in the ruin a while if you want to get fat, so we don't want to make it an actively toxic place to feast in.

## Changelog

:cl: ATHATH
fix: The gluttony sin ruin is no longer radioactive.
/:cl: