### PR TITLE
Void cloak (and other items intended to be invisible) can longer be seen and unequipped in the strip menu

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -478,6 +478,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_WIELDED "wielded"
 /// Buckling yourself to objects with this trait won't immobilize you
 #define TRAIT_NO_IMMOBILIZE "no_immobilize"
+/// Prevents stripping this equipment
+#define TRAIT_NO_STRIP "no_strip"
 
 //quirk traits
 #define TRAIT_ALCOHOL_TOLERANCE "alcohol_tolerance"

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -148,6 +148,9 @@
 	if (isnull(item))
 		return FALSE
 
+	if (item.item_flags & EXAMINE_SKIP)
+		return FALSE
+
 	source.visible_message(
 		span_warning("[user] tries to remove [source]'s [item.name]."),
 		span_userdanger("[user] tries to remove your [item.name]."),
@@ -363,7 +366,7 @@
 			continue
 
 		var/obj/item/item = item_data.get_item(owner)
-		if (isnull(item))
+		if (isnull(item) || (item.item_flags & EXAMINE_SKIP))
 			items[strippable_key] = result
 			continue
 

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -148,7 +148,7 @@
 	if (isnull(item))
 		return FALSE
 
-	if (item.item_flags & EXAMINE_SKIP)
+	if (HAS_TRAIT(item, TRAIT_NO_STRIP))
 		return FALSE
 
 	source.visible_message(
@@ -366,7 +366,7 @@
 			continue
 
 		var/obj/item/item = item_data.get_item(owner)
-		if (isnull(item) || (item.item_flags & EXAMINE_SKIP))
+		if (isnull(item) || (HAS_TRAIT(item, TRAIT_NO_STRIP)))
 			items[strippable_key] = result
 			continue
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -194,8 +194,10 @@
 	alternative_mode = TRUE
 
 /obj/item/clothing/suit/hooded/cultrobes/void/RemoveHood()
+	if (!HAS_TRAIT(src, TRAIT_NO_STRIP))
+		return ..()
 	var/mob/living/carbon/carbon_user = loc
-	to_chat(carbon_user,span_notice("The kaleidoscope of colours collapses around you, as the cloak shifts to visibility!"))
+	to_chat(carbon_user, span_notice("The kaleidoscope of colours collapses around you, as the cloak shifts to visibility!"))
 	item_flags &= ~EXAMINE_SKIP
 	REMOVE_TRAIT(src, TRAIT_NO_STRIP, src)
 	return ..()

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -176,6 +176,10 @@
 	item_flags = EXAMINE_SKIP
 	armor = list(MELEE = 30, BULLET = 30, LASER = 30,ENERGY = 30, BOMB = 15, BIO = 0, FIRE = 0, ACID = 0)
 
+/obj/item/clothing/head/hooded/cult_hoodie/void/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NO_STRIP, src)
+
 /obj/item/clothing/suit/hooded/cultrobes/void
 	name = "void cloak"
 	desc = "Black like tar, doesn't reflect any light. Runic symbols line the outside, with each flash you loose comprehension of what you are seeing."
@@ -193,6 +197,7 @@
 	var/mob/living/carbon/carbon_user = loc
 	to_chat(carbon_user,span_notice("The kaleidoscope of colours collapses around you, as the cloak shifts to visibility!"))
 	item_flags &= ~EXAMINE_SKIP
+	REMOVE_TAIT(src, TRAIT_NO_STRIP, src)
 	return ..()
 
 /obj/item/clothing/suit/hooded/cultrobes/void/MakeHood()
@@ -204,6 +209,7 @@
 		. = ..()
 		to_chat(carbon_user,span_notice("The light shifts around you making the cloak invisible!"))
 		item_flags |= EXAMINE_SKIP
+		ADD_TRAIT(src, TRAIT_NO_STRIP, src)
 		return
 
 	to_chat(carbon_user,span_danger("You can't force the hood onto your head!"))

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -197,7 +197,7 @@
 	var/mob/living/carbon/carbon_user = loc
 	to_chat(carbon_user,span_notice("The kaleidoscope of colours collapses around you, as the cloak shifts to visibility!"))
 	item_flags &= ~EXAMINE_SKIP
-	REMOVE_TAIT(src, TRAIT_NO_STRIP, src)
+	REMOVE_TRAIT(src, TRAIT_NO_STRIP, src)
 	return ..()
 
 /obj/item/clothing/suit/hooded/cultrobes/void/MakeHood()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/63044
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
its supposed tob ein visible

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Void cloak (and other items intended to be invisible) can longer be seen and unequipped in the strip menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
