### PR TITLE
Lowers reagent size of spider bites.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -105,7 +105,7 @@
 	health = 50
 	melee_damage_lower = 15
 	melee_damage_upper = 20
-	poison_per_bite = 10
+	poison_per_bite = 5
 	move_to_delay = 5
 	speed = -0.1
 	menu_description = "Fast spider variant specializing in catching running prey and toxin injection, but has less health and damage. Toxin injection of 10u per bite."
@@ -231,7 +231,7 @@
 	health = 40
 	melee_damage_lower = 5
 	melee_damage_upper = 5
-	poison_per_bite = 6
+	poison_per_bite = 5
 	move_to_delay = 4
 	poison_type = /datum/reagent/toxin/venom
 	speed = -0.5


### PR DESCRIPTION

## About The Pull Request

Certain spiders were able to reliably cause more than 40 damage per spider bite, this is kind of absurd so I'm lowering the rates to make it more reasonable.

## Why It's Good For The Game

30+ Toxin damage from each bite from spiders really isn't fun. 

## Changelog


:cl:
balance: Nerfs level of toxin/venom spat out by spiders.
/:cl:
