### PR TITLE
Stops aux base turrets from hard-deleting (and 1 other fix)

### DIFF
--- a/code/game/objects/structures/construction_console/construction_actions.dm
+++ b/code/game/objects/structures/construction_console/construction_actions.dm
@@ -149,5 +149,5 @@
 		to_chat(owner, span_notice("<b>Warning:</b> Aux base controller not found. Turrets might not work properly."))
 		return
 
-	turret_controller.add_turret(placed_structure)
+	LAZYADD(turret_controller.turrets, WEAKREF(placed_structure))
 	to_chat(owner, span_notice("You've constructed an additional turret. [remaining] turrets remaining."))

--- a/code/game/objects/structures/construction_console/construction_actions.dm
+++ b/code/game/objects/structures/construction_console/construction_actions.dm
@@ -133,7 +133,7 @@
 	structure_path = /obj/structure/fans/tiny
 	place_sound = 'sound/machines/click.ogg'
 
-/datum/action/innate/construction/place_structure/turret/after_place(obj/placed_structure, remaining)
+/datum/action/innate/construction/place_structure/fan/after_place(obj/placed_structure, remaining)
 	to_chat(owner, span_notice("Tiny fan placed. [remaining] fans remaining."))
 
 /datum/action/innate/construction/place_structure/turret
@@ -148,5 +148,6 @@
 	if(!turret_controller)
 		to_chat(owner, span_notice("<b>Warning:</b> Aux base controller not found. Turrets might not work properly."))
 		return
-	turret_controller.turrets += placed_structure
+
+	turret_controller.add_turret(placed_structure)
 	to_chat(owner, span_notice("You've constructed an additional turret. [remaining] turrets remaining."))

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -251,7 +251,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/auxiliary_base, 32)
 /*
  * Signal proc for [COMSIG_PARENT_QDELETING], set on turrets the aux base creates.
  *
- * Remove [new_turret] from our list of turrets in the event they're deleted.
+ * Remove [source] from our list of turrets, in the event they're deleted.
  */
 /obj/machinery/computer/auxiliary_base/proc/remove_turret(datum/source, force)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

Fixes #62643

Fixes aux-base turrets from hard-deleting by handling their deleting on the aux base itself.
Converts the turrets list to a proper lazylist and cleans up some surrounding code involving the turrets list.
Also fixes a copy+paste error with tiny fans being placed.

## Why It's Good For The Game

Aux base doesn't break if you remove turrets.

## Changelog

:cl: Melbert
fix: Placing tiny fans in the aux base gives feedback
fix: Breaking / deconstructing aux base turrets no longer brick the console
/:cl:

