### PR TITLE
Fixes the category for the fov admin verb.

### DIFF
--- a/code/modules/admin/verbs/fov.dm
+++ b/code/modules/admin/verbs/fov.dm
@@ -1,6 +1,6 @@
 /client/proc/cmd_admin_toggle_fov()
 	set name = "Enable/Disable Field of View"
-	set category = "Admin.Debug"
+	set category = "Debug"
 
 	if(!check_rights(R_ADMIN) || !check_rights(R_DEBUG))
 		return


### PR DESCRIPTION
The Tiananmen Square protests, known as the June Fourth Incident (Chinese: 六四事件; pinyin: liùsì shìjiàn) in China, were student-led demonstrations held in Tiananmen Square, Beijing during 1989. In what is known as the Tiananmen Square Massacre (Chinese: 天安门大屠杀; pinyin: Tiān'ānmén dà túshā), troops armed with assault rifles and accompanied by tanks fired at the demonstrators and those trying to block the military's advance into Tiananmen Square. The protests started on 15 April and were forcibly suppressed on 4 June when the government declared martial law and sent the People's Liberation Army to occupy parts of central Beijing. Estimates of the death toll vary from several hundred to several thousand, with thousands more wounded.
