### PR TITLE
Fixes NtOS chat bluescreen, muting

### DIFF
--- a/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
@@ -86,7 +86,7 @@
 	offline_clients.Add(offline)
 
 /datum/ntnet_conversation/proc/mute_user(datum/computer_file/program/chatclient/op, datum/computer_file/program/chatclient/muted)
-	if(operator != op) //sanity even if the person shouldn't be able to see the mute button
+	if(!op.netadmin_mode && operator != op) //sanity even if the person shouldn't be able to see the mute button
 		return
 	if(muted in muted_clients)
 		muted_clients.Remove(muted)

--- a/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
@@ -86,7 +86,7 @@
 	offline_clients.Add(offline)
 
 /datum/ntnet_conversation/proc/mute_user(datum/computer_file/program/chatclient/op, datum/computer_file/program/chatclient/muted)
-	if(!op.netadmin_mode && operator != op) // sanity even if the person shouldn't be able to see the mute button
+	if(!op.netadmin_mode && operator != op) //sanity even if the person shouldn't be able to see the mute button
 		return
 	if(muted in muted_clients)
 		muted_clients.Remove(muted)

--- a/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
+++ b/code/modules/modular_computers/NTNet/NTNRC/conversation.dm
@@ -86,7 +86,7 @@
 	offline_clients.Add(offline)
 
 /datum/ntnet_conversation/proc/mute_user(datum/computer_file/program/chatclient/op, datum/computer_file/program/chatclient/muted)
-	if(!op.netadmin_mode && operator != op) //sanity even if the person shouldn't be able to see the mute button
+	if(!op.netadmin_mode && operator != op) // sanity even if the person shouldn't be able to see the mute button
 		return
 	if(muted in muted_clients)
 		muted_clients.Remove(muted)

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -91,8 +91,7 @@
 		if("PRG_toggleadmin")
 			if(netadmin_mode)
 				netadmin_mode = FALSE
-				if(channel)
-					channel.remove_client(src) // We shouldn't be in channel's user list, but just in case...
+				channel?.add_client(src)
 				return TRUE
 			var/mob/living/user = usr
 			if(can_run(user, TRUE, ACCESS_NETWORK))

--- a/tgui/packages/tgui/interfaces/NtosNetChat.js
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.js
@@ -8,9 +8,9 @@ const CLIENT_AWAY = 1;
 const CLIENT_OFFLINE = 0;
 
 const STATUS2TEXT = {
-  0: 'Offline',
-  1: 'Away',
-  2: 'Online',
+  0: "Offline",
+  1: "Away",
+  2: "Online",
 };
 
 const NoChannelDimmer = (props, context) => {
@@ -22,13 +22,24 @@ const NoChannelDimmer = (props, context) => {
         <Stack.Item>
           <Stack ml={-2}>
             <Stack.Item>
-              <Icon color="green" name="grin-beam" size={10} />
+              <Icon
+                color="green"
+                name="grin-beam"
+                size={10}
+              />
             </Stack.Item>
             <Stack.Item mt={-8}>
-              <Icon name="comment-dots" size={10} />
+              <Icon
+                name="comment-dots"
+                size={10}
+              />
             </Stack.Item>
             <Stack.Item ml={-1}>
-              <Icon color="green" name="smile" size={10} />
+              <Icon
+                color="green"
+                name="smile"
+                size={10}
+              />
             </Stack.Item>
           </Stack>
         </Stack.Item>
@@ -59,8 +70,8 @@ export const NtosNetChat = (props, context) => {
     clients = [],
     messages = [],
   } = data;
-  const in_channel = active_channel !== null;
-  const authorized = authed || adminmode;
+  const in_channel = (active_channel !== null);
+  const authorized = (authed || adminmode);
   // this list has cliented ordered from their status. online > away > offline
   const displayed_clients = clients.sort((clientA, clientB) => {
     if (clientA.operator) {
@@ -73,22 +84,24 @@ export const NtosNetChat = (props, context) => {
   });
   const client_color = (client) => {
     if (client.operator) {
-      return 'green';
+      return "green";
     }
     switch (client.status) {
       case CLIENT_ONLINE:
-        return 'white';
+        return "white";
       case CLIENT_AWAY:
-        return 'yellow';
+        return "yellow";
       case CLIENT_OFFLINE:
       default:
-        return 'label';
+        return "label";
     }
   };
   // client from this computer!
-  const this_client = clients.find((client) => client.ref === selfref);
+  const this_client = clients.find(client => client.ref === selfref);
   return (
-    <NtosWindow width={1000} height={675}>
+    <NtosWindow
+      width={1000}
+      height={675}>
       <NtosWindow.Content>
         <Stack fill>
           <Stack.Item>
@@ -98,45 +111,40 @@ export const NtosNetChat = (props, context) => {
                   <Button.Input
                     fluid
                     content="New Channel..."
-                    onCommit={(e, value) =>
-                      act('PRG_newchannel', {
-                        new_channel_name: value,
-                      })}
-                  />
-                  {all_channels.map((channel) => (
+                    onCommit={(e, value) => act('PRG_newchannel', {
+                      new_channel_name: value,
+                    })} />
+                  {all_channels.map(channel => (
                     <Button
                       fluid
                       key={channel.chan}
                       content={channel.chan}
                       selected={channel.id === active_channel}
                       color="transparent"
-                      onClick={() =>
-                        act('PRG_joinchannel', {
-                          id: channel.id,
-                        })}
-                    />
+                      onClick={() => act('PRG_joinchannel', {
+                        id: channel.id,
+                      })} />
                   ))}
                 </Stack.Item>
                 <Stack.Item>
-                  <Box>Username:</Box>
+                  <Box>
+                    Username:
+                  </Box>
                   <Button.Input
                     fluid
                     mt={1}
                     content={username + '...'}
                     currentValue={username}
-                    onCommit={(e, value) =>
-                      act('PRG_changename', {
-                        new_name: value,
-                      })}
-                  />
+                    onCommit={(e, value) => act('PRG_changename', {
+                      new_name: value,
+                    })} />
                   {!!can_admin && (
                     <Button
                       fluid
                       bold
-                      content={'ADMIN MODE: ' + (adminmode ? 'ON' : 'OFF')}
+                      content={"ADMIN MODE: " + (adminmode ? 'ON' : 'OFF')}
                       color={adminmode ? 'bad' : 'good'}
-                      onClick={() => act('PRG_toggleadmin')}
-                    />
+                      onClick={() => act('PRG_toggleadmin')} />
                   )}
                 </Stack.Item>
               </Stack>
@@ -147,42 +155,49 @@ export const NtosNetChat = (props, context) => {
             <Stack vertical fill>
               <Stack.Item grow>
                 <Section scrollable fill>
-                  {(in_channel
-                    && (authorized ? (
-                      messages.map((message) => (
-                        <Box key={message.msg}>{message.msg}</Box>
+                  {in_channel && (
+                    authorized ? (
+                      messages.map(message => (
+                        <Box
+                          key={message.msg}>
+                          {message.msg}
+                        </Box>
                       ))
                     ) : (
-                      <Box textAlign="center">
+                      <Box
+                        textAlign="center">
                         <Icon
                           name="exclamation-triangle"
                           mt={4}
-                          fontSize="40px"
-                        />
-                        <Box mt={1} bold fontSize="18px">
+                          fontSize="40px" />
+                        <Box
+                          mt={1}
+                          bold
+                          fontSize="18px">
                           THIS CHANNEL IS PASSWORD PROTECTED
                         </Box>
-                        <Box mt={1}>INPUT PASSWORD TO ACCESS</Box>
+                        <Box mt={1}>
+                          INPUT PASSWORD TO ACCESS
+                        </Box>
                       </Box>
-                    ))) || <NoChannelDimmer />}
+                    )
+                  ) || (
+                    <NoChannelDimmer />
+                  )}
                 </Section>
               </Stack.Item>
               {!!in_channel && (
                 <Input
-                  backgroundColor={this_client && this_client.muted && 'red'}
+                  backgroundColor={(this_client && this_client.muted) && "red"}
                   height="22px"
-                  placeholder={
-                    (this_client && this_client.muted && 'You are muted!')
-                    || 'Message ' + title
-                  }
+                  placeholder={(this_client && this_client.muted)
+                    && "You are muted!" || "Message "+title}
                   fluid
                   selfClear
                   mt={1}
-                  onEnter={(e, value) =>
-                    act('PRG_speak', {
-                      message: value,
-                    })}
-                />
+                  onEnter={(e, value) => act('PRG_speak', {
+                    message: value,
+                  })} />
               )}
             </Stack>
           </Stack.Item>
@@ -194,7 +209,7 @@ export const NtosNetChat = (props, context) => {
                   <Stack.Item grow>
                     <Section scrollable fill>
                       <Stack vertical>
-                        {displayed_clients.map((client) => (
+                        {displayed_clients.map(client => (
                           <Stack height="18px" fill key={client.name}>
                             <Stack.Item
                               basis={0}
@@ -209,38 +224,27 @@ export const NtosNetChat = (props, context) => {
                                     disabled={this_client?.muted}
                                     compact
                                     icon="bullhorn"
-                                    tooltip={
-                                      (!this_client?.muted && 'Ping')
-                                      || 'You are muted!'
-                                    }
+                                    tooltip={!this_client?.muted
+                                      && "Ping" || "You are muted!"}
                                     tooltipPosition="left"
-                                    onClick={() =>
-                                      act('PRG_ping_user', {
-                                        ref: client.ref,
-                                      })}
-                                  />
+                                    onClick={() => act('PRG_ping_user', {
+                                      ref: client.ref,
+                                    })} />
                                 </Stack.Item>
                                 {!!is_operator && (
                                   <Stack.Item>
                                     <Button
                                       compact
-                                      icon={
-                                        (!client.muted && 'volume-up')
-                                        || 'volume-mute'
-                                      }
-                                      color={
-                                        (!client.muted && 'green') || 'red'
-                                      }
-                                      tooltip={
-                                        (!client.muted && 'Mute this User')
-                                        || 'Unmute this User'
-                                      }
+                                      icon={!client.muted
+                                        && "volume-up" || "volume-mute"}
+                                      color={!client.muted
+                                        && "green" || "red"}
+                                      tooltip={!client.muted
+                                        && "Mute this User" || "Unmute this User"}
                                       tooltipPosition="left"
-                                      onClick={() =>
-                                        act('PRG_mute_user', {
-                                          ref: client.ref,
-                                        })}
-                                    />
+                                      onClick={() => act('PRG_mute_user', {
+                                        ref: client.ref,
+                                      })} />
                                   </Stack.Item>
                                 )}
                               </>
@@ -251,7 +255,9 @@ export const NtosNetChat = (props, context) => {
                     </Section>
                   </Stack.Item>
                   <Section>
-                    <Stack.Item mb="8px">Settings for {title}:</Stack.Item>
+                    <Stack.Item mb="8px">
+                      Settings for {title}:
+                    </Stack.Item>
                     <Stack.Item>
                       {!!(in_channel && authorized) && (
                         <>
@@ -259,16 +265,13 @@ export const NtosNetChat = (props, context) => {
                             fluid
                             content="Save log..."
                             defaultValue="new_log"
-                            onCommit={(e, value) =>
-                              act('PRG_savelog', {
-                                log_name: value,
-                              })}
-                          />
+                            onCommit={(e, value) => act('PRG_savelog', {
+                              log_name: value,
+                            })} />
                           <Button.Confirm
                             fluid
                             content="Leave Channel"
-                            onClick={() => act('PRG_leavechannel')}
-                          />
+                            onClick={() => act('PRG_leavechannel')} />
                         </>
                       )}
                       {!!(is_operator && authed) && (
@@ -277,25 +280,20 @@ export const NtosNetChat = (props, context) => {
                             fluid
                             disabled={strong}
                             content="Delete Channel"
-                            onClick={() => act('PRG_deletechannel')}
-                          />
+                            onClick={() => act('PRG_deletechannel')} />
                           <Button.Input
                             fluid
                             disabled={strong}
                             content="Rename Channel..."
-                            onCommit={(e, value) =>
-                              act('PRG_renamechannel', {
-                                new_name: value,
-                              })}
-                          />
+                            onCommit={(e, value) => act('PRG_renamechannel', {
+                              new_name: value,
+                            })} />
                           <Button.Input
                             fluid
                             content="Set Password..."
-                            onCommit={(e, value) =>
-                              act('PRG_setpassword', {
-                                new_password: value,
-                              })}
-                          />
+                            onCommit={(e, value) => act('PRG_setpassword', {
+                              new_password: value,
+                            })} />
                         </>
                       )}
                     </Stack.Item>

--- a/tgui/packages/tgui/interfaces/NtosNetChat.js
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.js
@@ -1,5 +1,13 @@
 import { useBackend } from '../backend';
-import { Box, Button, Dimmer, Icon, Input, Section, Stack } from '../components';
+import {
+  Box,
+  Button,
+  Dimmer,
+  Icon,
+  Input,
+  Section,
+  Stack,
+} from '../components';
 import { NtosWindow } from '../layouts';
 
 // byond defines for the program state
@@ -8,9 +16,9 @@ const CLIENT_AWAY = 1;
 const CLIENT_OFFLINE = 0;
 
 const STATUS2TEXT = {
-  0: "Offline",
-  1: "Away",
-  2: "Online",
+  0: 'Offline',
+  1: 'Away',
+  2: 'Online',
 };
 
 const NoChannelDimmer = (props, context) => {
@@ -22,24 +30,13 @@ const NoChannelDimmer = (props, context) => {
         <Stack.Item>
           <Stack ml={-2}>
             <Stack.Item>
-              <Icon
-                color="green"
-                name="grin-beam"
-                size={10}
-              />
+              <Icon color="green" name="grin-beam" size={10} />
             </Stack.Item>
             <Stack.Item mt={-8}>
-              <Icon
-                name="comment-dots"
-                size={10}
-              />
+              <Icon name="comment-dots" size={10} />
             </Stack.Item>
             <Stack.Item ml={-1}>
-              <Icon
-                color="green"
-                name="smile"
-                size={10}
-              />
+              <Icon color="green" name="smile" size={10} />
             </Stack.Item>
           </Stack>
         </Stack.Item>
@@ -70,8 +67,8 @@ export const NtosNetChat = (props, context) => {
     clients = [],
     messages = [],
   } = data;
-  const in_channel = (active_channel !== null);
-  const authorized = (authed || adminmode);
+  const in_channel = active_channel !== null;
+  const authorized = authed || adminmode;
   // this list has cliented ordered from their status. online > away > offline
   const displayed_clients = clients.sort((clientA, clientB) => {
     if (clientA.operator) {
@@ -84,24 +81,22 @@ export const NtosNetChat = (props, context) => {
   });
   const client_color = (client) => {
     if (client.operator) {
-      return "green";
+      return 'green';
     }
     switch (client.status) {
       case CLIENT_ONLINE:
-        return "white";
+        return 'white';
       case CLIENT_AWAY:
-        return "yellow";
+        return 'yellow';
       case CLIENT_OFFLINE:
       default:
-        return "label";
+        return 'label';
     }
   };
   // client from this computer!
-  const this_client = clients.find(client => client.ref === selfref);
+  const this_client = clients.find((client) => client.ref === selfref);
   return (
-    <NtosWindow
-      width={1000}
-      height={675}>
+    <NtosWindow width={1000} height={675}>
       <NtosWindow.Content>
         <Stack fill>
           <Stack.Item>
@@ -111,40 +106,45 @@ export const NtosNetChat = (props, context) => {
                   <Button.Input
                     fluid
                     content="New Channel..."
-                    onCommit={(e, value) => act('PRG_newchannel', {
-                      new_channel_name: value,
-                    })} />
-                  {all_channels.map(channel => (
+                    onCommit={(e, value) =>
+                      act('PRG_newchannel', {
+                        new_channel_name: value,
+                      })}
+                  />
+                  {all_channels.map((channel) => (
                     <Button
                       fluid
                       key={channel.chan}
                       content={channel.chan}
                       selected={channel.id === active_channel}
                       color="transparent"
-                      onClick={() => act('PRG_joinchannel', {
-                        id: channel.id,
-                      })} />
+                      onClick={() =>
+                        act('PRG_joinchannel', {
+                          id: channel.id,
+                        })}
+                    />
                   ))}
                 </Stack.Item>
                 <Stack.Item>
-                  <Box>
-                    Username:
-                  </Box>
+                  <Box>Username:</Box>
                   <Button.Input
                     fluid
                     mt={1}
                     content={username + '...'}
                     currentValue={username}
-                    onCommit={(e, value) => act('PRG_changename', {
-                      new_name: value,
-                    })} />
+                    onCommit={(e, value) =>
+                      act('PRG_changename', {
+                        new_name: value,
+                      })}
+                  />
                   {!!can_admin && (
                     <Button
                       fluid
                       bold
-                      content={"ADMIN MODE: " + (adminmode ? 'ON' : 'OFF')}
+                      content={'ADMIN MODE: ' + (adminmode ? 'ON' : 'OFF')}
                       color={adminmode ? 'bad' : 'good'}
-                      onClick={() => act('PRG_toggleadmin')} />
+                      onClick={() => act('PRG_toggleadmin')}
+                    />
                   )}
                 </Stack.Item>
               </Stack>
@@ -155,49 +155,42 @@ export const NtosNetChat = (props, context) => {
             <Stack vertical fill>
               <Stack.Item grow>
                 <Section scrollable fill>
-                  {in_channel && (
-                    authorized ? (
-                      messages.map(message => (
-                        <Box
-                          key={message.msg}>
-                          {message.msg}
-                        </Box>
+                  {(in_channel
+                    && (authorized ? (
+                      messages.map((message) => (
+                        <Box key={message.msg}>{message.msg}</Box>
                       ))
                     ) : (
-                      <Box
-                        textAlign="center">
+                      <Box textAlign="center">
                         <Icon
                           name="exclamation-triangle"
                           mt={4}
-                          fontSize="40px" />
-                        <Box
-                          mt={1}
-                          bold
-                          fontSize="18px">
+                          fontSize="40px"
+                        />
+                        <Box mt={1} bold fontSize="18px">
                           THIS CHANNEL IS PASSWORD PROTECTED
                         </Box>
-                        <Box mt={1}>
-                          INPUT PASSWORD TO ACCESS
-                        </Box>
+                        <Box mt={1}>INPUT PASSWORD TO ACCESS</Box>
                       </Box>
-                    )
-                  ) || (
-                    <NoChannelDimmer />
-                  )}
+                    ))) || <NoChannelDimmer />}
                 </Section>
               </Stack.Item>
               {!!in_channel && (
                 <Input
-                  backgroundColor={(this_client && this_client.muted) && "red"}
+                  backgroundColor={this_client && this_client.muted && 'red'}
                   height="22px"
-                  placeholder={(this_client && this_client.muted)
-                    && "You are muted!" || "Message "+title}
+                  placeholder={
+                    (this_client && this_client.muted && 'You are muted!')
+                    || 'Message ' + title
+                  }
                   fluid
                   selfClear
                   mt={1}
-                  onEnter={(e, value) => act('PRG_speak', {
-                    message: value,
-                  })} />
+                  onEnter={(e, value) =>
+                    act('PRG_speak', {
+                      message: value,
+                    })}
+                />
               )}
             </Stack>
           </Stack.Item>
@@ -209,7 +202,7 @@ export const NtosNetChat = (props, context) => {
                   <Stack.Item grow>
                     <Section scrollable fill>
                       <Stack vertical>
-                        {displayed_clients.map(client => (
+                        {displayed_clients.map((client) => (
                           <Stack height="18px" fill key={client.name}>
                             <Stack.Item
                               basis={0}
@@ -224,27 +217,38 @@ export const NtosNetChat = (props, context) => {
                                     disabled={this_client?.muted}
                                     compact
                                     icon="bullhorn"
-                                    tooltip={!this_client?.muted
-                                      && "Ping" || "You are muted!"}
+                                    tooltip={
+                                      (!this_client?.muted && 'Ping')
+                                      || 'You are muted!'
+                                    }
                                     tooltipPosition="left"
-                                    onClick={() => act('PRG_ping_user', {
-                                      ref: client.ref,
-                                    })} />
+                                    onClick={() =>
+                                      act('PRG_ping_user', {
+                                        ref: client.ref,
+                                      })}
+                                  />
                                 </Stack.Item>
                                 {!!is_operator && (
                                   <Stack.Item>
                                     <Button
                                       compact
-                                      icon={!client.muted
-                                        && "volume-up" || "volume-mute"}
-                                      color={!client.muted
-                                        && "green" || "red"}
-                                      tooltip={!client.muted
-                                        && "Mute this User" || "Unmute this User"}
+                                      icon={
+                                        (!client.muted && 'volume-up')
+                                        || 'volume-mute'
+                                      }
+                                      color={
+                                        (!client.muted && 'green') || 'red'
+                                      }
+                                      tooltip={
+                                        (!client.muted && 'Mute this User')
+                                        || 'Unmute this User'
+                                      }
                                       tooltipPosition="left"
                                       onClick={() =>
                                         act('PRG_mute_user', {
-                                          ref: client.ref })} />
+                                          ref: client.ref,
+                                        })}
+                                    />
                                   </Stack.Item>
                                 )}
                               </>
@@ -255,9 +259,7 @@ export const NtosNetChat = (props, context) => {
                     </Section>
                   </Stack.Item>
                   <Section>
-                    <Stack.Item mb="8px">
-                      Settings for {title}:
-                    </Stack.Item>
+                    <Stack.Item mb="8px">Settings for {title}:</Stack.Item>
                     <Stack.Item>
                       {!!(in_channel && authorized) && (
                         <>
@@ -265,13 +267,16 @@ export const NtosNetChat = (props, context) => {
                             fluid
                             content="Save log..."
                             defaultValue="new_log"
-                            onCommit={(e, value) => act('PRG_savelog', {
-                              log_name: value,
-                            })} />
+                            onCommit={(e, value) =>
+                              act('PRG_savelog', {
+                                log_name: value,
+                              })}
+                          />
                           <Button.Confirm
                             fluid
                             content="Leave Channel"
-                            onClick={() => act('PRG_leavechannel')} />
+                            onClick={() => act('PRG_leavechannel')}
+                          />
                         </>
                       )}
                       {!!(is_operator && authed) && (
@@ -280,20 +285,25 @@ export const NtosNetChat = (props, context) => {
                             fluid
                             disabled={strong}
                             content="Delete Channel"
-                            onClick={() => act('PRG_deletechannel')} />
+                            onClick={() => act('PRG_deletechannel')}
+                          />
                           <Button.Input
                             fluid
                             disabled={strong}
                             content="Rename Channel..."
-                            onCommit={(e, value) => act('PRG_renamechannel', {
-                              new_name: value,
-                            })} />
+                            onCommit={(e, value) =>
+                              act('PRG_renamechannel', {
+                                new_name: value,
+                              })}
+                          />
                           <Button.Input
                             fluid
                             content="Set Password..."
-                            onCommit={(e, value) => act('PRG_setpassword', {
-                              new_password: value,
-                            })} />
+                            onCommit={(e, value) =>
+                              act('PRG_setpassword', {
+                                new_password: value,
+                              })}
+                          />
                         </>
                       )}
                     </Stack.Item>

--- a/tgui/packages/tgui/interfaces/NtosNetChat.js
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.js
@@ -1,13 +1,5 @@
 import { useBackend } from '../backend';
-import {
-  Box,
-  Button,
-  Dimmer,
-  Icon,
-  Input,
-  Section,
-  Stack,
-} from '../components';
+import { Box, Button, Dimmer, Icon, Input, Section, Stack } from '../components';
 import { NtosWindow } from '../layouts';
 
 // byond defines for the program state

--- a/tgui/packages/tgui/interfaces/NtosNetChat.js
+++ b/tgui/packages/tgui/interfaces/NtosNetChat.js
@@ -100,7 +100,7 @@ export const NtosNetChat = (props, context) => {
   const this_client = clients.find(client => client.ref === selfref);
   return (
     <NtosWindow
-      width={900}
+      width={1000}
       height={675}>
       <NtosWindow.Content>
         <Stack fill>
@@ -151,7 +151,7 @@ export const NtosNetChat = (props, context) => {
             </Section>
           </Stack.Item>
           <Stack.Divider />
-          <Stack.Item grow={5}>
+          <Stack.Item grow={4}>
             <Stack vertical fill>
               <Stack.Item grow>
                 <Section scrollable fill>
@@ -204,7 +204,7 @@ export const NtosNetChat = (props, context) => {
           {!!in_channel && (
             <>
               <Stack.Divider />
-              <Stack.Item grow={1}>
+              <Stack.Item grow={2}>
                 <Stack vertical fill>
                   <Stack.Item grow>
                     <Section scrollable fill>
@@ -221,10 +221,10 @@ export const NtosNetChat = (props, context) => {
                               <>
                                 <Stack.Item>
                                   <Button
-                                    disabled={this_client.muted}
+                                    disabled={this_client?.muted}
                                     compact
                                     icon="bullhorn"
-                                    tooltip={!this_client.muted
+                                    tooltip={!this_client?.muted
                                       && "Ping" || "You are muted!"}
                                     tooltipPosition="left"
                                     onClick={() => act('PRG_ping_user', {
@@ -242,9 +242,9 @@ export const NtosNetChat = (props, context) => {
                                       tooltip={!client.muted
                                         && "Mute this User" || "Unmute this User"}
                                       tooltipPosition="left"
-                                      onClick={() => act('PRG_mute_user', {
-                                        ref: client.ref,
-                                      })} />
+                                      onClick={() =>
+                                        act('PRG_mute_user', {
+                                          ref: client.ref })} />
                                   </Stack.Item>
                                 )}
                               </>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Could not actually mute other clients
- Turning on admin permanently deleted the user
- Screen sizing was bonk
**New screen sizing with muted users, admin mode on:**
![1](https://user-images.githubusercontent.com/42397676/146273002-720a2658-49be-4abb-a5b8-1cba97af3e4e.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #62472 
- Chat client is a little easier to view, user panel is fully visible
- No more bluescreen
- (chat) admins can mute others
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes a bluescreen when turning on admin mode in NtOS chat software.
fix: Literally 1984: NtOS chat admins can now properly mute others.
fix: Turning off NtOS admin mode now properly returns you to the channel.
fix: NtOS chat screen widened slightly to fix clipping issue on the participants panel.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
