### PR TITLE
BCI implanters no longer drop their BCI on the floor when opened

### DIFF
--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -339,6 +339,11 @@
 	. = ..()
 	occupant_typecache = typecacheof(/mob/living/carbon)
 
+/obj/machinery/bci_implanter/on_deconstruction()
+	var/obj/item/organ/cyberimp/bci/bci_to_implant_resolved = bci_to_implant?.resolve()
+	bci_to_implant_resolved?.forceMove(drop_location())
+	bci_to_implant = null
+
 /obj/machinery/bci_implanter/Destroy()
 	QDEL_NULL(bci_to_implant)
 	return ..()

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -416,7 +416,7 @@
 		var/obj/item/organ/cyberimp/bci/previous_bci_to_implant = bci_to_implant?.resolve()
 
 		bci_to_implant = WEAKREF(weapon)
-		weapon.forceMove(src)
+		weapon.moveToNullspace()
 
 		if (isnull(previous_bci_to_implant))
 			balloon_alert(user, "inserted bci")
@@ -475,7 +475,7 @@
 
 		if (isnull(bci_to_implant_resolved))
 			say("Occupant's previous brain-computer interface has been transferred to internal storage unit.")
-			bci_organ.forceMove(src)
+			bci_organ.moveToNullspace()
 			bci_to_implant = WEAKREF(bci_organ)
 		else
 			say("Occupant's previous brain-computer interface has been ejected.")


### PR DESCRIPTION
## About The Pull Request

Exactly what it says in the title. Implanters used to drop the BCI they contained when opened up. Now they don't. For good measure I made them drop their contained BCIs when deconstructed as well in case they already did that as a consequence of the BCI being located inside the implanter, which was the cause of the issue in the first place.

## Why It's Good For The Game

There might be an open issue corresponding to what this PR fixes but I dunno, I just found out about the issue while messing about with circuits.

## Changelog

:cl:
fix: BCI manipulation chambers no longer drop the contained BCI when opened.
/:cl: