### PR TITLE
Fixes bitfield_to_list() not working if not passed a wordlist

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -416,10 +416,10 @@
 				return_list += wordlist[i]
 			bit = bit << 1
 	else
-        //"(1 << 23) << 1" is 0 because byond:tm:, and probably floats.
-        //Since we start at 0, this is the only way bit can be lower than 1.
-        //The alternative is to either move the check in the for loop with a break or hardcode a number to check for
-        for(var/bit=1, bit != 0, bit = bit << 1)
+		//"(1 << 23) << 1" is 0 because byond:tm:, and probably floats.
+		//Since we start at 0, this is the only way bit can be lower than 1.
+		//The alternative is to either move the check in the for loop with a break or hardcode a number to check for
+		for(var/bit=1, bit != 0, bit = bit << 1)
 			if(bitfield & bit)
 				return_list += bit
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -416,7 +416,10 @@
 				return_list += wordlist[i]
 			bit = bit << 1
 	else
-		for(var/bit = 1, bit <= (1<<24), bit = bit << 1)
+        //"(1 << 23) << 1" is 0 because byond:tm:, and probably floats.
+        //Since we start at 0, this is the only way bit can be lower than 1.
+        //The alternative is to either move the check in the for loop with a break or hardcode a number to check for
+        for(var/bit=1, bit != 0, bit = bit << 1)
 			if(bitfield & bit)
 				return_list += bit
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -416,10 +416,8 @@
 				return_list += wordlist[i]
 			bit = bit << 1
 	else
-		//"(1 << 23) << 1" is 0 because byond:tm:, and probably floats.
-		//Since we start at 1, this is the only way bit can be 0.
-		//The alternative is to either move the check in the for loop with a break or hardcode a number to check for
-		for(var/bit=1, bit != 0, bit = bit << 1)
+		for(var/bit_number = 0 to 23)
+			var/bit = 1 << bit_number
 			if(bitfield & bit)
 				return_list += bit
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -417,7 +417,7 @@
 			bit = bit << 1
 	else
 		//"(1 << 23) << 1" is 0 because byond:tm:, and probably floats.
-		//Since we start at 0, this is the only way bit can be lower than 1.
+		//Since we start at 1, this is the only way bit can be 0.
 		//The alternative is to either move the check in the for loop with a break or hardcode a number to check for
 		for(var/bit=1, bit != 0, bit = bit << 1)
 			if(bitfield & bit)


### PR DESCRIPTION
Testing using Discord:tm: Stumbled across the bug in coderbus when someone pointed out the max precise integer limit for BYOND and i grepped tg for 1<<24

## About The Pull Request

(1<<24) is 0 so the loop would immediatly exit. This PR replaces the `<= (1<<24)` condition with a condition that relies on the behaviour for (1<<24) by checking if `bit` is 0

## Why It's Good For The Game

Procs doing what they say they do is good

## Changelog

:cl:
fix: Fixed the bitfield_to_field() proc not working
/:cl:
