### PR TITLE
Fixes pandemic bluescreen on premade viruses

### DIFF
--- a/tgui/packages/tgui/interfaces/Pandemic.tsx
+++ b/tgui/packages/tgui/interfaces/Pandemic.tsx
@@ -207,7 +207,7 @@ const BeakerInfoDisplay = (_, context) => {
 /** If antibodies are present, returns buttons to create vaccines */
 const AntibodyInfoDisplay = (_, context) => {
   const { act, data } = useBackend<PandemicContext>(context);
-  const { is_ready, resistances } = data;
+  const { is_ready, resistances = [] } = data;
   if (!resistances) {
     return <NoticeBox>Nothing detected</NoticeBox>;
   }
@@ -241,7 +241,7 @@ const AntibodyInfoDisplay = (_, context) => {
 const SpecimenDisplay = (_, context) => {
   const { act, data } = useBackend<PandemicContext>(context);
   const [tab, setTab] = useSharedState(context, 'tab', 0);
-  const { is_ready, viruses } = data;
+  const { is_ready, viruses = [] } = data;
   if (!viruses?.length) {
     return <NoticeBox>No viruses detected</NoticeBox>;
   }
@@ -280,7 +280,8 @@ const SpecimenDisplay = (_, context) => {
           <VirusDisplay virus={virus} />
         </Stack.Item>
         <Stack.Item>
-          <SymptomDisplay symptoms={virus.symptoms} />
+          {virus.symptoms
+          && <SymptomDisplay symptoms={virus.symptoms} />}
         </Stack.Item>
       </Stack>
     </Section>
@@ -293,7 +294,7 @@ const SpecimenDisplay = (_, context) => {
 const VirusTabs = (props: TabsProps, context) => {
   const { data } = useBackend<PandemicContext>(context);
   const { tab, tabHandler } = props;
-  const { viruses } = data;
+  const { viruses = [] } = data;
   if (!viruses) {
     return <NoticeBox>No viruses detected</NoticeBox>;
   }
@@ -416,7 +417,7 @@ const VirusTraitInfo = (props: VirusInfoProps) => {
  * Returns info about symptoms as collapsibles.
  */
 const SymptomDisplay = (props: SymptomDisplayProps) => {
-  const { symptoms } = props;
+  const { symptoms = [] } = props;
   if (!symptoms.length) {
     return <NoticeBox>No symptoms detected.</NoticeBox>;
   }
@@ -488,11 +489,11 @@ const SymptomTraitInfo = (props: SymptomInfoProps) => {
 
 /** Displays threshold data */
 const ThresholdDisplay = (props: ThresholdDisplayProps) => {
-  const { thresholds } = props;
+  const { thresholds = [] } = props;
   let convertedThresholds: Threshold[] = [];
   // Converts obj of obj => array of thresholds
   // I'm sure there's a more succinct way to do this
-  Object.entries(thresholds).map((label, value) => {
+  Object.entries(thresholds).map((label) => {
     return convertedThresholds.push({
       label: label[0],
       descr: label[1].toString(),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It turns out premade viruses have null symptoms (??) so I disabled showing the symptom panel when none exist
Casts some other props as array so we can be sure to have .length available
I believe I caused this error during the refactor (so no gbp please)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #63155 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Pandemic machine no longer blue screens while inserting premade viruses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
