### PR TITLE
Fixes the overflow station trait not working

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -106,15 +106,15 @@
 
 /datum/station_trait/overflow_job_bureaucracy/New()
 	. = ..()
-	var/datum/job/picked_job = pick(SSjob.joinable_occupations)
-	chosen_job = picked_job.type
 	RegisterSignal(SSjob, COMSIG_SUBSYSTEM_POST_INITIALIZE, .proc/set_overflow_job_override)
 
 /datum/station_trait/overflow_job_bureaucracy/get_report()
 	return "[name] - It seems for some reason we put out the wrong job-listing for the overflow role this shift...I hope you like [chosen_job]s."
 
-/datum/station_trait/overflow_job_bureaucracy/proc/set_overflow_job_override(datum/source, new_overflow_role)
+/datum/station_trait/overflow_job_bureaucracy/proc/set_overflow_job_override(datum/source)
 	SIGNAL_HANDLER
+	var/datum/job/picked_job = pick(SSjob.joinable_occupations)
+	chosen_job = picked_job.type
 	SSjob.set_overflow_role(chosen_job)
 
 /datum/station_trait/slow_shuttle

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -102,20 +102,20 @@
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 5
 	show_in_report = TRUE
-	var/chosen_job
+	var/chosen_job_name
 
 /datum/station_trait/overflow_job_bureaucracy/New()
 	. = ..()
 	RegisterSignal(SSjob, COMSIG_SUBSYSTEM_POST_INITIALIZE, .proc/set_overflow_job_override)
 
 /datum/station_trait/overflow_job_bureaucracy/get_report()
-	return "[name] - It seems for some reason we put out the wrong job-listing for the overflow role this shift...I hope you like [chosen_job]s."
+	return "[name] - It seems for some reason we put out the wrong job-listing for the overflow role this shift...I hope you like [chosen_job_name]s."
 
 /datum/station_trait/overflow_job_bureaucracy/proc/set_overflow_job_override(datum/source)
 	SIGNAL_HANDLER
 	var/datum/job/picked_job = pick(SSjob.joinable_occupations)
-	chosen_job = picked_job.type
-	SSjob.set_overflow_role(chosen_job)
+	chosen_job_name = lowertext(picked_job.title) // like Chief Engineers vs like chief engineers
+	SSjob.set_overflow_role(picked_job.type)
 
 /datum/station_trait/slow_shuttle
 	name = "Slow Shuttle"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Station traits init before jobs, soooooo this just runtimed

We could fix this with GetJob or 
if(!length(all_occupations))
	SetupOccupations()
or something, but this is cleaner, since we're waiting for subsystem init anyway

## Why It's Good For The Game

I wish to stop getting random runtimes on my local
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The job overflow station trait will now work again. I look forward to infinite captains
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
