### PR TITLE
Makes the pride pin reskin ability actually work

### DIFF
--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -93,10 +93,12 @@
 	return
 
 /obj/item/clothing/accessory/AltClick(mob/user)
-	if(user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
-		if(initial(above_suit))
-			above_suit = !above_suit
-			to_chat(user, "[src] will be worn [above_suit ? "above" : "below"] your suit.")
+	if(initial(above_suit) && user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
+		above_suit = !above_suit
+		to_chat(user, "[src] will be worn [above_suit ? "above" : "below"] your suit.")
+		return
+
+	return ..()
 
 /obj/item/clothing/accessory/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The pride pin altclick proc was overriden by the base accessory type.
This meant that alt click didn't actually call the reskin functionality, so it didn't work.

So, accessory/altclick now calls parent conditionally - if the accessory doesn't have the `above_suit` behavior, it will call parent with alt click. Which means it can reskin as expected.

## Why It's Good For The Game

I can properly chose the correct form of gay.

## Changelog

:cl: Melbert
fix: You can actually reskin the pride pin now
/:cl:
