### PR TITLE
Makes priming a grenade logged in combat instead of game

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -145,7 +145,7 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
 	var/bomb_message = "[details][bomb ? " [bomb.name] at [AREACOORD(bomb)]": ""][additional_details ? " [additional_details]" : ""]."
 
 	if(user)
-		user.log_message(bomb_message, LOG_GAME) //let it go to individual logs as well as the game log
+		user.log_message(bomb_message, LOG_ATTACK) //let it go to individual logs as well as the game log
 		bomb_message = "[key_name(user)] at [AREACOORD(user)] [bomb_message]"
 	else
 		log_game(bomb_message)

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -102,6 +102,7 @@
 
 /obj/item/grenade/proc/log_grenade(mob/user)
 	log_bomber(user, "has primed a", src, "for detonation")
+	log_combat(user, src, "has primed a", src, "for detonation")
 
 /**
  * arm_grenade (formerly preprime) refers to when a grenade with a standard time fuze is activated, making it go beepbeepbeep and then detonate a few seconds later.

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -102,7 +102,6 @@
 
 /obj/item/grenade/proc/log_grenade(mob/user)
 	log_bomber(user, "has primed a", src, "for detonation")
-	log_combat(user, src, "has primed a", src, "for detonation")
 
 /**
  * arm_grenade (formerly preprime) refers to when a grenade with a standard time fuze is activated, making it go beepbeepbeep and then detonate a few seconds later.


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/53777086/140860622-32e78a5d-3a78-4303-8a04-db65c3b29e3d.png)

## Why It's Good For The Game

If you ignite a grenade and don't throw it, it isn't logged in the individual logs, so admins have to go check bomber logs instead. This is very confusing since bombs are part of combat so using one should show up in your individual logs' attack logs.

## Changelog

:cl:
admin: Priming grenades are now logged in individual's attack logs.
/:cl: