### PR TITLE
fixes bots getting stuck on railings and crashing clients

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -82,6 +82,11 @@
 		return . || mover.throwing || mover.movement_type & (FLYING | FLOATING)
 	return TRUE
 
+/obj/structure/railing/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
+	if (to_dir & dir)
+		return FALSE
+	return . = ..()
+
 /obj/structure/railing/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER
 

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -85,7 +85,7 @@
 /obj/structure/railing/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller)
 	if (to_dir & dir)
 		return FALSE
-	return . = ..()
+	return ..()
 
 /obj/structure/railing/proc/on_exit(datum/source, atom/movable/leaving, direction)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

big issue downstream, with railings and stuff, bots would get stuck on railings (**_and the pathfinding would actually actively steer them into these spots where they get stuck_**), and any time someone went near them with a diagnostic hud on, they crashed, and kept crashing any time they opened up the game

I'm not sure of the full reasoning as to why this actually fixes it, but I basically looked through the code and was like "huh, this proc isn't here and it should be", tested it, and it actually fixed the issue

I assume it's something to do with the corner railings not having density while the edge railings do have density

(Just in case you misread it, yes, I do know how and why the CanAStarPass proc that I wrote works (why would I submit code that I don't know how it works), I just don't know why it fixes the issue specifically because I can't be fucked diving too deep into pathfinding code tbh)

Fixes #63228 

## Why It's Good For The Game

bug fix

## Changelog

:cl:
fix: fixed bots getting stuck on railings and crashing anyone with a diagnostic hud who dares come near
/:cl: