### PR TITLE
Adds an additional queue to the qdel subsystem to quickly filter out things that garbage collect within the first second.

### DIFF
--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -24,9 +24,10 @@
 #define QDEL_HINT_IFFAIL_FINDREFERENCE 6
 #endif
 
-#define GC_QUEUE_CHECK 1
-#define GC_QUEUE_HARDDELETE 2
-#define GC_QUEUE_COUNT 2 //increase this when adding more steps.
+#define GC_QUEUE_FILTER 1
+#define GC_QUEUE_CHECK 2
+#define GC_QUEUE_HARDDELETE 3
+#define GC_QUEUE_COUNT 3 //increase this when adding more steps.
 
 #define QDEL_ITEM_ADMINS_WARNED (1<<0) //! Set when admins are told about lag causing qdels in this type.
 #define QDEL_ITEM_SUSPENDED_FOR_LAG (1<<1) //! Set when a type can no longer be hard deleted on failure because of lag it causes while this happens.
@@ -36,7 +37,8 @@
 #define GC_CURRENTLY_BEING_QDELETED -2
 
 // Defines for the time left for an item to get its reference cleaned
-#define GC_FILTER_QUEUE 5 MINUTES
+#define GC_FILTER_QUEUE 1 SECONDS
+#define GC_CHECK_QUEUE 5 MINUTES
 #define GC_DEL_QUEUE 10 SECONDS
 
 #define QDELING(X) (X.gc_destroyed)

--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -24,10 +24,17 @@
 #define QDEL_HINT_IFFAIL_FINDREFERENCE 6
 #endif
 
-#define GC_QUEUE_FILTER 1
-#define GC_QUEUE_CHECK 2
-#define GC_QUEUE_HARDDELETE 3
-#define GC_QUEUE_COUNT 3 //increase this when adding more steps.
+// Defines for the ssgarbage queues
+#define GC_QUEUE_FILTER 1 //! short queue to filter out quick gc successes so they don't hang around in the main queue for 5 minutes
+#define GC_QUEUE_CHECK 2 //! main queue that waits 5 minutes because thats the longest byond can hold a reference to our shit.
+#define GC_QUEUE_HARDDELETE 3 //! short queue for things that hard delete instead of going thru the gc subsystem, this is purely so if they *can* softdelete, they will soft delete rather then wasting time with a hard delete.
+#define GC_QUEUE_COUNT 3 //! Number of queues, used for allocating the nested lists. Don't forget to increase this if you add a new queue stage
+
+// Defines for the time an item has to get its reference cleaned before it fails the queue and moves to the next.
+#define GC_FILTER_QUEUE 1 SECONDS
+#define GC_CHECK_QUEUE 5 MINUTES
+#define GC_DEL_QUEUE 10 SECONDS
+
 
 #define QDEL_ITEM_ADMINS_WARNED (1<<0) //! Set when admins are told about lag causing qdels in this type.
 #define QDEL_ITEM_SUSPENDED_FOR_LAG (1<<1) //! Set when a type can no longer be hard deleted on failure because of lag it causes while this happens.
@@ -35,11 +42,6 @@
 // Defines for the [gc_destroyed][/datum/var/gc_destroyed] var.
 #define GC_QUEUED_FOR_QUEUING -1
 #define GC_CURRENTLY_BEING_QDELETED -2
-
-// Defines for the time left for an item to get its reference cleaned
-#define GC_FILTER_QUEUE 1 SECONDS
-#define GC_CHECK_QUEUE 5 MINUTES
-#define GC_DEL_QUEUE 10 SECONDS
 
 #define QDELING(X) (X.gc_destroyed)
 #define QDELETED(X) (!X || QDELING(X))


### PR DESCRIPTION
Before, all items deleted would sit in a queue for 5 minutes, with all shrinks and expansions of said queue requiring byond to copy all of these items over to the new list.

Theory: 99% of items soft-delete within byond within the first second. (5 minutes is only needed because a byond quirk with items referenced by verbs)

Result:

Within the first 7 minutes of a local test launch and round start, ~35,000 things get qdeleted.

Of those 35 **THOUSAND** things, only 12 things failed as still referenced with a 1 second pre-queue.

Said 12 things passed as garbage collected at the 5 minute queue.

(Note: 30 thousand of these items are from world start and round init.)

I have no data on how much this speeds anything up, leaving a 30 thousand list (that has to be copyed every time qdelete processes it and cuts off the items it processed) hanging around for no reason for the first 5 minutes of the round was all i needed to justify the pr.