### PR TITLE
Nerfs the shit out of the negative sprayed with water mood event for Felinids

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -354,5 +354,5 @@
 
 /datum/mood_event/watersprayed
 	description = "<span class='boldwarning'>I hate being sprayed with water!</span>\n"
-	mood_change = -5
+	mood_change = -1
 	timeout = 30 SECONDS


### PR DESCRIPTION
Mood controls your movespeed. Making Felinids get their movespeed tanked because someone tried to fire extinguisher them is insane. Movespeed is the most important factor in SS13 when it comes to just about everything, it's how we punish people for damage after all.

A -5 mood is insanely punishing. It is equivalent to getting smitten by the gods, worse than a terrible noogie, worse than being bald, worse than literally throwing up all over yourself, worse than losing your family heirloom, and worse than having your eye stabbed out. This sucks for how easy it is to inflict on someone, especially considering the most common method of inflicting this is trying to fire extinguisher someone who's lit themselves on fire.

🆑
balance: Nerfs the felinid water spray moodlet
/🆑