### PR TITLE
Added an examine message to wired glass tiles

### DIFF
--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -14,6 +14,10 @@
 	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/copper = 5)
 	merge_type = /obj/item/stack/light_w
 
+/obj/item/stack/light_w/examine(mob/user)
+	. = ..()
+	. += span_warning("The [name] looks unfinished, add iron to complete it.")
+
 /obj/item/stack/light_w/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/stack/sheet/iron))
 		var/obj/item/stack/sheet/iron/M = O

--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -16,7 +16,7 @@
 
 /obj/item/stack/light_w/examine(mob/user)
 	. = ..()
-	. += span_warning("The [name] looks unfinished, add iron to complete it.")
+	. += span_warning("The [name] looks unfinished, add <b>iron</b> to complete it.")
 
 /obj/item/stack/light_w/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/stack/sheet/iron))


### PR DESCRIPTION
## About The Pull Request
See title

## Why It's Good For The Game
I thought that not being able to place those tiles were a bug. Seems like it's a feature.

## Changelog
:cl:
qol: Wired glass tiles need iron to make it a full fledged floor, this is now explained in the examine message.
/:cl: