### PR TITLE
Silicon are no longer allowed to do research.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -101,6 +101,9 @@
 		if ("researchNode")
 			if(!SSresearch.science_tech.available_nodes[params["node_id"]])
 				return TRUE
+			if(issilicon(usr))
+				to_chat(usr, "Silicons are banned from researching anything under the United Space Rights convention of 2561.")
+				return FALSE
 			research_node(params["node_id"], usr)
 			return TRUE
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -306,6 +306,9 @@ Nothing else in the console has ID requirements.
 		if ("researchNode")
 			if(!SSresearch.science_tech.available_nodes[params["node_id"]])
 				return TRUE
+			if(issilicon(usr))
+				to_chat(usr, "Silicons are banned from researching anything under the United Space Rights convention of 2561.")
+				return FALSE
 			research_node(params["node_id"], usr)
 			return TRUE
 		if ("ejectDisk")


### PR DESCRIPTION
"AI LAW 2 RESEARCH X" results in so many issues of players being forced to do things that actively fuck over Research. When we design systems such as Experiments to encourage people to do things before running down the tech web, if some greytider demands the AI research some 10k point thing that nobody actually needs, and the goon server's been stolen, the R&D department has been fucked over for a significant amount of time.

Additionally, having to manage R&D as the AI is fucking stupid and annoying and nobody likes doing it. Ever. And it's always done because someone screamed at you to do it despite the fact **every head of staff can do Research from their tablet if R&D themselves are being slow.**

I was inspired after watching 3 Terry rounds in a row where players screamed at the AI to research Jaws of Life roundstart and told it they would declare the AI malf if they did not research it immediately

:cl:
del: AIs and Cyborgs are no longer allowed to do research
/:cl: