### PR TITLE
Remove pick_weight_allow_zero, and allow pick_weight to take zero values

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -261,30 +261,15 @@
 	return result
 
 /**
- * Picks a random element from a list based on a weighting system:
- * 1. Adds up the total of weights for each element
- * 2. Gets a number between 1 and that total
- * 3. For each element in the list, subtracts its weighting from that number
- * 4. If that makes the number 0 or less, return that element.
- * Will output null sometimes if you use decimals (e.g. 0.1 instead of 10) as rand() uses integers, not floats
-**/
+ * Picks a random element from a list based on a weighting system.
+ * For example, given the following list:
+ * A = 6, B = 3, C = 1, D = 0
+ * A would have a 60% chance of being picked,
+ * B would have a 30% chance of being picked,
+ * C would have a 10% chance of being picked,
+ * and D would have a 0% chance of being picked.
+ */
 /proc/pick_weight(list/list_to_pick)
-	var/total = 0
-	var/item
-	for(item in list_to_pick)
-		if(!list_to_pick[item])
-			list_to_pick[item] = 1
-		total += list_to_pick[item]
-
-	total = rand(1, total)
-	for(item in list_to_pick)
-		total -= list_to_pick[item]
-		if(total <= 0)
-			return item
-
-	return null
-///The original pickweight proc will sometimes pick entries with zero weight.  I'm not sure if changing the original will break anything, so I left it be.
-/proc/pick_weight_allow_zero(list/list_to_pick)
 	var/total = 0
 	var/item
 	for(item in list_to_pick)

--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -268,6 +268,7 @@
  * B would have a 30% chance of being picked,
  * C would have a 10% chance of being picked,
  * and D would have a 0% chance of being picked.
+ * You should only pass integers in.
  */
 /proc/pick_weight(list/list_to_pick)
 	var/total = 0

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -261,7 +261,7 @@
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_UNIQUE_AI))
 		law_weights -= AI_LAWS_ASIMOV
 	while(!lawtype && law_weights.len)
-		var/possible_id = pick_weight_allow_zero(law_weights)
+		var/possible_id = pick_weight(law_weights)
 		lawtype = lawid_to_type(possible_id)
 		if(!lawtype)
 			law_weights -= possible_id

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -151,10 +151,10 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/waittime_l = 600
 	/// What is the higher bound of when the roundstart annoucement is sent out?
 	var/waittime_h = 1800
-	
+
 	/// Maximum amount of threat allowed to generate.
 	var/max_threat_level = 100
-	
+
 
 /datum/game_mode/dynamic/admin_panel()
 	var/list/dat = list("<html><head><meta http-equiv='Content-Type' content='text/html; charset=UTF-8'><title>Game Mode Panel</title></head><body><h1><B>Game Mode Panel</B></h1>")
@@ -470,7 +470,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/round_start_budget_left = round_start_budget
 
 	while (round_start_budget_left > 0)
-		var/datum/dynamic_ruleset/roundstart/ruleset = pick_weight_allow_zero(drafted_rules)
+		var/datum/dynamic_ruleset/roundstart/ruleset = pick_weight(drafted_rules)
 		if (isnull(ruleset))
 			log_game("DYNAMIC: No more rules can be applied, stopping with [round_start_budget] left.")
 			break

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -330,7 +330,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
  */
 /obj/machinery/computer/arcade/orion_trail/proc/encounter_event(path, gamer, gamer_skill, gamer_skill_level, gamer_skill_rands)
 	if(!path)
-		event = pick_weight_allow_zero(events)
+		event = pick_weight(events)
 	else
 		for(var/datum/orion_event/instance as anything in events)
 			if(instance.type == path)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames `pick_weight_allow_zero` to `pick_weight`, and removes the old implementation, which wasn't changed as not to "break anything, so I left it be."

Old `pick_weight` would turn 0 values into 1 values, which is a surprising behavior. Old consumers of this behavior have already been moved to explicitly specifying 1 weight.

This change has been battle tested by #62940.