### PR TITLE
Fixes throw mode putting you on click cooldown despite not throwing

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -119,9 +119,9 @@
 		return
 
 	if(throw_mode)
-		changeNext_move(CLICK_CD_THROW)
-		throw_item(A)
-		return
+		if(throw_item(A))
+			changeNext_move(CLICK_CD_THROW)
+			return
 
 	var/obj/item/W = get_active_held_item()
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -121,7 +121,7 @@
 	if(throw_mode)
 		if(throw_item(A))
 			changeNext_move(CLICK_CD_THROW)
-			return
+		return
 
 	var/obj/item/W = get_active_held_item()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The click cooldown from throw mode would result in you being put on cooldown even if you otherwise didn't actually throw anything. This results in you getting locked out of any clicks whatsoever, so pretty brutal despite doing nothing at all. This could be resulting in swallowed up click inputs during heated fights.

To fix this problem, I've changed this to now only put you on click cooldown if you otherwise threw something.

## Why It's Good For The Game

This bitch empty

### **YEET**

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You now only go on click cooldown if you actually threw something.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
