### PR TITLE
Fixes random hell Move() call counts, removes the parent call from mob/Login

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -9,7 +9,8 @@
  * * tells the world to update it's status (for player count)
  * * create mob huds for the mob if needed
  * * reset next_move to 1
- * * parent call
+ * * Set statobj to our mob
+ * * NOT the parent call. The only unique thing it does is a very obtuse move op, see the comment lower down
  * * if the client exists set the perspective to the mob loc
  * * call on_log on the loc (sigh)
  * * reload the huds for the mob
@@ -43,7 +44,19 @@
 
 	next_move = 1
 
-	..()
+	client.statobj = src
+
+	// DO NOT CALL PARENT HERE
+	// BYOND's internal implementation of login does two things
+	// 1: Set statobj to the mob being logged into (We got this covered)
+	// 2: And I quote "If the mob has no location, place it near (1,1,1) if possible"
+	// See, near is doing an agressive amount of legwork there
+	// What it actually does is takes the area that (1,1,1) is in, and loops through all those turfs
+	// If you successfully move into one, it stops
+	// Because we want Move() to mean standard movements rather then just what byond treats it as (ALL moves)
+	// We don't allow moves from nullspace -> somewhere. This means the loop has to iterate all the turfs in (1,1,1)'s area
+	// For us, (1,1,1) is a space tile. This means roughly 200,000! calls to Move()
+	// You do not want this
 
 	if(!client)
 		return FALSE


### PR DESCRIPTION



<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Mothblocks pinged me with a profile of just a hellish amount of move calls
Way too many, like 4 million, just at the start of a round
![image](https://user-images.githubusercontent.com/58055496/145377839-c140e3a2-d725-4b22-ad0a-716fe970b7f4.png)

Started looking into it, got distracted by how expensive macros were
Turns out most of the cost of macros was in the nuke ops summon spawner
![image](https://user-images.githubusercontent.com/58055496/145377969-620cce01-f619-4f36-9246-3f1892776c22.png)


So I looked at why, only bit of it that was at all expensive was the login for the cyborgs
Tested on a local, huh that is slow yeah

![image](https://user-images.githubusercontent.com/58055496/145378007-204fd35c-3e7d-40a6-bad6-e8476bc10b46.png)

Looked at the profiler, huh there's that move count again
![image](https://user-images.githubusercontent.com/58055496/145378045-734ca34a-b6aa-48eb-ab77-c91734b4ae5a.png)
Melt kyler's brain with this move/login problem for a bit, just cause it's fun
![image](https://user-images.githubusercontent.com/58055496/145378183-46757c6a-9d04-4e9f-98fc-a3c731158b26.png)

So anyway, why is login so expensive

Spawned a few cyborgs in, dragged myself into them, nothing
Spawned myself in with sdql magic using the summon spawner, man it really is still there
I guess it has to do with move somehow, try and stick a breakpoint on it, get fucked by the debugger
I notice the hanging comes during the Login parent call

![image](https://user-images.githubusercontent.com/58055496/145378497-1bd2c1df-bf5a-411b-ab2e-45595f932ba0.png)

Try again, this time with good breakpoints.
We're trying to move, to (1,1,1), just like the reference says we [will](https://secure.byond.com/docs/ref/#/mob/proc/Login)

But man, it just keeps happening, and we don't actually move
![image](https://user-images.githubusercontent.com/58055496/145378734-3ecdae42-b00f-4c1a-823e-286729ef3805.png)
![image](https://user-images.githubusercontent.com/58055496/145378757-cbdcedfa-fefa-4bda-af30-faa4b0dc3570.png)

Step through the code, we've got that null loc check in atom/movable/Move

So the move to (1,1,1) isn't working

Here's the exact line from the reference
"If the mob has no location, place it near (1,1,1) if possible"
Keyword is **near**

Talked to lummox about this behavior, figured it was a bug
![image](https://user-images.githubusercontent.com/58055496/145378956-035180a5-9a61-499b-92f9-cd56c7695edd.png)

It turns out by near, they mean inside that tile's area
It'll keep trying to place you somewhere, in an attempt to effectively cover for shitty login systems, until you succeed in moving

That tile is space. There are 200,000 tiles with the same area as it
OH.

So anyway, we're not calling parent on mob/login anymore. We can do all the work it did that we care about ourselves (IE: Just the statobj set)

## Why It's Good For The Game

This way we don't need to worry about 4 SECONDS OF OVERTIME WHENEVER SOME POOR FUCK MESSES UP SPAWN ORDER

So yeah, I'm a genius and not at all just malding at the existance of keybind macros.
Hopefully another source of stutter bites the dust

Not actually sure how widespread this is, but even if it's just spawn beacons that's pretty banging

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Fixed some really insane move counts that were sourced from Login() betraying me. I've killed it now so there should be slightly less stutter sometimes depending on the weather and position of the moon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
