### PR TITLE
Downgrades the purchasable knives in cargo from 20 force knives to 15 force knives, moves them from Security to Service

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -32,11 +32,11 @@
 	access_view = ACCESS_BRIG
 	contains = list(/obj/item/grenade/stingbang)
 
-/datum/supply_pack/goody/combatknives_single
-	name = "Combat Knife Single-Pack"
-	desc = "Contains one sharpened combat knive. Guaranteed to fit snugly inside any Nanotrasen-standard boot."
+/datum/supply_pack/goody/Survivalknives_single
+	name = "Survival Knife Single-Pack"
+	desc = "Contains one sharpened survival knive. Guaranteed to fit snugly inside any Nanotrasen-standard boot."
 	cost = PAYCHECK_HARD * 1.75
-	contains = list(/obj/item/knife/combat)
+	contains = list(/obj/item/knife/combat/survival)
 
 /datum/supply_pack/goody/ballistic_single
 	name = "Combat Shotgun Single-Pack"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -479,15 +479,6 @@
 	contains = list(/obj/item/storage/box/chemimp)
 	crate_name = "chemical implant crate"
 
-/datum/supply_pack/security/armory/combatknives
-	name = "Combat Knives Crate"
-	desc = "Contains three sharpened combat knives. Each knife guaranteed to fit snugly inside any Nanotrasen-standard boot. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 3
-	contains = list(/obj/item/knife/combat,
-					/obj/item/knife/combat,
-					/obj/item/knife/combat)
-	crate_name = "combat knife crate"
-
 /datum/supply_pack/security/armory/ballistic
 	name = "Combat Shotguns Crate"
 	desc = "For when the enemy absolutely needs to be replaced with lead. Contains three Aussec-designed Combat Shotguns, and three Shotgun Bandoliers. Requires Armory access to open."
@@ -1634,6 +1625,15 @@
 	contains = list(/obj/item/storage/backpack/duffelbag/mining_conscript)
 	crate_name = "shaft miner starter kit"
 	crate_type = /obj/structure/closet/crate/secure
+
+/datum/supply_pack/service/survivalknives
+	name = "Survival Knives Crate"
+	desc = "Contains three sharpened survival knives. Each knife guaranteed to fit snugly inside any Nanotrasen-standard boot."
+	cost = CARGO_CRATE_VALUE * 3
+	contains = list(/obj/item/knife/combat/survival,
+					/obj/item/knife/combat/survival,
+					/obj/item/knife/combat/survival)
+	crate_name = "survival knife crate"
 
 /datum/supply_pack/service/wedding
 	name = "Wedding Crate"


### PR DESCRIPTION
## About The Pull Request

Downgrades the purchasable knives in cargo from Combat Knives to Survival Knives, moves them from Security to Service.
Closes #63122

## Why It's Good For The Game

Security really does not need pocket 20 force sharp weapons with wound bonuses hidden in their shoes ~~that are also literally nuke ops gear.~~ This was incorrect.

Security players were, evidently, ordering these every single shift roundstart. I'm going to ask about pulling cargo ordering stats soon to get actual numbers but this was one of the more often ordered crates.

## Changelog
:cl:
balance: Downgrades the purchasable knives in cargo from Combat Knives to Survival Knives, moves them from Security to Service.
/:cl: