### PR TITLE
Fixes the wrong cinematic playing on nukeop win.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -75,9 +75,9 @@ GLOBAL_VAR(station_nuke_source)
 	switch(off_station)
 		if(0)
 			if(get_antag_minds(/datum/antagonist/nukeop).len && syndies_escaped())
-				return CINEMATIC_ANNIHILATION
-			else
 				return CINEMATIC_NUKE_WIN
+			else
+				return CINEMATIC_ANNIHILATION
 		if(1)
 			return CINEMATIC_NUKE_MISS
 		if(2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes: #62868
This wasn't caused by my PR please spare me my GBP
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: itseasytosee
fix: The correct cinematic now plays when nuke ops fail to escape the station after blowing it up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
