### PR TITLE
Fix Camera Report verb

### DIFF
--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -119,7 +119,7 @@ GLOBAL_LIST_EMPTY(dirty_vars)
 					output += "<li><font color='red'>FULLY overlapping cameras at [ADMIN_VERBOSEJMP(C1)] Networks: [json_encode(C1.network)] and [json_encode(C2.network)]</font></li>"
 				if(C1.loc == C2.loc)
 					output += "<li>Overlapping cameras at [ADMIN_VERBOSEJMP(C1)] Networks: [json_encode(C1.network)] and [json_encode(C2.network)]</li>"
-		var/turf/T = get_step(C1,turn(C1.dir,180))
+		var/turf/T = get_step(C1,C1.dir)
 		if(!T || !isturf(T) || !T.density )
 			if(!(locate(/obj/structure/grille) in T))
 				var/window_check = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There is still the potential for false positives, since the way diagonal cameras were made didn't exactly line up with where their direction was.

However, this brings functionality back to parity with before the dir-sanity PR.

Sprite positions before, by ordinal direction:

```
+----------------+----------------+
|                |                |
|                |                |
|                |                |
|                |                |
|                |                |
|                |                |
|                |                |
|             o--|--o             |
|                |                |
|               \|/               |
+----------------+----------------+
|               /|\            |  |
|                |             |  |
|                |             o  |
|                |                |
|                |                |
|                |                |
|                |                |
|             o  |                |
|             |  |                |
|             |  |                |
+----------------+----------------+
```

Sprite positions after, by ordinal direction:

```
+----------------+----------------+
|             |  |                |
|             |  |                |
|             o  |                |
|                |                |
|                |                |
|                |                |
|                |                |
|                |             o  |
|                |             |  |
|               \|/            |  |
+----------------+----------------+
|               /|\               |
|                |                |
|                |                |
|                |                |
|                |                |
|                |                |
|                |                |
|--o             |             o--|
|                |                |
|                |                |
+----------------+----------------+
```

That is, the old `turn(dir, 180)` produced the same result as the newly coherent `dir`. Revisiting this to never get a false positive will require fancier logic, though. A NE, formerly SW, camera visually appears and appeared to be coming off the south wall, though it checks for the turf NE to be solid or have an appropriately angled window.

Note that the `turn(dir, 180)` on line 127 has been left untouched. This line actually now makes sense, as we want to find a window facing the opposite direction on the turf we're facing, if present.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Easier to find floating cameras, though there's still the possibility for both false positives and false negatives.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: The camera report verb now works... at least as well as it used to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
