### PR TITLE
Prevents closing out of the headcrab warning from blowing you up.

### DIFF
--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -9,8 +9,8 @@
 
 /datum/action/changeling/headcrab/sting_action(mob/living/user)
 	set waitfor = FALSE
-	var/confirm = tgui_alert(usr, "Are we sure we wish to kill ourself and create a headslug?", "Last Resort", list("Yes", "No"))
-	if(confirm == "No")
+	var/confirm = tgui_alert(user, "Are we sure we wish to kill ourself and create a headslug?", "Last Resort", list("Yes", "No"))
+	if(confirm != "Yes")
 		return
 
 	..()


### PR DESCRIPTION
## About The Pull Request

Only checking if they said no, rather than checking if they did say yes (in the headcrab alert menu), means that closing out of the TGUI alert menu will not return, and proceed to headcrab you.

## Why It's Good For The Game

When you close the tab, it generally means you didn't want to say yes.

## Changelog

:cl:
fix: Closing the confirmation alert from headcrabs will no longer continue to headcrab you.
/:cl: