### PR TITLE
Atmos machinery construction shouldn't null piping_layer by default

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -455,12 +455,12 @@
 		PIPING_FORWARD_SHIFT(pipe_overlay, piping_layer, 2)
 	return pipe_overlay
 
-/obj/machinery/atmospherics/on_construction(obj_color, set_layer)
+/obj/machinery/atmospherics/on_construction(obj_color, set_layer = PIPING_LAYER_DEFAULT)
 	if(can_unwrench)
 		add_atom_colour(obj_color, FIXED_COLOUR_PRIORITY)
 		pipe_color = obj_color
 	update_name()
-	set_piping_layer(set_layer || piping_layer || PIPING_LAYER_DEFAULT)
+	set_piping_layer(set_layer)
 	atmos_init()
 	var/list/nodes = pipeline_expansion()
 	for(var/obj/machinery/atmospherics/A in nodes)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -460,7 +460,7 @@
 		add_atom_colour(obj_color, FIXED_COLOUR_PRIORITY)
 		pipe_color = obj_color
 	update_name()
-	set_piping_layer(set_layer)
+	set_piping_layer(set_layer || piping_layer || PIPING_LAYER_DEFAULT)
 	atmos_init()
 	var/list/nodes = pipeline_expansion()
 	for(var/obj/machinery/atmospherics/A in nodes)


### PR DESCRIPTION
## About The Pull Request
`/obj/machinery/atmospherics/on_construction` actually sets the it's arg as piping layer, which is more often than not null. Not sure if it's actually a problem for any of our currently implemented machineries but It annoyed me somewhat while making another PR.

## Why It's Good For The Game
Reduces one cause of null piping layers.