### PR TITLE
Fixes midround traitor bypassing restricted_roles.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -222,6 +222,8 @@
 			living_players -= player // We don't autotator people in CentCom
 		else if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
 			living_players -= player // We don't autotator people with roles already
+		else if(player.mind.assigned_role.title in restricted_roles)
+			candidates -= player
 
 /datum/dynamic_ruleset/midround/autotraitor/ready(forced = FALSE)
 	if (required_candidates > living_players.len)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -223,7 +223,7 @@
 		else if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
 			living_players -= player // We don't autotator people with roles already
 		else if(player.mind.assigned_role.title in restricted_roles)
-			candidates -= player
+			living_players -= player
 
 /datum/dynamic_ruleset/midround/autotraitor/ready(forced = FALSE)
 	if (required_candidates > living_players.len)


### PR DESCRIPTION
## About The Pull Request

Fixes midround traitor bypassing restricted_roles.

## Why It's Good For The Game

Config modifications to the restricted_roles for dynamic wouldn't take effect for midround traitor.

## Changelog

:cl:
fix: Fixes midround traitor bypassing restricted_roles.
/:cl:
