### PR TITLE
adds health column to crew monitor usb component

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -247,7 +247,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				"toxdam" = round(tracked_living_mob.getToxLoss(), 1),
 				"burndam" = round(tracked_living_mob.getFireLoss(), 1),
 				"brutedam" = round(tracked_living_mob.getBruteLoss(), 1),
-				"health" = round(tracked_living_mob.health, 1)
+				"health" = round(tracked_living_mob.health, 1),
 			)
 
 		// Location

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -53,6 +53,7 @@
 		"burn",
 		"brute",
 		"location",
+		"health",
 	))
 
 
@@ -72,7 +73,7 @@
 		entry["burn"] = player_record["burndam"]
 		entry["brute"] = player_record["brutedam"]
 		entry["location"] = player_record["area"]
-
+		entry["health"] = player_record["health"]
 		new_table += list(entry)
 
 	records.set_output(new_table)
@@ -245,7 +246,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				"oxydam" = round(tracked_living_mob.getOxyLoss(), 1),
 				"toxdam" = round(tracked_living_mob.getToxLoss(), 1),
 				"burndam" = round(tracked_living_mob.getFireLoss(), 1),
-				"brutedam" = round(tracked_living_mob.getBruteLoss(), 1)
+				"brutedam" = round(tracked_living_mob.getBruteLoss(), 1),
+				"health" = round(tracked_living_mob.health, 1)
 			)
 
 		// Location


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Crew Monitor circuit component's output port will now give a table that contains a health column in addition to its current columns.

## Why It's Good For The Game

The main use of the crew monitor usb is to check for crewmates health,and with the addition of filter and for each components, it would make sense to make circuits that deal with everyones health... But the fact that you have to calculate the health by substracting the sum of type damages limits the console abilities since this calculation easily reach the circuit power limit/ the filter cpu limit...this PR allows to skip this part and just have the health given so that the circuits focus on the health manipulation part, instead of optimizing health calculations


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: adds health to the crew monitor's usb table
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
