### PR TITLE
Fixes a spelling mistake in cargo's error message

### DIFF
--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -14,7 +14,7 @@
 	var/contraband = FALSE
 	var/self_paid = FALSE
 	var/safety_warning = "For safety and ethical reasons, the automated supply shuttle \
-		cannot transport live organisms, human remains, classified nuclear weaponry, mail \
+		cannot transport live organisms, human remains, classified nuclear weaponry, mail, \
 		homing beacons, unstable eigenstates or machinery housing any form of artificial intelligence."
 	var/blockade_warning = "Bluespace instability detected. Shuttle movement impossible."
 	/// radio used by the console to send messages on supply channel


### PR DESCRIPTION
## About The Pull Request

small typo

## Why It's Good For The Game

I hate you all.

## Changelog

:cl:
spellcheck: Fixed a small typo in Cargo's mail console, saying mail had homing beacons in them.
/:cl: