### PR TITLE
Moves deconstructing beds and chairs to right click

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -36,12 +36,13 @@
 /obj/structure/bed/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)
 
-/obj/structure/bed/attackby_secondary(obj/item/weapon, mob/user, params)
-	if(weapon.tool_behaviour != TOOL_WRENCH || (flags_1&NODECONSTRUCT_1))
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+/obj/structure/bed/wrench_act_secondary(mob/living/user, obj/item/weapon)
+	if(flags_1&NODECONSTRUCT_1)
+		return TRUE
+	..()
 	weapon.play_tool_sound(src)
 	deconstruct(TRUE)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return TRUE
 
 /*
  * Roller beds

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -36,10 +36,10 @@
 /obj/structure/bed/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)
 
-/obj/structure/bed/attackby_secondary(obj/item/W, mob/user, params)
-	if(W.tool_behaviour != TOOL_WRENCH || (flags_1&NODECONSTRUCT_1))
+/obj/structure/bed/attackby_secondary(obj/item/weapon, mob/user, params)
+	if(weapon.tool_behaviour != TOOL_WRENCH || (flags_1&NODECONSTRUCT_1))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-	W.play_tool_sound(src)
+	weapon.play_tool_sound(src)
 	deconstruct(TRUE)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -36,7 +36,7 @@
 /obj/structure/bed/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)
 
-/obj/structure/bed/attackby(obj/item/W, mob/user, params)
+/obj/structure/bed/attackby_secondary(obj/item/W, mob/user, params)
 	if(W.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1))
 		W.play_tool_sound(src)
 		deconstruct(TRUE)

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -37,11 +37,11 @@
 	return attack_hand(user, modifiers)
 
 /obj/structure/bed/attackby_secondary(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1))
-		W.play_tool_sound(src)
-		deconstruct(TRUE)
-	else
-		return ..()
+	if(W.tool_behaviour != TOOL_WRENCH || (flags_1&NODECONSTRUCT_1))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	W.play_tool_sound(src)
+	deconstruct(TRUE)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /*
  * Roller beds

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -41,7 +41,7 @@
 		return TRUE
 	..()
 	weapon.play_tool_sound(src)
-	deconstruct(TRUE)
+	deconstruct(disassembled = TRUE)
 	return TRUE
 
 /*

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -55,7 +55,7 @@
 /obj/structure/chair/proc/RemoveFromLatejoin()
 	SSjob.latejoin_trackers -= src //These may be here due to the arrivals shuttle
 
-/obj/structure/chair/deconstruct()
+/obj/structure/chair/deconstruct(disassembled)
 	// If we have materials, and don't have the NOCONSTRUCT flag
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(buildstacktype)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -100,13 +100,13 @@
 		to_chat(user, "<span class='notice'> You cannot fit the shock kit onto the [name]!")
 
 
-/obj/structure/chair/attackby_secondary(obj/item/O, mob/user, params)
-	if(O.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1))
-		I.play_tool_sound(src)
-		deconstruct(TRUE)
-	else
-		return ..()
-
+/obj/structure/chair/attackby_secondary(obj/item/weapon, mob/user, params)
+	if(weapon.tool_behaviour != TOOL_WRENCH || (flags_1&NODECONSTRUCT_1))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	I.play_tool_sound(src)
+	deconstruct(TRUE)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	
 /obj/structure/chair/attack_tk(mob/user)
 	if(!anchored || has_buckled_mobs() || !isturf(user.loc))
 		return ..()

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -100,12 +100,13 @@
 		to_chat(user, "<span class='notice'> You cannot fit the shock kit onto the [name]!")
 
 
-/obj/structure/chair/attackby_secondary(obj/item/weapon, mob/user, params)
-	if(weapon.tool_behaviour != TOOL_WRENCH)
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+/obj/structure/chair/wrench_act_secondary(mob/living/user, obj/item/weapon)
+	if(flags_1&NODECONSTRUCT_1)
+		return TRUE
+	..()
 	weapon.play_tool_sound(src)
 	deconstruct(TRUE)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return TRUE
 	
 /obj/structure/chair/attack_tk(mob/user)
 	if(!anchored || has_buckled_mobs() || !isturf(user.loc))

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -101,7 +101,7 @@
 
 
 /obj/structure/chair/attackby_secondary(obj/item/weapon, mob/user, params)
-	if(weapon.tool_behaviour != TOOL_WRENCH || (flags_1&NODECONSTRUCT_1))
+	if(weapon.tool_behaviour != TOOL_WRENCH)
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	weapon.play_tool_sound(src)
 	deconstruct(TRUE)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -103,7 +103,7 @@
 /obj/structure/chair/attackby_secondary(obj/item/weapon, mob/user, params)
 	if(weapon.tool_behaviour != TOOL_WRENCH || (flags_1&NODECONSTRUCT_1))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-	I.play_tool_sound(src)
+	weapon.play_tool_sound(src)
 	deconstruct(TRUE)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -105,7 +105,7 @@
 		return TRUE
 	..()
 	weapon.play_tool_sound(src)
-	deconstruct(TRUE)
+	deconstruct(disassembled = TRUE)
 	return TRUE
 	
 /obj/structure/chair/attack_tk(mob/user)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -100,11 +100,12 @@
 		to_chat(user, "<span class='notice'> You cannot fit the shock kit onto the [name]!")
 
 
-/obj/structure/chair/wrench_act(mob/living/user, obj/item/I)
-	. = ..()
-	I.play_tool_sound(src)
-	deconstruct()
-	return TRUE
+/obj/structure/chair/attackby_secondary(obj/item/O, mob/user, params)
+	if(O.tool_behaviour == TOOL_WRENCH && !(flags_1&NODECONSTRUCT_1))
+		I.play_tool_sound(src)
+		deconstruct(TRUE)
+	else
+		return ..()
 
 /obj/structure/chair/attack_tk(mob/user)
 	if(!anchored || has_buckled_mobs() || !isturf(user.loc))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As part of my effort to both learn how to code DM and make all deconstruction happen on right click for consistency, I've started with the most prevalent thing I can think of: chairs (and beds too because they're in the same file). 


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Picture this: you are deconstructing the coutroom, trying to get more iron because all the miners died and you want to print a fancy gun. You just finished removing some tables, by right clicking them with a wrench of course, and you come across a chair you want to deconstruct. So, holding your trusty wrench, you right click the chair, assuming that deconstructing the chair would be the same button as deconstructing those tables you just got done with. But no, that couldn't be further from the truth! You slam the wrench into the chair, smacking it with all your force, and making a massive fool of yourself. If only deconstruction was consistently on right click, you could have avoided this massive embarrassment.

Consistency good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Chairs and beds are now deconstructed with right click, making them more consistent with other object deconstructions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
