### PR TITLE
Burnt-out flash in-hands update again

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -33,10 +33,6 @@
 	var/cooldown = 0
 	var/last_trigger = 0 //Last time it was successfully triggered.
 
-/obj/item/assembly/flash/ComponentInitialize()
-	. = ..()
-	AddElement(/datum/element/update_icon_updates_onmob)
-
 /obj/item/assembly/flash/suicide_act(mob/living/user)
 	if(burnt_out)
 		user.visible_message(span_suicide("[user] raises \the [src] up to [user.p_their()] eyes and activates it ... but it's burnt out!"))
@@ -49,6 +45,7 @@
 	return FIRELOSS
 
 /obj/item/assembly/flash/update_icon(updates=ALL, flash = FALSE)
+	inhand_icon_state = "[burnt_out ? "flashtool_burnt" : "[initial(inhand_icon_state)]"]"
 	flashing = flash
 	. = ..()
 	if(flash)
@@ -61,7 +58,6 @@
 	if(burnt_out)
 		. += "flashburnt"
 		attached_overlays += "flashburnt"
-		inhand_icon_state = "flashtool_burnt"
 	if(flashing)
 		. += flashing_overlay
 		attached_overlays += flashing_overlay
@@ -100,6 +96,7 @@
 	var/list/mob/targets = get_flash_targets(get_turf(src), range, FALSE)
 	if(user)
 		targets -= user
+		to_chat(user, span_danger("[src] emits a blinding light!"))
 	for(var/mob/living/carbon/C in targets)
 		flash_carbon(C, user, power, targeted, TRUE)
 	return TRUE
@@ -122,8 +119,10 @@
 	set_light_on(TRUE)
 	addtimer(CALLBACK(src, .proc/flash_end), FLASH_LIGHT_DURATION, TIMER_OVERRIDE|TIMER_UNIQUE)
 	times_used++
-	flash_recharge()
+	if(!flash_recharge())
+		return FALSE
 	update_icon(ALL, TRUE)
+	update_name(ALL) //so if burnt_out was somehow reverted to 0 the name changes back to flash
 	if(user && !clown_check(user))
 		return FALSE
 	return TRUE
@@ -265,7 +264,6 @@
 		return FALSE
 	if(!AOE_flash(FALSE, 3, 5, FALSE, user))
 		return FALSE
-	to_chat(user, span_danger("[src] emits a blinding light!"))
 
 /obj/item/assembly/flash/emp_act(severity)
 	. = ..()

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -61,16 +61,13 @@
 	if(burnt_out)
 		. += "flashburnt"
 		attached_overlays += "flashburnt"
+		inhand_icon_state = "flashtool_burnt"
 	if(flashing)
 		. += flashing_overlay
 		attached_overlays += flashing_overlay
 
 /obj/item/assembly/flash/update_name()
 	name = "[burnt_out ? "burnt-out [initial(name)]" : "[initial(name)]"]"
-	return ..()
-
-/obj/item/assembly/flash/update_desc()
-	desc = "[burnt_out ? "[initial(desc)] It's burnt out." : "[initial(desc)]"]"
 	return ..()
 
 /obj/item/assembly/flash/proc/clown_check(mob/living/carbon/human/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


Flashes that have burnt out will no longer have in-hands that don't look burnt out:

![](https://i.imgur.com/9kSxE43.png)

Also fixes flashing going through when the attempt already burnt out the flash:

![](https://i.imgur.com/Tb9jciu.png)

Also makes it so if a flash's burnt_out state is somehow reverted to 0 (such as during testing), the name updates in addition to its sprite when it's used.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes it immediately obvious when someone is holding a flash that has burnt out. Stops flashing happening when the attempt should fail.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Burnt-out flashes once again update their in-hands correctly
fix: Flashing no longer goes through when the attempt has burnt out the flash
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
