### PR TITLE
Fixes the accounting machine assigning bank accounts that bluescreen vendors.

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -21,10 +21,13 @@
 	var/config_job
 	/// An ID card with an access in this list can apply this trim to IDs or use it as a job template when adding access to a card. If the list is null, cannot be used as a template. Should be Head of Staff or ID Console accesses or it may do nothing.
 	var/list/template_access
-	/// The typepath to the job datum from the id_trim.
-	var/datum/job/job
+	/// The typepath to the job datum from the id_trim. This is converted to one of the job singletons in New().
+	var/datum/job/job = /datum/job/unassigned
 
 /datum/id_trim/job/New()
+	if(ispath(job))
+		job = SSjob.GetJobType(job)
+
 	if(isnull(job_changes))
 		job_changes = SSmapping.config.job_changes
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

https://github.com/tgstation/tgstation/pull/60690 added a feature to job ID trims allowing them to set a proper job for the bank account.

However, it used job datums instead of job singletons. Vending machines expect bank accounts to have job singletons.

I have added a simple fix. In New(), the appropriate job singleton will be instantiated in place of the ID card's job path.

All other code utilising this variable in game/machinery/accounting.dm now just works.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The account registration device should no longer create ID cards that cause vending machines to bluescreen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
