### PR TITLE
Fixed a mistake in the Drone repair message feedback when repaired by someone else.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -96,7 +96,7 @@
 			to_chat(user, span_notice("You start to tighten loose screws on [src]..."))
 			if(I.use_tool(src, user, 80))
 				adjustBruteLoss(-getBruteLoss())
-				visible_message(span_notice("[user] tightens [src == user ? "[user.p_their()]" : "[src]'s"] loose screws!"), span_notice("You tighten [src == user ? "your" : "[src]'s"] loose screws."))
+				visible_message(span_notice("[user] tightens [src == user ? "[user.p_their()]" : "[src]'s"] loose screws!"), span_notice("[src == user ? "You tighten" : "[user] tightens"] your loose screws."))
 			else
 				to_chat(user, span_warning("You need to remain still to tighten [src]'s screws!"))
 		else


### PR DESCRIPTION
## About The Pull Request
Title. The self-message always says the drone repaired itself even when it's actually someone else that did it.

## Why It's Good For The Game
This #62906.

## Changelog

:cl:
spellcheck: Fixed a mistake in the Drone repair message feedback when repaired by someone else.
/:cl:
