### PR TITLE
HoP can access sec records again

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -3,7 +3,7 @@
 	desc = "Used to view and edit personnel's security records."
 	icon_screen = "security"
 	icon_keyboard = "security_key"
-	req_one_access = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
+	req_one_access = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS, ACCESS_HOP)
 	circuit = /obj/item/circuitboard/computer/secure_data
 	light_color = COLOR_SOFT_RED
 	var/rank = null


### PR DESCRIPTION
## About The Pull Request

This is an oversight from when I removed HoP's access to security office- HoP's are supposed to have sec records console (there's a console in the Bridge and their office on certain maps) so they can change people's jobs there, something they are intended to have access to.

## Why It's Good For The Game

HoP can change people's job titles from sec records again, which is part of their job.

## Changelog

:cl:
fix: HoPs can now use security record consoles again.
/:cl: