### PR TITLE
Adds the ventriloquism behavior to disembodied heads.

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -266,7 +266,7 @@
 	return NOPASS
 
 /obj/item/bodypart/head/GetVoice()
-	return real_name
+	return "The head of [real_name]"
 
 /obj/item/bodypart/head/monkey
 	icon = 'icons/mob/animal_parts.dmi'

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -257,6 +257,17 @@
 			if(eyes.eye_color)
 				eyes_overlay.color = eyes.eye_color
 
+/obj/item/bodypart/head/talk_into(mob/holder, message, channel, spans, datum/language/language, list/message_mods)
+	var/mob/headholder = holder
+	if(istype(headholder))
+		headholder.log_talk(message, LOG_SAY, tag="beheaded talk")
+
+	say(message, language, sanitize = FALSE)
+	return NOPASS
+
+/obj/item/bodypart/head/GetVoice()
+	return real_name
+
 /obj/item/bodypart/head/monkey
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "default_monkey_head"

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -260,7 +260,7 @@
 /obj/item/bodypart/head/talk_into(mob/holder, message, channel, spans, datum/language/language, list/message_mods)
 	var/mob/headholder = holder
 	if(istype(headholder))
-		headholder.log_talk(message, LOG_SAY, tag="beheaded talk")
+		headholder.log_talk(message, LOG_SAY, tag = "beheaded talk")
 
 	say(message, language, sanitize = FALSE)
 	return NOPASS


### PR DESCRIPTION
## About The Pull Request
What is says on the tin. Same behaviour as a mime's dummy, except with more bodily injury.
The only thing this PR's missing is proper in-hands for heads but that's a much larger undertaking out of scope for this coder.
## Why It's Good For The Game
This image is begging for someone to set up a grotesque doll theatre except it's heads of your fellow crew members.
![image](https://user-images.githubusercontent.com/75863639/143828234-66b98091-bd9e-447a-9eef-7f73ac05fa10.png)

## Changelog
:cl:
expansion: Added ventriloquism to disembodied heads.
/:cl:
