### PR TITLE
Gasmaks tint and tint calculation update (Oranges approved edition)

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -134,7 +134,7 @@
 #define HEADCOVERSMOUTH (1<<4)
 #define PEPPERPROOF (1<<5) //protects against pepperspray
 
-#define TINT_NONE 0.25
+#define TINT_MINIMAL 0.25
 #define TINT_LIGHTER 1.5
 #define TINT_DARKENED 2.5 //Threshold of tint level to apply weld mask overlay
 #define TINT_BLIND 3 //Threshold of tint level to obscure vision fully

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -134,7 +134,9 @@
 #define HEADCOVERSMOUTH (1<<4)
 #define PEPPERPROOF (1<<5) //protects against pepperspray
 
-#define TINT_DARKENED 2 //Threshold of tint level to apply weld mask overlay
+#define TINT_NONE 0.25
+#define TINT_LIGHTER 1.5
+#define TINT_DARKENED 2.5 //Threshold of tint level to apply weld mask overlay
 #define TINT_BLIND 3 //Threshold of tint level to obscure vision fully
 
 // defines for AFK theft

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -1,4 +1,6 @@
-/mob/proc/overlay_fullscreen(category, type, severity)
+/mob/proc/overlay_fullscreen(category, type, severity, overlay_alpha)
+	if(!overlay_alpha)
+		overlay_alpha = 255
 	var/atom/movable/screen/fullscreen/screen = screens[category]
 	if (!screen || screen.type != type)
 		// needs to be recreated
@@ -9,6 +11,7 @@
 		return screen
 
 	screen.icon_state = "[initial(screen.icon_state)][severity]"
+	screen.alpha = overlay_alpha
 	screen.severity = severity
 	if (client && screen.should_show_to(src))
 		screen.update_for_view(client.view)

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -1,6 +1,4 @@
-/mob/proc/overlay_fullscreen(category, type, severity, overlay_alpha)
-	if(!overlay_alpha)
-		overlay_alpha = 255
+/mob/proc/overlay_fullscreen(category, type, severity, overlay_alpha = 255)
 	var/atom/movable/screen/fullscreen/screen = screens[category]
 	if (!screen || screen.type != type)
 		// needs to be recreated

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -287,7 +287,7 @@
 	inhand_icon_state = "sunglasses"
 	darkness_view = 1
 	flash_protect = FLASH_PROTECTION_FLASH
-	tint = 1
+	tint = 0.25
 	glass_colour_type = /datum/client_colour/glass_colour/gray
 	dog_fashion = /datum/dog_fashion/head
 
@@ -356,7 +356,7 @@
 	actions_types = list(/datum/action/item_action/toggle)
 	flash_protect = FLASH_PROTECTION_WELDER
 	custom_materials = list(/datum/material/iron = 250)
-	tint = 2
+	tint = 2.75
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT
 	flags_cover = GLASSESCOVERSEYES
 	glass_colour_type = /datum/client_colour/glass_colour/gray
@@ -612,7 +612,7 @@
 
 /obj/item/clothing/glasses/salesman/proc/moodshift(atom/movable/source, amount)
 	SIGNAL_HANDLER
-	if(amount < SANITY_UNSTABLE)	
+	if(amount < SANITY_UNSTABLE)
 		icon_state = "salesman_fzz"
 		desc = "A pair of glasses, the lenses are full of TV static. They've certainly seen better days..."
 		bigshot.update_inv_glasses()

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -65,7 +65,7 @@
 	icon_state = "sunhudmed"
 	darkness_view = 1
 	flash_protect = FLASH_PROTECTION_FLASH
-	tint = 1
+	tint = 0.25
 	glass_colour_type = /datum/client_colour/glass_colour/blue
 
 /obj/item/clothing/glasses/hud/diagnostic
@@ -92,7 +92,7 @@
 	icon_state = "sunhuddiag"
 	inhand_icon_state = "glasses"
 	flash_protect = FLASH_PROTECTION_FLASH
-	tint = 1
+	tint = 0.25
 
 /obj/item/clothing/glasses/hud/security
 	name = "security HUD"
@@ -137,7 +137,7 @@
 	icon_state = "sunhudsec"
 	darkness_view = 1
 	flash_protect = FLASH_PROTECTION_FLASH
-	tint = 1
+	tint = 0.25
 	glass_colour_type = /datum/client_colour/glass_colour/darkred
 
 /obj/item/clothing/glasses/hud/security/night
@@ -232,7 +232,7 @@
 	icon_state = "bigsunglasses"
 	darkness_view = 1
 	flash_protect = FLASH_PROTECTION_FLASH
-	tint = 1
+	tint = 0.25
 	glass_colour_type = /datum/client_colour/glass_colour/gray
 
 

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -118,7 +118,7 @@
 	dog_fashion = null
 	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_screen)
 	flash_protect = FLASH_PROTECTION_WELDER
-	tint = 2
+	tint = 2.75
 	flags_inv = HIDEEYES | HIDEFACE | HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	visor_vars_to_toggle = VISOR_FLASHPROTECT | VISOR_TINT

--- a/code/modules/clothing/head/welding.dm
+++ b/code/modules/clothing/head/welding.dm
@@ -6,7 +6,7 @@
 	inhand_icon_state = "welding"
 	custom_materials = list(/datum/material/iron=1750, /datum/material/glass=400)
 	flash_protect = FLASH_PROTECTION_WELDER
-	tint = 2
+	tint = 2.75
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 100, ACID = 60)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDESNOUT
 	actions_types = list(/datum/action/item_action/toggle)

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -9,6 +9,7 @@
 	permeability_coefficient = 0.01
 	flags_cover = MASKCOVERSEYES | MASKCOVERSMOUTH | PEPPERPROOF
 	resistance_flags = NONE
+	tint = 1.5
 	///Max numbers of installable filters
 	var/max_filters = 1
 	///List to keep track of each filter
@@ -122,7 +123,7 @@
 	icon_state = "weldingmask"
 	flash_protect = FLASH_PROTECTION_WELDER
 	custom_materials = list(/datum/material/iron=4000, /datum/material/glass=2000)
-	tint = 2
+	tint = 2.75
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 100, ACID = 55)
 	actions_types = list(/datum/action/item_action/toggle)
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDESNOUT
@@ -149,6 +150,8 @@
 	icon_state = "plaguedoctor"
 	inhand_icon_state = "gas_mask"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 2,ENERGY = 2, BOMB = 0, BIO = 75, FIRE = 0, ACID = 0)
+	flags_cover = MASKCOVERSEYES
+	tint = 0
 
 /obj/item/clothing/mask/gas/syndicate
 	name = "syndicate mask"
@@ -171,6 +174,7 @@
 	actions_types = list(/datum/action/item_action/adjust)
 	dog_fashion = /datum/dog_fashion/head/clown
 	species_exception = list(/datum/species/golem/bananium)
+	tint = 0
 	var/list/clownmask_designs = list()
 
 /obj/item/clothing/mask/gas/clown_hat/plasmaman
@@ -216,6 +220,7 @@
 	icon_state = "sexyclown"
 	inhand_icon_state = "sexyclown"
 	flags_cover = MASKCOVERSEYES
+	tint = 0
 	resistance_flags = FLAMMABLE
 	species_exception = list(/datum/species/golem/bananium)
 
@@ -227,6 +232,7 @@
 	inhand_icon_state = "mime"
 	w_class = WEIGHT_CLASS_SMALL
 	flags_cover = MASKCOVERSEYES
+	tint = 0
 	resistance_flags = FLAMMABLE
 	actions_types = list(/datum/action/item_action/adjust)
 	species_exception = list(/datum/species/golem)
@@ -272,6 +278,7 @@
 	icon_state = "monkeymask"
 	inhand_icon_state = "monkeymask"
 	flags_cover = MASKCOVERSEYES
+	tint = 0
 	resistance_flags = FLAMMABLE
 
 /obj/item/clothing/mask/gas/sexymime
@@ -281,6 +288,7 @@
 	icon_state = "sexymime"
 	inhand_icon_state = "sexymime"
 	flags_cover = MASKCOVERSEYES
+	tint = 0
 	resistance_flags = FLAMMABLE
 	species_exception = list(/datum/species/golem)
 
@@ -289,6 +297,8 @@
 	desc = "Beep boop."
 	icon_state = "death"
 	resistance_flags = FLAMMABLE
+	flags_cover = MASKCOVERSEYES
+	tint = 0
 
 /obj/item/clothing/mask/gas/owl_mask
 	name = "owl mask"
@@ -296,12 +306,15 @@
 	icon_state = "owl"
 	clothing_flags = MASKINTERNALS
 	flags_cover = MASKCOVERSEYES
+	tint = 0
 	resistance_flags = FLAMMABLE
 
 /obj/item/clothing/mask/gas/carp
 	name = "carp mask"
 	desc = "Gnash gnash."
 	icon_state = "carp_mask"
+	flags_cover = MASKCOVERSEYES
+	tint = 0
 
 /obj/item/clothing/mask/gas/tiki_mask
 	name = "tiki mask"
@@ -314,6 +327,8 @@
 	actions_types = list(/datum/action/item_action/adjust)
 	dog_fashion = null
 	species_exception = list(/datum/species/golem/wood)
+	flags_cover = MASKCOVERSEYES
+	tint = 0
 	var/list/tikimask_designs = list()
 
 /obj/item/clothing/mask/gas/tiki_mask/Initialize(mapload)
@@ -355,6 +370,8 @@
 	inhand_icon_state = "hunter"
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	flags_inv = HIDEFACIALHAIR|HIDEFACE|HIDEEYES|HIDEEARS|HIDEHAIR|HIDESNOUT
+	flags_cover = MASKCOVERSEYES
+	tint = 0
 
 /obj/item/clothing/mask/gas/driscoll
 	name = "driscoll mask"
@@ -363,3 +380,5 @@
 	flags_inv = HIDEFACIALHAIR
 	w_class = WEIGHT_CLASS_NORMAL
 	inhand_icon_state = "driscoll_mask"
+	flags_cover = MASKCOVERSEYES
+	tint = 0

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -160,6 +160,7 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	strip_delay = 60
 	w_class = WEIGHT_CLASS_SMALL
+	tint = 0.25
 
 /obj/item/clothing/mask/gas/clown_hat
 	name = "clown wig and mask"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -43,7 +43,7 @@
 	inhand_icon_state = "plasmaman-helm"
 	strip_delay = 80
 	flash_protect = FLASH_PROTECTION_WELDER
-	tint = 2
+	tint = 2.75
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 100, ACID = 75)
 	resistance_flags = FIRE_PROOF
 	light_system = MOVABLE_LIGHT_DIRECTIONAL

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -45,6 +45,7 @@
 	actions_types = list(/datum/action/item_action/adjust)
 	armor = list(MELEE = 10, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 0, BIO = 50, FIRE = 20, ACID = 40, WOUND = 5)
 	resistance_flags = FIRE_PROOF
+	tint = 0.25
 
 /obj/item/clothing/mask/gas/explorer/attack_self(mob/user)
 	adjustmask(user)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -584,6 +584,11 @@
 		if(!isnull(G.lighting_alpha))
 			lighting_alpha = min(lighting_alpha, G.lighting_alpha)
 
+	if(wear_mask)
+		var/obj/item/clothing/mask/dressed_mask = wear_mask
+		if(dressed_mask.tint || initial(dressed_mask.tint))
+			update_tint()
+
 	if(HAS_TRAIT(src, TRAIT_THERMAL_VISION))
 		sight |= (SEE_MOBS)
 		lighting_alpha = min(lighting_alpha, LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE)
@@ -606,13 +611,18 @@
 	if(!GLOB.tinted_weldhelh)
 		return
 	tinttotal = get_total_tint()
+	clear_fullscreen("tint", 0)
 	if(tinttotal >= TINT_BLIND)
 		become_blind(EYES_COVERED)
-	else if(tinttotal >= TINT_DARKENED)
-		cure_blind(EYES_COVERED)
-		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 2)
-	else
-		cure_blind(EYES_COVERED)
+		return
+	cure_blind(EYES_COVERED)
+	if(tinttotal > TINT_DARKENED && tinttotal < TINT_BLIND)
+		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 2, clamp(tinttotal * 100, 0, 255))
+	else if(tinttotal > TINT_LIGHTER && tinttotal <= TINT_DARKENED)
+		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 1, clamp(tinttotal * 100, 0, 255))
+	else if(tinttotal > TINT_NONE && tinttotal <= TINT_LIGHTER)
+		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 0, clamp(tinttotal * 100, 0, 255))
+	else if(tinttotal <= TINT_NONE)
 		clear_fullscreen("tint", 0)
 
 /mob/living/carbon/proc/get_total_tint()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -619,9 +619,9 @@
 	if(tinttotal > TINT_DARKENED && tinttotal < TINT_BLIND)
 		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 2, clamp(tinttotal * 100, 0, 255))
 	else if(tinttotal > TINT_LIGHTER && tinttotal <= TINT_DARKENED)
-		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 1, clamp(tinttotal * 100, 0, 255))
+		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 1, clamp(tinttotal * 150, 0, 255))
 	else if(tinttotal > TINT_MINIMAL && tinttotal <= TINT_LIGHTER)
-		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 0, clamp(tinttotal * 100, 0, 255))
+		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 0, clamp(tinttotal * 200, 0, 255))
 	else if(tinttotal <= TINT_MINIMAL)
 		clear_fullscreen("tint", 0)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -620,9 +620,9 @@
 		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 2, clamp(tinttotal * 100, 0, 255))
 	else if(tinttotal > TINT_LIGHTER && tinttotal <= TINT_DARKENED)
 		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 1, clamp(tinttotal * 100, 0, 255))
-	else if(tinttotal > TINT_NONE && tinttotal <= TINT_LIGHTER)
+	else if(tinttotal > TINT_MINIMAL && tinttotal <= TINT_LIGHTER)
 		overlay_fullscreen("tint", /atom/movable/screen/fullscreen/impaired, 0, clamp(tinttotal * 100, 0, 255))
-	else if(tinttotal <= TINT_NONE)
+	else if(tinttotal <= TINT_MINIMAL)
 		clear_fullscreen("tint", 0)
 
 /mob/living/carbon/proc/get_total_tint()

--- a/code/modules/ninja/suit/mask.dm
+++ b/code/modules/ninja/suit/mask.dm
@@ -13,3 +13,4 @@
 	inhand_icon_state = "s-ninja_mask"
 	strip_delay = 120
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	tint = 0.25


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gasmaks apply a darkening overlay similar to the welding one but much lighter and open. 
Without mask
![nomask](https://user-images.githubusercontent.com/42839747/142631723-f37c6da6-36ae-4c2c-b5a7-d7780e3caf5c.PNG)
With mask
![covid](https://user-images.githubusercontent.com/42839747/142631779-6e8ca6a7-ef9b-43f2-83fa-69a4fe6c8572.PNG)
With mask and sunglasses
![image](https://user-images.githubusercontent.com/42839747/142638220-a9efc9a9-45f6-4d26-99bf-37d7aef80472.png)

Note that other items that apply tint haven't been changed if worn on their own (sunglasses don't darken the vision) but will increase the darkening effect if staked (mask + sunglasses will give an even darker overlay). 

Oranges' approval
![dad2](https://user-images.githubusercontent.com/42839747/142632726-b4d7d44a-651c-43e8-9c71-a3bc4f324500.PNG)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
All upside and no downside are no fun.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: gasmasks give a slightly darkening overlay, effect will stack with other items that have tint.
code: tint code has been updated to properly work.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
