### PR TITLE
Fixes PDA skill tracker hard lock

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -401,7 +401,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 						var/exp = targetmind.get_skill_exp(type)
 						var/xp_prog_to_level = targetmind.exp_needed_to_level_up(type)
 						var/xp_req_to_level = 0
-						if (xp_prog_to_level)//is it even possible to level up?
+						if (xp_prog_to_level && lvl_num < length(SKILL_EXP_LIST)) // is it even possible to level up?
 							xp_req_to_level = SKILL_EXP_LIST[lvl_num+1] - SKILL_EXP_LIST[lvl_num]
 						dat += "<HR><b>[S.name]</b>"
 						dat += "<br><i>[S.desc]</i>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I decided to try to fix the PDA skill tracker even though I already have a PR to fix it in the long term. People still need to use the PDA's for loads of things after-all.

I manually manipulated the mind skill data until I produced runtimes. It appears there are edge cases where you can be legendary level on something and `mind.exp_needed_to_level_up()` still returns a value. (Basically somehow the total exp and the level got out of sync, not sure how that happens in normal gameplay, but whatever) This caused line 405 to runtime because it would use an index too high on `SKILL_EXP_LIST` on pda.dm:405. So now there's a boundary check. This was the only situation I could reproduce a freeze and I can't now so probably fixed. Looking through the code, it's the only place I can imagine a runtime happening anyway (outside of extremely unlikely scenarios like corrupt mind datum).

Closes #62968 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Hard-locked PDA's suck.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
fix: Fixed edgecase causing PDA Skill Tracker to hard lock the PDA as your reward for getting legendary level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
