### PR TITLE
pumping your heart doesnt require to be conscious

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -146,6 +146,7 @@
 
 /datum/action/item_action/organ_action/cursed_heart
 	name = "Pump your blood"
+	check_flags = NONE
 
 //You are now brea- pumping blood manually
 /datum/action/item_action/organ_action/cursed_heart/Trigger()


### PR DESCRIPTION
## About The Pull Request

Simply removes the requirement to be conscious to pump your blood with a cursed heart.

## Why It's Good For The Game

Entering crit or falling asleep is basically a life sentence since you are unable to pump your blood while asleep. The player still is manually pumping it, I don't see any reason why the user has to be awake for it.
This also means medical can't revive you, as you'll instantly lose all your blood before you have enough time to wake up to start pumping again. The only IC fix would be to remove your heart entirely, something most doctors wouldn't even notice.

## Changelog

:cl:
fix: You can manually pump your blood while asleep/in crit, rather than instantly lose all your blood and die forever.
/:cl: