### PR TITLE
Allows shells that requiring anchoring to take power from APCs

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -1478,6 +1478,10 @@
 /// Called when the integrated circuit is locked.
 #define COMSIG_CIRCUIT_SET_LOCKED "circuit_set_locked"
 
+/// Called before power is used in an integrated circuit (power_to_use)
+#define COMSIG_CIRCUIT_PRE_POWER_USAGE "circuit_pre_power_usage"
+	#define COMPONENT_OVERRIDE_POWER_USAGE (1<<0)
+
 /// Called right before the integrated circuit data is converted to json. Allows modification to the data right before it is returned.
 #define COMSIG_CIRCUIT_PRE_SAVE_TO_JSON "circuit_pre_save_to_json"
 

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -14,7 +14,18 @@
 	/// A list of components that cannot be removed
 	var/list/obj/item/circuit_component/unremovable_circuit_components
 
+	/// Whether the shell is locked or not
 	var/locked = FALSE
+
+	// The variables below are used only for anchored shells
+	/// The amount of power used in the last minute
+	var/power_used_in_minute = 0
+
+	/// The last time power was taken from the grid.
+	var/power_used_last = 0
+
+	/// The maximum power that the shell can use in a minute before entering overheating and destroying itself.
+	var/max_power_use_in_minute = 20000
 
 /datum/component/shell/Initialize(unremovable_circuit_components, capacity, shell_flags, starting_circuit)
 	. = ..()
@@ -119,11 +130,15 @@
 	examine_text += span_notice("The cover panel to the integrated circuit is [locked? "locked" : "unlocked"].")
 	var/obj/item/stock_parts/cell/cell = attached_circuit.cell
 	examine_text += span_notice("The charge meter reads [cell ? round(cell.percent(), 1) : 0]%.")
-	if((shell_flags & SHELL_FLAG_REQUIRE_ANCHOR) && !source.anchored)
-		examine_text += span_notice("The integrated circuit is non-functional whilst the shell is unanchored.")
 
 	if (shell_flags & SHELL_FLAG_USB_PORT)
 		examine_text += span_notice("There is a <b>USB port</b> on the front.")
+
+	if(shell_flags & SHELL_FLAG_REQUIRE_ANCHOR)
+		examine_text += span_notice("The shell does not require a battery to function and will draw from the area's APC whenever possible.")
+		if(!source.anchored)
+			examine_text += span_danger("<b>The integrated circuit is non-functional whilst the shell is unanchored.</b>")
+
 
 /**
  * Called when the shell is anchored.
@@ -256,6 +271,22 @@
 		source.balloon_alert(user, "it won't fit!")
 		return COMPONENT_CANCEL_ADD_COMPONENT
 
+/datum/component/shell/proc/override_power_usage(datum/source, power_to_use)
+	SIGNAL_HANDLER
+	if(world.time - power_used_last > 1 MINUTES)
+		power_used_in_minute = 0
+
+	var/area/location = get_area(parent)
+	if(location.powered(AREA_USAGE_EQUIP))
+		if(power_used_in_minute > max_power_use_in_minute)
+			explosion(parent, 0, 0, 1, explosion_cause = attached_circuit)
+			remove_circuit()
+			return
+		location.use_power(power_to_use, AREA_USAGE_EQUIP)
+		power_used_in_minute += power_to_use
+		power_used_last = world.time
+		return COMPONENT_OVERRIDE_POWER_USAGE
+
 /**
  * Attaches a circuit to the parent. Doesn't do any checks to see for any existing circuits so that should be done beforehand.
  */
@@ -267,6 +298,8 @@
 	attached_circuit = circuitboard
 	if(!(shell_flags & SHELL_FLAG_CIRCUIT_FIXED) && !circuitboard.admin_only)
 		RegisterSignal(circuitboard, COMSIG_MOVABLE_MOVED, .proc/on_circuit_moved)
+	if(shell_flags & SHELL_FLAG_REQUIRE_ANCHOR)
+		RegisterSignal(circuitboard, COMSIG_CIRCUIT_PRE_POWER_USAGE, .proc/override_power_usage)
 	RegisterSignal(circuitboard, COMSIG_PARENT_QDELETING, .proc/on_circuit_delete)
 	for(var/obj/item/circuit_component/to_add as anything in unremovable_circuit_components)
 		to_add.forceMove(attached_circuit)
@@ -295,6 +328,7 @@
 		COMSIG_MOVABLE_MOVED,
 		COMSIG_PARENT_QDELETING,
 		COMSIG_CIRCUIT_ADD_COMPONENT_MANUALLY,
+		COMSIG_CIRCUIT_PRE_POWER_USAGE,
 	))
 	if(attached_circuit.loc == parent || (!QDELETED(attached_circuit) && attached_circuit.loc == null))
 		var/atom/parent_atom = parent

--- a/code/modules/wiremod/core/component.dm
+++ b/code/modules/wiremod/core/component.dm
@@ -262,9 +262,11 @@
 			message_admins("[display_name] tried to execute on [parent.get_creator_admin()] that has admin_only set to 0")
 			return FALSE
 
-		var/obj/item/stock_parts/cell/cell = parent.get_cell()
-		if(!cell?.use(power_usage_per_input))
-			return FALSE
+		var/flags = SEND_SIGNAL(parent, COMSIG_CIRCUIT_PRE_POWER_USAGE, power_usage_per_input)
+		if(!(flags & COMPONENT_OVERRIDE_POWER_USAGE))
+			var/obj/item/stock_parts/cell/cell = parent.get_cell()
+			if(!cell?.use(power_usage_per_input))
+				return FALSE
 
 	if((!port || port.trigger == .proc/input_received) && (circuit_flags & CIRCUIT_FLAG_INPUT_SIGNAL) && !COMPONENT_TRIGGERED_BY(trigger_input, port))
 		return FALSE

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -18,7 +18,7 @@
 		/datum/component/shell, \
 		unremovable_circuit_components = list(new /obj/item/circuit_component/airlock, new /obj/item/circuit_component/airlock_access_event), \
 		capacity = SHELL_CAPACITY_LARGE, \
-		shell_flags = SHELL_FLAG_ALLOW_FAILURE_ACTION \
+		shell_flags = SHELL_FLAG_ALLOW_FAILURE_ACTION|SHELL_FLAG_REQUIRE_ANCHOR \
 	)
 
 /obj/machinery/door/airlock/shell/check_access(obj/item/I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Allows anchored shells to take power from APCs. If they take too much in a short period of time, they blow up and automatically eject the circuit to prevent someone from attempting to drain the grid.
Doors shells have been made to require anchoring but this'll have no player facing changes because they cannot be unanchored anyways.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Door shells require power to function and also require a separate cell to function too. This also improves the server shell as it makes it more viable as something that can handle heavy processing without needing to worry about recharging it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Shells that require anchoring to work now take their power from the room's APC rather than their cell. They can still use their cell as a backup battery. If they take too much power in a short period of time, they'll blow up and eject the circuit. You can examine the shell to see if it requires a cell to function.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
