### PR TITLE
Observers can't dispel paper wizard summons on examine

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -154,7 +154,10 @@
 
 /mob/living/simple_animal/hostile/boss/paper_wizard/copy/examine(mob/user)
 	. = ..()
-	qdel(src) //I see through your ruse!
+	if(isobserver(user))
+		. += span_notice("It's an illison - what is it hiding?")
+	else
+		qdel(src) //I see through your ruse!
 
 //fancy effects
 /obj/effect/temp_visual/paper_scatter

--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -155,7 +155,7 @@
 /mob/living/simple_animal/hostile/boss/paper_wizard/copy/examine(mob/user)
 	. = ..()
 	if(isobserver(user))
-		. += span_notice("It's an illison - what is it hiding?")
+		. += span_notice("It's an illusion - what is it hiding?")
 	else
 		qdel(src) //I see through your ruse!
 


### PR DESCRIPTION
## About The Pull Request

- This PR disallows observers from dispelling summons made by Mjol the Creative on examine.

## Why It's Good For The Game

- The summons are a "boss mechanic" that can technically be cheesed by having ghosts dispel them for you. Fixes that.

## Changelog

:cl: Melbert
fix: Mjol the Creative's summons can't be dispelled by observers anymore
/:cl:


