### PR TITLE
External organs now have names

### DIFF
--- a/code/modules/surgery/organs/external/_external_organs.dm
+++ b/code/modules/surgery/organs/external/_external_organs.dm
@@ -151,7 +151,9 @@
 
 /obj/item/organ/external/update_name()
 	. = ..()
-	name = "[friendly_name ? friendly_name : feature_key] ([sprite_datum.name])"
+	name = "[friendly_name ? friendly_name : feature_key]"
+	if(sprite_datum)
+		name += " ([sprite_datum.name])"
 
 ///The horns of a lizard!
 /obj/item/organ/external/horns

--- a/code/modules/surgery/organs/external/_external_organs.dm
+++ b/code/modules/surgery/organs/external/_external_organs.dm
@@ -32,6 +32,9 @@
 	///Reference to the limb we're inside of
 	var/obj/item/bodypart/ownerlimb
 
+	///Friendly version of feature_key (only used if feature_key is more than one word)
+	var/friendly_name = ""
+
 /**mob_sprite is optional if you havent set sprite_datums for the object, and is used mostly to generate sprite_datums from a persons DNA
 * For _mob_sprite we make a distinction between "Round Snout" and "round". Round Snout is the name of the sprite datum, while "round" would be part of the sprite
 * I'm sorry
@@ -40,6 +43,8 @@
 	. = ..()
 	if(mob_sprite)
 		set_sprite(mob_sprite)
+
+	update_name()
 
 /obj/item/organ/external/Insert(mob/living/carbon/reciever, special, drop_if_replaced)
 	var/obj/item/bodypart/limb = reciever.get_bodypart(zone)
@@ -65,6 +70,8 @@
 		ownerlimb = null
 
 	organ_owner.update_body_parts()
+
+	update_name()
 
 /obj/item/organ/external/transfer_to_limb(obj/item/bodypart/bodypart, mob/living/carbon/bodypart_owner)
 	. = ..()
@@ -142,6 +149,10 @@
 
 	set_sprite(feature_list[deconstruct_block(getblock(features, dna_block), feature_list.len)])
 
+/obj/item/organ/external/update_name()
+	. = ..()
+	name = "[friendly_name ? friendly_name : feature_key] ([sprite_datum.name])"
+
 ///The horns of a lizard!
 /obj/item/organ/external/horns
 	zone = BODY_ZONE_HEAD
@@ -215,6 +226,8 @@
 	var/burnt = FALSE
 	///Store our old sprite here for if our antennae wings are healed
 	var/original_sprite = ""
+
+	friendly_name = "antennae"
 
 /obj/item/organ/external/antennae/Insert(mob/living/carbon/reciever, special, drop_if_replaced)
 	. = ..()

--- a/code/modules/surgery/organs/external/wings.dm
+++ b/code/modules/surgery/organs/external/wings.dm
@@ -6,6 +6,8 @@
 
 	feature_key = "wings"
 
+	friendly_name = "wings" //Because feature_key could be "wingsopen" if/when the organ gets removed
+
 /obj/item/organ/external/wings/can_draw_on_bodypart(mob/living/carbon/human/human)
 	if(!human.wear_suit)
 		return TRUE
@@ -167,6 +169,8 @@
 	var/burnt = FALSE
 	///Store our old sprite here for if our burned wings are healed
 	var/original_sprite = ""
+
+	friendly_name = "moth wings"
 
 /obj/item/organ/external/wings/moth/get_global_feature_list()
 	return GLOB.moth_wings_list


### PR DESCRIPTION
## About The Pull Request

External organs now have names consisting of the type of feature they are, with the name of the used sprite datum in parenthesis.

## Why It's Good For The Game

I noticed one round, where there were disembodied external organs, that they didn't have names. This should make their existence a little less confusing if/when they are found or spawned in.

## Changelog

:cl:
spellcheck: If, for some reason, a mutant humanoid's external organs are removed from their body, the organs will have identifiable names.
/:cl:
