### PR TITLE
Exempts non-deadminned admins from all the chat filters so they can break the server rules and get banned if they want to.

### DIFF
--- a/code/__DEFINES/chat_filter.dm
+++ b/code/__DEFINES/chat_filter.dm
@@ -8,4 +8,5 @@
 #define REPORT_CHAT_FILTER_TO_USER(user, filter_result) \
 	to_chat(user, span_warning("The word <b>[html_encode(filter_result[CHAT_FILTER_INDEX_WORD])]</b> is prohibited: [html_encode(filter_result[CHAT_FILTER_INDEX_REASON])]"))
 
+/// Given a user, returns TRUE if they are allowed to bypass the filter.
 #define CAN_BYPASS_FILTER(user) (!isnull(user?.client?.holder))

--- a/code/__DEFINES/chat_filter.dm
+++ b/code/__DEFINES/chat_filter.dm
@@ -7,3 +7,5 @@
 /// Given a chat filter result, will send a to_chat to the user telling them about why their message was blocked
 #define REPORT_CHAT_FILTER_TO_USER(user, filter_result) \
 	to_chat(user, span_warning("The word <b>[html_encode(filter_result[CHAT_FILTER_INDEX_WORD])]</b> is prohibited: [html_encode(filter_result[CHAT_FILTER_INDEX_REASON])]"))
+
+#define CAN_BYPASS_FILTER(user) (!isnull(user?.client?.holder))

--- a/code/__HELPERS/chat_filter.dm
+++ b/code/__HELPERS/chat_filter.dm
@@ -2,9 +2,21 @@
 // This is sanity checked by unit tests.
 #define GET_MATCHED_GROUP(regex) (lowertext(regex.group[2] || regex.match))
 
+/// Returns TRUE if the current_mob can bypass the chat filter.
+/proc/can_bypass_chat_filter(mob/current_mob)
+	var/datum/admins/holder = current_mob?.client?.holder
+
+	if(!holder || holder.deadmined)
+		return FALSE
+
+	return holder.check_for_rights(R_ADMIN)
+
 /// Given a text, will return what word is on the IC filter, with the reason.
 /// Returns null if the message is OK.
 /proc/is_ic_filtered(message)
+	if(can_bypass_chat_filter(usr))
+		return null
+
 	if (config.ic_filter_regex?.Find(message))
 		var/matched_group = GET_MATCHED_GROUP(config.ic_filter_regex)
 		return list(
@@ -17,6 +29,9 @@
 /// Given a text, will return what word is on the IC filter, ignoring words allowed on the PDA, with the reason.
 /// Returns null if the message is OK.
 /proc/is_ic_filtered_for_pdas(message)
+	if(can_bypass_chat_filter(usr))
+		return null
+
 	if (config.ic_outside_pda_filter_regex?.Find(message))
 		var/matched_group = GET_MATCHED_GROUP(config.ic_outside_pda_filter_regex)
 		return list(
@@ -29,6 +44,9 @@
 /// Given a text, will return what word is on the OOC filter, with the reason.
 /// Returns null if the message is OK.
 /proc/is_ooc_filtered(message)
+	if(can_bypass_chat_filter(usr))
+		return null
+
 	if (config.ooc_filter_regex?.Find(message))
 		var/matched_group = GET_MATCHED_GROUP(config.ooc_filter_regex)
 		return list(matched_group, config.shared_filter_reasons[matched_group])
@@ -38,6 +56,9 @@
 /// Given a text, will return what word is on the soft IC filter, with the reason.
 /// Returns null if the message is OK.
 /proc/is_soft_ic_filtered(message)
+	if(can_bypass_chat_filter(usr))
+		return null
+
 	if (config.soft_ic_filter_regex?.Find(message))
 		var/matched_group = GET_MATCHED_GROUP(config.soft_ic_filter_regex)
 		return list(
@@ -50,6 +71,9 @@
 /// Given a text, will return what word is on the soft IC filter, ignoring words allowed on the PDA, with the reason.
 /// Returns null if the message is OK.
 /proc/is_soft_ic_filtered_for_pdas(message)
+	if(can_bypass_chat_filter(usr))
+		return null
+
 	if (config.soft_ic_outside_pda_filter_regex?.Find(message))
 		var/matched_group = GET_MATCHED_GROUP(config.soft_ic_outside_pda_filter_regex)
 		return list(
@@ -62,6 +86,9 @@
 ///Given a text, will return that word is on the soft OOC filter, with the reason.
 /// Returns null if the message is OK.
 /proc/is_soft_ooc_filtered(message)
+	if(can_bypass_chat_filter(usr))
+		return null
+
 	if (config.soft_ooc_filter_regex?.Find(message))
 		var/matched_group = GET_MATCHED_GROUP(config.soft_ooc_filter_regex)
 		return list(matched_group, config.soft_shared_filter_reasons[matched_group])

--- a/code/__HELPERS/chat_filter.dm
+++ b/code/__HELPERS/chat_filter.dm
@@ -2,21 +2,9 @@
 // This is sanity checked by unit tests.
 #define GET_MATCHED_GROUP(regex) (lowertext(regex.group[2] || regex.match))
 
-/// Returns TRUE if the current_mob can bypass the chat filter.
-/proc/can_bypass_chat_filter(mob/current_mob)
-	var/datum/admins/holder = current_mob?.client?.holder
-
-	if(!holder || holder.deadmined)
-		return FALSE
-
-	return holder.check_for_rights(R_ADMIN)
-
 /// Given a text, will return what word is on the IC filter, with the reason.
 /// Returns null if the message is OK.
 /proc/is_ic_filtered(message)
-	if(can_bypass_chat_filter(usr))
-		return null
-
 	if (config.ic_filter_regex?.Find(message))
 		var/matched_group = GET_MATCHED_GROUP(config.ic_filter_regex)
 		return list(
@@ -29,9 +17,6 @@
 /// Given a text, will return what word is on the IC filter, ignoring words allowed on the PDA, with the reason.
 /// Returns null if the message is OK.
 /proc/is_ic_filtered_for_pdas(message)
-	if(can_bypass_chat_filter(usr))
-		return null
-
 	if (config.ic_outside_pda_filter_regex?.Find(message))
 		var/matched_group = GET_MATCHED_GROUP(config.ic_outside_pda_filter_regex)
 		return list(
@@ -44,9 +29,6 @@
 /// Given a text, will return what word is on the OOC filter, with the reason.
 /// Returns null if the message is OK.
 /proc/is_ooc_filtered(message)
-	if(can_bypass_chat_filter(usr))
-		return null
-
 	if (config.ooc_filter_regex?.Find(message))
 		var/matched_group = GET_MATCHED_GROUP(config.ooc_filter_regex)
 		return list(matched_group, config.shared_filter_reasons[matched_group])
@@ -56,9 +38,6 @@
 /// Given a text, will return what word is on the soft IC filter, with the reason.
 /// Returns null if the message is OK.
 /proc/is_soft_ic_filtered(message)
-	if(can_bypass_chat_filter(usr))
-		return null
-
 	if (config.soft_ic_filter_regex?.Find(message))
 		var/matched_group = GET_MATCHED_GROUP(config.soft_ic_filter_regex)
 		return list(
@@ -71,9 +50,6 @@
 /// Given a text, will return what word is on the soft IC filter, ignoring words allowed on the PDA, with the reason.
 /// Returns null if the message is OK.
 /proc/is_soft_ic_filtered_for_pdas(message)
-	if(can_bypass_chat_filter(usr))
-		return null
-
 	if (config.soft_ic_outside_pda_filter_regex?.Find(message))
 		var/matched_group = GET_MATCHED_GROUP(config.soft_ic_outside_pda_filter_regex)
 		return list(
@@ -86,9 +62,6 @@
 ///Given a text, will return that word is on the soft OOC filter, with the reason.
 /// Returns null if the message is OK.
 /proc/is_soft_ooc_filtered(message)
-	if(can_bypass_chat_filter(usr))
-		return null
-
 	if (config.soft_ooc_filter_regex?.Find(message))
 		var/matched_group = GET_MATCHED_GROUP(config.soft_ooc_filter_regex)
 		return list(matched_group, config.soft_shared_filter_reasons[matched_group])

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -766,12 +766,12 @@ GLOBAL_LIST_EMPTY(PDAs)
 	if((last_text && world.time < last_text + 10) || (everyone && last_everyone && world.time < last_everyone + PDA_SPAM_DELAY))
 		return FALSE
 
-	var/list/filter_result = is_ic_filtered_for_pdas(message)
+	var/list/filter_result = CAN_BYPASS_FILTER(user) ? null : is_ic_filtered_for_pdas(message)
 	if (filter_result)
 		REPORT_CHAT_FILTER_TO_USER(user, filter_result)
 		return FALSE
 
-	var/list/soft_filter_result = is_soft_ic_filtered_for_pdas(message)
+	var/list/soft_filter_result = CAN_BYPASS_FILTER(user) ? null : is_soft_ic_filtered_for_pdas(message)
 	if (soft_filter_result)
 		if(tgui_alert(usr,"Your message contains \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\". \"[soft_filter_result[CHAT_FILTER_INDEX_REASON]]\", Are you sure you want to send it?", "Soft Blocked Word", list("Yes", "No")) != "Yes")
 			return FALSE

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -21,12 +21,12 @@
 	if(!input || !IsAvailable())
 		return
 
-	var/list/filter_result = is_ic_filtered(input)
+	var/list/filter_result = CAN_BYPASS_FILTER(usr) ? null : is_ic_filtered(input)
 	if(filter_result)
 		REPORT_CHAT_FILTER_TO_USER(usr, filter_result)
 		return
 
-	var/list/soft_filter_result = is_soft_ic_filtered(input)
+	var/list/soft_filter_result = CAN_BYPASS_FILTER(usr) ? null : is_soft_ic_filtered(input)
 	if(soft_filter_result)
 		if(tgui_alert(usr,"Your message contains \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\". \"[soft_filter_result[CHAT_FILTER_INDEX_REASON]]\", Are you sure you want to say it?", "Soft Blocked Word", list("Yes", "No")) != "Yes")
 			return

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -38,7 +38,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 	// Protect filter bypassers from themselves.
 	// Demote hard filter results to soft filter results if necessary due to the danger of accidentally speaking in OOC.
-	var/list/soft_filter_result = filter_result ? filter_result : is_soft_ooc_filtered(msg)
+	var/list/soft_filter_result = filter_result || is_soft_ooc_filtered(msg)
 
 	if (soft_filter_result)
 		if(tgui_alert(usr,"Your message contains \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\". \"[soft_filter_result[CHAT_FILTER_INDEX_REASON]]\", Are you sure you want to say it?", "Soft Blocked Word", list("Yes", "No")) != "Yes")

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -32,11 +32,14 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	var/raw_msg = msg
 
 	var/list/filter_result = is_ooc_filtered(msg)
-	if (filter_result)
+	if (!CAN_BYPASS_FILTER(usr) && filter_result)
 		REPORT_CHAT_FILTER_TO_USER(usr, filter_result)
 		return
 
-	var/list/soft_filter_result = is_soft_ooc_filtered(msg)
+	// Protect filter bypassers from themselves.
+	// Demote hard filter results to soft filter results if necessary due to the danger of accidentally speaking in OOC.
+	var/list/soft_filter_result = filter_result ? filter_result : is_soft_ooc_filtered(msg)
+
 	if (soft_filter_result)
 		if(tgui_alert(usr,"Your message contains \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\". \"[soft_filter_result[CHAT_FILTER_INDEX_REASON]]\", Are you sure you want to say it?", "Soft Blocked Word", list("Yes", "No")) != "Yes")
 			return

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -12,12 +12,12 @@
 /mob/dead/observer/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null, filterproof = null)
 	message = trim(message) //trim now and sanitize after checking for special admin radio keys
 
-	var/list/filter_result = is_ooc_filtered(message)
+	var/list/filter_result = CAN_BYPASS_FILTER(src) ? null : is_ooc_filtered(message)
 	if (filter_result)
 		REPORT_CHAT_FILTER_TO_USER(usr, filter_result)
 		return
 
-	var/list/soft_filter_result = is_soft_ooc_filtered(message)
+	var/list/soft_filter_result = CAN_BYPASS_FILTER(src) ? null : is_soft_ooc_filtered(message)
 	if (soft_filter_result)
 		if(tgui_alert(usr,"Your message contains \"[soft_filter_result[CHAT_FILTER_INDEX_WORD]]\". \"[soft_filter_result[CHAT_FILTER_INDEX_REASON]]\", Are you sure you want to say it?", "Soft Blocked Word", list("Yes", "No")) != "Yes")
 			return

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -97,9 +97,9 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	var/list/soft_filter_result
 	if(client && !forced && !filterproof)
 		//The filter doesn't act on the sanitized message, but the raw message.
-		filter_result = is_ic_filtered(message)
+		filter_result = CAN_BYPASS_FILTER(src) ? null : is_ic_filtered(message)
 		if(!filter_result)
-			soft_filter_result = is_soft_ic_filtered(message)
+			soft_filter_result = CAN_BYPASS_FILTER(src) ? null : is_soft_ic_filtered(message)
 
 	if(sanitize)
 		message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a helper define that holds logic to decide if the user can bypass the chat filter.

Currently the logic just looks for the client's admin datum holder.

Adds this proc to various places in the code where admins may want to bypass the filter.

As a special case for the OOC filter, demotes OOC hard filtered words to OOC soft filtered words instead of ignoring them entirely, to give admins a chance to not accidentally ick ock or whatever while still giving them the freedom to break the rules.

![image](https://user-images.githubusercontent.com/24975989/142580758-3cbf1c7a-c812-43f8-b091-7d349871d45a.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Lets adminned players bypass the chat filter, for example when doing things in the Thunderdome allowing you to discuss OOC concepts like antags or ahelps with players.

I needed this use case earlier as I was overseeing a group class on cult mechanics led by another player in the thunderdome, and I had to ghost out to take a ticket. I wasn't able to tell the players to `ahelp` if they needed any help while I was gone, and struggled to talk to them about converting other `antags` and what the `antag` directives priorities were.

I want to believe that this PR is preferable to me just deleting the world filters from SSconfig whenever they piss me off while adminned.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Non-deadminned admins are now exempt from all chat filters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
