### PR TITLE
Fixes a missing wire from Delta's Starboard Bow Solars

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -84314,6 +84314,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "sgm" = (


### PR DESCRIPTION
## About The Pull Request
This wire is needed here so the Solar Control Console has access to the solars to control them. Every other array ever has the wire, but this one lost it in the recent map changes somehow?
![image](https://user-images.githubusercontent.com/75863639/146652055-d1241f1c-0ec0-4fcc-b101-06d36723575c.png)

## Why It's Good For The Game
Saves Engineers the most critical resource of all - brain cells and 1 piece of cable coil

## Changelog
:cl:
fix: fixed a missing wire in Deltastation's Arrivals Solar array, connecting the control console to the array
/:cl:

