### PR TITLE
The Nuke kills everyone when it goes off.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -599,7 +599,7 @@ GLOBAL_VAR(station_nuke_source)
 		var/mob/living/victim = _victim
 		to_chat(victim, span_userdanger("You are shredded to atoms!"))
 		if(victim.stat != DEAD && victim.z == z)
-			victim.dust()
+			victim.gib()
 
 /*
 This is here to make the tiles around the station mininuke change when it's armed.

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -503,10 +503,11 @@ GLOBAL_VAR(station_nuke_source)
 /obj/machinery/nuclearbomb/proc/really_actually_explode(off_station)
 	var/turf/bomb_location = get_turf(src)
 	Cinematic(get_cinematic_type(off_station),world,CALLBACK(SSticker,/datum/controller/subsystem/ticker/proc/station_explosion_detonation,src))
-	INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, bomb_location.z)
+	if(off_station != NUKE_NEAR_MISS) // Don't kill people in the station if the nuke missed, even if we are technically on the same z-level
+		INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, bomb_location.z)
 
 /obj/machinery/nuclearbomb/proc/get_cinematic_type(off_station)
-	if(off_station < 2)
+	if(off_station < NUKE_NEAR_MISS)
 		return CINEMATIC_SELFDESTRUCT
 	else
 		return CINEMATIC_SELFDESTRUCT_MISS

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -501,8 +501,9 @@ GLOBAL_VAR(station_nuke_source)
 	SSticker.roundend_check_paused = FALSE
 
 /obj/machinery/nuclearbomb/proc/really_actually_explode(off_station)
+	var/turf/bomb_location = get_turf(src)
 	Cinematic(get_cinematic_type(off_station),world,CALLBACK(SSticker,/datum/controller/subsystem/ticker/proc/station_explosion_detonation,src))
-	INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, z)
+	INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, bomb_location.z)
 
 /obj/machinery/nuclearbomb/proc/get_cinematic_type(off_station)
 	if(off_station < 2)
@@ -595,8 +596,9 @@ GLOBAL_VAR(station_nuke_source)
 		return
 	for(var/_victim in GLOB.mob_living_list)
 		var/mob/living/victim = _victim
+		to_chat(victim, span_userdanger("You are shredded to atoms!"))
 		if(victim.stat != DEAD && victim.z == z)
-			victim.gib()
+			victim.dust()
 
 /*
 This is here to make the tiles around the station mininuke change when it's armed.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This does not make the nuke explode like it used to.
The nuke will now dust you in a similar way to the AI doomsday device when it goes off. This will only happen if the nuke successfully detonated on the station and not on a near miss. Otherwise, it kills everything on the z-level.

There has been code in the game for an extended period of time that was supposed to make this happen, but I believe it was bugged and did not properly give the z-level of the nuke in the explosion.

It should be noted that gameplay-wise this makes it so antagonists who need to escape will no longer get a free pass for being on the station when the nuke goes off, but they will still be counted as escaped if they are in lavaland/another z-level. I would say that this is only good for the game but I understand if it's controversial.

The original code gibbed people on the z-level, although I've considered changing it to dusting. I would like opinions on this or alternative methods of death.

fixes #62788
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The nuke doesn't feel impactful currently, which is in stark contrast to the AI's doomsday device and the blob's critical mass.
It feels weird standing around, perfectly fine after just watching a cutscene of the station getting absolutely annihilated with text on screen that says there are no survivors. In addition, I think this can drive antag on antag interaction by giving the antagonist a reason to care about whether or not the station is about to explode.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: itseasytosee
expansion: The Nanotrasen High Impact Weapons Division would like to apologize for manufacturing a large quantity of dud onboard nuclear warheads. Following a recall, we expect that the replacement batch of warheads will be 900% more likely to Anhilate all life within its radius.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
