### PR TITLE
de-hardcodes moth antennae preference icons

### DIFF
--- a/code/modules/client/preferences/species_features/moth.dm
+++ b/code/modules/client/preferences/species_features/moth.dm
@@ -15,7 +15,7 @@
 		var/datum/sprite_accessory/antennae = GLOB.moth_antennae_list[antennae_name]
 
 		var/icon/icon_with_antennae = new(moth_head)
-		icon_with_antennae.Blend(icon('icons/mob/moth_antennae.dmi', "m_moth_antennae_[antennae.icon_state]_FRONT"), ICON_OVERLAY)
+		icon_with_antennae.Blend(icon(antennae.icon, "m_moth_antennae_[antennae.icon_state]_FRONT"), ICON_OVERLAY)
 		icon_with_antennae.Scale(64, 64)
 		icon_with_antennae.Crop(15, 64, 15 + 31, 64 - 31)
 


### PR DESCRIPTION
## About The Pull Request

Tested in game and works:
![image](https://user-images.githubusercontent.com/53777086/142135531-44661846-7017-481f-831e-e67dcf8fe2b9.png)

## Why It's Good For The Game

It just makes the preferences actually appear for downstreams who have unique moth preferences.

## Changelog

Not needed.