### PR TITLE
Fixes gulag teleporter runtime

### DIFF
--- a/code/game/machinery/computer/prisoner/gulag_teleporter.dm
+++ b/code/game/machinery/computer/prisoner/gulag_teleporter.dm
@@ -90,6 +90,8 @@
 				id_insert(usr)
 			return TRUE
 		if("set_goal")
+			if(!contained_id)
+				return
 			var/new_goal = text2num(params["value"])
 			if(!isnum(new_goal))
 				return


### PR DESCRIPTION
## About The Pull Request

If you tried to set a point goal without an ID, it would just runtime. Joy.
It now checks for an ID before doing anything regarding point setting.

## Why It's Good For The Game

Runtimes are bad.

## Changelog

No player facing changes
