### PR TITLE
The word filter will now be less scared of double or trailing spaces

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -460,9 +460,11 @@ Example config:
 		else
 			to_join_on_whitespace_splits += REGEX_QUOTE(banned_word)
 
-	var/whitespace_split = @"(?:(?:^|\s+)(" + jointext(to_join_on_whitespace_splits, "|") + @")(?:$|\s+))"
+	// We don't want a whitespace_split part if there's no stuff that requires it
+	var/whitespace_split = to_join_on_whitespace_splits.len > 0 ? @"(?:(?:^|\s+)(" + jointext(to_join_on_whitespace_splits, "|") + @")(?:$|\s+))" : ""
 	var/word_bounds = @"(\b(" + jointext(to_join_on_word_bounds, "|") + @")\b)"
-	return regex("([whitespace_split]|[word_bounds])", "i")
+	var/regex_filter = whitespace_split != "" ? "([whitespace_split]|[word_bounds])" : word_bounds
+	return regex(regex_filter, "i")
 
 //Message admins when you can.
 /datum/controller/configuration/proc/DelayedMessageAdmins(text)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -28,7 +28,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	if(QDELETED(src))
 		return
 
-	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
+	msg = trim(copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN))
 	var/raw_msg = msg
 
 	var/list/filter_result = is_ooc_filtered(msg)

--- a/code/modules/unit_tests/chat_filter.dm
+++ b/code/modules/unit_tests/chat_filter.dm
@@ -50,6 +50,14 @@
 		BLOCKED_SHARED,
 	)
 
+	test_filter(
+		" This message has a space at the beginning, a  double space, and a space at the end, but it's fine! ",
+		null,
+		null,
+		null,
+		null,
+	)
+
 /datum/unit_test/chat_filter_sanity/proc/test_filter(
 	message,
 	blocked_word,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It kept on tripping because the RegEx expression was malformed due to an absence of words in `to_join_on_whitespace_splits`, which caused it to filter out spaces that were at the beginning or at the end of a message, or if there was two spaces one by the other.

Also prevents people from sending a message that's only spaces in OOC, because that's a little silly.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You should be able to send messages that contain multiple spaces if your `word_filter.toml` doesn't contain any numbers or special characters, and it definitely shouldn't prevent you from sending a message because you hit space once too many times when typing fast.

Also, I don't even know why we let people make OOC messages that were literally just ` `. So, I fixed that too.

Closes https://github.com/tgstation/tgstation/issues/62655
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

🆑 GoldenAlpharex
fix: The word filter has matured and is no longer scared of spaces before or after your messages, or double spaces in the middle of your sentences.
fix: You can no longer send a message in OOC that only contains spaces. No more chatbangs.
/🆑

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
