### PR TITLE
Antag HUDs will now animate if you have multiple antagonists, and will no longer clear on deconversion

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -62,24 +62,6 @@
 #define DATA_HUD_AI_DETECT 9
 #define DATA_HUD_FAN 10
 
-//antag HUD defines
-#define ANTAG_HUD_CULT 11
-#define ANTAG_HUD_REV 12
-#define ANTAG_HUD_OPS 13
-#define ANTAG_HUD_WIZ 14
-#define ANTAG_HUD_SHADOW 15
-#define ANTAG_HUD_TRAITOR 16
-#define ANTAG_HUD_NINJA 17
-#define ANTAG_HUD_CHANGELING 18
-#define ANTAG_HUD_ABDUCTOR 19
-#define ANTAG_HUD_BROTHER 20
-#define ANTAG_HUD_OBSESSED 21
-#define ANTAG_HUD_FUGITIVE 22
-#define ANTAG_HUD_GANGSTER 23
-#define ANTAG_HUD_SPACECOP 24
-#define ANTAG_HUD_HERETIC 25
-#define ANTAG_HUD_BRAINWASHED 26
-
 // Notification action types
 #define NOTIFY_JUMP "jump"
 #define NOTIFY_ATTACK "attack"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -1565,3 +1565,10 @@
 
 /// Called when a techweb design is removed (datum/design/removed_design, custom)
 #define COMSIG_TECHWEB_REMOVE_DESIGN "techweb_remove_design"
+
+// Antagonist signals
+/// Called on the mind when an antagonist is being gained, after the antagonist list has updated (datum/antagonist/antagonist)
+#define COMSIG_ANTAGONIST_GAINED "antagonist_gained"
+
+/// Called on the mind when an antagonist is being removed, after the antagonist list has updated (datum/antagonist/antagonist)
+#define COMSIG_ANTAGONIST_REMOVED "antagonist_removed"

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -230,10 +230,9 @@
 	CHECK_TICK
 
 	// Add AntagHUD to everyone, see who was really evil the whole time!
-	for(var/datum/atom_hud/antag/H in GLOB.huds)
-		for(var/m in GLOB.player_list)
-			var/mob/M = m
-			H.add_hud_to(M)
+	for(var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/antagonist_hud in GLOB.huds)
+		for(var/mob/player as anything in GLOB.player_list)
+			antagonist_hud.add_hud_to(player)
 
 	CHECK_TICK
 

--- a/code/controllers/subsystem/processing/antag_hud.dm
+++ b/code/controllers/subsystem/processing/antag_hud.dm
@@ -1,0 +1,4 @@
+PROCESSING_SUBSYSTEM_DEF(antag_hud)
+	name = "Antag HUDs"
+	flags = SS_NO_INIT
+	wait = 2 SECONDS

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -14,23 +14,7 @@ GLOBAL_LIST_INIT(huds, list(
 	DATA_HUD_SENTIENT_DISEASE = new/datum/atom_hud/sentient_disease(),
 	DATA_HUD_AI_DETECT = new/datum/atom_hud/ai_detector(),
 	DATA_HUD_FAN = new/datum/atom_hud/data/human/fan_hud(),
-	ANTAG_HUD_CULT = new/datum/atom_hud/antag(),
-	ANTAG_HUD_REV = new/datum/atom_hud/antag(),
-	ANTAG_HUD_OPS = new/datum/atom_hud/antag(),
-	ANTAG_HUD_WIZ = new/datum/atom_hud/antag(),
-	ANTAG_HUD_SHADOW = new/datum/atom_hud/antag(),
-	ANTAG_HUD_TRAITOR = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_NINJA = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_CHANGELING = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_ABDUCTOR = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_BROTHER = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_OBSESSED = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_FUGITIVE = new/datum/atom_hud/antag(),
-	ANTAG_HUD_GANGSTER = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_SPACECOP = new/datum/atom_hud/antag(),
-	ANTAG_HUD_HERETIC = new/datum/atom_hud/antag/hidden(),
-	ANTAG_HUD_BRAINWASHED = new/datum/atom_hud/antag/hidden()
-	))
+))
 
 /datum/atom_hud
 	var/list/atom/hudatoms = list() //list of all atoms which display this hud

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -54,7 +54,7 @@
 	var/miming = FALSE // Mime's vow of silence
 	var/list/antag_datums
 	var/antag_hud_icon_state = null //this mind's ANTAG_HUD should have this icon_state
-	var/datum/atom_hud/antag/antag_hud = null //this mind's antag HUD
+	var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/antag_hud = null //this mind's antag HUD
 	var/holy_role = NONE //is this person a chaplain or admin role allowed to use bibles, Any rank besides 'NONE' allows for this.
 
 	var/mob/living/enslaved_to //If this mind's master is another mob (i.e. adamantine golems)
@@ -102,6 +102,7 @@
 
 /datum/mind/Destroy()
 	SSticker.minds -= src
+	QDEL_NULL(antag_hud)
 	QDEL_LIST(memories)
 	QDEL_NULL(memory_panel)
 	QDEL_LIST(antag_datums)
@@ -155,19 +156,19 @@
 	if(new_character.mind) //disassociate any mind currently in our new body's mind variable
 		new_character.mind.set_current(null)
 
-	var/datum/atom_hud/antag/hud_to_transfer = antag_hud//we need this because leave_hud() will clear this list
 	var/mob/living/old_current = current
 	if(current)
 		current.transfer_observers_to(new_character) //transfer anyone observing the old character to the new one
 	set_current(new_character) //associate ourself with our new body
+	QDEL_NULL(antag_hud)
 	new_character.mind = src //and associate our new body with ourself
+	antag_hud = new_character.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/antagonist_hud, "antag_hud", src)
 	for(var/a in antag_datums) //Makes sure all antag datums effects are applied in the new body
 		var/datum/antagonist/A = a
 		A.on_body_transfer(old_current, current)
 	if(iscarbon(new_character))
 		var/mob/living/carbon/C = new_character
 		C.last_mind = src
-	transfer_antag_huds(hud_to_transfer) //inherit the antag HUD
 	transfer_actions(new_character)
 	transfer_martial_arts(new_character)
 	RegisterSignal(new_character, COMSIG_LIVING_DEATH, .proc/set_death_time)
@@ -837,7 +838,6 @@
 	if(!mind.name)
 		mind.name = real_name
 	mind.set_current(src)
-
 
 /mob/living/carbon/mind_initialize()
 	..()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -162,7 +162,7 @@
 	set_current(new_character) //associate ourself with our new body
 	QDEL_NULL(antag_hud)
 	new_character.mind = src //and associate our new body with ourself
-	antag_hud = new_character.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/antagonist_hud, "antag_hud", src)
+	antag_hud = new_character.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/antagonist_hud, "combo_hud", src)
 	for(var/a in antag_datums) //Makes sure all antag datums effects are applied in the new body
 		var/datum/antagonist/A = a
 		A.on_body_transfer(old_current, current)

--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -84,6 +84,7 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 
 /datum/atom_hud/alternate_appearance/basic/Destroy()
 	. = ..()
+	QDEL_NULL(image)
 	if(ghost_appearance)
 		QDEL_NULL(ghost_appearance)
 

--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -85,6 +85,7 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 /datum/atom_hud/alternate_appearance/basic/Destroy()
 	. = ..()
 	QDEL_NULL(image)
+	target = null
 	if(ghost_appearance)
 		QDEL_NULL(ghost_appearance)
 

--- a/code/game/alternate_appearance.dm
+++ b/code/game/alternate_appearance.dm
@@ -28,6 +28,10 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 	GLOB.active_alternate_appearances += src
 	appearance_key = key
 
+	for(var/mob in GLOB.player_list)
+		if(mobShouldSee(mob))
+			add_hud_to(mob)
+
 /datum/atom_hud/alternate_appearance/Destroy()
 	GLOB.active_alternate_appearances -= src
 	return ..()
@@ -56,14 +60,14 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 //an alternate appearance that attaches a single image to a single atom
 /datum/atom_hud/alternate_appearance/basic
 	var/atom/target
-	var/image/theImage
+	var/image/image
 	var/add_ghost_version = FALSE
 	var/ghost_appearance
 
 /datum/atom_hud/alternate_appearance/basic/New(key, image/I, options = AA_TARGET_SEE_APPEARANCE)
 	..()
 	transfer_overlays = options & AA_MATCH_TARGET_OVERLAYS
-	theImage = I
+	image = I
 	target = I.loc
 	if(transfer_overlays)
 		I.copy_overlays(target)
@@ -85,7 +89,7 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 
 /datum/atom_hud/alternate_appearance/basic/add_to_hud(atom/A)
 	LAZYINITLIST(A.hud_list)
-	A.hud_list[appearance_key] = theImage
+	A.hud_list[appearance_key] = image
 	. = ..()
 
 /datum/atom_hud/alternate_appearance/basic/remove_from_hud(atom/A)
@@ -95,27 +99,15 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 		qdel(src)
 
 /datum/atom_hud/alternate_appearance/basic/copy_overlays(atom/other, cut_old)
-		theImage.copy_overlays(other, cut_old)
+	image.copy_overlays(other, cut_old)
 
 /datum/atom_hud/alternate_appearance/basic/everyone
 	add_ghost_version = TRUE
-
-/datum/atom_hud/alternate_appearance/basic/everyone/New()
-	..()
-	for(var/mob in GLOB.mob_list)
-		if(mobShouldSee(mob))
-			add_hud_to(mob)
 
 /datum/atom_hud/alternate_appearance/basic/everyone/mobShouldSee(mob/M)
 	return !isdead(M)
 
 /datum/atom_hud/alternate_appearance/basic/silicons
-
-/datum/atom_hud/alternate_appearance/basic/silicons/New()
-	..()
-	for(var/mob in GLOB.silicon_mobs)
-		if(mobShouldSee(mob))
-			add_hud_to(mob)
 
 /datum/atom_hud/alternate_appearance/basic/silicons/mobShouldSee(mob/M)
 	if(issilicon(M))
@@ -125,22 +117,10 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 /datum/atom_hud/alternate_appearance/basic/observers
 	add_ghost_version = FALSE //just in case, to prevent infinite loops
 
-/datum/atom_hud/alternate_appearance/basic/observers/New()
-	..()
-	for(var/mob in GLOB.dead_mob_list)
-		if(mobShouldSee(mob))
-			add_hud_to(mob)
-
 /datum/atom_hud/alternate_appearance/basic/observers/mobShouldSee(mob/M)
 	return isobserver(M)
 
 /datum/atom_hud/alternate_appearance/basic/noncult
-
-/datum/atom_hud/alternate_appearance/basic/noncult/New()
-	..()
-	for(var/mob in GLOB.player_list)
-		if(mobShouldSee(mob))
-			add_hud_to(mob)
 
 /datum/atom_hud/alternate_appearance/basic/noncult/mobShouldSee(mob/M)
 	if(!IS_CULTIST(M))
@@ -149,24 +129,12 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 
 /datum/atom_hud/alternate_appearance/basic/cult
 
-/datum/atom_hud/alternate_appearance/basic/cult/New()
-	..()
-	for(var/mob in GLOB.player_list)
-		if(mobShouldSee(mob))
-			add_hud_to(mob)
-
 /datum/atom_hud/alternate_appearance/basic/cult/mobShouldSee(mob/M)
 	if(IS_CULTIST(M))
 		return TRUE
 	return FALSE
 
 /datum/atom_hud/alternate_appearance/basic/blessed_aware
-
-/datum/atom_hud/alternate_appearance/basic/blessed_aware/New()
-	..()
-	for(var/mob in GLOB.mob_list)
-		if(mobShouldSee(mob))
-			add_hud_to(mob)
 
 /datum/atom_hud/alternate_appearance/basic/blessed_aware/mobShouldSee(mob/M)
 	if(M.mind?.holy_role)
@@ -188,7 +156,5 @@ GLOBAL_LIST_EMPTY(active_alternate_appearances)
 /datum/atom_hud/alternate_appearance/basic/one_person/New(key, image/I, mob/living/M)
 	..(key, I, FALSE)
 	seer = M
-	add_hud_to(seer)
-
 
 /datum/atom_hud/alternate_appearance/basic/food_demands

--- a/code/game/machinery/computer/arena.dm
+++ b/code/game/machinery/computer/arena.dm
@@ -65,17 +65,6 @@
 /obj/machinery/computer/arena/Initialize(mapload, obj/item/circuitboard/C)
 	. = ..()
 	LoadDefaultArenas()
-	GenerateAntagHuds()
-
-/obj/machinery/computer/arena/proc/GenerateAntagHuds()
-	for(var/team in teams)
-		var/datum/atom_hud/antag/teamhud = team_huds[team]
-		if(!teamhud) //These will be shared between arenas because this stuff is expensive and cross arena fighting is not a thing anyway
-			teamhud = new
-			teamhud.icon_color = team_colors[team]
-			GLOB.huds += teamhud
-			team_huds[team] = teamhud
-			team_hud_index[team] = length(GLOB.huds)
 
 /**
  * Loads the arenas from config directory.
@@ -193,10 +182,6 @@
 	M.equipOutfit(outfits[team] ? outfits[team] : default_outfit)
 	M.faction += team //In case anyone wants to add team based stuff to arena special effects
 	M.key = ckey
-
-	var/datum/atom_hud/antag/team_hud = team_huds[team]
-	team_hud.join_hud(M)
-	set_antag_hud(M,"arena",team_hud_index[team])
 
 /obj/machinery/computer/arena/proc/change_outfit(mob/user,team)
 	outfits[team] = user.client.robust_dress_shop()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -720,7 +720,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	if(!holder)
 		return
 
-	if(has_antag_hud())
+	if(combo_hud_enabled)
 		toggle_combo_hud()
 
 	holder.deactivate()

--- a/code/modules/admin/team_panel.dm
+++ b/code/modules/admin/team_panel.dm
@@ -151,16 +151,17 @@
 	var/datum/atom_hud/antag/custom_hud
 	var/custom_hud_state = "traitor"
 
-/datum/team/custom/add_member(datum/mind/new_member)
-	. = ..()
-	if(custom_hud)
-		custom_hud.join_hud(new_member.current)
-		set_antag_hud(new_member.current,custom_hud_state)
+// MOTHBLOCKS TODO: Custom team HUDs
+// /datum/team/custom/add_member(datum/mind/new_member)
+// 	. = ..()
+// 	if(custom_hud)
+// 		custom_hud.join_hud(new_member.current)
+// 		set_antag_hud(new_member.current,custom_hud_state)
 
-/datum/team/custom/remove_member(datum/mind/member)
-	. = ..()
-	if(custom_hud)
-		custom_hud.leave_hud(member.current)
+// /datum/team/custom/remove_member(datum/mind/member)
+// 	. = ..()
+// 	if(custom_hud)
+// 		custom_hud.leave_hud(member.current)
 
 /datum/team/custom/get_admin_commands()
 	. = ..()
@@ -168,16 +169,16 @@
 
 //This is here if you want admin created teams to tell each other apart easily.
 /datum/team/custom/proc/admin_force_hud(mob/user)
-	var/list/possible_icons = icon_states('icons/mob/hud.dmi')
-	var/new_hud_state = input(user,"Choose hud icon state","Custom HUD","traitor") as null|anything in sort_list(possible_icons)
-	if(!new_hud_state)
-		return
-	//suppose could ask for color too
-	custom_hud_state = new_hud_state
-	custom_hud = new
-	custom_hud.self_visible = TRUE
-	GLOB.huds += custom_hud //Make it show in admin hud
+	// var/list/possible_icons = icon_states('icons/mob/hud.dmi')
+	// var/new_hud_state = input(user,"Choose hud icon state","Custom HUD","traitor") as null|anything in sort_list(possible_icons)
+	// if(!new_hud_state)
+	// 	return
+	// //suppose could ask for color too
+	// custom_hud_state = new_hud_state
+	// custom_hud = new
+	// custom_hud.self_visible = TRUE
+	// GLOB.huds += custom_hud //Make it show in admin hud
 
-	for(var/datum/mind/M in members)
-		custom_hud.join_hud(M.current)
-		set_antag_hud(M.current,custom_hud_state)
+	// for(var/datum/mind/M in members)
+	// 	custom_hud.join_hud(M.current)
+	// 	set_antag_hud(M.current,custom_hud_state)

--- a/code/modules/admin/team_panel.dm
+++ b/code/modules/admin/team_panel.dm
@@ -35,7 +35,7 @@
 	var/team_name = stripped_input(user,"Team name ?")
 	if(!team_name)
 		return
-	var/datum/team/custom/T = new()
+	var/datum/team/T = new()
 	T.name = team_name
 
 	message_admins("[key_name_admin(usr)] created new [name] antagonist team.")
@@ -145,40 +145,3 @@
 
 /datum/team/proc/get_admin_commands()
 	return list()
-
-//Custom team subtype created by the panel, allow forcing hud for the team for now
-/datum/team/custom
-	var/datum/atom_hud/antag/custom_hud
-	var/custom_hud_state = "traitor"
-
-// MOTHBLOCKS TODO: Custom team HUDs
-// /datum/team/custom/add_member(datum/mind/new_member)
-// 	. = ..()
-// 	if(custom_hud)
-// 		custom_hud.join_hud(new_member.current)
-// 		set_antag_hud(new_member.current,custom_hud_state)
-
-// /datum/team/custom/remove_member(datum/mind/member)
-// 	. = ..()
-// 	if(custom_hud)
-// 		custom_hud.leave_hud(member.current)
-
-/datum/team/custom/get_admin_commands()
-	. = ..()
-	.["Force HUD"] = CALLBACK(src,.proc/admin_force_hud)
-
-//This is here if you want admin created teams to tell each other apart easily.
-/datum/team/custom/proc/admin_force_hud(mob/user)
-	// var/list/possible_icons = icon_states('icons/mob/hud.dmi')
-	// var/new_hud_state = input(user,"Choose hud icon state","Custom HUD","traitor") as null|anything in sort_list(possible_icons)
-	// if(!new_hud_state)
-	// 	return
-	// //suppose could ask for color too
-	// custom_hud_state = new_hud_state
-	// custom_hud = new
-	// custom_hud.self_visible = TRUE
-	// GLOB.huds += custom_hud //Make it show in admin hud
-
-	// for(var/datum/mind/M in members)
-	// 	custom_hud.join_hud(M.current)
-	// 	set_antag_hud(M.current,custom_hud_state)

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -401,30 +401,26 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!check_rights(R_ADMIN))
 		return
 
-	var/adding_hud = !has_antag_hud()
+	combo_hud_enabled = !combo_hud_enabled
 
 	for(var/hudtype in list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_ADVANCED)) // add data huds
 		var/datum/atom_hud/H = GLOB.huds[hudtype]
-		(adding_hud) ? H.add_hud_to(usr) : H.remove_hud_from(usr)
-	for(var/datum/atom_hud/antag/H in GLOB.huds) // add antag huds
-		(adding_hud) ? H.add_hud_to(usr) : H.remove_hud_from(usr)
+		(combo_hud_enabled) ? H.add_hud_to(usr) : H.remove_hud_from(usr)
+	for(var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/H in GLOB.active_alternate_appearances) // add antag huds
+		(combo_hud_enabled) ? H.add_hud_to(usr) : H.remove_hud_from(usr)
 
 	if(prefs.toggles & COMBOHUD_LIGHTING)
-		if(adding_hud)
+		if(combo_hud_enabled)
 			mob.lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
 		else
 			mob.lighting_alpha = initial(mob.lighting_alpha)
 
 	mob.update_sight()
 
-	to_chat(usr, "You toggled your admin combo HUD [adding_hud ? "ON" : "OFF"].", confidential = TRUE)
-	message_admins("[key_name_admin(usr)] toggled their admin combo HUD [adding_hud ? "ON" : "OFF"].")
-	log_admin("[key_name(usr)] toggled their admin combo HUD [adding_hud ? "ON" : "OFF"].")
-	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Combo HUD", "[adding_hud ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/client/proc/has_antag_hud()
-	var/datum/atom_hud/A = GLOB.huds[ANTAG_HUD_TRAITOR]
-	return A.hudusers[mob]
+	to_chat(usr, "You toggled your admin combo HUD [combo_hud_enabled ? "ON" : "OFF"].", confidential = TRUE)
+	message_admins("[key_name_admin(usr)] toggled their admin combo HUD [combo_hud_enabled ? "ON" : "OFF"].")
+	log_admin("[key_name(usr)] toggled their admin combo HUD [combo_hud_enabled ? "ON" : "OFF"].")
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Combo HUD", "[combo_hud_enabled ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/show_traitor_panel(mob/target_mob in GLOB.mob_list)
 	set category = "Admin.Game"

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -56,6 +56,9 @@ GLOBAL_LIST_EMPTY(antagonists)
 	///button to access antag interface
 	var/datum/action/antag_info/info_button
 
+	/// The HUD shown to teammates, created by `add_team_hud`
+	var/datum/atom_hud/alternate_appearance/team_hud
+
 /datum/antagonist/New()
 	GLOB.antagonists += src
 	typecache_datum_blacklist = typecacheof(typecache_datum_blacklist)
@@ -64,6 +67,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	GLOB.antagonists -= src
 	if(owner)
 		LAZYREMOVE(owner.antag_datums, src)
+	QDEL_NULL(team_hud)
 	owner = null
 	return ..()
 
@@ -388,6 +392,18 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/antagonist/proc/hijack_speed()
 	var/datum/objective/hijack/H = locate() in objectives
 	return H?.hijack_speed_override || hijack_speed
+
+/// Adds a HUD that will show you other members with the same antagonist.
+/// If an antag typepath is passed to `antag_to_check`, will check that, otherwise will use the source type.
+/datum/antagonist/proc/add_team_hud(mob/target, antag_to_check)
+	QDEL_NULL(team_hud)
+
+	team_hud = target.add_alt_appearance(
+		/datum/atom_hud/alternate_appearance/basic/has_antagonist,
+		"antag_team_hud_[REF(src)]",
+		image('icons/mob/hud.dmi', target, antag_hud_name),
+		antag_to_check || type,
+	)
 
 //This one is created by admin tools for custom objectives
 /datum/antagonist/custom

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -31,8 +31,6 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/can_elimination_hijack = ELIMINATION_NEUTRAL
 	///If above 0, this is the multiplier for the speed at which we hijack the shuttle. Do not directly read, use hijack_speed().
 	var/hijack_speed = 0
-	///What is the configuration of this antagonist's hud icon, such as it's screen position and style, so thatit doesn't break other in-game hud icons.
-	var/antag_hud_type
 	///Name of the antag hud we provide to this mob.
 	var/antag_hud_name
 	/// If set to true, the antag will not be added to the living antag list.
@@ -111,22 +109,6 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/antagonist/proc/on_mindshield(mob/implanter, mob/living/mob_override)
 	SIGNAL_HANDLER
 	return
-
-// Adds the specified antag hud to the player. Usually called in an antag datum file
-// MOTHBLOCKS TODO: add_antag_hud
-/datum/antagonist/proc/add_antag_hud(antag_hud_type, antag_hud_name, mob/living/mob_override)
-	// var/datum/atom_hud/antag/hud = GLOB.huds[antag_hud_type]
-	// hud.join_hud(mob_override)
-	// set_antag_hud(mob_override, antag_hud_name)
-
-
-// Removes the specified antag hud from the player. Usually called in an antag datum file
-// MOTHBLOCKS TODO: remove_antag_hud
-/datum/antagonist/proc/remove_antag_hud(antag_hud_type, mob/living/mob_override)
-	// var/datum/atom_hud/antag/hud = GLOB.huds[antag_hud_type]
-	// hud.leave_hud(mob_override)
-	// set_antag_hud(mob_override, null)
-
 
 /// Handles adding and removing the clumsy mutation from clown antags. Gets called in apply/remove_innate_effects
 /datum/antagonist/proc/handle_clown_mutation(mob/living/mob_override, message, removing = TRUE)

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -113,17 +113,19 @@ GLOBAL_LIST_EMPTY(antagonists)
 	return
 
 // Adds the specified antag hud to the player. Usually called in an antag datum file
+// MOTHBLOCKS TODO: add_antag_hud
 /datum/antagonist/proc/add_antag_hud(antag_hud_type, antag_hud_name, mob/living/mob_override)
-	var/datum/atom_hud/antag/hud = GLOB.huds[antag_hud_type]
-	hud.join_hud(mob_override)
-	set_antag_hud(mob_override, antag_hud_name)
+	// var/datum/atom_hud/antag/hud = GLOB.huds[antag_hud_type]
+	// hud.join_hud(mob_override)
+	// set_antag_hud(mob_override, antag_hud_name)
 
 
 // Removes the specified antag hud from the player. Usually called in an antag datum file
+// MOTHBLOCKS TODO: remove_antag_hud
 /datum/antagonist/proc/remove_antag_hud(antag_hud_type, mob/living/mob_override)
-	var/datum/atom_hud/antag/hud = GLOB.huds[antag_hud_type]
-	hud.leave_hud(mob_override)
-	set_antag_hud(mob_override, null)
+	// var/datum/atom_hud/antag/hud = GLOB.huds[antag_hud_type]
+	// hud.leave_hud(mob_override)
+	// set_antag_hud(mob_override, null)
 
 
 /// Handles adding and removing the clumsy mutation from clown antags. Gets called in apply/remove_innate_effects
@@ -169,6 +171,8 @@ GLOBAL_LIST_EMPTY(antagonists)
 		owner.current.client.holder.auto_deadmin()
 	if(!soft_antag && owner.current.stat != DEAD)
 		owner.current.add_to_current_living_antags()
+
+	SEND_SIGNAL(owner, COMSIG_ANTAGONIST_GAINED, src)
 
 /**
  * Proc that checks the sent mob aganst the banlistfor this antagonist.
@@ -217,6 +221,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/datum/team/team = get_team()
 	if(team)
 		team.remove_member(owner)
+	SEND_SIGNAL(owner, COMSIG_ANTAGONIST_REMOVED, src)
 	qdel(src)
 
 /**

--- a/code/modules/antagonists/_common/antag_hud.dm
+++ b/code/modules/antagonists/_common/antag_hud.dm
@@ -1,58 +1,80 @@
-/datum/atom_hud/antag
-	hud_icons = list(ANTAG_HUD)
-	var/self_visible = TRUE
-	var/icon_color //will set the icon color to this
+/// An alternate appearance that will only show if you have the antag datum
+/datum/atom_hud/alternate_appearance/basic/has_antagonist
+	var/antag_datum_type
 
-/datum/atom_hud/antag/hidden
-	self_visible = FALSE
+/datum/atom_hud/alternate_appearance/basic/has_antagonist/New(key, image/I, antag_datum_type)
+	. = ..(key, I, NONE)
 
-/datum/atom_hud/antag/proc/join_hud(mob/M)
-	//sees_hud should be set to 0 if the mob does not get to see it's own hud type.
-	if(!istype(M))
-		CRASH("join_hud(): [M] ([M.type]) is not a mob!")
-	if(M.mind.antag_hud) //note: please let this runtime if a mob has no mind, as mindless mobs shouldn't be getting antagged
-		M.mind.antag_hud.leave_hud(M)
+	src.antag_datum_type = antag_datum_type
 
-	if(ANTAG_HUD in M.hud_possible) //Current mob does not support antag huds ie newplayer
-		add_to_hud(M)
-		if(self_visible)
-			add_hud_to(M)
+/datum/atom_hud/alternate_appearance/basic/has_antagonist/mobShouldSee(mob/M)
+	return M.mind?.has_antag_datum(antag_datum_type)
 
-	M.mind.antag_hud = src
+/// An alternate appearance that will show all the antagonists this mob has
+// TODO: process (with custom SS)
+/datum/atom_hud/alternate_appearance/basic/antagonist_hud
+	var/list/antag_hud_images = list()
+	var/index = 1
 
-/datum/atom_hud/antag/proc/leave_hud(mob/M)
-	if(!M)
-		return
-	if(!istype(M))
-		CRASH("leave_hud(): [M] ([M.type]) is not a mob!")
-	remove_from_hud(M)
-	remove_hud_from(M)
-	if(M.mind)
-		M.mind.antag_hud = null
+/datum/atom_hud/alternate_appearance/basic/antagonist_hud/New(key, datum/mind/mind)
+	antag_hud_images = get_antag_hud_images(mind)
 
-//GAME_MODE PROCS
-//called to set a mob's antag icon state
-/proc/set_antag_hud(mob/M, new_icon_state, hudindex)
-	if(!istype(M))
-		CRASH("set_antag_hud(): [M] ([M.type]) is not a mob!")
-	var/image/holder = M.hud_list[ANTAG_HUD]
-	var/datum/atom_hud/antag/specific_hud = hudindex ? GLOB.huds[hudindex] : null
-	if(holder)
-		holder.icon_state = new_icon_state
-		holder.color = specific_hud?.icon_color
-	if(M.mind || new_icon_state) //in mindless mobs, only null is acceptable, otherwise we're antagging a mindless mob, meaning we should runtime
-		M.mind.antag_hud_icon_state = new_icon_state
+	var/image/first_antagonist = get_antag_image(1) || image(icon('icons/blanks/32x32.dmi', "nothing"), mind.current)
 
+	RegisterSignal(
+		mind,
+		list(COMSIG_ANTAGONIST_GAINED, COMSIG_ANTAGONIST_REMOVED),
+		.proc/update_antag_hud_images
+	)
 
-//MIND PROCS
-//these are called by mind.transfer_to()
-/datum/mind/proc/transfer_antag_huds(datum/atom_hud/antag/newhud)
-	leave_all_antag_huds()
-	set_antag_hud(current, antag_hud_icon_state)
-	if(newhud)
-		newhud.join_hud(current)
+	check_processing()
 
-/datum/mind/proc/leave_all_antag_huds()
-	for(var/datum/atom_hud/antag/hud in GLOB.huds)
-		if(hud.hudusers[current])
-			hud.leave_hud(current)
+	return ..(key, first_antagonist, NONE)
+
+/datum/atom_hud/alternate_appearance/basic/antagonist_hud/Destroy()
+	QDEL_LIST(antag_hud_images)
+	STOP_PROCESSING(SSantag_hud, src)
+
+	return ..()
+
+/datum/atom_hud/alternate_appearance/basic/antagonist_hud/mobShouldSee(mob/mob)
+	return Master.current_runlevel >= RUNLEVEL_POSTGAME || mob.client?.combo_hud_enabled
+
+/datum/atom_hud/alternate_appearance/basic/antagonist_hud/process(delta_time)
+	index += 1
+	update_icon()
+
+/datum/atom_hud/alternate_appearance/basic/antagonist_hud/proc/check_processing()
+	if (antag_hud_images.len > 1 && !(DF_ISPROCESSING in datum_flags))
+		START_PROCESSING(SSantag_hud, src)
+	else if (antag_hud_images.len <= 1)
+		STOP_PROCESSING(SSantag_hud, src)
+
+/datum/atom_hud/alternate_appearance/basic/antagonist_hud/proc/get_antag_image(index)
+	RETURN_TYPE(/image)
+	if (antag_hud_images.len)
+		return antag_hud_images[(index % antag_hud_images.len) + 1]
+
+/datum/atom_hud/alternate_appearance/basic/antagonist_hud/proc/get_antag_hud_images(datum/mind/mind)
+	var/list/final_antag_hud_images = list()
+
+	for (var/datum/antagonist/antagonist as anything in mind?.antag_datums)
+		if (isnull(antagonist.antag_hud_name))
+			continue
+		final_antag_hud_images += image('icons/mob/hud.dmi', mind.current, antagonist.antag_hud_name)
+
+	return final_antag_hud_images
+
+/datum/atom_hud/alternate_appearance/basic/antagonist_hud/proc/update_icon()
+	if (antag_hud_images.len == 0)
+		image.icon = icon('icons/blanks/32x32.dmi', "nothing")
+	else
+		image.icon = icon('icons/mob/hud.dmi', get_antag_image(index).icon_state)
+
+/datum/atom_hud/alternate_appearance/basic/antagonist_hud/proc/update_antag_hud_images(datum/mind/source)
+	SIGNAL_HANDLER
+
+	antag_hud_images = get_antag_hud_images(source)
+	index = clamp(index, 1, antag_hud_images.len)
+	update_icon()
+	check_processing()

--- a/code/modules/antagonists/_common/antag_hud.dm
+++ b/code/modules/antagonists/_common/antag_hud.dm
@@ -14,7 +14,11 @@
 	var/list/antag_hud_images = list()
 	var/index = 1
 
+	var/datum/mind/mind
+
 /datum/atom_hud/alternate_appearance/basic/antagonist_hud/New(key, datum/mind/mind)
+	src.mind = mind
+
 	antag_hud_images = get_antag_hud_images(mind)
 
 	var/image/first_antagonist = get_antag_image(1) || image(icon('icons/blanks/32x32.dmi', "nothing"), mind.current)
@@ -32,6 +36,8 @@
 /datum/atom_hud/alternate_appearance/basic/antagonist_hud/Destroy()
 	QDEL_LIST(antag_hud_images)
 	STOP_PROCESSING(SSantag_hud, src)
+	mind.antag_hud = null
+	mind = null
 
 	return ..()
 

--- a/code/modules/antagonists/_common/antag_hud.dm
+++ b/code/modules/antagonists/_common/antag_hud.dm
@@ -3,15 +3,13 @@
 	var/antag_datum_type
 
 /datum/atom_hud/alternate_appearance/basic/has_antagonist/New(key, image/I, antag_datum_type)
-	. = ..(key, I, NONE)
-
 	src.antag_datum_type = antag_datum_type
+	return ..(key, I, NONE)
 
 /datum/atom_hud/alternate_appearance/basic/has_antagonist/mobShouldSee(mob/M)
-	return M.mind?.has_antag_datum(antag_datum_type)
+	return !!M.mind?.has_antag_datum(antag_datum_type)
 
 /// An alternate appearance that will show all the antagonists this mob has
-// TODO: process (with custom SS)
 /datum/atom_hud/alternate_appearance/basic/antagonist_hud
 	var/list/antag_hud_images = list()
 	var/index = 1

--- a/code/modules/antagonists/abductor/abductee/abductee.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee.dm
@@ -8,7 +8,6 @@
 	name = "Abductee"
 	roundend_category = "abductees"
 	antagpanel_category = "Other"
-	antag_hud_type = ANTAG_HUD_ABDUCTOR
 	antag_hud_name = "abductee"
 
 /datum/antagonist/abductee/on_gain()
@@ -27,11 +26,3 @@
 	var/objtype = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))
 	var/datum/objective/abductee/O = new objtype()
 	objectives += O
-
-/datum/antagonist/abductee/apply_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
-
-/datum/antagonist/abductee/remove_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -6,7 +6,6 @@ GLOBAL_LIST_INIT(possible_abductor_names, list("Alpha","Beta","Gamma","Delta","E
 	roundend_category = "abductors"
 	antagpanel_category = "Abductor"
 	job_rank = ROLE_ABDUCTOR
-	antag_hud_type = ANTAG_HUD_ABDUCTOR
 	antag_hud_name = "abductor"
 	show_in_antagpanel = FALSE //should only show subtypes
 	show_to_ghosts = TRUE
@@ -108,8 +107,6 @@ GLOBAL_LIST_INIT(possible_abductor_names, list("Alpha","Beta","Gamma","Delta","E
 		if(istype(LM, landmark_type) && LM.team_number == team.team_number)
 			H.forceMove(LM.loc)
 			break
-
-	add_antag_hud(antag_hud_type, antag_hud_name, owner.current)
 
 /datum/antagonist/abductor/scientist/on_gain()
 	ADD_TRAIT(owner, TRAIT_ABDUCTOR_SCIENTIST_TRAINING, ABDUCTOR_ANTAGONIST)

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -30,7 +30,6 @@
 	job_rank = ROLE_BRAINWASHED
 	roundend_category = "brainwashed victims"
 	show_in_antagpanel = TRUE
-	antag_hud_type = ANTAG_HUD_BRAINWASHED
 	antag_hud_name = "brainwashed"
 	antagpanel_category = "Other"
 	show_name_in_check_antagonists = TRUE
@@ -42,16 +41,6 @@
 	var/list/data = list()
 	data["objectives"] = get_objectives()
 	return data
-
-/datum/antagonist/brainwashed/apply_innate_effects(mob/living/mob_override)
-	. = ..()
-	var/mob/living/current_mob = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, current_mob)
-
-/datum/antagonist/brainwashed/remove_innate_effects(mob/living/mob_override)
-	var/mob/living/current_mob = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, current_mob)
-	return ..()
 
 /datum/antagonist/brainwashed/farewell()
 	to_chat(owner, span_warning("Your mind suddenly clears..."))

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -3,7 +3,6 @@
 	antagpanel_category = "Brother"
 	job_rank = ROLE_BROTHER
 	var/special_role = ROLE_BROTHER
-	antag_hud_type = ANTAG_HUD_BROTHER
 	antag_hud_name = "brother"
 	hijack_speed = 0.5
 	suicide_cry = "FOR MY BROTHER!!"
@@ -31,14 +30,6 @@
 		to_chat(owner.current,span_userdanger("You are no longer the [special_role]!"))
 	owner.special_role = null
 	return ..()
-
-/datum/antagonist/brother/apply_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
-
-/datum/antagonist/brother/remove_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)
 
 /datum/antagonist/brother/antag_panel_data()
 	return "Conspirators : [get_brother_names()]"

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -8,7 +8,6 @@
 	antagpanel_category = "Changeling"
 	job_rank = ROLE_CHANGELING
 	antag_moodlet = /datum/mood_event/focused
-	antag_hud_type = ANTAG_HUD_CHANGELING
 	antag_hud_name = "changeling"
 	hijack_speed = 0.5
 	ui_name = "AntagInfoChangeling"
@@ -382,12 +381,10 @@
 			B.decoy_override = TRUE
 		RegisterSignal(C, list(COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON), .proc/stingAtom)
 	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
 	handle_clown_mutation(M, "You have evolved beyond your clownish nature, allowing you to wield weapons without harming yourself.")
 
 /datum/antagonist/changeling/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)
 	handle_clown_mutation(M, removing = FALSE)
 	UnregisterSignal(owner.current, list(COMSIG_MOB_MIDDLECLICKON, COMSIG_MOB_ALTCLICKON))
 

--- a/code/modules/antagonists/changeling/fallen_changeling.dm
+++ b/code/modules/antagonists/changeling/fallen_changeling.dm
@@ -5,7 +5,6 @@
 	antagpanel_category = "Changeling"
 	job_rank = ROLE_CHANGELING
 	antag_moodlet = /datum/mood_event/fallen_changeling
-	antag_hud_type = ANTAG_HUD_CHANGELING
 	antag_hud_name = "changeling"
 
 /datum/mood_event/fallen_changeling

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -3,7 +3,6 @@
 	show_in_antagpanel = TRUE
 	antagpanel_category = "Other"
 	job_rank = ROLE_OBSESSED
-	antag_hud_type = ANTAG_HUD_OBSESSED
 	antag_hud_name = "obsessed"
 	show_name_in_check_antagonists = TRUE
 	roundend_category = "obsessed"
@@ -36,14 +35,6 @@
 	if(trauma)
 		qdel(trauma)
 	. = ..()
-
-/datum/antagonist/obsessed/apply_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
-
-/datum/antagonist/obsessed/remove_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)
 
 /datum/antagonist/obsessed/get_preview_icon()
 	var/mob/living/carbon/human/dummy/consistent/victim_dummy = new

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -14,7 +14,6 @@
 	var/datum/action/innate/cult/mastervote/vote = new
 	var/datum/action/innate/cult/blood_magic/magic = new
 	job_rank = ROLE_CULTIST
-	antag_hud_type = ANTAG_HUD_CULT
 	antag_hud_name = "cult"
 	var/ignore_implant = FALSE
 	var/give_equipment = FALSE
@@ -129,7 +128,6 @@
 	var/mob/living/current = owner.current
 	if(mob_override)
 		current = mob_override
-	add_antag_hud(antag_hud_type, antag_hud_name, current)
 	handle_clown_mutation(current, mob_override ? null : "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
 	current.faction |= "cult"
 	current.grant_language(/datum/language/narsie, TRUE, TRUE, LANGUAGE_CULTIST)
@@ -149,7 +147,6 @@
 	var/mob/living/current = owner.current
 	if(mob_override)
 		current = mob_override
-	remove_antag_hud(antag_hud_type, current)
 	handle_clown_mutation(current, removing = FALSE)
 	current.faction -= "cult"
 	current.remove_language(/datum/language/narsie, TRUE, TRUE, LANGUAGE_CULTIST)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -142,6 +142,8 @@
 		if(cult_team.cult_ascendent)
 			cult_team.ascend(current)
 
+	add_team_hud(current)
+
 /datum/antagonist/cult/remove_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/current = owner.current
@@ -220,13 +222,6 @@
 	QDEL_NULL(throwing)
 	return ..()
 
-/datum/antagonist/cult/master/on_gain()
-	. = ..()
-	var/mob/living/current = owner.current
-
-	// MOTHBLOCKS TODO: Update cultmaster HUD
-	// set_antag_hud(current, "cultmaster")
-
 /datum/antagonist/cult/master/greet()
 	to_chat(owner.current, "<span class='warningplain'><span class='cultlarge'>You are the cult's Master</span>. As the cult's Master, you have a unique title and loud voice when communicating, are capable of marking \
 	targets, such as a location or a noncultist, to direct the cult to them, and, finally, you are capable of summoning the entire living cult to your location <b><i>once</i></b>. Use these abilities to direct the cult to victory at any cost.</span>")
@@ -246,6 +241,7 @@
 		cult_team.rise(current)
 		if(cult_team.cult_ascendent)
 			cult_team.ascend(current)
+	add_team_hud(current, /datum/antagonist/cult)
 
 /datum/antagonist/cult/master/remove_innate_effects(mob/living/mob_override)
 	. = ..()

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -212,6 +212,7 @@
 /datum/antagonist/cult/master
 	ignore_implant = TRUE
 	show_in_antagpanel = FALSE //Feel free to add this later
+	antag_hud_name = "cultmaster"
 	var/datum/action/innate/cult/master/finalreck/reckoning = new
 	var/datum/action/innate/cult/master/cultmark/bloodmark = new
 	var/datum/action/innate/cult/master/pulse/throwing = new
@@ -225,7 +226,9 @@
 /datum/antagonist/cult/master/on_gain()
 	. = ..()
 	var/mob/living/current = owner.current
-	set_antag_hud(current, "cultmaster")
+
+	// MOTHBLOCKS TODO: Update cultmaster HUD
+	// set_antag_hud(current, "cultmaster")
 
 /datum/antagonist/cult/master/greet()
 	to_chat(owner.current, "<span class='warningplain'><span class='cultlarge'>You are the cult's Master</span>. As the cult's Master, you have a unique title and loud voice when communicating, are capable of marking \

--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -5,7 +5,6 @@
 	ui_name = "AntagInfoHeretic"
 	antag_moodlet = /datum/mood_event/heretics
 	job_rank = ROLE_HERETIC
-	antag_hud_type = ANTAG_HUD_HERETIC
 	antag_hud_name = "heretic"
 	hijack_speed = 0.5
 	suicide_cry = "THE MANSUS SMILES UPON ME!!"
@@ -182,7 +181,6 @@
 	var/mob/living/current = owner.current
 	if(mob_override)
 		current = mob_override
-	add_antag_hud(antag_hud_type, antag_hud_name, current)
 	handle_clown_mutation(current, mob_override ? null : "Ancient knowledge described in the book allows you to overcome your clownish nature, allowing you to use complex items effectively.")
 	current.faction |= "heretics"
 
@@ -191,7 +189,6 @@
 	var/mob/living/current = owner.current
 	if(mob_override)
 		current = mob_override
-	remove_antag_hud(antag_hud_type, current)
 	handle_clown_mutation(current, removing = FALSE)
 	current.faction -= "heretics"
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_monster_antag.dm
@@ -5,7 +5,6 @@
 	antagpanel_category = "Heretic Beast"
 	antag_moodlet = /datum/mood_event/heretics
 	job_rank = ROLE_HERETIC
-	antag_hud_type = ANTAG_HUD_HERETIC
 	antag_hud_name = "heretic_beast"
 	show_in_antagpanel = FALSE
 	var/datum/antagonist/master
@@ -35,11 +34,3 @@
 	owner.announce_objectives()
 	to_chat(owner, span_notice("Your master is [master.owner.current.real_name]"))
 	return
-
-/datum/antagonist/heretic_monster/apply_innate_effects(mob/living/mob_override)
-	. = ..()
-	add_antag_hud(antag_hud_type, antag_hud_name, owner.current)
-
-/datum/antagonist/heretic_monster/remove_innate_effects(mob/living/mob_override)
-	. = ..()
-	remove_antag_hud(antag_hud_type, owner.current)

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -244,14 +244,12 @@
 
 /datum/antagonist/ert/families
 	name = "Space Police Responder"
-	antag_hud_type = ANTAG_HUD_SPACECOP
 	antag_hud_name = "hud_spacecop"
 	suicide_cry = "FOR THE SPACE POLICE!!"
 
 /datum/antagonist/ert/families/apply_innate_effects(mob/living/mob_override)
 	..()
 	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
 	if(M.hud_used)
 		var/datum/hud/H = M.hud_used
 		var/atom/movable/screen/wanted/giving_wanted_lvl = new /atom/movable/screen/wanted()
@@ -263,7 +261,6 @@
 
 /datum/antagonist/ert/families/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)
 	if(M.hud_used)
 		var/datum/hud/H = M.hud_used
 		H.infodisplay -= H.wanted_lvl

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -66,6 +66,9 @@
 /datum/antagonist/fugitive/get_team()
 	return fugitive_team
 
+/datum/antagonist/fugitive/apply_innate_effects(mob/living/mob_override)
+	add_team_hud(mob_override || owner.current)
+
 /datum/team/fugitive/roundend_report() //shows the number of fugitives, but not if they won in case there is no security
 	var/list/fugitives = list()
 	for(var/datum/antagonist/fugitive/fugitive_antag in GLOB.antagonists)

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -5,20 +5,11 @@
 	silent = TRUE //greet called by the event
 	show_in_antagpanel = FALSE
 	prevent_roundtype_conversion = FALSE
-	antag_hud_type = ANTAG_HUD_FUGITIVE
 	antag_hud_name = "fugitive"
 	suicide_cry = "FOR FREEDOM!!"
 	var/datum/team/fugitive/fugitive_team
 	var/is_captured = FALSE
 	var/backstory = "error"
-
-/datum/antagonist/fugitive/apply_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
-
-/datum/antagonist/fugitive/remove_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)
 
 /datum/antagonist/fugitive/on_gain()
 	forge_objectives()

--- a/code/modules/antagonists/fugitive/hunter.dm
+++ b/code/modules/antagonists/fugitive/hunter.dm
@@ -5,19 +5,10 @@
 	silent = TRUE //greet called by the spawn
 	show_in_antagpanel = FALSE
 	prevent_roundtype_conversion = FALSE
-	antag_hud_type = ANTAG_HUD_FUGITIVE
 	antag_hud_name = "fugitive_hunter"
 	suicide_cry = "FOR GLORY!!"
 	var/datum/team/fugitive_hunters/hunter_team
 	var/backstory = "error"
-
-/datum/antagonist/fugitive_hunter/apply_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
-
-/datum/antagonist/fugitive_hunter/remove_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)
 
 /datum/antagonist/fugitive_hunter/on_gain()
 	forge_objectives()

--- a/code/modules/antagonists/gang/gang.dm
+++ b/code/modules/antagonists/gang/gang.dm
@@ -2,7 +2,6 @@
 	name = "Family Member"
 	roundend_category = "gangsters"
 	ui_name = "AntagInfoGangmember"
-	antag_hud_type = ANTAG_HUD_GANGSTER
 	antag_hud_name = "hud_gangster"
 	antagpanel_category = "Family"
 	show_in_antagpanel = FALSE // i don't *think* this base class is buggy but it's too worthless to test
@@ -80,8 +79,6 @@
 	my_gang.rename_gangster(owner, original_name, starter_gangster) // fully_replace_character_name
 	if(starter_gangster)
 		equip_gangster_in_inventory()
-	var/datum/atom_hud/gang_hud = GLOB.huds[ANTAG_HUD_GANGSTER]
-	gang_hud.add_hud_to(owner.current)
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/thatshowfamiliesworks.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
 	..()
 
@@ -95,8 +92,6 @@
 		have that datum onhand. it would be easier if all of the code the gang team calls on its my_gang_datum was
 		just in the team datum itself, and there were different types of teams instead of different types of gangster
 		that imprint on generic teams, but i'm too lazy to refactor THAT too */
-	var/datum/atom_hud/gang_hud = GLOB.huds[ANTAG_HUD_GANGSTER]
-	gang_hud.remove_hud_from(owner.current)
 	..()
 
 /datum/antagonist/gang/apply_innate_effects(mob/living/mob_override)
@@ -104,14 +99,10 @@
 	if(starter_gangster)
 		package_spawner.Grant(owner.current)
 		package_spawner.my_gang_datum = src
-	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
 
 /datum/antagonist/gang/remove_innate_effects(mob/living/mob_override)
 	if(starter_gangster)
 		package_spawner.Remove(owner.current)
-	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)
 	..()
 
 /// Gives a gangster their equipment in their backpack and / or pockets.

--- a/code/modules/antagonists/gang/gang.dm
+++ b/code/modules/antagonists/gang/gang.dm
@@ -99,6 +99,7 @@
 	if(starter_gangster)
 		package_spawner.Grant(owner.current)
 		package_spawner.my_gang_datum = src
+	add_team_hud(mob_override || owner.current, /datum/antagonist/gang)
 
 /datum/antagonist/gang/remove_innate_effects(mob/living/mob_override)
 	if(starter_gangster)

--- a/code/modules/antagonists/malf_ai/datum_malf_ai.dm
+++ b/code/modules/antagonists/malf_ai/datum_malf_ai.dm
@@ -6,7 +6,6 @@
 	roundend_category = "traitors"
 	antagpanel_category = "Malf AI"
 	job_rank = ROLE_MALF
-	antag_hud_type = ANTAG_HUD_TRAITOR
 	antag_hud_name = "traitor"
 	var/employer = "The Syndicate"
 	var/give_objectives = TRUE
@@ -100,7 +99,6 @@
 	. = ..()
 
 	var/mob/living/silicon/ai/datum_owner = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, datum_owner)
 
 	if(istype(datum_owner))
 		datum_owner.hack_software = TRUE
@@ -112,7 +110,6 @@
 	. = ..()
 
 	var/mob/living/silicon/ai/datum_owner = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, datum_owner)
 
 	if(istype(datum_owner))
 		datum_owner.hack_software = FALSE

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -52,6 +52,9 @@
 /datum/antagonist/nukeop/get_team()
 	return nuke_team
 
+/datum/antagonist/nukeop/apply_innate_effects(mob/living/mob_override)
+	add_team_hud(mob_override || owner.current)
+
 /datum/antagonist/nukeop/proc/assign_nuke()
 	if(nuke_team && !nuke_team.tracked_nuke)
 		nuke_team.memorized_code = random_nukecode()

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -3,7 +3,6 @@
 	roundend_category = "syndicate operatives" //just in case
 	antagpanel_category = "NukeOp"
 	job_rank = ROLE_OPERATIVE
-	antag_hud_type = ANTAG_HUD_OPS
 	antag_hud_name = "synd"
 	antag_moodlet = /datum/mood_event/focused
 	show_to_ghosts = TRUE
@@ -20,14 +19,6 @@
 	var/preview_outfit_behind = /datum/outfit/nuclear_operative
 	/// In the preview icon, a nuclear fission explosive device, only appearing if there's an icon state for it.
 	var/nuke_icon_state = "nuclearbomb_base"
-
-/datum/antagonist/nukeop/apply_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
-
-/datum/antagonist/nukeop/remove_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)
 
 /datum/antagonist/nukeop/proc/equip_op()
 	if(!ishuman(owner.current))

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -9,7 +9,6 @@
 	antagpanel_category = "Revolution"
 	job_rank = ROLE_REV
 	antag_moodlet = /datum/mood_event/revolution
-	antag_hud_type = ANTAG_HUD_REV
 	antag_hud_name = "rev"
 	suicide_cry = "VIVA LA REVOLUTION!!"
 	var/datum/team/revolution/rev_team
@@ -31,12 +30,10 @@
 
 /datum/antagonist/rev/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
 	handle_clown_mutation(M, mob_override ? null : "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
 
 /datum/antagonist/rev/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)
 	handle_clown_mutation(M, removing = FALSE)
 
 /datum/antagonist/rev/on_mindshield(mob/implanter)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -31,6 +31,7 @@
 /datum/antagonist/rev/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
 	handle_clown_mutation(M, mob_override ? null : "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
+	add_team_hud(M, /datum/antagonist/rev)
 
 /datum/antagonist/rev/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current

--- a/code/modules/antagonists/space_ninja/space_ninja.dm
+++ b/code/modules/antagonists/space_ninja/space_ninja.dm
@@ -2,7 +2,6 @@
 	name = "Space Ninja"
 	antagpanel_category = "Space Ninja"
 	job_rank = ROLE_NINJA
-	antag_hud_type = ANTAG_HUD_NINJA
 	antag_hud_name = "space_ninja"
 	hijack_speed = 1
 	show_name_in_check_antagonists = TRUE
@@ -14,14 +13,6 @@
 	var/give_objectives = TRUE
 	///Whether or not this ninja receives the standard equipment
 	var/give_equipment = TRUE
-
-/datum/antagonist/ninja/apply_innate_effects(mob/living/mob_override)
-	var/mob/living/ninja = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, ninja)
-
-/datum/antagonist/ninja/remove_innate_effects(mob/living/mob_override)
-	var/mob/living/ninja = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, ninja)
 
 /**
  * Proc that equips the space ninja outfit on a given individual.  By default this is the owner of the antagonist datum.

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -19,7 +19,6 @@
 	antagpanel_category = "Traitor"
 	job_rank = ROLE_TRAITOR
 	antag_moodlet = /datum/mood_event/focused
-	antag_hud_type = ANTAG_HUD_TRAITOR
 	antag_hud_name = "traitor"
 	hijack_speed = 0.5 //10 seconds per hijack stage by default
 	ui_name = "AntagInfoTraitor"
@@ -187,7 +186,6 @@
 	. = ..()
 	var/mob/living/datum_owner = mob_override || owner.current
 
-	add_antag_hud(antag_hud_type, antag_hud_name, datum_owner)
 	handle_clown_mutation(datum_owner, mob_override ? null : "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
 	if(should_give_codewords)
 		datum_owner.AddComponent(/datum/component/codeword_hearing, GLOB.syndicate_code_phrase_regex, "blue", src)
@@ -196,7 +194,6 @@
 /datum/antagonist/traitor/remove_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/datum_owner = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, datum_owner)
 	handle_clown_mutation(datum_owner, removing = FALSE)
 
 	for(var/datum/component/codeword_hearing/component as anything in datum_owner.GetComponents(/datum/component/codeword_hearing))

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -37,6 +37,7 @@
 /datum/antagonist/wizard_minion/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/current_mob = mob_override || owner.current
 	current_mob.faction |= ROLE_WIZARD
+	add_team_hud(current_mob)
 
 /datum/antagonist/wizard_minion/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/last_mob = mob_override || owner.current
@@ -187,6 +188,7 @@
 /datum/antagonist/wizard/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
 	M.faction |= ROLE_WIZARD
+	add_team_hud(M)
 
 /datum/antagonist/wizard/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -3,7 +3,6 @@
 	roundend_category = "wizards/witches"
 	antagpanel_category = "Wizard"
 	job_rank = ROLE_WIZARD
-	antag_hud_type = ANTAG_HUD_WIZ
 	antag_hud_name = "wizard"
 	antag_moodlet = /datum/mood_event/focused
 	hijack_speed = 0.5
@@ -22,7 +21,6 @@
 /datum/antagonist/wizard_minion
 	name = "Wizard Minion"
 	antagpanel_category = "Wizard"
-	antag_hud_type = ANTAG_HUD_WIZ
 	antag_hud_name = "apprentice"
 	show_in_roundend = FALSE
 	show_name_in_check_antagonists = TRUE
@@ -38,12 +36,10 @@
 
 /datum/antagonist/wizard_minion/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/current_mob = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, current_mob)
 	current_mob.faction |= ROLE_WIZARD
 
 /datum/antagonist/wizard_minion/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/last_mob = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, last_mob)
 	last_mob.faction -= ROLE_WIZARD
 
 /datum/antagonist/wizard_minion/on_gain()
@@ -90,7 +86,6 @@
 	wiz_team = new(owner)
 	wiz_team.name = "[owner.current.real_name] team"
 	wiz_team.master_wizard = src
-	add_antag_hud(antag_hud_type, antag_hud_name, owner.current)
 
 /datum/antagonist/wizard/proc/send_to_lair()
 	if(!owner)
@@ -191,12 +186,10 @@
 
 /datum/antagonist/wizard/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
-	add_antag_hud(antag_hud_type, antag_hud_name, M)
 	M.faction |= ROLE_WIZARD
 
 /datum/antagonist/wizard/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
-	remove_antag_hud(antag_hud_type, M)
 	M.faction -= ROLE_WIZARD
 
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -214,3 +214,6 @@
 
 	/// Whether or not this client has standard hotkeys enabled
 	var/hotkeys = TRUE
+
+	/// Whether or not this client has the combo HUD enabled
+	var/combo_hud_enabled = FALSE

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -230,7 +230,6 @@
 	name = "police aviators"
 	desc = "For thinking you look cool while brutalizing protestors and minorities."
 	icon_state = "bigsunglasses"
-	hud_type = ANTAG_HUD_GANGSTER
 	darkness_view = 1
 	flash_protect = FLASH_PROTECTION_FLASH
 	tint = 1

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -419,6 +419,7 @@
 #include "code\controllers\subsystem\processing\ai_basic_avoidance.dm"
 #include "code\controllers\subsystem\processing\ai_behaviors.dm"
 #include "code\controllers\subsystem\processing\ai_movement.dm"
+#include "code\controllers\subsystem\processing\antag_hud.dm"
 #include "code\controllers\subsystem\processing\aura_healing.dm"
 #include "code\controllers\subsystem\processing\clock_component.dm"
 #include "code\controllers\subsystem\processing\fastprocess.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is for the admin combo HUD. Players shouldn't notice any difference (except at roundend).

https://user-images.githubusercontent.com/35135081/141036990-e32af38c-192f-40fd-8462-dcb27736cbb8.mp4

Removes the ability to set custom antag HUDs for custom admin teams for complexity, though if there's a large enough demand I can try to bring it back in another PR.

Fixes #59767

TM candidate only so that I can make sure antags aren't getting leaked to people who shouldn't see them.

## Changelog

:cl:
fix: Antag HUDs will no longer clear on deconversion if the player was another antag.
qol: Antag HUDs (as seen by admins and at the round end) will now animate between all antagonists, rather than just choosing the most latest.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
