### PR TITLE
Double beds can now have two people buckled to them at a time. Also doubles the material costs to make them and their sheets.

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -322,6 +322,8 @@
  * user - The mob unbuckling buckled_mob
  */
 /atom/movable/proc/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
+	if(!(buckled_mob in buckled_mobs) || !user.CanReach(buckled_mob))
+		return
 	var/mob/living/M = unbuckle_mob(buckled_mob)
 	if(M)
 		if(M != user)

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -18,7 +18,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("stool", /obj/structure/chair/stool, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("bar stool", /obj/structure/chair/stool/bar, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("bed", /obj/structure/bed, 2, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("double bed", /obj/structure/bed/double, 2, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("double bed", /obj/structure/bed/double, 4, one_per_turf = TRUE, on_floor = TRUE), \
 	null, \
 	new/datum/stack_recipe_list("office chairs", list( \
 		new/datum/stack_recipe("dark office chair", /obj/structure/chair/office, 5, one_per_turf = TRUE, on_floor = TRUE), \
@@ -356,7 +356,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("improvised gauze", /obj/item/stack/medical/gauze/improvised, 1, 2, 6), \
 	new/datum/stack_recipe("rag", /obj/item/reagent_containers/glass/rag, 1), \
 	new/datum/stack_recipe("bedsheet", /obj/item/bedsheet, 3), \
-	new/datum/stack_recipe("double bedsheet", /obj/item/bedsheet/double, 3), \
+	new/datum/stack_recipe("double bedsheet", /obj/item/bedsheet/double, 6), \
 	new/datum/stack_recipe("empty sandbag", /obj/item/emptysandbag, 4), \
 	null, \
 	new/datum/stack_recipe("fingerless gloves", /obj/item/clothing/gloves/fingerless, 1), \

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -234,3 +234,11 @@
 	name = "double bed"
 	desc = "A luxurious double bed, for those too important for small dreams."
 	icon_state = "bed_double"
+	max_buckled_mobs = 2
+
+/obj/structure/bed/double/post_buckle_mob(mob/living/target)
+	if(buckled_mobs.len > 1) //Push the second buckled mob a bit higher from the normal lying position
+		target.pixel_y = target.base_pixel_y + 6
+
+/obj/structure/bed/double/post_unbuckle_mob(mob/living/target)
+	target.pixel_y = target.base_pixel_y + target.body_position_pixel_y_offset

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -234,11 +234,17 @@
 	name = "double bed"
 	desc = "A luxurious double bed, for those too important for small dreams."
 	icon_state = "bed_double"
+	buildstackamount = 4
 	max_buckled_mobs = 2
+	///The mob who buckled to this bed second, to avoid other mobs getting pixel-shifted before he unbuckles.
+	var/mob/living/goldilocks
 
 /obj/structure/bed/double/post_buckle_mob(mob/living/target)
-	if(buckled_mobs.len > 1) //Push the second buckled mob a bit higher from the normal lying position
+	if(buckled_mobs.len > 1 && !goldilocks) //Push the second buckled mob a bit higher from the normal lying position
 		target.pixel_y = target.base_pixel_y + 6
+		goldilocks = target
 
 /obj/structure/bed/double/post_unbuckle_mob(mob/living/target)
 	target.pixel_y = target.base_pixel_y + target.body_position_pixel_y_offset
+	if(target == goldilocks)
+		goldilocks = null

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -27,12 +27,16 @@ LINEN BINS
 
 	dog_fashion = /datum/dog_fashion/head/ghost
 	var/list/dream_messages = list("white")
+	var/stack_amount = 3
 	var/bedsheet_type = BEDSHEET_SINGLE
 
 /obj/item/bedsheet/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/surgery_initiator)
 	AddElement(/datum/element/bed_tuckable, 0, 0, 0)
+	if(bedsheet_type == BEDSHEET_DOUBLE)
+		stack_amount *= 2
+		dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 
 /obj/item/bedsheet/attack_self(mob/user)
 	if(!user.CanReach(src)) //No telekenetic grabbing.
@@ -53,7 +57,7 @@ LINEN BINS
 /obj/item/bedsheet/attackby(obj/item/I, mob/user, params)
 	if(I.tool_behaviour == TOOL_WIRECUTTER || I.get_sharpness())
 		if (!(flags_1 & HOLOGRAM_1))
-			var/obj/item/stack/sheet/cloth/shreds = new (get_turf(src), 3)
+			var/obj/item/stack/sheet/cloth/shreds = new (get_turf(src), stack_amount)
 			if(!QDELETED(shreds)) //stacks merged
 				transfer_fingerprints_to(shreds)
 				shreds.add_fingerprint(user)
@@ -312,25 +316,21 @@ LINEN BINS
 /obj/item/bedsheet/double
 	icon_state = "double_sheetwhite"
 	worn_icon_state = "sheetwhite"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/blue/double
 	icon_state = "double_sheetblue"
 	worn_icon_state = "sheetblue"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/green/double
 	icon_state = "double_sheetgreen"
 	worn_icon_state = "sheetgreen"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/grey/double
 	icon_state = "double_sheetgrey"
 	worn_icon_state = "sheetgrey"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/orange/double
@@ -342,25 +342,21 @@ LINEN BINS
 /obj/item/bedsheet/purple/double
 	icon_state = "double_sheetpurple"
 	worn_icon_state = "sheetpurple"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/patriot/double
 	icon_state = "double_sheetUSA"
 	worn_icon_state = "sheetUSA"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/rainbow/double
 	icon_state = "double_sheetrainbow"
 	worn_icon_state = "sheetrainbow"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/red/double
 	icon_state = "double_sheetred"
 	worn_icon_state = "sheetred"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/yellow/double
@@ -372,121 +368,101 @@ LINEN BINS
 /obj/item/bedsheet/mime/double
 	icon_state = "double_sheetmime"
 	worn_icon_state = "sheetmime"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/clown/double
 	icon_state = "double_sheetclown"
 	worn_icon_state = "sheetclown"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/captain/double
 	icon_state = "double_sheetcaptain"
 	worn_icon_state = "sheetcaptain"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/rd/double
 	icon_state = "double_sheetrd"
 	worn_icon_state = "sheetrd"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/medical/double
 	icon_state = "double_sheetmedical"
 	worn_icon_state = "sheetmedical"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/cmo/double
 	icon_state = "double_sheetcmo"
 	worn_icon_state = "sheetcmo"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/hos/double
 	icon_state = "double_sheethos"
 	worn_icon_state = "sheethos"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/hop/double
 	icon_state = "double_sheethop"
 	worn_icon_state = "sheethop"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/ce/double
 	icon_state = "double_sheetce"
 	worn_icon_state = "sheetce"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/qm/double
 	icon_state = "double_sheetqm"
 	worn_icon_state = "sheetqm"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/chaplain/double
 	icon_state = "double_sheetchap"
 	worn_icon_state = "sheetchap"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/brown/double
 	icon_state = "double_sheetbrown"
 	worn_icon_state = "sheetbrown"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/black/double
 	icon_state = "double_sheetblack"
 	worn_icon_state = "sheetblack"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/centcom/double
 	icon_state = "double_sheetcentcom"
 	worn_icon_state = "sheetcentcom"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/syndie/double
 	icon_state = "double_sheetsyndie"
 	worn_icon_state = "sheetsyndie"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/cult/double
 	icon_state = "double_sheetcult"
 	worn_icon_state = "sheetcult"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/wiz/double
 	icon_state = "double_sheetwiz"
 	worn_icon_state = "sheetwiz"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/nanotrasen/double
 	icon_state = "double_sheetNT"
 	worn_icon_state = "sheetNT"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/ian/double
 	icon_state = "double_sheetian"
 	worn_icon_state = "sheetian"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/cosmos/double
 	icon_state = "double_sheetcosmos"
 	worn_icon_state = "sheetcosmos"
-	dying_key = DYE_REGISTRY_DOUBLE_BEDSHEET
 	bedsheet_type = BEDSHEET_DOUBLE
 
 /obj/item/bedsheet/dorms_double


### PR DESCRIPTION
## About The Pull Request
See the title.

## Why It's Good For The Game
It makes double beds function like actual double beds. They are meant to be able to hold two mobs, not only one. Also fixes an oversight from the original creator of these.

## Changelog

:cl:
expansion: Double beds can now hold two people at a time.
balance: Double beds and double bedsheets, being double the size of normal beds and bedsheets, just like their names suggest, now also cost double the materials to craft and give double the materials when deconstructed.
/:cl:
