### PR TITLE
Abductor Frankenstein edition: How aliens got a limb grower.

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -966,9 +966,15 @@
 /turf/open/floor/wood/tile,
 /area/centcom/holding)
 "ed" = (
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/wood/parquet,
-/area/centcom/holding)
+/obj/structure/closet/abductor,
+/obj/item/storage/box/alienhandcuffs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/item/disk/design_disk/limbs/ethereal,
+/obj/item/disk/design_disk/limbs/felinid,
+/obj/item/disk/design_disk/limbs/lizard,
+/obj/item/disk/design_disk/limbs/plasmaman,
+/turf/open/floor/plating/abductor,
+/area/abductor_ship)
 "eh" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/ert_spawn,
@@ -3215,7 +3221,7 @@
 /turf/open/floor/plating/abductor,
 /area/abductor_ship)
 "lj" = (
-/obj/structure/closet/abductor,
+/obj/machinery/limbgrower/fullupgrade,
 /turf/open/floor/plating/abductor,
 /area/abductor_ship)
 "lk" = (
@@ -14894,6 +14900,11 @@
 "RQ" = (
 /obj/structure/closet/abductor,
 /obj/item/storage/box/alienhandcuffs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/obj/item/disk/design_disk/limbs/plasmaman,
+/obj/item/disk/design_disk/limbs/lizard,
+/obj/item/disk/design_disk/limbs/felinid,
+/obj/item/disk/design_disk/limbs/ethereal,
 /turf/open/floor/plating/abductor,
 /area/abductor_ship)
 "RU" = (
@@ -15956,15 +15967,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating/beach/sand,
 /area/centcom/holding)
-"VX" = (
-/obj/structure/chair/stool/directional/east,
-/obj/effect/landmark/start/nukeop,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/syndicate_mothership/control)
 "VZ" = (
 /obj/structure/closet/secure_closet/ert_med,
 /obj/structure/sign/directions/medical{
@@ -18957,7 +18959,7 @@ aa
 aa
 ks
 kP
-RQ
+ed
 lG
 lj
 mw
@@ -19014,7 +19016,7 @@ aa
 aa
 ks
 kP
-RQ
+ed
 lG
 lj
 mw

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -965,16 +965,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/holding)
-"ed" = (
-/obj/structure/closet/abductor,
-/obj/item/storage/box/alienhandcuffs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/item/disk/design_disk/limbs/ethereal,
-/obj/item/disk/design_disk/limbs/felinid,
-/obj/item/disk/design_disk/limbs/lizard,
-/obj/item/disk/design_disk/limbs/plasmaman,
-/turf/open/floor/plating/abductor,
-/area/abductor_ship)
 "eh" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/ert_spawn,
@@ -14901,10 +14891,6 @@
 /obj/structure/closet/abductor,
 /obj/item/storage/box/alienhandcuffs,
 /obj/item/reagent_containers/glass/beaker/synthflesh,
-/obj/item/disk/design_disk/limbs/plasmaman,
-/obj/item/disk/design_disk/limbs/lizard,
-/obj/item/disk/design_disk/limbs/felinid,
-/obj/item/disk/design_disk/limbs/ethereal,
 /turf/open/floor/plating/abductor,
 /area/abductor_ship)
 "RU" = (
@@ -18959,7 +18945,7 @@ aa
 aa
 ks
 kP
-ed
+RQ
 lG
 lj
 mw
@@ -19016,7 +19002,7 @@ aa
 aa
 ks
 kP
-ed
+RQ
 lG
 lj
 mw

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -269,6 +269,13 @@
 	flags_1 = NODECONSTRUCT_1
 	circuit = /obj/item/circuitboard/machine/limbgrower/fullupgrade
 
+/obj/machinery/limbgrower/fullupgrade/Initialize(mapload)
+    . = ..()
+	for(var/id in SSresearch.techweb_designs)
+        var/datum/design/found_design = SSresearch.techweb_design_by_id(id)
+        if((found_design.build_type & LIMBGROWER) && !("emagged" in found_design.category))
+            stored_research.add_design(found_design)
+
 /// Emagging a limbgrower allows you to build synthetic armblades.
 /obj/machinery/limbgrower/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -263,7 +263,7 @@
 			return FALSE
 	return TRUE
 
-/obj/machinery/limgrower/fullupgrade //Inherently cheaper organ production. This is to NEVER be inherently emagged, no valids.
+/obj/machinery/limbgrower/fullupgrade //Inherently cheaper organ production. This is to NEVER be inherently emagged, no valids.
 	desc = "It grows new limbs using Synthflesh. This alien model seems more efficient"
 	obj_flags = CAN_BE_HIT
 	flags_1 = NODECONSTRUCT_1

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -270,7 +270,7 @@
 	circuit = /obj/item/circuitboard/machine/limbgrower/fullupgrade
 
 /obj/machinery/limbgrower/fullupgrade/Initialize(mapload)
-    . = ..()
+	. = ..()
 	for(var/id in SSresearch.techweb_designs)
 		var/datum/design/found_design = SSresearch.techweb_design_by_id(id)
 		if((found_design.build_type & LIMBGROWER) && !("emagged" in found_design.category))

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -264,7 +264,7 @@
 	return TRUE
 
 /obj/machinery/limbgrower/fullupgrade //Inherently cheaper organ production. This is to NEVER be inherently emagged, no valids.
-	desc = "It grows new limbs using Synthflesh. This alien model seems more efficient"
+	desc = "It grows new limbs using Synthflesh. This alien model seems more efficient."
 	obj_flags = CAN_BE_HIT
 	flags_1 = NODECONSTRUCT_1
 	circuit = /obj/item/circuitboard/machine/limbgrower/fullupgrade

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -264,9 +264,9 @@
 	return TRUE
 
 /obj/machinery/limgrower/fullupgrade //Inherently cheaper organ production. This is to NEVER be inherently emagged, no valids.
-desc = "It grows new limbs using Synthflesh. This alien model seems more efficient"
-obj_flags = CAN_BE_HIT
-flags_1 = NODECONSTRUCT_1
+	desc = "It grows new limbs using Synthflesh. This alien model seems more efficient"
+	obj_flags = CAN_BE_HIT
+	flags_1 = NODECONSTRUCT_1
 
 /// Emagging a limbgrower allows you to build synthetic armblades.
 /obj/machinery/limbgrower/emag_act(mob/user)

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -267,6 +267,7 @@
 	desc = "It grows new limbs using Synthflesh. This alien model seems more efficient"
 	obj_flags = CAN_BE_HIT
 	flags_1 = NODECONSTRUCT_1
+	circuit = /obj/item/circuitboard/machine/limbgrower/fullupgrade
 
 /// Emagging a limbgrower allows you to build synthetic armblades.
 /obj/machinery/limbgrower/emag_act(mob/user)

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -274,7 +274,7 @@
 	for(var/id in SSresearch.techweb_designs)
         var/datum/design/found_design = SSresearch.techweb_design_by_id(id)
         if((found_design.build_type & LIMBGROWER) && !("emagged" in found_design.category))
-            stored_research.add_design(found_design)
+            stored_research.add_design(found_design )
 
 /// Emagging a limbgrower allows you to build synthetic armblades.
 /obj/machinery/limbgrower/emag_act(mob/user)

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -263,6 +263,11 @@
 			return FALSE
 	return TRUE
 
+/obj/machinery/limgrower/fullupgrade //Inherently cheaper organ production. This is to NEVER be inherently emagged, no valids.
+desc = "It grows new limbs using Synthflesh. This alien model seems more efficient"
+obj_flags = CAN_BE_HIT
+flags_1 = NODECONSTRUCT_1
+
 /// Emagging a limbgrower allows you to build synthetic armblades.
 /obj/machinery/limbgrower/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -272,9 +272,9 @@
 /obj/machinery/limbgrower/fullupgrade/Initialize(mapload)
     . = ..()
 	for(var/id in SSresearch.techweb_designs)
-        var/datum/design/found_design = SSresearch.techweb_design_by_id(id)
-        if((found_design.build_type & LIMBGROWER) && !("emagged" in found_design.category))
-            stored_research.add_design(found_design )
+		var/datum/design/found_design = SSresearch.techweb_design_by_id(id)
+		if((found_design.build_type & LIMBGROWER) && !("emagged" in found_design.category))
+			stored_research.add_design(found_design)
 
 /// Emagging a limbgrower allows you to build synthetic armblades.
 /obj/machinery/limbgrower/emag_act(mob/user)

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -757,6 +757,15 @@
 		/obj/item/reagent_containers/glass/beaker = 2,
 		/obj/item/stack/sheet/glass = 1)
 
+/obj/item/circuitboard/machine/limbgrower/fullupgrade
+	name = "Limb Grower (Machine Board)"
+	greyscale_colors = CIRCUIT_COLOR_MEDICAL
+	build_path = /obj/machinery/limbgrower
+	req_components = list(
+		/obj/item/stock_parts/manipulator/femto  = 1,
+		/obj/item/reagent_containers/glass/beaker/bluespace = 2,
+		/obj/item/stack/sheet/glass = 1)
+
 /obj/item/circuitboard/machine/protolathe/department/medical
 	name = "Departmental Protolathe (Machine Board) - Medical"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL

--- a/code/modules/antagonists/abductor/abductee/abductee.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee.dm
@@ -21,6 +21,7 @@
 
 /datum/antagonist/abductee/proc/give_objective()
 	var/mob/living/carbon/human/H = owner.current
+	if(istype(H))
 	var/objtype = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))
 	var/datum/objective/abductee/O = new objtype()
 	objectives += O

--- a/code/modules/antagonists/abductor/abductee/abductee.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee.dm
@@ -20,7 +20,6 @@
 	owner.announce_objectives()
 
 /datum/antagonist/abductee/proc/give_objective()
-	var/mob/living/carbon/human/
 	var/objtype = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))
 	var/datum/objective/abductee/O = new objtype()
 	objectives += O

--- a/code/modules/antagonists/abductor/abductee/abductee.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee.dm
@@ -21,8 +21,6 @@
 
 /datum/antagonist/abductee/proc/give_objective()
 	var/mob/living/carbon/human/H = owner.current
-	if(istype(H))
-		H.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_LOBOTOMY)
 	var/objtype = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))
 	var/datum/objective/abductee/O = new objtype()
 	objectives += O

--- a/code/modules/antagonists/abductor/abductee/abductee.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee.dm
@@ -20,7 +20,7 @@
 	owner.announce_objectives()
 
 /datum/antagonist/abductee/proc/give_objective()
-	var/mob/living/carbon/human/H = owner.current
+	var/mob/living/carbon/human/
 	var/objtype = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))
 	var/datum/objective/abductee/O = new objtype()
 	objectives += O

--- a/code/modules/antagonists/abductor/abductee/abductee.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee.dm
@@ -21,7 +21,6 @@
 
 /datum/antagonist/abductee/proc/give_objective()
 	var/mob/living/carbon/human/H = owner.current
-	if(istype(H))
 	var/objtype = (prob(75) ? /datum/objective/abductee/random : pick(subtypesof(/datum/objective/abductee/) - /datum/objective/abductee/random))
 	var/datum/objective/abductee/O = new objtype()
 	objectives += O

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -661,5 +661,7 @@
 		/datum/reagent/drug/space_drugs,
 		/datum/reagent/toxin,
 		/datum/reagent/toxin/plasma,
-		/datum/reagent/uranium
+		/datum/reagent/uranium,
+		/datum/reagent/consumable/liquidelectricity/enriched,
+		/datum/reagent/medicine/c2/synthflesh
 	)


### PR DESCRIPTION
## About The Pull Request

This PR will completely remove the brain traumas component of being abducted. in its place, there will be a round start limb grower machine to make up for it. All upgrade disks for the machine come in the above locker and I was even nice enough to include 50 units of synthflesh! Wow!

![image](https://user-images.githubusercontent.com/16896032/141780353-c5aba061-3dec-4725-97d4-6d84ceb35f90.png)

The abductor chem dispenser has been modified to better accommodate this change, now having synthflesh with a single button as well as the chems needed for plasmeme/ethereal limbs and organs.

## Why It's Good For The Game

Gives more agency towards people wanting to experiment and do fun things as abductors, traumas were always something that got in the way of being able to have fun for all parties involved. Hopefully, people will be able to think up some fun things to do with this simple thing!

Uhh, also traumas are cringe.

## Changelog

:cl:
expansion: Abductors now have a limb grower to play with, for scientific purposes. Brain traumas are no longer forced after abductions.
/:cl: