### PR TITLE
fixes vent and scrubber map edited names resetting

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -181,7 +181,9 @@
 	radio_connection.post_signal(src, signal, radio_filter_out)
 
 /obj/machinery/atmospherics/components/unary/vent_pump/update_name()
-	..()
+	. = ..()
+	if(override_naming)
+		return
 	var/area/vent_area = get_area(src)
 	name = "\proper [vent_area.name] [name] [id_tag]"
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -121,6 +121,8 @@
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/update_name()
 	. = ..()
+	if(override_naming)
+		return
 	var/area/scrub_area = get_area(src)
 	name = "\proper [scrub_area.name] [name] [id_tag]"
 


### PR DESCRIPTION
Fixes #63006

:cl: ShizCalev
fix: Fixed mapeditted scrubbers and vents having the incorrect names.
/:cl:
