### PR TITLE
Makes welding plasma bars/statues/floors use flooder component

### DIFF
--- a/code/datums/components/combustible_flooder.dm
+++ b/code/datums/components/combustible_flooder.dm
@@ -15,7 +15,6 @@
 	RegisterSignal(parent, COMSIG_ATOM_FIRE_ACT, .proc/flame_react)
 	RegisterSignal(parent, COMSIG_ATOM_BULLET_ACT, .proc/projectile_react)
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), .proc/welder_react)
-	RegisterSignal(parent, COMSIG_ATOM_SECONDARY_TOOL_ACT(TOOL_WELDER), .proc/welder_react)
 	if(isturf(parent))
 		RegisterSignal(parent, COMSIG_TURF_EXPOSE, .proc/hotspots_react)
 
@@ -24,20 +23,19 @@
 	UnregisterSignal(parent, COMSIG_ATOM_FIRE_ACT)
 	UnregisterSignal(parent, COMSIG_ATOM_BULLET_ACT)
 	UnregisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER))
-	UnregisterSignal(parent, COMSIG_ATOM_SECONDARY_TOOL_ACT(TOOL_WELDER))
 	if(isturf(parent))
 		UnregisterSignal(parent, COMSIG_TURF_EXPOSE)
 
 /// Do the flooding. Trigger temperature is the temperature we will flood at if we dont have a temp set at the start. Trigger referring to whatever triggered it.
 /datum/component/combustible_flooder/proc/flood(mob/user, trigger_temperature)
-	var/delete = TRUE
+	var/delete_parent = TRUE
 	var/turf/open/flooded_turf = get_turf(parent)
 
 	// We do this check early so closed turfs are still be able to flood.
 	if(isturf(parent)) // Walls and floors.
 		var/turf/parent_turf = parent
 		flooded_turf = parent_turf.ScrapeAway(1, CHANGETURF_INHERIT_AIR)
-		delete = FALSE
+		delete_parent = FALSE
 
 	flooded_turf.atmos_spawn_air("[gas_id]=[gas_amount];TEMP=[temp_amount || trigger_temperature]")
 	
@@ -53,7 +51,7 @@
 	message_admins(admin_message)
 	log_game(log_message)
 
-	if(delete && !QDELETED(parent))
+	if(delete_parent && !QDELETED(parent))
 		qdel(parent) // For things with the explodable component like plasma mats this isn't necessary, but there's no harm. 
 	qdel(src)
 

--- a/code/datums/components/combustible_flooder.dm
+++ b/code/datums/components/combustible_flooder.dm
@@ -39,7 +39,7 @@
 		flooded_turf = parent_turf.ScrapeAway(1, CHANGETURF_INHERIT_AIR)
 		delete = FALSE
 
-	flooded_turf.atmos_spawn_air("[gas_id]=[gas_amount];TEMP=[temp_amount ? temp_amount : trigger_temperature]")
+	flooded_turf.atmos_spawn_air("[gas_id]=[gas_amount];TEMP=[temp_amount || trigger_temperature]")
 	
 	// Logging-related
 	var/admin_message = "[parent] ignited in [ADMIN_VERBOSEJMP(flooded_turf)]"

--- a/code/datums/components/combustible_flooder.dm
+++ b/code/datums/components/combustible_flooder.dm
@@ -1,26 +1,45 @@
+/// Component that floods gas when ignited by fire.
 /datum/component/combustible_flooder
 	// Gas type, molar count, and temperature. All self explanatory.
 	var/gas_id
 	var/gas_amount
 	var/temp_amount
 
-/datum/component/combustible_flooder/Initialize(gas_id, gas_amount, temp_amount)
+/datum/component/combustible_flooder/Initialize(initialize_gas_id, initialize_gas_amount, initialize_temp_amount)
 
-	src.gas_id = gas_id
-	src.gas_amount = gas_amount
-	src.temp_amount = temp_amount
+	src.gas_id = initialize_gas_id
+	src.gas_amount = initialize_gas_amount
+	src.temp_amount = initialize_temp_amount
 
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/attackby_react)
 	RegisterSignal(parent, COMSIG_ATOM_FIRE_ACT, .proc/flame_react)
+	RegisterSignal(parent, COMSIG_ATOM_BULLET_ACT, .proc/projectile_react)
+	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), .proc/welder_react)
+	RegisterSignal(parent, COMSIG_ATOM_SECONDARY_TOOL_ACT(TOOL_WELDER), .proc/welder_react)
+	if(isturf(parent))
+		RegisterSignal(parent, COMSIG_TURF_EXPOSE, .proc/hotspots_react)
 
 /datum/component/combustible_flooder/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_PARENT_ATTACKBY)
 	UnregisterSignal(parent, COMSIG_ATOM_FIRE_ACT)
+	UnregisterSignal(parent, COMSIG_ATOM_BULLET_ACT)
+	UnregisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER))
+	UnregisterSignal(parent, COMSIG_ATOM_SECONDARY_TOOL_ACT(TOOL_WELDER))
+	if(isturf(parent))
+		UnregisterSignal(parent, COMSIG_TURF_EXPOSE)
 
-/// Do the flooding.
-/datum/component/combustible_flooder/proc/flood(mob/user, temp_amount)
+/// Do the flooding. Trigger temperature is the temperature we will flood at if we dont have a temp set at the start. Trigger referring to whatever triggered it.
+/datum/component/combustible_flooder/proc/flood(mob/user, trigger_temperature)
+	var/delete = TRUE
 	var/turf/open/flooded_turf = get_turf(parent)
-	flooded_turf.atmos_spawn_air("[gas_id]=[gas_amount];TEMP=[temp_amount]")
+
+	// We do this check early so closed turfs are still be able to flood.
+	if(isturf(parent)) // Walls and floors.
+		var/turf/parent_turf = parent
+		flooded_turf = parent_turf.ScrapeAway(1, CHANGETURF_INHERIT_AIR)
+		delete = FALSE
+
+	flooded_turf.atmos_spawn_air("[gas_id]=[gas_amount];TEMP=[temp_amount ? temp_amount : trigger_temperature]")
 	
 	// Logging-related
 	var/admin_message = "[parent] ignited in [ADMIN_VERBOSEJMP(flooded_turf)]"
@@ -33,20 +52,24 @@
 		log_message += " by fire"
 	message_admins(admin_message)
 	log_game(log_message)
-	
-	// For floors
-	if(isturf(parent))
-		var/turf/K = parent
-		K.ScrapeAway(1, CHANGETURF_INHERIT_AIR)
-	else
-		qdel(parent)
 
-/// Hotspot related flooding reaction.
+	if(delete && !QDELETED(parent))
+		qdel(parent) // For things with the explodable component like plasma mats this isn't necessary, but there's no harm. 
+	Destroy() // Dont want to stick around.
+
+/// fire_act reaction.
 /datum/component/combustible_flooder/proc/flame_react(datum/source, exposed_temperature, exposed_volume)
 	SIGNAL_HANDLER
 
 	if(exposed_temperature > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
-		flood(temp_amount = exposed_temperature)
+		flood(null, exposed_temperature)
+
+/// Hotspot reaction.
+/datum/component/combustible_flooder/proc/hotspots_react(datum/source, air, exposed_temperature)
+	SIGNAL_HANDLER
+
+	if(exposed_temperature > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+		flood(null, exposed_temperature)
 
 /// Being attacked by something
 /datum/component/combustible_flooder/proc/attackby_react(datum/source, obj/item/thing, mob/user, params)
@@ -54,3 +77,18 @@
 
 	if(thing.get_temperature() > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		flood(user, thing.get_temperature())
+
+/// Shot by something
+/datum/component/combustible_flooder/proc/projectile_react(datum/source, obj/projectile/projectile)
+	SIGNAL_HANDLER
+
+	if(projectile.damage_type == BURN && !projectile.nodamage)
+		flood(projectile.firer, 2500)
+
+/// Welder check. Here because tool_act is higher priority than attackby.
+/datum/component/combustible_flooder/proc/welder_react(datum/source, mob/user, obj/item/tool)
+	SIGNAL_HANDLER
+
+	if(tool.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+		flood(user, tool.get_temperature())
+		return COMPONENT_BLOCK_TOOL_ATTACK

--- a/code/datums/components/combustible_flooder.dm
+++ b/code/datums/components/combustible_flooder.dm
@@ -55,7 +55,7 @@
 
 	if(delete && !QDELETED(parent))
 		qdel(parent) // For things with the explodable component like plasma mats this isn't necessary, but there's no harm. 
-	Destroy() // Dont want to stick around.
+	qdel(src)
 
 /// fire_act reaction.
 /datum/component/combustible_flooder/proc/flame_react(datum/source, exposed_temperature, exposed_volume)

--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -22,6 +22,8 @@
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, .proc/explodable_attack)
 	RegisterSignal(parent, COMSIG_TRY_STORAGE_INSERT, .proc/explodable_insert_item)
 	RegisterSignal(parent, COMSIG_ATOM_EX_ACT, .proc/detonate)
+	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), .proc/welder_react)
+	RegisterSignal(parent, COMSIG_ATOM_SECONDARY_TOOL_ACT(TOOL_WELDER), .proc/welder_react)
 	if(ismovable(parent))
 		RegisterSignal(parent, COMSIG_MOVABLE_IMPACT, .proc/explodable_impact)
 		RegisterSignal(parent, COMSIG_MOVABLE_BUMP, .proc/explodable_bump)
@@ -64,6 +66,13 @@
 	SIGNAL_HANDLER
 
 	check_if_detonate(target)
+
+/// Welder check. Here because tool_act is higher priority than attackby.
+/datum/component/explodable/proc/welder_react(datum/source, mob/user, obj/item/tool)
+	SIGNAL_HANDLER
+
+	if(check_if_detonate(tool))
+		return COMPONENT_BLOCK_TOOL_ATTACK
 
 ///Called when you attack a specific body part of the thing this is equipped on. Useful for exploding pants.
 /datum/component/explodable/proc/explodable_attack_zone(datum/source, damage, damagetype, def_zone)
@@ -119,10 +128,9 @@
 	if(!isitem(target))
 		return
 	var/obj/item/I = target
-	if(!I.get_temperature())
-		return
-	detonate() //If we're touching a hot item we go boom
-
+	if(I.get_temperature() > FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+		detonate() //If we're touching a hot item we go boom
+		return TRUE
 
 /// Explode and remove the object
 /datum/component/explodable/proc/detonate()

--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -23,7 +23,6 @@
 	RegisterSignal(parent, COMSIG_TRY_STORAGE_INSERT, .proc/explodable_insert_item)
 	RegisterSignal(parent, COMSIG_ATOM_EX_ACT, .proc/detonate)
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WELDER), .proc/welder_react)
-	RegisterSignal(parent, COMSIG_ATOM_SECONDARY_TOOL_ACT(TOOL_WELDER), .proc/welder_react)
 	if(ismovable(parent))
 		RegisterSignal(parent, COMSIG_MOVABLE_IMPACT, .proc/explodable_impact)
 		RegisterSignal(parent, COMSIG_MOVABLE_BUMP, .proc/explodable_bump)

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -137,11 +137,14 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	. = ..()
 	if(ismovable(source))
 		source.AddElement(/datum/element/firestacker, amount=1)
-		source.AddComponent(/datum/component/explodable, 0, 0, amount / 2500, 0, amount / 1250)
+		// Ideally exploding plasma objects should delete themselves but we still have the flooder and SSexplosions to rely on deleting it asynchronously so it's not that bad.
+		source.AddComponent(/datum/component/explodable, 0, 0, amount / 2500, 0, amount / 1250, FALSE)
+	source.AddComponent(/datum/component/combustible_flooder, "plasma", amount*0.05, null)
 
 /datum/material/plasma/on_removed(atom/source, amount, material_flags)
-	. = ..()
+	. = ..()	
 	source.RemoveElement(/datum/element/firestacker, amount=1)
+	qdel(source.GetComponent(/datum/component/combustible_flooder))
 	qdel(source.GetComponent(/datum/component/explodable))
 
 /datum/material/plasma/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -139,7 +139,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 		source.AddElement(/datum/element/firestacker, amount=1)
 		// Ideally exploding plasma objects should delete themselves but we still have the flooder and SSexplosions to rely on deleting it asynchronously so it's not that bad.
 		source.AddComponent(/datum/component/explodable, 0, 0, amount / 2500, 0, amount / 1250, FALSE)
-	source.AddComponent(/datum/component/combustible_flooder, "plasma", amount*0.05, null)
+	source.AddComponent(/datum/component/combustible_flooder, "plasma", amount*0.05) //Empty temp arg, fully dependent on whatever ignited it.
 
 /datum/material/plasma/on_removed(atom/source, amount, material_flags)
 	. = ..()

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -142,7 +142,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	source.AddComponent(/datum/component/combustible_flooder, "plasma", amount*0.05, null)
 
 /datum/material/plasma/on_removed(atom/source, amount, material_flags)
-	. = ..()	
+	. = ..()
 	source.RemoveElement(/datum/element/firestacker, amount=1)
 	qdel(source.GetComponent(/datum/component/combustible_flooder))
 	qdel(source.GetComponent(/datum/component/explodable))

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -230,43 +230,15 @@
 	desc = "No way this can end badly."
 	icon = 'icons/obj/doors/airlocks/station/plasma.dmi'
 	assemblytype = /obj/structure/door_assembly/door_assembly_plasma
-
+	material_flags = MATERIAL_EFFECTS
+	material_modifier = 0.25
+	
 /obj/machinery/door/airlock/plasma/Initialize(mapload)
+	custom_materials = custom_materials ? custom_materials : list(/datum/material/plasma = 20000)
 	. = ..()
-	AddElement(/datum/element/atmos_sensitive, mapload)
-
-/obj/machinery/door/airlock/plasma/proc/ignite(exposed_temperature)
-	if(exposed_temperature > 300)
-		PlasmaBurn(exposed_temperature)
-
-/obj/machinery/door/airlock/plasma/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	return (exposed_temperature > 300)
-
-/obj/machinery/door/airlock/plasma/atmos_expose(datum/gas_mixture/air, exposed_temperature)
-	PlasmaBurn()
-
-/obj/machinery/door/airlock/plasma/proc/PlasmaBurn()
-	atmos_spawn_air("plasma=500;TEMP=1000")
-	var/obj/structure/door_assembly/DA
-	DA = new /obj/structure/door_assembly(loc)
-	if(glass)
-		DA.glass = TRUE
-	if(heat_proof)
-		DA.heat_proof_finished = TRUE
-	DA.update_appearance()
-	DA.update_name()
-	qdel(src)
 
 /obj/machinery/door/airlock/plasma/block_superconductivity() //we don't stop the heat~
 	return 0
-
-/obj/machinery/door/airlock/plasma/attackby(obj/item/C, mob/user, params)
-	if(C.get_temperature() > 300)//If the temperature of the object is over 300, then ignite
-		message_admins("Plasma airlock ignited by [ADMIN_LOOKUPFLW(user)] in [ADMIN_VERBOSEJMP(src)]")
-		log_game("Plasma airlock ignited by [key_name(user)] in [AREACOORD(src)]")
-		ignite(C.get_temperature())
-	else
-		return ..()
 
 /obj/machinery/door/airlock/plasma/glass
 	opacity = FALSE

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -25,7 +25,7 @@ Mineral Sheets
 
 GLOBAL_LIST_INIT(sandstone_recipes, list ( \
 	new/datum/stack_recipe("pile of dirt", /obj/machinery/hydroponics/soil, 3, time = 10, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("sandstone door", /obj/structure/mineral_door/sandstone, 10, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("sandstone door", /obj/structure/mineral_door/sandstone, 10, one_per_turf = TRUE, on_floor = TRUE, applies_mats = TRUE), \
 	new/datum/stack_recipe("Breakdown into sand", /obj/item/stack/ore/glass, 1, one_per_turf = FALSE, on_floor = TRUE) \
 	))
 
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	walltype = /turf/closed/wall/mineral/diamond
 
 GLOBAL_LIST_INIT(diamond_recipes, list ( \
-	new/datum/stack_recipe("diamond door", /obj/structure/mineral_door/transparent/diamond, 10, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("diamond door", /obj/structure/mineral_door/transparent/diamond, 10, one_per_turf = 1, on_floor = 1, applies_mats = TRUE), \
 	new/datum/stack_recipe("diamond tile", /obj/item/stack/tile/mineral/diamond, 1, 4, 20),  \
 	))
 
@@ -133,7 +133,7 @@ GLOBAL_LIST_INIT(diamond_recipes, list ( \
 	walltype = /turf/closed/wall/mineral/uranium
 
 GLOBAL_LIST_INIT(uranium_recipes, list ( \
-	new/datum/stack_recipe("uranium door", /obj/structure/mineral_door/uranium, 10, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("uranium door", /obj/structure/mineral_door/uranium, 10, one_per_turf = 1, on_floor = 1, applies_mats = TRUE), \
 	new/datum/stack_recipe("uranium tile", /obj/item/stack/tile/mineral/uranium, 1, 4, 20), \
 	))
 
@@ -167,26 +167,13 @@ GLOBAL_LIST_INIT(uranium_recipes, list ( \
 	return TOXLOSS//dont you kids know that stuff is toxic?
 
 GLOBAL_LIST_INIT(plasma_recipes, list ( \
-	new/datum/stack_recipe("plasma door", /obj/structure/mineral_door/transparent/plasma, 10, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("plasma door", /obj/structure/mineral_door/transparent/plasma, 10, one_per_turf = 1, on_floor = 1, applies_mats = TRUE), \
 	new/datum/stack_recipe("plasma tile", /obj/item/stack/tile/mineral/plasma, 1, 4, 20), \
 	))
 
 /obj/item/stack/sheet/mineral/plasma/get_main_recipes()
 	. = ..()
 	. += GLOB.plasma_recipes
-
-/obj/item/stack/sheet/mineral/plasma/attackby(obj/item/W as obj, mob/user as mob, params)
-	if(W.get_temperature() > 300)//If the temperature of the object is over 300, then ignite
-		var/turf/T = get_turf(src)
-		message_admins("Plasma sheets ignited by [ADMIN_LOOKUPFLW(user)] in [ADMIN_VERBOSEJMP(T)]")
-		log_game("Plasma sheets ignited by [key_name(user)] in [AREACOORD(T)]")
-		fire_act(W.get_temperature())
-	else
-		return ..()
-
-/obj/item/stack/sheet/mineral/plasma/fire_act(exposed_temperature, exposed_volume)
-	atmos_spawn_air("plasma=[amount*10];TEMP=[exposed_temperature]")
-	qdel(src)
 
 /obj/item/stack/sheet/mineral/plasma/five
 	amount = 5
@@ -211,7 +198,7 @@ GLOBAL_LIST_INIT(plasma_recipes, list ( \
 	walltype = /turf/closed/wall/mineral/gold
 
 GLOBAL_LIST_INIT(gold_recipes, list ( \
-	new/datum/stack_recipe("golden door", /obj/structure/mineral_door/gold, 10, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("golden door", /obj/structure/mineral_door/gold, 10, one_per_turf = 1, on_floor = 1, applies_mats = TRUE), \
 	new/datum/stack_recipe("gold tile", /obj/item/stack/tile/mineral/gold, 1, 4, 20), \
 	new/datum/stack_recipe("blank plaque", /obj/item/plaque, 1), \
 	new/datum/stack_recipe("Simple Crown", /obj/item/clothing/head/crown, 5), \
@@ -239,7 +226,7 @@ GLOBAL_LIST_INIT(gold_recipes, list ( \
 	walltype = /turf/closed/wall/mineral/silver
 
 GLOBAL_LIST_INIT(silver_recipes, list ( \
-	new/datum/stack_recipe("silver door", /obj/structure/mineral_door/silver, 10, one_per_turf = 1, on_floor = 1), \
+	new/datum/stack_recipe("silver door", /obj/structure/mineral_door/silver, 10, one_per_turf = 1, on_floor = 1, applies_mats = TRUE), \
 	new/datum/stack_recipe("silver tile", /obj/item/stack/tile/mineral/silver, 1, 4, 20), \
 	))
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -114,7 +114,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("extinguisher cabinet frame", /obj/item/wallframe/extinguisher_cabinet, 2), \
 	new/datum/stack_recipe("button frame", /obj/item/wallframe/button, 1), \
 	null, \
-	new/datum/stack_recipe("iron door", /obj/structure/mineral_door/iron, 20, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("iron door", /obj/structure/mineral_door/iron, 20, one_per_turf = TRUE, on_floor = TRUE, applies_mats = TRUE), \
 	new/datum/stack_recipe("filing cabinet", /obj/structure/filingcabinet, 2, time = 10 SECONDS, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("floodlight frame", /obj/structure/floodlight_frame, 5, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("voting box", /obj/structure/votebox, 15, time = 50), \

--- a/code/game/objects/items/stacks/tiles/tile_mineral.dm
+++ b/code/game/objects/items/stacks/tiles/tile_mineral.dm
@@ -35,19 +35,6 @@
 	mats_per_unit = list(/datum/material/plasma=MINERAL_MATERIAL_AMOUNT*0.25)
 	merge_type = /obj/item/stack/tile/mineral/plasma
 
-/obj/item/stack/tile/mineral/plasma/attackby(obj/item/W, mob/user, params)
-	if(W.get_temperature() > 300)//If the temperature of the object is over 300, then ignite
-		var/turf/T = get_turf(src)
-		message_admins("Plasma tiles ignited by [ADMIN_LOOKUPFLW(user)] in [ADMIN_VERBOSEJMP(T)]")
-		log_game("Plasma tiles ignited by [key_name(user)] in [AREACOORD(T)]")
-		fire_act(W.get_temperature())
-	else
-		return ..()
-
-/obj/item/stack/tile/mineral/plasma/fire_act(exposed_temperature, exposed_volume)
-	atmos_spawn_air("plasma=[amount*2.5];TEMP=[exposed_temperature]")
-	qdel(src)
-
 /obj/item/stack/tile/mineral/uranium
 	name = "uranium tile"
 	singular_name = "uranium floor tile"

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -18,6 +18,7 @@
 	can_be_unanchored = FALSE
 	can_atmos_pass = ATMOS_PASS_DENSITY
 	rad_insulation = RAD_MEDIUM_INSULATION
+	material_flags = MATERIAL_EFFECTS
 	var/mineral = /obj/item/stack/sheet/iron
 	var/mineral_amount = 2
 	var/walltype = /turf/closed/wall
@@ -27,6 +28,9 @@
 
 /obj/structure/falsewall/Initialize(mapload)
 	. = ..()
+	var/obj/item/stack/initialized_mineral = new mineral // Okay this kinda sucks.
+	set_custom_materials(initialized_mineral.mats_per_unit, mineral_amount)
+	qdel(initialized_mineral)
 	air_update_turf(TRUE, TRUE)
 
 /obj/structure/falsewall/attack_hand(mob/user, list/modifiers)
@@ -246,31 +250,6 @@
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_PLASMA_WALLS)
 	canSmoothWith = list(SMOOTH_GROUP_PLASMA_WALLS)
-
-/obj/structure/falsewall/plasma/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/atmos_sensitive, mapload)
-
-/obj/structure/falsewall/plasma/attackby(obj/item/W, mob/user, params)
-	if(W.get_temperature() > 300)
-		var/turf/T = get_turf(src)
-		message_admins("Plasma falsewall ignited by [ADMIN_LOOKUPFLW(user)] in [ADMIN_VERBOSEJMP(T)]")
-		log_game("Plasma falsewall ignited by [key_name(user)] in [AREACOORD(T)]")
-		burnbabyburn()
-	else
-		return ..()
-
-/obj/structure/falsewall/plasma/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	return exposed_temperature > 300
-
-/obj/structure/falsewall/plasma/atmos_expose(datum/gas_mixture/air, exposed_temperature)
-	burnbabyburn()
-
-/obj/structure/falsewall/plasma/proc/burnbabyburn(user)
-	playsound(src, 'sound/items/welder.ogg', 100, TRUE)
-	atmos_spawn_air("plasma=400;TEMP=1000")
-	new /obj/structure/girder/displaced(loc)
-	qdel(src)
 
 /obj/structure/falsewall/bananium
 	name = "bananium wall"

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -59,14 +59,14 @@
 		if(istype(W, /obj/item/stack/rods))
 			var/obj/item/stack/rods/S = W
 			if(state == GIRDER_DISPLACED)
-				if(S.get_amount() < 2)
+				if(S.get_amount() < 5)
 					to_chat(user, span_warning("You need at least two rods to create a false wall!"))
 					return
 				to_chat(user, span_notice("You start building a reinforced false wall..."))
 				if(do_after(user, 20, target = src))
-					if(S.get_amount() < 2)
+					if(S.get_amount() < 5)
 						return
-					S.use(2)
+					S.use(5)
 					to_chat(user, span_notice("You create a false wall. Push on it to open or close the passage."))
 					var/obj/structure/falsewall/iron/FW = new (loc)
 					transfer_fingerprints_to(FW)

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -7,6 +7,7 @@
 	anchored = TRUE
 	opacity = TRUE
 	layer = CLOSED_DOOR_LAYER
+	material_flags = MATERIAL_EFFECTS
 
 	icon = 'icons/obj/doors/mineral_doors.dmi'
 	icon_state = "metal"
@@ -14,6 +15,8 @@
 	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 100, BOMB = 10, BIO = 100, FIRE = 50, ACID = 50)
 	can_atmos_pass = ATMOS_PASS_DENSITY
 	rad_insulation = RAD_MEDIUM_INSULATION
+	material_flags = MATERIAL_EFFECTS
+	material_modifier = 0.25
 
 	var/door_opened = FALSE //if it's open or not.
 	var/isSwitchingStates = FALSE //don't try to change stats if we're already opening
@@ -23,10 +26,13 @@
 	var/closeSound = 'sound/effects/stonedoor_openclose.ogg'
 
 	var/sheetType = /obj/item/stack/sheet/iron //what we're made of
-	var/sheetAmount = 7 //how much we drop when deconstructed
+	var/sheetAmount = 10 //how much it takes to construct us.
 
 /obj/structure/mineral_door/Initialize(mapload)
 	. = ..()
+	var/obj/item/stack/initialized_mineral = new sheetType // Okay this kinda sucks.
+	set_custom_materials(initialized_mineral.mats_per_unit, sheetAmount)
+	qdel(initialized_mineral)
 	air_update_turf(TRUE, TRUE)
 
 /obj/structure/mineral_door/Destroy()
@@ -205,6 +211,7 @@
 /obj/structure/mineral_door/iron
 	name = "iron door"
 	max_integrity = 300
+	sheetAmount = 20
 
 /obj/structure/mineral_door/silver
 	name = "silver door"
@@ -247,32 +254,6 @@
 	name = "plasma door"
 	icon_state = "plasma"
 	sheetType = /obj/item/stack/sheet/mineral/plasma
-
-/obj/structure/mineral_door/transparent/plasma/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/atmos_sensitive, mapload)
-
-/obj/structure/mineral_door/transparent/plasma/welder_act(mob/living/user, obj/item/I)
-	return
-
-/obj/structure/mineral_door/transparent/plasma/attackby(obj/item/W, mob/user, params)
-	if(W.get_temperature())
-		var/turf/T = get_turf(src)
-		message_admins("Plasma mineral door ignited by [ADMIN_LOOKUPFLW(user)] in [ADMIN_VERBOSEJMP(T)]")
-		log_game("Plasma mineral door ignited by [key_name(user)] in [AREACOORD(T)]")
-		TemperatureAct()
-	else
-		return ..()
-
-/obj/structure/mineral_door/transparent/plasma/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	return exposed_temperature > 300
-
-/obj/structure/mineral_door/transparent/plasma/atmos_expose(datum/gas_mixture/air, exposed_temperature)
-	TemperatureAct()
-
-/obj/structure/mineral_door/transparent/plasma/proc/TemperatureAct()
-	atmos_spawn_air("plasma=500;TEMP=1000")
-	deconstruct(FALSE)
 
 /obj/structure/mineral_door/transparent/diamond
 	name = "diamond door"

--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -134,35 +134,6 @@
 	canSmoothWith = list(SMOOTH_GROUP_PLASMA_WALLS)
 	custom_materials = list(/datum/material/plasma = 4000)
 
-/turf/closed/wall/mineral/plasma/attackby(obj/item/W, mob/user, params)
-	if(W.get_temperature() > 300)//If the temperature of the object is over 300, then ignite
-		message_admins("Plasma wall ignited by [ADMIN_LOOKUPFLW(user)] in [ADMIN_VERBOSEJMP(src)]")
-		log_game("Plasma wall ignited by [key_name(user)] in [AREACOORD(src)]")
-		ignite(W.get_temperature())
-		return
-	..()
-
-/turf/closed/wall/mineral/plasma/proc/PlasmaBurn(temperature)
-	new girder_type(src)
-	ScrapeAway()
-	var/turf/open/T = src
-	T.atmos_spawn_air("plasma=400;TEMP=[temperature]")
-
-/turf/closed/wall/mineral/plasma/temperature_expose(datum/gas_mixture/air, exposed_temperature)//Doesn't work because walls have superconduction turned off
-	if(exposed_temperature > 300)
-		PlasmaBurn(exposed_temperature)
-
-/turf/closed/wall/mineral/plasma/proc/ignite(exposed_temperature)
-	if(exposed_temperature > 300)
-		PlasmaBurn(exposed_temperature)
-
-/turf/closed/wall/mineral/plasma/bullet_act(obj/projectile/Proj)
-	if(istype(Proj, /obj/projectile/beam))
-		PlasmaBurn(2500)
-	else if(istype(Proj, /obj/projectile/ion))
-		PlasmaBurn(500)
-	. = ..()
-
 /turf/closed/wall/mineral/wood
 	name = "wooden wall"
 	desc = "A wall with wooden plating. Stiff."

--- a/code/game/turfs/open/floor/mineral_floor.dm
+++ b/code/game/turfs/open/floor/mineral_floor.dm
@@ -38,26 +38,6 @@
 	icons = list("plasma","plasma_dam")
 	custom_materials = list(/datum/material/plasma = 500)
 
-/turf/open/floor/mineral/plasma/temperature_expose(datum/gas_mixture/air, exposed_temperature)
-	if(exposed_temperature > 300)
-		PlasmaBurn(exposed_temperature)
-
-/turf/open/floor/mineral/plasma/attackby(obj/item/W, mob/user, params)
-	if(W.get_temperature() > 300)//If the temperature of the object is over 300, then ignite
-		message_admins("Plasma flooring was ignited by [ADMIN_LOOKUPFLW(user)] in [ADMIN_VERBOSEJMP(src)]")
-		log_game("Plasma flooring was ignited by [key_name(user)] in [AREACOORD(src)]")
-		ignite(W.get_temperature())
-		return
-	..()
-
-/turf/open/floor/mineral/plasma/proc/PlasmaBurn(temperature)
-	make_plating()
-	atmos_spawn_air("plasma=20;TEMP=[temperature]")
-
-/turf/open/floor/mineral/plasma/proc/ignite(exposed_temperature)
-	if(exposed_temperature > 300)
-		PlasmaBurn(exposed_temperature)
-
 //Plasma floor that can't be removed, for disco inferno
 
 /turf/open/floor/mineral/plasma/disco/crowbar_act(mob/living/user, obj/item/I)

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -96,52 +96,6 @@
 	name = "statue of a xenomorph"
 	icon_state = "xeno"
 
-/obj/structure/statue/plasma/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/atmos_sensitive, mapload)
-
-/obj/structure/statue/plasma/bullet_act(obj/projectile/Proj)
-	var/burn = FALSE
-	if(!(Proj.nodamage) && Proj.damage_type == BURN && !QDELETED(src))
-		burn = TRUE
-	if(burn)
-		var/turf/T = get_turf(src)
-		if(Proj.firer)
-			message_admins("Plasma statue ignited by [ADMIN_LOOKUPFLW(Proj.firer)] in [ADMIN_VERBOSEJMP(T)]")
-			log_game("Plasma statue ignited by [key_name(Proj.firer)] in [AREACOORD(T)]")
-		else
-			message_admins("Plasma statue ignited by [Proj]. No known firer, in [ADMIN_VERBOSEJMP(T)]")
-			log_game("Plasma statue ignited by [Proj] in [AREACOORD(T)]. No known firer.")
-		PlasmaBurn(2500)
-	. = ..()
-
-/obj/structure/statue/plasma/attackby(obj/item/W, mob/user, params)
-	if(W.get_temperature() > 300 && !QDELETED(src))//If the temperature of the object is over 300, then ignite
-		var/turf/T = get_turf(src)
-		message_admins("Plasma statue ignited by [ADMIN_LOOKUPFLW(user)] in [ADMIN_VERBOSEJMP(T)]")
-		log_game("Plasma statue ignited by [key_name(user)] in [AREACOORD(T)]")
-		ignite(W.get_temperature())
-	else
-		return ..()
-
-/obj/structure/statue/plasma/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	return exposed_temperature > 300
-
-/obj/structure/statue/plasma/atmos_expose(datum/gas_mixture/air, exposed_temperature)
-	PlasmaBurn(exposed_temperature)
-
-/obj/structure/statue/plasma/proc/PlasmaBurn(temperature)
-	if(QDELETED(src))
-		return
-	if(custom_materials[/datum/material/plasma])
-		var/plasma_amount = round(custom_materials[/datum/material/plasma]/MINERAL_MATERIAL_AMOUNT)
-		atmos_spawn_air("plasma=[plasma_amount*10];TEMP=[temperature]")
-	deconstruct(FALSE)
-
-/obj/structure/statue/plasma/proc/ignite(exposed_temperature)
-	if(exposed_temperature > 300)
-		PlasmaBurn(exposed_temperature)
-
 //////////////////////gold///////////////////////////////////////
 
 /obj/structure/statue/gold


### PR DESCRIPTION
## About The Pull Request
I originally wanted to do this in #60406 but didn't want to deal with the gameplay changes then.

Most plasma-derived items will now flood plasma, with movables also exploding. I don't really like how it's implemented code wise but at the same time I don't want to change the behavior significantly. Considered making this a prob but shooting your laser at a plasma bar with a 50% chance for it to work determined when spawned feels stupid.

~~Numbers are possibly a bit off ? I'll patch them up later.~~

Okay for mole numbers i looked into plasma bars and floors as a baseline. 
Use old bars as baseline: 10 per sheet, 50 per floor tile
Use old floors as baseline: 4 per sheet, 20 per floor tile
I chose 5 per sheet, 25 per tile. 250 a statue from old 50, but oh well the code taketh and the code giveth.

Equipment targeting check not implemented because I'm not sure we have any widely used right now (and lazy).

## Why It's Good For The Game
Makes things more consistent. Sort of a compromise solution to the outcomes I brought up in the linked PR.

## Changelog
:cl:
fix: Plasma material objects that didn't spawn plasma gas when ignited due to weird code reasons will now do just that.
fix: Fixed plasma material objects exploding when used with condenser.
fix: Fixed uranium manual doors and false walls not radiating.
fix: You can no longer duplicate rods with rough false walls.
code: Due to code structural changes the mole amount from welding plasma related objects may get buffed or nerfed. Mostly buffed.
/:cl: