### PR TITLE
Fixes nearspace tiles not lighting up properly

### DIFF
--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -51,7 +51,7 @@
 		SET_BITFLAG_LIST(canSmoothWith)
 
 	var/area/our_area = loc
-	if(our_area.static_lighting && always_lit) //Only provide your own lighting if the area doesn't for you
+	if(our_area.area_has_base_lighting && always_lit) //Only provide your own lighting if the area doesn't for you
 		add_overlay(GLOB.fullbright_overlay)
 
 	if(requires_activation)

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -50,6 +50,9 @@
 			smoothing_flags |= SMOOTH_OBJ
 		SET_BITFLAG_LIST(canSmoothWith)
 
+	var/area/our_area = loc
+	if(our_area.static_lighting && always_lit) //Only provide your own lighting if the area doesn't for you
+		add_overlay(GLOB.fullbright_overlay)
 
 	if(requires_activation)
 		SSair.add_to_active(src, TRUE)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -83,6 +83,10 @@ GLOBAL_LIST_EMPTY(station_turfs)
  * Turf Initialize
  *
  * Doesn't call parent, see [/atom/proc/Initialize]
+ * Please note, space tiles do not run this code.
+ * This is done because it's called so often that any extra code just slows things down too much
+ * If you add something relevant here add it there too
+ * [/turf/open/space/Initialize]
  */
 /turf/Initialize(mapload)
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -117,7 +117,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	for(var/atom/movable/content as anything in src)
 		Entered(content, null)
 
-	if(always_lit)
+	var/area/our_area = loc
+	if(our_area.area_has_base_lighting && always_lit) //Only provide your own lighting if the area doesn't for you
 		add_overlay(GLOB.fullbright_overlay)
 
 	if(requires_activation)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When tivi redid area lighting, he removed the bit of code from space initialize that lit the space turf if its
area didn't do it for it.
This broke things, because space init does not call parent, and so never got the fullbright overlay.

This resolves that, and adds a comment in the hopes of preventing this in future.

Oh also I added some extra logic to prevent adding the overlay if we're already in a non static lighting area, since it's redundant (and really hot code)
I think this is fine? Advise @TiviPlus?

I have a feeling this fixes some things, but I'm not really 100% on what. Taking suggestions 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pre Area Lighting:
![image](https://user-images.githubusercontent.com/58055496/142995759-9234e6b9-2ded-4cc4-a8d5-ca3430328342.png)
On Live:
![image](https://user-images.githubusercontent.com/58055496/142995677-cabf9d77-a6a0-4e0c-983b-b3b8a1b8cbe8.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed solars and nearstation areas being pitch black, restores the fullbright they ought to have
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
