### PR TITLE
Saboteur syndieborg RCD buffed so it can deconstruct rwalls again.

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -811,6 +811,8 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	return .
 
 /obj/item/construction/rcd/borg/syndicate
+	name = "syndicate RCD"
+	desc = "A reverse-engineered RCD with black market upgrades that allow this device to deconstruct reinforced walls. Property of Donk Co."
 	icon_state = "ircd"
 	inhand_icon_state = "ircd"
 	energyfactor = 66

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -814,6 +814,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	icon_state = "ircd"
 	inhand_icon_state = "ircd"
 	energyfactor = 66
+	canRturf = TRUE
 
 /obj/item/construction/rcd/loaded
 	matter = 160


### PR DESCRIPTION
## About The Pull Request
See the title. Saboteur syndieborgs have had their RCDs buffed to deconstruct rwalls again.

## Why It's Good For The Game
Having played as a syndicate saboteur borg a few times and also from what I've heard from players, I can tell the syndicate saboteur is **hardly** better than an average engiborg (Whereas the medical syndieborg has a medbeam gun and a nanite hypospray and the syndie assault borg an e-sword, a weak but infinite lmg and a 6-shots 40mm launcher, the only noteworthy thing the syndicate saboteur borg has is a disguise easily foiled by any bop). They don't need their RCD nerfed when it's pretty meh at sabotaging the station short of welderbombing hit'n'runs (at least it doesn't have to rely on an awful team that forgets about cable coil and welding tools).

## Changelog

:cl: Ghommie and MrDoomBringer
balance: The Syndicate's Robotics Division is glad to announce their line of Syndicate Saboteur cyborgs hasn't been affected by CentCom's Robotics decision to downgrade the Engiborg RCDs. This is because The Syndicate is not CentCom or Nanotrasen despite what some tinfoil hat-wearing billies-bobs may say.
/:cl:
