### PR TITLE
Fix telecomms to work with multi-z

### DIFF
--- a/code/game/machinery/telecomms/machines/relay.dm
+++ b/code/game/machinery/telecomms/machines/relay.dm
@@ -21,14 +21,14 @@
 
 /obj/machinery/telecomms/relay/receive_information(datum/signal/subspace/signal, obj/machinery/telecomms/machine_from)
 	// Add our level and send it back
-	var/turf/T = get_turf(src)
-	if(can_send(signal) && T)
+	var/turf/relay_turf = get_turf(src)
+	if(can_send(signal) && relay_turf)
 		// Relays send signals to all ZTRAIT_STATION z-levels
-		if(SSmapping.level_trait(T.z, ZTRAIT_STATION))
+		if(SSmapping.level_trait(relay_turf.z, ZTRAIT_STATION))
 			for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
 				signal.levels |= z
 		else
-			signal.levels |= T.z
+			signal.levels |= relay_turf.z
 
 // Checks to see if it can send/receive.
 

--- a/code/game/machinery/telecomms/machines/relay.dm
+++ b/code/game/machinery/telecomms/machines/relay.dm
@@ -23,7 +23,12 @@
 	// Add our level and send it back
 	var/turf/T = get_turf(src)
 	if(can_send(signal) && T)
-		signal.levels |= T.z
+		// Relays send signals to all ZTRAIT_STATION z-levels
+		if(SSmapping.level_trait(T.z, ZTRAIT_STATION))
+			for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
+				signals.levels |= z
+		else
+			signals.levels |= T.z
 
 // Checks to see if it can send/receive.
 

--- a/code/game/machinery/telecomms/machines/relay.dm
+++ b/code/game/machinery/telecomms/machines/relay.dm
@@ -26,9 +26,9 @@
 		// Relays send signals to all ZTRAIT_STATION z-levels
 		if(SSmapping.level_trait(T.z, ZTRAIT_STATION))
 			for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
-				signals.levels |= z
+				signal.levels |= z
 		else
-			signals.levels |= T.z
+			signal.levels |= T.z
 
 // Checks to see if it can send/receive.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This fixes #47075 

Telecomms on stations had to add a relay to each z-level to get the radio to work.  This removes that requirement and should free up some mapping space.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Less janky mapping hacks.  Also this could be useful for multi-z ruins in the future.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix telecomms relays to work across multi-z
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
