### PR TITLE
Prevents failrp from missing ! and hitting ~

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -24,6 +24,7 @@
 	var/verb_whisper = "whispers"
 	var/verb_sing = "sings"
 	var/verb_yell = "yells"
+	var/verb_sexy = "whispers huskily"
 	var/speech_span
 	var/inertia_dir = 0
 	var/atom/inertia_last_loc

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -24,7 +24,7 @@
 	var/verb_whisper = "whispers"
 	var/verb_sing = "sings"
 	var/verb_yell = "yells"
-	var/verb_sexy = "whispers huskily"
+	var/verb_sexy = "draws out the last word in their sentence as if to either delay the next thought (as if you needed to do something before continuing) or alternatively perhaps they are singing but only to the last word, in a cutesy kind of very casual way. You would never do that in a formal setting, so make sure to adminhelp if they do. Anyways, most of space station 13 environments are pretty casual ala dorms kitchen bar and other places so I think its fine."
 	var/speech_span
 	var/inertia_dir = 0
 	var/atom/inertia_last_loc

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -92,6 +92,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		return verb_ask
 	else if(ending == "!")
 		return verb_exclaim
+	else if(ending == "~")
+		return verb_sexy
 	else
 		return verb_say
 


### PR DESCRIPTION
## About The Pull Request
Adds the new sexy say mod verb

## Why It's Good For The Game
Sometimes you miss the ! and hit ~ and this leads to failrp because without any IC context, ~ will be OOC in ic chat.
## Changelog
:cl: oranges
add: You can now use ~ for modifying your say verb for those intimate moments
/:cl:
