### PR TITLE
Department Order Consoles now have fallback areas, if the first area doesn't exist on a map (plus map logging)

### DIFF
--- a/code/modules/cargo/department_order.dm
+++ b/code/modules/cargo/department_order.dm
@@ -17,10 +17,20 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 	var/datum/supply_order/department_order
 	///access required to override an order - this should be a head of staff for the department
 	var/override_access
-	///where this computer expects deliveries to need to go, passed onto orders
-	var/department_delivery_area
+	///where this computer expects deliveries to need to go, passed onto orders. it will see if the FIRST one exists, then try a fallback. if no fallbacks it throws an error
+	var/list/department_delivery_areas = list()
 	///which groups this computer can order from
 	var/list/dep_groups = list()
+
+/obj/machinery/computer/department_orders/Initialize(mapload, obj/item/circuitboard/board)
+	. = ..()
+	if(mapload) //check for mapping errors
+		for(var/delivery_area_type in department_delivery_areas)
+			if(GLOB.areas_by_type[delivery_area_type])
+				break
+		//every area fallback didn't exist on this map so throw a mapping error and set some generic area that uuuh please exist okay
+		log_mapping("[src] has no valid areas to deliver to on this map, add some more fallback areas to its \"department_delivery_areas\" var.")
+		department_delivery_areas = list(/area/hallway/primary/central) //if this doesn't exist like honestly fuck your map man
 
 /obj/machinery/computer/department_orders/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -120,7 +130,12 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 		rank = "Silicon"
 	//already have a signal to finalize the order
 	var/already_signalled = department_order ? TRUE : FALSE
-	department_order = new(pack, name, rank, ckey, "", null, department_delivery_area, null)
+	var/chosen_delivery_area
+	for(var/delivery_area_type in department_delivery_areas)
+		if(GLOB.areas_by_type[delivery_area_type])
+			chosen_delivery_area = delivery_area_type
+			break
+	department_order = new(pack, name, rank, ckey, "", null, chosen_delivery_area, null)
 	SSshuttle.shoppinglist += department_order
 	if(!already_signalled)
 		RegisterSignal(SSshuttle, COMSIG_SUPPLY_SHUTTLE_BUY, .proc/finalize_department_order)
@@ -147,7 +162,7 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 /obj/machinery/computer/department_orders/service
 	name = "service order console"
 	circuit = /obj/item/circuitboard/computer/service_orders
-	department_delivery_area = /area/hallway/secondary/service
+	department_delivery_areas = list(/area/hallway/secondary/service, /area/service/bar/atrium)
 	override_access = ACCESS_HOP
 	req_one_access = list(ACCESS_KITCHEN, ACCESS_BAR, ACCESS_HYDROPONICS, ACCESS_JANITOR, ACCESS_THEATRE)
 	dep_groups = list("Service", "Food & Hydroponics", "Livestock", "Costumes & Toys")
@@ -155,7 +170,7 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 /obj/machinery/computer/department_orders/engineering
 	name = "engineering order console"
 	circuit = /obj/item/circuitboard/computer/engineering_orders
-	department_delivery_area = /area/engineering/main
+	department_delivery_areas = list(/area/engineering/main)
 	override_access = ACCESS_CE
 	req_one_access = REGION_ACCESS_ENGINEERING
 	dep_groups = list("Engineering", "Engine Construction", "Canisters & Materials")
@@ -163,7 +178,7 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 /obj/machinery/computer/department_orders/science
 	name = "science order console"
 	circuit = /obj/item/circuitboard/computer/science_orders
-	department_delivery_area = /area/science/research
+	department_delivery_areas = list(/area/science/research)
 	override_access = ACCESS_RD
 	req_one_access = REGION_ACCESS_RESEARCH
 	dep_groups = list("Science", "Livestock")
@@ -171,7 +186,7 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 /obj/machinery/computer/department_orders/security
 	name = "security order console"
 	circuit = /obj/item/circuitboard/computer/security_orders
-	department_delivery_area = /area/security/brig
+	department_delivery_areas = list(/area/security/brig)
 	override_access = ACCESS_HOS
 	req_one_access = REGION_ACCESS_SECURITY
 	dep_groups = list("Security", "Armory")
@@ -179,7 +194,7 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 /obj/machinery/computer/department_orders/medical
 	name = "medical order console"
 	circuit = /obj/item/circuitboard/computer/medical_orders
-	department_delivery_area = /area/medical/medbay/central
+	department_delivery_areas = list(/area/medical/medbay/central)
 	override_access = ACCESS_CMO
 	req_one_access = REGION_ACCESS_MEDBAY
 	dep_groups = list("Medical")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Maploaded department order consoles will now check if they have a valid destination, and set a generic one if they don't while throwing a mapping log.

## Why It's Good For The Game

fixes #63062
fixes https://tgstation13.org/phpBB/viewtopic.php?p=621025#p621025 from feedback thread

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can now deliver kilo department orders (the delivery area didn't exist on kilo)
/:cl:
