### PR TITLE
Icebox miscellanous wall mounts and fixes

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -12738,9 +12738,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/official/space_cops{
-	pixel_y = -32
-	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science)
 "cFN" = (
@@ -13657,7 +13654,6 @@
 /turf/open/floor/carpet/red,
 /area/commons/vacant_room/office)
 "cZR" = (
-/obj/item/radio/intercom/directional/west,
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -13665,6 +13661,9 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/sign/poster/official/space_cops{
+	pixel_x = -32
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science)
@@ -16907,20 +16906,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
-"eNq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/warning/coldtemp{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/white/side{
-	dir = 5
-	},
-/area/science/research)
 "eNs" = (
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
@@ -17230,18 +17215,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"eYr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/white/side{
-	dir = 9
-	},
-/area/science/research)
 "eYz" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -17561,6 +17534,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science)
 "feO" = (
@@ -17698,6 +17672,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/warning/coldtemp{
+	pixel_y = -32
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "fic" = (
@@ -17780,7 +17757,6 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "fjI" = (
-/obj/machinery/airalarm/directional/north,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -20761,16 +20737,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
-"gKa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white,
-/area/science/research)
 "gKr" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -30194,6 +30160,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/office)
+"lDm" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white/side{
+	dir = 10
+	},
+/area/science/research)
 "lDz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -38661,6 +38633,18 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"pUn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white/side{
+	dir = 9
+	},
+/area/science/research)
 "pUp" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas{
@@ -45076,6 +45060,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "tlW" = (
@@ -52740,7 +52725,6 @@
 /area/science/misc_lab)
 "xhE" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/machinery/newscaster/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -55054,6 +55038,7 @@
 	},
 /obj/item/multitool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "ylm" = (
@@ -55065,10 +55050,6 @@
 /obj/effect/turf_decal/siding/wideplating,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"ylt" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/openspace,
-/area/service/chapel)
 "ylH" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
@@ -98416,8 +98397,8 @@ boG
 bqa
 cIe
 box
-bpZ
-eYr
+lDm
+iPG
 byf
 nPJ
 bAA
@@ -98931,7 +98912,7 @@ biL
 eiU
 box
 wjP
-eNq
+hZM
 byf
 dby
 oNk
@@ -99445,7 +99426,7 @@ cIb
 pTM
 box
 eij
-gKa
+kEi
 byi
 gYL
 sXX
@@ -99702,7 +99683,7 @@ bqd
 hyc
 box
 bpZ
-iPG
+pUn
 byi
 prp
 jqV
@@ -101994,7 +101975,7 @@ iim
 iim
 iim
 iim
-ylt
+iim
 iim
 iim
 fVt


### PR DESCRIPTION
## About The Pull Request

Fixes #63367
Fixes #63323
Fixes a floating beacon over the chapel, probably from a merge conflict

No GBP here, probably

## Why It's Good For The Game

Damn you, posters. Players being able to access wallmounts, etc.

## Changelog

:cl: Melbert
fix: Removed a floating teleport beacon in Icebox's chapel
fix: Fixed APC visibilty in icebox science outpost / RD office
fix: Fixed Air alarm accessibility in icebox atmos office
/:cl:
