### PR TITLE
Numpad keys will now be recognised by the keybinds menu

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
@@ -49,6 +49,12 @@ const KEY_CODE_TO_BYOND: Record<string, string> = {
   "UP": "North",
 };
 
+/* So, as it turns out, KeyboardEvent seems to be broken with IE 11, the
+ * DOM_KEY_LOCATION_X codes are all undefined. See this to see why it's 3:
+ * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/location
+ */
+const DOM_KEY_LOCATION_NUMPAD: number = 3;
+
 const sortKeybindings = sortBy(
   ([_, keybinding]: [string, Keybinding]) => {
     return keybinding.name;
@@ -74,7 +80,7 @@ const formatKeyboardEvent = (event: KeyboardEvent): string => {
     text += "Shift";
   }
 
-  if (event.location === KeyboardEvent.DOM_KEY_LOCATION_NUMPAD) {
+  if (event.location === DOM_KEY_LOCATION_NUMPAD) {
     text += "Numpad";
   }
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/KeybindingsPage.tsx
@@ -49,11 +49,12 @@ const KEY_CODE_TO_BYOND: Record<string, string> = {
   "UP": "North",
 };
 
-/* So, as it turns out, KeyboardEvent seems to be broken with IE 11, the
+/**
+ * So, as it turns out, KeyboardEvent seems to be broken with IE 11, the
  * DOM_KEY_LOCATION_X codes are all undefined. See this to see why it's 3:
  * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/location
  */
-const DOM_KEY_LOCATION_NUMPAD: number = 3;
+const DOM_KEY_LOCATION_NUMPAD = 3;
 
 const sortKeybindings = sortBy(
   ([_, keybinding]: [string, Keybinding]) => {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So, I was trying to rebind some emotes using CTRL+Numpad1, and then noticed it, in fact, did not let me do that. Curious, I reported it and nothing was ever done about it, because the code checks out, right?

Well, ladies and gentlemen, let me show you how great IE is:
![image](https://user-images.githubusercontent.com/58045821/143792489-74ee446b-7774-40a1-911b-83f2ec94f668.png)

That's right, all the KeyboardEvent values are undefined, which means that we literally can't use those things. Great.
So I had to make a constant for the numpad, we can easily add more in the future if it's needed, but... Yeah, this was annoying to figure out.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You can finally bind some things to the numpad keys, as intended.
Which means you can do this:
![image](https://user-images.githubusercontent.com/58045821/143792556-aa124c65-3411-4574-81e4-291ca35aad71.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: GoldenAlpharex
fix: Numpad keys are now properly recognized by the keybinds menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
