### PR TITLE
Adds damage deflection to prison gates

### DIFF
--- a/code/game/machinery/prisongate.dm
+++ b/code/game/machinery/prisongate.dm
@@ -7,6 +7,7 @@
 	icon_state = "prisongate_on"
 	/// roughly the same health/armor as an airlock
 	max_integrity = 450
+	damage_deflection = 30
 	armor = list(MELEE = 30, BULLET = 30, LASER = 20, ENERGY = 20, BOMB = 10, BIO = 100, FIRE = 80, ACID = 70)
 	use_power = IDLE_POWER_USE
 	power_channel = AREA_USAGE_EQUIP


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds 30 damage deflection to the prison gate.

## Why It's Good For The Game

Makes it so you can't break the prison gate with the stools that spawn in said prison.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: MMMiracles
fix: The prison gate in Tramstation's Prison is no longer made of Papier-mâché
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
