### PR TITLE
Gives blind people a chat message when someone tries to handcuff them

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -62,7 +62,7 @@
 			C.visible_message(span_danger("[user] is trying to put [name] on [C]!"), \
 								span_userdanger("[user] is trying to put [name] on you!"))
 			if(C.is_blind())
-				C.show_message(span_userdanger("You feel someone grab your wrists, the clink of [name] rattling around your ears!"), MSG_AUDIBLE)
+				to_chat(C, span_userdanger("You feel someone grab your wrists, the cold metal of [name] starting to dig into your skin!"))
 			playsound(loc, cuffsound, 30, TRUE, -2)
 			log_combat(user, C, "attempted to handcuff")
 			if(do_mob(user, C, 30, timed_action_flags = IGNORE_SLOWDOWNS) && C.canBeHandcuffed())

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -60,9 +60,9 @@
 	if(!C.handcuffed)
 		if(C.canBeHandcuffed())
 			C.visible_message(span_danger("[user] is trying to put [name] on [C]!"), \
-								span_userdanger("[user] is trying to put [name] on you!"), \
-								span_userdanger("You feel someone grab your wrists, the clink of [name] rattling around your ears!"))
-
+								span_userdanger("[user] is trying to put [name] on you!"))
+			if(C.is_blind())
+				C.show_message(span_userdanger("You feel someone grab your wrists, the clink of [name] rattling around your ears!"), MSG_AUDIBLE)
 			playsound(loc, cuffsound, 30, TRUE, -2)
 			log_combat(user, C, "attempted to handcuff")
 			if(do_mob(user, C, 30, timed_action_flags = IGNORE_SLOWDOWNS) && C.canBeHandcuffed())

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -59,9 +59,9 @@
 
 	if(!C.handcuffed)
 		if(C.canBeHandcuffed())
-			C.visible_message(span_danger("[user] is trying to put [src.name] on [C]!"), \
-								span_userdanger("[user] is trying to put [src.name] on you!"), \
-								span_userdanger("You feel someone grab your wrists, the clink of [src.name] rattling around your ears!"))
+			C.visible_message(span_danger("[user] is trying to put [name] on [C]!"), \
+								span_userdanger("[user] is trying to put [name] on you!"), \
+								span_userdanger("You feel someone grab your wrists, the clink of [name] rattling around your ears!"))
 
 			playsound(loc, cuffsound, 30, TRUE, -2)
 			log_combat(user, C, "attempted to handcuff")

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -60,7 +60,8 @@
 	if(!C.handcuffed)
 		if(C.canBeHandcuffed())
 			C.visible_message(span_danger("[user] is trying to put [src.name] on [C]!"), \
-								span_userdanger("[user] is trying to put [src.name] on you!"))
+								span_userdanger("[user] is trying to put [src.name] on you!"), \
+								span_userdanger("You feel someone grab your wrists, the clink of [src.name] rattling around your ears!"))
 
 			playsound(loc, cuffsound, 30, TRUE, -2)
 			log_combat(user, C, "attempted to handcuff")


### PR DESCRIPTION
## About The Pull Request

Gives blind people a chat message when someone tries to cuff them.

## Why It's Good For The Game

Currently, blind people get _zero_ feedback that they're being cuffed other than the noise - which is, somewhat ironically, not very disability friendly, and can be easy to miss even if you can hear fine.

It is not something that you should not be able to realise ICly due to lack of sight, as someone cuffing you would be pretty obvious to just about anyone - so it makes no sense to limit it OOCly.

I suppose it is technically a balance change, but it honestly feels more like an oversight than a feature.

## Changelog
:cl:
fix: Blind people now get a chat message when being cuffed.
/:cl: