### PR TITLE
Nerf Irish Car Bomb clown car effect to throwing out all the mobs, without a big explosion

### DIFF
--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -61,8 +61,8 @@
 				addtimer(CALLBACK(src, .proc/irish_car_bomb), 5 SECONDS)
 
 /obj/vehicle/sealed/car/clowncar/proc/irish_car_bomb()
-	dump_mobs(randomstep = FALSE) // the mobs must be dumped or else they won't explode
-	explosion(src, devastation_range = 2, heavy_impact_range = 5, light_impact_range = 10, flame_range = 10) // half a max cap. yep
+	dump_mobs()
+	explosion(src, light_impact_range = 1)
 
 /obj/vehicle/sealed/car/clowncar/after_add_occupant(mob/M, control_flags)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Frankly this is what I had in my head for the original PR but didn't spend too much time on it

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently gibs everyone inside the clown car, which sucks considering this is always non-antagonists doing it, also not what I expected it to be when I merged it 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The Irish Car Bomb + clown car interaction has been nerfed from a big gibbing explosion to throwing out all the mobs (with the usual chance of spilling out slipping foam)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
