### PR TITLE
Fixes some issues and an exploit with abandoned crates.

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -19,9 +19,8 @@
 	if(user)
 		to_chat(user, span_danger("The crate's anti-tamper system activates!"))
 		log_bomber(user, "has detonated a", src)
-	for(var/atom/movable/content as anything in src)
-		if(!isliving(content))
-			qdel(content)
+	for(var/obj/loot in src)
+		SSexplosions.high_mov_atom += loot
 	explosion(src, heavy_impact_range = 1, light_impact_range = 5, flash_range = 5)
 	qdel(src)
 

--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -19,8 +19,9 @@
 	if(user)
 		to_chat(user, span_danger("The crate's anti-tamper system activates!"))
 		log_bomber(user, "has detonated a", src)
-	for(var/atom/movable/AM in src)
-		qdel(AM)
+	for(var/atom/movable/content as anything in src)
+		if(!isliving(content))
+			qdel(content)
 	explosion(src, heavy_impact_range = 1, light_impact_range = 5, flash_range = 5)
 	qdel(src)
 

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -44,12 +44,10 @@
 						sanitycheck = FALSE //if a digit is repeated, reject the input
 			if(input == code)
 				to_chat(user, span_notice("The crate unlocks!"))
-				locked = FALSE
-				cut_overlays()
-				add_overlay("securecrateg")
-				tamperproof = 0 // set explosion chance to zero, so we dont accidently hit it with a multitool and instantly die
 				if(!spawned_loot)
 					spawn_loot()
+				tamperproof = 0 // set explosion chance to zero, so we dont accidently hit it with a multitool and instantly die
+				togglelock()
 			else if(!input || !sanitycheck || length(sanitised) != codelen)
 				to_chat(user, span_notice("You leave the crate alone."))
 			else
@@ -104,17 +102,26 @@
 /obj/structure/closet/crate/secure/loot/emag_act(mob/user)
 	if(locked)
 		boom(user)
+		return
+	return ..()
 
 /obj/structure/closet/crate/secure/loot/togglelock(mob/user, silent = FALSE)
-	if(locked)
+	if(!locked)
+		tamperproof = initial(tamperproof) //reset the anti-tampering when the lock is re-enabled.
+		return ..()
+	if(tamperproof)
 		boom(user)
-	else
-		if (qdel_on_open)
-			qdel(src)
-		..()
+		return
+	if (qdel_on_open)
+		qdel(src)
+		return
+	return ..()
 
 /obj/structure/closet/crate/secure/loot/deconstruct(disassembled = TRUE)
-	boom()
+	if(locked)
+		boom()
+		return
+	return ..()
 
 /obj/structure/closet/crate/secure/loot/proc/spawn_loot()
 	var/loot = rand(1,100) //100 different crates with varying chances of spawning


### PR DESCRIPTION
## About The Pull Request
Stops abandoned crates from deleting living mobs inside them when exploding. Also stops the thing from exploding when deconstructed or emagged if unlocked. Also resets their tamperproof value if locked again after being unlocked.

## Why It's Good For The Game
Fixing some annoyances regarding abandoned crates. This will fix #62945.

## Changelog

:cl:
fix: Abandoned crates no longer delete living mobs or indestructible objects inside them when exploding.
fix: They also no longer explode when deconstructed/emagged while unlocked.
fix: Their anti-tampering mechanism will now properly reactive if locked again after being unlocked.
/:cl:
