### PR TITLE
Nerfs the shit out of the felinid tail grab mood buff.

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -26,8 +26,9 @@
 
 /datum/mood_event/tailpulled
 	description = "<span class='nicegreen'>I love getting my tail pulled!</span>\n"
-	mood_change = 5
+	mood_change = 1
 	timeout = 2 MINUTES
+
 /datum/mood_event/arcade
 	description = "<span class='nicegreen'>I beat the arcade game!</span>\n"
 	mood_change = 3


### PR DESCRIPTION
Mood controls your movespeed. Making Felinids objectively the best mood management race provided your ~~metagame buddy~~friend pulls your tail once every two minutes is insane, even as a meme.

A +5 mood buff was ridiculously good. This is better than the antag mood buff which is 4, equal to the cult buff for sacrificing which is 5, better than tripping balls, better than playing an arcade game and winning, better than the upgraded hug, equal with the best hug, and frankly one of the easiest best mood buffs you can get. And stacks with all the other ones.

:cl:
balance: Nerfs the felinid tail grab mood buff.
/:cl:
