### PR TITLE
Adds telecrystal golems

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -299,3 +299,4 @@ GLOBAL_LIST_INIT(organ_process_order, list(
 #define SPECIES_GOLEM_BONE "bone_golem"
 #define SPECIES_GOLEM_SNOW "snow_golem"
 #define SPECIES_GOLEM_HYDROGEN "metallic_hydrogen_golem"
+#define SPECIES_GOLEM_TELECRYSTAL "telecrystal_golem"

--- a/code/__DEFINES/uplink.dm
+++ b/code/__DEFINES/uplink.dm
@@ -8,3 +8,6 @@
 
 /// This item is purchasable to clown ops
 #define UPLINK_CLOWN_OPS (1 << 2)
+
+/// This item is purchasable to telecrystal golems
+#define UPLINK_TELECRYSTAL_GOLEM (1 << 3)

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -370,6 +370,14 @@ Key procs
 							/datum/language/terrum = list(LANGUAGE_ATOM),
 							/datum/language/narsie = list(LANGUAGE_ATOM))
 
+/datum/language_holder/golem/telecrystal
+	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+								/datum/language/terrum = list(LANGUAGE_ATOM),
+								/datum/language/codespeak = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+							/datum/language/terrum = list(LANGUAGE_ATOM),
+							/datum/language/codespeak = list(LANGUAGE_ATOM))
+
 /datum/language_holder/fly
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 								/datum/language/buzzwords = list(LANGUAGE_ATOM))

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -1269,3 +1269,31 @@
 /datum/species/golem/mhydrogen/on_species_loss(mob/living/carbon/C)
 	REMOVE_TRAIT(C, TRAIT_ANTIMAGIC, SPECIES_TRAIT)
 	return ..()
+
+/datum/species/golem/telecrystal
+	name = "Telecrystal Golem"
+	id = SPECIES_GOLEM_TELECRYSTAL
+	fixed_mut_color = "#ff3333"
+	species_language_holder = /datum/language_holder/golem/telecrystal
+	info_text = "As a <span class='danger'>Telecrystal Golem</span>, you are a living syndicate uplink capable of drawing upon your own life force to purchase restricted equipment."
+	prefix = "Telecrystal"
+	meat = /obj/item/stack/telecrystal
+	inherent_factions = list("syndicate")
+	changesource_flags = MIRROR_BADMIN
+	var/datum/component/uplink/golem/inherent_uplink
+
+/datum/species/golem/telecrystal/random_name(gender, unique, lastname)
+	var/list/letters = list()
+	var/last_letter
+	for(var/letter_index in 1 to rand(2,3))
+		last_letter = pick(GLOB.phonetic_alphabet - last_letter)
+		letters += last_letter
+	return "[prefix] [letters.Join(" ")]"
+
+/datum/species/golem/telecrystal/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+	. = ..()
+	inherent_uplink = C.AddComponent(/datum/component/uplink/golem, C.key, FALSE, TRUE, UPLINK_TELECRYSTAL_GOLEM)
+
+/datum/species/golem/telecrystal/on_species_loss(mob/living/carbon/human/C, datum/species/new_species, pref_load)
+	. = ..()
+	qdel(inherent_uplink)

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -73,6 +73,7 @@
 		/obj/item/stack/sheet/cotton/durathread = /datum/species/golem/durathread,
 		/obj/item/stack/sheet/mineral/snow = /datum/species/golem/snow,
 		/obj/item/stack/sheet/mineral/metal_hydrogen= /datum/species/golem/mhydrogen,
+		/obj/item/stack/telecrystal = /datum/species/golem/telecrystal,
 	)
 
 	if(!istype(I, /obj/item/stack))

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -290,6 +290,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "1 Raw Telecrystal"
 	desc = "A telecrystal in its rawest and purest form; can be utilized on active uplinks to increase their telecrystal count."
 	item = /obj/item/stack/telecrystal
+	purchasable_from = UPLINK_TRAITORS | UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
 	cost = 1
 	// Don't add telecrystals to the purchase_log since
 	// it's just used to buy more items (including itself!)
@@ -1678,6 +1679,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	// An empty uplink is kinda useless.
 	surplus = 0
 	restricted = TRUE
+	purchasable_from = UPLINK_TRAITORS | UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
 
 /datum/uplink_item/implants/uplink/spawn_item(spawn_path, mob/user, datum/component/uplink/purchaser_uplink)
 	var/obj/item/storage/box/syndie_kit/uplink_box = ..()


### PR DESCRIPTION
## About The Pull Request

This PR adds telecrystal golems, created the same way you would make any other kind of golem. They have an innate uplink that allows them to buy traitor items at a cost of 20 clone damage per TC (this can be adjusted as deemed appropriate). They cannot buy items with a price high enough to put them into crit, nor can they buy uplink implants or raw telecrystals. Uplinks have been very slightly refactored to allow for mobs to have uplinks components directly added to them.

## Why It's Good For The Game

Adds a funny niche interaction for traitor xenobiologists.

## Changelog

:cl:
expansion: Telecrystal golems can be constructed by using 10 telecrystals on a golem shell. They are able to use their own life force to buy cheap items from an innate uplink.
refactor: Uplink components can directly be added to mobs.
/:cl:

Also I have a feeling that this code is extremely smelly and should be thoroughly reviewed for better ways of implementing the features it attempts to add.
