### PR TITLE
Changes the heretic sac from gib to spill all your organs and kills you

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -226,7 +226,7 @@
 	. = ..()
 	for(var/mob/living/carbon/human/sacrifices in atoms)
 		atoms -= sacrifices
-		sacrifices.gib()
+		sacrifices.spill_organs()
 
 
 ///////////////

--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -226,7 +226,7 @@
 	. = ..()
 	for(var/mob/living/carbon/human/sacrifices in atoms)
 		atoms -= sacrifices
-		sacrifices.spill_organs()
+		sacrifices.gib()
 
 
 ///////////////
@@ -260,7 +260,9 @@
 		if(heart.target && heart.target.stat == DEAD)
 			to_chat(carbon_user,span_danger("Your patrons accepts your offer.."))
 			var/mob/living/carbon/human/current_target = heart.target
-			current_target.gib()
+			current_target.spill_organs()
+			current_target.adjustBruteLoss(250)
+			new /obj/effect/gibspawner/generic(get_turf(current_target))
 			heart.target = null
 			var/datum/antagonist/heretic/heretic_datum = carbon_user.mind.has_antag_datum(/datum/antagonist/heretic)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Heretics no longer gibs their target, instead spill all their organs and killing them.

## Why It's Good For The Game

Gives heretic the choice to round remove people or let them be revived eventually. Round removing an organless body isn't so hard, and it's a choice you decide to make. The previous sac forced you to gib your target and moving away from forcing such powerful consequences is better for the game health, especially on MRP where gibbing someone should be rare.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Heretics no longer gib their target when sacrificing them, instead outright killing them and spilling all their organs everywhere in a gruesome manner.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
