### PR TITLE
Proper custom job name support

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -137,10 +137,11 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 			manifest_inject(N.new_character, N.client)
 		CHECK_TICK
 
-/datum/datacore/proc/manifest_modify(name, assignment)
+/datum/datacore/proc/manifest_modify(name, assignment, trim)
 	var/datum/data/record/foundrecord = find_record("name", name, GLOB.data_core.general)
 	if(foundrecord)
 		foundrecord.fields["rank"] = assignment
+		foundrecord.fields["trim"] = trim
 
 
 /datum/datacore/proc/get_manifest()
@@ -153,8 +154,9 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 	var/list/departments_by_type = SSjob.joinable_departments_by_type
 	for(var/datum/data/record/record as anything in GLOB.data_core.general)
 		var/name = record.fields["name"]
-		var/rank = record.fields["rank"]
-		var/datum/job/job = SSjob.GetJob(rank)
+		var/rank = record.fields["rank"] // user-visible job
+		var/trim = record.fields["trim"] // internal jobs by trim type
+		var/datum/job/job = SSjob.GetJob(trim)
 		if(!job || !(job.job_flags & JOB_CREW_MANIFEST) || !LAZYLEN(job.departments_list)) // In case an unlawful custom rank is added.
 			var/list/misc_list = manifest_out[DEPARTMENT_UNASSIGNED]
 			misc_list[++misc_list.len] = list(
@@ -243,6 +245,7 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 		G.fields["id"] = id
 		G.fields["name"] = H.real_name
 		G.fields["rank"] = assignment
+		G.fields["trim"] = assignment
 		G.fields["age"] = H.age
 		G.fields["species"] = H.dna.species.name
 		G.fields["fingerprint"] = md5(H.dna.unique_identity)
@@ -290,6 +293,7 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 		L.fields["id"] = md5("[H.real_name][assignment]") //surely this should just be id, like the others?
 		L.fields["name"] = H.real_name
 		L.fields["rank"] = assignment
+		L.fields["trim"] = assignment
 		L.fields["age"] = H.age
 		L.fields["gender"] = H.gender
 		if(H.gender == "male")

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -246,6 +246,7 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 		G.fields["name"] = H.real_name
 		G.fields["rank"] = assignment
 		G.fields["trim"] = assignment
+		G.fields["initial_rank"] = assignment
 		G.fields["age"] = H.age
 		G.fields["species"] = H.dna.species.name
 		G.fields["fingerprint"] = md5(H.dna.unique_identity)
@@ -294,6 +295,7 @@ GLOBAL_DATUM_INIT(data_core, /datum/datacore, new)
 		L.fields["name"] = H.real_name
 		L.fields["rank"] = assignment
 		L.fields["trim"] = assignment
+		G.fields["initial_rank"] = assignment
 		L.fields["age"] = H.age
 		L.fields["gender"] = H.gender
 		if(H.gender == "male")

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -231,7 +231,9 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		if (id_card)
 			entry["name"] = id_card.registered_name
 			entry["assignment"] = id_card.assignment
-			entry["ijob"] = jobs[id_card.assignment]
+			var/trim_assignment = id_card.get_trim_assignment()
+			if (jobs[trim_assignment])
+				entry["ijob"] = jobs[trim_assignment]
 
 		// Binary living/dead status
 		if (sensor_mode >= SENSOR_LIVING)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -339,6 +339,7 @@
 						<tr><td>Age:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=age'>&nbsp;[active1.fields["age"]]&nbsp;</A></td></tr>"}
 						dat += "<tr><td>Species:</td><td><A href ='?src=[REF(src)];choice=Edit Field;field=species'>&nbsp;[active1.fields["species"]]&nbsp;</A></td></tr>"
 						dat += {"<tr><td>Rank:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=rank'>&nbsp;[active1.fields["rank"]]&nbsp;</A></td></tr>
+						<tr><td>Initial Rank:</td><td>[active1.fields["initial_rank"]]</td>
 						<tr><td>Fingerprint:</td><td><A href='?src=[REF(src)];choice=Edit Field;field=fingerprint'>&nbsp;[active1.fields["fingerprint"]]&nbsp;</A></td></tr>
 						<tr><td>Physical Status:</td><td>&nbsp;[active1.fields["p_stat"]]&nbsp;</td></tr>
 						<tr><td>Mental Status:</td><td>&nbsp;[active1.fields["m_stat"]]&nbsp;</td></tr>
@@ -684,6 +685,7 @@ What a mess.*/
 				G.fields["id"] = "[num2hex(rand(1, 1.6777215E7), 6)]"
 				G.fields["rank"] = "Unassigned"
 				G.fields["trim"] = "Unassigned"
+				G.fields["initial_rank"] = "Unassigned"
 				G.fields["gender"] = "Male"
 				G.fields["age"] = "Unknown"
 				G.fields["species"] = "Human"
@@ -921,8 +923,6 @@ What a mess.*/
 						if(active1)
 							active1.fields["rank"] = strip_html(href_list["rank"])
 							active1.fields["trim"] = active1.fields["rank"]
-							if(href_list["rank"] in SSjob.station_jobs)
-								active1.fields["real_rank"] = href_list["real_rank"]
 
 					if("Change Criminal Status")
 						if(active2)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -683,6 +683,7 @@ What a mess.*/
 				G.fields["name"] = "New Record"
 				G.fields["id"] = "[num2hex(rand(1, 1.6777215E7), 6)]"
 				G.fields["rank"] = "Unassigned"
+				G.fields["trim"] = "Unassigned"
 				G.fields["gender"] = "Male"
 				G.fields["age"] = "Unknown"
 				G.fields["species"] = "Human"
@@ -919,6 +920,7 @@ What a mess.*/
 					if("Change Rank")
 						if(active1)
 							active1.fields["rank"] = strip_html(href_list["rank"])
+							active1.fields["trim"] = active1.fields["rank"]
 							if(href_list["rank"] in SSjob.station_jobs)
 								active1.fields["real_rank"] = href_list["real_rank"]
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -608,6 +608,10 @@
 
 	name = "[name_string][assignment_string]"
 
+/// Returns the trim assignment name.
+/obj/item/card/id/proc/get_trim_assignment()
+	return trim?.assignment || assignment
+
 /obj/item/card/id/away
 	name = "\proper a perfectly generic identification card"
 	desc = "A perfectly generic identification card. Looks like it could use some flavor."
@@ -799,6 +803,14 @@
 		return
 
 	. += mutable_appearance(trim_icon_file, trim_icon_state)
+
+/obj/item/card/id/advanced/get_trim_assignment()
+	if(trim_assignment_override)
+		return trim_assignment_override
+	else if(ispath(trim))
+		return SSid_access.trim_singletons_by_path[trim].assignment
+
+	return ..()
 
 /obj/item/card/id/advanced/silver
 	name = "silver identification card"

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -808,7 +808,8 @@
 	if(trim_assignment_override)
 		return trim_assignment_override
 	else if(ispath(trim))
-		return SSid_access.trim_singletons_by_path[trim].assignment
+		var/datum/id_trim/trim_singleton = SSid_access.trim_singletons_by_path[trim]
+		return trim_singleton.assignment
 
 	return ..()
 

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -120,7 +120,7 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 			var/dat = "<B>Showing Crew Manifest.</B><HR>"
 			dat += "<table cellspacing=5><tr><th>Name</th><th>Position</th></tr>"
 			for(var/datum/data/record/t in GLOB.data_core.general)
-				dat += "<tr><td>[t.fields["name"]]</td><td>[t.fields["rank"]]</td></tr>"
+				dat += "<tr><td>[t.fields["name"]]</td><td>[t.fields["rank"]][t.fields["rank"] != t.fields["trim"] ? " ([t.fields["trim"]])" : ""]</td></tr>"
 			dat += "</table>"
 			holder << browse(dat, "window=manifest;size=440x410")
 		if("dna")

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -111,21 +111,7 @@
 	if(!id_card)
 		return "hudno_id"
 
-	var/card_assignment
-	if(istype(id_card, /obj/item/card/id/advanced))
-		var/obj/item/card/id/advanced/advanced_id_card = id_card
-		if(advanced_id_card.trim_assignment_override)
-			card_assignment = advanced_id_card.trim_assignment_override
-		else if(ispath(advanced_id_card.trim))
-			var/datum/id_trim/trim = SSid_access.trim_singletons_by_path[advanced_id_card.trim]
-			card_assignment = trim.assignment
-		else
-			card_assignment = advanced_id_card.trim?.assignment
-	else
-		card_assignment = id_card.trim?.assignment
-
-	if(!card_assignment)
-		card_assignment = id_card.assignment
+	var/card_assignment = id_card.get_trim_assignment()
 
 	// Is this one of the jobs with dedicated HUD icons?
 	if(card_assignment in SSjob.station_jobs)

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -144,7 +144,7 @@
 			if(!computer || !card_slot2)
 				return TRUE
 			if(target_id_card)
-				GLOB.data_core.manifest_modify(target_id_card.registered_name, target_id_card.assignment)
+				GLOB.data_core.manifest_modify(target_id_card.registered_name, target_id_card.assignment, target_id_card.get_trim_assignment())
 				return card_slot2.try_eject(user)
 			else
 				var/obj/item/I = user.get_active_held_item()

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -85,7 +85,7 @@
 			if(!computer || !card_slot)
 				return
 			if(id_card)
-				GLOB.data_core.manifest_modify(id_card.registered_name, id_card.assignment)
+				GLOB.data_core.manifest_modify(id_card.registered_name, id_card.assignment, id_card.get_trim_assignment())
 				card_slot.try_eject(current_user)
 			else
 				playsound(get_turf(ui_host()) , 'sound/machines/buzz-sigh.ogg', 25, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Here at Plexagon Corp, we acknowledge that in these ever-changing times, there is more need than ever for custom job assignments. Thus, we made our systems finally support them properly.

* The datacore now has a hidden `trim` field that contains the trim assignment of the id card, or the same value as `rank` in all spawning and legacy situations.
* ID cards now have a `get_trim_assignment()` proc that better modularizes and breaks out the logic from `get_sechud_job_icon_state()` making the ID card code incidentally cleaner.
* When the HoP assigns a card using the Plexagon Access System program, `trim` is assigned to the id card's get_trim_assignment. This way, the "real" job underlying a custom job name is still maintained.
* The PDA manifest now uses `trim` to sort them, finally resolving the issue of custom jobs being mixed into Unassigned.
* The security console now shows the initial rank on spawn/latejoin (stored in the general datacore as `field["initial_rank"]`.
* The admin secrets manifest shows the trim in parenthesis, if it differs.
* To follow this pattern, the crew monitoring computer now also uses `trim` to color and sort crew instead of `assignment`.
  * Further, the crew monitor will now place completely unrecognized jobs at the bottom as it should have.

![Manifest](https://i.imgur.com/yV33Yyc.png)
![Monitor](https://i.imgur.com/tVqbEkL.png)
![Datacore](https://i.imgur.com/aKWN2MI.png)
![Secrets](https://i.imgur.com/Yy91NIZ.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Custom jobs finally don't make all of the interfaces stain their pants.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The crew monitor and crew manifest now correctly sort custom jobs according to ID trim.
refactor: Data cores now internally track ID trim when HoP updates cards, as well as initial job.
admin: The secrets manifest now also shows the registered trim for each player.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
