### PR TITLE
Makes the color matrix editor log all color edits

### DIFF
--- a/code/modules/admin/view_variables/color_matrix_editor.dm
+++ b/code/modules/admin/view_variables/color_matrix_editor.dm
@@ -115,7 +115,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/color_matrix_proxy_view)
 /datum/color_matrix_editor/proc/on_confirm()
 	var/atom/target_atom = target?.resolve()
 	if(istype(target_atom))
-		target_atom.add_atom_colour(current_color, ADMIN_COLOUR_PRIORITY)
+		target_atom.vv_edit_var("color", current_color)
 
 /datum/color_matrix_editor/proc/wait()
 	while(!closed)


### PR DESCRIPTION
## About The Pull Request

#62664 suggests that it is possible to make extremely obnoxious color edits with the color matrix editor without admins being informed about it. I figured out that the offending code was calling `add_atom_color` when it should have been wrapped in `vv_edit_var`

## Why It's Good For The Game

Fixes #62664

## Changelog

:cl:
fix: The color matrix editor now logs all modifications it makes to colors.
/:cl: