### PR TITLE
Getting an IV drip ripped out of you now causes a pierce wound

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -128,7 +128,7 @@
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
 		to_chat(attached, span_userdanger("The IV drip needle is ripped out of you!"))
 		var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
-		attached.apply_damage(3, BRUTE, selected_limb))
+		attached.apply_damage(3, BRUTE, selected_limb)
 		var/datum/wound/pierce/moderate/iv_wound = new
 		iv_wound.apply_wound(selected_limb, silent)
 		detach_iv()

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -128,9 +128,9 @@
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
 		to_chat(attached, span_userdanger("The IV drip needle is ripped out of you!"))
 		var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
-		attached.apply_damage(3, BRUTE, selected_limb)
 		var/datum/wound/pierce/moderate/iv_wound = new
-		iv_wound.apply_wound(selected_limn)
+		attached.apply_damage(3, BRUTE, selected_limb)
+		iv_wound.apply_wound(selected_limb)
 		detach_iv()
 		return PROCESS_KILL
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -126,13 +126,13 @@
 		return PROCESS_KILL
 
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
-        to_chat(attached, span_userdanger("The IV drip needle is ripped out of you!"))
-        var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
-        var/chosen_limb = pick(/obj/item/bodypart/l_arm, /obj/item/bodypart/r_arm)
-        attached.apply_damage(3, BRUTE, selected_limb)
-        chosen_limb.force_wound_upwards(/datum/wound/blunt/moderate)
-        detach_iv()
-        return PROCESS_KILL
+		to_chat(attached, span_userdanger("The IV drip needle is ripped out of you, leaving an open bleeding wound!"))
+		var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
+		var/obj/item/bodypart/chosen_limb = attached.get_bodypart(selected_limb)
+		attached.apply_damage(3, BRUTE, selected_limb)
+		chosen_limb.force_wound_upwards(/datum/wound/pierce/moderate)
+		detach_iv()
+		return PROCESS_KILL
 
 	var/datum/reagents/target_reagents = get_reagent_holder()
 	if(target_reagents)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -128,9 +128,10 @@
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
 		to_chat(attached, span_userdanger("The IV drip needle is ripped out of you!"))
 		var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
-		var/datum/wound/slash/moderate/iv_wound = new
 		attached.apply_damage(3, BRUTE, selected_limb)
-		iv_wound.apply_wound(selected_limb)
+		var/obj/item/bodypart/pierced_limb = selected_limb
+		var/datum/wound/pierce/moderate/iv_wound = new
+		pierced_limb.force_wound_upwards(iv_wound)
 		detach_iv()
 		return PROCESS_KILL
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -127,7 +127,10 @@
 
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
 		to_chat(attached, span_userdanger("The IV drip needle is ripped out of you!"))
-		attached.apply_damage(3, BRUTE, pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM))
+		var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
+		attached.apply_damage(3, BRUTE, selected_limb))
+		var/datum/wound/pierce/moderate/iv_wound = new
+		iv_wound.apply_wound(selected_limb, silent)
 		detach_iv()
 		return PROCESS_KILL
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -127,12 +127,10 @@
 
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
 		to_chat(attached, span_userdanger("The IV drip needle is ripped out of you, leaving an open bleeding wound!"))
-		var/selected_limb = BODY_ZONE_CHEST
-		if((/obj/item/bodypart/l_arm && /obj/item/bodypart/r_arm) in attached.bodyparts)
-			selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
-		var/obj/item/bodypart/pierced_limb = attached.get_bodypart(selected_limb)
-		attached.apply_damage(3, BRUTE, selected_limb)
-		pierced_limb.force_wound_upwards(/datum/wound/pierce/moderate)
+		var/list/arm_zones = shuffle(list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM))
+		var/obj/item/bodypart/chosen_limb = attached.get_bodypart(arm_zones[1]) || attached.get_bodypart(arm_zones[2]) || attached.get_bodypart(BODY_ZONE_CHEST)
+		chosen_limb.receive_damage(3)
+		chosen_limb.force_wound_upwards(/datum/wound/pierce/moderate)
 		detach_iv()
 		return PROCESS_KILL
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -195,7 +195,10 @@
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 ///called when an IV is attached
-/obj/machinery/iv_drip/proc/attach_iv(mob/living/target, mob/user)
+/obj/machinery/iv_drip/proc/attach_iv(mob/living/target, mob/user, self)
+	user.visible_message(span_warning("[usr] begins attaching [src] to [target]..."), span_warning("You begin attaching [src] to [target]."))
+	if(!do_after(usr, 1 SECONDS, target))
+		return
 	usr.visible_message(span_warning("[usr] attaches [src] to [target]."), span_notice("You attach [src] to [target]."))
 	var/datum/reagents/container = get_reagent_holder()
 	log_combat(usr, target, "attached", src, "containing: ([container.log_list()])")

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -128,8 +128,8 @@
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
 		to_chat(attached, span_userdanger("The IV drip needle is ripped out of you!"))
 		var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
+		var/obj/item/bodypart/pierced_limb
 		attached.apply_damage(3, BRUTE, selected_limb)
-		var/obj/item/bodypart/pierced_limb = selected_limb
 		var/datum/wound/pierce/moderate/iv_wound = new
 		pierced_limb.force_wound_upwards(iv_wound)
 		detach_iv()

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -130,7 +130,7 @@
 		var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
 		attached.apply_damage(3, BRUTE, selected_limb)
 		var/datum/wound/pierce/moderate/iv_wound = new
-		iv_wound.apply_wound(selected_limb, silent)
+		iv_wound.apply_wound(selected_limn)
 		detach_iv()
 		return PROCESS_KILL
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -195,7 +195,7 @@
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 ///called when an IV is attached
-/obj/machinery/iv_drip/proc/attach_iv(mob/living/target, mob/user, self)
+/obj/machinery/iv_drip/proc/attach_iv(mob/living/target, mob/user)
 	user.visible_message(span_warning("[usr] begins attaching [src] to [target]..."), span_warning("You begin attaching [src] to [target]."))
 	if(!do_after(usr, 1 SECONDS, target))
 		return

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -127,10 +127,12 @@
 
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
 		to_chat(attached, span_userdanger("The IV drip needle is ripped out of you, leaving an open bleeding wound!"))
-		var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
-		var/obj/item/bodypart/chosen_limb = attached.get_bodypart(selected_limb)
+		var/selected_limb = BODY_ZONE_CHEST
+		if((/obj/item/bodypart/l_arm && /obj/item/bodypart/r_arm) in attached.bodyparts)
+			selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
+		var/obj/item/bodypart/pierced_limb = attached.get_bodypart(selected_limb)
 		attached.apply_damage(3, BRUTE, selected_limb)
-		chosen_limb.force_wound_upwards(/datum/wound/pierce/moderate)
+		pierced_limb.force_wound_upwards(/datum/wound/pierce/moderate)
 		detach_iv()
 		return PROCESS_KILL
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -128,7 +128,7 @@
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
 		to_chat(attached, span_userdanger("The IV drip needle is ripped out of you!"))
 		var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
-		var/datum/wound/pierce/moderate/iv_wound = new
+		var/datum/wound/slash/moderate/iv_wound = new
 		attached.apply_damage(3, BRUTE, selected_limb)
 		iv_wound.apply_wound(selected_limb)
 		detach_iv()

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -126,14 +126,13 @@
 		return PROCESS_KILL
 
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
-		to_chat(attached, span_userdanger("The IV drip needle is ripped out of you!"))
-		var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
-		attached.apply_damage(3, BRUTE, selected_limb)
-		for(var/i in attached.bodyparts)
-			var/obj/item/bodypart/squish_part = i
-		squish_part.force_wound_upwards(/datum/wound/blunt/moderate)
-		detach_iv()
-		return PROCESS_KILL
+        to_chat(attached, span_userdanger("The IV drip needle is ripped out of you!"))
+        var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
+        var/chosen_limb = pick(/obj/item/bodypart/l_arm, /obj/item/bodypart/r_arm)
+        attached.apply_damage(3, BRUTE, selected_limb)
+        chosen_limb.force_wound_upwards(/datum/wound/blunt/moderate)
+        detach_iv()
+        return PROCESS_KILL
 
 	var/datum/reagents/target_reagents = get_reagent_holder()
 	if(target_reagents)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -128,10 +128,10 @@
 	if(!(get_dist(src, attached) <= 1 && isturf(attached.loc)))
 		to_chat(attached, span_userdanger("The IV drip needle is ripped out of you!"))
 		var/selected_limb = pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
-		var/obj/item/bodypart/pierced_limb
 		attached.apply_damage(3, BRUTE, selected_limb)
-		var/datum/wound/pierce/moderate/iv_wound = new
-		pierced_limb.force_wound_upwards(iv_wound)
+		for(var/i in attached.bodyparts)
+			var/obj/item/bodypart/squish_part = i
+		squish_part.force_wound_upwards(/datum/wound/blunt/moderate)
 		detach_iv()
 		return PROCESS_KILL
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As said in the title, getting an IV needle ripped out of you by getting too far from it without detaching will, on top of the 3 brute damage it dealt before, cause a Minor Breakage (lowest tier of pierce wounds) on the affected arm. The intensity does not increase with further detachments but both arms can become pierced.
Also, as a shitter safety net, they now have a 1 second delay in order to attach them.

Oh and the warning message has been changed accordingly to "The IV drip needle is ripped out of you, leaving an open bleeding wound!"


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mainly two things:

As it is, people mostly ignore the concept of detaching IVs  and I want to make it so that there's an actual reason to do so that's not particularly bad but still effective, unlike the current 3 brute damage penalty. 
IVs are in medbay and pierced wounds are slow bleeders, so you can easily get it treated on the spot and walk away just fine. However, it's still annoying enough to encourage players, patients and doctors alike, to actually detach IVs,

The other reason is just cause I like the flavour of ripping out IVs actually causing bleeding, as it should.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: IV drips now cause a moderate pierce wound when ripped out
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
