### PR TITLE
You will once again have random events run!

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -362,20 +362,21 @@
 	var/active_players = 0
 	for(var/i = 1; i <= GLOB.player_list.len; i++)
 		var/mob/player_mob = GLOB.player_list[i]
-		if(player_mob?.client)
-			if(alive_check && player_mob.stat)
+		if(!player_mob?.client)
+			continue
+		if(alive_check && player_mob.stat)
+			continue
+		else if(afk_check && player_mob.client.is_afk())
+			continue
+		else if(human_check && !ishuman(player_mob))
+			continue
+		else if(isnewplayer(player_mob)) // exclude people in the lobby
+			continue
+		else if(isobserver(player_mob)) // Ghosts are fine if they were playing once (didn't start as observers)
+			var/mob/dead/observer/ghost_player = player_mob
+			if(ghost_player.started_as_observer) // Exclude people who started as observers
 				continue
-			else if(afk_check && player_mob.client.is_afk())
-				continue
-			else if(human_check && !ishuman(player_mob))
-				continue
-			else if(isnewplayer(player_mob)) // exclude people in the lobby
-				continue
-			else if(isobserver(player_mob)) // Ghosts are fine if they were playing once (didn't start as observers)
-				var/mob/dead/observer/ghost_player = player_mob
-				if(ghost_player.started_as_observer) // Exclude people who started as observers
-					continue
-			active_players++
+		active_players++
 	return active_players
 
 ///Show the poll window to the candidate mobs

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -362,7 +362,7 @@
 	var/active_players = 0
 	for(var/i = 1; i <= GLOB.player_list.len; i++)
 		var/mob/player_mob = GLOB.player_list[i]
-		if(!player_mob?.client)
+		if(player_mob?.client)
 			if(alive_check && player_mob.stat)
 				continue
 			else if(afk_check && player_mob.client.is_afk())


### PR DESCRIPTION
## About The Pull Request

Basically just removes a null check in `get_active_player_count` which was introduced in PR:
https://github.com/tgstation/tgstation/pull/61859

![Code_bY4RSsI7gZ](https://user-images.githubusercontent.com/9026500/145104825-5daefc29-9fb8-473f-ae4d-face81dbf9d4.png)

Which meant you were missing out on any random event that required a player count, which includes:

- Abductors
- Alien infestation
- Bluespace anomaly
- Flux anomaly
- Gravity anomaly
- Pyroclastic anomaly
- Vortex anomaly
- Brain trauma
- Aurora caelus
- Blob
- Bureaucratic error
- Camera failure
- Carp migration
- Creep awakening
- Disease outbreak
- Electrical storm
- Fake virus
- False alarm
- Fugitive spawning
- Heart attack
- Immovable rod
- Ion storm
- Major spacedust
- Normal meteor wave
- Moderate meteor wave
- Major meteor wave
- Mice migration
- Nightmare
- Lone operative
- Pirates
- Portal storm
- Prison break
- Processor overload
- Radiation storm
- Shuttle catastrophe
- Shuttle loan
- Space ninja
- Space vine
- Spider infestation
- Spontaneous appendicitis
- Swarmers
- Wisdom cow
- Wormholes

## Why It's Good For The Game

You like having a game to play, right?

fixes #63191

## Changelog

:cl:
fix: You will once again see events that required a playercount to run.
/:cl:

