### PR TITLE
Wings negate fall damage from short falls (remake)

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -50,7 +50,7 @@
 /mob/living/carbon/human/ZImpactDamage(turf/T, levels)
 	if(levels > 1) // you're not The One
 		return ..()
-	var/obj/item/organ/external/wings/gliders = src.getorgan(/obj/item/organ/external/wings)
+	var/obj/item/organ/external/wings/gliders = getorgan(/obj/item/organ/external/wings)
 	if(HAS_TRAIT(src, TRAIT_FREERUNNING) || gliders?.can_soften_fall()) // the power of parkour or wings allows falling short distances unscathed
 		visible_message(span_danger("[src] makes a hard landing on [T] but remains unharmed from the fall."), \
 						span_userdanger("You brace for the fall. You make a hard landing on [T] but remain unharmed."))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -48,7 +48,7 @@
 	return ..()
 
 /mob/living/carbon/human/ZImpactDamage(turf/T, levels)
-	if(levels > 1) // falling off one level
+	if(levels > 1) // you're not The One
 		return ..()
 	var/obj/item/organ/external/wings/gliders = src.getorgan(/obj/item/organ/external/wings)
 	if(HAS_TRAIT(src, TRAIT_FREERUNNING) || gliders?.can_soften_fall()) // the power of parkour or wings allows falling short distances unscathed

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -48,11 +48,15 @@
 	return ..()
 
 /mob/living/carbon/human/ZImpactDamage(turf/T, levels)
-	if(!HAS_TRAIT(src, TRAIT_FREERUNNING) || levels > 1) // falling off one level
+	if(levels > 1) // falling off one level
 		return ..()
-	visible_message(span_danger("[src] makes a hard landing on [T] but remains unharmed from the fall."), \
-					span_userdanger("You brace for the fall. You make a hard landing on [T] but remain unharmed."))
-	Knockdown(levels * 40)
+	var/obj/item/organ/external/wings/gliders = src.getorgan(/obj/item/organ/external/wings)
+	if(HAS_TRAIT(src, TRAIT_FREERUNNING) || gliders?.can_soften_fall()) // the power of parkour or wings allows falling short distances unscathed
+		visible_message(span_danger("[src] makes a hard landing on [T] but remains unharmed from the fall."), \
+						span_userdanger("You brace for the fall. You make a hard landing on [T] but remain unharmed."))
+		Knockdown(levels * 40)
+		return
+	return ..()
 
 /mob/living/carbon/human/prepare_data_huds()
 	//Update med hud images...

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -48,7 +48,7 @@
 	return ..()
 
 /mob/living/carbon/human/ZImpactDamage(turf/T, levels)
-	if(levels > 1) // you're not The One
+	if(stat != CONSCIOUS || levels > 1) // you're not The One
 		return ..()
 	var/obj/item/organ/external/wings/gliders = getorgan(/obj/item/organ/external/wings)
 	if(HAS_TRAIT(src, TRAIT_FREERUNNING) || gliders?.can_soften_fall()) // the power of parkour or wings allows falling short distances unscathed

--- a/code/modules/surgery/organs/external/wings.dm
+++ b/code/modules/surgery/organs/external/wings.dm
@@ -15,6 +15,10 @@
 		return TRUE
 	return FALSE
 
+///Checks if the wings can soften short falls
+/obj/item/organ/external/wings/proc/can_soften_fall()
+	return TRUE
+
 ///The true wings that you can use to fly and shit (you cant actually shit with them)
 /obj/item/organ/external/wings/functional
 	///The flight action object
@@ -186,6 +190,11 @@
 
 	UnregisterSignal(organ_owner, list(COMSIG_HUMAN_BURNING, COMSIG_LIVING_POST_FULLY_HEAL, COMSIG_MOVABLE_PRE_MOVE))
 	REMOVE_TRAIT(organ_owner, TRAIT_FREE_FLOAT_MOVEMENT, src)
+
+/obj/item/organ/external/wings/moth/can_soften_fall()
+	if (burnt)
+		return FALSE
+	return TRUE
 
 ///Check if we can flutter around
 /obj/item/organ/external/wings/moth/proc/update_float_move()

--- a/code/modules/surgery/organs/external/wings.dm
+++ b/code/modules/surgery/organs/external/wings.dm
@@ -192,9 +192,7 @@
 	REMOVE_TRAIT(organ_owner, TRAIT_FREE_FLOAT_MOVEMENT, src)
 
 /obj/item/organ/external/wings/moth/can_soften_fall()
-	if (burnt)
-		return FALSE
-	return TRUE
+	return !burnt
 
 ///Check if we can flutter around
 /obj/item/organ/external/wings/moth/proc/update_float_move()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/moth.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/moth.ts
@@ -8,8 +8,8 @@ const Moth: Species = {
     good: [{
       icon: "feather-alt",
       name: "Precious Wings",
-      description: "Moths can fly in pressurized, zero-g environments using \
-        their wings.",
+      description: "Moths can fly in pressurized, zero-g environments and \
+        safely land short falls using their wings.",
     }, {
       icon: "tshirt",
       name: "Meal Plan",


### PR DESCRIPTION
## About The Pull Request

This is a remake of  #50618 with no spaghetti now that wing code doesn't suck, thanks to whoever did all the hard work for me

Unlike the original it only applies to 1 level falls

## Why It's Good For The Game

It's a small perk that makes thematic sense, is fairly inconsequential for balance (1 levels falls do like 10 damage) and could lead to some interesting situations. Feel free to throw your local moths off of balconies with impunity

:cl:
balance: Wings now allow falling short distances without taking damage (you will still suffer from knockdown)
/:cl: