### PR TITLE
the boat in a bottle is now resistant to both lavaland lava and icebox/snowdin plasma rivers

### DIFF
--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -73,6 +73,7 @@
 	name = "mysterious boat"
 	desc = "This boat moves where you will it, without the need for an oar."
 	icon_state = "dragon_boat"
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | FREEZE_PROOF
 
 /obj/vehicle/ridden/lavaboat/dragon/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
It can be found on both lavaland and icebox but due to an oversight it only works on lava.
This will fix #51505. <--- Whoneedsspace misread the issue and thought it was only about normal boats.

## Changelog

:cl:
fix: The ship-in-a-bottle is now resistant to icebox/snowdin plasma rivers.
/:cl:
