### PR TITLE
returns functionality to machine sect's self android conversion

### DIFF
--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -67,7 +67,7 @@
 
 /datum/religion_rites/synthconversion
 	name = "Synthetic Conversion"
-	desc = "Convert a human-esque individual into a (superior) Android."
+	desc = "Convert a human-esque individual into a (superior) Android. Buckle a human to convert them, otherwise it will convert you."
 	ritual_length = 30 SECONDS
 	ritual_invocations = list("By the inner workings of our god ...",
 						"... We call upon you, in the face of adversity ...",
@@ -82,13 +82,16 @@
 	var/atom/movable/movable_reltool = religious_tool
 	if(!movable_reltool)
 		return FALSE
-	if(!LAZYLEN(movable_reltool.buckled_mobs))
-		. = FALSE
+	if(LAZYLEN(movable_reltool.buckled_mobs))
+		to_chat(user, span_warning("You're going to convert the one buckled on [movable_reltool]."))
+	else
 		if(!movable_reltool.can_buckle) //yes, if you have somehow managed to have someone buckled to something that now cannot buckle, we will still let you perform the rite!
 			to_chat(user, span_warning("This rite requires a religious device that individuals can be buckled to."))
-			return
-		to_chat(user, span_warning("This rite requires an individual to be buckled to [movable_reltool]."))
-		return
+			return FALSE
+		if(isandroid(user))
+			to_chat(user, span_warning("You've already converted yourself. To convert others, they must be buckled to [movable_reltool]."))
+			return FALSE
+		to_chat(user, span_warning("You're going to convert yourself with this ritual."))
 	return ..()
 
 /datum/religion_rites/synthconversion/invoke_effect(mob/living/user, atom/religious_tool)
@@ -96,17 +99,18 @@
 	if(!ismovable(religious_tool))
 		CRASH("[name]'s perform_rite had a movable atom that has somehow turned into a non-movable!")
 	var/atom/movable/movable_reltool = religious_tool
+	var/mob/living/carbon/human/rite_target
 	if(!movable_reltool?.buckled_mobs?.len)
+		rite_target = user
+	else
+		for(var/buckled in movable_reltool.buckled_mobs)
+			if(istype(buckled, /mob/living/carbon/human))
+				rite_target = buckled
+				break
+	if(!rite_target)
 		return FALSE
-	var/mob/living/carbon/human/human2borg
-	for(var/i in movable_reltool.buckled_mobs)
-		if(istype(i,/mob/living/carbon/human))
-			human2borg = i
-			break
-	if(!human2borg)
-		return FALSE
-	human2borg.set_species(/datum/species/android)
-	human2borg.visible_message(span_notice("[human2borg] has been converted by the rite of [name]!"))
+	rite_target.set_species(/datum/species/android)
+	rite_target.visible_message(span_notice("[rite_target] has been converted by the rite of [name]!"))
 	return TRUE
 
 

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -104,7 +104,7 @@
 		rite_target = user
 	else
 		for(var/buckled in movable_reltool.buckled_mobs)
-			if(istype(buckled, /mob/living/carbon/human))
+			if(ishuman(buckled))
 				rite_target = buckled
 				break
 	if(!rite_target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Chaplains can now invoke the rite with nobody on the altar to convert themselves. The bugged functionality of religious tool that let anyone invoke rites allowed chaplains to be converted by others, which became somewhat of a core feature of the sect. In fixing the previous bug the sect lost a somewhat large part of itself, and I think the best solution is to just make it intended

## Why It's Good For The Game

fixes #63100 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: chaplains can once again convert themselves into an android
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
