### PR TITLE
APC being burnt now no longer spams runtimes.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1531,10 +1531,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, APC_PIXEL_OFFSET
 			L.update(FALSE)
 		CHECK_TICK
 
-/obj/machinery/power/apc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "")
+/obj/machinery/power/apc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE)
 	// APC being at 0 integrity doesnt delete it outright. Combined with take_damage this might cause runtimes.
 	if(machine_stat & BROKEN && atom_integrity <= 0)
-		play_attack_sound(damage_amount, damage_type, damage_flag)
+		if(sound_effect)
+			play_attack_sound(damage_amount, damage_type, damage_flag)
 		return
 	return ..()
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -317,9 +317,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, APC_PIXEL_OFFSET
 	return (exposed_temperature > 2000)
 
 /obj/machinery/power/apc/atmos_expose(datum/gas_mixture/air, exposed_temperature)
-	// APC being at 0 integrity doesnt delete it outright. Combined with take_damage this might cause runtimes.
-	if(machine_stat & BROKEN)
-		return
 	take_damage(min(exposed_temperature/100, 10), BURN)
 
 /obj/machinery/power/apc/examine(mob/user)
@@ -1534,6 +1531,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, APC_PIXEL_OFFSET
 			L.update(FALSE)
 		CHECK_TICK
 
+/obj/machinery/power/apc/take_damage()
+	// APC being at 0 integrity doesnt delete it outright. Combined with take_damage this might cause runtimes.
+	if(machine_stat & BROKEN && atom_integrity <= 0)
+		return
+	return ..()
 
 #undef APC_CHANNEL_OFF
 #undef APC_CHANNEL_AUTO_OFF

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1531,9 +1531,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, APC_PIXEL_OFFSET
 			L.update(FALSE)
 		CHECK_TICK
 
-/obj/machinery/power/apc/take_damage()
+/obj/machinery/power/apc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "")
 	// APC being at 0 integrity doesnt delete it outright. Combined with take_damage this might cause runtimes.
 	if(machine_stat & BROKEN && atom_integrity <= 0)
+		play_attack_sound(damage_amount, damage_type, damage_flag)
 		return
 	return ..()
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -317,6 +317,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, APC_PIXEL_OFFSET
 	return (exposed_temperature > 2000)
 
 /obj/machinery/power/apc/atmos_expose(datum/gas_mixture/air, exposed_temperature)
+	// APC being at 0 integrity doesnt delete it outright. Combined with take_damage this might cause runtimes.
+	if(machine_stat & BROKEN)
+		return
 	take_damage(min(exposed_temperature/100, 10), BURN)
 
 /obj/machinery/power/apc/examine(mob/user)


### PR DESCRIPTION
## About The Pull Request
APC being at 0 integrity doesnt delete it outright. Combined with take_damage this causes runtimes.

## Why It's Good For The Game
Less runtime spam.

## Changelog
:cl:
fix: fixed APC making too many damage runtimes.
/:cl: