### PR TITLE
Adds a single puncuation mark (to roach emotes).

### DIFF
--- a/code/datums/ai/basic_mobs/basic_subtrees/speech_subtree.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/speech_subtree.dm
@@ -36,7 +36,7 @@
 
 /datum/ai_planning_subtree/random_speech/cockroach
 	speech_chance = 5
-	emote_hear = list("chitters")
+	emote_hear = list("chitters.")
 
 /datum/ai_planning_subtree/random_speech/cow
 	speech_chance = 1


### PR DESCRIPTION
## About The Pull Request

Roaches will now punctuate their chitters.

This is anarchy:
![image](https://user-images.githubusercontent.com/51863163/146295031-cd5a863c-339a-461d-a461-f1c9f0f06eb2.png)

This is epic:
![image](https://user-images.githubusercontent.com/51863163/146294220-c01654c6-0928-42b3-a47d-727e554412b8.png)

## Why It's Good For The Game

Punctuation is important.

## Changelog

:cl: Melbert
spellcheck: Roaches now punctuate their chitters.
/:cl:

