### PR TITLE
Fix some nuke z-level related bugs involving KillEveryoneOnZLevel and the "you are shredded to atoms" message

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -605,8 +605,8 @@ GLOBAL_VAR(station_nuke_source)
 		return
 	for(var/_victim in GLOB.mob_living_list)
 		var/mob/living/victim = _victim
-		to_chat(victim, span_userdanger("You are shredded to atoms!"))
 		if(victim.stat != DEAD && victim.z == z)
+			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()
 
 /*

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -604,8 +604,7 @@ GLOBAL_VAR(station_nuke_source)
 	stationwide_foam()
 
 /proc/KillEveryoneOnStation()
-	for(var/_victim in GLOB.mob_living_list)
-		var/mob/living/victim = _victim
+	for(var/mob/living/victim as anything in GLOB.mob_living_list)
 		if(victim.stat != DEAD && is_station_level(victim.z))
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -512,7 +512,7 @@ GLOBAL_VAR(station_nuke_source)
 	var/turf/bomb_location = get_turf(src)
 	Cinematic(get_cinematic_type(off_station),world,CALLBACK(SSticker,/datum/controller/subsystem/ticker/proc/station_explosion_detonation,src))
 	if(off_station != NUKE_NEAR_MISS) // Don't kill people in the station if the nuke missed, even if we are technically on the same z-level
-		INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, bomb_location.z)
+		INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneByZLevel, off_station == STATION_DESTROYED_NUKE, bomb_location.z)
 
 /obj/machinery/nuclearbomb/proc/get_cinematic_type(off_station)
 	if(off_station < NUKE_NEAR_MISS)
@@ -600,12 +600,15 @@ GLOBAL_VAR(station_nuke_source)
 	disarm()
 	stationwide_foam()
 
-/proc/KillEveryoneOnZLevel(z)
-	if(!z)
+
+/// KillEveryoneByZLevel
+/// Kills everyone on a station z level if kill_everyone_on_station is true, otherwise kills everyone on z_level_otherwise
+/proc/KillEveryoneByZLevel(kill_everyone_on_station, z_level_otherwise)
+	if(!kill_everyone_on_station && !z_level_otherwise)
 		return
 	for(var/_victim in GLOB.mob_living_list)
 		var/mob/living/victim = _victim
-		if(victim.stat != DEAD && victim.z == z)
+		if(victim.stat != DEAD && (kill_everyone_on_station ? is_station_level(victim.z) : victim.z == z_level_otherwise))
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -511,6 +511,9 @@ GLOBAL_VAR(station_nuke_source)
 /obj/machinery/nuclearbomb/proc/really_actually_explode(off_station)
 	var/turf/bomb_location = get_turf(src)
 	Cinematic(get_cinematic_type(off_station),world,CALLBACK(SSticker,/datum/controller/subsystem/ticker/proc/station_explosion_detonation,src))
+	if(off_station == STATION_DESTROYED_NUKE)
+		INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnStation)
+		return
 	if(off_station != NUKE_NEAR_MISS) // Don't kill people in the station if the nuke missed, even if we are technically on the same z-level
 		INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, bomb_location.z)
 
@@ -599,6 +602,13 @@ GLOBAL_VAR(station_nuke_source)
 /obj/machinery/nuclearbomb/beer/really_actually_explode()
 	disarm()
 	stationwide_foam()
+
+/proc/KillEveryoneOnStation()
+	for(var/_victim in GLOB.mob_living_list)
+		var/mob/living/victim = _victim
+		if(victim.stat != DEAD && is_station_level(victim.z))
+			to_chat(victim, span_userdanger("You are shredded to atoms!"))
+			victim.gib()
 
 /proc/KillEveryoneOnZLevel(z)
 	if(!z)

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -512,7 +512,7 @@ GLOBAL_VAR(station_nuke_source)
 	var/turf/bomb_location = get_turf(src)
 	Cinematic(get_cinematic_type(off_station),world,CALLBACK(SSticker,/datum/controller/subsystem/ticker/proc/station_explosion_detonation,src))
 	if(off_station != NUKE_NEAR_MISS) // Don't kill people in the station if the nuke missed, even if we are technically on the same z-level
-		INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneByZLevel, off_station == STATION_DESTROYED_NUKE, bomb_location.z)
+		INVOKE_ASYNC(GLOBAL_PROC,.proc/KillEveryoneOnZLevel, bomb_location.z)
 
 /obj/machinery/nuclearbomb/proc/get_cinematic_type(off_station)
 	if(off_station < NUKE_NEAR_MISS)
@@ -600,15 +600,12 @@ GLOBAL_VAR(station_nuke_source)
 	disarm()
 	stationwide_foam()
 
-
-/// KillEveryoneByZLevel
-/// Kills everyone on a station z level if kill_everyone_on_station is true, otherwise kills everyone on z_level_otherwise
-/proc/KillEveryoneByZLevel(kill_everyone_on_station, z_level_otherwise)
-	if(!kill_everyone_on_station && !z_level_otherwise)
+/proc/KillEveryoneOnZLevel(z)
+	if(!z)
 		return
 	for(var/_victim in GLOB.mob_living_list)
 		var/mob/living/victim = _victim
-		if(victim.stat != DEAD && (kill_everyone_on_station ? is_station_level(victim.z) : victim.z == z_level_otherwise))
+		if(victim.stat != DEAD && victim.z == z)
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The message is sent by KillEveryoneOnZLevel(z), which is called when a nuke goes off and doesn't miss the station, but it didn't check for the z when sending the message.
Now, if the nuke blew up on the station (and didn't miss it, ie not in space), then everyone on station z's will die and get the message. Otherwise, only everyone on the z-level will die and get the message.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #63406 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: When the nuke goes off, the "you are shredded to atoms" message no longer displays to people not on the z-level or on the station.
fix: The nuke now kills everyone on a station z-level if blown up on the station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
