### PR TITLE
Fixes another TK teleportation trick, but more literally

### DIFF
--- a/code/game/objects/structures/gym.dm
+++ b/code/game/objects/structures/gym.dm
@@ -34,6 +34,8 @@
 	. = ..()
 	if(.)
 		return
+	if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+		return
 	if(obj_flags & IN_USE)
 		to_chat(user, span_warning("It's already in use - wait a bit!"))
 		return


### PR DESCRIPTION
## About The Pull Request

Stop people with TK being able to instantly teleport onto weight machines

## Why It's Good For The Game

Fixes an oversight

## Changelog
:cl:
fix: TK can no longer be used to teleport onto weight machines.
/:cl: