### PR TITLE
PORT: Makes diagonal movement euclidean

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -4,6 +4,8 @@
 
 #define NUM_E 2.71828183
 
+#define SQRT_2 1.414214 //CLOSE ENOUGH!
+
 #define PI 3.1416
 #define INFINITY 1e31 //closer then enough
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -144,7 +144,7 @@
 	. = ..()
 
 	if((direct & (direct - 1)) && mob.loc == new_loc) //moved diagonally successfully
-		add_delay *= 2
+		add_delay *= SQRT_2
 	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay))
 	move_delay += add_delay
 	if(.) // If mob is null here, we deserve the runtime

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -122,7 +122,7 @@
 
 	//We are now going to move
 	var/add_delay = mob.cached_multiplicative_slowdown
-	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay * ( (NSCOMPONENT(direct) && EWCOMPONENT(direct)) ? 2 : 1 ) )) // set it now in case of pulled objects
+	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay * ( (NSCOMPONENT(direct) && EWCOMPONENT(direct)) ? SQRT_2 : 1 ) )) // set it now in case of pulled objects
 	if(old_move_delay + (add_delay*MOVEMENT_DELAY_BUFFER_DELTA) + MOVEMENT_DELAY_BUFFER > world.time)
 		move_delay = old_move_delay
 	else


### PR DESCRIPTION
## About The Pull Request

Ports: https://github.com/Citadel-Station-13/Citadel-Station-13/pull/14911

![image](https://user-images.githubusercontent.com/9026500/143377336-dff037f0-0f91-49a8-aed7-6dd5b0716f79.png)

To quote from the other PR:

"Right now, diagonal movement takes twice as long as orthogonal movement. In other words, in terms of mob movement, SS13 treats the tile grid as a taxicab geometry. The issue here is that much of the game doesn't. Projectiles are euclidean: it takes just as much time to move 10 meters diagonally as it does to move 10 meters orthogonally. The thing is, 10 meters diagonally is just under 7 meters north/south and 7 meters east/west, which always takes the equivalent of 14 orthogonal tile movements for units.

In other words: on diagonals, projectiles move sqrt(2) times as fast as mobs do. This fixes that."

## Why It's Good For The Game

Have two comparisons to decide:

**Without SQRT**

https://user-images.githubusercontent.com/9026500/143377073-3f86055a-75a2-4fee-a3ef-1814bfeb97d6.mp4

**With SQRT**

https://user-images.githubusercontent.com/9026500/143377110-8fc7570c-1d80-45e2-8902-9af76084b1fd.mp4

In my humble opinion, I feel like this improves movement by a large degree.

## Changelog

:cl:
balance: Diagonal movement is now slightly faster
/:cl:

