### PR TITLE
HoS, warden and officers no longer spawn with a stunbaton in their bags.

### DIFF
--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -52,7 +52,7 @@
 	suit = /obj/item/clothing/suit/armor/hos/trenchcoat
 	suit_store = /obj/item/gun/energy/e_gun
 	backpack_contents = list(
-		/obj/item/melee/baton/security/loaded = 1,
+		/obj/item/melee/baton/telescopic = 1,
 		/obj/item/modular_computer/tablet/preset/advanced/command = 1,
 		)
 	belt = /obj/item/pda/heads/hos

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -52,7 +52,6 @@
 	suit = /obj/item/clothing/suit/armor/hos/trenchcoat
 	suit_store = /obj/item/gun/energy/e_gun
 	backpack_contents = list(
-		/obj/item/melee/baton/telescopic = 1,
 		/obj/item/modular_computer/tablet/preset/advanced/command = 1,
 		)
 	belt = /obj/item/pda/heads/hos

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -199,7 +199,6 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	suit = /obj/item/clothing/suit/armor/vest/alt
 	suit_store = /obj/item/gun/energy/disabler
 	backpack_contents = list(
-		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/modular_computer/tablet/preset/advanced/security = 1,
 		)
 	belt = /obj/item/pda/security

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -50,7 +50,6 @@
 	suit = /obj/item/clothing/suit/armor/vest/warden/alt
 	suit_store = /obj/item/gun/energy/disabler
 	backpack_contents = list(
-		/obj/item/melee/baton/security/loaded = 1,
 		/obj/item/modular_computer/tablet/preset/advanced/security = 1,
 		)
 	belt = /obj/item/pda/warden


### PR DESCRIPTION
## About The Pull Request
The HoS, warden and officers no longer spawn with a stunbaton in their bags.

## Why It's Good For The Game
More often than not, we end up with every security role (minus det) having two stunbatons since both their outfits and their closets have a stunbaton. This entails situations in which power cell drainage or losing the first stunbaton in a way that doesn't result in them becoming the receiving end of the stick would hardly impact their gameplay because of the backup one in their bag. It's also worth mentioning stunbatons are pretty powerful (the nerf they received 2 years ago helped, but the time window between the first and second hit is damn short) and most of their supposed counters (like stims, maint pump-up) barely help against the stamina loss and the knockdown right now.
In short, getting in a melee scuffle an officer can be tough, disposing his baton only for him to whip out another is just frustrating.
This also means they won't be as battle-ready but the chances are they'll take a walk to the brig and gear up anyway. It also adds a scarcity factor. Any extra security baton taken is a baton deprived from new officers, so that security and his officers have a reason to order stunbatons from cargo and interact with one another, but i'm just speculating here.
Here's Orange's blessing:
![citrus hath spoken](https://user-images.githubusercontent.com/42542238/141889896-6d2b2d34-2270-4cd0-8909-46cc4b46ea54.png)

## Changelog

:cl:
balance: The HoS, warden and officers no longer spawn with a stunbaton in their bags.
/:cl:
