### PR TITLE
Forces areas to create their lighting objects when loaded from a map template

### DIFF
--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -82,6 +82,11 @@
 
 	SSatoms.InitializeAtoms(areas + turfs + movables, returns_created_atoms ? created_atoms : null)
 
+	for(var/area/area as anything in areas)
+		if(area.static_lighting)
+			// We gotta get those lighting objects generated, yo
+			area.create_area_lighting_objects()
+
 	// NOTE, now that Initialize and LateInitialize run correctly, do we really
 	// need these two below?
 	SSmachines.setup_template_powernets(cables)

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -82,10 +82,11 @@
 
 	SSatoms.InitializeAtoms(areas + turfs + movables, returns_created_atoms ? created_atoms : null)
 
-	for(var/area/area as anything in areas)
-		if(area.static_lighting)
-			// We gotta get those lighting objects generated, yo
-			area.create_area_lighting_objects()
+	for(var/turf/unlit as anything in turfs)
+		if(!unlit.always_lit && istype(unlit.loc, /area))
+			var/area/loc_area = unlit.loc
+			if(loc_area.static_lighting)
+				unlit.lighting_build_overlay()
 
 	// NOTE, now that Initialize and LateInitialize run correctly, do we really
 	// need these two below?

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -83,10 +83,12 @@
 	SSatoms.InitializeAtoms(areas + turfs + movables, returns_created_atoms ? created_atoms : null)
 
 	for(var/turf/unlit as anything in turfs)
-		if(!unlit.always_lit)
-			var/area/loc_area = unlit.loc
-			if(loc_area.static_lighting)
-				unlit.lighting_build_overlay()
+		if(unlit.always_lit)
+			continue
+		var/area/loc_area = unlit.loc
+		if(!loc_area.static_lighting)
+			continue
+		unlit.lighting_build_overlay()
 
 	// NOTE, now that Initialize and LateInitialize run correctly, do we really
 	// need these two below?

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -83,7 +83,7 @@
 	SSatoms.InitializeAtoms(areas + turfs + movables, returns_created_atoms ? created_atoms : null)
 
 	for(var/turf/unlit as anything in turfs)
-		if(!unlit.always_lit && istype(unlit.loc, /area))
+		if(!unlit.always_lit)
 			var/area/loc_area = unlit.loc
 			if(loc_area.static_lighting)
 				unlit.lighting_build_overlay()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Continues the journey of https://github.com/tgstation/tgstation/pull/61730. This time, all map templates will see their area lighting objects created upon getting loaded if they have `static_lighting = TRUE`. This means that places like Hilbert's hotel, as well as any map placed by an admin during the round, will now be able to properly have dynamic lights without any need for VV shenanigans.

Tested and working, I tested with Hilbert's hotel and by spawning a couple of other map templates to confirm.

Fixes https://github.com/tgstation/tgstation/issues/61558, closes https://github.com/tgstation/tgstation/issues/61340 (kinda not, but it's already fixed anyway, and loosely related to this) and should be the final nail in the coffin of https://github.com/tgstation/tgstation/issues/61349.

Courtesy ping to @TiviPlus, just in case you had anything to say about it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having Hilbert's hotel be pitch-black when you enter it isn't fun for anyone, and this lightens admin load slightly by not forcing them to do a proc call on an area to get it to light up properly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: GoldenAlpharex
fix: Areas loaded from map templates should generate their lighting objects upon being loaded, which means that admin or game-spawned map templates will now have functional lights.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
