### PR TITLE
Account Registration Device now tells the user his new account ID number, adds it to service and cargo techfabs for accessibility.

### DIFF
--- a/code/game/machinery/accounting.dm
+++ b/code/game/machinery/accounting.dm
@@ -35,6 +35,7 @@
 		else
 			bank_account.account_job = /datum/job/unassigned
 		playsound(loc, 'sound/machines/synth_yes.ogg', 30 , TRUE)
+		to_chat(user, span_notice("New account registered under account identification number [bank_account.account_id]."))
 		update_appearance()
 		return
 	return ..()

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -671,7 +671,7 @@
 	name = "Machine Design (Account Registration Device)"
 	desc = "The circuit board for a Account Registration Device."
 	id = "accounting"
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SECURITY | DEPARTMENTAL_FLAG_SERVICE
 	build_path = /obj/item/circuitboard/machine/accounting
 	category = list ("Misc. Machinery")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When the accounting machine is used, it will now tell the user his new account ID for him to remember. Thought of adding it to memories but it would mean that a Head of Personnel operating this machine for new IDs will end up with a dozen of account ID memories. Account IDs are important and there was previously no way of knowing what your new account ID number was upon using the machine.

This PR also aims to make the accounting machine more common, if you feel that this belongs in a separate PR feel free to tell me so. The accounting machine was added back in August of 2020 and its uses are extremely rare. The main reason behind that is the fact the boards are exclusive to the security techfab once the proper research requirement is met which is the last place people look for RP-oriented items. Not a single member of the security personnel gains anything in building that machine, the primary user is usually the Head of Personnel who does not have security techfab access on all maps but Meta. 

The original PR was added back when passive income was still a thing and I do not see any particular issue in letting non-security personnel build it. The only gameplay advantage it gives over an accountless ID is being able to make multiple IDs to take on more civilian bounties than a person should, but since the civilian bounty rework, that ID would still need a trim to accept them and thus the need to check in with the HoP anyway.
I decided that adding the machine to service and cargo techfabs would allow for more common uses of the machine, as it mostly exists for RP purposes with no gameplay benefit that isn't obtained through easier/more efficient means already.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Being able to know your new account ID means you do not have to start at 0 if you lost your newly created ID again. 
It also means that you could share account IDs with other people easily, for RP purposes such as setting up shops with friends, sharing a newly created account with your coworkers without having to use yours or another crewmember's roundstart accounts.

The account registration device being added to cargo and service lathes will mean that the machine will become more common, increasing RP potentials associated with it. As it is currently, a security lathe-exclusive machine, it is rarely seen.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Account registration devices will now tell the user their new account ID number, previously unobtainable.
add: Account registration devices added to service and cargo techfabs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
