### PR TITLE
Make USB cables attached to locked circuits unable to be modified

### DIFF
--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -346,7 +346,7 @@
 	SIGNAL_HANDLER
 	if(!is_authorized(user))
 		return
-
+	
 	if (!(shell_flags & SHELL_FLAG_USB_PORT))
 		source.balloon_alert(user, "this shell has no usb ports")
 		return COMSIG_CANCEL_USB_CABLE_ATTACK
@@ -354,7 +354,11 @@
 	if (isnull(attached_circuit))
 		source.balloon_alert(user, "no circuit inside")
 		return COMSIG_CANCEL_USB_CABLE_ATTACK
-
+	
+	if(attached_circuit.locked)
+		source.balloon_alert(user, "circuit is locked")
+		return COMSIG_CANCEL_USB_CABLE_ATTACK
+	
 	usb_cable.attached_circuit = attached_circuit
 	return COMSIG_USB_CABLE_CONNECTED_TO_CIRCUIT
 

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -346,7 +346,7 @@
 	SIGNAL_HANDLER
 	if(!is_authorized(user))
 		return
-	
+
 	if (!(shell_flags & SHELL_FLAG_USB_PORT))
 		source.balloon_alert(user, "this shell has no usb ports")
 		return COMSIG_CANCEL_USB_CABLE_ATTACK
@@ -354,9 +354,9 @@
 	if (isnull(attached_circuit))
 		source.balloon_alert(user, "no circuit inside")
 		return COMSIG_CANCEL_USB_CABLE_ATTACK
-	
+
 	if(attached_circuit.locked)
-		source.balloon_alert(user, "circuit is locked")
+		source.balloon_alert(user, "circuit is locked!")
 		return COMSIG_CANCEL_USB_CABLE_ATTACK
 	
 	usb_cable.attached_circuit = attached_circuit

--- a/code/datums/components/usb_port.dm
+++ b/code/datums/components/usb_port.dm
@@ -152,10 +152,9 @@
 		if(user)
 			connecting_cable.balloon_alert(user, "too far away")
 		return COMSIG_CANCEL_USB_CABLE_ATTACK
-	
+
 	if (connecting_cable.attached_circuit.locked)
-		if(user)
-			connecting_cable.balloon_alert(user, "shell is locked")
+		connecting_cable.balloon_alert(user, "shell is locked!")
 		return COMSIG_CANCEL_USB_CABLE_ATTACK
 	
 	usb_cable_ref = WEAKREF(connecting_cable)

--- a/code/datums/components/usb_port.dm
+++ b/code/datums/components/usb_port.dm
@@ -153,7 +153,7 @@
 			connecting_cable.balloon_alert(user, "too far away")
 		return COMSIG_CANCEL_USB_CABLE_ATTACK
 	
-	if (connectingcable.attached_circuit.locked)
+	if (connecting_cable.attached_circuit.locked)
 		if(user)
 			connecting_cable.balloon_alert(user, "shell is locked")
 		return COMSIG_CANCEL_USB_CABLE_ATTACK

--- a/code/datums/components/usb_port.dm
+++ b/code/datums/components/usb_port.dm
@@ -152,7 +152,12 @@
 		if(user)
 			connecting_cable.balloon_alert(user, "too far away")
 		return COMSIG_CANCEL_USB_CABLE_ATTACK
-
+	
+	if (connectingcable.attached_circuit.locked)
+		if(user)
+			connecting_cable.balloon_alert(user, "shell is locked")
+		return COMSIG_CANCEL_USB_CABLE_ATTACK
+	
 	usb_cable_ref = WEAKREF(connecting_cable)
 	attached_circuit = connecting_cable.attached_circuit
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stops: USB cables from being added to locked circuits, and, USB cables already attached to locked circuits from being attached to other machinery.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #63071 , it also makes sense that you can't add USB cables or add things to attached USB cables for locked circuits.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Locked circuits cannot have USB cables attached to them anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
