### PR TITLE
Adds tag to parent helmet path to prevent future mapping mistakes

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -12,6 +12,7 @@
 	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEHAIR
+	tag = "ATTN MAPPERS: Please use /sec variant for normal usage"
 
 	dog_fashion = /datum/dog_fashion/head/helmet
 


### PR DESCRIPTION
Adds a short mapping tag to hopefully stop future mappers from accidentally using /obj/item/clothing/head/helmet rather than /obj/item/clothing/head/helmet/sec
(Ala https://github.com/tgstation/tgstation/issues/63329)