### PR TITLE
Add station trait for varying colored assistant jumpsuits

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -125,5 +125,5 @@
 /datum/station_trait/colored_assistants/New()
 	. = ..()
 
-	var/new_colored_assistant_type = pick(subtypesof(/datum/colored_assistant) - GLOB.colored_assistant)
+	var/new_colored_assistant_type = pick(subtypesof(/datum/colored_assistant) - get_configured_colored_assistant_type())
 	GLOB.colored_assistant = new new_colored_assistant_type

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -114,3 +114,16 @@
 /datum/station_trait/announcement_medbot/New()
 	. = ..()
 	SSstation.announcer = /datum/centcom_announcer/medbot
+
+/datum/station_trait/colored_assistants
+	name = "Colored Assistants"
+	trait_type = STATION_TRAIT_NEUTRAL
+	weight = 10
+	show_in_report = TRUE
+	report_message = "Due to a shortage in standard issue jumpsuits, we have provided your assistants with one of our backup supplies."
+
+/datum/station_trait/colored_assistants/New()
+	. = ..()
+
+	var/new_colored_assistant_type = pick(subtypesof(/datum/colored_assistant) - GLOB.colored_assistant)
+	GLOB.colored_assistant = new new_colored_assistant_type

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -19,12 +19,23 @@
 	fitted = FEMALE_UNIFORM_TOP
 	icon_state = "jumpskirt"
 
+/// Returns a random, acceptable jumpsuit typepath
+/proc/get_random_jumpsuit()
+	return pick(
+		subtypesof(/obj/item/clothing/under/color) \
+			- typesof(/obj/item/clothing/under/color/jumpskirt) \
+			- /obj/item/clothing/under/color/random \
+			- /obj/item/clothing/under/color/grey/ancient \
+			- /obj/item/clothing/under/color/black/ghost \
+			- /obj/item/clothing/under/rank/prisoner \
+	)
+
 /obj/item/clothing/under/color/random
 	icon_state = "random_jumpsuit"
 
 /obj/item/clothing/under/color/random/Initialize(mapload)
 	..()
-	var/obj/item/clothing/under/color/C = pick(subtypesof(/obj/item/clothing/under/color) - typesof(/obj/item/clothing/under/color/jumpskirt) - /obj/item/clothing/under/color/random - /obj/item/clothing/under/color/grey/ancient - /obj/item/clothing/under/color/black/ghost - /obj/item/clothing/under/rank/prisoner)
+	var/obj/item/clothing/under/color/C = get_random_jumpsuit()
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		H.equip_to_slot_or_del(new C(H), ITEM_SLOT_ICLOTHING, initial=TRUE) //or else you end up with naked assistants running around everywhere...
@@ -32,12 +43,20 @@
 		new C(loc)
 	return INITIALIZE_HINT_QDEL
 
+/// Returns a random, acceptable jumpskirt typepath
+/proc/get_random_jumpskirt()
+	return pick(
+		subtypesof(/obj/item/clothing/under/color/jumpskirt) \
+			- /obj/item/clothing/under/color/jumpskirt/random \
+			- /obj/item/clothing/under/rank/prisoner/skirt \
+	)
+
 /obj/item/clothing/under/color/jumpskirt/random
 	icon_state = "random_jumpsuit" //Skirt variant needed
 
 /obj/item/clothing/under/color/jumpskirt/random/Initialize(mapload)
 	..()
-	var/obj/item/clothing/under/color/jumpskirt/C = pick(subtypesof(/obj/item/clothing/under/color/jumpskirt) - /obj/item/clothing/under/color/jumpskirt/random - /obj/item/clothing/under/rank/prisoner/skirt)
+	var/obj/item/clothing/under/color/jumpskirt/C = get_random_jumpskirt()
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		H.equip_to_slot_or_del(new C(H), ITEM_SLOT_ICLOTHING, initial=TRUE)

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -1,3 +1,5 @@
+GLOBAL_DATUM_INIT(colored_assistant, /datum/colored_assistant, get_configured_colored_assistant())
+
 /*
 Assistant
 */
@@ -37,28 +39,27 @@ Assistant
 	jobtype = /datum/job/assistant
 	id_trim = /datum/id_trim/job/assistant
 
-/datum/outfit/job/assistant/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/assistant/pre_equip(mob/living/carbon/human/target)
 	..()
-	if (CONFIG_GET(flag/grey_assistants))
-		give_grey_suit(H)
-	else
-		if(H.jumpsuit_style == PREF_SUIT)
-			uniform = /obj/item/clothing/under/color/random
-		else
-			uniform = /obj/item/clothing/under/color/jumpskirt/random
+	give_jumpsuit(target)
 
-/datum/outfit/job/assistant/proc/give_grey_suit(mob/living/carbon/human/target)
+/datum/outfit/job/assistant/proc/give_jumpsuit(mob/living/carbon/human/target)
+	var/static/jumpsuit_number = 0
+
+	jumpsuit_number += 1
+
+	var/index = (jumpsuit_number % GLOB.colored_assistant.jumpsuits.len) + 1
+
 	if (target.jumpsuit_style == PREF_SUIT)
-		uniform = /obj/item/clothing/under/color/grey
+		uniform = GLOB.colored_assistant.jumpsuits[index]
 	else
-		uniform = /obj/item/clothing/under/color/jumpskirt/grey
+		uniform = GLOB.colored_assistant.jumpskirts[index]
 
 /datum/outfit/job/assistant/consistent
 	name = "Assistant - Consistent"
 
-/datum/outfit/job/assistant/consistent/pre_equip(mob/living/carbon/human/H)
-	..()
-	give_grey_suit(H)
+/datum/outfit/job/assistant/consistent/give_jumpsuit(mob/living/carbon/human/target)
+	uniform = /obj/item/clothing/under/color/grey
 
 /datum/outfit/job/assistant/consistent/post_equip(mob/living/carbon/human/H, visualsOnly)
 	..()
@@ -66,3 +67,124 @@ Assistant
 	// This outfit is used by the assets SS, which is ran before the atoms SS
 	if (SSatoms.initialized == INITIALIZATION_INSSATOMS)
 		H.w_uniform?.update_greyscale()
+
+/proc/get_configured_colored_assistant()
+	return CONFIG_GET(flag/grey_assistants) ? new /datum/colored_assistant/grey : new /datum/colored_assistant/random
+
+/// Defines a style of jumpsuit/jumpskirt for assistants.
+/// Jumpsuit and jumpskirt lists should match in colors, as they are used interchangably.
+/datum/colored_assistant
+	var/list/jumpsuits
+	var/list/jumpskirts
+
+/datum/colored_assistant/grey
+	jumpsuits = list(/obj/item/clothing/under/color/grey)
+	jumpskirts = list(/obj/item/clothing/under/color/jumpskirt/grey)
+
+/datum/colored_assistant/random
+	jumpsuits = list(/obj/item/clothing/under/color/random)
+	jumpskirts = list(/obj/item/clothing/under/color/jumpskirt/random)
+
+/datum/colored_assistant/christmas
+	jumpsuits = list(
+		/obj/item/clothing/under/color/green,
+		/obj/item/clothing/under/color/red,
+	)
+
+	jumpskirts = list(
+		/obj/item/clothing/under/color/jumpskirt/green,
+		/obj/item/clothing/under/color/jumpskirt/red,
+	)
+
+/datum/colored_assistant/mcdonalds
+	jumpsuits = list(
+		/obj/item/clothing/under/color/yellow,
+		/obj/item/clothing/under/color/red,
+	)
+
+	jumpskirts = list(
+		/obj/item/clothing/under/color/jumpskirt/yellow,
+		/obj/item/clothing/under/color/jumpskirt/red,
+	)
+
+/datum/colored_assistant/halloween
+	jumpsuits = list(
+		/obj/item/clothing/under/color/orange,
+		/obj/item/clothing/under/color/black,
+	)
+
+	jumpskirts = list(
+		/obj/item/clothing/under/color/jumpskirt/orange,
+		/obj/item/clothing/under/color/jumpskirt/black,
+	)
+
+/datum/colored_assistant/ikea
+	jumpsuits = list(
+		/obj/item/clothing/under/color/yellow,
+		/obj/item/clothing/under/color/blue,
+	)
+
+	jumpskirts = list(
+		/obj/item/clothing/under/color/jumpskirt/yellow,
+		/obj/item/clothing/under/color/jumpskirt/blue,
+	)
+
+/datum/colored_assistant/mud
+	jumpsuits = list(
+		/obj/item/clothing/under/color/brown,
+		/obj/item/clothing/under/color/lightbrown,
+	)
+
+	jumpskirts = list(
+		/obj/item/clothing/under/color/jumpskirt/brown,
+		/obj/item/clothing/under/color/jumpskirt/lightbrown,
+	)
+
+/datum/colored_assistant/warm
+	jumpsuits = list(
+		/obj/item/clothing/under/color/red,
+		/obj/item/clothing/under/color/pink,
+		/obj/item/clothing/under/color/orange,
+		/obj/item/clothing/under/color/yellow,
+	)
+
+	jumpskirts = list(
+		/obj/item/clothing/under/color/jumpskirt/red,
+		/obj/item/clothing/under/color/jumpskirt/pink,
+		/obj/item/clothing/under/color/jumpskirt/orange,
+		/obj/item/clothing/under/color/jumpskirt/yellow,
+	)
+
+/datum/colored_assistant/cold
+	jumpsuits = list(
+		/obj/item/clothing/under/color/blue,
+		/obj/item/clothing/under/color/darkblue,
+		/obj/item/clothing/under/color/darkgreen,
+		/obj/item/clothing/under/color/green,
+		/obj/item/clothing/under/color/lightpurple,
+		/obj/item/clothing/under/color/teal,
+	)
+
+	jumpskirts = list(
+		/obj/item/clothing/under/color/jumpskirt/blue,
+		/obj/item/clothing/under/color/jumpskirt/darkblue,
+		/obj/item/clothing/under/color/jumpskirt/darkgreen,
+		/obj/item/clothing/under/color/jumpskirt/green,
+		/obj/item/clothing/under/color/jumpskirt/lightpurple,
+		/obj/item/clothing/under/color/jumpskirt/teal,
+	)
+
+/// Will pick one color, and stick with it
+/datum/colored_assistant/solid
+
+/datum/colored_assistant/solid/New()
+	var/obj/item/clothing/under/color/random_jumpsuit_type = get_random_jumpsuit()
+	jumpsuits = list(random_jumpsuit_type)
+
+	for (var/obj/item/clothing/under/color/jumpskirt/jumpskirt_type as anything in subtypesof(/obj/item/clothing/under/color/jumpskirt))
+		if (initial(jumpskirt_type.greyscale_colors) == initial(random_jumpsuit_type.greyscale_colors))
+			jumpskirts = list(jumpskirt_type)
+			return
+
+	// Couldn't find a matching jumpskirt, oh well
+	jumpskirts = list(get_random_jumpskirt())

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -1,4 +1,4 @@
-GLOBAL_DATUM_INIT(colored_assistant, /datum/colored_assistant, get_configured_colored_assistant())
+GLOBAL_DATUM(colored_assistant, /datum/colored_assistant)
 
 /*
 Assistant
@@ -45,8 +45,11 @@ Assistant
 
 /datum/outfit/job/assistant/proc/give_jumpsuit(mob/living/carbon/human/target)
 	var/static/jumpsuit_number = 0
-
 	jumpsuit_number += 1
+
+	if (isnull(GLOB.colored_assistant))
+		var/configured_type = get_configured_colored_assistant_type()
+		GLOB.colored_assistant = new configured_type
 
 	var/index = (jumpsuit_number % GLOB.colored_assistant.jumpsuits.len) + 1
 
@@ -68,8 +71,8 @@ Assistant
 	if (SSatoms.initialized == INITIALIZATION_INSSATOMS)
 		H.w_uniform?.update_greyscale()
 
-/proc/get_configured_colored_assistant()
-	return CONFIG_GET(flag/grey_assistants) ? new /datum/colored_assistant/grey : new /datum/colored_assistant/random
+/proc/get_configured_colored_assistant_type()
+	return CONFIG_GET(flag/grey_assistants) ? /datum/colored_assistant/grey : /datum/colored_assistant/random
 
 /// Defines a style of jumpsuit/jumpskirt for assistants.
 /// Jumpsuit and jumpskirt lists should match in colors, as they are used interchangably.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new station trait to color the assistant jumpsuits semi-randomly.

There are several styles for it to choose from, including some especially colored ones, and some randomized ones. This includes the current alternative rainbow jumpsuits, but if `GREY_ASSISTANTS` is not enabled, then grey jumpsuits will be a valid random option.

I don't really want to hear too much more about the config, I got the OK on this from head admins.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds more variety to look at on assistants, while still mostly preserving a consistent style if `GREY_ASSISTANTS` is enabled (as it is a station trait).

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a station trait for varying colored assistant jumpsuits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
