### PR TITLE
TGUI input conversions 3: Say/Me/Whisper/OOC

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -1,7 +1,8 @@
 GLOBAL_VAR_INIT(OOC_COLOR, null)//If this is null, use the CSS for OOC. Otherwise, use a custom colour.
 GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
-/client/verb/ooc(msg as text)
+/client/verb/ooc()
+	var/msg = tgui_input_text(usr, title = "OOC", encode = FALSE)
 	set name = "OOC" //Gave this shit a shorter name so you only have to time out "ooc" rather than "ooc message" to use it --NeoFite
 	set category = "OOC"
 

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -2,7 +2,7 @@ GLOBAL_VAR_INIT(OOC_COLOR, null)//If this is null, use the CSS for OOC. Otherwis
 GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 /client/verb/ooc()
-	var/msg = tgui_input_text(usr, title = "OOC", encode = FALSE)
+	var/msg = tgui_input_text(usr, title = "Out of Character", encode = FALSE)
 	set name = "OOC" //Gave this shit a shorter name so you only have to time out "ooc" rather than "ooc message" to use it --NeoFite
 	set category = "OOC"
 

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -1,7 +1,8 @@
 //Speech verbs.
 
 ///Say verb
-/mob/verb/say_verb(message as text)
+/mob/verb/say_verb()
+	var/message = tgui_input_text(usr, title = "Say", encode = FALSE)
 	set name = "Say"
 	set category = "IC"
 	if(GLOB.say_disabled) //This is here to try to identify lag problems
@@ -11,7 +12,8 @@
 		say(message)
 
 ///Whisper verb
-/mob/verb/whisper_verb(message as text)
+/mob/verb/whisper_verb()
+	var/message = tgui_input_text(usr, title = "Whisper", encode = FALSE)
 	set name = "Whisper"
 	set category = "IC"
 	if(GLOB.say_disabled) //This is here to try to identify lag problems
@@ -24,7 +26,8 @@
 	say(message, language) //only living mobs actually whisper, everything else just talks
 
 ///The me emote verb
-/mob/verb/me_verb(message as text)
+/mob/verb/me_verb()
+	var/message = tgui_input_text(usr, title = "Me", encode = FALSE)
 	set name = "Me"
 	set category = "IC"
 

--- a/code/modules/tgui/tgui_input_text.dm
+++ b/code/modules/tgui/tgui_input_text.dm
@@ -15,7 +15,7 @@
  * * encode - Toggling this determines if input is filtered via html_encode. Setting this to FALSE gives raw input.
  * * timeout - The timeout of the textbox, after which the modal will close and qdel itself. Set to zero for no timeout.
  */
-/proc/tgui_input_text(mob/user, message = null, title = "Text Input", default = null, max_length = MAX_MESSAGE_LEN, multiline = FALSE, encode = TRUE, timeout = 0)
+/proc/tgui_input_text(mob/user, message = "", title = "Text Input", default = null, max_length = MAX_MESSAGE_LEN, multiline = FALSE, encode = TRUE, timeout = 0)
 	if (!user)
 		user = usr
 	if (!istype(user))
@@ -26,7 +26,7 @@
 			return
 	/// Client does NOT have tgui_input on: Returns regular input
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
-		if(max_length)
+		if(encode)
 			if(multiline)
 				return stripped_multiline_input(user, message, title, default, max_length)
 			else

--- a/tgui/packages/tgui/interfaces/NumberInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/NumberInputModal.tsx
@@ -1,6 +1,6 @@
 import { Loader } from './common/Loader';
 import { InputButtons, Preferences } from './common/InputButtons';
-import { KEY_ENTER } from 'common/keycodes';
+import { KEY_ENTER } from '../../common/keycodes';
 import { useBackend, useLocalState } from '../backend';
 import { Box, Button, NumberInput, Section, Stack } from '../components';
 import { Window } from '../layouts';

--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -4,6 +4,7 @@ import { useBackend, useLocalState } from '../backend';
 import { KEY_ENTER } from 'common/keycodes';
 import { Box, Input, Section, Stack, TextArea } from '../components';
 import { Window } from '../layouts';
+import { KEY_ESCAPE } from '../../common/keycodes';
 
 type TextInputData = {
   max_length: number;
@@ -44,7 +45,7 @@ export const TextInputModal = (_, context) => {
   // Dynamically changes the window height based on the message.
   const windowHeight
     = 125
-    + Math.ceil(message?.length / 3)
+    + Math.ceil(message.length / 3)
     + (multiline ? 75 : 0)
     + (large_buttons ? 5 : 0);
 
@@ -56,6 +57,9 @@ export const TextInputModal = (_, context) => {
           const keyCode = window.event ? event.which : event.keyCode;
           if (keyCode === KEY_ENTER && inputIsValid.isValid) {
             act('submit', { entry: input });
+          }
+          if (keyCode === KEY_ESCAPE) {
+            act('cancel');
           }
         }}>
         <Section fill>

--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -1,10 +1,9 @@
 import { Loader } from './common/Loader';
 import { InputButtons, Preferences, Validator } from './common/InputButtons';
 import { useBackend, useLocalState } from '../backend';
-import { KEY_ENTER } from 'common/keycodes';
+import { KEY_ENTER, KEY_ESCAPE } from '../../common/keycodes';
 import { Box, Input, Section, Stack, TextArea } from '../components';
 import { Window } from '../layouts';
-import { KEY_ESCAPE } from '../../common/keycodes';
 
 type TextInputData = {
   max_length: number;


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You read the title
This could really go one of two ways...

- Say, me, whisper, and OOC are converted to TGUI input
- This also ensures the text input modal (itself) sizes appropriately when the prompt is null
- Text input now responds to the escape key

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Input in SS13 is pretty ugly and TGUI is just more thematic
Much more flexibility for filtering input if ever needed
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Speech verbs have been converted to TGUI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
