### PR TITLE
Cyborgs doing research is now logged IC

### DIFF
--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -197,6 +197,8 @@
 			var/logname = "Unknown"
 			if(isAI(user))
 				logname = "AI: [user.name]"
+			if(iscyborg(user))
+				logname = "Cyborg: [user.name]"
 			if(iscarbon(user))
 				var/obj/item/card/id/idcard = user.get_active_held_item()
 				if(istype(idcard))

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -105,6 +105,8 @@ Nothing else in the console has ID requirements.
 			var/logname = "Unknown"
 			if(isAI(user))
 				logname = "AI: [user.name]"
+			if(iscyborg(user))
+				logname = "Cyborg: [user.name]"
 			if(iscarbon(user))
 				var/obj/item/card/id/idcard = user.get_active_held_item()
 				if(istype(idcard))


### PR DESCRIPTION
## About The Pull Request

From a conversation in the discord's coding channel
![image](https://user-images.githubusercontent.com/53777086/142144410-2f430b20-aca1-4cab-9929-70642258d2e0.png)
![image](https://user-images.githubusercontent.com/53777086/142144420-c37fcdbe-2ea8-451a-b880-c3c9c884d2de.png)
![image](https://user-images.githubusercontent.com/53777086/142144426-a305d26d-5014-43e3-bb25-9c2b0309f322.png)


Example of how it looks in game:
![image](https://user-images.githubusercontent.com/53777086/142144155-8725ea78-a3db-4841-907d-92b372f19f07.png)

## Why It's Good For The Game

AI's doing research is logged to the RD, but Cyborgs doing it just shows up as 'Unknown', which makes no sense because some AI can order a Cyborg to do research on their behalf so the RD doesn't know who did it.
It also makes the RD's job easier to find out what rogue cyborg is doing research when told not to.

## Changelog

:cl:
fix: Cyborgs who perform research is now logged in the RD's server console, rather than showing up as Unknown.
/:cl: