### PR TITLE
Require Node 16, Disable experimental Yarn PnP ESM loader

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,8 +11,8 @@ export BYOND_MINOR=1560
 export RUST_G_VERSION=0.5.0
 
 #node version
-export NODE_VERSION=12
-export NODE_VERSION_PRECISE=12.22.4
+export NODE_VERSION=16
+export NODE_VERSION_PRECISE=16.13.1
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.7.1

--- a/tgui/.yarnrc.yml
+++ b/tgui/.yarnrc.yml
@@ -10,6 +10,8 @@ plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
     spec: "@yarnpkg/plugin-interactive-tools"
 
+pnpEnableEsmLoader: false
+
 preferAggregateCacheInfo: true
 
 preferInteractive: true

--- a/tgui/README.md
+++ b/tgui/README.md
@@ -29,7 +29,7 @@ If you are using the tooling provided in this repo, everything is included! Feel
 
 However, if you want finer control over the installation or build process, you will need these:
 
-- [Node v12.20+](https://nodejs.org/en/download/)
+- [Node v16.13+](https://nodejs.org/en/download/)
   - **DO NOT install Chocolatey if Node installer asks you to!**
 - [Yarn v1.22.4+](https://yarnpkg.com/getting-started/install)
   - You only need to run `npm install -g yarn`.

--- a/tgui/README.md
+++ b/tgui/README.md
@@ -30,6 +30,7 @@ If you are using the tooling provided in this repo, everything is included! Feel
 However, if you want finer control over the installation or build process, you will need these:
 
 - [Node v16.13+](https://nodejs.org/en/download/)
+  - **LTS** release is recommended instead of latest
   - **DO NOT install Chocolatey if Node installer asks you to!**
 - [Yarn v1.22.4+](https://yarnpkg.com/getting-started/install)
   - You only need to run `npm install -g yarn`.


### PR DESCRIPTION
- Fixes problems with building tgui on certain versions of Node.
- Bumps required NodeJS version to 16 (which is the current LTS)

These two things are atomic, they're just bundled in one PR for convenience.