### PR TITLE
fix oversight where HFR can EMP its own APC

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -956,7 +956,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/south,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
 "ahS" = (
@@ -2619,7 +2618,7 @@
 "avB" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/textured,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "avG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -8065,6 +8064,9 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/service/library)
+"bHq" = (
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "bHz" = (
 /obj/structure/sink{
 	dir = 4;
@@ -8762,7 +8764,7 @@
 	dir = 5
 	},
 /turf/closed/wall,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "bRs" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/item/radio/intercom/directional/north,
@@ -15573,7 +15575,7 @@
 /turf/open/floor/iron/stairs/left{
 	dir = 8
 	},
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "dwJ" = (
 /obj/structure/lattice,
 /obj/effect/spawner/random/structure/grille,
@@ -17583,6 +17585,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eeW" = (
@@ -22519,7 +22522,7 @@
 "fJz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/closed/wall,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "fJA" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
@@ -24355,7 +24358,6 @@
 /obj/item/hfr_box/body/fuel_input,
 /obj/item/hfr_box/body/interface,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
 "gqZ" = (
@@ -25485,7 +25487,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "gLa" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -26232,7 +26234,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "gZM" = (
 /obj/structure/sign/warning/pods,
 /turf/closed/wall/r_wall,
@@ -27051,12 +27053,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/cytology)
-"hnT" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron/dark,
-/area/engineering/atmospherics_engine)
 "hnX" = (
 /obj/machinery/computer/holodeck{
 	dir = 4
@@ -27090,7 +27086,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "hop" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27167,7 +27163,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "hps" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cleaning Closet";
@@ -30119,6 +30115,9 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
 /area/service/theater)
+"isG" = (
+/turf/closed/wall,
+/area/engineering/atmospherics_engine)
 "isH" = (
 /obj/structure/table/glass,
 /obj/item/experi_scanner{
@@ -33850,7 +33849,7 @@
 "jNK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "jNL" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -34836,7 +34835,7 @@
 /turf/open/floor/iron/stairs/right{
 	dir = 8
 	},
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "kfy" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -35591,6 +35590,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
+"kvs" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/engineering/atmospherics_engine)
 "kvt" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -39519,11 +39522,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet/restrooms)
-"lQx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/atmospherics_engine)
 "lQF" = (
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/yellow{
@@ -40380,7 +40378,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "mfg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/reagent_dispensers/watertank,
@@ -40756,7 +40754,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "mlT" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/door/window/eastleft{
@@ -41719,7 +41717,6 @@
 "mDP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Hypertorus Fusion Reactor";
 	req_access_txt = "24"
@@ -46553,7 +46550,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "ogx" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -47662,9 +47659,10 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/west,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "oCW" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
@@ -48025,7 +48023,7 @@
 /turf/open/floor/iron/stairs/medium{
 	dir = 8
 	},
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "oIC" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Ordnance Gas Storage Maintenance";
@@ -49362,7 +49360,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron/dark/textured,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "pgX" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -49983,7 +49981,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "prS" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -53627,7 +53625,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "qFh" = (
 /obj/item/wrench,
 /turf/open/floor/iron/dark,
@@ -54080,6 +54078,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"qPh" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/iron,
+/area/engineering/atmospherics_engine)
 "qPj" = (
 /obj/structure/sign/map/left{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -54842,6 +54844,7 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rfU" = (
@@ -55255,7 +55258,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "rnV" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -55749,7 +55752,6 @@
 /area/science/xenobiology)
 "rvz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/camera/directional/south{
 	c_tag = "Atmospherics - Hypertorus Fusion Reactor Chamber Aft"
 	},
@@ -60318,7 +60320,7 @@
 "tdS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/closed/wall/r_wall,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "tee" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -61391,7 +61393,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "twp" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -63538,7 +63540,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "uln" = (
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/trimline/brown/filled/line,
@@ -65747,7 +65749,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/atmospherics_engine)
 "vct" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -69662,7 +69664,6 @@
 "wvB" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
 "wwb" = (
@@ -119191,11 +119192,11 @@ aLz
 nXY
 nXY
 nXY
-nXY
+kvs
 fJz
 fJz
 bRo
-mvS
+isG
 mvS
 mvS
 ezQ
@@ -119448,7 +119449,7 @@ oGw
 oGw
 oGw
 iLe
-jMk
+bJI
 twh
 ulj
 vco
@@ -119705,11 +119706,11 @@ aaa
 lMJ
 lMJ
 iFR
-cor
+njR
 prP
 jNK
 mfa
-lye
+bHq
 vDj
 unQ
 qmX
@@ -119962,11 +119963,11 @@ aaa
 lMJ
 aaa
 iFR
-cor
+njR
 hoj
 avB
-dtQ
-lye
+qPh
+bHq
 lGq
 oKH
 qmX
@@ -120219,11 +120220,11 @@ aaa
 lMJ
 aaa
 iFR
-cor
+njR
 qFe
 rnU
 hpn
-lye
+bHq
 lGq
 oKH
 qmX
@@ -120476,7 +120477,7 @@ aaa
 lMJ
 lMJ
 iFR
-cor
+njR
 gKY
 mlP
 ogd
@@ -122538,7 +122539,7 @@ iqE
 bEN
 gFw
 dtK
-lQx
+cvK
 mDP
 oCK
 lye
@@ -123307,7 +123308,7 @@ dtK
 dtK
 urP
 dtK
-hnT
+nby
 wvB
 gql
 bJI


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
move HFR apc to the west in the same room as the crystallizer
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
HFR won't emp itself due to an oversight
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fix oversight where HFR can EMP its own APC
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
