### PR TITLE
Fixing quantum pads teleporting themselves, or How I Stopped People Stealing The Self-Destruction Terminal

### DIFF
--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -174,12 +174,12 @@
 
 				// if is anchored, don't let through
 				if(ROI.anchored)
-					if(isliving(ROI))
-						var/mob/living/L = ROI
-						//only TP living mobs buckled to non anchored items
-						if(L.buckled && L.buckled.anchored)
-							continue
-					else
+					continue
+
+				if(isliving(ROI))
+					var/mob/living/living_subject = ROI
+					//only TP living mobs buckled to non anchored items
+					if(living_subject.buckled && living_subject.buckled.anchored)
 						continue
 
 				do_teleport(ROI, get_turf(target_pad), no_effects = TRUE, channel = TELEPORT_CHANNEL_QUANTUM)

--- a/code/game/machinery/quantum_pad.dm
+++ b/code/game/machinery/quantum_pad.dm
@@ -179,8 +179,7 @@
 						//only TP living mobs buckled to non anchored items
 						if(L.buckled && L.buckled.anchored)
 							continue
-					//Don't TP ghosts
-					else if(isobserver(ROI))
+					else
 						continue
 
 				do_teleport(ROI, get_turf(target_pad), no_effects = TRUE, channel = TELEPORT_CHANNEL_QUANTUM)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
There was a problem of logic introduced by https://github.com/tgstation/tgstation/pull/62682 that made it so they were entirely dysfunctional. That's why you test your code before making the PR, I won't believe for a second that it was actually tested at all, considering how obvious the fact that it teleported itself was. It even allowed you to teleport everything that was anchored and not meant to be moveable, such as the self-destruct terminal, and possibly, with a LOT of skill, the SM.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #62773 

## Why It's Good For The Game
Restoring intended behavior of the quantum pads
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: GoldenAlpharex
fix: Quantum pads have had their blueprint tweaked by Nanotrasen's finest Bluespace Technicians, and will no longer break the laws of teleportation by teleporting themselves when they shouldn't.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
