### PR TITLE
Disables bot lock access in ui

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -882,6 +882,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 	data["can_hack"] = (issilicon(user) || isAdminGhostAI(user))
 	data["custom_controls"] = list()
 	data["emagged"] = bot_cover_flags & BOT_COVER_EMAGGED
+	data["has_access"] = check_access(user)
 	data["locked"] = bot_cover_flags & BOT_COVER_LOCKED
 	data["pai"] = list()
 	data["settings"] = list()

--- a/tgui/packages/tgui/interfaces/SimpleBot.tsx
+++ b/tgui/packages/tgui/interfaces/SimpleBot.tsx
@@ -7,6 +7,7 @@ type SimpleBotContext = {
   can_hack: number;
   locked: number;
   emagged: number;
+  has_access: number;
   pai: Pai;
   settings: Settings;
   custom_controls: Controls;
@@ -60,7 +61,7 @@ export const SimpleBot = (_, context) => {
 /** Creates a lock button at the top of the controls */
 const TabDisplay = (_, context) => {
   const { act, data } = useBackend<SimpleBotContext>(context);
-  const { can_hack, locked, pai } = data;
+  const { can_hack, has_access, locked, pai } = data;
   const { allow_pai } = pai;
 
   return (
@@ -69,6 +70,7 @@ const TabDisplay = (_, context) => {
       {!!allow_pai && <PaiButton />}
       <Button
         color="transparent"
+        disabled={!has_access && !can_hack}
         icon={locked ? 'lock' : 'lock-open'}
         onClick={() => act('lock')}
         selected={locked}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
#63259 was closed and fixed through dm side.
However, I want to make doubly sure by disabling cover lock access in the UI when the user does not have sufficient access.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Hackproofing bots
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Bot cover lock button is now disabled when you lack sufficient access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
