### PR TITLE
Donuts found in sec vendors and boxes can now be used to make glazed donuts

### DIFF
--- a/_maps/RandomZLevels/wildwest.dmm
+++ b/_maps/RandomZLevels/wildwest.dmm
@@ -909,7 +909,7 @@
 /area/awaymission/wildwest/mines)
 "dY" = (
 /obj/structure/table/wood,
-/obj/item/food/donut/jelly/slimejelly,
+/obj/item/food/donut/jelly/slimejelly/plain,
 /turf/open/floor/carpet,
 /area/awaymission/wildwest/mines)
 "dZ" = (
@@ -919,12 +919,12 @@
 /area/awaymission/wildwest/mines)
 "ea" = (
 /obj/structure/table/wood,
-/obj/item/food/donut/jelly,
+/obj/item/food/donut/jelly/plain,
 /turf/open/floor/carpet,
 /area/awaymission/wildwest/mines)
 "eb" = (
 /obj/structure/table/wood,
-/obj/item/food/donut,
+/obj/item/food/donut/plain,
 /turf/open/floor/carpet,
 /area/awaymission/wildwest/mines)
 "ec" = (
@@ -1070,7 +1070,7 @@
 "eG" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/coffee,
-/obj/item/food/donut/jelly/slimejelly,
+/obj/item/food/donut/jelly/slimejelly/plain,
 /turf/open/floor/carpet,
 /area/awaymission/wildwest/mines)
 "eH" = (
@@ -1715,10 +1715,6 @@
 	},
 /turf/open/floor/grass,
 /area/awaymission/wildwest/gov)
-"Gw" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/carpet,
-/area/awaymission/wildwest/mines)
 "Kh" = (
 /obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -75559,7 +75559,7 @@
 /obj/item/clothing/accessory/armband/deputy,
 /obj/item/clothing/accessory/armband/deputy,
 /obj/item/clothing/accessory/armband/deputy,
-/obj/item/food/donut,
+/obj/item/food/donut/plain,
 /obj/item/inspector,
 /turf/open/floor/iron/dark,
 /area/security/office)

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -70,7 +70,7 @@
 /obj/item/storage/fancy/donut_box{
 	pixel_y = -7
 	},
-/obj/item/food/donut{
+/obj/item/food/donut/plain{
 	pixel_x = 5;
 	pixel_y = 10
 	},

--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -36,7 +36,7 @@
 /datum/recipe
 	var/list/reagents_list // example:  = list(/datum/reagent/consumable/berryjuice = 5) // do not list same reagent twice
 	var/list/items // example: =list(/obj/item/crowbar, /obj/item/welder) // place /foo/bar before /foo
-	var/result //example: = /obj/item/food/donut
+	var/result //example: = /obj/item/food/donut/plain
 	var/time = 100 // 1/10 part of second
 
 

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -8,7 +8,6 @@
 	name = "donut"
 	desc = "Goes great with robust coffee."
 	icon = 'icons/obj/food/donuts.dmi'
-	icon_state = "donut"
 	bite_consumption = 5
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/sugar = 3)
 	tastes = list("donut" = 1)
@@ -61,6 +60,7 @@
 
 //Use this donut ingame
 /obj/item/food/donut/plain
+	icon_state = "donut"
 
 /obj/item/food/donut/chaos
 	name = "chaos donut"
@@ -161,7 +161,6 @@
 	name = "jelly donut"
 	desc = "You jelly?"
 	icon_state = "jelly"
-	decorated_icon = "jelly_homer"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/sugar = 3, /datum/reagent/consumable/sugar = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
 	extra_reagent = /datum/reagent/consumable/berryjuice
 	tastes = list("jelly" = 1, "donut" = 3)
@@ -177,6 +176,7 @@
 		reagents.add_reagent(extra_reagent, 3)
 
 /obj/item/food/donut/jelly/plain //use this ingame to avoid inheritance related crafting issues.
+	decorated_icon = "jelly_homer"
 
 /obj/item/food/donut/jelly/berry
 	name = "pink jelly donut"
@@ -254,11 +254,11 @@
 /obj/item/food/donut/jelly/slimejelly
 	name = "jelly donut"
 	desc = "You jelly?"
-	icon_state = "jelly"
 	extra_reagent = /datum/reagent/toxin/slimejelly
 	foodtypes = JUNKFOOD | GRAIN | FRIED | TOXIC | SUGAR | BREAKFAST
 
 /obj/item/food/donut/jelly/slimejelly/plain
+	icon_state = "jelly"
 
 /obj/item/food/donut/jelly/slimejelly/berry
 	name = "pink jelly donut"

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -79,7 +79,7 @@
 	icon = 'icons/obj/food/donuts.dmi'
 	icon_state = "donutbox_inner"
 	base_icon_state = "donutbox"
-	spawn_type = /obj/item/food/donut
+	spawn_type = /obj/item/food/donut/plain
 	is_open = TRUE
 	appearance_flags = KEEP_TOGETHER
 	custom_premium_price = PAYCHECK_HARD * 1.75

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -12,7 +12,7 @@
 		/obj/item/restraints/handcuffs/cable/zipties = 10,
 		/obj/item/grenade/flashbang = 4,
 		/obj/item/assembly/flash/handheld = 5,
-		/obj/item/food/donut = 12,
+		/obj/item/food/donut/plain = 12,
 		/obj/item/storage/box/evidence = 6,
 		/obj/item/flashlight/seclite = 4,
 		/obj/item/restraints/legcuffs/bola/energy = 7


### PR DESCRIPTION
## About The Pull Request
Replaces many instances in both .dm and .dmm files of abstract types `/obj/item/food/donut`, `/obj/item/food/donut/jelly` and `/obj/item/food/donut/jelly/slimejelly` that would lead to those items being spawned in-game with their `plain` subtypes.

Also moved the base donut icon_state away from the abstract types to make it clearer they shouldn't be spawned in-game.

## Why It's Good For The Game
This will fix #62871.

## Changelog

:cl:
fix: Donuts found in sec vendors and boxes can now be used to make glazed donuts
/:cl:
