### PR TITLE
Minor improvements and fixes to the access report paper from the Plexagon computer program

### DIFF
--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -15,6 +15,8 @@
 	/// If TRUE, this program is authenticated with limited departmental access.
 	var/minor = FALSE
 	/// The name/assignment combo of the ID card used to authenticate.
+	var/authenticated_card
+	/// The name of the registered user, related to `authenticated_card`.
 	var/authenticated_user
 	/// The regions this program has access to based on the authenticated ID.
 	var/list/region_access = list()
@@ -46,7 +48,8 @@
 	// If the program isn't locked to a specific department or is_centcom and we have ACCESS_CHANGE_IDS in our auth card, we're not minor.
 	if((!target_dept || is_centcom) && (ACCESS_CHANGE_IDS in id_card.access))
 		minor = FALSE
-		authenticated_user = "[id_card.name]"
+		authenticated_card = "[id_card.name]"
+		authenticated_user = id_card.registered_name ? id_card.registered_name : "Unknown"
 		job_templates = is_centcom ? SSid_access.centcom_job_templates.Copy() : SSid_access.station_job_templates.Copy()
 		valid_access = is_centcom ? SSid_access.get_region_access_list(list(REGION_CENTCOM)) : SSid_access.get_region_access_list(list(REGION_ALL_STATION))
 		update_static_data(user)
@@ -64,7 +67,7 @@
 	if(length(region_access))
 		minor = TRUE
 		valid_access |= SSid_access.get_region_access_list(region_access)
-		authenticated_user = "[id_card.name] \[LIMITED ACCESS\]"
+		authenticated_card = "[id_card.name] \[LIMITED ACCESS\]"
 		update_static_data(user)
 		return TRUE
 
@@ -100,6 +103,7 @@
 				return TRUE
 		// Log out.
 		if("PRG_logout")
+			authenticated_card = null
 			authenticated_user = null
 			playsound(computer, 'sound/machines/terminal_off.ogg', 50, FALSE)
 			return TRUE
@@ -107,10 +111,10 @@
 		if("PRG_print")
 			if(!computer || !printer)
 				return TRUE
-			if(!authenticated_user)
+			if(!authenticated_card)
 				return TRUE
 			var/contents = {"<h4>Access Report</h4>
-						<u>Prepared By:</u> [user_id_card?.registered_name ? user_id_card.registered_name : "Unknown"]<br>
+						<u>Prepared By:</u> [authenticated_user]<br>
 						<u>For:</u> [target_id_card.registered_name ? target_id_card.registered_name : "Unregistered"]<br>
 						<hr>
 						<u>Assignment:</u> [target_id_card.assignment]<br>
@@ -122,7 +126,7 @@
 				if(A in known_access_rights)
 					contents += "  [SSid_access.get_access_desc(A)]"
 
-			if(!printer.print_text(contents,"access report"))
+			if(!printer.print_text(contents,"access report - [target_id_card.registered_name ? target_id_card.registered_name : "Unregistered"]"))
 				to_chat(usr, span_notice("Hardware error: Printer was unable to print the file. It may be out of paper."))
 				return TRUE
 			else
@@ -153,7 +157,7 @@
 			return TRUE
 		// Used to fire someone. Wipes all access from their card and modifies their assignment.
 		if("PRG_terminate")
-			if(!computer || !authenticated_user)
+			if(!computer || !authenticated_card)
 				return TRUE
 			if(minor)
 				if(!(target_id_card.trim?.type in job_templates))
@@ -168,7 +172,7 @@
 			return TRUE
 		// Change ID card assigned name.
 		if("PRG_edit")
-			if(!computer || !authenticated_user || !target_id_card)
+			if(!computer || !authenticated_card || !target_id_card)
 				return TRUE
 
 			var/old_name = target_id_card.registered_name
@@ -202,7 +206,7 @@
 			return TRUE
 		// Change age
 		if("PRG_age")
-			if(!computer || !authenticated_user || !target_id_card)
+			if(!computer || !authenticated_card || !target_id_card)
 				return TRUE
 
 			var/new_age = params["id_age"]
@@ -215,7 +219,7 @@
 			return TRUE
 		// Change assignment
 		if("PRG_assign")
-			if(!computer || !authenticated_user || !target_id_card)
+			if(!computer || !authenticated_card || !target_id_card)
 				return TRUE
 			var/new_asignment = sanitize(params["assignment"])
 			target_id_card.assignment = new_asignment
@@ -224,7 +228,7 @@
 			return TRUE
 		// Add/remove access.
 		if("PRG_access")
-			if(!computer || !authenticated_user || !target_id_card)
+			if(!computer || !authenticated_card || !target_id_card)
 				return TRUE
 			playsound(computer, "terminal_type", 50, FALSE)
 			var/access_type = params["access_target"]
@@ -249,7 +253,7 @@
 			return TRUE
 		// Apply template to ID card.
 		if("PRG_template")
-			if(!computer || !authenticated_user || !target_id_card)
+			if(!computer || !authenticated_card || !target_id_card)
 				return TRUE
 
 			playsound(computer, "terminal_type", 50, FALSE)
@@ -323,7 +327,7 @@
 	var/obj/item/card/id/auth_card = card_slot.stored_card
 	data["authIDName"] = auth_card ? auth_card.name : "-----"
 
-	data["authenticatedUser"] = authenticated_user
+	data["authenticatedUser"] = authenticated_card
 
 	var/obj/item/card/id/id_card = card_slot2.stored_card
 	data["has_id"] = !!id_card


### PR DESCRIPTION
## About The Pull Request
So, back when I was playing as the Head of Personnel, I really liked printing the access reports for record-keeping purposes. However, the papers were super non-descriptive, I had to add the person's name manually to the paper every time if I ever wanted to have the *hope* of finding the right paper in the future. Furthermore, unless you kept your ID in the machine after logging in (nobody does that, it's the worst idea in the world), it would always say that it was prepared by "Unknown", which is super lame.

This PR thus fixes both of these, as simple as that. I wanted to do this for like, nearly a year, and I just kept on forgetting all the time.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's just much better paperwork material.
![image](https://user-images.githubusercontent.com/58045821/144734504-12b28317-198d-4ff5-a6b6-8bbf96f3e833.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: GoldenAlpharex
qol: Plexagon is happy to announce its newest patch, which addresses a highly-requested quality of life change, consisting of adding the name of the person which had their ID modified to the name of their access report printout.
fix: The Access Report from the Plexagon Access Management app will now be smarter and actually remember who it was prepared by, even if the ID used for the login was removed before printing said Access Report.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
