### PR TITLE
Fixes a ton of mirror bugs, makes magic mirrors more open-minded

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -64,8 +64,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 	var/new_facial_hair_style = input(stylist, "Select a facial hairstyle", "Grooming")  as null|anything in GLOB.facial_hairstyles_list
 	if(!stylist.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		return //no tele-grooming
-	if(new_style)
-		stylist.facial_hairstyle = new_style
+	if(new_facial_hair_style)
+		stylist.facial_hairstyle = new_facial_hair_style
 		stylist.update_hair()
 		curse(stylist)
 
@@ -264,16 +264,16 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 						stylist.gender = MALE //we'll update their gender to match their body type- if they want their gender to not match their body type, they can change that using the gender-changing function of the mirror
 				else
 					return
-			H.dna.update_ui_block(DNA_GENDER_BLOCK)
-			H.update_body()
-			H.update_mutations_overlay() //(hulk male/female)
+			stylist.dna.update_ui_block(DNA_GENDER_BLOCK)
+			stylist.update_body()
+			stylist.update_mutations_overlay() //(hulk male/female)
 			curse(stylist)
 
 		if("hairstyle")
 			..()
 		
 		if("hair color")
-			var/new_hair_color = input(stylist, "What is the color of our hair again?", "Hair Color",H.hair_color) as color|null
+			var/new_hair_color = input(stylist, "What is the color of our hair again?", "Hair Color",stylist.hair_color) as color|null
 			if(!stylist.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 				return
 			

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -21,7 +21,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 	creation_time = world.time
 
 /obj/structure/mirror/examine(mob/user)
-	if(!ut_reference || desc != initial(desc)) //I'm really not a fan of hardcoding this, but I don't see another way to do this
+	if(!ut_reference || desc != initial(desc))
 		return ..()
 	else if(user.mind && user.mind.has_antag_datum(/datum/antagonist, TRUE) && user.key)
 		desc = "It's me, [user.key]." //uses the player's OOC name, not their IC one

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -42,10 +42,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 	if(!ishuman(user))
 		return
 
-	mirror_stuff(user)
+	change_appearance(user)
 
 //Mirror man, mirror man, does whatever a mirror can.
-/obj/structure/mirror/mirror_stuff(mob/living/carbon/human/stylist)
+/obj/structure/mirror/change_appearance(mob/living/carbon/human/stylist)
 	//see code/modules/mob/dead/new_player/preferences.dm at approx line 545 for comments!
 	//this is largely copypasted from there.
 
@@ -167,7 +167,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 			choosable_races += initial(species_type.name)
 	return ..()
 
-/obj/structure/mirror/magic/mirror_stuff(mob/living/carbon/human/stylist)
+/obj/structure/mirror/magic/change_appearance(mob/living/carbon/human/stylist)
 	var/choice = input(stylist, "Something to change?", "Magical Grooming") as null|anything in list("name", "species", "color", "gender", "sex", "hairstyle", "hair color", "eyes")
 
 	if(!stylist.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -9,6 +9,8 @@
 	max_integrity = 200
 	integrity_failure = 0.5
 	var/creation_time
+	///Should our description be able to be changed by the undertale easter egg? Make this false if the default description is not "It's you!". I'd check for a description of "It's you!" directly, but I've been directly told not to do that for some reason.
+	var/ut_reference = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 
@@ -19,15 +21,16 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 	creation_time = world.time
 
 /obj/structure/mirror/examine(mob/user)
+	if(!ut_reference || desc != initial(desc)) //I'm really not a fan of hardcoding this, but I don't see another way to do this
+		return ..()
+	else if(user.mind && user.mind.has_antag_datum(/datum/antagonist, TRUE) && user.key)
+		desc = "It's me, [user.key]." //uses the player's OOC name, not their IC one
+	else if(SSshuttle.emergency && SSshuttle.emergency.mode == SHUTTLE_ENDGAME)
+		desc = "Still just you, [user.real_name]."
+	else if(world.time >= creation_time + 60 MINUTES)
+		desc = "Despite everything, it's still you."
 	. = ..()
-	if(desc != "It's you!") //I'm really not a fan of hardcoding this, but I don't see another way to do this
-		return
-	if(user.mind && user.mind.has_antag_datum(/datum/antagonist, TRUE) && user.key)
-		return "It's me, [user.key]." //uses the player's OOC name, not their IC one
-	if(SSshuttle.emergency && SSshuttle.emergency.mode == SHUTTLE_ENDGAME)
-		return "Still just you, [user.real_name]."
-	if(world.time >= creation_time + 60 MINUTES)
-		return "Despite everything, it's still you."
+	desc = initial(desc)
 
 /obj/structure/mirror/attack_hand(mob/user, list/modifiers)
 	. = ..()
@@ -144,6 +147,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 	desc = "Turn and face the strange."
 	icon_state = "magic_mirror"
 	var/list/choosable_races = list()
+	ut_reference = FALSE
 
 /obj/structure/mirror/magic/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -1,7 +1,7 @@
 //wip wip wup
 /obj/structure/mirror
 	name = "mirror"
-	desc = "Mirror mirror on the wall, who's the most robust of them all?"
+	desc = "Despite everything, it's still you."
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "mirror"
 	density = FALSE
@@ -15,6 +15,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 	. = ..()
 	if(icon_state == "mirror_broke" && !broken)
 		atom_break(null, mapload)
+
+/obj/structure/mirror/examine(mob/user)
+	. = ..()
+	if(!broken && user.mind && user.mind.has_antag_datum(/datum/antagonist, TRUE) && user.key)
+		. = "It's me, [user.key]." //uses the player's OOC name, not their IC one
 
 /obj/structure/mirror/attack_hand(mob/user, list/modifiers)
 	. = ..()
@@ -128,7 +133,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 
 /obj/structure/mirror/magic
 	name = "magic mirror"
-	desc = "Turn and face the strange... face."
+	desc = "Turn and face the strange."
 	icon_state = "magic_mirror"
 	var/list/choosable_races = list()
 

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -45,7 +45,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 	change_appearance(user)
 
 //Mirror man, mirror man, does whatever a mirror can.
-/obj/structure/mirror/change_appearance(mob/living/carbon/human/stylist)
+/obj/structure/mirror/proc/change_appearance(mob/living/carbon/human/stylist)
 	//see code/modules/mob/dead/new_player/preferences.dm at approx line 545 for comments!
 	//this is largely copypasted from there.
 

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -1,13 +1,14 @@
 //wip wip wup
 /obj/structure/mirror
 	name = "mirror"
-	desc = "Despite everything, it's still you."
+	desc = "It's you!"
 	icon = 'icons/obj/watercloset.dmi'
 	icon_state = "mirror"
 	density = FALSE
 	anchored = TRUE
 	max_integrity = 200
 	integrity_failure = 0.5
+	var/creation_time
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 
@@ -15,11 +16,18 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 	. = ..()
 	if(icon_state == "mirror_broke" && !broken)
 		atom_break(null, mapload)
+	creation_time = world.time
 
 /obj/structure/mirror/examine(mob/user)
 	. = ..()
-	if(!broken && user.mind && user.mind.has_antag_datum(/datum/antagonist, TRUE) && user.key)
-		. = "It's me, [user.key]." //uses the player's OOC name, not their IC one
+	if(desc != "It's you!") //I'm really not a fan of hardcoding this, but I don't see another way to do this
+		return
+	if(user.mind && user.mind.has_antag_datum(/datum/antagonist, TRUE) && user.key)
+		return "It's me, [user.key]." //uses the player's OOC name, not their IC one
+	if(SSshuttle.emergency && SSshuttle.emergency.mode == SHUTTLE_ENDGAME)
+		return "Still just you, [user.real_name]."
+	if(world.time >= creation_time + 60 MINUTES)
+		return "Despite everything, it's still you."
 
 /obj/structure/mirror/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -119,7 +119,7 @@
 
 /obj/structure/mirror/magic/pride/curse(mob/user)
 	user.visible_message(span_danger("<B>The ground splits beneath [user] as [user.p_their()] hand leaves the mirror!</B>"), \
-	span_notice("Perfect. Much better! Now <i>nobody</i> will be able to resist yo-"))
+	span_notice("Perfect. Much better! Now <i>nobody</i> will be able to resist m-"))
 
 	var/turf/T = get_turf(user)
 	var/list/levels = SSmapping.levels_by_trait(ZTRAIT_SPACE_RUINS)
@@ -131,6 +131,7 @@
 	var/turf/open/chasm/C = T
 	C.set_target(dest)
 	C.drop(user)
+	return TRUE //don't give them another mirror pop-up
 
 //can't be bothered to do sloth right now, will make later
 


### PR DESCRIPTION
## About The Pull Request

Magic mirrors (including pride mirrors) will no longer pull up the normal mirror interface before their own when interacted with.

You can no longer avoid the curse of a pride mirror with some species by just walking away after finishing some, but not all of your changes to one of your features (i.e. walking away after choosing a species but before choosing your skin tone).

For magic mirrors, species selection has been moved out of the "race" feature category and into its own "species" category.

Magic mirrors can now modify your gender independently of your sex, and you can become nonbinary using one if you so desire.

Characters with a female body type can select a new facial hair style at any mirror, just like characters with male body types can, and are no longer forced to shave their facial hair when they use a mirror. Note that, according to mothblocks, characters with female body types are already capable of giving themselves beards during character creation, and mirrors were just never updated to reflect this.

Mirror code has been brought closer to our standards.

Some mirror-related descriptions have been tweaked. Nothing to see here.

Probably fixes half of https://github.com/tgstation/tgstation/issues/62691.

Testing for this PR will come Soon(TM), after Manuel's peak hours have passed.

## Why It's Good For The Game

Needing to dismiss the normal mirror interface to use a magic mirror is really annoying and also probably misleading for new players.

Our current mirror code is... Okay, I think the best way to summarize our current mirror code is that it uses "eyes" in the list of features you can opt to change, then checks for BODY_ZONE_PRECISE_EYES in its big switch statement. If the definition of BODY_ZONE_PRECISE_EYES ever changes (without this PR being merged), magic mirrors will silently lose their ability to change your eye color.

Also, like, the gender-related changes are probably nice to have.

![image](https://user-images.githubusercontent.com/42606352/140869802-83df8b38-e5aa-4756-bac4-921991fba42a.png)

## Changelog

:cl: ATHATH
fix: Magic mirrors (including pride mirrors) will no longer pull up the normal mirror interface before their own when interacted with.
fix: You can no longer avoid the curse of a pride mirror with some species by just walking away after finishing some, but not all of your changes to one of your features (i.e. walking away after choosing a species but before choosing your skin tone).
fix: For magic mirrors, species selection has been moved out of the "race" feature category and into its own "species" category.
fix: Magic mirrors can now modify your gender independently of your sex, and you can become nonbinary using one if you so desire.
fix: Characters with a female body type can select a new facial hair style at any mirror, just like characters with male body types can, and are no longer forced to shave their facial hair when they use a mirror. Note that, according to mothblocks, characters with female body types are already capable of giving themselves beards during character creation, and mirrors were just never updated to reflect this.
code: Mirror code has been brought closer to our standards.
spellcheck: Some mirror-related descriptions have been tweaked. Nothing to see here.
/:cl: