### PR TITLE
'Natural Insecticide' now graftable from certain flowers

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -18,6 +18,7 @@
 	genes = list(/datum/plant_gene/trait/preserved)
 	mutatelist = list(/obj/item/seeds/poppy/geranium, /obj/item/seeds/poppy/lily)
 	reagents_add = list(/datum/reagent/medicine/c2/libital = 0.2, /datum/reagent/consumable/nutriment = 0.05)
+	graft_gene = /datum/plant_gene/trait/preserved
 
 /obj/item/food/grown/poppy
 	seed = /obj/item/seeds/poppy


### PR DESCRIPTION
## About The Pull Request

Makes the 'Natural Insecticide' trait found in poppies, lillies, geraniums, and fraxinella graftable.

## Why It's Good For The Game

Food decomposition/ants are a very interesting addition to the game, but disproportionally affect hydroponics.  The stated intent of it was to get people to not leave food lying around.  However, while many botany plants may technically be classified as food, they are often associated with other types of projects.  Additionally, due to bulk harvesting and different plant strains belonging to the same species, simply putting the plants on a table or in the fridge often isn't a satisfactory solution.  Having to constantly keep numerous samples from decomposing while doing multiple/complex projects can be tedious.

Seeing as how certain flowers already naturally resist decomposition and ants, and that transferring plant traits is a staple of botany mechanics already, adding the ability to transfer this protection to other plants seems like a reasonable in-universe way of giving botanists more quality of life options in this regard, while leaving most of the other aspects of decomposition/ant related content unmolested.

## Changelog

Certain flowers are now more willing to share their protection against the insect menace.

:cl:
qol: made something easier to use
/:cl:
