### PR TITLE
Adds debug verbs for grabbing the amount of food and stacks on the station

### DIFF
--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -51,7 +51,9 @@ GLOBAL_LIST_INIT(admin_verbs_debug_mapping, list(
 	/client/proc/show_line_profiling,
 	/client/proc/create_mapping_job_icons,
 	/client/proc/debug_z_levels,
-	/client/proc/place_ruin
+	/client/proc/place_ruin,
+	/client/proc/station_food_debug,
+	/client/proc/station_stack_debug,
 ))
 GLOBAL_PROTECT(admin_verbs_debug_mapping)
 
@@ -373,3 +375,50 @@ GLOBAL_VAR_INIT(say_disabled, FALSE)
 	messages += "</table>"
 
 	to_chat(src, messages.Join(""), confidential = TRUE)
+
+/client/proc/station_food_debug()
+	set name = "Count Station Food"
+	set category = "Mapping"
+	var/list/foodcount = list()
+	for(var/obj/item/food/fuck_me in world)
+		var/turf/location = get_turf(fuck_me)
+		if(!location || SSmapping.level_trait(location.z, ZTRAIT_STATION))
+			continue
+		LAZYADDASSOC(foodcount, fuck_me.type, 1)
+
+	var/table_header = "<tr><th>Name</th> <th>Type</th> <th>Amount</th>"
+	var/table_contents = list()
+	for(var/atom/type as anything in foodcount)
+		var/foodname = initial(type.name)
+		var/count = foodcount[type]
+		table_contents += "<tr><td>[foodname]</td> <td>[type]</td> <td>[count]</td></tr>"
+
+	var/page_style = "<style>table, th, td {border: 1px solid black;border-collapse: collapse;}</style>"
+	var/page_contents = "[page_style]<table style=\"width:100%\">[table_header][jointext(table_contents, "")]</table>"
+	var/datum/browser/popup = new(mob, "fooddebug", "Station Food Count", 600, 400)
+	popup.set_content(page_contents)
+	popup.open()
+
+/client/proc/station_stack_debug()
+	set name = "Count Station Stacks"
+	set category = "Mapping"
+	var/list/stackcount = list()
+	for(var/obj/item/stack/fuck_me in world)
+		var/turf/location = get_turf(fuck_me)
+		if(!location || SSmapping.level_trait(location.z, ZTRAIT_STATION))
+			continue
+		LAZYADDASSOC(stackcount, fuck_me.type, fuck_me.amount)
+
+	var/table_header = "<tr><th>Name</th> <th>Type</th> <th>Amount</th>"
+	var/table_contents = list()
+	for(var/atom/type as anything in stackcount)
+		var/stackname = initial(type.name)
+		var/count = stackcount[type]
+		table_contents += "<tr><td>[stackname]</td> <td>[type]</td> <td>[count]</td></tr>"
+
+	var/page_style = "<style>table, th, td {border: 1px solid black;border-collapse: collapse;}</style>"
+	var/page_contents = "[page_style]<table style=\"width:100%\">[table_header][jointext(table_contents, "")]</table>"
+	var/datum/browser/popup = new(mob, "stackdebug", "Station Stack Count", 600, 400)
+	popup.set_content(page_contents)
+	popup.open()
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds mapping debug verbs that pull info about how many food/stacks are in the world and on the station.
Puts them into happy little html uis to make em easier to read.

A stacks amount is it's actual amount, so the amount of items inside it, rather then the amount of stack groups

![image](https://user-images.githubusercontent.com/58055496/141615059-aeb43edb-ffee-4a6d-b756-96be3d97c469.png)
![image](https://user-images.githubusercontent.com/58055496/141615068-6e413f21-7ddc-4ec3-9261-e56b24b5b54d.png)


## Why It's Good For The Game

@EOBGames asked, and I was feeling my soul die dealing with dumbassery in move code, so I gave it a go for the night
![image](https://user-images.githubusercontent.com/58055496/141615128-88b241e0-18e3-4770-b789-e5cb89345605.png)
![image](https://user-images.githubusercontent.com/58055496/141615148-310ed4f2-76e6-4799-b5b8-17d60c6ddae8.png)
I expect my payment in BlumpPoints
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
