### PR TITLE
Deltaservices Fixes: Two ORMs for the price of one (other minor fixes)

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -39418,17 +39418,6 @@
 /obj/machinery/mineral/ore_redemption,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/box,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/mineral/ore_redemption,
 /obj/machinery/door/window/southleft{
 	name = "Ore Redemption Access";
 	req_access_txt = "31;48;64"

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -71072,7 +71072,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Service Maintenance";
-	req_access_txt = "22;25;26;28;35;37;38;46;70"
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8


### PR DESCRIPTION
## About The Pull Request

- Removes some leftover up decals / a second ORM from Deltastation Cargo.
   - Likely, left over from a merge conflict by accident. Oops! 
- Fixes the access requirements on the service hall maint door.

No GBP here.

## Why It's Good For The Game

Stops confusing miners?

## Changelog

:cl: Melbert
fix: There is now the proper amount of ORMs in Deltastation's Cargo.
fix: Service jobs can leave the Deltastation Service Hall through maintenance 
/:cl:


