### PR TITLE
Makes sure the abandoned crates anti-tamper mechanism is reenabled only when the crate is actually locked.

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -107,8 +107,10 @@
 
 /obj/structure/closet/crate/secure/loot/togglelock(mob/user, silent = FALSE)
 	if(!locked)
-		tamperproof = initial(tamperproof) //reset the anti-tampering when the lock is re-enabled.
-		return ..()
+		. = ..()
+		if(locked)
+			tamperproof = initial(tamperproof) //reset the anti-tampering when the lock is re-enabled.
+		return
 	if(tamperproof)
 		boom(user)
 		return


### PR DESCRIPTION
## About The Pull Request
See the title. 

## Why It's Good For The Game
Fixes a little human error I did in #62949. `togglelock()` isn't guaranteed to always (un)lock closets.

## Changelog
No changelog. This is just a small quickfix to something I made that was recently merged and is really marginal anyway. No GBP update.