### PR TITLE
Makes you unable to pick up all CTF barstools and fixes their directions

### DIFF
--- a/_maps/map_files/CTF/downtown.dmm
+++ b/_maps/map_files/CTF/downtown.dmm
@@ -63,7 +63,7 @@
 /turf/open/floor/iron,
 /area/ctf)
 "bs" = (
-/obj/structure/chair/stool/bar{
+/obj/structure/chair/stool/bar/directional/south{
 	item_chair = null;
 	resistance_flags = 64
 	},
@@ -1384,9 +1384,9 @@
 /area/ctf)
 "Am" = (
 /obj/structure/window/reinforced/fulltile{
+	atom_integrity = 5000;
 	max_integrity = 5000;
-	name = "hardened window";
-	atom_integrity = 5000
+	name = "hardened window"
 	},
 /turf/open/floor/plating,
 /area/ctf)
@@ -1620,7 +1620,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
-/obj/structure/chair/stool/bar/directional/south,
+/obj/structure/chair/stool/bar/directional/north{
+	item_chair = null;
+	resistance_flags = 64
+	},
 /turf/open/floor/iron,
 /area/ctf)
 "DE" = (
@@ -3683,9 +3686,9 @@ xs
 td
 Bh
 ql
-hU
+go
 ql
-hU
+go
 QC
 td
 mB
@@ -3835,9 +3838,9 @@ BH
 Am
 Ug
 ql
-hU
+go
 ql
-hU
+go
 QC
 Am
 Ad
@@ -4180,7 +4183,7 @@ dO
 sZ
 Dm
 ql
-hU
+go
 td
 qT
 yX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#62601 messed up the directions of some of the stools on CTF map downtown, the directions have now been fixed.

This also prevents CTF players from picking up 5 of the bar stools that were missed in the maps original creation

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bar stools should face tables and picking up bar stools in CTF allows you to break them into metal, which in turn can be used to wall off the flag, which is bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: CTF Downtowns bar stools face the right way now
fix: CTF Downtowns bar stools have been bolted onto to the floor for insurance purposes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
