### PR TITLE
Pacifists can no longer attach c4 to other living creatures.

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -84,6 +84,9 @@
 	aim_dir = get_dir(user,bomb_target)
 	if(!flag)
 		return
+	if(bomb_target != user && HAS_TRAIT(user, TRAIT_PACIFISM) && isliving(bomb_target))
+		to_chat(user, span_warning("You don't want to harm other living beings!"))
+		return
 
 	to_chat(user, span_notice("You start planting [src]. The timer is set to [det_time]..."))
 


### PR DESCRIPTION
## About The Pull Request
See the title.

## Why It's Good For The Game
This will fix #62872, an oversight.

## Changelog

:cl:
fix: Pacifists can no longer attach c4 to other living creatures.
/:cl:
