### PR TITLE
Fixes Deltastation's rebellious helmets in the Armory

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -9591,19 +9591,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -9613,6 +9600,15 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/sec,
+/obj/item/clothing/head/helmet/sec{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)


### PR DESCRIPTION
## About The Pull Request
Replaces the helmets in the Armory with the correct sec helmet type, allowing for seclites or signallers to be attached. All those people reporting the issue were not crazy, they were just trolled by mappers all along.
Fixes #63329 (rather the cause of)

## Why It's Good For The Game
Less braincells lost in reporting the bug and brings some peace for issue jannies.

## Changelog
:cl:
fix: CentCom has finally begun shipping helmets with working flashlight mounts to Deltastation's armory.
/:cl: