### PR TITLE
Fixes basic mobs not counting as animals for DNA vault (+adds new helper)

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -106,6 +106,10 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 // basic mobs
 #define isbasicmob(A) (istype(A, /mob/living/basic))
 
+// either basic mob OR simple animal
+
+#define isanimal_or_basicmob(A) (istype(A, /mob/living/simple_animal) || istype(A, /mob/living/basic))
+
 //Simple animals
 #define isanimal(A) (istype(A, /mob/living/simple_animal))
 

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -106,8 +106,7 @@ GLOBAL_LIST_INIT(turfs_without_ground, typecacheof(list(
 // basic mobs
 #define isbasicmob(A) (istype(A, /mob/living/basic))
 
-// either basic mob OR simple animal
-
+/// returns whether or not the atom is either a basic mob OR simple animal
 #define isanimal_or_basicmob(A) (istype(A, /mob/living/simple_animal) || istype(A, /mob/living/basic))
 
 //Simple animals

--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -97,7 +97,7 @@
 
 	//animals
 	var/static/list/non_simple_animals = typecacheof(list(/mob/living/carbon/alien))
-	if(isanimal(target) || is_type_in_typecache(target,non_simple_animals) || ismonkey(target))
+	if(isanimal_or_basicmob(target) || is_type_in_typecache(target,non_simple_animals) || ismonkey(target))
 		if(isanimal(target))
 			var/mob/living/simple_animal/A = target
 			if(!A.healable)//simple approximation of being animal not a robot or similar

--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -33,7 +33,7 @@
 	return ..()
 
 /obj/vehicle/sealed/car/vim/mob_try_enter(mob/entering)
-	if(!isanimal(entering) && !isbasicmob(entering))
+	if(!isanimal_or_basicmob(entering))
 		return FALSE
 	var/mob/living/animal_or_basic = entering
 	if(animal_or_basic.mob_size != MOB_SIZE_TINY)


### PR DESCRIPTION
## About The Pull Request

adds a new helper for basic mob + simple animal, since I can already see a number of cases this would be helpful.
Uses it for DNA vault, letting them count as animal DNA

## Why It's Good For The Game

Closes #63356

## Changelog

:cl:
fix: Basic mobs (Cows, cockroaches), count as Animals for the DNA vault.
/:cl: