### PR TITLE
Makes the edible component not runtime due to connect_loc_behalf when applied to turfs

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -72,10 +72,13 @@ Behavior that's still missing from this component that original food items had t
 	RegisterSignal(parent, COMSIG_EDIBLE_INGREDIENT_ADDED, .proc/edible_ingredient_added)
 	RegisterSignal(parent, COMSIG_OOZE_EAT_ATOM, .proc/on_ooze_eat)
 
-	var/static/list/loc_connections = list(
-		COMSIG_ATOM_ENTERED = .proc/on_entered,
-	)
-	AddComponent(/datum/component/connect_loc_behalf, parent, loc_connections)
+	if(!isturf(parent))
+		var/static/list/loc_connections = list(
+			COMSIG_ATOM_ENTERED = .proc/on_entered,
+		)
+		AddComponent(/datum/component/connect_loc_behalf, parent, loc_connections)
+	else
+		RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/on_entered)
 
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_ATTACK, .proc/UseFromHand)


### PR DESCRIPTION
## About The Pull Request
This makes it so it stops trying to use `connect_loc_behalf` if the parent of the edible component is a turf, just registering the signal normally instead, which should hopefully be the same functionality.

There you go @LemonInTheDark 😎

## Why It's Good For The Game
Runtimes are bad, and even if there's not really any relevant use of that proc in most cases, this is to future-proof things anyway.

## Changelog

:cl: GoldenAlpharex
fix: Meat and pizza walls and floors should no longer cause a runtime every time they're built.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
