### PR TITLE
Removes a double layered pipe from the pizzaria ruin

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
@@ -64,9 +64,6 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/ruin/pizzeria)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

```
[19:52:59] Runtime in stack_trace.dm,3: addMachineryMember: Nonexistent (empty list) or null machinery gasmix added to pipeline datum from the omni pressure tank (Air) which is of type /obj/machinery/atmospherics/components/tank/air. Nearby: (42, 198, 5)
  proc name: stack trace (/proc/stack_trace)
  src: null
  call stack:
  stack trace("addMachineryMember: Nonexisten...")
  /datum/pipeline (/datum/pipeline): add machinery member(the omni pressure tank (Air) (/obj/machinery/atmospherics/components/tank/air))
  /datum/pipeline (/datum/pipeline): build pipeline blocking(the blue air supply pipe (/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden))
  Atmospherics (/datum/controller/subsystem/air): setup pipenets()
  Atmospherics (/datum/controller/subsystem/air): Initialize(31519)
  Master (/datum/controller/master): Initialize(10, 0, 1)
  ```
Kept seeing this error on a local, thought it must be an internal bug, nope, some motherfucker just decided to toss a pump and pipe on the same tile

## Why It's Good For The Game

:sadkirby:

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Removed a hidden doublepipe, you'll never find the rest, FOOLS
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
