### PR TITLE
Hair gradient preference no longer shows for species that don't have hair

### DIFF
--- a/code/modules/client/preferences/species_features/basic.dm
+++ b/code/modules/client/preferences/species_features/basic.dm
@@ -104,6 +104,7 @@
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "hair_gradient"
+	relevant_species_trait = HAIR
 
 /datum/preference/choiced/hair_gradient/init_possible_values()
 	return assoc_to_keys(GLOB.hair_gradients_list)
@@ -119,6 +120,7 @@
 	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "hair_gradient_color"
+	relevant_species_trait = HAIR
 
 /datum/preference/color/hair_gradient/apply_to_human(mob/living/carbon/human/target, value)
 	target.grad_color = value


### PR DESCRIPTION
## About The Pull Request
TItle.

## Why It's Good For The Game
Someone forgot lizardfolk & co don't have hair on this server. This will fix #62801.

## Changelog

:cl:
fix: Hair gradient preference no longer shows for species that don't have hair
/:cl:
