### PR TITLE
Merge MACHINE/port_gen/Initialize definitions

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -94,9 +94,6 @@
 	if(anchored)
 		connect_to_network()
 
-/obj/machinery/power/port_gen/pacman/Initialize(mapload)
-	. = ..()
-
 	var/obj/S = sheet_path
 	sheet_name = initial(S.name)
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This apparently happened in 58d0f12c5c7, four year ago, where a `New()` was renamed to `Initialize()`.

Apparently in this case, the second definition runs first, and the first definition runs in the second's parent call. Since the second immediately calls the first with the parent call, just merging them, with the first's body first, preserves behavior.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is slightly horrifying.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Nothing player facing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
