### PR TITLE
Allows you to tie shoes in your hand again (and stops you from tying shoes without laces)

### DIFF
--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -262,6 +262,9 @@
 
 /obj/item/clothing/shoes/attack_self(mob/user)
 	. = ..()
+	
+	if (!can_be_tied)
+		return
 
 	if(DOING_INTERACTION_WITH_TARGET(user, src))
 		to_chat(user, span_warning("You're already interacting with [src]!"))
@@ -271,4 +274,4 @@
 
 	if(do_after(user, lace_time, target = src,extra_checks = CALLBACK(src, .proc/still_shoed, user)))
 		to_chat(user, span_notice("You [tied ? "untie" : "tie"] the laces on [src]."))
-		adjust_laces(tied ? SHOES_TIED : SHOES_UNTIED, user)
+		adjust_laces(tied ? SHOES_UNTIED : SHOES_TIED, user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You weren't able to tie shoes in your hand before... now you can.
Also stops you from attempting to tie shoes that have no laces

Fixes https://github.com/tgstation/tgstation/issues/62781
Fixes https://github.com/tgstation/tgstation/issues/59126


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

i should be able to tie my own gd shoes

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can tie your shoes in-hand again.
fix: You can no longer try to tie lace-less shoes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
