### PR TITLE
Security Officers, Wardens and the HoS now start with one evidence bag.

### DIFF
--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -52,6 +52,7 @@
 	suit = /obj/item/clothing/suit/armor/hos/trenchcoat
 	suit_store = /obj/item/gun/energy/e_gun
 	backpack_contents = list(
+		/obj/item/evidencebag = 1,
 		/obj/item/modular_computer/tablet/preset/advanced/command = 1,
 		)
 	belt = /obj/item/pda/heads/hos

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -199,6 +199,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	suit = /obj/item/clothing/suit/armor/vest/alt
 	suit_store = /obj/item/gun/energy/disabler
 	backpack_contents = list(
+		/obj/item/evidencebag = 1,
 		/obj/item/modular_computer/tablet/preset/advanced/security = 1,
 		)
 	belt = /obj/item/pda/security

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -50,6 +50,7 @@
 	suit = /obj/item/clothing/suit/armor/vest/warden/alt
 	suit_store = /obj/item/gun/energy/disabler
 	backpack_contents = list(
+		/obj/item/evidencebag = 1,
 		/obj/item/modular_computer/tablet/preset/advanced/security = 1,
 		)
 	belt = /obj/item/pda/warden


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Simply that, one evidence bag added to their backpack.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Detective rounds often devolve into being a Sec Officer with a revolver, either because you don't have enough staff and can't sit back and focus on investigations or the team isn't cooperative and giving you cases.

But on the rare few rounds that Security cooperates and bring you evidence to scan, it is a joy.
Even if most are not as important, just figuring out if that screwdriver with blood on it was some serial eye stabber or an new player clicking themselves by matching the fingerprints with the blood is rewarding.

So the goal of this is to nudge Officers into cooperating more with Detectives by bringing them more evidence to scan and also makes security be more professional, it's really annoying when Sec Officers bring evidence outside of a bag and just leave them around on top of a table at the brig, often being looted by other officers if it is something valuable like tools.

We already have evidence boxes for free on some stations, spare boxes on the Det locker and the box is as expensive as a flashbang on the vendor, this just cut on the begging you have to do for Officers to carry them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
balance: To improve the forensics efforts and professionalism our Security staff, evidence bags are standard equipment given to every member of security now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
