### PR TITLE
TGUI pAI Hotfix 1

### DIFF
--- a/code/__DEFINES/pai.dm
+++ b/code/__DEFINES/pai.dm
@@ -1,0 +1,2 @@
+/// Total percent required to hack a door.
+#define HACK_COMPLETE 100

--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -12,6 +12,7 @@ SUBSYSTEM_DEF(pai)
 	/// All pAI cards on the map.
 	var/list/pai_card_list = list()
 
+/// Created when a user clicks the "pAI candidate" window
 /datum/pai_candidate
 	/// User inputted OOC comments
 	var/comments
@@ -62,11 +63,9 @@ SUBSYSTEM_DEF(pai)
 		candidates.Add(candidate)
 	ui_interact(user)
 
-/// Ensures an observer has the window open
 /datum/controller/subsystem/pai/ui_state(mob/user)
 	return GLOB.observer_state
 
-/// Opens the TGUI window
 /datum/controller/subsystem/pai/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -74,7 +73,6 @@ SUBSYSTEM_DEF(pai)
 		ui = new(user, src, "PaiSubmit")
 		ui.open()
 
-/// The data sent to the window.
 /datum/controller/subsystem/pai/ui_static_data(mob/user)
 	. = ..()
 	var/list/data = list()
@@ -87,7 +85,6 @@ SUBSYSTEM_DEF(pai)
 	data["name"] = candidate.name
 	return data
 
-/// Actions sent by TGUI
 /datum/controller/subsystem/pai/ui_act(action, list/params, datum/tgui/ui)
 	. = ..()
 	if(.)
@@ -95,6 +92,8 @@ SUBSYSTEM_DEF(pai)
 	/// The matching candidate from search
 	var/datum/pai_candidate/candidate = check_candidate(usr)
 	if(isnull(candidate))
+		to_chat(usr, span_warning("There was an error. Please resubmit."))
+		ui.close()
 		return FALSE
 	switch(action)
 		if("submit")

--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -3,16 +3,25 @@ SUBSYSTEM_DEF(pai)
 
 	flags = SS_NO_INIT|SS_NO_FIRE
 
+	/// List of pAI candidates, including those not submitted.
 	var/list/candidates = list()
+	/// Prevents a crew member from hitting "request pAI"
 	var/request_spam = FALSE
+	/// Prevents a pAI from submitting itself repeatedly and sounding an alert.
 	var/submit_spam = FALSE
+	/// All pAI cards on the map.
 	var/list/pai_card_list = list()
 
 /datum/pai_candidate
+	/// User inputted OOC comments
 	var/comments
+	/// User inputted behavior description
 	var/description
+	/// User's ckey - not input
 	var/key
+	/// User's pAI name. If blank, ninja name.
 	var/name
+	/// If the user has hit "submit"
 	var/ready = FALSE
 
 /**
@@ -100,7 +109,6 @@ SUBSYSTEM_DEF(pai)
 			candidate.description = params["candidate"]["description"]
 			candidate.name = params["candidate"]["name"]
 			candidate.savefile_save(usr)
-			to_chat(usr, span_boldnotice("You have saved pAI information locally."))
 		if("load")
 			candidate.savefile_load(usr)
 			//In case people have saved unsanitized stuff.

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -678,6 +678,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 						pai.attack_self(U)
 					if("2") // Eject pAI device
 						usr.put_in_hands(pai)
+						pai.slotted = FALSE
 						to_chat(usr, span_notice("You remove the pAI from the [name]."))
 
 //SKILL FUNCTIONS===================================
@@ -1085,6 +1086,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		if(!user.transferItemToLoc(C, src))
 			return
 		pai = C
+		pai.slotted = TRUE
 		to_chat(user, span_notice("You slot \the [C] into [src]."))
 		update_appearance()
 		updateUsrDialog()

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -11,6 +11,8 @@
 	custom_premium_price = PAYCHECK_HARD * 1.25
 	///don't spam alert messages.
 	var/alert_cooldown
+	/// If the pAIcard is slotted in a PDA
+	var/slotted = FALSE
 	/// Any pAI personalities inserted
 	var/mob/living/silicon/pai/pai
 	///what emotion icon we have. handled in /mob/living/silicon/pai/Topic()
@@ -57,7 +59,6 @@
 	user.set_machine(src)
 	ui_interact(user)
 
-/// Opens the TGUI window
 /obj/item/paicard/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -65,11 +66,9 @@
 		ui = new(user, src, "PaiCard")
 		ui.open()
 
-/// Ensures the paicard is in hand
 /obj/item/paicard/ui_state(mob/user)
-	return GLOB.inventory_state
+	return GLOB.paicard_state
 
-/// Data sent to TGUI
 /obj/item/paicard/ui_data(mob/user)
 	. = ..()
 	var/list/data = list()
@@ -89,7 +88,6 @@
 	data["pai"]["receive"] = pai.can_receive
 	return data
 
-/// Actions received from TGUI
 /obj/item/paicard/ui_act(action, list/params)
 	. = ..()
 	if(.)

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -11,8 +11,10 @@
 	custom_premium_price = PAYCHECK_HARD * 1.25
 	///don't spam alert messages.
 	var/alert_cooldown
+	/// Any pAI personalities inserted
 	var/mob/living/silicon/pai/pai
-	var/emotion_icon = "off" ///what emotion icon we have. handled in /mob/living/silicon/pai/Topic()
+	///what emotion icon we have. handled in /mob/living/silicon/pai/Topic()
+	var/emotion_icon = "off"
 	resistance_flags = FIRE_PROOF | ACID_PROOF | INDESTRUCTIBLE
 
 /obj/item/paicard/suicide_act(mob/living/user)
@@ -55,6 +57,7 @@
 	user.set_machine(src)
 	ui_interact(user)
 
+/// Opens the TGUI window
 /obj/item/paicard/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -62,9 +65,11 @@
 		ui = new(user, src, "PaiCard")
 		ui.open()
 
+/// Ensures the paicard is in hand
 /obj/item/paicard/ui_state(mob/user)
 	return GLOB.inventory_state
 
+/// Data sent to TGUI
 /obj/item/paicard/ui_data(mob/user)
 	. = ..()
 	var/list/data = list()
@@ -84,6 +89,7 @@
 	data["pai"]["receive"] = pai.can_receive
 	return data
 
+/// Actions received from TGUI
 /obj/item/paicard/ui_act(action, list/params)
 	. = ..()
 	if(.)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -179,9 +179,7 @@
 	aiPDA.name = real_name + " (" + aiPDA.ownjob + ")"
 
 /mob/living/silicon/pai/proc/process_hack(delta_time, times_fired)
-	if(hacking_cable && hacking_cable.machine && istype(hacking_cable.machine, /obj/machinery/door) && hacking_cable.machine == hackdoor && get_dist(src, hackdoor) <= 1)
-		if(!hackbar)
-			hackbar = new(src, HACK_COMPLETE, hacking_cable.machine)
+	if(hacking_cable?.machine && istype(hacking_cable.machine, /obj/machinery/door) && hacking_cable.machine == hackdoor && get_dist(src, hackdoor) <= 1)
 		hackprogress = clamp(hackprogress + (2 * delta_time), 0, HACK_COMPLETE)
 		hackbar.update(hackprogress)
 	else

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -1,6 +1,3 @@
-/// Total percent required to hack a door.
-#define HACK_COMPLETE 100
-
 /mob/living/silicon/pai
 	name = "pAI"
 	icon = 'icons/mob/pai.dmi'
@@ -197,7 +194,6 @@
 		hackprogress = 0
 		hacking = FALSE
 		hackbar.end_progress()
-		/// The door being opened by the pAI
 		var/obj/machinery/door/door = hacking_cable.machine
 		door.open()
 		QDEL_NULL(hackbar)

--- a/code/modules/mob/living/silicon/pai/personality.dm
+++ b/code/modules/mob/living/silicon/pai/personality.dm
@@ -12,17 +12,14 @@
 
 /datum/pai_candidate/proc/savefile_save(mob/user)
 	if(is_guest_key(user.key))
+		to_chat(usr, span_warning("You cannot save pAI information as a guest."))
 		return FALSE
-
 	var/savefile/F = new /savefile(src.savefile_path(user))
-
-
 	WRITE_FILE(F["name"], name)
 	WRITE_FILE(F["description"], description)
 	WRITE_FILE(F["comments"], comments)
-
 	WRITE_FILE(F["version"], 1)
-
+	to_chat(usr, span_boldnotice("You have saved pAI information locally."))
 	return TRUE
 
 // loads the savefile corresponding to the mob's ckey

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -277,6 +277,8 @@
 			to_chat(AI, "<font color = red><b>Network Alert: Brute-force security override in progress in [turf.loc].</b></font>")
 		else
 			to_chat(AI, "<font color = red><b>Network Alert: Brute-force security override in progress. Unable to pinpoint location.</b></font>")
+	if(!hackbar)
+		hackbar = new(src, HACK_COMPLETE, hacking_cable.machine)
 	hacking = TRUE
 
 /**

--- a/code/modules/tgui/states/paicard.dm
+++ b/code/modules/tgui/states/paicard.dm
@@ -1,0 +1,20 @@
+/**
+ * tgui state: paicard_state
+ *
+ * Checks that the paicard is in the user's top-level
+ * (hand, ear, pocket, belt, etc) inventory OR
+ *  if the paicard has been slotted into a PDA which
+ * is also on the user's person.
+ *
+ */
+
+GLOBAL_DATUM_INIT(paicard_state, /datum/ui_state/paicard_state, new)
+
+/datum/ui_state/paicard_state/can_use_topic(obj/item/paicard/paicard, mob/user)
+	/// paicard is in the user's closest inventory
+	if(!paicard.slotted && (paicard in user))
+		return user.shared_ui_interaction(paicard)
+	/// paicard is in a pda slot which is in the user's closest inventory
+	if(paicard.slotted && (paicard.loc in user))
+		return user.shared_ui_interaction(paicard)
+	return UI_CLOSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3850,6 +3850,7 @@
 #include "code\modules\tgui\states\not_incapacitated.dm"
 #include "code\modules\tgui\states\notcontained.dm"
 #include "code\modules\tgui\states\observer.dm"
+#include "code\modules\tgui\states\paicard.dm"
 #include "code\modules\tgui\states\physical.dm"
 #include "code\modules\tgui\states\self.dm"
 #include "code\modules\tgui\states\zlevel.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -109,6 +109,7 @@
 #include "code\__DEFINES\networks.dm"
 #include "code\__DEFINES\nitrile.dm"
 #include "code\__DEFINES\obj_flags.dm"
+#include "code\__DEFINES\pai.dm"
 #include "code\__DEFINES\pinpointers.dm"
 #include "code\__DEFINES\pipe_construction.dm"
 #include "code\__DEFINES\plumbing.dm"

--- a/tgui/packages/tgui/interfaces/PaiCard.tsx
+++ b/tgui/packages/tgui/interfaces/PaiCard.tsx
@@ -169,7 +169,7 @@ const PaiOptions = (_, context) => {
             </Button>
           )}
         </LabeledList.Item>
-        {master && <LabeledList.Item label="DNA">{dna}</LabeledList.Item>}
+        {!!master && <LabeledList.Item label="DNA">{dna}</LabeledList.Item>}
         <LabeledList.Item label="Laws">{laws}</LabeledList.Item>
         <LabeledList.Item label="Holoform">
           <Button

--- a/tgui/packages/tgui/interfaces/PaiSubmit.tsx
+++ b/tgui/packages/tgui/interfaces/PaiSubmit.tsx
@@ -116,6 +116,7 @@ const InputDisplay = (props) => {
 const ButtonsDisplay = (props, context) => {
   const { act } = useBackend<CandidateData>(context);
   const { input } = props;
+
   return (
     <Section fill>
       <Stack>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Adds a new ui state so that players can access the paicard tgui while it's slotted in their PDA (inside the pda wasn't technically in the user's close inventory).
- Adds some documentation for the pAI candidate file
- Users now get notifications if they can't save files (guest keys).
- pAIs previously had NO on screen indicator of hack progress, so I've given them a progressbar over the door

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More visual output for pAIs
More output for edge cases
More documentation
Fixes #63161 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Saving pAI candidacy information now outputs an error when unsuccessful.
add: pAIs now get a door jacking progressbar. It remains obscenely slow, though.
fix: Fixes not being able to access pAI config if it's slotted into your PDA.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
