### PR TITLE
Fixes a potential oversight in regards to Runechat layer placement.

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -138,21 +138,19 @@
 ///Debug Atmos Overlays
 #define ATMOS_GROUP_PLANE 450
 
+///--------------- FULLSCREEN IMAGES ------------
+
+#define FULLSCREEN_PLANE 500
 ///Popup Chat Messages
 #define RUNECHAT_PLANE 501
-
 /// Plane for balloon text (text that fades up)
 #define BALLOON_CHAT_PLANE 502
-
-///--------------- FULLSCREEN IMAGES ------------
-#define FULLSCREEN_PLANE 500
 #define FLASH_LAYER 1
 #define FULLSCREEN_LAYER 2
 #define UI_DAMAGE_LAYER 3
 #define BLIND_LAYER 4
 #define CRIT_LAYER 5
 #define CURSE_LAYER 6
-
 
 //-------------------- Rendering ---------------------
 #define RENDER_PLANE_GAME 990

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -140,10 +140,6 @@
 
 ///--------------- FULLSCREEN IMAGES ------------
 
-#define FULLSCREEN_PLANE 500
-///Popup Chat Messages
-#define RUNECHAT_PLANE 501
-/// Plane for balloon text (text that fades up)
 #define BALLOON_CHAT_PLANE 502
 #define FLASH_LAYER 1
 #define FULLSCREEN_LAYER 2
@@ -151,6 +147,13 @@
 #define BLIND_LAYER 4
 #define CRIT_LAYER 5
 #define CURSE_LAYER 6
+
+///--------------- FULLSCREEN RUNECHAT BUBBLES ------------
+
+#define FULLSCREEN_PLANE 500
+///Popup Chat Messages
+#define RUNECHAT_PLANE 501
+/// Plane for balloon text (text that fades up)
 
 //-------------------- Rendering ---------------------
 #define RENDER_PLANE_GAME 990

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -140,7 +140,7 @@
 
 ///--------------- FULLSCREEN IMAGES ------------
 
-#define BALLOON_CHAT_PLANE 502
+#define FULLSCREEN_PLANE 500
 #define FLASH_LAYER 1
 #define FULLSCREEN_LAYER 2
 #define UI_DAMAGE_LAYER 3
@@ -150,10 +150,10 @@
 
 ///--------------- FULLSCREEN RUNECHAT BUBBLES ------------
 
-#define FULLSCREEN_PLANE 500
 ///Popup Chat Messages
 #define RUNECHAT_PLANE 501
 /// Plane for balloon text (text that fades up)
+#define BALLOON_CHAT_PLANE 502
 
 //-------------------- Rendering ---------------------
 #define RENDER_PLANE_GAME 990

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -135,14 +135,14 @@
 ///AI Camera Static
 #define CAMERA_STATIC_PLANE 200
 
+///Debug Atmos Overlays
+#define ATMOS_GROUP_PLANE 450
+
 ///Popup Chat Messages
 #define RUNECHAT_PLANE 501
 
 /// Plane for balloon text (text that fades up)
 #define BALLOON_CHAT_PLANE 502
-
-///Debug Atmos Overlays
-#define ATMOS_GROUP_PLANE 450
 
 ///--------------- FULLSCREEN IMAGES ------------
 #define FULLSCREEN_PLANE 500

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -136,10 +136,10 @@
 #define CAMERA_STATIC_PLANE 200
 
 ///Popup Chat Messages
-#define RUNECHAT_PLANE 250
+#define RUNECHAT_PLANE 501
 
 /// Plane for balloon text (text that fades up)
-#define BALLOON_CHAT_PLANE 251
+#define BALLOON_CHAT_PLANE 502
 
 ///Debug Atmos Overlays
 #define ATMOS_GROUP_PLANE 450


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

edits the runechat layers to go over lighting/fullscreen fx while remaining under the hud, allowing for players to see people's messages while they're dying or blind, standardizes how runechat should be observed in accordance with #54522

## Why It's Good For The Game

incredibly funny to see bubbletext from cyborgs trying to heal you out of near-uncon crit and just reading screaming, also allows you to, when blind, 'hear' where people are talking from

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: edited runechat layers for clarity and consistency with old PRs

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
