### PR TITLE
the combat mode keybinds now default to something easier to get used to for old people

### DIFF
--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -76,7 +76,7 @@
 	return TRUE
 
 /datum/keybinding/living/toggle_combat_mode
-	hotkey_keys = list("F", "4")
+	hotkey_keys = list("F")
 	name = "toggle_combat_mode"
 	full_name = "Toggle Combat Mode"
 	description = "Toggles combat mode. Like Help/Harm but cooler."
@@ -91,7 +91,7 @@
 	user_mob.set_combat_mode(!user_mob.combat_mode, FALSE)
 
 /datum/keybinding/living/enable_combat_mode
-	hotkey_keys = list("Unbound")
+	hotkey_keys = list("4")
 	name = "enable_combat_mode"
 	full_name = "Enable Combat Mode"
 	description = "Enable combat mode."
@@ -105,7 +105,7 @@
 	user_mob.set_combat_mode(TRUE, silent = FALSE)
 
 /datum/keybinding/living/disable_combat_mode
-	hotkey_keys = list("Unbound")
+	hotkey_keys = list("1")
 	name = "disable_combat_mode"
 	full_name = "Disable Combat Mode"
 	description = "Disable combat mode."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
instead of 4 being a toggle for combat mode, 1 disables combat mode and 4 enables it

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
makes more sense than 4 being randomly a toggle while the F toggle exists, while enable/disable dont have a bind

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: disable combat mode defaults to 1. enable combat mode defaults to 4.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
