### PR TITLE
lenturi uses acetone instead of silver

### DIFF
--- a/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
+++ b/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
@@ -91,7 +91,7 @@
 //Since it requires silver - I don't want to make it too hard
 /datum/chemical_reaction/medicine/lenturi
 	results = list(/datum/reagent/medicine/c2/lenturi = 5)
-	required_reagents = list(/datum/reagent/ammonia = 1, /datum/reagent/silver = 1, /datum/reagent/sulfur = 1, /datum/reagent/oxygen = 1, /datum/reagent/chlorine = 1)
+	required_reagents = list(/datum/reagent/ammonia = 1, /datum/reagent/acetone = 1, /datum/reagent/sulfur = 1, /datum/reagent/oxygen = 1, /datum/reagent/chlorine = 1)
 	required_temp = 200
 	optimal_temp = 300
 	overheat_temp = 500


### PR DESCRIPTION
## About The Pull Request

see title.

## Why It's Good For The Game

lenturi used silver before it got removed from the chem dispenser. i think that lenturi isn't nearly strong enough to warrant needing silver.

before anyone asks, yes i tested this locally, and no it doesn't conflict with any other recipes.
there are no runtimes either, and it does produce the chem properly.

## Changelog

:cl:
balance: lenturi now uses acetone instead of silver
/:cl: