### PR TITLE
the ultimate hulk nerf

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -200,6 +200,8 @@
 	var/hulk_verb = pick("smash","pummel")
 	if(check_shields(user, 15, "the [hulk_verb]ing", attack_type = UNARMED_ATTACK))
 		return
+	if(check_block()) //everybody is kung fu fighting
+		return
 	playsound(loc, user.dna.species.attack_sound, 25, TRUE, -1)
 	visible_message(span_danger("[user] [hulk_verb]ed [src]!"), \
 					span_userdanger("[user] [hulk_verb]ed [src]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, user)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -198,7 +198,7 @@
 	if(!.)
 		return
 	var/hulk_verb = pick("smash","pummel")
-	if(check_shields(user, 15, "the [hulk_verb]ing"))
+	if(check_shields(user, 15, "the [hulk_verb]ing", attack_type = UNARMED_ATTACK))
 		return
 	playsound(loc, user.dna.species.attack_sound, 25, TRUE, -1)
 	visible_message(span_danger("[user] [hulk_verb]ed [src]!"), \


### PR DESCRIPTION
## About The Pull Request

Hulk punches now count as unarmed attacks for the purposes of blocking. They also now call check_block(). This effectively means two things:
* Held chairs, which can only deflect unarmed attacks, can now deflect hulk punches if their block chance procs.
* Martial arts that grant their users the ability to block unarmed and melee attacks while they're in throw mode can now block hulk punches.

## Why It's Good For The Game

Hulk hands may be green and strong, but they're still hands.

## Changelog

:cl: ATHATH
fix: Hulk punches now count as unarmed attacks for the purposes of blocking.
fix: Martial arts that grant their users the ability to block unarmed and melee attacks while they're in throw mode can now block hulk punches.
/:cl: