### PR TITLE
Powersinks take a few seconds to wrench/unwrench.

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -82,7 +82,7 @@
 				attached = locate() in T
 				if(!attached)
 					to_chat(user, span_warning("\The [src] must be placed over an exposed, powered cable node!"))
-				else if(do_after(user, 5 SECONDS, target = src))
+				else if(do_after(user, 5 SECONDS, target = src) && attached)
 					set_mode(CLAMPED_OFF)
 					user.visible_message( \
 						"[user] attaches \the [src] to the cable.", \

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -176,10 +176,11 @@
 	if(!attached)
 		set_mode(DISCONNECTED)
 
+	release_heat()
+
 	if(mode != OPERATING)
 		return
 
-	release_heat()
 	drain_power()
 
 	if(internal_heat > max_heat * ALERT / 100)

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -82,7 +82,7 @@
 				attached = locate() in T
 				if(!attached)
 					to_chat(user, span_warning("\The [src] must be placed over an exposed, powered cable node!"))
-				else
+				else if(do_after(user, 5 SECONDS, target = src))
 					set_mode(CLAMPED_OFF)
 					user.visible_message( \
 						"[user] attaches \the [src] to the cable.", \
@@ -90,7 +90,7 @@
 						span_hear("You hear some wires being connected to something."))
 			else
 				to_chat(user, span_warning("\The [src] must be placed over an exposed, powered cable node!"))
-		else
+		else if(do_after(user, 5 SECONDS, target = src))
 			set_mode(DISCONNECTED)
 			user.visible_message( \
 				"[user] detaches \the [src] from the cable.", \
@@ -176,11 +176,10 @@
 	if(!attached)
 		set_mode(DISCONNECTED)
 
-	release_heat()
-
 	if(mode != OPERATING)
 		return
 
+	release_heat()
 	drain_power()
 
 	if(internal_heat > max_heat * ALERT / 100)


### PR DESCRIPTION
## About The Pull Request
Powersinks now take a few seconds to wrench/unwrench.

## Why It's Good For The Game

Being able to nullify the downside of the powersink by just unwrenching it right before it's about to blow up and ~~causing the engineers to zap everyone with overcharged APCs for absolutely no benefit is stupid and bad and results in people screaming at the engineers for doing the literal thing they're supposed to do to counter powersinks.~~ is stupid because it lets you completely nullify the downside unless the grid has enough power in it to blow the sink in one tick.

## Changelog

:cl:
balance: Powersinks now take a few seconds to wrench/unwrench.
/:cl:
