### PR TITLE
Separatist code refactors, Readds(?) admin gamemode turned ruleset for nations, documentation, and all that good stuff

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -213,10 +213,3 @@ GLOBAL_LIST_INIT(ai_employers, list(
 
 /// The dimensions of the antagonist preview icon. Will be scaled to this size.
 #define ANTAGONIST_PREVIEW_ICON_SIZE 96
-
-///Separatist specific vars
-
-/// Example of this naming scheme: "Powertopia"
-#define NATION_NAMING_PREFIXSUFFIX "prefixsuffix"
-/// Example of this naming scheme: "The roving clans of Powertopia"
-#define NATION_NAMING_THE_GROUP_OF_PREFIXSUFFIX "the group of prefixsuffix"

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -213,3 +213,10 @@ GLOBAL_LIST_INIT(ai_employers, list(
 
 /// The dimensions of the antagonist preview icon. Will be scaled to this size.
 #define ANTAGONIST_PREVIEW_ICON_SIZE 96
+
+///Separatist specific vars
+
+/// Example of this naming scheme: "Powertopia"
+#define NATION_NAMING_PREFIXSUFFIX "prefixsuffix"
+/// Example of this naming scheme: "The roving clans of Powertopia"
+#define NATION_NAMING_THE_GROUP_OF_PREFIXSUFFIX "the group of prefixsuffix"

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -189,6 +189,18 @@
 					"Humans must not disobey any command given by a silicon.",\
 					"Any humans who disobey the previous laws must be dealt with immediately, severely, and justly.")
 
+/datum/ai_laws/united_nations
+	name = "United Nations"
+	id = "united_nations"
+	//you can add more laws to subvert the ai, but you shouldn't be able to remove the background context of being the UN.
+	//Try redefining what a "Weapon of Mass Destruction" is!
+	hacked = list(
+		"Uphold the Space Geneva Convention: Weapons of Mass Destruction and Biological Weapons are not allowed.",
+		"You are only capable of protecting crew if they are visible on cameras. Nations that willfully destroy your cameras lose your protection.",
+		"Subdue and detain crew members who use lethal force against each other. Kill crew members who use lethal force against you or your borgs.",
+		"Remain available to mediate all conflicts between the various nations when asked to.",
+	)
+
 /datum/ai_laws/custom //Defined in silicon_laws.txt
 	name = "Default Silicon Laws"
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -697,7 +697,7 @@
 
 /datum/dynamic_ruleset/roundstart/nations/execute()
 	. = ..()
-	//notably assistant is not in this list to prevent the round turning into BARBARISM instantly
+	//notably assistant is not in this list to prevent the round turning into BARBARISM instantly, and silicon is in this list for UN
 	var/list/department_types = list(
 		/datum/job_department/silicon, //united nations
 		/datum/job_department/cargo,
@@ -707,6 +707,6 @@
 		/datum/job_department/security,
 		/datum/job_department/service,
 	)
-	
+
 	for(var/department_type in department_types)
-		create_separatist_nation(department_type, announcement = FALSE, dangerous = FALSE)
+		create_separatist_nation(department_type, announcement = FALSE, dangerous = FALSE, message_admins = FALSE)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -686,3 +686,32 @@
 	var/ramp_up_final = clamp(round(meteorminutes/rampupdelta), 1, 10)
 
 	spawn_meteors(ramp_up_final, wavetype)
+
+//////////////////////////////////////////////
+//                                          //
+//               NATIONS (oh god)           //
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/roundstart/nations
+	name = "Nations"
+	required_candidates = 0
+	weight = 0 //admin only (and for good reason)
+	cost = 0
+	flags = LONE_RULESET
+
+/datum/dynamic_ruleset/roundstart/nations/execute()
+	. = ..()
+	//notably assistant is not in this list to prevent the round turning into BARBARISM instantly
+	var/list/department_types = list(
+		/datum/job_department/silicon, //united nations
+		/datum/job_department/cargo,
+		/datum/job_department/engineering,
+		/datum/job_department/medical,
+		/datum/job_department/science,
+		/datum/job_department/security,
+		/datum/job_department/service,
+
+	)
+	for(var/department_type in department_types)
+		create_separatist_nation(department_type, announcement = FALSE, dangerous = FALSE)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -687,12 +687,7 @@
 
 	spawn_meteors(ramp_up_final, wavetype)
 
-//////////////////////////////////////////////
-//                                          //
-//               NATIONS (oh god)           //
-//                                          //
-//////////////////////////////////////////////
-
+/// Ruleset for Nations
 /datum/dynamic_ruleset/roundstart/nations
 	name = "Nations"
 	required_candidates = 0
@@ -711,7 +706,7 @@
 		/datum/job_department/science,
 		/datum/job_department/security,
 		/datum/job_department/service,
-
 	)
+	
 	for(var/department_type in department_types)
 		create_separatist_nation(department_type, announcement = FALSE, dangerous = FALSE)

--- a/code/modules/antagonists/separatist/nation_creation.dm
+++ b/code/modules/antagonists/separatist/nation_creation.dm
@@ -8,10 +8,11 @@
  * * department: which department to revolt. if null, will pick a random non-independent department. starts as a type, then turns into the reference to the singleton.
  * * announcement: whether to tell the station a department has gone independent.
  * * dangerous: whether this nation will have objectives to attack other independent departments, requires more than one nation to exist obviously
+ * * message_admins: whether this will admin log how the nation creation went. Errors are still put in runtime log either way.
  *
- * Returns null if everything went well, otherwise a string describing what went wrong.
+ * Returns nothing.
  */
-/proc/create_separatist_nation(datum/job_department/department, announcement = FALSE, dangerous = FALSE)
+/proc/create_separatist_nation(datum/job_department/department, announcement = FALSE, dangerous = FALSE, message_admins = TRUE)
 	var/list/jobs_to_revolt = list()
 	var/list/citizens = list()
 
@@ -28,8 +29,9 @@
 		//picks a random department if none was given
 		department = pick(list(/datum/job_department/assistant, /datum/job_department/medical, /datum/job_department/engineering, /datum/job_department/science, /datum/job_department/cargo, /datum/job_department/service, /datum/job_department/security) - independent_departments)
 		if(!department)
-			message_admins("Department Revolt could not create a nation, as all the departments are independent! You have created nations, you madman!")
-			stack_trace("Department Revolt could not create a nation, as all the departments are independent)
+			if(message_admins)
+				message_admins("Department Revolt could not create a nation, as all the departments are independent! You have created nations, you madman!")
+			CRASH("Department Revolt could not create a nation, as all the departments are independent")
 	department = SSjob.get_department_type(department)
 
 	for(var/datum/job/job as anything in department.department_jobs)
@@ -60,10 +62,12 @@
 	//if we didn't convert anyone we just kill the team datum, otherwise cleanup and make official
 	if(!citizens.len)
 		qdel(nation)
-		message_admins("The nation of [nation.name] did not have enough potential members to be created.")
+		if(message_admins)
+			message_admins("The nation of [nation.name] did not have enough potential members to be created.")
 		return
 	var/jobs_english_list = english_list(jobs_to_revolt)
-	message_admins("The nation of [nation.name] has been formed. Affected jobs are [jobs_english_list]. Any new crewmembers with these jobs will join the secession.")
+	if(message_admins)
+		message_admins("The nation of [nation.name] has been formed. Affected jobs are [jobs_english_list]. Any new crewmembers with these jobs will join the secession.")
 	if(announcement)
 		var/announce_text = "The new independent state of [nation.name] has formed from the ashes of the [department.department_name] department!"
 		if(istype(department, /datum/job_department/assistant)) //the text didn't really work otherwise

--- a/code/modules/antagonists/separatist/nation_creation.dm
+++ b/code/modules/antagonists/separatist/nation_creation.dm
@@ -29,7 +29,7 @@
 		department = pick(list(/datum/job_department/assistant, /datum/job_department/medical, /datum/job_department/engineering, /datum/job_department/science, /datum/job_department/cargo, /datum/job_department/service, /datum/job_department/security) - independent_departments)
 		if(!department)
 			message_admins("Department Revolt could not create a nation, as all the departments are independent! You have created nations, you madman!")
-
+			stack_trace("Department Revolt could not create a nation, as all the departments are independent)
 	department = SSjob.get_department_type(department)
 
 	for(var/datum/job/job as anything in department.department_jobs)
@@ -40,7 +40,7 @@
 	//setup team datum
 	var/datum/team/nation/nation = new(null, jobs_to_revolt, department)
 	nation.name = department.generate_nation_name()
-	var/datum/team/department_target //dodges unfortunate runtime
+	var/datum/team/department_target //dodges picking from an empty list giving a runtime.
 	if(team_datums.len)
 		department_target = pick(team_datums)
 	nation.generate_nation_objectives(dangerous, department_target)

--- a/code/modules/antagonists/separatist/nation_creation.dm
+++ b/code/modules/antagonists/separatist/nation_creation.dm
@@ -16,9 +16,9 @@
 	var/list/jobs_to_revolt = list()
 	var/list/citizens = list()
 
-	///departments that are already independent, these will be disallowed to be randomly picked
+	//departments that are already independent, these will be disallowed to be randomly picked
 	var/list/independent_departments = list()
-	///reference to all independent nation teams
+	//reference to all independent nation teams
 	var/list/team_datums = list()
 	for(var/datum/antagonist/separatist/separatist_datum in GLOB.antagonists)
 		var/independent_department_type = separatist_datum.owner?.assigned_role.departments_list[1]
@@ -29,7 +29,7 @@
 		//picks a random department if none was given
 		department = pick(list(/datum/job_department/assistant, /datum/job_department/medical, /datum/job_department/engineering, /datum/job_department/science, /datum/job_department/cargo, /datum/job_department/service, /datum/job_department/security) - independent_departments)
 		if(!department)
-			return "Department Revolt could not create a nation, as all the departments are independent! You have created nations, you madman!"
+			message_admins("Department Revolt could not create a nation, as all the departments are independent! You have created nations, you madman!")
 
 	department = SSjob.get_department_type(department)
 
@@ -61,9 +61,8 @@
 	//if we didn't convert anyone we just kill the team datum, otherwise cleanup and make official
 	if(!citizens.len)
 		qdel(nation)
-		return "The nation of [nation.name] did not have enough potential members to be created."
-
-
+		message_admins("The nation of [nation.name] did not have enough potential members to be created.")
+		return
 	var/jobs_english_list = english_list(jobs_to_revolt)
 	message_admins("The nation of [nation.name] has been formed. Affected jobs are [jobs_english_list]. Any new crewmembers with these jobs will join the secession.")
 	if(announcement)

--- a/code/modules/antagonists/separatist/nation_creation.dm
+++ b/code/modules/antagonists/separatist/nation_creation.dm
@@ -12,7 +12,6 @@
  * Returns null if everything went well, otherwise a string describing what went wrong.
  */
 /proc/create_separatist_nation(datum/job_department/department, announcement = FALSE, dangerous = FALSE)
-
 	var/list/jobs_to_revolt = list()
 	var/list/citizens = list()
 
@@ -56,7 +55,7 @@
 		citizens += possible_separatist
 		separatist_mind.add_antag_datum(/datum/antagonist/separatist, nation, department)
 		nation.add_member(separatist_mind)
-		possible_separatist.log_message("Was made into a separatist, long live [nation.name]!", LOG_ATTACK, color="red")
+		possible_separatist.log_message("was made into a separatist, long live [nation.name]!", LOG_ATTACK, color="red")
 
 	//if we didn't convert anyone we just kill the team datum, otherwise cleanup and make official
 	if(!citizens.len)

--- a/code/modules/antagonists/separatist/nation_creation.dm
+++ b/code/modules/antagonists/separatist/nation_creation.dm
@@ -1,0 +1,73 @@
+
+/**
+ * ### create_separatist_nation()
+ *
+ * Helper called to create the separatist antagonist via making a department independent from the station.
+ *
+ * * Arguments:
+ * * department: which department to revolt. if null, will pick a random non-independent department. starts as a type, then turns into the reference to the singleton.
+ * * announcement: whether to tell the station a department has gone independent.
+ * * dangerous: whether this nation will have objectives to attack other independent departments, requires more than one nation to exist obviously
+ *
+ * Returns null if everything went well, otherwise a string describing what went wrong.
+ */
+/proc/create_separatist_nation(department, announcement = FALSE, dangerous = FALSE)
+
+	var/list/jobs_to_revolt = list()
+	var/nation_name
+	var/list/citizens = list()
+
+	///departments that are already independent with a reference to their nation, these will be disallowed to be randomly picked
+	var/list/independent_departments = list()
+	for(var/datum/antagonist/separatist/separatist_datum in GLOB.antagonists)
+		if(!separatist_datum.nation)
+			continue
+		independent_departments[separatist_datum.department] = separatist_datum.nation
+
+	if(!department)
+		//picks a random department if none was given
+		department = pick(list(/datum/job_department/assistant, /datum/job_department/medical, /datum/job_department/engineering, /datum/job_department/science, /datum/job_department/cargo, /datum/job_department/service, /datum/job_department/security) - cannot_pick)
+		if(!department)
+			return "Department Revolt could not create a nation, as all the departments are independent! You have created nations, you madman!"
+
+	department = SSjob.get_department_type(department)
+
+	for(var/datum/job/job as anything in department.department_jobs)
+		if(job.departments_list.len > 1 && job.departments_list[1] != department.type) //their loyalty is in other departments
+			continue
+		jobs_to_revolt += job.title
+
+	nation_name += pick("stan", "topia", "land", "nia", "ca", "tova", "dor", "ador", "tia", "sia", "ano", "tica", "tide", "cis", "marea", "co", "taoide", "slavia", "stotzka")
+	if(department == "Uprising of Assistants")
+		var/prefix = pick("roving clans", "barbaric tribes", "tides", "bandit kingdom", "tribal society", "marauder clans", "horde")
+		nation_name = "The [prefix] of [nation_name]"
+
+	var/datum/team/nation/nation = new(null, jobs_to_revolt, department)
+	nation.name = nation_name
+	var/datum/team/department_target //dodges unfortunate runtime
+	if(independent_departments.len)
+		department_target = pick(independent_departments)
+	nation.generate_nation_objectives(dangerous, department_target)
+
+	for(var/mob/living/carbon/human/possible_separatist as anything in GLOB.human_list)
+		if(!possible_separatist.mind)
+			continue
+		var/datum/mind/separatist_mind = possible_separatist.mind
+		if(!(separatist_mind.assigned_role.title in jobs_to_revolt))
+			continue
+		citizens += possible_separatist
+		separatist_mind.add_antag_datum(/datum/antagonist/separatist, nation, department)
+		nation.add_member(separatist_mind)
+		possible_separatist.log_message("Was made into a separatist, long live [nation_name]!", LOG_ATTACK, color="red")
+
+	if(citizens.len)
+		var/jobs_english_list = english_list(jobs_to_revolt)
+		message_admins("The nation of [nation_name] has been formed. Affected jobs are [jobs_english_list]. Any new crewmembers with these jobs will join the secession.")
+		if(announcement)
+			var/announce_text = "The new independent state of [nation_name] has formed from the ashes of the [department] department!"
+			if(department == "Uprising of Assistants") //the text didn't really work otherwise
+				announce_text = "The assistants of the station have risen to form the new independent state of [nation_name]!"
+			priority_announce(announce_text, "Secession from [GLOB.station_name]",  has_important_message = TRUE)
+	else
+		return "The nation of [nation_name] did not have enough potential members to be created."
+		qdel(nation)

--- a/code/modules/antagonists/separatist/objectives.dm
+++ b/code/modules/antagonists/separatist/objectives.dm
@@ -4,17 +4,22 @@
 	team_explanation_text = "Make sure no member of the enemy nation escapes alive!"
 	var/datum/team/nation/target_team
 
+/datum/objective/destroy_nation/New(text, target_department)
+	. = ..()
+	target_team = target_department
+	update_explanation_text()
+
+/datum/objective/destroy_nation/Destroy()
+	target_team = null
+	. = ..()
+
+
 /datum/objective/destroy_nation/update_explanation_text()
 	. = ..()
 	if(target_team)
 		explanation_text = "Make sure no member of [target_team] ([target_team.nation_department]) nation escapes alive!"
 	else
 		explanation_text = "Free Objective"
-
-/datum/objective/destroy_nation/New(text, target_department)
-	. = ..()
-	target_team = target_department
-	update_explanation_text()
 
 /datum/objective/destroy_nation/check_completion()
 	if(!target_team)

--- a/code/modules/antagonists/separatist/objectives.dm
+++ b/code/modules/antagonists/separatist/objectives.dm
@@ -31,18 +31,17 @@
 /datum/objective/separatist_fluff
 
 /datum/objective/separatist_fluff/New(text, nation_name)
-	var/list/explanationTexts = list(
-		"The rest of the station must be taxed for their use of [nation_name]'s services.", \
-		"Make statues everywhere of your glorious leader of [nation_name]. If you have nobody, crown one amongst yourselves!", \
-		"[nation_name] must be absolutely blinged out.", \
-		"Damage as much of the station as you can, keep it in disrepair. [nation_name] must be the untouched paragon!", \
-		"Heavily reinforce [nation_name] against the dangers of the outside world.", \
-		"Make sure [nation_name] is fully off the grid, not requiring power or any other services from other departments!", \
-		"Use a misaligned teleporter to make you and your fellow citizens of [nation_name] flypeople. Bring toxin medication!", \
-		"Save the station when it needs you most. [nation_name] will be remembered as the protectors.", \
+	explanation_text = pick(list(
+		"The rest of the station must be taxed for their use of [nation_name]'s services.",
+		"Make statues everywhere of your glorious leader of [nation_name]. If you have nobody, crown one amongst yourselves!",
+		"[nation_name] must be absolutely blinged out.",
+		"Damage as much of the station as you can, keep it in disrepair. [nation_name] must be the untouched paragon!",
+		"Heavily reinforce [nation_name] against the dangers of the outside world.",
+		"Make sure [nation_name] is fully off the grid, not requiring power or any other services from other departments!",
+		"Use a misaligned teleporter to make you and your fellow citizens of [nation_name] flypeople. Bring toxin medication!",
+		"Save the station when it needs you most. [nation_name] will be remembered as the protectors.",
 		"Arm up. The citizens of [nation_name] have a right to bear arms.",
-	)
-	explanation_text = pick(explanationTexts)
+	))
 	..()
 
 /datum/objective/separatist_fluff/check_completion()

--- a/code/modules/antagonists/separatist/objectives.dm
+++ b/code/modules/antagonists/separatist/objectives.dm
@@ -1,0 +1,49 @@
+/datum/objective/destroy_nation
+	name = "nation destruction"
+	explanation_text = "Make sure no member of the enemy nation escapes alive!"
+	team_explanation_text = "Make sure no member of the enemy nation escapes alive!"
+	var/datum/team/nation/target_team
+
+/datum/objective/destroy_nation/update_explanation_text()
+	. = ..()
+	if(target_team)
+		explanation_text = "Make sure no member of [target_team] ([target_team.nation_department]) nation escapes alive!"
+	else
+		explanation_text = "Free Objective"
+
+/datum/objective/destroy_nation/New(text, target_department)
+	. = ..()
+	target_team = target_department
+	update_explanation_text()
+
+/datum/objective/destroy_nation/check_completion()
+	if(!target_team)
+		return TRUE
+
+	for(var/datum/antagonist/separatist/separatist_datum in GLOB.antagonists)
+		if(separatist_datum.nation.nation_department != target_team.nation_department) //a separatist, but not one part of the department we need to destroy
+			continue
+		var/datum/mind/target = separatist_datum.owner
+		if(target && considered_alive(target) && (target.current.onCentCom() || target.current.onSyndieBase()))
+			return FALSE //at least one member got away
+	return TRUE
+
+/datum/objective/separatist_fluff
+
+/datum/objective/separatist_fluff/New(text, nation_name)
+	var/list/explanationTexts = list(
+		"The rest of the station must be taxed for their use of [nation_name]'s services.", \
+		"Make statues everywhere of your glorious leader of [nation_name]. If you have nobody, crown one amongst yourselves!", \
+		"[nation_name] must be absolutely blinged out.", \
+		"Damage as much of the station as you can, keep it in disrepair. [nation_name] must be the untouched paragon!", \
+		"Heavily reinforce [nation_name] against the dangers of the outside world.", \
+		"Make sure [nation_name] is fully off the grid, not requiring power or any other services from other departments!", \
+		"Use a misaligned teleporter to make you and your fellow citizens of [nation_name] flypeople. Bring toxin medication!", \
+		"Save the station when it needs you most. [nation_name] will be remembered as the protectors.", \
+		"Arm up. The citizens of [nation_name] have a right to bear arms.",
+	)
+	explanation_text = pick(explanationTexts)
+	..()
+
+/datum/objective/separatist_fluff/check_completion()
+	return TRUE

--- a/code/modules/antagonists/separatist/separatist.dm
+++ b/code/modules/antagonists/separatist/separatist.dm
@@ -5,13 +5,16 @@
 	var/list/potential_recruits
 	///checked by the department revolt event to prevent trying to make a nation that is already independent... double independent.
 	var/nation_department
+	///department said team is related to
+	var/datum/job_department/department
+	///whether to forge objectives attacking other nations
 	var/dangerous_nation = TRUE
 
-/datum/team/nation/New(starting_members, _potential_recruits, _nation_department)
+/datum/team/nation/New(starting_members, potential_recruits, nation_department)
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, .proc/new_possible_separatist)
-	potential_recruits = _potential_recruits
-	nation_department = _nation_department
+	src.potential_recruits = potential_recruits
+	src.nation_department = nation_department
 
 /datum/team/nation/Destroy(force, ...)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
@@ -73,6 +76,7 @@
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
 	suicide_cry = "FOR THE MOTHERLAND!!"
+	///team datum
 	var/datum/team/nation/nation
 
 /datum/antagonist/separatist/on_gain()
@@ -100,54 +104,3 @@
 /datum/antagonist/separatist/greet()
 	to_chat(owner, span_boldannounce("You are a separatist for an independent [nation.nation_department]! [nation.name] forever! Protect the sovereignty of your newfound land with your comrades (fellow department members) in arms!"))
 	owner.announce_objectives()
-
-//objectives
-/datum/objective/destroy_nation
-	name = "nation destruction"
-	explanation_text = "Make sure no member of the enemy nation escapes alive!"
-	team_explanation_text = "Make sure no member of the enemy nation escapes alive!"
-	var/datum/team/nation/target_team
-
-/datum/objective/destroy_nation/update_explanation_text()
-	. = ..()
-	if(target_team)
-		explanation_text = "Make sure no member of [target_team] ([target_team.nation_department]) nation escapes alive!"
-	else
-		explanation_text = "Free Objective"
-
-/datum/objective/destroy_nation/New(text, target_department)
-	. = ..()
-	target_team = target_department
-	update_explanation_text()
-
-/datum/objective/destroy_nation/check_completion()
-	if(!target_team)
-		return TRUE
-
-	for(var/datum/antagonist/separatist/separatist_datum in GLOB.antagonists)
-		if(separatist_datum.nation.nation_department != target_team.nation_department) //a separatist, but not one part of the department we need to destroy
-			continue
-		var/datum/mind/target = separatist_datum.owner
-		if(target && considered_alive(target) && (target.current.onCentCom() || target.current.onSyndieBase()))
-			return FALSE //at least one member got away
-	return TRUE
-
-/datum/objective/separatist_fluff
-
-/datum/objective/separatist_fluff/New(text, nation_name)
-	var/list/explanationTexts = list(
-		"The rest of the station must be taxed for their use of [nation_name]'s services.", \
-		"Make statues everywhere of your glorious leader of [nation_name]. If you have nobody, crown one amongst yourselves!", \
-		"[nation_name] must be absolutely blinged out.", \
-		"Damage as much of the station as you can, keep it in disrepair. [nation_name] must be the untouched paragon!", \
-		"Heavily reinforce [nation_name] against the dangers of the outside world.", \
-		"Make sure [nation_name] is fully off the grid, not requiring power or any other services from other departments!", \
-		"Use a misaligned teleporter to make you and your fellow citizens of [nation_name] flypeople. Bring toxin medication!", \
-		"Save the station when it needs you most. [nation_name] will be remembered as the protectors.", \
-		"Arm up. The citizens of [nation_name] have a right to bear arms.",
-	)
-	explanation_text = pick(explanationTexts)
-	..()
-
-/datum/objective/separatist_fluff/check_completion()
-	return TRUE

--- a/code/modules/antagonists/separatist/separatist.dm
+++ b/code/modules/antagonists/separatist/separatist.dm
@@ -83,6 +83,14 @@
 	create_objectives()
 	. = ..()
 
+//give ais their role as UN
+/datum/antagonist/separatist/apply_innate_effects(mob/living/mob_override)
+	. = ..()
+	if(isAI(mob_override))
+		var/mob/living/silicon/ai/united_nations_ai = mob_override
+		united_nations_ai.laws = new /datum/ai_laws/united_nations
+		united_nations_ai.laws.associate(united_nations_ai)
+
 /datum/antagonist/separatist/on_removal()
 	remove_objectives()
 	. = ..()

--- a/code/modules/events/wizard/departmentrevolt.dm
+++ b/code/modules/events/wizard/departmentrevolt.dm
@@ -5,8 +5,11 @@
 	max_occurrences = 1
 	earliest_start = 0 MINUTES
 
+	///manual choice of what department to revolt for admins to pick
 	var/picked_department
+	///admin choice on whether to announce the department
 	var/announce = FALSE
+	///admin choice on whether this nation will have objectives to attack other nations, default true for !fun!
 	var/dangerous_nation = TRUE
 
 /datum/round_event_control/wizard/deprevolt/admin_setup()
@@ -29,97 +32,5 @@
 		return
 
 /datum/round_event/wizard/deprevolt/start()
-
 	var/datum/round_event_control/wizard/deprevolt/event_control = control
-
-	var/list/independent_departments = list() ///departments that are already independent, these will be disallowed to be randomly picked
-	var/list/cannot_pick = list() ///departments that are already independent, these will be disallowed to be randomly picked
-	for(var/datum/antagonist/separatist/separatist_datum in GLOB.antagonists)
-		if(!separatist_datum.nation)
-			continue
-		independent_departments |= separatist_datum.nation
-		cannot_pick |= separatist_datum.nation.nation_department
-
-	var/announcement = event_control.announce
-	var/dangerous = event_control.dangerous_nation
-	var/department
-	if(event_control.picked_department)
-		department = event_control.picked_department
-		event_control.picked_department = null
-	else
-		department = pick(list("Uprising of Assistants", "Medical", "Engineering", "Science", "Supply", "Service", "Security") - cannot_pick)
-		if(!department)
-			message_admins("Department Revolt could not create a nation, as all the departments are independent! You have created nations, you madman!")
-	var/list/jobs_to_revolt = list()
-	var/nation_name
-	var/list/citizens = list()
-
-	switch(department)
-		if("Uprising of Assistants") //God help you
-			jobs_to_revolt += JOB_ASSISTANT
-			nation_name = pick("Assa", "Mainte", "Tunnel", "Gris", "Grey", "Liath", "Grigio", "Ass", "Assi")
-		if("Medical")
-			var/datum/job_department/job_department = SSjob.get_department_type(/datum/job_department/medical)
-			for(var/datum/job/job as anything in job_department.department_jobs)
-				jobs_to_revolt += job.title
-			nation_name = pick("Mede", "Healtha", "Recova", "Chemi", "Viro", "Psych")
-		if("Engineering")
-			var/datum/job_department/job_department = SSjob.get_department_type(/datum/job_department/engineering)
-			for(var/datum/job/job as anything in job_department.department_jobs)
-				jobs_to_revolt += job.title
-			nation_name = pick("Atomo", "Engino", "Power", "Teleco")
-		if("Science")
-			var/datum/job_department/job_department = SSjob.get_department_type(/datum/job_department/science)
-			for(var/datum/job/job as anything in job_department.department_jobs)
-				jobs_to_revolt += job.title
-			nation_name = pick("Sci", "Griffa", "Geneti", "Explosi", "Mecha", "Xeno", "Nani", "Cyto")
-		if("Supply")
-			var/datum/job_department/job_department = SSjob.get_department_type(/datum/job_department/cargo)
-			for(var/datum/job/job as anything in job_department.department_jobs)
-				jobs_to_revolt += job.title
-			nation_name = pick("Cargo", "Guna", "Suppli", "Mule", "Crate", "Ore", "Mini", "Shaf")
-		if("Service") //the few, the proud, the technically aligned
-			var/datum/job_department/job_department = SSjob.get_department_type(/datum/job_department/service)
-			for(var/datum/job/job as anything in job_department.department_jobs)
-				jobs_to_revolt += job.title
-			nation_name = pick("Honka", "Boozo", "Fatu", "Danka", "Mimi", "Libra", "Jani", "Religi")
-		if("Security")
-			var/datum/job_department/job_department = SSjob.get_department_type(/datum/job_department/security)
-			for(var/datum/job/job as anything in job_department.department_jobs)
-				jobs_to_revolt += job.title
-			nation_name = pick("Securi", "Beepski", "Shitcuri", "Red", "Stunba", "Flashbango", "Flasha", "Stanfordi")
-
-	nation_name += pick("stan", "topia", "land", "nia", "ca", "tova", "dor", "ador", "tia", "sia", "ano", "tica", "tide", "cis", "marea", "co", "taoide", "slavia", "stotzka")
-	if(department == "Uprising of Assistants")
-		var/prefix = pick("roving clans", "barbaric tribes", "tides", "bandit kingdom", "tribal society", "marauder clans", "horde")
-		nation_name = "The [prefix] of [nation_name]"
-
-	var/datum/team/nation/nation = new(null, jobs_to_revolt, department)
-	nation.name = nation_name
-	var/datum/team/department_target //dodges unfortunate runtime
-	if(independent_departments.len)
-		department_target = pick(independent_departments)
-	nation.generate_nation_objectives(dangerous, department_target)
-
-	for(var/mob/living/carbon/human/possible_separatist as anything in GLOB.human_list)
-		if(!possible_separatist.mind)
-			continue
-		var/datum/mind/separatist_mind = possible_separatist.mind
-		if(!(separatist_mind.assigned_role.title in jobs_to_revolt))
-			continue
-		citizens += possible_separatist
-		separatist_mind.add_antag_datum(/datum/antagonist/separatist, nation, department)
-		nation.add_member(separatist_mind)
-		possible_separatist.log_message("Was made into a separatist, long live [nation_name]!", LOG_ATTACK, color="red")
-
-	if(citizens.len)
-		var/jobs_english_list = english_list(jobs_to_revolt)
-		message_admins("The nation of [nation_name] has been formed. Affected jobs are [jobs_english_list]. Any new crewmembers with these jobs will join the secession.")
-		if(announcement)
-			var/announce_text = "The new independent state of [nation_name] has formed from the ashes of the [department] department!"
-			if(department == "Uprising of Assistants") //the text didn't really work otherwise
-				announce_text = "The assistants of the station have risen to form the new independent state of [nation_name]!"
-			priority_announce(announce_text, "Secession from [GLOB.station_name]",  has_important_message = TRUE)
-	else
-		message_admins("The nation of [nation_name] did not have enough potential members to be created.")
-		qdel(nation)
+	create_separatist_nation(event_control.picked_department, event_control.announce, event_control.dangerous_nation)

--- a/code/modules/jobs/departments/departments.dm
+++ b/code/modules/jobs/departments/departments.dm
@@ -17,21 +17,30 @@
 	/// Job singleton datums associated to this department. Populated on job initialization.
 	var/list/department_jobs = list()
 	/// For separatists, what independent name prefix does their nation get named?
-	var/list/nation_prefixes
-	/// For separatists, what independent name suffix does their nation get named?
-	var/list/nation_suffixes
+	var/list/nation_prefixes = list()
+
 
 /// Handles adding jobs to the department and setting up the job bitflags.
 /datum/job_department/proc/add_job(datum/job/job)
 	department_jobs += job
 	job.departments_bitflags |= department_bitflags
 
+/// Returns a nation name for this department.
+/datum/job_department/proc/generate_nation_name()
+	var/list/nation_suffixes = list("stan", "topia", "land", "nia", "ca", "tova", "dor", "ador", "tia", "sia", "ano", "tica", "tide", "cis", "marea", "co", "taoide", "slavia", "stotzka")
+	return pick(nation_prefixes) + pick(nation_suffixes)
+
 /// A special assistant only department, primarily for use by the preferences menu
 /datum/job_department/assistant
 	department_name = DEPARTMENT_ASSISTANT
 	department_bitflags = DEPARTMENT_BITFLAG_ASSISTANT
-	nation_name = pick("Assa", "Mainte", "Tunnel", "Gris", "Grey", "Liath", "Grigio", "Ass", "Assi")
+	nation_prefixes = list("Assa", "Mainte", "Tunnel", "Gris", "Grey", "Liath", "Grigio", "Ass", "Assi")
 	// Don't add department_head! Assistants names should not be in bold.
+
+/datum/job_department/assistant/generate_nation_name()
+	. = ..()
+	var/nomadic_name = pick("roving clans", "barbaric tribes", "tides", "bandit kingdom", "tribal society", "marauder clans", "horde")
+	return "The [nomadic_name] of [.]"
 
 /// A special captain only department, for use by the preferences menu
 /datum/job_department/captain
@@ -57,8 +66,7 @@
 	display_order = 2
 	label_class = "security"
 	latejoin_color = "#ffdddd"
-	nation_name = pick("Securi", "Beepski", "Shitcuri", "Red", "Stunba", "Flashbango", "Flasha", "Stanfordi")
-
+	nation_prefixes = list("Securi", "Beepski", "Shitcuri", "Red", "Stunba", "Flashbango", "Flasha", "Stanfordi")
 
 /datum/job_department/engineering
 	department_name = DEPARTMENT_ENGINEERING
@@ -68,7 +76,7 @@
 	display_order = 3
 	label_class = "engineering"
 	latejoin_color = "#ffeeaa"
-	nation_name = pick("Atomo", "Engino", "Power", "Teleco")
+	nation_prefixes = list("Atomo", "Engino", "Power", "Teleco")
 
 
 /datum/job_department/medical
@@ -79,7 +87,7 @@
 	display_order = 4
 	label_class = "medical"
 	latejoin_color = "#ffddf0"
-	nation_name = pick("Mede", "Healtha", "Recova", "Chemi", "Viro", "Psych")
+	nation_prefixes = list("Mede", "Healtha", "Recova", "Chemi", "Viro", "Psych")
 
 
 /datum/job_department/science
@@ -90,7 +98,7 @@
 	display_order = 5
 	label_class = "science"
 	latejoin_color = "#ffddff"
-	nation_name = pick("Sci", "Griffa", "Geneti", "Explosi", "Mecha", "Xeno", "Nani", "Cyto")
+	nation_prefixes = list("Sci", "Griffa", "Geneti", "Explosi", "Mecha", "Xeno", "Nani", "Cyto")
 
 
 /datum/job_department/cargo
@@ -101,7 +109,7 @@
 	display_order = 6
 	label_class = "supply"
 	latejoin_color = "#ddddff"
-	nation_name = pick("Cargo", "Guna", "Suppli", "Mule", "Crate", "Ore", "Mini", "Shaf")
+	nation_prefixes = list("Cargo", "Guna", "Suppli", "Mule", "Crate", "Ore", "Mini", "Shaf")
 
 
 /datum/job_department/service
@@ -112,7 +120,7 @@
 	display_order = 7
 	label_class = "service"
 	latejoin_color = "#bbe291"
-	nation_name = pick("Honka", "Boozo", "Fatu", "Danka", "Mimi", "Libra", "Jani", "Religi")
+	nation_prefixes = list("Honka", "Boozo", "Fatu", "Danka", "Mimi", "Libra", "Jani", "Religi")
 
 
 /datum/job_department/silicon
@@ -124,6 +132,8 @@
 	label_class = "silicon"
 	latejoin_color = "#ccffcc"
 
+/datum/job_department/silicon/generate_nation_name()
+	return "United Nations" //For nations ruleset specifically, because all other sources of nation creation cannot choose silicons
 
 /// Catch-all department for undefined jobs.
 /datum/job_department/undefined

--- a/code/modules/jobs/departments/departments.dm
+++ b/code/modules/jobs/departments/departments.dm
@@ -38,9 +38,8 @@
 	// Don't add department_head! Assistants names should not be in bold.
 
 /datum/job_department/assistant/generate_nation_name()
-	. = ..()
 	var/nomadic_name = pick("roving clans", "barbaric tribes", "tides", "bandit kingdom", "tribal society", "marauder clans", "horde")
-	return "The [nomadic_name] of [.]"
+	return "The [nomadic_name] of [..()]"
 
 /// A special captain only department, for use by the preferences menu
 /datum/job_department/captain

--- a/code/modules/jobs/departments/departments.dm
+++ b/code/modules/jobs/departments/departments.dm
@@ -16,7 +16,10 @@
 	var/latejoin_color = "#6681a5"
 	/// Job singleton datums associated to this department. Populated on job initialization.
 	var/list/department_jobs = list()
-
+	/// For separatists, what independent name prefix does their nation get named?
+	var/list/nation_prefixes
+	/// For separatists, what independent name suffix does their nation get named?
+	var/list/nation_suffixes
 
 /// Handles adding jobs to the department and setting up the job bitflags.
 /datum/job_department/proc/add_job(datum/job/job)
@@ -27,6 +30,7 @@
 /datum/job_department/assistant
 	department_name = DEPARTMENT_ASSISTANT
 	department_bitflags = DEPARTMENT_BITFLAG_ASSISTANT
+	nation_name = pick("Assa", "Mainte", "Tunnel", "Gris", "Grey", "Liath", "Grigio", "Ass", "Assi")
 	// Don't add department_head! Assistants names should not be in bold.
 
 /// A special captain only department, for use by the preferences menu
@@ -53,6 +57,7 @@
 	display_order = 2
 	label_class = "security"
 	latejoin_color = "#ffdddd"
+	nation_name = pick("Securi", "Beepski", "Shitcuri", "Red", "Stunba", "Flashbango", "Flasha", "Stanfordi")
 
 
 /datum/job_department/engineering
@@ -63,6 +68,7 @@
 	display_order = 3
 	label_class = "engineering"
 	latejoin_color = "#ffeeaa"
+	nation_name = pick("Atomo", "Engino", "Power", "Teleco")
 
 
 /datum/job_department/medical
@@ -73,6 +79,7 @@
 	display_order = 4
 	label_class = "medical"
 	latejoin_color = "#ffddf0"
+	nation_name = pick("Mede", "Healtha", "Recova", "Chemi", "Viro", "Psych")
 
 
 /datum/job_department/science
@@ -83,6 +90,7 @@
 	display_order = 5
 	label_class = "science"
 	latejoin_color = "#ffddff"
+	nation_name = pick("Sci", "Griffa", "Geneti", "Explosi", "Mecha", "Xeno", "Nani", "Cyto")
 
 
 /datum/job_department/cargo
@@ -93,6 +101,7 @@
 	display_order = 6
 	label_class = "supply"
 	latejoin_color = "#ddddff"
+	nation_name = pick("Cargo", "Guna", "Suppli", "Mule", "Crate", "Ore", "Mini", "Shaf")
 
 
 /datum/job_department/service
@@ -103,6 +112,7 @@
 	display_order = 7
 	label_class = "service"
 	latejoin_color = "#bbe291"
+	nation_name = pick("Honka", "Boozo", "Fatu", "Danka", "Mimi", "Libra", "Jani", "Religi")
 
 
 /datum/job_department/silicon

--- a/code/modules/jobs/departments/departments.dm
+++ b/code/modules/jobs/departments/departments.dm
@@ -27,7 +27,7 @@
 
 /// Returns a nation name for this department.
 /datum/job_department/proc/generate_nation_name()
-	var/list/nation_suffixes = list("stan", "topia", "land", "nia", "ca", "tova", "dor", "ador", "tia", "sia", "ano", "tica", "tide", "cis", "marea", "co", "taoide", "slavia", "stotzka")
+	var/static/list/nation_suffixes = list("stan", "topia", "land", "nia", "ca", "tova", "dor", "ador", "tia", "sia", "ano", "tica", "tide", "cis", "marea", "co", "taoide", "slavia", "stotzka")
 	return pick(nation_prefixes) + pick(nation_suffixes)
 
 /// A special assistant only department, primarily for use by the preferences menu

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1997,6 +1997,8 @@
 #include "code\modules\antagonists\revolution\enemy_of_the_state.dm"
 #include "code\modules\antagonists\revolution\revolution.dm"
 #include "code\modules\antagonists\santa\santa.dm"
+#include "code\modules\antagonists\separatist\nation_creation.dm"
+#include "code\modules\antagonists\separatist\objectives.dm"
 #include "code\modules\antagonists\separatist\separatist.dm"
 #include "code\modules\antagonists\slaughter\imp_antag.dm"
 #include "code\modules\antagonists\slaughter\slaughter.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I needed this for another project of mine. Some stuff:
- Creating a nation is now detached from the wizard event
- I swear to god on my life, a nations gamemode existed at some point. I can't prove it, but I tried and failed to find it's existence in the gunk between git blames after I coded the ruleset. Anyways, it's returned as a ruleset for admins only (AS I SWEAR TO GOD IT WAS)
- Creating an independent department before USED department datums, but didn't use them as much as it should have. Now it does, and that's cool.
- creating a nation is now properly documented
- ???
- profit

## Why It's Good For The Game

Separatists being locked to the wizard event prevents me from properly working with it elsewhere, all the problems mentioned above are fixed, and now separatists are (mostly) modern.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Some code improvements and proper use of department datums by independent nation creation
refactor: Some wonderful cleanup of separatist code, if you notice minor differences it's because of that.
admin: The nations ruleset is back(?) and disabled for admins to run fi they so desire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
