### PR TITLE
Limit repository announcements to a whitelist, Discord announces to a blacklist

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -377,7 +377,7 @@ function handle_pr($payload) {
 
 	$repo_name = $payload['repository']['name'];
 
-	if (in_array($repo_name, $repo_announce_whitelist)) {
+	if (in_array($repo_name, $game_announce_whitelist)) {
 		game_announce($action, $payload, $pr_flags);
 	}
 

--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -40,6 +40,13 @@ $tracked_branch = 'master';
 $require_changelogs = false;
 $discordWebHooks = array();
 
+// Only these repositories will announce in game and on Discord.
+// Any repository that players actually care about.
+$repo_announce_whitelist = array(
+	"tgstation",
+	"TerraGov-Marine-Corps",
+);
+
 require_once 'secret.php';
 
 //CONFIG END
@@ -352,9 +359,11 @@ function handle_pr($payload) {
 	if (!$validated) {
 		$pr_flags |= F_UNVALIDATED_USER;
 	}
-	discord_announce($action, $payload, $pr_flags);
-	game_announce($action, $payload, $pr_flags);
 
+	if (in_array($payload['repository']['name'], $repo_announce_whitelist)) {
+		discord_announce($action, $payload, $pr_flags);
+		game_announce($action, $payload, $pr_flags);
+	}
 }
 
 function filter_announce_targets($targets, $owner, $repo, $action, $pr_flags) {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Limits the game announcers only to arrays in a fixed whitelist.

Discord announcements, as they're more for those interested in the technical side, are on a blacklist of patterns. This is set to blacklist anything starting with event-*.

This stops a lot of internal repos from clogging chat, but more importantly is going to be used as events will now be hosted on the tgstation organization, and we want to limit spoilers/confusion on that for people who don't go looking for it.