### PR TITLE
Wethide now dries into leather after burning

### DIFF
--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -76,6 +76,15 @@
 	grilled_result.pixel_x = original_object.pixel_x
 	grilled_result.pixel_y = original_object.pixel_y
 
+	if(istype(parent, /obj/item/stack)) //Check if its a sheet
+		var/obj/item/stack/itemstack = original_object
+		for(var/i in 1 to itemstack.amount)
+			var/atom/movable/resulting_atom = new grilled_result(parent.drop_location())
+		grill_source.visible_message("<span class='[positive_result ? "notice" : "warning"]'>[parent] turns into \a [grilled_result]!</span>")
+		SEND_SIGNAL(parent, COMSIG_GRILL_COMPLETED, grilled_result)
+		currently_grilling = FALSE
+		qdel(parent)
+		return
 	grill_source.visible_message("<span class='[positive_result ? "notice" : "warning"]'>[parent] turns into \a [grilled_result]!</span>")
 	SEND_SIGNAL(parent, COMSIG_GRILL_COMPLETED, grilled_result)
 	currently_grilling = FALSE

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -79,10 +79,9 @@
 	if(istype(parent, /obj/item/stack)) //Check if its a sheet
 		var/obj/item/stack/itemstack = original_object
 		for(var/i in 1 to itemstack.amount)
-			var/atom/movable/resulting_atom = new grilled_result(parent.drop_location())
-		grill_source.visible_message("<span class='[positive_result ? "notice" : "warning"]'>[parent] turns into \a [grilled_result]!</span>")
-		SEND_SIGNAL(parent, COMSIG_GRILL_COMPLETED, grilled_result)
-		currently_grilling = FALSE
+			grill_source.visible_message("<span class='[positive_result ? "notice" : "warning"]'>[parent] turns into \a [grilled_result]!</span>")
+			SEND_SIGNAL(parent, COMSIG_GRILL_COMPLETED, grilled_result)
+			currently_grilling = FALSE
 		qdel(parent)
 		return
 	grill_source.visible_message("<span class='[positive_result ? "notice" : "warning"]'>[parent] turns into \a [grilled_result]!</span>")

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -68,6 +68,18 @@
 /datum/component/grillable/proc/FinishGrilling(atom/grill_source)
 
 	var/atom/original_object = parent
+
+	if(istype(parent, /obj/item/stack)) //Check if its a sheet, for grilling multiple things in a stack
+		var/obj/item/stack/itemstack = original_object
+		var/atom/grilled_result = new cook_result(original_object.loc, itemstack.amount)
+		SEND_SIGNAL(parent, COMSIG_GRILL_COMPLETED, grilled_result)
+		currently_grilling = FALSE
+		grill_source.visible_message("<span class='[positive_result ? "notice" : "warning"]'>[parent] turns into \a [grilled_result]!</span>")
+		grilled_result.pixel_x = original_object.pixel_x
+		grilled_result.pixel_y = original_object.pixel_y	
+		qdel(parent)
+		return
+
 	var/atom/grilled_result = new cook_result(original_object.loc)
 
 	if(original_object.custom_materials)
@@ -76,14 +88,7 @@
 	grilled_result.pixel_x = original_object.pixel_x
 	grilled_result.pixel_y = original_object.pixel_y
 
-	if(istype(parent, /obj/item/stack)) //Check if its a sheet
-		var/obj/item/stack/itemstack = original_object
-		for(var/i in 1 to itemstack.amount)
-			grill_source.visible_message("<span class='[positive_result ? "notice" : "warning"]'>[parent] turns into \a [grilled_result]!</span>")
-			SEND_SIGNAL(parent, COMSIG_GRILL_COMPLETED, grilled_result)
-			currently_grilling = FALSE
-		qdel(parent)
-		return
+	
 	grill_source.visible_message("<span class='[positive_result ? "notice" : "warning"]'>[parent] turns into \a [grilled_result]!</span>")
 	SEND_SIGNAL(parent, COMSIG_GRILL_COMPLETED, grilled_result)
 	currently_grilling = FALSE

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -158,6 +158,7 @@ GLOBAL_LIST_INIT(xeno_recipes, list ( \
 	. = ..()
 	AddElement(/datum/element/dryable, /obj/item/stack/sheet/leather)
 	AddElement(/datum/element/atmos_sensitive, mapload)
+	AddComponent(/datum/component/grillable, /obj/item/stack/sheet/leather, rand(1 SECONDS, 3 SECONDS), TRUE)
 
 /obj/item/stack/sheet/wethide/burn()
 	visible_message(span_notice("[src] finishes drying!"))

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -159,6 +159,12 @@ GLOBAL_LIST_INIT(xeno_recipes, list ( \
 	AddElement(/datum/element/dryable, /obj/item/stack/sheet/leather)
 	AddElement(/datum/element/atmos_sensitive, mapload)
 
+/obj/item/stack/sheet/wethide/burn()
+	visible_message(span_notice("[src] finishes drying!"))
+	new /obj/item/stack/sheet/leather(loc)
+	qdel(src)
+	
+
 /*
  * Leather SHeet
  */

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -161,8 +161,8 @@ GLOBAL_LIST_INIT(xeno_recipes, list ( \
 	AddComponent(/datum/component/grillable, /obj/item/stack/sheet/leather, rand(1 SECONDS, 3 SECONDS), TRUE)
 
 /obj/item/stack/sheet/wethide/burn()
-	visible_message(span_notice("[src] finishes drying!"))
-	new /obj/item/stack/sheet/leather(loc)
+	visible_message(span_notice("[src] burns up, leaving a sheet of leather behind!"))
+	new /obj/item/stack/sheet/leather(loc) // only one sheet remains to incentivise not burning your wethide to dry it
 	qdel(src)
 	
 

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -138,6 +138,7 @@
 			if(grill && isitem(burned_object))
 				var/obj/item/grilled_item = burned_object
 				SEND_SIGNAL(grilled_item, COMSIG_ITEM_GRILLED, src, delta_time) //Not a big fan, maybe make this use fire_act() in the future.
+				SEND_SIGNAL(grilled_item, COMSIG_ITEM_DRIED, src, delta_time) //Allows wethide to be dried on bonfire grills
 				continue
 			burned_object.fire_act(1000, 250 * delta_time)
 

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -138,7 +138,6 @@
 			if(grill && isitem(burned_object))
 				var/obj/item/grilled_item = burned_object
 				SEND_SIGNAL(grilled_item, COMSIG_ITEM_GRILLED, src, delta_time) //Not a big fan, maybe make this use fire_act() in the future.
-				SEND_SIGNAL(grilled_item, COMSIG_ITEM_DRIED, src, delta_time) //Allows wethide to be dried on bonfire grills
 				continue
 			burned_object.fire_act(1000, 250 * delta_time)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can now dry wet hide (obtainable by skinning and wetting goliath plates or other animal hides) into leather by lighting it on fire (with a bonfire grill especially, though the heat of being on fire will dry it regardless of the origin of the fire)

This also means that ashwalkers will be able to obtain leather without getting power, since drying racks require power, which, as shown in https://github.com/tgstation/tgstation/pull/63195, is apparenly intended and not a bug.

Fixes the other half of #63180
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ashwalkers can now dry hide to get leather by igniting it on a bonfire grill. Tanning hide rarely comes up on station, if ever, so this won't affect stationside life.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: You can now tan wet hide into leather by lighting it on fire or placing it on a bonfire grill.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
