### PR TITLE
Deltaservice: Updates the cook's additional CQC areas

### DIFF
--- a/_maps/deltastation.json
+++ b/_maps/deltastation.json
@@ -11,7 +11,7 @@
 	},
 	"job_changes": {
 		"cook": {
-			"additional_cqc_areas": ["/area/service/bar/atrium"]
+			"additional_cqc_areas": ["/area/service/cafeteria"]
 		}
 	}
 }


### PR DESCRIPTION
## About The Pull Request

Updates the chef's list of additional CQC areas to accommodate the new Delta service layout.

No GBP here.

## Why It's Good For The Game

They can fight in the bar but not in their cafe, that's wack. 

## Changelog

:cl: Melbert
fix: Chefs on Deltastation can now tussle in their Cafeteria.
/:cl:

