### PR TITLE
Allows players to send more visible adminhelps when no admins are on, which'll definitely alert admins

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -13,7 +13,7 @@ Version 5.19, 10 November 2021, by WalterMeldron
 Adds an urgent column to tickets for ahelps marked as urgent.
 
 ```
-ALTER TABLE `ticket` ADD COLUMN (`urgent` TINYINT(1) NOT NULL DEFAULT 0);
+ALTER TABLE `ticket` ADD COLUMN (`urgent` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0');
 ```
 
 -----------------------------------------------------

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -2,9 +2,9 @@ Any time you make a change to the schema files, remember to increment the databa
 
 The latest database version is 5.19; The query to update the schema revision table is:
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 18);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 19);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 18);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 19);
 
 In any query remember to add a prefix to the table names if you use one.
 

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,20 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.17; The query to update the schema revision table is:
+The latest database version is 5.19; The query to update the schema revision table is:
 
 INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 18);
 or
 INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 18);
 
 In any query remember to add a prefix to the table names if you use one.
+
+-----------------------------------------------------
+Version 5.19, 10 November 2021, by WalterMeldron
+Adds an urgent column to tickets for ahelps marked as urgent.
+
+```
+ALTER TABLE `ticket` ADD COLUMN (`urgent` TINYINT(1) NOT NULL DEFAULT 0);
+```
 
 -----------------------------------------------------
 Version 5.18, 1 November 2021, by Mothblocks

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -13,7 +13,7 @@ Version 5.19, 10 November 2021, by WalterMeldron
 Adds an urgent column to tickets for ahelps marked as urgent.
 
 ```
-ALTER TABLE `ticket` ADD COLUMN (`urgent` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0');
+ALTER TABLE `ticket` ADD COLUMN `urgent` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `sender`;
 ```
 
 -----------------------------------------------------

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -588,6 +588,7 @@ CREATE TABLE `ticket` (
   `round_id` int(11) unsigned NULL,
   `ticket` smallint(11) unsigned NOT NULL,
   `action` varchar(20) NOT NULL DEFAULT 'Message',
+  `urgent` TINYINT(1) unsigned NOT NULL DEFAULT 0,
   `message` text NOT NULL,
   `timestamp` datetime NOT NULL,
   `recipient` varchar(32) DEFAULT NULL,

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -588,7 +588,7 @@ CREATE TABLE `ticket` (
   `round_id` int(11) unsigned NULL,
   `ticket` smallint(11) unsigned NOT NULL,
   `action` varchar(20) NOT NULL DEFAULT 'Message',
-  `urgent` TINYINT(1) unsigned NOT NULL DEFAULT 0,
+  `urgent` TINYINT(1) unsigned NOT NULL DEFAULT '0',
   `message` text NOT NULL,
   `timestamp` datetime NOT NULL,
   `recipient` varchar(32) DEFAULT NULL,

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -588,7 +588,7 @@ CREATE TABLE `SS13_ticket` (
   `round_id` int(11) unsigned NULL,
   `ticket` smallint(11) unsigned NOT NULL,
   `action` varchar(20) NOT NULL DEFAULT 'Message',
-  `urgent` TINYINT(1) unsigned NOT NULL DEFAULT 0,
+  `urgent` TINYINT(1) unsigned NOT NULL DEFAULT '0',
   `message` text NOT NULL,
   `timestamp` datetime NOT NULL,
   `recipient` varchar(32) DEFAULT NULL,

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -588,6 +588,7 @@ CREATE TABLE `SS13_ticket` (
   `round_id` int(11) unsigned NULL,
   `ticket` smallint(11) unsigned NOT NULL,
   `action` varchar(20) NOT NULL DEFAULT 'Message',
+  `urgent` TINYINT(1) unsigned NOT NULL DEFAULT 0,
   `message` text NOT NULL,
   `timestamp` datetime NOT NULL,
   `recipient` varchar(32) DEFAULT NULL,

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
  *
  * make sure you add an update to the schema_version stable in the db changelog
  */
-#define DB_MINOR_VERSION 18
+#define DB_MINOR_VERSION 19
 
 
 //! ## Timing subsystem

--- a/code/__HELPERS/chat.dm
+++ b/code/__HELPERS/chat.dm
@@ -40,21 +40,22 @@ In TGS3 it will always be sent to all connected designated game chats.
  *
  * message - The message to send.
  * channel_tag - Required. If "", the message with be sent to all connected (Game-type for TGS3) channels. Otherwise, it will be sent to TGS4 channels with that tag (Delimited by ','s).
+ * admin_only - Determines if this communication can only be sent to admin only channels.
  */
-/proc/send2chat(message, channel_tag)
+/proc/send2chat(message, channel_tag, admin_only = FALSE)
 	if(channel_tag == null || !world.TgsAvailable())
 		return
 
 	var/datum/tgs_version/version = world.TgsVersion()
 	if(channel_tag == "" || version.suite == 3)
-		world.TgsTargetedChatBroadcast(message, FALSE)
+		world.TgsTargetedChatBroadcast(message, admin_only)
 		return
 
 	var/list/channels_to_use = list()
 	for(var/I in world.TgsChatChannelInfo())
 		var/datum/tgs_chat_channel/channel = I
 		var/list/applicable_tags = splittext(channel.custom_tag, ",")
-		if(channel_tag in applicable_tags)
+		if((!admin_only || channel.is_admin_channel) && (channel_tag in applicable_tags))
 			channels_to_use += channel
 
 	if(channels_to_use.len)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -551,7 +551,7 @@
 	default = "No message provided"
 
 /datum/config_entry/string/urgent_ahelp_user_prompt
-	default = "There are no admins currently on. Do not press the button below if your ahelp is a joke or a request, use it only for cases of obvious grief."
+	default = "There are no admins currently on. Do not press the button below if your ahelp is a joke, a request or a question. Use it only for cases of obvious grief."
 
 /datum/config_entry/string/adminhelp_webhook_url
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -543,3 +543,9 @@
 	min_val = 0
 
 /datum/config_entry/str_list/motd
+
+/datum/config_entry/number/urgent_ahelp_cooldown
+	default = 300
+
+/datum/config_entry/string/urgent_ahelp_message
+	default = 300

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -552,3 +552,9 @@
 
 /datum/config_entry/string/urgent_ahelp_user_prompt
 	default = "There are no admins currently on. Do not press the button below if your ahelp is a joke or a request, use it only for cases of obvious grief."
+
+/datum/config_entry/string/adminhelp_webhook_url
+
+/datum/config_entry/string/adminhelp_webhook_pfp
+
+/datum/config_entry/string/adminhelp_webhook_name

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -548,4 +548,4 @@
 	default = 300
 
 /datum/config_entry/string/urgent_ahelp_message
-	default = 300
+	default = "No message provided"

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -548,7 +548,7 @@
 	default = 300
 
 /datum/config_entry/string/urgent_ahelp_message
-	default = "No message provided"
+	default = "This ahelp is urgent!"
 
 /datum/config_entry/string/urgent_ahelp_user_prompt
 	default = "There are no admins currently on. Do not press the button below if your ahelp is a joke, a request or a question. Use it only for cases of obvious grief."

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -549,3 +549,6 @@
 
 /datum/config_entry/string/urgent_ahelp_message
 	default = "No message provided"
+
+/datum/config_entry/string/urgent_ahelp_user_prompt
+	default = "There are no admins currently on. Do not press the button below if your ahelp is a joke or a request, use it only for cases of obvious grief."

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -288,14 +288,25 @@ Versioning
 	key = new_key
 	key_type = new_key_type
 
-/datum/controller/subsystem/blackbox/proc/LogAhelp(ticket, action, message, recipient, sender)
+/datum/controller/subsystem/blackbox/proc/LogAhelp(ticket, action, message, recipient, sender, urgent = FALSE)
 	if(!SSdbcore.Connect())
 		return
 
 	var/datum/db_query/query_log_ahelp = SSdbcore.NewQuery({"
-		INSERT INTO [format_table_name("ticket")] (ticket, action, message, recipient, sender, server_ip, server_port, round_id, timestamp)
-		VALUES (:ticket, :action, :message, :recipient, :sender, INET_ATON(:server_ip), :server_port, :round_id, :time)
-	"}, list("ticket" = ticket, "action" = action, "message" = message, "recipient" = recipient, "sender" = sender, "server_ip" = world.internet_address || "0", "server_port" = world.port, "round_id" = GLOB.round_id, "time" = SQLtime()))
+		INSERT INTO [format_table_name("ticket")] (ticket, action, message, recipient, sender, server_ip, server_port, round_id, timestamp, urgent)
+		VALUES (:ticket, :action, :message, :recipient, :sender, INET_ATON(:server_ip), :server_port, :round_id, :time, :urgent)
+	"}, list(
+		"ticket" = ticket,
+		"action" = action,
+		"message" = message,
+		"recipient" = recipient,
+		"sender" = sender,
+		"server_ip" = world.internet_address || "0",
+		"server_port" = world.port,
+		"round_id" = GLOB.round_id,
+		"time" = SQLtime(),
+		"urgent" = urgent,
+	))
 	query_log_ahelp.Execute()
 	qdel(query_log_ahelp)
 

--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -14,7 +14,7 @@
 	. = ..()
 	if(.)
 		return
-	user.get_adminhelp()
+	user.adminhelp()
 	return TRUE
 
 

--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -279,7 +279,7 @@
 			break_counter = 0
 
 		var/list/other_job_lists = list(
-			"Abstract" = list("Appearance", "Emote", "Deadchat", "OOC"),
+			"Abstract" = list("Appearance", "Emote", "Deadchat", "OOC", "Urgent Adminhelp"),
 			)
 		for(var/department in other_job_lists)
 			output += "<div class='column'><label class='rolegroup [ckey(department)]'>[tgui_fancy ? "<input type='checkbox' name='[department]' class='hidden' onClick='header_click_all_checkboxes(this)'>" : ""][department]</label><div class='content'>"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -562,6 +562,7 @@ GLOBAL_DATUM_INIT(admin_help_ui_handler, /datum/admin_help_ui_handler, new)
 /datum/admin_help_ui_handler/ui_static_data(mob/user)
 	. = list()
 	.["bannedFromUrgentAhelp"] = is_banned_from(user.ckey, "Urgent Adminhelp")
+	.["urgentAhelpPromptMessage"] = CONFIG_GET(string/urgent_ahelp_user_prompt)
 
 /datum/admin_help_ui_handler/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -630,7 +631,7 @@ GLOBAL_DATUM_INIT(admin_help_ui_handler, /datum/admin_help_ui_handler, new)
 	var/urgent = FALSE
 	var/list/admins = get_admin_counts(R_BAN)
 	if(!is_banned_from(ckey, "Urgent Adminhelp") && length(admins["present"]) == 0 && (GLOB.admin_help_ui_handler.ahelp_cooldowns?[ckey] || 0) <= world.time)
-		urgent = alert(src, "There are no admins on. Is this an ahelp reporting a rulebreak? Pressing yes when it isn't can lead to punishments.", \
+		urgent = alert(src, "Request an admin? [CONFIG_GET(string/urgent_ahelp_user_prompt)]", \
 			"No admins on", "No", "Yes") == "Yes"
 
 	var/list/potentially_new_admins = get_admin_counts(R_BAN)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -634,11 +634,11 @@ GLOBAL_DATUM_INIT(admin_help_ui_handler, /datum/admin_help_ui_handler, new)
 			ahelp_cooldowns[user.ckey] = world.time + CONFIG_GET(number/urgent_ahelp_cooldown) * (1 SECONDS)
 
 	if(user.current_ticket)
+		user.current_ticket.TimeoutVerb()
 		if(urgent)
 			var/sanitized_message = sanitize(copytext_char(message, 1, MAX_MESSAGE_LEN))
 			user.current_ticket.send_message_to_tgs(sanitized_message, TRUE)
 		user.current_ticket.MessageNoRecipient(message, urgent)
-		user.current_ticket.TimeoutVerb()
 		return
 
 	new /datum/admin_help(message, user, FALSE, urgent)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -595,13 +595,14 @@ GLOBAL_DATUM_INIT(admin_help_ui_handler, /datum/admin_help_ui_handler, new)
 	if(.)
 		return
 	var/client/user = usr.client
-	if(user.adminhelptimerid)
-		return
 	var/message = sanitize_text(trim(params["message"]), null)
 	var/urgent = sanitize_integer(params["urgent"], FALSE, TRUE, FALSE)
 	var/list/admins = get_admin_counts(R_BAN)
 	if(length(admins["present"]) != 0 || is_banned_from(user.ckey, "Urgent Adminhelp"))
 		urgent = FALSE
+
+	if(user.adminhelptimerid)
+		return
 
 	perform_adminhelp(user, message, urgent)
 	ui.close()

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -256,8 +256,10 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		webhook_info["avatar_url"] = CONFIG_GET(string/adminhelp_webhook_pfp)
 	// Uncomment when servers are moved to TGS4
 	// send2chat("[initiator_ckey] | [message_content]", "ahelp", TRUE)
+	var/list/headers = list()
+	headers["Content-Type"] = "application/json"
 	var/datum/http_request/request = new()
-	request.prepare(RUSTG_HTTP_METHOD_POST, "[CONFIG_GET(string/adminhelp_webhook_url)]", json_encode(webhook_info))
+	request.prepare(RUSTG_HTTP_METHOD_POST, "[CONFIG_GET(string/adminhelp_webhook_url)]", json_encode(webhook_info), headers)
 	request.begin_async()
 
 /datum/admin_help/Destroy()

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -259,7 +259,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	var/list/headers = list()
 	headers["Content-Type"] = "application/json"
 	var/datum/http_request/request = new()
-	request.prepare(RUSTG_HTTP_METHOD_POST, "[CONFIG_GET(string/adminhelp_webhook_url)]", json_encode(webhook_info), headers)
+	request.prepare(RUSTG_HTTP_METHOD_POST, CONFIG_GET(string/adminhelp_webhook_url), json_encode(webhook_info), headers, "tmp/response.json")
 	request.begin_async()
 
 /datum/admin_help/Destroy()

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -582,6 +582,9 @@ GLOBAL_DATUM_INIT(admin_help_ui_handler, /datum/admin_help_ui_handler, new)
 	. = list()
 	.["bannedFromUrgentAhelp"] = is_banned_from(user.ckey, "Urgent Adminhelp")
 	.["urgentAhelpPromptMessage"] = CONFIG_GET(string/urgent_ahelp_user_prompt)
+	var/webhook_url = CONFIG_GET(string/adminhelp_webhook_url)
+	if(webhook_url)
+		.["urgentAhelpEnabled"] = TRUE
 
 /datum/admin_help_ui_handler/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -648,17 +651,8 @@ GLOBAL_DATUM_INIT(admin_help_ui_handler, /datum/admin_help_ui_handler, new)
 		return
 
 	message = trim(message)
-	var/urgent = FALSE
-	var/list/admins = get_admin_counts(R_BAN)
-	if(!is_banned_from(ckey, "Urgent Adminhelp") && length(admins["present"]) == 0 && (GLOB.admin_help_ui_handler.ahelp_cooldowns?[ckey] || 0) <= world.time)
-		urgent = alert(src, "Request an admin? [CONFIG_GET(string/urgent_ahelp_user_prompt)]", \
-			"No admins on", "No", "Yes") == "Yes"
 
-	var/list/potentially_new_admins = get_admin_counts(R_BAN)
-	if(length(potentially_new_admins["present"]) != 0)
-		urgent = FALSE
-
-	GLOB.admin_help_ui_handler.perform_adminhelp(src, message, urgent)
+	GLOB.admin_help_ui_handler.perform_adminhelp(src, message, FALSE)
 
 /client/verb/adminhelp()
 	set category = "Admin"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -235,7 +235,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		if(extra_message)
 			extra_message_to_send += " ([extra_message])"
 		to_chat(initiator, span_boldwarning("Sent a notification to admins through TGS."))
-		send2adminchat_webhook(extra_message_to_send)
+		send2adminchat_webhook("[initiator_ckey] | [extra_message_to_send]")
 	//send it to TGS if nobody is on and tell us how many were on
 	var/admin_number_present = send2tgs_adminless_only(initiator_ckey, "Ticket #[id]: [message_to_send]")
 	log_admin_private("Ticket #[id]: [key_name(initiator)]: [name] - heard by [admin_number_present] non-AFK admins who have +BAN.")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -235,7 +235,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		if(extra_message)
 			extra_message_to_send += " ([extra_message])"
 		to_chat(initiator, span_boldwarning("Sent a notification to admins through TGS."))
-		send2adminchat_webhook()
+		send2adminchat_webhook(extra_message_to_send)
 	//send it to TGS if nobody is on and tell us how many were on
 	var/admin_number_present = send2tgs_adminless_only(initiator_ckey, "Ticket #[id]: [message_to_send]")
 	log_admin_private("Ticket #[id]: [key_name(initiator)]: [name] - heard by [admin_number_present] non-AFK admins who have +BAN.")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -235,7 +235,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		if(extra_message)
 			extra_message_to_send += " ([extra_message])"
 		to_chat(initiator, span_boldwarning("Sent a notification to admins through TGS."))
-		send2adminchat_webhook("[initiator_ckey] | [extra_message_to_send]")
+		send2adminchat_webhook("RELAY: [initiator_ckey] | Ticket #[id]: [extra_message_to_send]")
 	//send it to TGS if nobody is on and tell us how many were on
 	var/admin_number_present = send2tgs_adminless_only(initiator_ckey, "Ticket #[id]: [message_to_send]")
 	log_admin_private("Ticket #[id]: [key_name(initiator)]: [name] - heard by [admin_number_present] non-AFK admins who have +BAN.")

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -234,7 +234,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		var/extra_message = CONFIG_GET(string/urgent_ahelp_message)
 		if(extra_message)
 			message_to_send += " ([extra_message])"
-		to_chat(initiator, span_boldwarning("Sent an urgent message to admins through TGS."))
+		to_chat(initiator, span_boldwarning("Sent a notification to admins through TGS."))
 
 	//send it to TGS if nobody is on and tell us how many were on
 	var/admin_number_present = send2tgs_adminless_only(initiator_ckey, "Ticket #[id]: [message_to_send]")

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -34,6 +34,9 @@
 	COOLDOWN_DECLARE(cryo_warned)
 	///Tracks say() usage for ic/dchat while slowmode is enabled
 	COOLDOWN_DECLARE(say_slowmode)
+	/// The last urgent ahelp that this player sent
+	COOLDOWN_DECLARE(urgent_ahelp_cooldown)
+
 		/////////
 		//OTHER//
 		/////////

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -100,6 +100,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(href_list["priv_msg"])
 		cmd_admin_pm(href_list["priv_msg"],null)
 		return
+	// TGUIless adminhelp
+	if(href_list["tguiless_adminhelp"])
+		no_tgui_adminhelp(input(src, "Enter your ahelp", "Ahelp") as null|message)
+		return
 
 	switch(href_list["_src_"])
 		if("holder")

--- a/config/config.txt
+++ b/config/config.txt
@@ -559,6 +559,12 @@ DEFAULT_VIEW_SQUARE 15x15
 ## Once a typepath causes overrun from hard deletes this many times, stop hard deleting it on garbage collection failures. (set to 0 to disable)
 #HARD_DELETES_OVERRUN_LIMIT 0
 
+## The urgent ahelp cooldown for a given player if they're alone on a server and need to send an urgent ahelp.
+URGENT_AHELP_COOLDOWN 300
+
+## The message that is sent to the discord if an urgent ahelp is sent. Useful for sending a role ping.
+#URGENT_AHELP_MESSAGE Ban ban ban ban
+
 ## Sets an MOTD of the server.
 ## You can use this multiple times, and the MOTDs will be appended in order.
 ## Based on config directory, so "motd.txt" points to "config/motd.txt"

--- a/config/config.txt
+++ b/config/config.txt
@@ -559,6 +559,10 @@ DEFAULT_VIEW_SQUARE 15x15
 ## Once a typepath causes overrun from hard deletes this many times, stop hard deleting it on garbage collection failures. (set to 0 to disable)
 #HARD_DELETES_OVERRUN_LIMIT 0
 
+## The URL to the webhook for adminhelps to relay the urgent ahelp message to
+## If not set, will disable urgent ahelps.
+#ADMINHELP_WEBHOOK_URL
+
 ## The urgent ahelp cooldown for a given player if they're alone on a server and need to send an urgent ahelp.
 URGENT_AHELP_COOLDOWN 300
 
@@ -567,9 +571,6 @@ URGENT_AHELP_COOLDOWN 300
 
 ## The message that the player receives whenever prompted whether they want to send an urgent ahelp or not.
 #URGENT_AHELP_USER_PROMPT This'll ping the admins!
-
-## The URL to the webhook for adminhelps to relay the urgent ahelp message to
-#ADMINHELP_WEBHOOK_URL
 
 ## The URL for the pfp of the webhook
 #ADMINHELP_WEBHOOK_PFP

--- a/config/config.txt
+++ b/config/config.txt
@@ -568,6 +568,15 @@ URGENT_AHELP_COOLDOWN 300
 ## The message that the player receives whenever prompted whether they want to send an urgent ahelp or not.
 #URGENT_AHELP_USER_PROMPT This'll ping the admins!
 
+## The URL to the webhook for adminhelps to relay the urgent ahelp message to
+#ADMINHELP_WEBHOOK_URL
+
+## The URL for the pfp of the webhook
+#ADMINHELP_WEBHOOK_PFP
+
+## The name of the webhook
+#ADMINHELP_WEBHOOK_NAME
+
 ## Sets an MOTD of the server.
 ## You can use this multiple times, and the MOTDs will be appended in order.
 ## Based on config directory, so "motd.txt" points to "config/motd.txt"

--- a/config/config.txt
+++ b/config/config.txt
@@ -565,6 +565,9 @@ URGENT_AHELP_COOLDOWN 300
 ## The message that is sent to the discord if an urgent ahelp is sent. Useful for sending a role ping.
 #URGENT_AHELP_MESSAGE Ban ban ban ban
 
+## The message that the player receives whenever prompted whether they want to send an urgent ahelp or not.
+#URGENT_AHELP_USER_PROMPT This'll ping the admins!
+
 ## Sets an MOTD of the server.
 ## You can use this multiple times, and the MOTDs will be appended in order.
 ## Based on config directory, so "motd.txt" points to "config/motd.txt"

--- a/tgui/packages/tgui/components/TextArea.js
+++ b/tgui/packages/tgui/components/TextArea.js
@@ -104,6 +104,16 @@ export class TextArea extends Component {
     if (input) {
       input.value = toInputValue(nextValue);
     }
+
+    if (this.props.autoFocus || this.props.autoSelect) {
+      setTimeout(() => {
+        input.focus();
+
+        if (this.props.autoSelect) {
+          input.select();
+        }
+      }, 1);
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/tgui/packages/tgui/interfaces/Adminhelp.tsx
+++ b/tgui/packages/tgui/interfaces/Adminhelp.tsx
@@ -14,7 +14,7 @@ export const Adminhelp = (props, context) => {
     adminCount,
     bannedFromUrgentAhelp,
   } = data;
-  const [requestforadmin, setRequestForAdmin] = useLocalState(context, "requestforadmin", false);
+  const [requestForAdmin, setRequestForAdmin] = useLocalState(context, "request_for_admin", false);
   const [ahelpMessage, setAhelpMessage] = useLocalState(context, "ahelp_message", "");
   return (
     <Window
@@ -43,8 +43,8 @@ export const Adminhelp = (props, context) => {
                 <Button
                   mt={1}
                   content="Request an admin?"
-                  onClick={() => setRequestForAdmin(!requestforadmin)}
-                  icon={requestforadmin? 'check-square-o' : 'square-o'}
+                  onClick={() => setRequestForAdmin(!requestForAdmin)}
+                  icon={requestForAdmin? 'check-square-o' : 'square-o'}
                   disabled={bannedFromUrgentAhelp}
                   fluid
                   textAlign="center"
@@ -60,7 +60,7 @@ export const Adminhelp = (props, context) => {
               content="Submit"
               textAlign="center"
               onClick={() => act("ahelp", {
-                urgent: requestforadmin,
+                urgent: requestForAdmin,
                 message: ahelpMessage,
               })}
             />

--- a/tgui/packages/tgui/interfaces/Adminhelp.tsx
+++ b/tgui/packages/tgui/interfaces/Adminhelp.tsx
@@ -1,0 +1,73 @@
+import { BooleanLike } from "common/react";
+import { useBackend, useLocalState } from "../backend";
+import { TextArea, Stack, Button, NoticeBox } from "../components";
+import { Window } from "../layouts";
+
+type AdminhelpData = {
+  adminCount: number,
+  bannedFromUrgentAhelp: BooleanLike
+}
+
+export const Adminhelp = (props, context) => {
+  const { act, data } = useBackend<AdminhelpData>(context);
+  const {
+    adminCount,
+    bannedFromUrgentAhelp,
+  } = data;
+  const [requestforadmin, setRequestForAdmin] = useLocalState(context, "requestforadmin", false);
+  const [ahelpMessage, setAhelpMessage] = useLocalState(context, "ahelp_message", "");
+  return (
+    <Window
+      title="Create Adminhelp"
+      theme="admin"
+      height={300}
+      width={500}>
+      <Window.Content style={{
+        "background-image": "none",
+      }}>
+        <Stack vertical fill>
+          <Stack.Item grow>
+            <TextArea
+              height="100%"
+              value={ahelpMessage}
+              placeholder="Admin help"
+              onChange={(e, value) => setAhelpMessage(value)}
+            />
+          </Stack.Item>
+          {adminCount <= 0 && (
+            <Stack.Item>
+              <NoticeBox info>
+                There are no admins currently on.
+                Do not press the button below if your ahelp is
+                a joke or a request, use it only for cases of rulebreak.
+                <Button
+                  mt={1}
+                  content="Request an admin?"
+                  onClick={() => setRequestForAdmin(!requestforadmin)}
+                  icon={requestforadmin? 'check-square-o' : 'square-o'}
+                  disabled={bannedFromUrgentAhelp}
+                  fluid
+                  textAlign="center"
+                  tooltip="Examples of bad ahelps to use this button for: TC trades, joke ahelps, "
+                />
+              </NoticeBox>
+            </Stack.Item>
+          )}
+          <Stack.Item>
+            <Button
+              color="good"
+              fluid
+              content="Submit"
+              textAlign="center"
+              onClick={() => act("ahelp", {
+                requestforadmin: requestforadmin,
+                message: ahelpMessage,
+              })}
+            />
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+
+  );
+};

--- a/tgui/packages/tgui/interfaces/Adminhelp.tsx
+++ b/tgui/packages/tgui/interfaces/Adminhelp.tsx
@@ -80,9 +80,10 @@ export const Adminhelp = (props, context) => {
                         setCurrentlyInputting(true);
                       }
                     }}
-                    color={requestForAdmin? "orange" : "blue"}
-                    icon={requestForAdmin? 'check-square-o' : 'square-o'}
+                    color={requestForAdmin ? "orange" : "blue"}
+                    icon={requestForAdmin ? "check-square-o" : "square-o"}
                     disabled={bannedFromUrgentAhelp}
+                    tooltip={bannedFromUrgentAhelp ? "You are banned from using urgent ahelps." : null}
                     fluid
                     textAlign="center"
                   />

--- a/tgui/packages/tgui/interfaces/Adminhelp.tsx
+++ b/tgui/packages/tgui/interfaces/Adminhelp.tsx
@@ -28,6 +28,7 @@ export const Adminhelp = (props, context) => {
         <Stack vertical fill>
           <Stack.Item grow>
             <TextArea
+              autoFocus
               height="100%"
               value={ahelpMessage}
               placeholder="Admin help"

--- a/tgui/packages/tgui/interfaces/Adminhelp.tsx
+++ b/tgui/packages/tgui/interfaces/Adminhelp.tsx
@@ -60,7 +60,7 @@ export const Adminhelp = (props, context) => {
               content="Submit"
               textAlign="center"
               onClick={() => act("ahelp", {
-                requestforadmin: requestforadmin,
+                urgent: requestforadmin,
                 message: ahelpMessage,
               })}
             />

--- a/tgui/packages/tgui/interfaces/Adminhelp.tsx
+++ b/tgui/packages/tgui/interfaces/Adminhelp.tsx
@@ -5,7 +5,8 @@ import { Window } from "../layouts";
 
 type AdminhelpData = {
   adminCount: number,
-  bannedFromUrgentAhelp: BooleanLike
+  bannedFromUrgentAhelp: BooleanLike,
+  urgentAhelpPromptMessage: string,
 }
 
 export const Adminhelp = (props, context) => {
@@ -13,6 +14,7 @@ export const Adminhelp = (props, context) => {
   const {
     adminCount,
     bannedFromUrgentAhelp,
+    urgentAhelpPromptMessage,
   } = data;
   const [requestForAdmin, setRequestForAdmin] = useLocalState(context, "request_for_admin", false);
   const [ahelpMessage, setAhelpMessage] = useLocalState(context, "ahelp_message", "");
@@ -38,9 +40,7 @@ export const Adminhelp = (props, context) => {
           {adminCount <= 0 && (
             <Stack.Item>
               <NoticeBox info>
-                There are no admins currently on.
-                Do not press the button below if your ahelp is
-                a joke or a request, use it only for cases of rulebreak.
+                {urgentAhelpPromptMessage}
                 <Button
                   mt={1}
                   content="Request an admin?"

--- a/tgui/packages/tgui/interfaces/Adminhelp.tsx
+++ b/tgui/packages/tgui/interfaces/Adminhelp.tsx
@@ -1,10 +1,11 @@
 import { BooleanLike } from "common/react";
 import { useBackend, useLocalState } from "../backend";
-import { TextArea, Stack, Button, NoticeBox } from "../components";
+import { TextArea, Stack, Button, NoticeBox, Input, Box } from "../components";
 import { Window } from "../layouts";
 
 type AdminhelpData = {
   adminCount: number,
+  urgentAhelpEnabled: BooleanLike,
   bannedFromUrgentAhelp: BooleanLike,
   urgentAhelpPromptMessage: string,
 }
@@ -13,11 +14,15 @@ export const Adminhelp = (props, context) => {
   const { act, data } = useBackend<AdminhelpData>(context);
   const {
     adminCount,
+    urgentAhelpEnabled,
     bannedFromUrgentAhelp,
     urgentAhelpPromptMessage,
   } = data;
   const [requestForAdmin, setRequestForAdmin] = useLocalState(context, "request_for_admin", false);
+  const [currentlyInputting, setCurrentlyInputting] = useLocalState(context, "confirm_request", false);
   const [ahelpMessage, setAhelpMessage] = useLocalState(context, "ahelp_message", "");
+
+  const confirmationText = "alert admins";
   return (
     <Window
       title="Create Adminhelp"
@@ -37,19 +42,51 @@ export const Adminhelp = (props, context) => {
               onChange={(e, value) => setAhelpMessage(value)}
             />
           </Stack.Item>
-          {adminCount <= 0 && (
+          {(urgentAhelpEnabled && adminCount <= 0) && (
             <Stack.Item>
               <NoticeBox info>
                 {urgentAhelpPromptMessage}
-                <Button
-                  mt={1}
-                  content="Request an admin?"
-                  onClick={() => setRequestForAdmin(!requestForAdmin)}
-                  icon={requestForAdmin? 'check-square-o' : 'square-o'}
-                  disabled={bannedFromUrgentAhelp}
-                  fluid
-                  textAlign="center"
-                />
+                {currentlyInputting && (
+                  <Box
+                    mt={1}
+                    width="100%"
+                    fontFamily="arial"
+                    backgroundColor="grey"
+                    style={{
+                      "font-style": "normal",
+                    }}
+                  >
+                    Input &apos;{confirmationText}&apos; to proceed.
+                    <Input
+                      placeholder="Confirmation Prompt"
+                      autoFocus
+                      fluid
+                      onChange={(e, value) => {
+                        if (value === confirmationText) {
+                          setRequestForAdmin(true);
+                        }
+                        setCurrentlyInputting(false);
+                      }}
+                    />
+                  </Box>
+                ) || (
+                  <Button
+                    mt={1}
+                    content="Alert admins?"
+                    onClick={() => {
+                      if (requestForAdmin) {
+                        setRequestForAdmin(false);
+                      } else {
+                        setCurrentlyInputting(true);
+                      }
+                    }}
+                    color={requestForAdmin? "orange" : "blue"}
+                    icon={requestForAdmin? 'check-square-o' : 'square-o'}
+                    disabled={bannedFromUrgentAhelp}
+                    fluid
+                    textAlign="center"
+                  />
+                )}
               </NoticeBox>
             </Stack.Item>
           )}

--- a/tgui/packages/tgui/interfaces/Adminhelp.tsx
+++ b/tgui/packages/tgui/interfaces/Adminhelp.tsx
@@ -49,7 +49,6 @@ export const Adminhelp = (props, context) => {
                   disabled={bannedFromUrgentAhelp}
                   fluid
                   textAlign="center"
-                  tooltip="Examples of bad ahelps to use this button for: TC trades, joke ahelps, "
                 />
               </NoticeBox>
             </Stack.Item>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
See title
Admins get an alert when players ahelp (if no admins are on) and they select an option asking if they're ahelp is for a rulebreak matter. Adminhelps have been TGUI-ified but there is a fallback version that can be accessed through a chat link and a hidden verb that players can use if things have really gone to shit.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
More admin responsiveness, more admin effectiveness.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Players can now send urgent ahelps when no admins are on for potentially better responses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
