### PR TITLE
Fixes cargo console breaking when you ordered canisters, and makes it break softer when it does anyways

### DIFF
--- a/code/modules/cargo/department_order.dm
+++ b/code/modules/cargo/department_order.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 		target_group["packs"] += list(list(
 			"name" = pack.name,
 			"cost" = pack.get_cost(),
-			"id" = pack.type,
+			"id" = pack.id,
 			"desc" = pack.desc || pack.name, // If there is a description, use it. Otherwise use the pack's name.
 		))
 	data["supplies"] = supply_data
@@ -106,6 +106,8 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 	. = TRUE
 	var/id = text2path(params["id"])
 	var/datum/supply_pack/pack = SSshuttle.supply_packs[id]
+	if(!pack)
+		CRASH("requested supply pack id \"[id]\" not found!")
 	var/name = "*None Provided*"
 	var/rank = "*None Provided*"
 	var/ckey = usr.ckey

--- a/code/modules/cargo/department_order.dm
+++ b/code/modules/cargo/department_order.dm
@@ -107,6 +107,7 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 	var/id = text2path(params["id"])
 	var/datum/supply_pack/pack = SSshuttle.supply_packs[id]
 	if(!pack)
+		say("Something went wrong. A report has been sent to NT code monkeys.")
 		CRASH("requested supply pack id \"[id]\" not found!")
 	var/name = "*None Provided*"
 	var/rank = "*None Provided*"

--- a/code/modules/cargo/department_order.dm
+++ b/code/modules/cargo/department_order.dm
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 	var/id = text2path(params["id"])
 	var/datum/supply_pack/pack = SSshuttle.supply_packs[id]
 	if(!pack)
-		say("Something went wrong. A report has been sent to NT code monkeys.")
+		say("Something went wrong!")
 		CRASH("requested supply pack id \"[id]\" not found!")
 	var/name = "*None Provided*"
 	var/rank = "*None Provided*"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

type worked for every single type of pack EXCEPT canisters, as canisters generate their id. arrrrrr... also, implements a little sanity so cargo doesn't stop working entirely when this happens

## Why It's Good For The Game

### cargo console when engineers order a can of oxygen:

![](https://c.tenor.com/CcCDRhgwP78AAAAC/overheat-computer.gif)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: cargo consoles aren't breaking when department orders buys a canister. seriously though who buys canisters man
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
