### PR TITLE
Correcting hints in bureaucracy forms

### DIFF
--- a/tgui/packages/tgui/interfaces/Photocopier.js
+++ b/tgui/packages/tgui/interfaces/Photocopier.js
@@ -211,6 +211,7 @@ const Blanks = (props, context) => {
         {visibleBlanks.map(blank => (
           <Button
             key={blank.code}
+            title={blank.name}
             disabled={!has_toner}
             onClick={() => act("print_blank", {
               name: blank.name,


### PR DESCRIPTION
## About The Pull Request

Adding tooltips with the names of forms when hovering over the button with their code. 

## Why It's Good For The Game

According to the original idea of this PR #61323, when you hover over the button form should have popped up a tooltip with its normal name. But in the end the code for displaying the button changed a lot and I forgot to add a tooltip to it. 

## Changelog

:cl:
fix: Hints in bureaucracy forms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
