### PR TITLE
Log telemetry connections in DB

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -20,6 +20,8 @@ CREATE TABLE `telemetry_connections` (
     `telemetry_ckey` VARCHAR(32) NOT NULL,
     `address` INT(10) NOT NULL,
     `computer_id` VARCHAR(32) NOT NULL,
+	`first_round_id` INT(11) UNSIGNED NULL,
+    `latest_round_id` INT(11) UNSIGNED NULL,
     PRIMARY KEY (`id`),
     UNIQUE INDEX `unique_constraints` (`ckey` , `telemetry_ckey` , `address` , `computer_id`)
 );

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -20,7 +20,7 @@ CREATE TABLE `telemetry_connections` (
     `telemetry_ckey` VARCHAR(32) NOT NULL,
     `address` INT(10) NOT NULL,
     `computer_id` VARCHAR(32) NOT NULL,
-	`first_round_id` INT(11) UNSIGNED NULL,
+    `first_round_id` INT(11) UNSIGNED NULL,
     `latest_round_id` INT(11) UNSIGNED NULL,
     PRIMARY KEY (`id`),
     UNIQUE INDEX `unique_constraints` (`ckey` , `telemetry_ckey` , `address` , `computer_id`)

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,12 +1,30 @@
 Any time you make a change to the schema files, remember to increment the database schema version. Generally increment the minor number, major should be reserved for significant changes to the schema. Both values go up to 255.
 
-The latest database version is 5.20; The query to update the schema revision table is:
+Make sure to also update `DB_MAJOR_VERSION` and `DB_MINOR_VERSION`, which can be found in `code/__DEFINES/subsystem.dm`.
 
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 20);
+The latest database version is 5.21; The query to update the schema revision table is:
+
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 21);
 or
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 20);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 21);
 
 In any query remember to add a prefix to the table names if you use one.
+
+Version 5.21, 15 December 2021, by Mothblocks
+Adds `telemetry_connections` table for tracking tgui telemetry.
+
+```
+CREATE TABLE `telemetry_connections` (
+    `id` INT NOT NULL AUTO_INCREMENT,
+	`ckey` VARCHAR(32) NOT NULL,
+    `telemetry_ckey` VARCHAR(32) NOT NULL,
+    `address` INT(10) NOT NULL,
+    `computer_id` VARCHAR(32) NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `unique_constraints` (`ckey` , `telemetry_ckey` , `address` , `computer_id`)
+);
+```
+-----------------------------------------------------
 
 Version 5.20, 11 November 2021, by Mothblocks
 Adds `admin_ckey` field to the `known_alts` table to track who added what.

--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -16,7 +16,7 @@ Adds `telemetry_connections` table for tracking tgui telemetry.
 ```
 CREATE TABLE `telemetry_connections` (
     `id` INT NOT NULL AUTO_INCREMENT,
-	`ckey` VARCHAR(32) NOT NULL,
+    `ckey` VARCHAR(32) NOT NULL,
     `telemetry_ckey` VARCHAR(32) NOT NULL,
     `address` INT(10) NOT NULL,
     `computer_id` VARCHAR(32) NOT NULL,

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -683,7 +683,7 @@ CREATE TABLE `known_alts` (
 DROP TABLE IF EXISTS `telemetry_connections`;
 CREATE TABLE `telemetry_connections` (
     `id` INT NOT NULL AUTO_INCREMENT,
-	`ckey` VARCHAR(32) NOT NULL,
+    `ckey` VARCHAR(32) NOT NULL,
     `telemetry_ckey` VARCHAR(32) NOT NULL,
     `address` INT(10) NOT NULL,
     `computer_id` VARCHAR(32) NOT NULL,

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -677,6 +677,20 @@ CREATE TABLE `known_alts` (
     UNIQUE INDEX `unique_contraints` (`ckey1` , `ckey2`)
 );
 
+--
+-- Table structure for table `telemetry_connections`
+--
+DROP TABLE IF EXISTS `telemetry_connections`;
+CREATE TABLE `telemetry_connections` (
+    `id` INT NOT NULL AUTO_INCREMENT,
+	`ckey` VARCHAR(32) NOT NULL,
+    `telemetry_ckey` VARCHAR(32) NOT NULL,
+    `address` INT(10) NOT NULL,
+    `computer_id` VARCHAR(32) NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `unique_constraints` (`ckey` , `telemetry_ckey` , `address` , `computer_id`)
+);
+
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -687,6 +687,8 @@ CREATE TABLE `telemetry_connections` (
     `telemetry_ckey` VARCHAR(32) NOT NULL,
     `address` INT(10) NOT NULL,
     `computer_id` VARCHAR(32) NOT NULL,
+    `first_round_id` INT(11) UNSIGNED NULL,
+    `latest_round_id` INT(11) UNSIGNED NULL,
     PRIMARY KEY (`id`),
     UNIQUE INDEX `unique_constraints` (`ckey` , `telemetry_ckey` , `address` , `computer_id`)
 );

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -683,7 +683,7 @@ CREATE TABLE `SS13_known_alts` (
 DROP TABLE IF EXISTS `SS13_telemetry_connections`;
 CREATE TABLE `SS13_telemetry_connections` (
     `id` INT NOT NULL AUTO_INCREMENT,
-	`ckey` VARCHAR(32) NOT NULL,
+    `ckey` VARCHAR(32) NOT NULL,
     `telemetry_ckey` VARCHAR(32) NOT NULL,
     `address` INT(10) NOT NULL,
     `computer_id` VARCHAR(32) NOT NULL,

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -687,7 +687,9 @@ CREATE TABLE `SS13_telemetry_connections` (
     `telemetry_ckey` VARCHAR(32) NOT NULL,
     `address` INT(10) NOT NULL,
     `computer_id` VARCHAR(32) NOT NULL,
-    PRIMARY KEY (`id`),
+    `first_round_id` INT(11) UNSIGNED NULL,
+    `latest_round_id` INT(11) UNSIGNED NULL,
+	PRIMARY KEY (`id`),
     UNIQUE INDEX `unique_constraints` (`ckey` , `telemetry_ckey` , `address` , `computer_id`)
 );
 

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -689,7 +689,7 @@ CREATE TABLE `SS13_telemetry_connections` (
     `computer_id` VARCHAR(32) NOT NULL,
     `first_round_id` INT(11) UNSIGNED NULL,
     `latest_round_id` INT(11) UNSIGNED NULL,
-	PRIMARY KEY (`id`),
+    PRIMARY KEY (`id`),
     UNIQUE INDEX `unique_constraints` (`ckey` , `telemetry_ckey` , `address` , `computer_id`)
 );
 

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -677,6 +677,20 @@ CREATE TABLE `SS13_known_alts` (
     UNIQUE INDEX `unique_contraints` (`ckey1` , `ckey2`)
 );
 
+--
+-- Table structure for table `telemetry_connections`
+--
+DROP TABLE IF EXISTS `SS13_telemetry_connections`;
+CREATE TABLE `SS13_telemetry_connections` (
+    `id` INT NOT NULL AUTO_INCREMENT,
+	`ckey` VARCHAR(32) NOT NULL,
+    `telemetry_ckey` VARCHAR(32) NOT NULL,
+    `address` INT(10) NOT NULL,
+    `computer_id` VARCHAR(32) NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `unique_constraints` (`ckey` , `telemetry_ckey` , `address` , `computer_id`)
+);
+
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
  *
  * make sure you add an update to the schema_version stable in the db changelog
  */
-#define DB_MINOR_VERSION 20
+#define DB_MINOR_VERSION 21
 
 
 //! ## Timing subsystem

--- a/code/modules/tgui_panel/telemetry.dm
+++ b/code/modules/tgui_panel/telemetry.dm
@@ -88,17 +88,30 @@
 		if (!row || row.len < 3 || (!row["ckey"] || !row["address"] || !row["computer_id"]))
 			return
 
-		var/datum/db_query/insert_query = SSdbcore.NewQuery({"
-			INSERT IGNORE INTO [format_table_name("telemetry_connections")] (ckey, telemetry_ckey, address, computer_id)
-			VALUES(:ckey, :telemetry_ckey, INET_ATON(:address), :computer_id)
-		"}, list(
-			"ckey" = ckey,
-			"telemetry_ckey" = row["ckey"],
-			"address" = row["address"],
-			"computer_id" = row["computer_id"],
-		))
-
-		insert_queries += insert_query
+		if (!isnull(GLOB.round_id))
+			insert_queries += SSdbcore.NewQuery({"
+				INSERT INTO [format_table_name("telemetry_connections")] (
+					ckey,
+					telemetry_ckey,
+					address,
+					computer_id,
+					first_round_id,
+					latest_round_id
+				) VALUES(
+					:ckey,
+					:telemetry_ckey,
+					INET_ATON(:address),
+					:computer_id,
+					:round_id,
+					:round_id
+				) ON DUPLICATE KEY UPDATE latest_round_id = :round_id
+			"}, list(
+				"ckey" = ckey,
+				"telemetry_ckey" = row["ckey"],
+				"address" = row["address"],
+				"computer_id" = row["computer_id"],
+				"round_id" = GLOB.round_id,
+			))
 
 		if (row["ckey"] in our_known_alts)
 			continue

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -3,17 +3,17 @@
 ## administration, and the in game library.
 
 ## Should SQL be enabled? Uncomment to enable
-#SQL_ENABLED
+SQL_ENABLED
 
 ## Server the MySQL database can be found at.
 ## Examples: localhost, 200.135.5.43, www.mysqldb.com, etc.
 ADDRESS localhost
 
 ## MySQL server port (default is 3306).
-PORT 3306
+PORT 3333
 
 ## Database for all SQL functions, not just feedback.
-FEEDBACK_DATABASE feedback
+FEEDBACK_DATABASE tgstation
 
 ## Prefix to be added to the name of every table, older databases will require this be set to erro_
 ## Note, this does not change the table names in the database, you will have to do that yourself.
@@ -21,13 +21,13 @@ FEEDBACK_DATABASE feedback
 ##	FEEDBACK_TABLEPREFIX
 ##	FEEDBACK_TABLEPREFIX SS13_
 ## Remove "SS13_" if you are using the standard schema file.
-FEEDBACK_TABLEPREFIX SS13_
+FEEDBACK_TABLEPREFIX
 
 ## Username/Login used to access the database.
-FEEDBACK_LOGIN username
+FEEDBACK_LOGIN root
 
 ## Password used to access the database.
-FEEDBACK_PASSWORD password
+FEEDBACK_PASSWORD
 
 ## Time in seconds for asynchronous queries to timeout
 ## Set to 0 for infinite

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -3,17 +3,17 @@
 ## administration, and the in game library.
 
 ## Should SQL be enabled? Uncomment to enable
-SQL_ENABLED
+#SQL_ENABLED
 
 ## Server the MySQL database can be found at.
 ## Examples: localhost, 200.135.5.43, www.mysqldb.com, etc.
 ADDRESS localhost
 
 ## MySQL server port (default is 3306).
-PORT 3333
+PORT 3306
 
 ## Database for all SQL functions, not just feedback.
-FEEDBACK_DATABASE tgstation
+FEEDBACK_DATABASE feedback
 
 ## Prefix to be added to the name of every table, older databases will require this be set to erro_
 ## Note, this does not change the table names in the database, you will have to do that yourself.
@@ -21,13 +21,13 @@ FEEDBACK_DATABASE tgstation
 ##	FEEDBACK_TABLEPREFIX
 ##	FEEDBACK_TABLEPREFIX SS13_
 ## Remove "SS13_" if you are using the standard schema file.
-FEEDBACK_TABLEPREFIX
+FEEDBACK_TABLEPREFIX SS13_
 
 ## Username/Login used to access the database.
-FEEDBACK_LOGIN root
+FEEDBACK_LOGIN username
 
 ## Password used to access the database.
-FEEDBACK_PASSWORD
+FEEDBACK_PASSWORD password
 
 ## Time in seconds for asynchronous queries to timeout
 ## Set to 0 for infinite


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Logs tgui telemetry connections into the database. Useful since they are normally capped to 5.

Does not change the fact that the "banned account in connection history" part is still based on your history at that time. I figured it could potentially be very slow to go through your entire database history.