### PR TITLE
Spades can now dig up botany soil plots on right click

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -942,7 +942,7 @@
 	return // Has no lights
 
 /obj/machinery/hydroponics/soil/attackby_secondary(obj/item/weapon, mob/user, params)
-	if(weapon.tool_behaviour == !TOOL_SHOVEL) //Spades can still uproot plants on left click
+	if(weapon.tool_behaviour != TOOL_SHOVEL) //Spades can still uproot plants on left click
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	balloon_alert(user, "clearing up soil...")
 	if(weapon.use_tool(src, user, 1 SECONDS, volume=50))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -943,8 +943,11 @@
 
 /obj/machinery/hydroponics/soil/attackby_secondary(obj/item/O, mob/user, params)
 	if(O.tool_behaviour == TOOL_SHOVEL) //Spades can still uproot plants on left click
-		to_chat(user, span_notice("You clear up [src]!"))
-		qdel(src)
+		to_chat(user, span_notice("You begin clearing up [src]..."))
+		if(O.use_tool(src, user, 10, volume=50))
+			to_chat(user, span_notice("You clear up [src]!"))
+			qdel(src)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	else
 		return ..()
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -943,7 +943,7 @@
 
 /obj/machinery/hydroponics/soil/attackby_secondary(obj/item/O, mob/user, params)
 	if(O.tool_behaviour == TOOL_SHOVEL) //Spades can still uproot plants on left click
-		to_chat(user, span_notice("You begin clearing up [src]..."))
+		balloon_alert(user, "clearing up soil...")
 		if(O.use_tool(src, user, 1 SECONDS, volume=50))
 			to_chat(user, span_notice("You clear up [src]!"))
 			qdel(src)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -945,7 +945,7 @@
 	if(weapon.tool_behaviour == !TOOL_SHOVEL) //Spades can still uproot plants on left click
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	balloon_alert(user, "clearing up soil...")
-	if(O.use_tool(src, user, 1 SECONDS, volume=50))
+	if(weapon.use_tool(src, user, 1 SECONDS, volume=50))
 		balloon_alert(user, "cleared")
 		qdel(src)
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -944,7 +944,7 @@
 /obj/machinery/hydroponics/soil/attackby_secondary(obj/item/O, mob/user, params)
 	if(O.tool_behaviour == TOOL_SHOVEL) //Spades can still uproot plants on left click
 		to_chat(user, span_notice("You begin clearing up [src]..."))
-		if(O.use_tool(src, user, 10, volume=50))
+		if(O.use_tool(src, user, 1 SECONDS, volume=50))
 			to_chat(user, span_notice("You clear up [src]!"))
 			qdel(src)
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -941,15 +941,14 @@
 /obj/machinery/hydroponics/soil/update_status_light_overlays()
 	return // Has no lights
 
-/obj/machinery/hydroponics/soil/attackby_secondary(obj/item/O, mob/user, params)
-	if(O.tool_behaviour == TOOL_SHOVEL) //Spades can still uproot plants on left click
-		balloon_alert(user, "clearing up soil...")
-		if(O.use_tool(src, user, 1 SECONDS, volume=50))
-			balloon_alert(user, "cleared")
-			qdel(src)
+/obj/machinery/hydroponics/soil/attackby_secondary(obj/item/weapon, mob/user, params)
+	if(weapon.tool_behaviour == !TOOL_SHOVEL) //Spades can still uproot plants on left click
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-	else
-		return ..()
+	balloon_alert(user, "clearing up soil...")
+	if(O.use_tool(src, user, 1 SECONDS, volume=50))
+		balloon_alert(user, "cleared")
+		qdel(src)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/hydroponics/soil/CtrlClick(mob/user)
 	return //Soil has no electricity.

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -948,7 +948,7 @@
 	if(weapon.use_tool(src, user, 1 SECONDS, volume=50))
 		balloon_alert(user, "cleared")
 		qdel(src)
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/hydroponics/soil/CtrlClick(mob/user)
 	return //Soil has no electricity.

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -941,8 +941,8 @@
 /obj/machinery/hydroponics/soil/update_status_light_overlays()
 	return // Has no lights
 
-/obj/machinery/hydroponics/soil/attackby(obj/item/O, mob/user, params)
-	if(O.tool_behaviour == TOOL_SHOVEL && !istype(O, /obj/item/shovel/spade)) //Doesn't include spades because of uprooting plants
+/obj/machinery/hydroponics/soil/attackby_secondary(obj/item/O, mob/user, params)
+	if(O.tool_behaviour == TOOL_SHOVEL) //Spades can still uproot plants on left click
 		to_chat(user, span_notice("You clear up [src]!"))
 		qdel(src)
 	else

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -945,7 +945,7 @@
 	if(O.tool_behaviour == TOOL_SHOVEL) //Spades can still uproot plants on left click
 		balloon_alert(user, "clearing up soil...")
 		if(O.use_tool(src, user, 1 SECONDS, volume=50))
-			to_chat(user, span_notice("You clear up [src]!"))
+			balloon_alert(user, "cleared")
 			qdel(src)
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently, there is a check in place on agricultural soil plots, the ghetto hydroponic trays that are actually just a mound of dirt or sand, that prevents the use of spades to dig them up, because spades should be used to uproot plants. This was *likely* made the case before the intents were reworked to allow right click functions. This PR removes that check and also moves digging up these botanical soil plots to a right click function.

Special thanks to MrMelbert for guiding me to this fix.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Maint gardeners, prisoners, and anyone else using these horticultural soil plots instead of the normal hydroponic plant trays for growing plants can now dig up their planters with spades, so they don't have to go find a shovel to do so.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Spades can now be used to dig up botanical soil plots as well as shovels.
qol: Digging up botanical soil plots has been changed to a right click action. Left clicking with a spade still uproots plants as expected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
