### PR TITLE
You can now resist out of nested containers (also fixes the GBJ associated with it)

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -576,6 +576,16 @@
 	return TRUE
 
 /obj/structure/closet/container_resist_act(mob/living/user)
+	if(istype(loc, /obj/structure/bodycontainer))
+		var/obj/structure/bodycontainer/gbj = loc
+		to_chat(user, span_notice("You attempt to break out of [gbj.name]... (This will take around 30 seconds.)"))
+		if(do_after(user, 10 SECONDS))
+			gbj?.open()
+	if(istype(loc, /obj/structure/closet))
+		var/obj/structure/closet/gbj = loc
+		to_chat(user, span_notice("You attempt to break out of [gbj.name]... (This will take around 30 seconds.)"))
+		if(do_after(user, 10 SECONDS))
+			gbj?.open()
 	if(opened)
 		return
 	if(ismovable(loc))

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -218,10 +218,6 @@
 
 /obj/structure/closet/proc/can_close(mob/living/user)
 	var/turf/T = get_turf(src)
-	for (var/obj/obj in loc.contents)
-		if (istype(obj, /obj/structure/closet) && obj != src)
-			to_chat(user, span_warning("[obj.name] is too big for [name]!"))
-			return FALSE
 	for(var/obj/structure/closet/closet in T)
 		if(closet != src && !closet.wall_mounted)
 			return FALSE

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -576,16 +576,8 @@
 	return TRUE
 
 /obj/structure/closet/container_resist_act(mob/living/user)
-	if(istype(loc, /obj/structure/bodycontainer))
-		var/obj/structure/bodycontainer/gbj = loc
-		to_chat(user, span_notice("You attempt to break out of [gbj.name]... (This will take around 30 seconds.)"))
-		if(do_after(user, 30 SECONDS))
-			gbj?.open()
-	if(istype(loc, /obj/structure/closet))
-		var/obj/structure/closet/gbj = loc
-		to_chat(user, span_notice("You attempt to break out of [gbj.name]... (This will take around 30 seconds.)"))
-		if(do_after(user, 30 SECONDS))
-			gbj?.open()
+	if(isstructure(loc))
+		relay_container_resist_act(user, loc)
 	if(opened)
 		return
 	if(ismovable(loc))
@@ -614,6 +606,10 @@
 	else
 		if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
 			to_chat(user, span_warning("You fail to break out of [src]!"))
+
+/obj/structure/closet/relay_container_resist_act(mob/living/user, obj/container)
+	container.container_resist_act()
+
 
 /obj/structure/closet/proc/bust_open()
 	SIGNAL_HANDLER

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -218,6 +218,10 @@
 
 /obj/structure/closet/proc/can_close(mob/living/user)
 	var/turf/T = get_turf(src)
+	for (var/obj/obj in loc.contents)
+		if (istype(obj, /obj/structure/closet) && obj != src)
+			to_chat(user, span_warning("[obj.name] is too big for [name]!"))
+			return FALSE
 	for(var/obj/structure/closet/closet in T)
 		if(closet != src && !closet.wall_mounted)
 			return FALSE

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -579,12 +579,12 @@
 	if(istype(loc, /obj/structure/bodycontainer))
 		var/obj/structure/bodycontainer/gbj = loc
 		to_chat(user, span_notice("You attempt to break out of [gbj.name]... (This will take around 30 seconds.)"))
-		if(do_after(user, 10 SECONDS))
+		if(do_after(user, 30 SECONDS))
 			gbj?.open()
 	if(istype(loc, /obj/structure/closet))
 		var/obj/structure/closet/gbj = loc
 		to_chat(user, span_notice("You attempt to break out of [gbj.name]... (This will take around 30 seconds.)"))
-		if(do_after(user, 10 SECONDS))
+		if(do_after(user, 30 SECONDS))
 			gbj?.open()
 	if(opened)
 		return

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -334,6 +334,10 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	if(.)
 		return
 	if (src.connected)
+		for (var/obj/obj in loc.contents)
+			if (istype(obj, /obj/structure/closet))
+				to_chat(user, span_warning("[obj.name] is blocking the tray!"))
+				return
 		connected.close()
 		add_fingerprint(user)
 	else

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -334,10 +334,6 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	if(.)
 		return
 	if (src.connected)
-		for (var/obj/obj in loc.contents)
-			if (istype(obj, /obj/structure/closet))
-				to_chat(user, span_warning("[obj.name] is blocking the tray!"))
-				return
 		connected.close()
 		add_fingerprint(user)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/31656

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You can finally resist out of nested containers.
Also this stops a literal unbreakable GBJ that requires a third party to save you

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Nested containers (lockers, crates, etc) can be resisted out of.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
