### PR TITLE
Makes mulebot wires accessible again

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -102,6 +102,7 @@
 /mob/living/simple_animal/bot/mulebot/examine(mob/user)
 	. = ..()
 	if(bot_cover_flags & BOT_COVER_OPEN)
+		. += span_info("You can access the wires using <b>wirecutters</b> or a <b>multitool</b>.")
 		if(cell)
 			. += span_notice("It has \a [cell] installed.")
 			. += span_info("You can use a <b>crowbar</b> to remove it.")

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -168,7 +168,7 @@
 		cell = null
 		diag_hud_set_mulebotcell()
 	else if(is_wire_tool(I) && bot_cover_flags & BOT_COVER_OPEN)
-		return attack_hand(user)
+		wires.interact(user)
 	else if(load && ismob(load))  // chance to knock off rider
 		if(prob(1 + I.force * 2))
 			unload(0)


### PR DESCRIPTION
## About The Pull Request

Apparently converting the mulebot interface to TGUI rendered the wires inaccessible by writing the code incorrectly. This PR fixes that.

## Why It's Good For The Game

Reintroduces mulebot hacking and all it entails.

## Changelog

:cl:
fix: Mulebot wires are once again accessible. Use wirecutters or a multitool while the maintenance panel is open.
/:cl: