### PR TITLE
outfit_sanity unit test now reports what the item that was trying to equip was

### DIFF
--- a/code/modules/unit_tests/outfit_sanity.dm
+++ b/code/modules/unit_tests/outfit_sanity.dm
@@ -2,7 +2,7 @@
 	H.equip_to_slot_or_del(new outfit.##outfit_key(H), ##slot_name, TRUE); \
 	/* We don't check the result of equip_to_slot_or_del because it returns false for random jumpsuits, as they delete themselves on init */ \
 	if (!H.get_item_by_slot(##slot_name)) { \
-		Fail("[outfit.name]'s [#outfit_key] is invalid!"); \
+		Fail("[outfit.name]'s [#outfit_key] is invalid! Could not equip a [outfit.##outfit_key] into that slot."); \
 	} \
 }
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/40974010/146188965-ef09e688-5ad9-45b7-ab82-5c2a8e1e6506.png)

## Why It's Good For The Game

Outfits for mob corpses and other weird setpieces often randomize what they're going to equip, making the failures spontaneous for one but secondarily making the actual culprit for the slot weird to figure out. In the end it didn't really help me find and squash that spontaneous golem outfit fail but I'll find it

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

not player facing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
