### PR TITLE
Portable atmos machines can properly forget their destroyed tanks.

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -725,4 +725,4 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 
 /obj/machinery/portable_atmospherics/canister/unregister_holding()
 	valve_open = FALSE
-	. = ..()
+	return ..()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -722,3 +722,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 				replace_tank(usr, FALSE)
 				. = TRUE
 	update_appearance()
+
+/obj/machinery/portable_atmospherics/canister/unregister_holding()
+	valve_open = FALSE
+	. = ..()

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -133,9 +133,11 @@
 		return FALSE
 	if(holding)
 		user.put_in_hands(holding)
+		UnregisterSignal(holding, COMSIG_PARENT_QDELETING)
 		holding = null
 	if(new_tank)
 		holding = new_tank
+		RegisterSignal(holding, COMSIG_PARENT_QDELETING, .proc/unregister_holding)
 
 	SSair.start_processing_machine(src)
 	update_appearance()
@@ -190,3 +192,9 @@
 	investigate_log("was smacked with \a [item] by [key_name(user)].", INVESTIGATE_ATMOS)
 	add_fingerprint(user)
 	return ..()
+
+/// Holding tanks can get to zero integrity and be destroyed without other warnings due to pressure change. 
+/// This checks for that case and removes our reference to it.
+/obj/machinery/portable_atmospherics/proc/unregister_holding()
+	UnregisterSignal(holding, COMSIG_PARENT_QDELETING)
+	holding = null

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -196,5 +196,7 @@
 /// Holding tanks can get to zero integrity and be destroyed without other warnings due to pressure change. 
 /// This checks for that case and removes our reference to it.
 /obj/machinery/portable_atmospherics/proc/unregister_holding()
+	SIGNAL_HANDLER
+	
 	UnregisterSignal(holding, COMSIG_PARENT_QDELETING)
 	holding = null

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -175,4 +175,4 @@
 
 /obj/machinery/portable_atmospherics/pump/unregister_holding()
 	on = FALSE
-	. = ..()
+	return ..()

--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -172,3 +172,7 @@
 				replace_tank(usr, FALSE)
 				. = TRUE
 	update_appearance()
+
+/obj/machinery/portable_atmospherics/pump/unregister_holding()
+	on = FALSE
+	. = ..()

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -216,3 +216,7 @@
 			on = FALSE
 	else
 		return ..()
+
+/obj/machinery/portable_atmospherics/pump/unregister_holding()
+	on = FALSE
+	. = ..()

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -169,6 +169,10 @@
 			. = TRUE
 	update_appearance()
 
+/obj/machinery/portable_atmospherics/scrubber/unregister_holding()
+	on = FALSE
+	. = ..()
+
 /obj/machinery/portable_atmospherics/scrubber/huge
 	name = "huge air scrubber"
 	icon_state = "scrubber"
@@ -216,7 +220,3 @@
 			on = FALSE
 	else
 		return ..()
-
-/obj/machinery/portable_atmospherics/pump/unregister_holding()
-	on = FALSE
-	. = ..()

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -171,7 +171,7 @@
 
 /obj/machinery/portable_atmospherics/scrubber/unregister_holding()
 	on = FALSE
-	. = ..()
+	return ..()
 
 /obj/machinery/portable_atmospherics/scrubber/huge
 	name = "huge air scrubber"


### PR DESCRIPTION
## About The Pull Request
Tanks can be overpressurized due to insane temperature/heat_capacity deltas or reactions happening inside it. All of this can occur inside cans. If they explode players wont notice it bluescreening, which happens most of the time due to the can dying. If they don't explode players do, this is one such case.

<image src="https://cdn.discordapp.com/attachments/326822144233439242/915175388706131978/unknown.png">

Also possible to hook this in process_atmos but i figure this is better.

## Why It's Good For The Game
Fixes a bluescreen/runtime/possible harddel?

## Changelog
:cl:
fix: tanks being destroyed in cans/pumps/scrubbers wont cause errors now
/:cl: