### PR TITLE
removes tail pulling in its entirety

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -687,8 +687,6 @@
 #define COMSIG_CARBON_HUGGED "carbon_hugged"
 ///When a carbon mob is headpatted, this is called on the carbon that is headpatted. (mob/living/headpatter)
 #define COMSIG_CARBON_HEADPAT "carbon_headpatted"
-///When a carbon mob has their tail pulled, this is called on the carbon that is the target. (mob/living/tailpuller)
-#define COMSIG_CARBON_TAILPULL "carbon_tailpulled"
 ///Before a carbon mob is shoved, sent to the turf we're trying to shove onto (mob/living/carbon/shover, mob/living/carbon/target)
 #define COMSIG_CARBON_DISARM_PRESHOVE "carbon_disarm_preshove"
 	#define COMSIG_CARBON_ACT_SOLID (1<<0) //Tells disarm code to act as if the mob was shoved into something solid, even we we're not

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -24,11 +24,6 @@
 	mood_change = 1
 	timeout = 2 MINUTES
 
-/datum/mood_event/tailpulled
-	description = "<span class='nicegreen'>I love getting my tail pulled!</span>\n"
-	mood_change = 1
-	timeout = 2 MINUTES
-
 /datum/mood_event/arcade
 	description = "<span class='nicegreen'>I beat the arcade game!</span>\n"
 	mood_change = 3

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -417,13 +417,6 @@
 		if(HAS_TRAIT(src, TRAIT_BADTOUCH))
 			to_chat(M, span_warning("[src] looks visibly upset as you pat [p_them()] on the head."))
 
-	else if ((M.zone_selected == BODY_ZONE_PRECISE_GROIN) && !isnull(src.getorgan(/obj/item/organ/tail)))
-		SEND_SIGNAL(src, COMSIG_CARBON_TAILPULL, M)
-		M.visible_message(span_notice("[M] pulls on [src]'s tail!"), \
-					null, span_hear("You hear a soft patter."), DEFAULT_MESSAGE_RANGE, list(M, src))
-		to_chat(M, span_notice("You pull on [src]'s tail!"))
-		to_chat(src, span_notice("[M] pulls on your tail!"))
-		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "tailpulled", /datum/mood_event/tailpulled)
 	else
 		SEND_SIGNAL(src, COMSIG_CARBON_HUGGED, M)
 		SEND_SIGNAL(M, COMSIG_CARBON_HUG, M, src)


### PR DESCRIPTION
## About The Pull Request

removes tail pulling, effectively obliterating #62763.

## Why It's Good For The Game

literally the first moment i entered the game as a felinid, i was approached behind and feared for my earthly dominion, only to realize that somebody was attempting to pull my tail. i was CONFUSED. what IS this? and so, i looked onward. the github. the discord. everywhere i saw, tail pulling. why? what on god's green earth did we do to deserve this?

i've only seen bad/creepy stuff with this. literally hearing somebody say it felt like it was the equivalent of being sexually harassed when cornered and tail pulled is kind of off-putting, and this overall isn't something we need. it's inevitably you-know-what bait at best, and perverted shit at worst.

## Changelog
del: removed the ability to pull felinid tails.
/:cl: