### PR TITLE
Autolathe takes as many sheets as it can fit

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -140,7 +140,7 @@
 				to_chat(user, span_warning("[parent] can't hold any more of [I] sheets."))
 				return
 			//split the amount we don't need off
-			stack_to_split.split_stack(user, stack_to_split.amount - sheets_to_insert)
+			INVOKE_ASYNC(stack_to_split, .proc/split_stack, user, stack_to_split.amount - sheets_to_insert)
 		else
 			to_chat(user, span_warning("[I] contains more materials than [parent] has space to hold."))
 			return

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -140,7 +140,7 @@
 				to_chat(user, span_warning("[parent] can't hold any more of [I] sheets."))
 				return
 			//split the amount we don't need off
-			INVOKE_ASYNC(stack_to_split, .proc/split_stack, user, stack_to_split.amount - sheets_to_insert)
+			INVOKE_ASYNC(stack_to_split, /obj/item/stack.proc/split_stack, user, stack_to_split.amount - sheets_to_insert)
 		else
 			to_chat(user, span_warning("[I] contains more materials than [parent] has space to hold."))
 			return

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -129,8 +129,21 @@
 		to_chat(user, span_warning("[I] does not contain sufficient materials to be accepted by [parent]."))
 		return
 	if(!has_space(material_amount))
-		to_chat(user, span_warning("[parent] is full. Please remove materials from [parent] in order to insert more."))
-		return
+		if(istype(I, /obj/item/stack))
+			//figure out how much space is left
+			var/space_left = max_amount - total_amount
+			//figure out the amount of sheets that can fit that space
+			var/obj/item/stack/stack_to_split = I
+			var/material_per_sheet = material_amount / stack_to_split.amount
+			var/sheets_to_insert = round(space_left / material_per_sheet)
+			if(!sheets_to_insert)
+				to_chat(user, span_warning("[parent] can't hold any more of [I] sheets."))
+				return
+			//split the amount we don't need off
+			stack_to_split.split_stack(user, stack_to_split.amount - sheets_to_insert)
+		else
+			to_chat(user, span_warning("[I] contains more materials than [parent] has space to hold."))
+			return
 	user_insert(I, user, mat_container_flags)
 
 /// Proc used for when player inserts materials


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If you try to put too many sheets into the autolathe (or whatever else uses the material container component), the excess sheets will be split into your offhand while the rest are inserted.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Don't have a whole stack rejected when there's space for some. Don't have to guess how many sheets it'll take to fill.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: cacogen
qol: When inserting too many sheets for the autolathe to hold, it will take what it can instead of rejecting the whole stack
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
