### PR TITLE
Fix syntax error in "do not abuse associated list" rule, consistent whitespace

### DIFF
--- a/.github/guides/STANDARDS.md
+++ b/.github/guides/STANDARDS.md
@@ -243,7 +243,7 @@ Bad:
 ```dm
 /obj/machine/update_overlays(var/blah)
 	var/static/our_overlays
-	if(isnull(our_overlays)
+	if (isnull(our_overlays))
 		our_overlays = list("on" = iconstate2appearance(overlay_icon, "on"), "off" = iconstate2appearance(overlay_icon, "off"), "broken" = iconstate2appearance(overlay_icon, "broken"))
 	if (stat & broken)
 		add_overlay(our_overlays["broken"]) 
@@ -256,9 +256,10 @@ Good:
 #define OUR_ON_OVERLAY 1
 #define OUR_OFF_OVERLAY 2
 #define OUR_BROKEN_OVERLAY 3
-/obj/machine/update_overlays(var/blah
+
+/obj/machine/update_overlays(var/blah)
 	var/static/our_overlays
-	if(isnull(our_overlays)
+	if (isnull(our_overlays))
 		our_overlays = list(iconstate2appearance(overlay_icon, "on"), iconstate2appearance(overlay_icon, "off"), iconstate2appearance(overlay_icon, "broken"))
 	if (stat & broken)
 		add_overlay(our_overlays[OUR_BROKEN_OVERLAY])


### PR DESCRIPTION
Fixes two syntax errors, and makes the whitespace consistent. Yes bla bla bla we don't care about whitespace but this is the style guide code.