### PR TITLE
Families Bugfixes + Tweaks: Even Distribution of Leaders, Fixes HoS-Family-Leaders, Adds Admin Tool to make Leaders

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -252,7 +252,7 @@
 	antag_flag_override = ROLE_FAMILIES
 	protected_roles = list("Prisoner", "Head of Personnel")
 	restricted_roles = list("Cyborg", "AI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Research Director")
-	required_candidates = 9
+	required_candidates = 0
 	weight = 2
 	cost = 19
 	requirements = list(101,101,40,40,30,20,10,10,10,10)
@@ -272,6 +272,8 @@
 		else if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
 			candidates -= player
 		else if(HAS_TRAIT(player, TRAIT_MINDSHIELD))
+			candidates -= player
+		else if(player.mind.assigned_role.title in restricted_roles)
 			candidates -= player
 
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -252,7 +252,7 @@
 	antag_flag_override = ROLE_FAMILIES
 	protected_roles = list("Prisoner", "Head of Personnel")
 	restricted_roles = list("Cyborg", "AI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Research Director")
-	required_candidates = 0
+	required_candidates = 3
 	weight = 2
 	cost = 19
 	requirements = list(101,101,40,40,30,20,10,10,10,10)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -496,7 +496,7 @@
 	antag_flag = ROLE_FAMILIES
 	protected_roles = list("Prisoner", "Head of Personnel")
 	restricted_roles = list("Cyborg", "AI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Research Director")
-	required_candidates = 9
+	required_candidates = 0
 	weight = 1
 	cost = 19
 	requirements = list(101,101,40,40,30,20,10,10,10,10)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -496,7 +496,7 @@
 	antag_flag = ROLE_FAMILIES
 	protected_roles = list("Prisoner", "Head of Personnel")
 	restricted_roles = list("Cyborg", "AI", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Research Director")
-	required_candidates = 0
+	required_candidates = 3
 	weight = 1
 	cost = 19
 	requirements = list(101,101,40,40,30,20,10,10,10,10)

--- a/code/modules/antagonists/gang/gang.dm
+++ b/code/modules/antagonists/gang/gang.dm
@@ -40,7 +40,17 @@
 
 /datum/antagonist/gang/get_admin_commands()
 	. = ..()
-	.["Give extra equipment"] = CALLBACK(src,.proc/equip_gangster_in_inventory)
+	.["Give extra equipment"] = CALLBACK(src, .proc/equip_gangster_in_inventory)
+	if(!starter_gangster)
+		.["Make Leader"] = CALLBACK(src, .proc/make_gangster_leader)
+
+/datum/antagonist/gang/proc/make_gangster_leader()
+	if(starter_gangster)
+		return
+	starter_gangster = TRUE
+	package_spawner.Grant(owner.current)
+	package_spawner.my_gang_datum = src
+	my_gang.rename_gangster(owner, original_name, TRUE) // gives them the leader name
 
 /datum/antagonist/gang/create_team(team_given) // gets called whenever add_antag_datum() is called on a mind
 	if(team_given)

--- a/code/modules/antagonists/gang/handler.dm
+++ b/code/modules/antagonists/gang/handler.dm
@@ -152,45 +152,21 @@ GLOBAL_VAR(families_override_theme)
  * * return_if_no_gangs - Boolean that determines if the proc should return FALSE should it find no eligible family members. Should be used for dynamic only.
  */
 /datum/gang_handler/proc/post_setup_analogue(return_if_no_gangs = FALSE)
-	var/replacement_gangsters = 0
-	for(var/datum/mind/gangbanger in gangbangers)
-		if(!ishuman(gangbanger.current))
-			if(!midround_ruleset)
-				GLOB.pre_setup_antags -= gangbanger
-			gangbangers.Remove(gangbanger)
-			log_game("[gangbanger] was not a human, and thus has lost their gangster role.")
-			replacement_gangsters++
-	if(replacement_gangsters)
-		for(var/j in 1 to replacement_gangsters)
-			if(!antag_candidates.len)
-				log_game("Unable to find more replacement gangsters. Not all of the gangs will spawn.")
-				break
-			var/taken = pick_n_take(antag_candidates)
-			var/datum/mind/gangbanger
-			if(istype(taken, /mob)) // boilerplate needed because antag_candidates might not contain minds
-				var/mob/T = taken
-				gangbanger = T.mind
-			else
-				gangbanger = taken
-			gangbangers += gangbanger
-			log_game("[key_name(gangbanger)] has been selected as a replacement gangster!")
-	if(!gangbangers.len)
-		if(return_if_no_gangs)
-			return FALSE // ending early is bad if we're not in dynamic
-
 	var/list/gangs_to_use = current_theme.involved_gangs
 	var/amount_of_gangs = gangs_to_use.len
+	var/amount_of_gangsters = amount_of_gangs * current_theme.starting_gangsters
+	for(var/_ in 1 to amount_of_gangsters)
+		if(!gangbangers.len) // We ran out of candidates!
+			break
+		if(!gangs_to_use.len)
+			gangs_to_use = current_theme.involved_gangs
+		var/gang_to_use = pick_n_take(gangs_to_use) // Evenly distributes Leaders among the gangs
+		var/datum/mind/gangster_mind = pick_n_take(gangbangers)
+		var/datum/antagonist/gang/new_gangster = new gang_to_use()
+		new_gangster.handler = src
+		new_gangster.starter_gangster = TRUE
+		gangster_mind.add_antag_datum(new_gangster)
 
-	for(var/_ in 1 to amount_of_gangs)
-		var/gang_to_use = pick_n_take(gangs_to_use)
-		for(var/__ in 1 to current_theme.starting_gangsters)
-			if(!gangbangers.len)
-				break
-			var/datum/mind/gangster_mind = pick_n_take(gangbangers)
-			var/datum/antagonist/gang/new_gangster = new gang_to_use()
-			new_gangster.handler = src
-			new_gangster.starter_gangster = TRUE
-			gangster_mind.add_antag_datum(new_gangster)
 
 		// see /datum/antagonist/gang/create_team() for how the gang team datum gets instantiated and added to our gangs list
 


### PR DESCRIPTION
## About The Pull Request

Leaders are now distributed evenly among the Families.
As a result, the Families rulesets now only require 3 people to start, instead of 9.
You can no longer become a Family Leader as a restricted role, such as a Head of Security.
Admins can now promote people to Family Leader with a button from the traitor panel.

## Why It's Good For The Game

Bugfixes are good. Better distribution of family leaders is also good.

## Changelog

:cl:
qol: Leaders are now distributed evenly among the Families.
qol: As a result, the Families rulesets now only require 3 people to start, instead of 9.
fix: You can no longer become a Family Leader as a restricted role, such as a Head of Security.
admin: Admins can now promote people to Family Leader with a button from the traitor panel.
/:cl: