### PR TITLE
fugitives now poll for a fugitive role, instead of being based on traitors

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -25,13 +25,14 @@
 #define ROLE_BLOB "Blob"
 #define ROLE_BLOB_INFECTION "Blob Infection"
 #define ROLE_FAMILY_HEAD_ASPIRANT "Family Head Aspirant"
+#define ROLE_FUGITIVE "Fugitive"
 #define ROLE_LONE_OPERATIVE "Lone Operative"
 #define ROLE_MALF_MIDROUND "Malf AI (Midround)"
 #define ROLE_NIGHTMARE "Nightmare"
 #define ROLE_NINJA "Space Ninja"
-#define ROLE_REV_HEAD "Head Revolutionary"
 #define ROLE_OBSESSED "Obsessed"
 #define ROLE_OPERATIVE_MIDROUND "Operative (Midround)"
+#define ROLE_REV_HEAD "Head Revolutionary"
 #define ROLE_SENTIENT_DISEASE "Sentient Disease"
 #define ROLE_SLEEPER_AGENT "Syndicate Sleeper Agent"
 #define ROLE_SPACE_DRAGON "Space Dragon"
@@ -124,6 +125,7 @@ GLOBAL_LIST_INIT(special_roles, list(
 	ROLE_BLOB = 0,
 	ROLE_BLOB_INFECTION = 0,
 	ROLE_FAMILY_HEAD_ASPIRANT = 0,
+	ROLE_FUGITIVE = 0,
 	ROLE_LONE_OPERATIVE = 14,
 	ROLE_MALF_MIDROUND = 0,
 	ROLE_NIGHTMARE = 0,

--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -74,7 +74,6 @@
 #define ROLE_SLAUGHTER_DEMON "Slaughter Demon"
 #define ROLE_MORPH "Morph"
 #define ROLE_SANTA "Santa"
-#define ROLE_FUGITIVE "Fugitive"
 
 //Spawner roles
 #define ROLE_GHOST_ROLE "Ghost Role"

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -2,14 +2,39 @@
 /datum/antagonist/fugitive
 	name = "Fugitive"
 	roundend_category = "Fugitive"
+	job_rank = ROLE_FUGITIVE
 	silent = TRUE //greet called by the event
 	show_in_antagpanel = FALSE
 	prevent_roundtype_conversion = FALSE
 	antag_hud_name = "fugitive"
 	suicide_cry = "FOR FREEDOM!!"
+	preview_outfit = /datum/outfit/prisoner/consistent
 	var/datum/team/fugitive/fugitive_team
 	var/is_captured = FALSE
 	var/backstory = "error"
+
+/datum/antagonist/fugitive/get_preview_icon()
+	//start with prisoner at the front
+	var/icon/final_icon = render_preview_outfit(preview_outfit)
+
+	//then to the left add cultists of yalp elor
+	final_icon.Blend(make_background_fugitive_icon(/datum/outfit/yalp_cultist), ICON_UNDERLAY, -8, 0)
+	//to the right add waldo (we just had to, okay?)
+	final_icon.Blend(make_background_fugitive_icon(/datum/outfit/waldo), ICON_UNDERLAY, 8, 0)
+
+	final_icon.Scale(64, 64)
+
+	return finish_preview_icon(final_icon)
+
+/datum/antagonist/fugitive/proc/make_background_fugitive_icon(datum/outfit/fugitive_fit)
+	var/mob/living/carbon/human/dummy/consistent/fugitive = new
+
+	var/icon/fugitive_icon = render_preview_outfit(fugitive_fit, fugitive)
+	fugitive_icon.ChangeOpacity(0.5)
+	qdel(fugitive)
+
+	return fugitive_icon
+
 
 /datum/antagonist/fugitive/on_gain()
 	forge_objectives()

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -8,7 +8,7 @@
 	prevent_roundtype_conversion = FALSE
 	antag_hud_name = "fugitive"
 	suicide_cry = "FOR FREEDOM!!"
-	preview_outfit = /datum/outfit/prisoner/consistent
+	preview_outfit = /datum/outfit/prisoner
 	var/datum/team/fugitive/fugitive_team
 	var/is_captured = FALSE
 	var/backstory = "error"

--- a/code/modules/antagonists/fugitive/fugitive_outfits.dm
+++ b/code/modules/antagonists/fugitive/fugitive_outfits.dm
@@ -9,6 +9,15 @@
 		return
 	H.fully_replace_character_name(null,"NTP #CC-0[rand(111,999)]") //same as the lavaland prisoner transport, but this time they are from CC, or CentCom
 
+/datum/outfit/prisoner/consistent
+
+/datum/outfit/prisoner/consistent/post_equip(mob/living/carbon/human/prisoner, visualsOnly)
+	..()
+
+	// This outfit is used by the assets SS, which is ran before the atoms SS
+	if (SSatoms.initialized == INITIALIZATION_INSSATOMS)
+		prisoner.w_uniform?.update_greyscale()
+
 /datum/outfit/yalp_cultist
 	name = "Cultist of Yalp Elor"
 	uniform = /obj/item/clothing/under/rank/civilian/chaplain

--- a/code/modules/antagonists/fugitive/fugitive_outfits.dm
+++ b/code/modules/antagonists/fugitive/fugitive_outfits.dm
@@ -5,13 +5,12 @@
 	r_pocket = /obj/item/knife/shiv
 
 /datum/outfit/prisoner/post_equip(mob/living/carbon/human/prisoner, visualsOnly=FALSE)
+	// This outfit is used by the assets SS, which is ran before the atoms SS
+	if(SSatoms.initialized == INITIALIZATION_INSSATOMS)
+		prisoner.w_uniform?.update_greyscale()
 	if(visualsOnly)
 		return
 	prisoner.fully_replace_character_name(null,"NTP #CC-0[rand(111,999)]") //same as the lavaland prisoner transport, but this time they are from CC, or CentCom
-
-	// This outfit is used by the assets SS, which is ran before the atoms SS
-	if (SSatoms.initialized == INITIALIZATION_INSSATOMS)
-		prisoner.w_uniform?.update_greyscale()
 
 /datum/outfit/yalp_cultist
 	name = "Cultist of Yalp Elor"

--- a/code/modules/antagonists/fugitive/fugitive_outfits.dm
+++ b/code/modules/antagonists/fugitive/fugitive_outfits.dm
@@ -9,11 +9,6 @@
 		return
 	H.fully_replace_character_name(null,"NTP #CC-0[rand(111,999)]") //same as the lavaland prisoner transport, but this time they are from CC, or CentCom
 
-/datum/outfit/prisoner/consistent
-
-/datum/outfit/prisoner/consistent/post_equip(mob/living/carbon/human/prisoner, visualsOnly)
-	..()
-
 	// This outfit is used by the assets SS, which is ran before the atoms SS
 	if (SSatoms.initialized == INITIALIZATION_INSSATOMS)
 		prisoner.w_uniform?.update_greyscale()

--- a/code/modules/antagonists/fugitive/fugitive_outfits.dm
+++ b/code/modules/antagonists/fugitive/fugitive_outfits.dm
@@ -4,10 +4,10 @@
 	shoes = /obj/item/clothing/shoes/sneakers/orange
 	r_pocket = /obj/item/knife/shiv
 
-/datum/outfit/prisoner/post_equip(mob/living/carbon/human/H, visualsOnly=FALSE)
+/datum/outfit/prisoner/post_equip(mob/living/carbon/human/prisoner, visualsOnly=FALSE)
 	if(visualsOnly)
 		return
-	H.fully_replace_character_name(null,"NTP #CC-0[rand(111,999)]") //same as the lavaland prisoner transport, but this time they are from CC, or CentCom
+	prisoner.fully_replace_character_name(null,"NTP #CC-0[rand(111,999)]") //same as the lavaland prisoner transport, but this time they are from CC, or CentCom
 
 	// This outfit is used by the assets SS, which is ran before the atoms SS
 	if (SSatoms.initialized == INITIALIZATION_INSSATOMS)

--- a/code/modules/client/preferences/middleware/antags.dm
+++ b/code/modules/client/preferences/middleware/antags.dm
@@ -112,8 +112,8 @@
 /datum/asset/spritesheet/antagonists/register()
 	// Antagonists that don't have a dynamic ruleset, but do have a preference
 	var/static/list/non_ruleset_antagonists = list(
-		ROLE_LONE_OPERATIVE = /datum/antagonist/nukeop/lone,
 		ROLE_FUGITIVE = /datum/antagonist/fugitive,
+		ROLE_LONE_OPERATIVE = /datum/antagonist/nukeop/lone,
 	)
 
 	var/list/antagonists = non_ruleset_antagonists.Copy()

--- a/code/modules/client/preferences/middleware/antags.dm
+++ b/code/modules/client/preferences/middleware/antags.dm
@@ -113,6 +113,7 @@
 	// Antagonists that don't have a dynamic ruleset, but do have a preference
 	var/static/list/non_ruleset_antagonists = list(
 		ROLE_LONE_OPERATIVE = /datum/antagonist/nukeop/lone,
+		ROLE_FUGITIVE = /datum/antagonist/fugitive,
 	)
 
 	var/list/antagonists = non_ruleset_antagonists.Copy()

--- a/code/modules/events/fugitive_spawning.dm
+++ b/code/modules/events/fugitive_spawning.dm
@@ -20,7 +20,7 @@
 		return MAP_ERROR
 	var/turf/landing_turf = pick(possible_spawns)
 	var/list/possible_backstories = list()
-	var/list/candidates = get_candidates(ROLE_TRAITOR, ROLE_TRAITOR)
+	var/list/candidates = get_candidates(ROLE_FUGITIVE, ROLE_FUGITIVE)
 	if(candidates.len >= 1) //solo refugees
 		if(prob(30))
 			possible_backstories.Add("waldo") //less common as it comes with magicks and is kind of immershun shattering

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/fugitive.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/fugitive.ts
@@ -1,0 +1,16 @@
+import { Antagonist, Category } from "../base";
+import { multiline } from "common/string";
+
+const Fugitive: Antagonist = {
+  key: "fugitive",
+  name: "Fugitive",
+  description: [
+    multiline`
+    Wherever you come from, you're being hunted. You have 10 minutes to prepare
+    before fugitive hunters arrive and start hunting you and your friends down!
+    `,
+  ],
+  category: Category.Midround,
+};
+
+export default Fugitive;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fugitives will now poll for people who have fugitives on in their settings (hunters are untouched as they are ghost spawners)

This means that the antagonists ui now has a new entry, with fugitives! Neat, I can't show it right now due to a gags glitch

## Why It's Good For The Game

Fugitives are not traitors and this should have been fixed a long time ago

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fugitives are now their own antagonist toggle, instead of polling for traitors for some reason
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
