### PR TITLE
Fixes hydroponics tray icon on spading / changing seeds

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -351,6 +351,7 @@
 	if(myseed && myseed.loc != src)
 		myseed.forceMove(src)
 	SEND_SIGNAL(src, COMSIG_HYDROTRAY_SET_SEED, new_seed)
+	update_appearance()
 
 /*
  * Setter proc to set a tray to a new self_sustaining state and update all values associated with it.


### PR DESCRIPTION
## About The Pull Request

Fixes #62893

Updates the appearance of a tray after a new seed is set. I didn't include an `update_icon` argument since I feel that changing the seed should always change the icon, but I can if it's needed.

## Why It's Good For The Game

Makes plants you destroy actually go away.

## Changelog

:cl: Melbert
fix: Spading plants correctly updates the tray icon again
/:cl:
