### PR TITLE
test disables ai static to see if it helps maptick enough to justify a refactor of how it works

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -40,16 +40,16 @@
 	var/turf/pixel_turf = get_turf_pixel(A)
 	if(isnull(pixel_turf))
 		return
-	if(!can_see(A))
-		if(isturf(A)) //On unmodified clients clicking the static overlay clicks the turf underneath
-			return //So there's no point messaging admins
-		message_admins("[ADMIN_LOOKUPFLW(src)] might be running a modified client! (failed can_see on AI click of [A] (Turf Loc: [ADMIN_VERBOSEJMP(pixel_turf)]))")
-		var/message = "[key_name(src)] might be running a modified client! (failed can_see on AI click of [A] (Turf Loc: [AREACOORD(pixel_turf)]))"
-		log_admin(message)
-		if(REALTIMEOFDAY >= chnotify + 9000)
-			chnotify = REALTIMEOFDAY
-			send2tgs_adminless_only("NOCHEAT", message)
-		return
+	//if(!can_see(A))
+	//	if(isturf(A)) //On unmodified clients clicking the static overlay clicks the turf underneath
+	//		return //So there's no point messaging admins
+		//message_admins("[ADMIN_LOOKUPFLW(src)] might be running a modified client! (failed can_see on AI click of [A] (Turf Loc: [ADMIN_VERBOSEJMP(pixel_turf)]))")
+		//var/message = "[key_name(src)] might be running a modified client! (failed can_see on AI click of [A] (Turf Loc: [AREACOORD(pixel_turf)]))"
+		//.log_admin(message)
+	//	if(REALTIMEOFDAY >= chnotify + 9000)
+	//		chnotify = REALTIMEOFDAY
+	//		send2tgs_adminless_only("NOCHEAT", message)
+	//	return
 
 	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, SHIFT_CLICK))

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -80,12 +80,12 @@
 	obscuredTurfs = turfs - newVisibleTurfs
 
 	var/static/list/vis_contents_opaque = GLOB.cameranet.vis_contents_opaque //ba dum tsss
-	for(var/turf/added_turf as anything in visAdded)
-		added_turf.vis_contents -= vis_contents_opaque
+	//for(var/turf/added_turf as anything in visAdded)
+	//	added_turf.vis_contents -= vis_contents_opaque
 
-	for(var/turf/removed_turf as anything in visRemoved)
-		if(obscuredTurfs[removed_turf] && !istype(removed_turf, /turf/open/ai_visible))
-			removed_turf.vis_contents += vis_contents_opaque
+	//for(var/turf/removed_turf as anything in visRemoved)
+	//	if(obscuredTurfs[removed_turf] && !istype(removed_turf, /turf/open/ai_visible))
+	//		removed_turf.vis_contents += vis_contents_opaque
 
 	changed = FALSE
 
@@ -122,9 +122,9 @@
 
 	obscuredTurfs = turfs - visibleTurfs
 
-	var/list/vis_contents_opaque = GLOB.cameranet.vis_contents_opaque
-	for(var/turf/obscured_turf as anything in obscuredTurfs)
-		obscured_turf.vis_contents += vis_contents_opaque
+	//var/list/vis_contents_opaque = GLOB.cameranet.vis_contents_opaque
+	//for(var/turf/obscured_turf as anything in obscuredTurfs)
+	//	obscured_turf.vis_contents += vis_contents_opaque
 
 #undef UPDATE_BUFFER_TIME
 #undef CHUNK_SIZE

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -71,9 +71,9 @@
 				newVisibleTurfs[vis_turf] = vis_turf
 
 	//new turfs will be in visibleTurfs but werent last update
-	var/list/visAdded = newVisibleTurfs - visibleTurfs
+	//var/list/visAdded = newVisibleTurfs - visibleTurfs
 	//old turfs that will no longer be in visibleTurfs but were last update
-	var/list/visRemoved = visibleTurfs - newVisibleTurfs
+	//var/list/visRemoved = visibleTurfs - newVisibleTurfs
 
 	visibleTurfs = newVisibleTurfs
 	//turfs that are included in the chunks normal turfs list minus the turfs the cameras CAN see


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
looked at the sendmaps profilers on live and found out that the average movables examined per iteration were > 800 a lot of the time, in a panic i tested things that would justify that number. turns out that vis_contents on turfs is scanned with somewhere between a +10 to +12 radius on view range while normal movables are scanned with a radius of about 1 + view size

this means that vis_contents on turfs are scanned over a huge area, and the most common vis_contents on turfs by far is the ai static movable added to all tiles the ai moves over but arent in range of cameras. if everything counted by the looking for movables step of the sendmaps profiler was equal i expect this would be a large improvement, but i also suspect that vis_contents for shared movables arent as costly to scan as movables on turfs. so we'll see what happens
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
maptick sucks i hate it its still the single largest cause of lag and its been slowly but surely increasing since underlay lighting. i want to bring it below at least 0.4 so we dont hit the maptick time dilation threshold at 15 players below our expected high pop numbers but i need data on whats causing it
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
