### PR TITLE
Move current pick_weight consumers to not pass in zeros

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -273,6 +273,7 @@
 	var/item
 	for(item in list_to_pick)
 		if(!list_to_pick[item])
+			stack_trace("Weight of zero passed to `pick_weight` instead of `pick_weight_allow_zero`. Item: [item]")
 			list_to_pick[item] = 1
 		total += list_to_pick[item]
 

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -273,7 +273,6 @@
 	var/item
 	for(item in list_to_pick)
 		if(!list_to_pick[item])
-			stack_trace("Weight of zero passed to `pick_weight` instead of `pick_weight_allow_zero`. Item: [item]")
 			list_to_pick[item] = 1
 		total += list_to_pick[item]
 

--- a/code/datums/looping_sounds/item_sounds.dm
+++ b/code/datums/looping_sounds/item_sounds.dm
@@ -1,20 +1,20 @@
 /datum/looping_sound/reverse_bear_trap
-	mid_sounds = list('sound/effects/clock_tick.ogg')
+	mid_sounds = list('sound/effects/clock_tick.ogg' = 1)
 	mid_length = 3.5
 	volume = 25
 
 
 /datum/looping_sound/reverse_bear_trap_beep
-	mid_sounds = list('sound/machines/beep.ogg')
+	mid_sounds = list('sound/machines/beep.ogg' = 1)
 	mid_length = 60
 	volume = 10
 
 /datum/looping_sound/siren
-	mid_sounds = list('sound/items/weeoo1.ogg')
+	mid_sounds = list('sound/items/weeoo1.ogg' = 1)
 	mid_length = 15
 	volume = 20
 
 /datum/looping_sound/tape_recorder_hiss
-	mid_sounds = list('sound/items/taperecorder/taperecorder_hiss_mid.ogg')
-	start_sound = list('sound/items/taperecorder/taperecorder_hiss_start.ogg')
+	mid_sounds = list('sound/items/taperecorder/taperecorder_hiss_mid.ogg' = 1)
+	start_sound = list('sound/items/taperecorder/taperecorder_hiss_start.ogg' = 1)
 	volume = 10

--- a/code/datums/looping_sounds/machinery_sounds.dm
+++ b/code/datums/looping_sounds/machinery_sounds.dm
@@ -94,7 +94,7 @@
 
 /datum/looping_sound/jackpot
 	mid_length = 11
-	mid_sounds = list('sound/machines/roulettejackpot.ogg')
+	mid_sounds = list('sound/machines/roulettejackpot.ogg'=1)
 	volume = 85
 	vary = TRUE
 

--- a/code/game/objects/effects/spawners/random/random.dm
+++ b/code/game/objects/effects/spawners/random/random.dm
@@ -62,9 +62,9 @@
 	if(loot?.len)
 		var/loot_spawned = 0
 		while((spawn_loot_count-loot_spawned) && loot.len)
-			var/lootspawn = pick_weight(loot)
+			var/lootspawn = pick_weight(fill_with_ones(loot))
 			while(islist(lootspawn))
-				lootspawn = pick_weight(lootspawn)
+				lootspawn = pick_weight(fill_with_ones(lootspawn))
 			if(!spawn_loot_double)
 				loot.Remove(lootspawn)
 			if(lootspawn && (spawn_scatter_radius == 0 || spawn_locations.len))
@@ -139,7 +139,22 @@
 		stat_table[item] /= loot_count
 
 /obj/item/loot_table_maker/proc/pick_loot(lootpool) //selects path from loot table and returns it
-	var/lootspawn = pick_weight(lootpool)
+	var/lootspawn = pick_weight(fill_with_ones(lootpool))
 	while(islist(lootspawn))
-		lootspawn = pick_weight(lootspawn)
+		lootspawn = pick_weight(fill_with_ones(lootspawn))
 	return lootspawn
+
+// Lets loot tables be both list(a, b, c), as well as list(a = 3, b = 2, c = 2)
+/proc/fill_with_ones(list/table)
+	if (!islist(table))
+		return table
+
+	var/list/final_table = list()
+
+	for (var/key in table)
+		if (table[key])
+			final_table[key] = table[key]
+		else
+			final_table[key] = 1
+
+	return final_table

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -229,7 +229,7 @@
 	defer_change = TRUE
 	mineralSpawnChanceList = list(
 		/obj/item/stack/ore/uranium = 35, /obj/item/stack/ore/diamond = 30, /obj/item/stack/ore/gold = 45, /obj/item/stack/ore/titanium = 45,
-		/obj/item/stack/ore/silver = 50, /obj/item/stack/ore/plasma = 50, /obj/item/stack/ore/bluespace_crystal)
+		/obj/item/stack/ore/silver = 50, /obj/item/stack/ore/plasma = 50, /obj/item/stack/ore/bluespace_crystal = 1)
 
 /turf/closed/mineral/random/low_chance
 	icon_state = "rock_lowchance"

--- a/code/modules/meteors/meteors.dm
+++ b/code/modules/meteors/meteors.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_INIT(meteors_catastrophic, list(/obj/effect/meteor/medium=5, /obj/ef
 
 GLOBAL_LIST_INIT(meteorsB, list(/obj/effect/meteor/meaty=5, /obj/effect/meteor/meaty/xeno=1)) //for meaty ore event
 
-GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
+GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust=1)) //for space dust event
 
 
 ///////////////////////////////

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -20,7 +20,7 @@
 	maxbodytemp = 400
 	unsuitable_atmos_damage = 0.5
 	animal_species = /mob/living/simple_animal/pet/cat
-	childtype = list(/mob/living/simple_animal/pet/cat/kitten)
+	childtype = list(/mob/living/simple_animal/pet/cat/kitten = 1)
 	butcher_results = list(/obj/item/food/meat/slab = 1, /obj/item/organ/ears/cat = 1, /obj/item/organ/tail/cat = 1, /obj/item/stack/sheet/animalhide/cat = 1)
 	response_help_continuous = "pets"
 	response_help_simple = "pet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
`pick_weight_allow_zero` was a backwards compatible hack, so it exists alongside `pick_weight`.

I would really like to just remove the old proc and just rename it, so I want to log what, if anything, is relying on this behavior, to see if it's a bug or if it needs to be handled especially in that case.