### PR TITLE
MOVES psychologist AND lawyer to SERVICE in preferences menu

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/jobs/jobs/lawyer.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/jobs/jobs/lawyer.ts
@@ -1,11 +1,11 @@
 import { Job } from "../base";
-import { Security } from "../departments";
+import { Service } from "../departments";
 
 const Lawyer: Job = {
   name: "Lawyer",
   description: "Advocate for prisoners, create law-binding contracts, \
     ensure Security is following protocol and Space Law.",
-  department: Security,
+  department: Service,
 };
 
 export default Lawyer;

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/jobs/jobs/psychologist.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/jobs/jobs/psychologist.ts
@@ -1,11 +1,11 @@
 import { Job } from "../base";
-import { Medical } from "../departments";
+import { Service } from "../departments";
 
 const Psychologist: Job = {
   name: "Psychologist",
   description: "Advocate sanity, self-esteem, and teamwork in a station \
     staffed with headcases.",
-  department: Medical,
+  department: Service,
 };
 
 export default Psychologist;


### PR DESCRIPTION
## About The Pull Request

I am literally BRINGING back https://github.com/tgstation/tgstation/pull/61476 because THIS time ORANGES approved of it happening and YEAH.

![image](https://user-images.githubusercontent.com/53777086/144125363-e707a644-8600-4ded-95b2-439848839e05.png)
![image](https://user-images.githubusercontent.com/53777086/144125309-e50faa7a-9379-42d4-817f-22121c3b9f96.png)
![image](https://user-images.githubusercontent.com/53777086/144125321-651b8491-8228-4aab-8b5b-c236f9ba11eb.png)


## Why It's Good For The Game

I HATE SECURITY
I HATE MEDICAL
MY LOVE IS ONLY FOR SERVICE

or you can just check my old PR where I explain it seriously.

## Changelog

:cl:
fix: Lawyers and Psychologists show up under Service rather than Security and Medical, in the new job selection screen.
/:cl: