### PR TITLE
Upgrades the Fission360 app to be more on par to the old pinpointer

### DIFF
--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -1335,18 +1335,7 @@
 	id = "infiltrator_starboardblast";
 	name = "Infiltrator Starboard Hatch"
 	},
-/obj/docking_port/mobile{
-	dheight = 1;
-	dir = 8;
-	dwidth = 12;
-	height = 17;
-	hidden = 1;
-	id = "syndicate";
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "syndicate infiltrator";
-	port_direction = 4;
-	width = 23
-	},
+/obj/docking_port/mobile/infiltrator,
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/box,
 /obj/machinery/button/door/directional/north{

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -428,18 +428,7 @@
 	id = "smindicate";
 	name = "outer blast door"
 	},
-/obj/docking_port/mobile{
-	dheight = 1;
-	dir = 8;
-	dwidth = 12;
-	height = 17;
-	hidden = 1;
-	id = "syndicate";
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
-	name = "syndicate infiltrator";
-	port_direction = 4;
-	width = 23
-	},
+/obj/docking_port/mobile/infiltrator,
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1

--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -55,3 +55,8 @@
 #define COMSIG_ALARM_CLEAR(alarm_type) "!alarm_clear [alarm_type]"
 ///global mob logged in signal! (/mob/added_player)
 #define COMSIG_GLOB_MOB_LOGGED_IN "!mob_logged_in"
+
+/// global signal sent when a nuclear device is armed (/obj/machinery/nuclearbomb/nuke/exploding_nuke)
+#define COMSIG_GLOB_NUKE_DEVICE_ARMED "!nuclear_device_armed"
+/// global signal sent when a nuclear device is disarmed (/obj/machinery/nuclearbomb/nuke/disarmed_nuke)
+#define COMSIG_GLOB_NUKE_DEVICE_DISARMED "!nuclear_device_disarmed"

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -424,6 +424,9 @@ GLOBAL_VAR(station_nuke_source)
 		detonation_timer = world.time + (timer_set * 10)
 		for(var/obj/item/pinpointer/nuke/syndicate/S in GLOB.pinpointer_list)
 			S.switch_mode_to(TRACK_INFILTRATOR)
+
+		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NUKE_DEVICE_ARMED, src)
+
 		countdown.start()
 		set_security_level("delta")
 	else
@@ -435,6 +438,9 @@ GLOBAL_VAR(station_nuke_source)
 			S.switch_mode_to(initial(S.mode))
 			S.alert = FALSE
 		countdown.stop()
+
+		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NUKE_DEVICE_DISARMED, src)
+
 	update_appearance()
 
 /obj/machinery/nuclearbomb/proc/get_time_left()

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -274,17 +274,20 @@
 	if(!.)
 		return
 
-	RegisterSignal(computer, COMSIG_PARENT_EXAMINE, .proc/on_examine)
-	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED, .proc/on_nuke_armed)
+	if(computer)
+		RegisterSignal(computer, COMSIG_PARENT_EXAMINE, .proc/on_examine)
+		RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED, .proc/on_nuke_armed)
 
 /datum/computer_file/program/radar/fission360/kill_program(forced)
-	UnregisterSignal(computer, COMSIG_PARENT_EXAMINE)
-	UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
+	if(computer)
+		UnregisterSignal(computer, COMSIG_PARENT_EXAMINE)
+		UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
 	return ..()
 
 /datum/computer_file/program/radar/fission360/Destroy()
-	UnregisterSignal(computer, COMSIG_PARENT_EXAMINE)
-	UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
+	if(computer)
+		UnregisterSignal(computer, COMSIG_PARENT_EXAMINE)
+		UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
 	return ..()
 
 /datum/computer_file/program/radar/fission360/find_atom()

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -349,6 +349,6 @@
 		to_chat(computer.loc, span_userdanger("Your [computer.name] vibrates and lets out an ominous alarm. Uh oh."))
 	else
 		computer.audible_message(
-			span_danger("[src] vibrates and lets out an ominous alarm. Uh oh."),
-			span_notice("[src] begins to vibrate rapidly. Wonder what that means..."),
+			span_danger("[computer] vibrates and lets out an ominous alarm. Uh oh."),
+			span_notice("[computer] begins to vibrate rapidly. Wonder what that means..."),
 			)

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -268,6 +268,29 @@
 	program_icon = "bomb"
 	arrowstyle = "ntosradarpointerS.png"
 	pointercolor = "red"
+	/// Whether this program has alerted any user that a nuke is armed. To prevent spam.
+	var/alerted_user = FALSE
+
+/datum/computer_file/program/radar/fission360/run_program(mob/living/user)
+	. = ..()
+	if(!.)
+		return
+
+	if(computer)
+		RegisterSignal(computer, COMSIG_PARENT_EXAMINE, .proc/on_examine)
+		RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED, .proc/on_nuke_armed)
+
+/datum/computer_file/program/radar/fission360/kill_program(forced)
+	if(computer)
+		UnregisterSignal(computer, COMSIG_PARENT_EXAMINE)
+		UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
+	return ..()
+
+/datum/computer_file/program/radar/fission360/Destroy()
+	if(computer)
+		UnregisterSignal(computer, COMSIG_PARENT_EXAMINE)
+		UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
+	return ..()
 
 /datum/computer_file/program/radar/fission360/find_atom()
 	return SSpoints_of_interest.get_poi_atom_by_ref(selected)
@@ -277,17 +300,57 @@
 		return
 	next_scan = world.time + (2 SECONDS)
 	objects = list()
-	for(var/i in GLOB.nuke_list)
-		var/obj/machinery/nuclearbomb/nuke = i
 
-		var/list/nukeinfo = list(
+	// All the nukes
+	for(var/obj/machinery/nuclearbomb/nuke as anything in GLOB.nuke_list)
+		var/list/nuke_info = list(
 			ref = REF(nuke),
 			name = nuke.name,
 			)
-		objects += list(nukeinfo)
+		objects += list(nuke_info)
+
+	// Dat fukken disk
 	var/obj/item/disk/nuclear/disk = locate() in SSpoints_of_interest.real_nuclear_disks
-	var/list/nukeinfo = list(
+	var/list/disk_info = list(
 		ref = REF(disk),
 		name = "Nuke Auth. Disk",
 		)
-	objects += list(nukeinfo)
+	objects += list(disk_info)
+
+	// The infiltrator
+	var/obj/docking_port/mobile/infiltrator = SSshuttle.getShuttle("syndicate")
+	var/list/ship_info = list(
+		ref = REF(infiltrator),
+		name = "Infiltrator",
+		)
+	objects += list(ship_info)
+
+/*
+ * Signal proc for [COMSIG_PARENT_EXAMINE], registered on the computer.
+ * Shows how long any armed nukes are to detonating.
+ */
+/datum/computer_file/program/radar/fission360/proc/on_examine(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	for(var/obj/machinery/nuclearbomb/bomb as anything in GLOB.nuke_list)
+		if(bomb.timing)
+			examine_list += span_danger("Extreme danger. Arming signal detected. Time remaining: [bomb.get_time_left()].")
+
+/*
+ * Signal proc for [COMSIG_GLOB_NUKE_DEVICE_ARMED].
+ * Warns anyone nearby or holding the computer that a nuke was armed.
+ */
+/datum/computer_file/program/radar/fission360/proc/on_nuke_armed(datum/source, obj/machinery/nuclearbomb/bomb)
+	SIGNAL_HANDLER
+
+	if(!computer)
+		return
+
+	playsound(computer, 'sound/items/nuke_toy_lowpower.ogg', 50, FALSE)
+	if(isliving(computer.loc))
+		to_chat(computer.loc, span_userdanger("Your [computer.name] vibrates and lets out an ominous alarm. Uh oh."))
+	else
+		computer.audible_message(
+			span_danger("[src] vibrates and lets out an ominous alarm. Uh oh."),
+			span_notice("[src] begins to vibrate rapidly. Wonder what that means..."),
+			)

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -268,8 +268,6 @@
 	program_icon = "bomb"
 	arrowstyle = "ntosradarpointerS.png"
 	pointercolor = "red"
-	/// Whether this program has alerted any user that a nuke is armed. To prevent spam.
-	var/alerted_user = FALSE
 
 /datum/computer_file/program/radar/fission360/run_program(mob/living/user)
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -274,20 +274,17 @@
 	if(!.)
 		return
 
-	if(computer)
-		RegisterSignal(computer, COMSIG_PARENT_EXAMINE, .proc/on_examine)
-		RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED, .proc/on_nuke_armed)
+	RegisterSignal(computer, COMSIG_PARENT_EXAMINE, .proc/on_examine)
+	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED, .proc/on_nuke_armed)
 
 /datum/computer_file/program/radar/fission360/kill_program(forced)
-	if(computer)
-		UnregisterSignal(computer, COMSIG_PARENT_EXAMINE)
-		UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
+	UnregisterSignal(computer, COMSIG_PARENT_EXAMINE)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
 	return ..()
 
 /datum/computer_file/program/radar/fission360/Destroy()
-	if(computer)
-		UnregisterSignal(computer, COMSIG_PARENT_EXAMINE)
-		UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
+	UnregisterSignal(computer, COMSIG_PARENT_EXAMINE)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
 	return ..()
 
 /datum/computer_file/program/radar/fission360/find_atom()

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -274,20 +274,20 @@
 	if(!.)
 		return
 
+	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED, .proc/on_nuke_armed)
 	if(computer)
 		RegisterSignal(computer, COMSIG_PARENT_EXAMINE, .proc/on_examine)
-		RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED, .proc/on_nuke_armed)
 
 /datum/computer_file/program/radar/fission360/kill_program(forced)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
 	if(computer)
 		UnregisterSignal(computer, COMSIG_PARENT_EXAMINE)
-		UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
 	return ..()
 
 /datum/computer_file/program/radar/fission360/Destroy()
+	UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
 	if(computer)
 		UnregisterSignal(computer, COMSIG_PARENT_EXAMINE)
-		UnregisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED)
 	return ..()
 
 /datum/computer_file/program/radar/fission360/find_atom()

--- a/code/modules/shuttle/infiltrator.dm
+++ b/code/modules/shuttle/infiltrator.dm
@@ -17,4 +17,4 @@
 
 /obj/docking_port/mobile/infiltrator/Destroy(force)
 	SSpoints_of_interest.remove_point_of_interest(src)
-	. = ..()
+	return ..()

--- a/code/modules/shuttle/infiltrator.dm
+++ b/code/modules/shuttle/infiltrator.dm
@@ -1,0 +1,20 @@
+/// The syndicate infiltrator shuttle port.
+/obj/docking_port/mobile/infiltrator
+	name = "syndicate infiltrator"
+	id = "syndicate"
+	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
+	hidden = TRUE
+	dheight = 1
+	dwidth = 12
+	height = 17
+	width = 23
+	dir = 8
+	port_direction = 4
+
+/obj/docking_port/mobile/infiltrator/Initialize(mapload)
+	. = ..()
+	SSpoints_of_interest.make_point_of_interest(src)
+
+/obj/docking_port/mobile/infiltrator/Destroy(force)
+	SSpoints_of_interest.remove_point_of_interest(src)
+	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3685,6 +3685,7 @@
 #include "code\modules\shuttle\elevator.dm"
 #include "code\modules\shuttle\emergency.dm"
 #include "code\modules\shuttle\ferry.dm"
+#include "code\modules\shuttle\infiltrator.dm"
 #include "code\modules\shuttle\manipulator.dm"
 #include "code\modules\shuttle\medisim.dm"
 #include "code\modules\shuttle\monastery.dm"


### PR DESCRIPTION
## About The Pull Request

- The Fission360 now shows you, when examining the tablet it's hosted on, how long it will be until any armed nuke detonates.
![image](https://user-images.githubusercontent.com/51863163/143197060-05080e31-8ac8-4d2d-9561-aadc4461afdb.png)

- Additionally, when a nuke is armed, it plays a sound effect + gives you a warning, much like pinpointers did.
![image](https://user-images.githubusercontent.com/51863163/143197165-f231b62f-f308-4452-a909-28ab5c6549fc.png)

- The Fission360 can now also track the Infiltrator itself.
![image](https://user-images.githubusercontent.com/51863163/143197111-b71f1cbe-8f0c-4371-b34b-8ea48f22f1d2.png)

## Why It's Good For The Game

I've been really missing some of the features of the old nuke pinpointer as a nukie. Not knowing how long until the nuke blows is extremely annoying for trying to extract with all operatives alive. Missing the infiltrator is also very annoying. Both of these, the old pinpointer handled, but neither functionalities came to the Fission360 when it replaced it. 

## Changelog

:cl: Melbert
expansion: The Fission360 has been upgraded, operatives. Examining a tablet running the Fission360 when a bomb is armed will show you the time remaining until detonation, and it can now point back to the Infiltrator. Hopefully you'll stop missing your pinpointers now.
expansion: The Syndicate Infiltrator is now a point of interest in the orbit menu that ghosts can jump to.
/:cl:
