### PR TITLE
subtrees now have a proc for setting up and cleaning up

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -192,6 +192,13 @@
 
 ///Basic Mob Keys
 
+///mobs with ranged subtree !must! have either this or projectile type, tells it what to shoot
+#define BB_BASIC_MOB_CASING_TYPE "BB_basic_casing_type"
+///mobs with ranged subtree !must! have either this or casing type, tells it what to shoot
+#define BB_BASIC_MOB_PROJECTILE_TYPE "BB_basic_projectile_type"
+///mobs that use the ranged subtree !can! have a blackboard for their shooting sounds
+#define BB_BASIC_MOB_PROJECTILE_SOUND "BB_basic_projectile_sound"
+
 ///Tipped blackboards
 ///Bool that means a basic mob will start reacting to being tipped in it's planning
 #define BB_BASIC_MOB_TIP_REACTING "BB_basic_tip_reacting"

--- a/code/datums/ai/_ai_behavior.dm
+++ b/code/datums/ai/_ai_behavior.dm
@@ -19,6 +19,7 @@
 
 ///Called when the action is finished. This needs the same args as perform besides the default ones
 /datum/ai_behavior/proc/finish_action(datum/ai_controller/controller, succeeded, ...)
+	SHOULD_CALL_PARENT(TRUE)
 	LAZYREMOVE(controller.current_behaviors, src)
 	controller.behavior_args -= type
 	if(behavior_flags & AI_BEHAVIOR_REQUIRE_MOVEMENT) //If this was a movement task, reset our movement target.

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -61,6 +61,7 @@ multiple modular subtrees with behaviors
 	PossessPawn(new_pawn)
 
 /datum/ai_controller/Destroy(force, ...)
+	forget_subtrees()
 	set_ai_status(AI_STATUS_OFF)
 	UnpossessPawn(FALSE)
 	return ..()
@@ -80,9 +81,15 @@ multiple modular subtrees with behaviors
 		return
 	var/list/temp_subtree_list = list()
 	for(var/subtree in planning_subtrees)
-		var/subtree_instance = SSai_controllers.ai_subtrees[subtree]
+		var/datum/ai_planning_subtree/subtree_instance = SSai_controllers.ai_subtrees[subtree]
 		temp_subtree_list += subtree_instance
+		subtree_instance.SetupSubtree(src)
 	planning_subtrees = temp_subtree_list
+
+///Loops over the subtrees in planning_subtrees and calls `ForgetSubtree()`. This must be called before an ai stops using a set of subtrees to clean up signals
+/datum/ai_controller/proc/forget_subtrees()
+	for(var/datum/ai_planning_subtree/subtree as anything in planning_subtrees)
+		subtree.ForgetSubtree(src)
 
 ///Proc to move from one pawn to another, this will destroy the target's existing controller.
 /datum/ai_controller/proc/PossessPawn(atom/new_pawn)

--- a/code/datums/ai/_ai_planning_subtree.dm
+++ b/code/datums/ai/_ai_planning_subtree.dm
@@ -1,7 +1,46 @@
-///A subtree is attached to a controller and is occasionally called by /ai_controller/SelectBehaviors(), this mainly exists to act as a way to subtype and modify SelectBehaviors() without needing to subtype the ai controller itself
+/**
+ * ## !ONLY BEHAVIORS SHOULD BE SETTING, SUBTREES PLAN ONLY!
+ *
+ * A subtree is a datum that plans for how the pawn should respond to the world.
+ *
+ * They come as a list with the first subtree in the list being planned out first, and they can cancel
+ * subsequent planning trees by returning `SUBTREE_RETURN_FINISH_PLANNING`. What this means is that we can
+ * set priority on conditional responses to the world, letting the AI focus on one thing and saving lower
+ * priority subtrees for when there's less action.
+ *
+ * One good example is the Monkey Combat Subtree. It plans how the Monkey is going to attack their blackboard
+ * target (run away, hit them, disposals them, etc), and will cancel further subtrees if it is actually in combat.
+ *
+ * Arguments:
+ * * controller - controller that has just stopped using this subtree
+ */
 /datum/ai_planning_subtree
 
 
 ///Determines what behaviors should the controller try processing; if this returns SUBTREE_RETURN_FINISH_PLANNING then the controller won't go through the other subtrees should multiple exist in controller.planning_subtrees
 /datum/ai_planning_subtree/proc/SelectBehaviors(datum/ai_controller/controller, delta_time)
+	return
+
+/**
+ * SetupSubtree - Called when an ai_controller is linking to the singleton subtrees.
+ *
+ * Used for:
+ * * Signals! Sometimes the pawn needs to respond to events in the world by setting blackboards
+ * * Blackboards! Since this is a "Subtree Initialize" subtrees should initialize their related blackboards to their default values
+ *
+ * Arguments:
+ * * controller - controller that has just started using this subtree- usually on creation of the ai controller.
+ */
+/datum/ai_planning_subtree/proc/SetupSubtree(datum/ai_controller/controller)
+	return
+
+/**
+ * SetupSubtree - Called when an ai_controller is unlinking from a singleton subtree
+ *
+ * Most important usage is to get rid of signals.
+ *
+ * Arguments:
+ * * controller - controller that has just stopped using this subtree
+ */
+/datum/ai_planning_subtree/proc/ForgetSubtree(datum/ai_controller/controller)
 	return

--- a/code/datums/ai/basic_mobs/basic_subtrees/simple_attack_target.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/simple_attack_target.dm
@@ -9,9 +9,22 @@
 	controller.queue_behavior(melee_attack_behavior, BB_BASIC_MOB_CURRENT_TARGET, BB_TARGETTING_DATUM, BB_BASIC_MOB_CURRENT_TARGET_HIDING_LOCATION)
 	return SUBTREE_RETURN_FINISH_PLANNING //we are going into battle...no distractions.
 
-//If you give this to something without the element you are a dumbass.
 /datum/ai_planning_subtree/basic_ranged_attack_subtree
 	var/datum/ai_behavior/basic_ranged_attack/ranged_attack_behavior = /datum/ai_behavior/basic_ranged_attack
+
+/datum/ai_planning_subtree/basic_ranged_attack_subtree/SetupSubtree(datum/ai_controller/controller)
+	controller.pawn.AddElement(/datum/element/ranged_attacks, \
+		controller.blackboard[BB_BASIC_MOB_CASING_TYPE], \
+		controller.blackboard[BB_BASIC_MOB_PROJECTILE_SOUND], \
+		controller.blackboard[BB_BASIC_MOB_PROJECTILE_TYPE] \
+	)
+
+/datum/ai_planning_subtree/basic_ranged_attack_subtree/ForgetSubtree(datum/ai_controller/controller)
+	controller.pawn.RemoveElement(/datum/element/ranged_attacks, \
+		controller.blackboard[BB_BASIC_MOB_CASING_TYPE], \
+		controller.blackboard[BB_BASIC_MOB_PROJECTILE_SOUND], \
+		controller.blackboard[BB_BASIC_MOB_PROJECTILE_TYPE] \
+	)
 
 /datum/ai_planning_subtree/basic_ranged_attack_subtree/SelectBehaviors(datum/ai_controller/controller, delta_time)
 	. = ..()

--- a/code/modules/mob/living/basic/ruin_defender/stickman.dm
+++ b/code/modules/mob/living/basic/ruin_defender/stickman.dm
@@ -72,9 +72,13 @@
 /mob/living/basic/stickman/ranged/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/death_drops, list(/obj/item/gun/ballistic/automatic/pistol/stickman))
-	AddElement(/datum/element/ranged_attacks, /obj/item/ammo_casing/c9mm, 'sound/misc/bang.ogg')
 
 /datum/ai_controller/basic_controller/stickman/ranged
+	blackboard = list(
+		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic(),
+		BB_BASIC_MOB_CASING_TYPE = /obj/item/ammo_casing/c9mm,
+		BB_BASIC_MOB_PROJECTILE_SOUND = 'sound/misc/bang.ogg',
+	)
 	planning_subtrees = list(
 		/datum/ai_planning_subtree/simple_find_target,
 		/datum/ai_planning_subtree/basic_ranged_attack_subtree/stickman

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -78,11 +78,11 @@
 	faction = list("hostile")
 	ai_controller = /datum/ai_controller/basic_controller/cockroach/glockroach
 
-/mob/living/basic/cockroach/glockroach/Initialize(mapload)
-	. = ..()
-	AddElement(/datum/element/ranged_attacks, /obj/item/ammo_casing/glockroach)
-
 /datum/ai_controller/basic_controller/cockroach/glockroach
+	blackboard = list(
+		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic(),
+		BB_BASIC_MOB_CASING_TYPE = /obj/item/ammo_casing/glockroach,
+	)
 	planning_subtrees = list(
 		/datum/ai_planning_subtree/random_speech/cockroach,
 		/datum/ai_planning_subtree/simple_find_target,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Subtrees get procs called when added and removed from controllers, that let them add and remove subtree SPECIFIC elements and behaviors. My example is moving a controller initialize bit into a subtree setup

## Why It's Good For The Game

Someone working on subtrees were annoyed they had to put an element on init for the mob, and not only do i agree that elements for the controller should be on the ai side.

More scary than that, it led into people making vars for ranged mobs, which is kind of like mutating state directly in react: you can do it, but it removes the entire point we're using the system

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

Not player facing

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
