### PR TITLE
Fixes hydroponics harvest feedback message

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -200,5 +200,5 @@
 	podman.set_cloned_appearance()
 	log_cloning("[key_name(mind)] cloned as a podman via [src] in [parent] at [AREACOORD(parent)].")
 
-	parent.update_tray()
+	parent.update_tray(user, 1)
 	return result

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -236,7 +236,7 @@
 		product_name = parent.myseed.plantname
 	if(product_count >= 1)
 		SSblackbox.record_feedback("tally", "food_harvested", product_count, product_name)
-	parent.update_tray(user)
+	parent.update_tray(user, product_count)
 
 	return result
 


### PR DESCRIPTION
## About The Pull Request

Fixes #62892 

A recent PR changed it so you had to pass the number of products to `update_tray`, but didn't update anything that called it

This PR updates all the places `update_tray` is called to include user and amount of produce.

## Why It's Good For The Game

Lets botanists see how much produce came out of the plant.

## Changelog

:cl: Melbert
fix: Harvesting plants says the correct number of produce again
/:cl:

