### PR TITLE
Deltaservice Fixes: Protolathe -> Techfab

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -50581,11 +50581,11 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "jdg" = (
-/obj/machinery/rnd/production/protolathe/department/service,
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
+/obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/iron/checker,
 /area/hallway/secondary/service)
 "jdv" = (


### PR DESCRIPTION
## About The Pull Request

The service lathe was accidentally a protolathe instead of a techfab, never noticed in testing because I don't often print boards when I play service jobs. Makes it a techfab correctly.

No GBP here.

## Why It's Good For The Game

Service can print boards.

## Changelog

:cl: Melbert
fix: The lathe in Deltastation's service hall can print circuit boards again.
/:cl:

