### PR TITLE
Updates /code/game/objects/item/food/* to follow the style guide

### DIFF
--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -69,7 +69,7 @@
 
 /obj/item/food/breadslice/moldy/bacteria/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOLD, CELL_VIRUS_TABLE_GENERIC, rand(2,4), 25)
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOLD, CELL_VIRUS_TABLE_GENERIC, rand(2, 4), 25)
 
 
 /obj/item/food/bread/meat
@@ -328,19 +328,19 @@
 /obj/item/food/deepfryholder/proc/fry(cook_time = 30)
 	switch(cook_time)
 		if(0 to 15)
-			add_atom_colour(rgb(166,103,54), FIXED_COLOUR_PRIORITY)
+			add_atom_colour(rgb(166, 103, 54), FIXED_COLOUR_PRIORITY)
 			name = "lightly-fried [name]"
 			desc = "[desc] It's been lightly fried in a deep fryer."
 		if(16 to 49)
-			add_atom_colour(rgb(103,63,24), FIXED_COLOUR_PRIORITY)
+			add_atom_colour(rgb(103, 63, 24), FIXED_COLOUR_PRIORITY)
 			name = "fried [name]"
 			desc = "[desc] It's been fried, increasing its tastiness value by [rand(1, 75)]%."
 		if(50 to 59)
-			add_atom_colour(rgb(63,23,4), FIXED_COLOUR_PRIORITY)
+			add_atom_colour(rgb(63, 23, 4), FIXED_COLOUR_PRIORITY)
 			name = "deep-fried [name]"
 			desc = "[desc] Deep-fried to perfection."
 		if(60 to INFINITY)
-			add_atom_colour(rgb(33,19,9), FIXED_COLOUR_PRIORITY)
+			add_atom_colour(rgb(33, 19, 9), FIXED_COLOUR_PRIORITY)
 			name = "\proper the physical manifestation of the very concept of fried foods"
 			desc = "A heavily-fried... something. Who can tell anymore?"
 	foodtypes |= FRIED

--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -164,7 +164,7 @@
 	switch(paranormal_activity)
 		if(97 to 100)
 			audible_message("[src] rattles a length of chain.")
-			playsound(loc,'sound/misc/chain_rattling.ogg', 300, TRUE)
+			playsound(loc, 'sound/misc/chain_rattling.ogg', 300, TRUE)
 		if(91 to 96)
 			say(pick("OoOoOoo.", "OoooOOooOoo!!"))
 		if(84 to 90)
@@ -176,11 +176,11 @@
 			var/obj/machinery/light/L = locate(/obj/machinery/light) in view(4, src)
 			L?.flicker()
 		if(62 to 64)
-			playsound(loc,pick('sound/hallucinations/i_see_you1.ogg', 'sound/hallucinations/i_see_you2.ogg'), 50, TRUE, ignore_walls = FALSE)
+			playsound(loc, pick('sound/hallucinations/i_see_you1.ogg', 'sound/hallucinations/i_see_you2.ogg'), 50, TRUE, ignore_walls = FALSE)
 		if(61)
 			visible_message("[src] spews out a glob of ectoplasm!")
 			new /obj/effect/decal/cleanable/greenglow/ecto(loc)
-			playsound(loc,'sound/effects/splat.ogg', 200, TRUE)
+			playsound(loc, 'sound/effects/splat.ogg', 200, TRUE)
 
 		//If i was less lazy i would make the burger forcefeed itself to a nearby mob here.
 

--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -39,12 +39,13 @@
 /obj/item/food/burger/human/CheckParts(list/parts_list)
 	..()
 	var/obj/item/food/patty/human/human_patty = locate(/obj/item/food/patty/human) in contents
-	if(LAZYLEN(human_patty.custom_materials))
-		for(var/datum/material/meat/mob_meat/mob_meat_material in human_patty.custom_materials)
-			if(mob_meat_material.subjectname)
-				name = "[mob_meat_material.subjectname] burger"
-			else if(mob_meat_material.subjectjob)
-				name = "[mob_meat_material.subjectjob] burger"
+	if(!LAZYLEN(human_patty.custom_materials))
+		return
+	for(var/datum/material/meat/mob_meat/mob_meat_material in human_patty.custom_materials)
+		if(mob_meat_material.subjectname)
+			name = "[mob_meat_material.subjectname] burger"
+		else if(mob_meat_material.subjectjob)
+			name = "[mob_meat_material.subjectjob] burger"
 
 /obj/item/food/burger/corgi
 	name = "corgi burger"
@@ -173,8 +174,8 @@
 		if(71 to 83)
 			step(src, dir)
 		if(65 to 70)
-			var/obj/machinery/light/L = locate(/obj/machinery/light) in view(4, src)
-			L?.flicker()
+			var/obj/machinery/light/light = locate(/obj/machinery/light) in view(4, src)
+			light?.flicker()
 		if(62 to 64)
 			playsound(loc, pick('sound/hallucinations/i_see_you1.ogg', 'sound/hallucinations/i_see_you2.ogg'), 50, TRUE, ignore_walls = FALSE)
 		if(61)

--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -39,8 +39,6 @@
 /obj/item/food/burger/human/CheckParts(list/parts_list)
 	..()
 	var/obj/item/food/patty/human/human_patty = locate(/obj/item/food/patty/human) in contents
-	if(!LAZYLEN(human_patty.custom_materials))
-		return
 	for(var/datum/material/meat/mob_meat/mob_meat_material in human_patty.custom_materials)
 		if(mob_meat_material.subjectname)
 			name = "[mob_meat_material.subjectname] burger"

--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -185,7 +185,7 @@
 /obj/item/food/cake/birthday/MakeProcessable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/cakeslice/birthday, 5, 30)
 
-/obj/item/food/cake/birthday/microwave_act(obj/machinery/microwave/M) //super sekrit club
+/obj/item/food/cake/birthday/microwave_act(obj/machinery/microwave/microwave) //super sekrit club
 	new /obj/item/clothing/head/hardhat/cakehat(get_turf(src))
 	qdel(src)
 

--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -34,7 +34,7 @@
 	name = "plain cake slice"
 	desc = "Just a slice of cake, it is enough for everyone."
 	icon_state = "plaincake_slice"
-	tastes = list("sweetness" = 2,"cake" = 5)
+	tastes = list("sweetness" = 2, "cake" = 5)
 	foodtypes = GRAIN | DAIRY | SUGAR
 
 /obj/item/food/cake/carrot
@@ -211,14 +211,14 @@
 
 /obj/item/food/cake/birthday/energy/proc/energy_bite(mob/living/user)
 	to_chat(user, "<font color='red' size='5'>As you eat the cake, you accidentally hurt yourself on the embedded energy sword!</font>")
-	user.apply_damage(30,BRUTE,BODY_ZONE_HEAD)
+	user.apply_damage(30, BRUTE, BODY_ZONE_HEAD)
 	playsound(user, 'sound/weapons/blade1.ogg', 5, TRUE)
 
-/obj/item/food/cake/birthday/energy/attack(mob/living/M, mob/living/user)
+/obj/item/food/cake/birthday/energy/attack(mob/living/target_mob, mob/living/user)
 	. = ..()
-	if(HAS_TRAIT(user, TRAIT_PACIFISM) && M != user) //Prevents pacifists from attacking others directly
+	if(HAS_TRAIT(user, TRAIT_PACIFISM) && target_mob != user) //Prevents pacifists from attacking others directly
 		return
-	energy_bite(M, user)
+	energy_bite(target_mob, user)
 
 /obj/item/food/cake/birthday/energy/microwave_act(obj/machinery/microwave/M) //super sekriter club
 	new /obj/item/clothing/head/hardhat/cakehat/energycake(get_turf(src))
@@ -235,14 +235,14 @@
 
 /obj/item/food/cakeslice/birthday/energy/proc/energy_bite(mob/living/user)
 	to_chat(user, "<font color='red' size='5'>As you eat the cake slice, you accidentally hurt yourself on the embedded energy dagger!</font>")
-	user.apply_damage(18,BRUTE,BODY_ZONE_HEAD)
+	user.apply_damage(18, BRUTE, BODY_ZONE_HEAD)
 	playsound(user, 'sound/weapons/blade1.ogg', 5, TRUE)
 
-/obj/item/food/cakeslice/birthday/energy/attack(mob/living/M, mob/living/user)
+/obj/item/food/cakeslice/birthday/energy/attack(mob/living/target_mob, mob/living/user)
 	. = ..()
-	if(HAS_TRAIT(user, TRAIT_PACIFISM) && M != user) //Prevents pacifists from attacking others directly
+	if(HAS_TRAIT(user, TRAIT_PACIFISM) && target_mob != user) //Prevents pacifists from attacking others directly
 		return
-	energy_bite(M, user)
+	energy_bite(target_mob, user)
 
 /obj/item/food/cake/apple
 	name = "apple cake"
@@ -316,7 +316,7 @@
 	name = "blackberry and strawberry vanilla cake slice"
 	desc = "Just a slice of cake  filled with assortment of blackberries and strawberries!"
 	icon_state = "blackbarry_strawberries_cake_vanilla_slice"
-	tastes = list("blackberry" = 2, "strawberries" = 2, "vanilla" = 2, "sweetness" = 2,"cake" = 3)
+	tastes = list("blackberry" = 2, "strawberries" = 2, "vanilla" = 2, "sweetness" = 2, "cake" = 3)
 	foodtypes = GRAIN | DAIRY | FRUIT | SUGAR
 
 /obj/item/food/cake/bscc // blackbarry strawberries chocolate cake <- this is a relic from before resprite
@@ -324,7 +324,7 @@
 	desc = "A chocolate cake with five strawberries on top. For some reason, this configuration of cake is particularly aesthetically pleasing to AIs in SELF."
 	icon_state = "liars_cake"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/consumable/nutriment/vitamin = 5, /datum/reagent/consumable/coco = 5)
-	tastes = list("blackberry" = 2, "strawberries" = 2, "chocolate" = 2, "sweetness" = 2,"cake" = 3)
+	tastes = list("blackberry" = 2, "strawberries" = 2, "chocolate" = 2, "sweetness" = 2, "cake" = 3)
 	foodtypes = GRAIN | DAIRY | FRUIT | SUGAR
 
 /obj/item/food/cake/bscc/MakeProcessable()
@@ -334,7 +334,7 @@
 	name = "strawberry chocolate cake slice"
 	desc = "Just a slice of cake with five strawberries on top. For some reason, this configuration of cake is particularly aesthetically pleasing to AIs in SELF." //yes, I know the one referenced has cherries, but I'm not implementing a new cake today.
 	icon_state = "liars_slice"
-	tastes = list("strawberries" = 2, "chocolate" = 2, "sweetness" = 2,"cake" = 3)
+	tastes = list("strawberries" = 2, "chocolate" = 2, "sweetness" = 2, "cake" = 3)
 	foodtypes = GRAIN | DAIRY | FRUIT | SUGAR
 
 /obj/item/food/cake/holy_cake

--- a/code/game/objects/items/food/egg.dm
+++ b/code/game/objects/items/food/egg.dm
@@ -46,12 +46,11 @@
 
 	var/turf/hit_turf = get_turf(hit_atom)
 	new /obj/effect/decal/cleanable/food/egg_smudge(hit_turf)
-	if(!prob(13)) //Roughly a 1/8 (12.5%) chance to make a chick, as in Minecraft. I decided not to include the chances for the creation of multiple chicks from the impact of one egg, since that'd probably require nested prob()s or something (and people might think that it was a bug, anyway).
-		return
-
-	if(chick_count < MAX_CHICKENS) //Chicken code uses this MAX_CHICKENS variable, so I figured that I'd use it again here. Even this check and the check in chicken code both use the MAX_CHICKENS variable, they use independent counter variables and thus are independent of each other.
+	//Chicken code uses this MAX_CHICKENS variable, so I figured that I'd use it again here. Even this check and the check in chicken code both use the MAX_CHICKENS variable, they use independent counter variables and thus are independent of each other.
+	if(prob(13) && chick_count < MAX_CHICKENS) //Roughly a 1/8 (12.5%) chance to make a chick, as in Minecraft. I decided not to include the chances for the creation of multiple chicks from the impact of one egg, since that'd probably require nested prob()s or something (and people might think that it was a bug, anyway).
 		new /mob/living/simple_animal/chick(hit_turf)
 		chick_count++
+
 	reagents.expose(hit_atom, TOUCH)
 	qdel(src)
 

--- a/code/game/objects/items/food/egg.dm
+++ b/code/game/objects/items/food/egg.dm
@@ -42,35 +42,35 @@
 
 /obj/item/food/egg/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(!..()) //was it caught by a mob?
-		var/turf/T = get_turf(hit_atom)
-		new /obj/effect/decal/cleanable/food/egg_smudge(T)
+		var/turf/hit_turf = get_turf(hit_atom)
+		new /obj/effect/decal/cleanable/food/egg_smudge(hit_turf)
 		if(prob(13)) //Roughly a 1/8 (12.5%) chance to make a chick, as in Minecraft. I decided not to include the chances for the creation of multiple chicks from the impact of one egg, since that'd probably require nested prob()s or something (and people might think that it was a bug, anyway).
 			if(chick_count < MAX_CHICKENS) //Chicken code uses this MAX_CHICKENS variable, so I figured that I'd use it again here. Even this check and the check in chicken code both use the MAX_CHICKENS variable, they use independent counter variables and thus are independent of each other.
-				new /mob/living/simple_animal/chick(T)
+				new /mob/living/simple_animal/chick(hit_turf)
 				chick_count++
 		reagents.expose(hit_atom, TOUCH)
 		qdel(src)
 
-/obj/item/food/egg/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/toy/crayon))
-		var/obj/item/toy/crayon/C = W
-		var/clr = C.crayon_color
+/obj/item/food/egg/attackby(obj/item/item, mob/user, params)
+	if(istype(item, /obj/item/toy/crayon))
+		var/obj/item/toy/crayon/crayon = item
+		var/clr = crayon.crayon_color
 
 		if(!(clr in list("blue", "green", "mime", "orange", "purple", "rainbow", "red", "yellow")))
 			to_chat(usr, span_notice("[src] refuses to take on this colour!"))
 			return
 
-		to_chat(usr, span_notice("You colour [src] with [W]."))
+		to_chat(usr, span_notice("You colour [src] with [item]."))
 		icon_state = "egg-[clr]"
 
-	else if(istype(W, /obj/item/stamp/clown))
+	else if(istype(item, /obj/item/stamp/clown))
 		var/clowntype = pick("grock", "grimaldi", "rainbow", "chaos", "joker", "sexy", "standard", "bobble", "krusty", "bozo", "pennywise", "ronald", "jacobs", "kelly", "popov", "cluwne")
 		icon_state = "egg-clown-[clowntype]"
 		desc = "An egg that has been decorated with the grotesque, robustable likeness of a clown's face. "
-		to_chat(usr, span_notice("You stamp [src] with [W], creating an artistic and not remotely horrifying likeness of clown makeup."))
+		to_chat(usr, span_notice("You stamp [src] with [item], creating an artistic and not remotely horrifying likeness of clown makeup."))
 
-	else if(is_reagent_container(W))
-		var/obj/item/reagent_containers/dunk_test_container = W
+	else if(is_reagent_container(item))
+		var/obj/item/reagent_containers/dunk_test_container = item
 		if(dunk_test_container.is_drainable() && dunk_test_container.reagents.has_reagent(/datum/reagent/water))
 			to_chat(user, span_notice("You check if [src] is rotten."))
 			if(istype(src, /obj/item/food/egg/rotten))
@@ -152,19 +152,19 @@
 	foodtypes = MEAT | BREAKFAST | DAIRY
 	venue_value = FOOD_PRICE_CHEAP
 
-/obj/item/food/omelette/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/kitchen/fork))
-		var/obj/item/kitchen/fork/F = W
-		if(F.forkload)
+/obj/item/food/omelette/attackby(obj/item/item, mob/user, params)
+	if(istype(item, /obj/item/kitchen/fork))
+		var/obj/item/kitchen/fork/fork = item
+		if(fork.forkload)
 			to_chat(user, span_warning("You already have omelette on your fork!"))
 		else
-			F.icon_state = "forkloaded"
+			fork.icon_state = "forkloaded"
 			user.visible_message(span_notice("[user] takes a piece of omelette with [user.p_their()] fork!"), \
 				span_notice("You take a piece of omelette with your fork."))
 
-			var/datum/reagent/R = pick(reagents.reagent_list)
-			reagents.remove_reagent(R.type, 1)
-			F.forkload = R
+			var/datum/reagent/reagent = pick(reagents.reagent_list)
+			reagents.remove_reagent(reagent.type, 1)
+			fork.forkload = reagent
 			if(reagents.total_volume <= 0)
 				qdel(src)
 		return

--- a/code/game/objects/items/food/egg.dm
+++ b/code/game/objects/items/food/egg.dm
@@ -41,15 +41,19 @@
 	add_atom_colour(color, FIXED_COLOUR_PRIORITY)
 
 /obj/item/food/egg/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	if(!..()) //was it caught by a mob?
-		var/turf/hit_turf = get_turf(hit_atom)
-		new /obj/effect/decal/cleanable/food/egg_smudge(hit_turf)
-		if(prob(13)) //Roughly a 1/8 (12.5%) chance to make a chick, as in Minecraft. I decided not to include the chances for the creation of multiple chicks from the impact of one egg, since that'd probably require nested prob()s or something (and people might think that it was a bug, anyway).
-			if(chick_count < MAX_CHICKENS) //Chicken code uses this MAX_CHICKENS variable, so I figured that I'd use it again here. Even this check and the check in chicken code both use the MAX_CHICKENS variable, they use independent counter variables and thus are independent of each other.
-				new /mob/living/simple_animal/chick(hit_turf)
-				chick_count++
-		reagents.expose(hit_atom, TOUCH)
-		qdel(src)
+	if (..()) // was it caught by a mob?
+		return
+
+	var/turf/hit_turf = get_turf(hit_atom)
+	new /obj/effect/decal/cleanable/food/egg_smudge(hit_turf)
+	if(!prob(13)) //Roughly a 1/8 (12.5%) chance to make a chick, as in Minecraft. I decided not to include the chances for the creation of multiple chicks from the impact of one egg, since that'd probably require nested prob()s or something (and people might think that it was a bug, anyway).
+		return
+
+	if(chick_count < MAX_CHICKENS) //Chicken code uses this MAX_CHICKENS variable, so I figured that I'd use it again here. Even this check and the check in chicken code both use the MAX_CHICKENS variable, they use independent counter variables and thus are independent of each other.
+		new /mob/living/simple_animal/chick(hit_turf)
+		chick_count++
+	reagents.expose(hit_atom, TOUCH)
+	qdel(src)
 
 /obj/item/food/egg/attackby(obj/item/item, mob/user, params)
 	if(istype(item, /obj/item/toy/crayon))
@@ -71,12 +75,14 @@
 
 	else if(is_reagent_container(item))
 		var/obj/item/reagent_containers/dunk_test_container = item
-		if(dunk_test_container.is_drainable() && dunk_test_container.reagents.has_reagent(/datum/reagent/water))
-			to_chat(user, span_notice("You check if [src] is rotten."))
-			if(istype(src, /obj/item/food/egg/rotten))
-				to_chat(user, span_warning("[src] floats in the [dunk_test_container]!"))
-			else
-				to_chat(user, span_notice("[src] sinks into the [dunk_test_container]!"))
+		if (!dunk_test_container.is_drainable() || !dunk_test_container.reagents.has_reagent(/datum/reagent/water))
+			return
+
+		to_chat(user, span_notice("You check if [src] is rotten."))
+		if(istype(src, /obj/item/food/egg/rotten))
+			to_chat(user, span_warning("[src] floats in the [dunk_test_container]!"))
+		else
+			to_chat(user, span_notice("[src] sinks into the [dunk_test_container]!"))
 	else
 		..()
 

--- a/code/game/objects/items/food/frozen.dm
+++ b/code/game/objects/items/food/frozen.dm
@@ -267,7 +267,7 @@
 	icon = 'icons/obj/food/frozen_treats.dmi'
 	icon_state = "popsicle_stick"
 	desc = "This humble little stick usually carries a frozen treat, at the moment it seems freed from this Atlassian burden."
-	custom_materials = list(/datum/material/wood=20)
+	custom_materials = list(/datum/material/wood = 20)
 	w_class = WEIGHT_CLASS_TINY
 	force = 0
 

--- a/code/game/objects/items/food/frozen.dm
+++ b/code/game/objects/items/food/frozen.dm
@@ -225,11 +225,13 @@
 	tastes = list("beetlejuice")
 	trash_type = /obj/item/popsicle_stick
 	w_class = WEIGHT_CLASS_SMALL
+	foodtypes = DAIRY | SUGAR
+	food_flags = FOOD_FINGER_FOOD
+
 	var/overlay_state = "creamsicle_o" //This is the edible part of the popsicle.
 	var/bite_states = 4 //This value value is used for correctly setting the bite_consumption to ensure every bite changes the sprite. Do not set to zero.
 	var/bitecount = 0
-	foodtypes = DAIRY | SUGAR
-	food_flags = FOOD_FINGER_FOOD
+
 
 /obj/item/food/popsicle/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/food/lizard.dm
+++ b/code/game/objects/items/food/lizard.dm
@@ -14,7 +14,7 @@
 
 /obj/item/food/raw_tiziran_sausage/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/dryable,  /obj/item/food/tiziran_sausage)
+	AddElement(/datum/element/dryable, /obj/item/food/tiziran_sausage)
 
 /obj/item/food/tiziran_sausage
 	name = "\improper Tiziran blood sausage"

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -416,7 +416,7 @@
 /obj/item/food/monkeycube/proc/finish_suicide(mob/living/user) ///internal proc called by a monkeycube's suicide_act using a timer and callback. takes as argument the mob/living who activated the suicide
 	if(QDELETED(user) || QDELETED(src))
 		return
-	if((src.loc != user)) //how the hell did you manage this
+	if(src.loc != user) //how the hell did you manage this
 		to_chat(user, span_warning("Something happened to [src]..."))
 		return
 	Expand()
@@ -1076,7 +1076,6 @@
 	..()
 	if(!istype(original_atom, /obj/item/food/meat/slab))
 		return
-
 	var/obj/item/food/meat/slab/original_slab = original_atom
 	var/mutable_appearance/filling = mutable_appearance(icon, "rawcutlet_coloration")
 	filling.color = original_slab.slab_color
@@ -1098,14 +1097,15 @@
 
 /obj/item/food/meat/rawcutlet/plain/human/OnCreatedFromProcessing(mob/living/user, obj/item/item, list/chosen_option, atom/original_atom)
 	. = ..()
-	if(istype(original_atom, /obj/item/food/meat))
-		var/obj/item/food/meat/origin_meat = original_atom
-		subjectname = origin_meat.subjectname
-		subjectjob = origin_meat.subjectjob
-		if(subjectname)
-			name = "raw [origin_meat.subjectname] cutlet"
-		else if(subjectjob)
-			name = "raw [origin_meat.subjectjob] cutlet"
+	if(!istype(original_atom, /obj/item/food/meat))
+		return
+	var/obj/item/food/meat/origin_meat = original_atom
+	subjectname = origin_meat.subjectname
+	subjectjob = origin_meat.subjectjob
+	if(subjectname)
+		name = "raw [origin_meat.subjectname] cutlet"
+	else if(subjectjob)
+		name = "raw [origin_meat.subjectjob] cutlet"
 
 /obj/item/food/meat/rawcutlet/killertomato
 	name = "raw killer tomato cutlet"

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -615,9 +615,9 @@
 
 /obj/item/food/meat
 	custom_materials = list(/datum/material/meat = MINERAL_MATERIAL_AMOUNT * 4)
+	w_class = WEIGHT_CLASS_SMALL
 	var/subjectname = ""
 	var/subjectjob = null
-	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/meat/slab
 	name = "meat"
@@ -741,6 +741,7 @@
 
 /obj/item/food/meat/slab/synthmeat/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/plain/synth, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE)
+
 /obj/item/food/meat/slab/meatproduct
 	name = "meat product"
 	icon_state = "meatproduct"
@@ -1073,13 +1074,15 @@
 
 /obj/item/food/meat/rawcutlet/OnCreatedFromProcessing(mob/living/user, obj/item/item, list/chosen_option, atom/original_atom)
 	..()
-	if(istype(original_atom, /obj/item/food/meat/slab))
-		var/obj/item/food/meat/slab/original_slab = original_atom
-		var/mutable_appearance/filling = mutable_appearance(icon, "rawcutlet_coloration")
-		filling.color = original_slab.slab_color
-		add_overlay(filling)
-		name = "raw [original_atom.name] cutlet"
-		meat_type = original_atom.name
+	if(!istype(original_atom, /obj/item/food/meat/slab))
+		return
+
+	var/obj/item/food/meat/slab/original_slab = original_atom
+	var/mutable_appearance/filling = mutable_appearance(icon, "rawcutlet_coloration")
+	filling.color = original_slab.slab_color
+	add_overlay(filling)
+	name = "raw [original_atom.name] cutlet"
+	meat_type = original_atom.name
 
 /obj/item/food/meat/rawcutlet/plain
 	foodtypes = MEAT

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -396,32 +396,32 @@
 		visible_message(span_notice("[src] fails to expand!"))
 	qdel(src)
 
-/obj/item/food/monkeycube/suicide_act(mob/living/M)
-	M.visible_message(span_suicide("[M] is putting [src] in [M.p_their()] mouth! It looks like [M.p_theyre()] trying to commit suicide!"))
-	var/eating_success = do_after(M, 1 SECONDS, src)
-	if(QDELETED(M)) //qdeletion: the nuclear option of self-harm
+/obj/item/food/monkeycube/suicide_act(mob/living/user)
+	user.visible_message(span_suicide("[user] is putting [src] in [user.p_their()] mouth! It looks like [user.p_theyre()] trying to commit suicide!"))
+	var/eating_success = do_after(user, 1 SECONDS, src)
+	if(QDELETED(user)) //qdeletion: the nuclear option of self-harm
 		return SHAME
 	if(!eating_success || QDELETED(src)) //checks if src is gone or if they failed to wait for a second
-		M.visible_message(span_suicide("[M] chickens out!"))
+		user.visible_message(span_suicide("[user] chickens out!"))
 		return SHAME
-	if(HAS_TRAIT(M, TRAIT_NOHUNGER)) //plasmamen don't have saliva/stomach acid
-		M.visible_message(span_suicide("[M] realizes [M.p_their()] body won't activate [src]!")
+	if(HAS_TRAIT(user, TRAIT_NOHUNGER)) //plasmamen don't have saliva/stomach acid
+		user.visible_message(span_suicide("[user] realizes [user.p_their()] body won't activate [src]!")
 		,span_warning("Your body won't activate [src]..."))
 		return SHAME
-	playsound(M, 'sound/items/eatfood.ogg', rand(10, 50), TRUE)
-	M.temporarilyRemoveItemFromInventory(src) //removes from hands, keeps in M
-	addtimer(CALLBACK(src, .proc/finish_suicide, M), 15) //you've eaten it, you can run now
+	playsound(user, 'sound/items/eatfood.ogg', rand(10, 50), TRUE)
+	user.temporarilyRemoveItemFromInventory(src) //removes from hands, keeps in M
+	addtimer(CALLBACK(src, .proc/finish_suicide, user), 15) //you've eaten it, you can run now
 	return MANUAL_SUICIDE
 
-/obj/item/food/monkeycube/proc/finish_suicide(mob/living/M) ///internal proc called by a monkeycube's suicide_act using a timer and callback. takes as argument the mob/living who activated the suicide
-	if(QDELETED(M) || QDELETED(src))
+/obj/item/food/monkeycube/proc/finish_suicide(mob/living/user) ///internal proc called by a monkeycube's suicide_act using a timer and callback. takes as argument the mob/living who activated the suicide
+	if(QDELETED(user) || QDELETED(src))
 		return
-	if((src.loc != M)) //how the hell did you manage this
-		to_chat(M, span_warning("Something happened to [src]..."))
+	if((src.loc != user)) //how the hell did you manage this
+		to_chat(user, span_warning("Something happened to [src]..."))
 		return
 	Expand()
-	M.visible_message(span_danger("[M]'s torso bursts open as a primate emerges!"))
-	M.gib(null, TRUE, null, TRUE)
+	user.visible_message(span_danger("[user]'s torso bursts open as a primate emerges!"))
+	user.gib(null, TRUE, null, TRUE)
 
 /obj/item/food/monkeycube/syndicate
 	faction = list("neutral", ROLE_SYNDICATE)
@@ -1071,7 +1071,7 @@
 /obj/item/food/meat/rawcutlet/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/cutlet/plain, rand(35 SECONDS, 50 SECONDS), TRUE, TRUE)
 
-/obj/item/food/meat/rawcutlet/OnCreatedFromProcessing(mob/living/user, obj/item/I, list/chosen_option, atom/original_atom)
+/obj/item/food/meat/rawcutlet/OnCreatedFromProcessing(mob/living/user, obj/item/item, list/chosen_option, atom/original_atom)
 	..()
 	if(istype(original_atom, /obj/item/food/meat/slab))
 		var/obj/item/food/meat/slab/original_slab = original_atom
@@ -1093,7 +1093,7 @@
 /obj/item/food/meat/rawcutlet/plain/human/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/cutlet/plain/human, rand(35 SECONDS, 50 SECONDS), TRUE, TRUE)
 
-/obj/item/food/meat/rawcutlet/plain/human/OnCreatedFromProcessing(mob/living/user, obj/item/I, list/chosen_option, atom/original_atom)
+/obj/item/food/meat/rawcutlet/plain/human/OnCreatedFromProcessing(mob/living/user, obj/item/item, list/chosen_option, atom/original_atom)
 	. = ..()
 	if(istype(original_atom, /obj/item/food/meat))
 		var/obj/item/food/meat/origin_meat = original_atom

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -22,7 +22,7 @@
 	bite_consumption = 6
 	tastes = list("fish" = 1)
 	foodtypes = SEAFOOD
-	eatverbs = list("bite","chew","gnaw","swallow","chomp")
+	eatverbs = list("bite", "chew", "gnaw", "swallow", "chomp")
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/fishmeat/carp
@@ -297,7 +297,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 5, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("meat" = 1)
 	foodtypes = MEAT | RAW
-	eatverbs = list("bite","chew","nibble","deep throat","gobble","chomp")
+	eatverbs = list("bite", "chew", "nibble", "deep throat", "gobble", "chomp")
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/raw_sausage/MakeGrillable()
@@ -311,7 +311,7 @@
 	tastes = list("meat" = 1)
 	foodtypes = MEAT | BREAKFAST
 	food_flags = FOOD_FINGER_FOOD
-	eatverbs = list("bite","chew","nibble","deep throat","gobble","chomp")
+	eatverbs = list("bite", "chew", "nibble", "deep throat", "gobble", "chomp")
 	w_class = WEIGHT_CLASS_SMALL
 	burns_on_grill = TRUE
 	venue_value = FOOD_PRICE_CHEAP
@@ -408,7 +408,7 @@
 		M.visible_message(span_suicide("[M] realizes [M.p_their()] body won't activate [src]!")
 		,span_warning("Your body won't activate [src]..."))
 		return SHAME
-	playsound(M, 'sound/items/eatfood.ogg', rand(10,50), TRUE)
+	playsound(M, 'sound/items/eatfood.ogg', rand(10, 50), TRUE)
 	M.temporarilyRemoveItemFromInventory(src) //removes from hands, keeps in M
 	addtimer(CALLBACK(src, .proc/finish_suicide, M), 15) //you've eaten it, you can run now
 	return MANUAL_SUICIDE
@@ -456,7 +456,7 @@
 	icon_state = "stewedsoymeat"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/protein = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("soy" = 1, "vegetables" = 1)
-	eatverbs = list("slurp","sip","inhale","drink")
+	eatverbs = list("slurp", "sip", "inhale", "drink")
 	foodtypes = VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
 
@@ -740,7 +740,7 @@
 	foodtypes = RAW | MEAT //hurr durr chemicals we're harmed in the production of this meat thus its non-vegan.
 
 /obj/item/food/meat/slab/synthmeat/MakeGrillable()
-	AddComponent(/datum/component/grillable,/obj/item/food/meat/steak/plain/synth, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE)
+	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/plain/synth, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE)
 /obj/item/food/meat/slab/meatproduct
 	name = "meat product"
 	icon_state = "meatproduct"

--- a/code/game/objects/items/food/mexican.dm
+++ b/code/game/objects/items/food/mexican.dm
@@ -12,7 +12,7 @@
 	name = "burrito"
 	desc = "Tortilla wrapped goodness."
 	icon_state = "burrito"
-	food_reagents = list(/datum/reagent/consumable/nutriment = 2,/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/nutriment/vitamin = 1)
+	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/nutriment/vitamin = 1)
 	tastes = list("torilla" = 2, "beans" = 3)
 	foodtypes = GRAIN
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -405,7 +405,7 @@
 	slot_flags = ITEM_SLOT_MASK
 	w_class = WEIGHT_CLASS_TINY
 	var/mutable_appearance/head
-	var/headcolor = rgb(0, 0, 0)
+	var/head_color = rgb(0, 0, 0)
 
 /obj/item/food/lollipop/Initialize(mapload)
 	. = ..()
@@ -414,7 +414,7 @@
 	AddElement(/datum/element/chewable)
 
 /obj/item/food/lollipop/proc/change_head_color(C)
-	headcolor = C
+	head_color = C
 	cut_overlay(head)
 	head.color = C
 	add_overlay(head)

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -1,6 +1,16 @@
 
 ////////////////////////////////////////////OTHER////////////////////////////////////////////
 
+/obj/item/food/cheese
+	name = "cheese wedge"
+	desc = "A wedge of delicious Cheddar. The cheese wheel it was cut from can't have gone far."
+	icon_state = "cheesewedge"
+	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/protein = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
+	tastes = list("cheese" = 1)
+	foodtypes = DAIRY
+	w_class = WEIGHT_CLASS_SMALL
+	/// used to determine how much health rats/regal rats recover when they eat it.
+	var/rat_heal = 10
 
 /obj/item/food/cheese/wheel
 	name = "cheese wheel"
@@ -25,17 +35,6 @@
 	w_class = WEIGHT_CLASS_BULKY
 	tastes = list("cheese" = 4, "royalty" = 1)
 	rat_heal = 70
-
-/obj/item/food/cheese
-	name = "cheese wedge"
-	desc = "A wedge of delicious Cheddar. The cheese wheel it was cut from can't have gone far."
-	icon_state = "cheesewedge"
-	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/protein = 1, /datum/reagent/consumable/nutriment/vitamin = 1)
-	tastes = list("cheese" = 1)
-	foodtypes = DAIRY
-	w_class = WEIGHT_CLASS_SMALL
-	/// used to determine how much health rats/regal rats recover when they eat it.
-	var/rat_heal = 10
 
 /obj/item/food/cheese/Initialize(mapload)
 	. = ..()
@@ -400,13 +399,13 @@
 	icon_state = "lollipop_stick"
 	inhand_icon_state = "lollipop_stick"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/iron = 10, /datum/reagent/consumable/sugar = 5, /datum/reagent/medicine/omnizine = 2) //Honk
-	var/mutable_appearance/head
-	var/headcolor = rgb(0, 0, 0)
 	tastes = list("candy" = 1)
 	foodtypes = JUNKFOOD | SUGAR
 	food_flags = FOOD_FINGER_FOOD
 	slot_flags = ITEM_SLOT_MASK
 	w_class = WEIGHT_CLASS_TINY
+	var/mutable_appearance/head
+	var/headcolor = rgb(0, 0, 0)
 
 /obj/item/food/lollipop/Initialize(mapload)
 	. = ..()
@@ -702,7 +701,7 @@
 				junkiness = junkiness,\
 				check_liked = CALLBACK(src, .proc/check_liked))
 
-/obj/item/food/rationpack/proc/check_liked(fraction, mob/M) //Nobody likes rationpacks. Nobody.
+/obj/item/food/rationpack/proc/check_liked(fraction, mob/mob) //Nobody likes rationpacks. Nobody.
 	return FOOD_DISLIKED
 
 /obj/item/food/ant_candy

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -107,7 +107,7 @@
 	bite_consumption = 0.1 //this snack is supposed to be eating during looooong time. And this it not dinner food! --rastaf0
 	tastes = list("popcorn" = 3, "butter" = 1)
 	foodtypes = JUNKFOOD
-	eatverbs = list("bite","nibble","gnaw","gobble","chomp")
+	eatverbs = list("bite", "nibble", "gnaw", "gobble", "chomp")
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/loadedbakedpotato
@@ -211,7 +211,7 @@
 
 /obj/item/food/badrecipe/moldy/bacteria/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOLD, CELL_VIRUS_TABLE_GENERIC, rand(2,4), 25)
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOLD, CELL_VIRUS_TABLE_GENERIC, rand(2, 4), 25)
 
 ///Prevents grilling burnt shit from well, burning.
 /obj/item/food/badrecipe/proc/OnGrill()
@@ -497,9 +497,9 @@
 		return
 	if(prob(15))
 		new /datum/hallucination/oh_yeah(victim)
-		to_chat(victim, span_colossus("<b>[pick("I AM IMMORTAL.","I SHALL TAKE YOUR WORLD.","I SEE YOU.","YOU CANNOT ESCAPE ME FOREVER.","NOTHING CAN HOLD ME.")]</b>"))
+		to_chat(victim, span_colossus("<b>[pick("I AM IMMORTAL.", "I SHALL TAKE YOUR WORLD.", "I SEE YOU.", "YOU CANNOT ESCAPE ME FOREVER.", "NOTHING CAN HOLD ME.")]</b>"))
 	else
-		to_chat(victim, span_warning("[pick("You hear faint whispers.","You smell ash.","You feel hot.","You hear a roar in the distance.")]"))
+		to_chat(victim, span_warning("[pick("You hear faint whispers.", "You smell ash.", "You feel hot.", "You hear a roar in the distance.")]"))
 
 /obj/item/food/gumball
 	name = "gumball"
@@ -541,16 +541,16 @@
 	. = ..()
 	. += span_notice("If you had a rod you could make <b>butter on a stick</b>.")
 
-/obj/item/food/butter/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/stack/rods))
-		var/obj/item/stack/rods/R = W
-		if(!R.use(1))//borgs can still fail this if they have no metal
+/obj/item/food/butter/attackby(obj/item/item, mob/user, params)
+	if(istype(item, /obj/item/stack/rods))
+		var/obj/item/stack/rods/rods = item
+		if(!rods.use(1))//borgs can still fail this if they have no metal
 			to_chat(user, span_warning("You do not have enough iron to put [src] on a stick!"))
 			return ..()
 		to_chat(user, span_notice("You stick the rod into the stick of butter."))
 		var/obj/item/food/butter/on_a_stick/new_item = new(usr.loc)
-		var/replace = (user.get_inactive_held_item() == R)
-		if(!R && replace)
+		var/replace = (user.get_inactive_held_item() == rods)
+		if(!rods && replace)
 			user.put_in_hands(new_item)
 		qdel(src)
 		return TRUE
@@ -618,7 +618,7 @@
 		icon_state = "[icon_state]_open"
 	return ..()
 
-/obj/item/food/canned/attack(mob/living/M, mob/user, def_zone)
+/obj/item/food/canned/attack(mob/living/target, mob/user, def_zone)
 	if (!is_drainable())
 		to_chat(user, span_warning("[src]'s lid hasn't been opened!"))
 		return FALSE
@@ -758,5 +758,5 @@
 		span_nicegreen("You chow down on [src]."),
 		span_notice("You hear sloppy eating noises."))
 	SEND_SIGNAL(src, COMSIG_FOOD_CONSUMED, hungry_pet, dog_mom ? dog_mom : hungry_pet)//If there is no dog mom, we assume the pet fed itself.
-	playsound(loc,'sound/items/eatfood.ogg', rand(30,50), TRUE)
+	playsound(loc, 'sound/items/eatfood.ogg', rand(30, 50), TRUE)
 	qdel(src)

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -54,8 +54,8 @@
 	return "[icon_state]_inbox"
 
 ///Override for checkliked in edible component, because all cops LOVE donuts
-/obj/item/food/donut/proc/check_liked(fraction, mob/living/carbon/human/H)
-	if(!HAS_TRAIT(H, TRAIT_AGEUSIA) && H.mind && HAS_TRAIT(H.mind, TRAIT_DONUT_LOVER))
+/obj/item/food/donut/proc/check_liked(fraction, mob/living/carbon/human/consumer)
+	if(!HAS_TRAIT(consumer, TRAIT_AGEUSIA) && consumer.mind && HAS_TRAIT(consumer.mind, TRAIT_DONUT_LOVER))
 		return FOOD_LIKED
 
 //Use this donut ingame
@@ -367,7 +367,7 @@
 
 /obj/item/food/muffin/moffin/Initialize(mapload)
 	. = ..()
-	icon_state = "[icon_state]_[rand(1,3)]"
+	icon_state = "[icon_state]_[rand(1, 3)]"
 
 /obj/item/food/muffin/moffin/examine(mob/user)
 	. = ..()
@@ -785,7 +785,7 @@
 	name = contents.len ? "stack of pancakes" : initial(name)
 	return ..()
 
-/obj/item/food/pancakes/update_icon(updates=ALL)
+/obj/item/food/pancakes/update_icon(updates = ALL)
 	if(!(updates & UPDATE_OVERLAYS))
 		return ..()
 
@@ -843,17 +843,17 @@
 	..()
 
 /obj/item/food/pancakes/proc/update_snack_overlays(obj/item/pancake)
-	var/mutable_appearance/pancake_visual = mutable_appearance(icon, "[pancake.inhand_icon_state]_[rand(1,3)]")
-	pancake_visual.pixel_x = rand(-1,1)
+	var/mutable_appearance/pancake_visual = mutable_appearance(icon, "[pancake.inhand_icon_state]_[rand(1, 3)]")
+	pancake_visual.pixel_x = rand(-1, 1)
 	pancake_visual.pixel_y = 3 * contents.len - 1
 	add_overlay(pancake_visual)
 	update_appearance()
 
-/obj/item/food/pancakes/attack(mob/M, mob/living/user, params, stacked = TRUE)
+/obj/item/food/pancakes/attack(mob/target, mob/living/user, params, stacked = TRUE)
 	if(user.combat_mode || !contents.len || !stacked)
 		return ..()
-	var/obj/item/O = contents[contents.len]
-	. = O.attack(M, user, params, FALSE)
+	var/obj/item/item = contents[contents.len]
+	. = item.attack(target, user, params, FALSE)
 	update_appearance()
 
 #undef PANCAKE_MAX_STACK

--- a/code/game/objects/items/food/pie.dm
+++ b/code/game/objects/items/food/pie.dm
@@ -44,8 +44,8 @@
 /obj/item/food/pie/cream/proc/splat(atom/movable/hit_atom)
 	if(isliving(loc)) //someone caught us!
 		return
-	var/turf/T = get_turf(hit_atom)
-	new/obj/effect/decal/cleanable/food/pie_smudge(T)
+	var/turf/hit_turf = get_turf(hit_atom)
+	new/obj/effect/decal/cleanable/food/pie_smudge(hit_turf)
 	if(reagents?.total_volume)
 		reagents.expose(hit_atom, TOUCH)
 	if(isliving(hit_atom))

--- a/code/game/objects/items/food/pizza.dm
+++ b/code/game/objects/items/food/pizza.dm
@@ -286,7 +286,7 @@
 
 /obj/item/food/pizzaslice/moldy/bacteria/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOLD, CELL_VIRUS_TABLE_GENERIC, rand(2,4), 25)
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOLD, CELL_VIRUS_TABLE_GENERIC, rand(2, 4), 25)
 
 
 // Arnold Pizza
@@ -311,8 +311,8 @@
 	AddComponent(/datum/component/bakeable, /obj/item/food/pizza/arnold, rand(70 SECONDS, 80 SECONDS), TRUE, TRUE)
 
 //fuck it, i will leave this at the food level for now.
-/obj/item/food/proc/try_break_off(mob/living/M, mob/living/user) //maybe i give you a pizza maybe i break off your arm
-	if(prob(50) || (M != user) || !iscarbon(user) || HAS_TRAIT(user, TRAIT_NODISMEMBER))
+/obj/item/food/proc/try_break_off(mob/living/attacker, mob/living/user) //maybe i give you a pizza maybe i break off your arm
+	if(prob(50) || (attacker != user) || !iscarbon(user) || HAS_TRAIT(user, TRAIT_NODISMEMBER))
 		return
 	var/obj/item/bodypart/l_arm = user.get_bodypart(BODY_ZONE_L_ARM)
 	var/obj/item/bodypart/r_arm = user.get_bodypart(BODY_ZONE_R_ARM)
@@ -323,21 +323,21 @@
 	user.visible_message(span_warning("\The [src] breaks off [user]'s arm!"), span_warning("\The [src] breaks off your arm!"))
 	playsound(user, "desecration", 50, TRUE, -1)
 
-/obj/item/food/proc/i_kill_you(obj/item/I, mob/living/user)
-	if(istype(I, /obj/item/food/pineappleslice))
+/obj/item/food/proc/i_kill_you(obj/item/item, mob/living/user)
+	if(istype(item, /obj/item/food/pineappleslice))
 		to_chat(user, "<font color='red' size='7'>If you want something crazy like pineapple, I'll kill you.</font>") //this is in bigger text because it's hard to spam something that gibs you, and so that you're perfectly aware of the reason why you died
 		user.gib() //if you want something crazy like pineapple, i'll kill you
-	else if(istype(I, /obj/item/food/grown/mushroom) && iscarbon(user))
+	else if(istype(item, /obj/item/food/grown/mushroom) && iscarbon(user))
 		to_chat(user, span_userdanger("So, if you want mushroom, shut up.")) //not as large as the pineapple text, because you could in theory spam it
 		var/mob/living/carbon/shutup = user
 		shutup.gain_trauma(/datum/brain_trauma/severe/mute)
 
-/obj/item/food/pizza/arnold/attack(mob/living/M, mob/living/user)
+/obj/item/food/pizza/arnold/attack(mob/living/target, mob/living/user)
 	. = ..()
-	try_break_off(M, user)
+	try_break_off(target, user)
 
-/obj/item/food/pizza/arnold/attackby(obj/item/I, mob/user)
-	i_kill_you(I, user)
+/obj/item/food/pizza/arnold/attackby(obj/item/item, mob/user)
+	i_kill_you(item, user)
 	. = ..()
 
 /obj/item/food/pizzaslice/arnold
@@ -347,12 +347,12 @@
 	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "pepperoni" = 2, "9 millimeter bullets" = 2)
 	foodtypes = GRAIN | VEGETABLES | DAIRY | MEAT
 
-/obj/item/food/pizzaslice/arnold/attack(mob/living/M, mob/living/user)
+/obj/item/food/pizzaslice/arnold/attack(mob/living/target, mob/living/user)
 	. =..()
-	try_break_off(M, user)
+	try_break_off(target, user)
 
-/obj/item/food/pizzaslice/arnold/attackby(obj/item/I, mob/user)
-	i_kill_you(I, user)
+/obj/item/food/pizzaslice/arnold/attackby(obj/item/item, mob/user)
+	i_kill_you(item, user)
 	. = ..()
 
 // Ant Pizza, now with more ants.

--- a/code/game/objects/items/food/salad.dm
+++ b/code/game/objects/items/food/salad.dm
@@ -8,7 +8,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 7, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("leaves" = 1)
 	foodtypes = VEGETABLES
-	eatverbs = list("devour","nibble","gnaw","gobble","chomp") //who the fuck gnaws and devours on a salad
+	eatverbs = list("devour", "nibble", "gnaw", "gobble", "chomp") //who the fuck gnaws and devours on a salad
 	venue_value = FOOD_PRICE_NORMAL
 
 /obj/item/food/salad/aesirsalad

--- a/code/game/objects/items/food/snacks.dm
+++ b/code/game/objects/items/food/snacks.dm
@@ -46,8 +46,8 @@
 /obj/item/food/candy/bronx/proc/after_eat(mob/living/eater)
 	if(ishuman(eater))
 		var/mob/living/carbon/human/carl = eater
-		var/datum/disease/P = new /datum/disease/parasite()
-		carl.ForceContractDisease(P, make_copy=FALSE, del_on_fail=TRUE)
+		var/datum/disease/disease = new /datum/disease/parasite()
+		carl.ForceContractDisease(disease, make_copy = FALSE, del_on_fail = TRUE)
 
 /obj/item/food/candy/bronx/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/food/soup.dm
+++ b/code/game/objects/items/food/soup.dm
@@ -7,7 +7,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 8, /datum/reagent/water = 5, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("tasteless soup" = 1)
 	foodtypes = VEGETABLES
-	eatverbs = list("slurp","sip","inhale","drink")
+	eatverbs = list("slurp", "sip", "inhale", "drink")
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/soup/wish
@@ -185,7 +185,7 @@
 
 /obj/item/food/soup/beet/Initialize(mapload)
 	. = ..()
-	name = pick("borsch","bortsch","borstch","borsh","borshch","borscht")
+	name = pick("borsch", "bortsch", "borstch", "borsh", "borshch", "borscht")
 	tastes = list(name = 1)
 
 

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -545,7 +545,7 @@
 /obj/projectile/bullet/reusable/lollipop/Initialize(mapload)
 	. = ..()
 	var/obj/item/food/lollipop/S = new ammo_type(src)
-	color2 = S.headcolor
+	color2 = S.head_color
 	var/mutable_appearance/head = mutable_appearance('icons/obj/guns/projectiles.dmi', "lollipop_2")
 	head.color = color2
 	add_overlay(head)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Updates every file in /code/game/objects/item/food/ to follow the style guide.
if i missed something please lmk


**regex used for finding errors**

`,[^ \\]`  # For finding non spaced commas
`[^ +/*-=]=[^ =]` # finding non spaced equal signs
`/[A-Za-z]([, )]|$)` finding single letter variable assignments

## Why It's Good For The **CODEBASE**

i like giving the maintainers a shitload of work (and burning myself out in the process)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Nothing to see here

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
