### PR TITLE
Fixes 2 drone console UI issues

### DIFF
--- a/tgui/packages/tgui/interfaces/ExodroneConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ExodroneConsole.tsx
@@ -3,123 +3,123 @@ import { BlockQuote, Box, Button, Dimmer, Icon, LabeledList, Modal, ProgressBar,
 import { Window } from '../layouts';
 import { resolveAsset } from '../assets';
 import { formatTime } from '../format';
-import { capitalize } from '../../common/string';
+import { capitalize } from 'common/string';
 import nt_logo from '../assets/bg-nanotrasen.svg';
 import { Fragment } from 'inferno';
 
 type ExplorationEventData = {
-  name: string;
-  ref: string;
-};
+  name: string,
+  ref: string
+}
 
 type FullEventData = {
-  image: string;
-  description: string;
-  action_enabled: boolean;
-  action_text: string;
-  skippable: boolean;
-  ignore_text: string;
-  ref: string;
-};
+  image: string,
+  description: string,
+  action_enabled: boolean,
+  action_text: string,
+  skippable: boolean,
+  ignore_text: string,
+  ref: string
+}
 
 type ChoiceData = {
-  key: string;
-  text: string;
-};
+  key: string,
+  text: string
+}
 
 type AdventureData = {
-  description: string;
-  image: string;
-  raw_image: string;
-  choices: Array<ChoiceData>;
-};
+  description: string,
+  image: string,
+  raw_image: string,
+  choices: Array<ChoiceData>
+}
 
 type SiteData = {
-  name: string;
-  ref: string;
-  description: string;
-  coordinates: string;
-  distance: number;
-  band_info: Record<string, number>;
-  revealed: boolean;
-  point_scan_complete: boolean;
-  deep_scan_complete: boolean;
-  events: Array<ExplorationEventData>;
-};
+  name: string,
+  ref: string,
+  description: string,
+  coordinates: string,
+  distance: number,
+  band_info: Record<string, number>,
+  revealed: boolean,
+  point_scan_complete: boolean,
+  deep_scan_complete: boolean,
+  events: Array<ExplorationEventData>
+}
+
 
 enum DroneStatusEnum {
-  Idle = 'idle',
-  Travel = 'travel',
-  Exploration = 'exploration',
-  Adventure = 'adventure',
-  Busy = 'busy',
+  Idle = "idle",
+  Travel = "travel",
+  Exploration = "exploration",
+  Adventure = "adventure",
+  Busy = "busy"
 }
 
 enum CargoType {
-  Tool = 'tool',
-  Cargo = 'cargo',
-  Empty = 'empty',
+  Tool = "tool",
+  Cargo = "cargo",
+  Empty = "empty"
 }
 
 type CargoData = {
-  type: CargoType;
-  name: string;
-};
+  type: CargoType,
+  name: string
+}
 
 type DroneBasicData = {
-  name: string;
-  description: string;
-  controlled: boolean;
-  ref: string;
-};
+  name: string,
+  description: string,
+  controlled: boolean,
+  ref: string,
+}
 
 export type AdventureDataProvider = {
-  adventure_data: AdventureData;
-};
+  adventure_data: AdventureData,
+}
 
 type DroneAdventure = AdventureDataProvider & {
-  drone_status: DroneStatusEnum.Adventure;
+  drone_status: DroneStatusEnum.Adventure,
 };
 
 type DroneData = {
-  drone_name: string;
-  drone_integrity: number;
-  drone_max_integrity: number;
-  drone_travel_coefficent: number;
-  drone_log: Array<string>;
-  configurable: boolean;
-  cargo: Array<CargoData>;
-  can_travel: boolean;
-  travel_error: string;
+  drone_name: string,
+  drone_integrity: number,
+  drone_max_integrity: number,
+  drone_travel_coefficent: number,
+  drone_log: Array<string>,
+  configurable: boolean,
+  cargo: Array<CargoData>,
+  can_travel: boolean,
+  travel_error: string,
 };
 
 type DroneBusy = {
-  drone_status: DroneStatusEnum.Busy;
-  wait_time_left: number;
-  wait_message: string;
+  drone_status: DroneStatusEnum.Busy,
+  wait_time_left: number,
+  wait_message: string,
 };
 
 type DroneExploration = {
-  drone_status: DroneStatusEnum.Exploration;
-  sites: Array<SiteData>;
-  site: SiteData;
-  event?: FullEventData;
+  drone_status: DroneStatusEnum.Exploration,
+  sites: Array<SiteData>,
+  site: SiteData,
+  event?: FullEventData,
 };
 
 type DroneIdle = {
-  drone_status: DroneStatusEnum.Idle;
-  sites: Array<SiteData>;
-  site: null;
+  drone_status: DroneStatusEnum.Idle,
+  sites: Array<SiteData>,
+  site: null,
 };
 
 type DroneTravel = {
-  drone_status: DroneStatusEnum.Travel;
-  travel_time: number;
-  travel_time_left: number;
+  drone_status: DroneStatusEnum.Travel,
+  travel_time: number,
+  travel_time_left: number,
 };
 
-type ActiveDrone =
-  | DroneAdventure
+type ActiveDrone = DroneAdventure
   | DroneBusy
   | DroneExploration
   | DroneIdle
@@ -143,19 +143,20 @@ type ExodroneConsoleData = {
 );
 
 type ToolData = {
-  description: string;
-  icon: string;
-};
+  description: string,
+  icon: string
+}
 
 export const ExodroneConsole = (props, context) => {
   const { data } = useBackend<ExodroneConsoleData>(context);
-  const { signal_lost } = data;
+  const {
+    signal_lost,
+  } = data;
 
-  const [choosingTools, setChoosingTools] = useLocalState(
-    context,
-    'choosingTools',
-    false
-  );
+  const [
+    choosingTools,
+    setChoosingTools,
+  ] = useLocalState(context, 'choosingTools', false);
 
   return (
     <Window width={750} height={600}>
@@ -177,45 +178,45 @@ const SignalLostModal = (props, context) => {
       width={30}
       height={22}
       p={0}
-      style={{ 'border-radius': '5%' }}>
+      style={{ "border-radius": "5%" }}>
       <img src={nt_logo} width={64} height={64} />
       <Box
         backgroundColor="black"
         textColor="red"
         fontSize={2}
-        style={{ 'border-radius': '-10%' }}>
+        style={{ "border-radius": "-10%" }}>
         CONNECTION LOST
       </Box>
       <Box p={2} italic>
-        Connection to exploration drone interrupted. Please contact nearest
-        Nanotrasen Exploration Division representative for further instructions.
+        Connection to exploration drone interrupted.
+        Please contact nearest Nanotrasen Exploration Division
+        representative for further instructions.
       </Box>
-      <Icon name="exclamation-triangle" textColor="black" size={5} />
+      <Icon
+        name="exclamation-triangle"
+        textColor="black"
+        size={5} />
       <Box>
         <Button
           content="Confirm"
           color="danger"
-          style={{ 'border': '1px solid black' }}
-          onClick={() => act('confirm_signal_lost')}
-        />
+          style={{ "border": "1px solid black" }}
+          onClick={() => act("confirm_signal_lost")} />
       </Box>
     </Modal>
   );
 };
 
-const DroneSelectionSection = (
-  props: {
-    all_drones: Array<DroneBasicData>;
-  },
-  context
-) => {
+const DroneSelectionSection = (props: {
+  all_drones: Array<DroneBasicData>,
+}, context) => {
   const { act } = useBackend<ExodroneConsoleData>(context);
   const { all_drones } = props;
 
   return (
     <Section scrollable fill title="Exploration Drone Listing">
       <Stack vertical>
-        {all_drones.map((drone) => (
+        {all_drones.map(drone => (
           <Fragment key={drone.ref}>
             <Stack.Item grow>
               <Stack fill>
@@ -229,13 +230,13 @@ const DroneSelectionSection = (
                 <Stack.Item grow />
                 <Stack.Divider mr={1} />
                 <Stack.Item ml={0}>
-                  {(drone.controlled && 'Controlled by another console.') || (
+                  {drone.controlled && (
+                    "Controlled by another console."
+                  ) || (
                     <Button
                       content="Assume Control"
                       icon="plug"
-                      onClick={() =>
-                        act('select_drone', { 'drone_ref': drone.ref })}
-                    />
+                      onClick={() => act("select_drone", { "drone_ref": drone.ref })} />
                   )}
                 </Stack.Item>
               </Stack>
@@ -248,45 +249,51 @@ const DroneSelectionSection = (
   );
 };
 
+
 const ToolSelectionModal = (props, context) => {
   const { act, data } = useBackend<ExodroneConsoleData>(context);
-  const { all_tools = {} } = data;
+  const {
+    all_tools = {},
+  } = data;
 
-  const [choosingTools, setChoosingTools] = useLocalState(
-    context,
-    'choosingTools',
-    false
-  );
+  const [
+    choosingTools,
+    setChoosingTools,
+  ] = useLocalState(context, 'choosingTools', false);
 
   const toolData = Object.keys(all_tools);
   return (
     <Modal>
       <Stack fill vertical pr={2}>
-        <Stack.Item>Select Tool:</Stack.Item>
+        <Stack.Item>
+          Select Tool:
+        </Stack.Item>
         <Stack.Item>
           <Stack textAlign="center">
-            {(!!toolData
-              && toolData.map((tool_name) => (
-                <Stack.Item key={tool_name}>
-                  <Button
-                    onClick={() => {
-                      setChoosingTools(false);
-                      act('add_tool', { tool_type: tool_name });
-                    }}
-                    width={6}
-                    height={6}
-                    tooltip={all_tools[tool_name].description}>
-                    <Stack vertical>
-                      <Stack.Item>{capitalize(tool_name)}</Stack.Item>
-                      <Stack.Item ml={2.5}>
-                        <Icon name={all_tools[tool_name].icon} size={3} />
-                      </Stack.Item>
-                    </Stack>
-                  </Button>
-                </Stack.Item>
-              ))) || (
+            {!!toolData && toolData.map(tool_name => (
+              <Stack.Item key={tool_name}>
+                <Button
+                  onClick={() => {
+                    setChoosingTools(false);
+                    act("add_tool", { tool_type: tool_name });
+                  }}
+                  width={6}
+                  height={6}
+                  tooltip={all_tools[tool_name].description}>
+                  <Stack vertical>
+                    <Stack.Item>
+                      {capitalize(tool_name)}
+                    </Stack.Item>
+                    <Stack.Item ml={2.5}>
+                      <Icon name={all_tools[tool_name].icon} size={3} />
+                    </Stack.Item>
+                  </Stack>
+                </Button>
+              </Stack.Item>
+            )) || (
               <Stack.Item>
-                <Button content="Back" />
+                <Button
+                  content="Back" />
               </Stack.Item>
             )}
           </Stack>
@@ -296,20 +303,17 @@ const ToolSelectionModal = (props, context) => {
   );
 };
 
-const EquipmentBox = (
-  props: {
-    cargo: CargoData;
-    drone: DroneData;
-  },
-  context
-) => {
+const EquipmentBox = (props: {
+  cargo: CargoData,
+  drone: DroneData,
+}, context) => {
   const { act, data } = useBackend<ExodroneConsoleData>(context);
   const { all_tools = {} } = data;
   const { configurable } = props.drone;
   const cargo = props.cargo;
-  const boxContents = (cargo) => {
+  const boxContents = cargo => {
     switch (cargo.type) {
-      case 'tool': // Tool icon+Remove button if configurable
+      case "tool": // Tool icon+Remove button if configurable
         return (
           <Stack direction="column">
             <Stack.Item grow>
@@ -324,24 +328,22 @@ const EquipmentBox = (
                   name={all_tools[cargo.name].icon}
                   size={3}
                   pl={1.5}
-                  pt={2}
-                />
+                  pt={2} />
               </Button>
             </Stack.Item>
             {!!configurable && (
               <Stack.Item textAlign="right">
                 <Button
-                  onClick={() => act('remove_tool', { tool_type: cargo.name })}
+                  onClick={() => act("remove_tool", { tool_type: cargo.name })}
                   color="danger"
                   icon="minus"
                   tooltipPosition="right"
-                  tooltip="Remove Tool"
-                />
+                  tooltip="Remove Tool" />
               </Stack.Item>
             )}
           </Stack>
         );
-      case 'cargo': // Jettison button.
+      case "cargo":// Jettison button.
         return (
           <Stack direction="column">
             <Stack.Item>
@@ -352,22 +354,26 @@ const EquipmentBox = (
                 tooltip={capitalize(cargo.name)}
                 tooltipPosition="right"
                 color="transparent">
-                <Icon color="white" name="box" size={3} pl={2.2} pt={2} />
+                <Icon
+                  color="white"
+                  name="box"
+                  size={3}
+                  pl={2.2}
+                  pt={2} />
               </Button>
             </Stack.Item>
             <Stack.Item mt={-9.4} textAlign="right">
               <Button
-                onClick={() => act('jettison', { target_ref: cargo.ref })}
+                onClick={() => act("jettison", { target_ref: cargo.ref })}
                 color="danger"
                 icon="minus"
                 tooltipPosition="right"
-                tooltip={`Jettison ${cargo.name}`}
-              />
+                tooltip={`Jettison ${cargo.name}`} />
             </Stack.Item>
           </Stack>
         );
-      case 'empty':
-        return '';
+      case "empty":
+        return "";
     }
   };
   return (
@@ -381,19 +387,18 @@ const EquipmentBox = (
   );
 };
 
-const EquipmentGrid = (
-  props: {
-    drone: ActiveDrone & DroneData;
-  },
-  context
-) => {
+const EquipmentGrid = (props: {
+  drone: ActiveDrone & DroneData,
+}, context) => {
   const { act } = useBackend<ExodroneConsoleData>(context);
-  const { cargo, configurable } = props.drone;
-  const [choosingTools, setChoosingTools] = useLocalState(
-    context,
-    'choosingTools',
-    false
-  );
+  const {
+    cargo,
+    configurable,
+  } = props.drone;
+  const [
+    choosingTools,
+    setChoosingTools,
+  ] = useLocalState(context, 'choosingTools', false);
   return (
     <Stack vertical fill>
       <Stack.Item grow>
@@ -404,8 +409,7 @@ const EquipmentGrid = (
                 fluid
                 icon="plug"
                 content="Disconnect"
-                onClick={() => act('end_control')}
-              />
+                onClick={() => act('end_control')} />
             </Stack.Item>
             <Stack.Divider />
             <Stack.Item>
@@ -414,8 +418,7 @@ const EquipmentGrid = (
                 icon="bomb"
                 content="Self-Destruct"
                 color="bad"
-                onClick={() => act('self_destruct')}
-              />
+                onClick={() => act('self_destruct')} />
             </Stack.Item>
           </Stack>
         </Section>
@@ -429,18 +432,16 @@ const EquipmentGrid = (
                 color="average"
                 icon="wrench"
                 content="Install Tool"
-                onClick={() => setChoosingTools(true)}
-              />
+                onClick={() => setChoosingTools(true)} />
             )}
           </Stack.Item>
           <Stack.Item>
             <Stack wrap="wrap" width={10}>
-              {cargo.map((cargo_element) => (
+              {cargo.map(cargo_element => (
                 <EquipmentBox
                   drone={props.drone}
                   key={cargo_element.name}
-                  cargo={cargo_element}
-                />
+                  cargo={cargo_element} />
               ))}
             </Stack>
           </Stack.Item>
@@ -450,14 +451,14 @@ const EquipmentGrid = (
   );
 };
 
-const DroneStatus = (
-  props: {
-    drone_integrity: number;
-    drone_max_integrity: number;
-  },
-  context
-) => {
-  const { drone_integrity, drone_max_integrity } = props;
+const DroneStatus = (props: {
+  drone_integrity: number,
+  drone_max_integrity: number,
+}, context) => {
+  const {
+    drone_integrity,
+    drone_max_integrity,
+  } = props;
 
   return (
     <Stack ml={-45}>
@@ -473,8 +474,7 @@ const DroneStatus = (
             bad: [-Infinity, 0.4 * drone_max_integrity],
           }}
           value={drone_integrity}
-          maxValue={drone_max_integrity}
-        />
+          maxValue={drone_max_integrity} />
       </Stack.Item>
     </Stack>
   );
@@ -485,7 +485,11 @@ const NoSiteDimmer = () => {
     <Dimmer>
       <Stack textAlign="center" vertical>
         <Stack.Item>
-          <Icon color="red" name="map" size={10} />
+          <Icon
+            color="red"
+            name="map"
+            size={10}
+          />
         </Stack.Item>
         <Stack.Item fontSize="18px" color="red">
           No Destinations.
@@ -498,60 +502,58 @@ const NoSiteDimmer = () => {
   );
 };
 
-const TravelTargetSelectionScreen = (
-  props: {
-    drone: (DroneExploration | DroneIdle | DroneTravel) & DroneData;
-    showCancelButton?: boolean;
-  },
-  context
-) => {
+const TravelTargetSelectionScreen = (props: {
+  drone: (DroneExploration | DroneIdle | DroneTravel) & DroneData,
+  showCancelButton?: boolean,
+}, context) => {
   // List of sites and eta travel times to each
   const { act, data } = useBackend<ExodroneConsoleData>(context);
   const { drone } = props;
   const { all_bands } = data;
-  const { can_travel, travel_error, drone_travel_coefficent } = drone;
+  const {
+    can_travel,
+    travel_error,
+    drone_travel_coefficent,
+  } = drone;
 
-  const site = 'site' in drone ? drone.site : null;
-  const sites = 'sites' in drone ? drone.sites : null;
+  const site = ("site" in drone) ? drone.site : null;
+  const sites = ("sites" in drone) ? drone.sites : null;
 
-  const travel_cost = (target_site) => {
+  const travel_cost = target_site => {
     if (site) {
-      return (
-        Math.max(Math.abs(site.distance - target_site.distance), 1)
-        * drone_travel_coefficent
-      );
-    } else {
+      return Math.max(Math.abs(site.distance - target_site.distance), 1)
+        * drone_travel_coefficent;
+    }
+    else {
       return target_site.distance * drone_travel_coefficent;
     }
   };
-  const [choosingTools, setChoosingTools] = useLocalState(
-    context,
-    'choosingTools',
-    false
-  );
-  const [TravelDimmerShown, setTravelDimmerShown] = useLocalState(
-    context,
-    'TravelDimmerShown',
-    false
-  );
+  const [
+    choosingTools,
+    setChoosingTools,
+  ] = useLocalState(context, 'choosingTools', false);
+  const [
+    TravelDimmerShown,
+    setTravelDimmerShown,
+  ] = useLocalState(context, 'TravelDimmerShown', false);
 
-  const travel_to = (ref) => {
+  const travel_to = ref => {
     setTravelDimmerShown(false);
-    act('start_travel', { 'target_site': ref });
+    act("start_travel", { "target_site": ref });
   };
 
-  const non_empty_bands = (dest: SiteData) => {
-    const band_check = (s: string) =>
-      dest.band_info[s] !== undefined && dest.band_info[s] !== 0;
+  const non_empty_bands = (dest : SiteData) => {
+    const band_check = (s: string) => dest.band_info[s] !== undefined
+      && dest.band_info[s] !== 0;
     return Object.keys(all_bands).filter(band_check);
   };
-  const valid_destinations
-    = sites
-    && sites.filter((destination) => !site || destination.ref !== site.ref);
+  const valid_destinations = sites && sites.filter(destination => (
+    !site || destination.ref !== site.ref
+  ));
   return (
-    (drone.drone_status === DroneStatusEnum.Travel && (
+    drone.drone_status === DroneStatusEnum.Travel && (
       <TravelDimmer drone={drone} />
-    )) || (
+    ) || (
       <Section
         title="Travel Destinations"
         fill
@@ -563,8 +565,7 @@ const TravelTargetSelectionScreen = (
                 ml={5}
                 mr={0}
                 content="Cancel"
-                onClick={() => setTravelDimmerShown(false)}
-              />
+                onClick={() => setTravelDimmerShown(false)} />
             )}
             <Box mt={props.showCancelButton && -3.5}>
               <DroneStatus
@@ -574,38 +575,37 @@ const TravelTargetSelectionScreen = (
             </Box>
           </>
         }>
-        {sites && !sites.length && !choosingTools && <NoSiteDimmer />}
+        {((sites && !sites.length) && !choosingTools) && (
+          <NoSiteDimmer />
+        )}
         {site && (
           <Section
             mt={1}
             title="Home"
             buttons={
               <Box>
-                ETA:{' '}
-                {formatTime(site.distance * drone_travel_coefficent, 'short')}
+                ETA: {formatTime(site.distance * drone_travel_coefficent, "short")}
                 <Button
                   ml={1}
-                  content={can_travel ? 'Launch!' : travel_error}
+                  content={can_travel ? "Launch!" : travel_error}
                   onClick={() => travel_to(null)}
-                  disabled={!can_travel}
-                />
+                  disabled={!can_travel} />
               </Box>
             }
           />
         )}
-        {valid_destinations?.map((destination) => (
+        {valid_destinations?.map(destination => (
           <Section
             key={destination.ref}
             title={destination.name}
             buttons={
               <>
-                ETA: {formatTime(travel_cost(destination), 'short')}
+                ETA: {formatTime(travel_cost(destination), "short")}
                 <Button
                   ml={1}
-                  content={can_travel ? 'Launch!' : travel_error}
+                  content={can_travel ? "Launch!" : travel_error}
                   onClick={() => travel_to(destination.ref)}
-                  disabled={!can_travel}
-                />
+                  disabled={!can_travel} />
               </>
             }>
             <LabeledList>
@@ -616,8 +616,10 @@ const TravelTargetSelectionScreen = (
                 {destination.description}
               </LabeledList.Item>
               <LabeledList.Divider />
-              {non_empty_bands(destination).map((band) => (
-                <LabeledList.Item key={band} label={band}>
+              {non_empty_bands(destination).map(band => (
+                <LabeledList.Item
+                  key={band}
+                  label={band}>
                   {destination.band_info[band]}
                 </LabeledList.Item>
               ))}
@@ -629,19 +631,20 @@ const TravelTargetSelectionScreen = (
   );
 };
 
-const TravelDimmer = (
-  props: {
-    drone: DroneTravel;
-  },
-  context
-) => {
+const TravelDimmer = (props: {
+  drone: DroneTravel,
+}, context) => {
   const { travel_time_left } = props.drone;
   return (
     <Section fill>
       <Dimmer>
         <Stack textAlign="center" vertical>
           <Stack.Item>
-            <Icon color="yellow" name="route" size={10} />
+            <Icon
+              color="yellow"
+              name="route"
+              size={10}
+            />
           </Stack.Item>
           <Stack.Item fontSize="18px" color="yellow">
             Travel Time: {formatTime(travel_time_left)}
@@ -652,15 +655,24 @@ const TravelDimmer = (
   );
 };
 
-const TimeoutScreen = (props: { drone: DroneBusy }) => {
-  const { wait_time_left, wait_message } = props.drone;
+const TimeoutScreen = (props: {
+  drone: DroneBusy,
+}) => {
+  const {
+    wait_time_left,
+    wait_message,
+  } = props.drone;
 
   return (
     <Section fill>
       <Dimmer>
         <Stack textAlign="center" vertical>
           <Stack.Item>
-            <Icon color="green" name="cog" size={10} />
+            <Icon
+              color="green"
+              name="cog"
+              size={10}
+            />
           </Stack.Item>
           <Stack.Item fontSize="18px" color="green">
             {wait_message} ({formatTime(wait_time_left)})
@@ -671,24 +683,23 @@ const TimeoutScreen = (props: { drone: DroneBusy }) => {
   );
 };
 
-const ExplorationScreen = (
-  props: {
-    drone: DroneExploration & DroneData;
-  },
-  context
-) => {
+const ExplorationScreen = (props: {
+  drone: DroneExploration & DroneData,
+}, context) => {
   const { act } = useBackend(context);
   const { drone } = props;
   const { site } = drone;
 
-  const [TravelDimmerShown, setTravelDimmerShown] = useLocalState(
-    context,
-    'TravelDimmerShown',
-    false
-  );
+  const [
+    TravelDimmerShown,
+    setTravelDimmerShown,
+  ] = useLocalState(context, 'TravelDimmerShown', false);
 
   if (TravelDimmerShown) {
-    return <TravelTargetSelectionScreen drone={drone} showCancelButton />;
+    return (<TravelTargetSelectionScreen
+      drone={drone}
+      showCancelButton
+    />);
   }
   return (
     <Section
@@ -704,40 +715,38 @@ const ExplorationScreen = (
         <Stack.Item grow>
           <LabeledList>
             <LabeledList.Item label="Site">{site.name}</LabeledList.Item>
-            <LabeledList.Item label="Location">
-              {site.coordinates}
-            </LabeledList.Item>
-            <LabeledList.Item label="Description">
-              {site.description}
-            </LabeledList.Item>
+            <LabeledList.Item label="Location">{site.coordinates}</LabeledList.Item>
+            <LabeledList.Item label="Description">{site.description}</LabeledList.Item>
           </LabeledList>
         </Stack.Item>
         <Stack.Item align="center" grow>
-          <Button content="Explore!" onClick={() => act('explore')} />
+          <Button
+            content="Explore!"
+            onClick={() => act("explore")} />
         </Stack.Item>
-        {site.events.map((e) => (
-          <Stack.Item align="center" key={site.ref} grow>
+        {site.events.map(e => (
+          <Stack.Item
+            align="center"
+            key={site.ref}
+            grow>
             <Button
               content={capitalize(e.name)}
-              onClick={() => act('explore_event', { target_event: e.ref })}
-            />
-          </Stack.Item>
-        ))}
+              onClick={() => act("explore_event", { target_event: e.ref })} />
+          </Stack.Item>))}
         <Stack.Item align="center" grow>
-          <Button content="Travel" onClick={() => setTravelDimmerShown(true)} />
+          <Button
+            content="Travel"
+            onClick={() => setTravelDimmerShown(true)} />
         </Stack.Item>
       </Stack>
     </Section>
   );
 };
 
-const EventScreen = (
-  props: {
-    drone: DroneData;
-    event: FullEventData;
-  },
-  context
-) => {
+const EventScreen = (props: {
+  drone: DroneData,
+  event: FullEventData,
+}, context) => {
   const { act } = useBackend(context);
   const { drone, event } = props;
 
@@ -755,37 +764,35 @@ const EventScreen = (
         <Stack.Item>
           <Stack fill>
             <Stack.Item>
-              <img
-                src={resolveAsset(event.image)}
+              <img src={resolveAsset(event.image)}
                 height="125px"
                 width="250px"
                 style={{
                   '-ms-interpolation-mode': 'nearest-neighbor',
-                }}
-              />
+                }} />
             </Stack.Item>
-            <Stack.Item>
-              <BlockQuote preserveWhitespace>{event.description}</BlockQuote>
+            <Stack.Item >
+              <BlockQuote preserveWhitespace>
+                {event.description}
+              </BlockQuote>
             </Stack.Item>
           </Stack>
         </Stack.Item>
         <Stack.Divider />
         <Stack.Item grow>
-          <Stack vertical fill>
+          <Stack vertical fill >
             <Stack.Item grow />
             <Stack.Item grow>
               <Button
                 content={event.action_text}
                 disabled={!event.action_enabled}
-                onClick={() => act('start_event')}
-              />
+                onClick={() => act("start_event")} />
             </Stack.Item>
             {!!event.skippable && (
               <Stack.Item mt={2}>
                 <Button
                   content={event.ignore_text}
-                  onClick={() => act('skip_event')}
-                />
+                  onClick={() => act("skip_event")} />
               </Stack.Item>
             )}
             <Stack.Item grow />
@@ -796,30 +803,28 @@ const EventScreen = (
   );
 };
 
-export const AdventureScreen = (
-  props: {
-    adventure_data: AdventureData;
-    drone_integrity: number;
-    drone_max_integrity: number;
-    hide_status?: boolean;
-  },
-  context
-) => {
+export const AdventureScreen = (props: {
+  adventure_data: AdventureData,
+  drone_integrity: number,
+  drone_max_integrity: number,
+  hide_status?: boolean,
+}, context) => {
   const { act } = useBackend(context);
-  const { adventure_data, drone_integrity, drone_max_integrity } = props;
+  const {
+    adventure_data,
+    drone_integrity,
+    drone_max_integrity,
+  } = props;
   const rawData = adventure_data.raw_image;
   const imgSource = rawData ? rawData : resolveAsset(adventure_data.image);
   return (
     <Section
       fill
       title="Exploration"
-      buttons={
-        !props.hide_status && (
-          <DroneStatus
-            drone_integrity={drone_integrity}
-            drone_max_integrity={drone_max_integrity}
-          />)
-      }>
+      buttons={!props.hide_status && <DroneStatus
+        drone_integrity={drone_integrity}
+        drone_max_integrity={drone_max_integrity}
+      />}>
       <Stack>
         <Stack.Item>
           <BlockQuote preserveWhitespace>
@@ -834,23 +839,19 @@ export const AdventureScreen = (
             width="200px"
             style={{
               '-ms-interpolation-mode': 'nearest-neighbor',
-            }}
-          />
+            }} />
           <Stack vertical>
             <Stack.Divider />
             <Stack.Item grow />
-            {!!adventure_data.choices
-              && adventure_data.choices.map((choice) => (
-                <Stack.Item key={choice.key}>
-                  <Button
-                    fluid
-                    content={choice.text}
-                    textAlign="center"
-                    onClick={() =>
-                      act('adventure_choice', { choice: choice.key })}
-                  />
-                </Stack.Item>
-              ))}
+            {!!adventure_data.choices && adventure_data.choices.map(choice => (
+              <Stack.Item key={choice.key}>
+                <Button
+                  fluid
+                  content={choice.text}
+                  textAlign="center"
+                  onClick={() => act('adventure_choice', { choice: choice.key })} />
+              </Stack.Item>
+            ))}
             <Stack.Item grow />
           </Stack>
         </Stack.Item>
@@ -859,7 +860,9 @@ export const AdventureScreen = (
   );
 };
 
-const DroneScreen = (props: { drone: ActiveDrone & DroneData }) => {
+const DroneScreen = (props: {
+  drone: ActiveDrone & DroneData,
+}) => {
   const { drone } = props;
 
   switch (drone.drone_status) {
@@ -869,17 +872,16 @@ const DroneScreen = (props: { drone: ActiveDrone & DroneData }) => {
     case DroneStatusEnum.Travel:
       return <TravelTargetSelectionScreen drone={drone} />;
     case DroneStatusEnum.Adventure:
-      return (
-        <AdventureScreen
-          adventure_data={drone.adventure_data}
-          drone_integrity={drone.drone_integrity}
-          drone_max_integrity={drone.drone_max_integrity}
-        />
-      );
+      return (<AdventureScreen
+        adventure_data={drone.adventure_data}
+        drone_integrity={drone.drone_integrity}
+        drone_max_integrity={drone.drone_max_integrity}
+      />);
     case DroneStatusEnum.Exploration:
       if (drone.event) {
         return <EventScreen drone={drone} event={drone.event} />;
-      } else {
+      }
+      else {
         return <ExplorationScreen drone={drone} />;
       }
   }

--- a/tgui/packages/tgui/interfaces/ExodroneConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ExodroneConsole.tsx
@@ -214,11 +214,11 @@ const DroneSelectionSection = (props: {
   const { all_drones } = props;
 
   return (
-    <Section scrollable fill title="Exploration Drone Listing">
+    <Section fill scrollable title="Exploration Drone Listing">
       <Stack vertical>
         {all_drones.map(drone => (
           <Fragment key={drone.ref}>
-            <Stack.Item grow>
+            <Stack.Item>
               <Stack fill>
                 <Stack.Item basis={10} fontFamily="monospace" fontSize="18px">
                   {drone.name}
@@ -234,9 +234,10 @@ const DroneSelectionSection = (props: {
                     "Controlled by another console."
                   ) || (
                     <Button
-                      content="Assume Control"
                       icon="plug"
-                      onClick={() => act("select_drone", { "drone_ref": drone.ref })} />
+                      onClick={() => act("select_drone", { "drone_ref": drone.ref })}>
+                      Assume Control
+                    </Button>
                   )}
                 </Stack.Item>
               </Stack>
@@ -425,26 +426,28 @@ const EquipmentGrid = (props: {
       </Stack.Item>
       <Stack.Item>
         <Section title="Cargo">
-          <Stack.Item>
-            {!!configurable && (
-              <Button
-                fluid
-                color="average"
-                icon="wrench"
-                content="Install Tool"
-                onClick={() => setChoosingTools(true)} />
-            )}
-          </Stack.Item>
-          <Stack.Item>
-            <Stack wrap="wrap" width={10}>
-              {cargo.map(cargo_element => (
-                <EquipmentBox
-                  drone={props.drone}
-                  key={cargo_element.name}
-                  cargo={cargo_element} />
-              ))}
-            </Stack>
-          </Stack.Item>
+          <Stack fill vertical>
+            <Stack.Item>
+              {!!configurable && (
+                <Button
+                  fluid
+                  color="average"
+                  icon="wrench"
+                  content="Install Tool"
+                  onClick={() => setChoosingTools(true)} />
+              )}
+            </Stack.Item>
+            <Stack.Item>
+              <Stack wrap="wrap" width={10}>
+                {cargo.map(cargo_element => (
+                  <EquipmentBox
+                    drone={props.drone}
+                    key={cargo_element.name}
+                    cargo={cargo_element} />
+                ))}
+              </Stack>
+            </Stack.Item>
+          </Stack>
         </Section>
       </Stack.Item>
     </Stack>

--- a/tgui/packages/tgui/interfaces/ExodroneConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ExodroneConsole.tsx
@@ -818,8 +818,7 @@ export const AdventureScreen = (
           <DroneStatus
             drone_integrity={drone_integrity}
             drone_max_integrity={drone_max_integrity}
-          />
-      )
+          />)
       }>
       <Stack>
         <Stack.Item>

--- a/tgui/packages/tgui/interfaces/ExodroneConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ExodroneConsole.tsx
@@ -3,123 +3,123 @@ import { BlockQuote, Box, Button, Dimmer, Icon, LabeledList, Modal, ProgressBar,
 import { Window } from '../layouts';
 import { resolveAsset } from '../assets';
 import { formatTime } from '../format';
-import { capitalize } from 'common/string';
+import { capitalize } from '../../common/string';
 import nt_logo from '../assets/bg-nanotrasen.svg';
 import { Fragment } from 'inferno';
 
 type ExplorationEventData = {
-  name: string,
-  ref: string
-}
+  name: string;
+  ref: string;
+};
 
 type FullEventData = {
-  image: string,
-  description: string,
-  action_enabled: boolean,
-  action_text: string,
-  skippable: boolean,
-  ignore_text: string,
-  ref: string
-}
+  image: string;
+  description: string;
+  action_enabled: boolean;
+  action_text: string;
+  skippable: boolean;
+  ignore_text: string;
+  ref: string;
+};
 
 type ChoiceData = {
-  key: string,
-  text: string
-}
+  key: string;
+  text: string;
+};
 
 type AdventureData = {
-  description: string,
-  image: string,
-  raw_image: string,
-  choices: Array<ChoiceData>
-}
+  description: string;
+  image: string;
+  raw_image: string;
+  choices: Array<ChoiceData>;
+};
 
 type SiteData = {
-  name: string,
-  ref: string,
-  description: string,
-  coordinates: string,
-  distance: number,
-  band_info: Record<string, number>,
-  revealed: boolean,
-  point_scan_complete: boolean,
-  deep_scan_complete: boolean,
-  events: Array<ExplorationEventData>
-}
-
+  name: string;
+  ref: string;
+  description: string;
+  coordinates: string;
+  distance: number;
+  band_info: Record<string, number>;
+  revealed: boolean;
+  point_scan_complete: boolean;
+  deep_scan_complete: boolean;
+  events: Array<ExplorationEventData>;
+};
 
 enum DroneStatusEnum {
-  Idle = "idle",
-  Travel = "travel",
-  Exploration = "exploration",
-  Adventure = "adventure",
-  Busy = "busy"
+  Idle = 'idle',
+  Travel = 'travel',
+  Exploration = 'exploration',
+  Adventure = 'adventure',
+  Busy = 'busy',
 }
 
 enum CargoType {
-  Tool = "tool",
-  Cargo = "cargo",
-  Empty = "empty"
+  Tool = 'tool',
+  Cargo = 'cargo',
+  Empty = 'empty',
 }
 
 type CargoData = {
-  type: CargoType,
-  name: string
-}
+  type: CargoType;
+  name: string;
+};
 
 type DroneBasicData = {
-  name: string,
-  description: string,
-  controlled: boolean,
-  ref: string,
-}
+  name: string;
+  description: string;
+  controlled: boolean;
+  ref: string;
+};
 
 export type AdventureDataProvider = {
-  adventure_data: AdventureData,
-}
+  adventure_data: AdventureData;
+};
 
 type DroneAdventure = AdventureDataProvider & {
-  drone_status: DroneStatusEnum.Adventure,
+  drone_status: DroneStatusEnum.Adventure;
 };
 
 type DroneData = {
-  drone_name: string,
-  drone_integrity: number,
-  drone_max_integrity: number,
-  drone_travel_coefficent: number,
-  drone_log: Array<string>,
-  configurable: boolean,
-  cargo: Array<CargoData>,
-  can_travel: boolean,
-  travel_error: string,
+  drone_name: string;
+  drone_integrity: number;
+  drone_max_integrity: number;
+  drone_travel_coefficent: number;
+  drone_log: Array<string>;
+  configurable: boolean;
+  cargo: Array<CargoData>;
+  can_travel: boolean;
+  travel_error: string;
 };
 
 type DroneBusy = {
-  drone_status: DroneStatusEnum.Busy,
-  wait_time_left: number,
-  wait_message: string,
+  drone_status: DroneStatusEnum.Busy;
+  wait_time_left: number;
+  wait_message: string;
 };
 
 type DroneExploration = {
-  drone_status: DroneStatusEnum.Exploration,
-  sites: Array<SiteData>,
-  site: SiteData,
-  event?: FullEventData,
+  drone_status: DroneStatusEnum.Exploration;
+  sites: Array<SiteData>;
+  site: SiteData;
+  event?: FullEventData;
 };
 
 type DroneIdle = {
-  drone_status: DroneStatusEnum.Idle,
-  sites: Array<SiteData>,
-  site: null,
+  drone_status: DroneStatusEnum.Idle;
+  sites: Array<SiteData>;
+  site: null;
 };
 
 type DroneTravel = {
-  drone_status: DroneStatusEnum.Travel,
-  travel_time: number,
-  travel_time_left: number,
+  drone_status: DroneStatusEnum.Travel;
+  travel_time: number;
+  travel_time_left: number;
 };
 
-type ActiveDrone = DroneAdventure
+type ActiveDrone =
+  | DroneAdventure
   | DroneBusy
   | DroneExploration
   | DroneIdle
@@ -143,23 +143,22 @@ type ExodroneConsoleData = {
 );
 
 type ToolData = {
-  description: string,
-  icon: string
-}
+  description: string;
+  icon: string;
+};
 
 export const ExodroneConsole = (props, context) => {
   const { data } = useBackend<ExodroneConsoleData>(context);
-  const {
-    signal_lost,
-  } = data;
+  const { signal_lost } = data;
 
-  const [
-    choosingTools,
-    setChoosingTools,
-  ] = useLocalState(context, 'choosingTools', false);
+  const [choosingTools, setChoosingTools] = useLocalState(
+    context,
+    'choosingTools',
+    false
+  );
 
   return (
-    <Window width={650} height={500}>
+    <Window width={750} height={600}>
       {!!signal_lost && <SignalLostModal />}
       {!!choosingTools && <ToolSelectionModal />}
       <Window.Content>
@@ -178,45 +177,45 @@ const SignalLostModal = (props, context) => {
       width={30}
       height={22}
       p={0}
-      style={{ "border-radius": "5%" }}>
+      style={{ 'border-radius': '5%' }}>
       <img src={nt_logo} width={64} height={64} />
       <Box
         backgroundColor="black"
         textColor="red"
         fontSize={2}
-        style={{ "border-radius": "-10%" }}>
+        style={{ 'border-radius': '-10%' }}>
         CONNECTION LOST
       </Box>
       <Box p={2} italic>
-        Connection to exploration drone interrupted.
-        Please contact nearest Nanotrasen Exploration Division
-        representative for further instructions.
+        Connection to exploration drone interrupted. Please contact nearest
+        Nanotrasen Exploration Division representative for further instructions.
       </Box>
-      <Icon
-        name="exclamation-triangle"
-        textColor="black"
-        size={5} />
+      <Icon name="exclamation-triangle" textColor="black" size={5} />
       <Box>
         <Button
           content="Confirm"
           color="danger"
-          style={{ "border": "1px solid black" }}
-          onClick={() => act("confirm_signal_lost")} />
+          style={{ 'border': '1px solid black' }}
+          onClick={() => act('confirm_signal_lost')}
+        />
       </Box>
     </Modal>
   );
 };
 
-const DroneSelectionSection = (props: {
-  all_drones: Array<DroneBasicData>,
-}, context) => {
+const DroneSelectionSection = (
+  props: {
+    all_drones: Array<DroneBasicData>;
+  },
+  context
+) => {
   const { act } = useBackend<ExodroneConsoleData>(context);
   const { all_drones } = props;
 
   return (
     <Section scrollable fill title="Exploration Drone Listing">
       <Stack vertical>
-        {all_drones.map(drone => (
+        {all_drones.map((drone) => (
           <Fragment key={drone.ref}>
             <Stack.Item grow>
               <Stack fill>
@@ -230,13 +229,13 @@ const DroneSelectionSection = (props: {
                 <Stack.Item grow />
                 <Stack.Divider mr={1} />
                 <Stack.Item ml={0}>
-                  {drone.controlled && (
-                    "Controlled by another console."
-                  ) || (
+                  {(drone.controlled && 'Controlled by another console.') || (
                     <Button
                       content="Assume Control"
                       icon="plug"
-                      onClick={() => act("select_drone", { "drone_ref": drone.ref })} />
+                      onClick={() =>
+                        act('select_drone', { 'drone_ref': drone.ref })}
+                    />
                   )}
                 </Stack.Item>
               </Stack>
@@ -249,51 +248,45 @@ const DroneSelectionSection = (props: {
   );
 };
 
-
 const ToolSelectionModal = (props, context) => {
   const { act, data } = useBackend<ExodroneConsoleData>(context);
-  const {
-    all_tools = {},
-  } = data;
+  const { all_tools = {} } = data;
 
-  const [
-    choosingTools,
-    setChoosingTools,
-  ] = useLocalState(context, 'choosingTools', false);
+  const [choosingTools, setChoosingTools] = useLocalState(
+    context,
+    'choosingTools',
+    false
+  );
 
   const toolData = Object.keys(all_tools);
   return (
     <Modal>
       <Stack fill vertical pr={2}>
-        <Stack.Item>
-          Select Tool:
-        </Stack.Item>
+        <Stack.Item>Select Tool:</Stack.Item>
         <Stack.Item>
           <Stack textAlign="center">
-            {!!toolData && toolData.map(tool_name => (
-              <Stack.Item key={tool_name}>
-                <Button
-                  onClick={() => {
-                    setChoosingTools(false);
-                    act("add_tool", { tool_type: tool_name });
-                  }}
-                  width={6}
-                  height={6}
-                  tooltip={all_tools[tool_name].description}>
-                  <Stack vertical>
-                    <Stack.Item>
-                      {capitalize(tool_name)}
-                    </Stack.Item>
-                    <Stack.Item ml={2.5}>
-                      <Icon name={all_tools[tool_name].icon} size={3} />
-                    </Stack.Item>
-                  </Stack>
-                </Button>
-              </Stack.Item>
-            )) || (
+            {(!!toolData
+              && toolData.map((tool_name) => (
+                <Stack.Item key={tool_name}>
+                  <Button
+                    onClick={() => {
+                      setChoosingTools(false);
+                      act('add_tool', { tool_type: tool_name });
+                    }}
+                    width={6}
+                    height={6}
+                    tooltip={all_tools[tool_name].description}>
+                    <Stack vertical>
+                      <Stack.Item>{capitalize(tool_name)}</Stack.Item>
+                      <Stack.Item ml={2.5}>
+                        <Icon name={all_tools[tool_name].icon} size={3} />
+                      </Stack.Item>
+                    </Stack>
+                  </Button>
+                </Stack.Item>
+              ))) || (
               <Stack.Item>
-                <Button
-                  content="Back" />
+                <Button content="Back" />
               </Stack.Item>
             )}
           </Stack>
@@ -303,17 +296,20 @@ const ToolSelectionModal = (props, context) => {
   );
 };
 
-const EquipmentBox = (props: {
-  cargo: CargoData,
-  drone: DroneData,
-}, context) => {
+const EquipmentBox = (
+  props: {
+    cargo: CargoData;
+    drone: DroneData;
+  },
+  context
+) => {
   const { act, data } = useBackend<ExodroneConsoleData>(context);
   const { all_tools = {} } = data;
   const { configurable } = props.drone;
   const cargo = props.cargo;
-  const boxContents = cargo => {
+  const boxContents = (cargo) => {
     switch (cargo.type) {
-      case "tool": // Tool icon+Remove button if configurable
+      case 'tool': // Tool icon+Remove button if configurable
         return (
           <Stack direction="column">
             <Stack.Item grow>
@@ -328,22 +324,24 @@ const EquipmentBox = (props: {
                   name={all_tools[cargo.name].icon}
                   size={3}
                   pl={1.5}
-                  pt={2} />
+                  pt={2}
+                />
               </Button>
             </Stack.Item>
             {!!configurable && (
-              <Stack.Item mt={-9.4} textAlign="right">
+              <Stack.Item textAlign="right">
                 <Button
-                  onClick={() => act("remove_tool", { tool_type: cargo.name })}
+                  onClick={() => act('remove_tool', { tool_type: cargo.name })}
                   color="danger"
                   icon="minus"
                   tooltipPosition="right"
-                  tooltip="Remove Tool" />
+                  tooltip="Remove Tool"
+                />
               </Stack.Item>
             )}
           </Stack>
         );
-      case "cargo":// Jettison button.
+      case 'cargo': // Jettison button.
         return (
           <Stack direction="column">
             <Stack.Item>
@@ -354,26 +352,22 @@ const EquipmentBox = (props: {
                 tooltip={capitalize(cargo.name)}
                 tooltipPosition="right"
                 color="transparent">
-                <Icon
-                  color="white"
-                  name="box"
-                  size={3}
-                  pl={2.2}
-                  pt={2} />
+                <Icon color="white" name="box" size={3} pl={2.2} pt={2} />
               </Button>
             </Stack.Item>
             <Stack.Item mt={-9.4} textAlign="right">
               <Button
-                onClick={() => act("jettison", { target_ref: cargo.ref })}
+                onClick={() => act('jettison', { target_ref: cargo.ref })}
                 color="danger"
                 icon="minus"
                 tooltipPosition="right"
-                tooltip={`Jettison ${cargo.name}`} />
+                tooltip={`Jettison ${cargo.name}`}
+              />
             </Stack.Item>
           </Stack>
         );
-      case "empty":
-        return "";
+      case 'empty':
+        return '';
     }
   };
   return (
@@ -387,18 +381,19 @@ const EquipmentBox = (props: {
   );
 };
 
-const EquipmentGrid = (props: {
-  drone: ActiveDrone & DroneData,
-}, context) => {
+const EquipmentGrid = (
+  props: {
+    drone: ActiveDrone & DroneData;
+  },
+  context
+) => {
   const { act } = useBackend<ExodroneConsoleData>(context);
-  const {
-    cargo,
-    configurable,
-  } = props.drone;
-  const [
-    choosingTools,
-    setChoosingTools,
-  ] = useLocalState(context, 'choosingTools', false);
+  const { cargo, configurable } = props.drone;
+  const [choosingTools, setChoosingTools] = useLocalState(
+    context,
+    'choosingTools',
+    false
+  );
   return (
     <Stack vertical fill>
       <Stack.Item grow>
@@ -409,7 +404,8 @@ const EquipmentGrid = (props: {
                 fluid
                 icon="plug"
                 content="Disconnect"
-                onClick={() => act('end_control')} />
+                onClick={() => act('end_control')}
+              />
             </Stack.Item>
             <Stack.Divider />
             <Stack.Item>
@@ -418,7 +414,8 @@ const EquipmentGrid = (props: {
                 icon="bomb"
                 content="Self-Destruct"
                 color="bad"
-                onClick={() => act('self_destruct')} />
+                onClick={() => act('self_destruct')}
+              />
             </Stack.Item>
           </Stack>
         </Section>
@@ -432,16 +429,18 @@ const EquipmentGrid = (props: {
                 color="average"
                 icon="wrench"
                 content="Install Tool"
-                onClick={() => setChoosingTools(true)} />
+                onClick={() => setChoosingTools(true)}
+              />
             )}
           </Stack.Item>
           <Stack.Item>
             <Stack wrap="wrap" width={10}>
-              {cargo.map(cargo_element => (
+              {cargo.map((cargo_element) => (
                 <EquipmentBox
                   drone={props.drone}
                   key={cargo_element.name}
-                  cargo={cargo_element} />
+                  cargo={cargo_element}
+                />
               ))}
             </Stack>
           </Stack.Item>
@@ -451,17 +450,17 @@ const EquipmentGrid = (props: {
   );
 };
 
-const DroneStatus = (props: {
-  drone_integrity: number,
-  drone_max_integrity: number,
-}, context) => {
-  const {
-    drone_integrity,
-    drone_max_integrity,
-  } = props;
+const DroneStatus = (
+  props: {
+    drone_integrity: number;
+    drone_max_integrity: number;
+  },
+  context
+) => {
+  const { drone_integrity, drone_max_integrity } = props;
 
   return (
-    <Stack ml={-40}>
+    <Stack ml={-45}>
       <Stack.Item color="label" mt={0.2}>
         Integrity:
       </Stack.Item>
@@ -474,7 +473,8 @@ const DroneStatus = (props: {
             bad: [-Infinity, 0.4 * drone_max_integrity],
           }}
           value={drone_integrity}
-          maxValue={drone_max_integrity} />
+          maxValue={drone_max_integrity}
+        />
       </Stack.Item>
     </Stack>
   );
@@ -485,11 +485,7 @@ const NoSiteDimmer = () => {
     <Dimmer>
       <Stack textAlign="center" vertical>
         <Stack.Item>
-          <Icon
-            color="red"
-            name="map"
-            size={10}
-          />
+          <Icon color="red" name="map" size={10} />
         </Stack.Item>
         <Stack.Item fontSize="18px" color="red">
           No Destinations.
@@ -502,58 +498,60 @@ const NoSiteDimmer = () => {
   );
 };
 
-const TravelTargetSelectionScreen = (props: {
-  drone: (DroneExploration | DroneIdle | DroneTravel) & DroneData,
-  showCancelButton?: boolean,
-}, context) => {
+const TravelTargetSelectionScreen = (
+  props: {
+    drone: (DroneExploration | DroneIdle | DroneTravel) & DroneData;
+    showCancelButton?: boolean;
+  },
+  context
+) => {
   // List of sites and eta travel times to each
   const { act, data } = useBackend<ExodroneConsoleData>(context);
   const { drone } = props;
   const { all_bands } = data;
-  const {
-    can_travel,
-    travel_error,
-    drone_travel_coefficent,
-  } = drone;
+  const { can_travel, travel_error, drone_travel_coefficent } = drone;
 
-  const site = ("site" in drone) ? drone.site : null;
-  const sites = ("sites" in drone) ? drone.sites : null;
+  const site = 'site' in drone ? drone.site : null;
+  const sites = 'sites' in drone ? drone.sites : null;
 
-  const travel_cost = target_site => {
+  const travel_cost = (target_site) => {
     if (site) {
-      return Math.max(Math.abs(site.distance - target_site.distance), 1)
-        * drone_travel_coefficent;
-    }
-    else {
+      return (
+        Math.max(Math.abs(site.distance - target_site.distance), 1)
+        * drone_travel_coefficent
+      );
+    } else {
       return target_site.distance * drone_travel_coefficent;
     }
   };
-  const [
-    choosingTools,
-    setChoosingTools,
-  ] = useLocalState(context, 'choosingTools', false);
-  const [
-    TravelDimmerShown,
-    setTravelDimmerShown,
-  ] = useLocalState(context, 'TravelDimmerShown', false);
+  const [choosingTools, setChoosingTools] = useLocalState(
+    context,
+    'choosingTools',
+    false
+  );
+  const [TravelDimmerShown, setTravelDimmerShown] = useLocalState(
+    context,
+    'TravelDimmerShown',
+    false
+  );
 
-  const travel_to = ref => {
+  const travel_to = (ref) => {
     setTravelDimmerShown(false);
-    act("start_travel", { "target_site": ref });
+    act('start_travel', { 'target_site': ref });
   };
 
-  const non_empty_bands = (dest : SiteData) => {
-    const band_check = (s: string) => dest.band_info[s] !== undefined
-      && dest.band_info[s] !== 0;
+  const non_empty_bands = (dest: SiteData) => {
+    const band_check = (s: string) =>
+      dest.band_info[s] !== undefined && dest.band_info[s] !== 0;
     return Object.keys(all_bands).filter(band_check);
   };
-  const valid_destinations = sites && sites.filter(destination => (
-    !site || destination.ref !== site.ref
-  ));
+  const valid_destinations
+    = sites
+    && sites.filter((destination) => !site || destination.ref !== site.ref);
   return (
-    drone.drone_status === DroneStatusEnum.Travel && (
+    (drone.drone_status === DroneStatusEnum.Travel && (
       <TravelDimmer drone={drone} />
-    ) || (
+    )) || (
       <Section
         title="Travel Destinations"
         fill
@@ -565,7 +563,8 @@ const TravelTargetSelectionScreen = (props: {
                 ml={5}
                 mr={0}
                 content="Cancel"
-                onClick={() => setTravelDimmerShown(false)} />
+                onClick={() => setTravelDimmerShown(false)}
+              />
             )}
             <Box mt={props.showCancelButton && -3.5}>
               <DroneStatus
@@ -575,37 +574,38 @@ const TravelTargetSelectionScreen = (props: {
             </Box>
           </>
         }>
-        {((sites && !sites.length) && !choosingTools) && (
-          <NoSiteDimmer />
-        )}
+        {sites && !sites.length && !choosingTools && <NoSiteDimmer />}
         {site && (
           <Section
             mt={1}
             title="Home"
             buttons={
               <Box>
-                ETA: {formatTime(site.distance * drone_travel_coefficent, "short")}
+                ETA:{' '}
+                {formatTime(site.distance * drone_travel_coefficent, 'short')}
                 <Button
                   ml={1}
-                  content={can_travel ? "Launch!" : travel_error}
+                  content={can_travel ? 'Launch!' : travel_error}
                   onClick={() => travel_to(null)}
-                  disabled={!can_travel} />
+                  disabled={!can_travel}
+                />
               </Box>
             }
           />
         )}
-        {valid_destinations?.map(destination => (
+        {valid_destinations?.map((destination) => (
           <Section
             key={destination.ref}
             title={destination.name}
             buttons={
               <>
-                ETA: {formatTime(travel_cost(destination), "short")}
+                ETA: {formatTime(travel_cost(destination), 'short')}
                 <Button
                   ml={1}
-                  content={can_travel ? "Launch!" : travel_error}
+                  content={can_travel ? 'Launch!' : travel_error}
                   onClick={() => travel_to(destination.ref)}
-                  disabled={!can_travel} />
+                  disabled={!can_travel}
+                />
               </>
             }>
             <LabeledList>
@@ -616,10 +616,8 @@ const TravelTargetSelectionScreen = (props: {
                 {destination.description}
               </LabeledList.Item>
               <LabeledList.Divider />
-              {non_empty_bands(destination).map(band => (
-                <LabeledList.Item
-                  key={band}
-                  label={band}>
+              {non_empty_bands(destination).map((band) => (
+                <LabeledList.Item key={band} label={band}>
                   {destination.band_info[band]}
                 </LabeledList.Item>
               ))}
@@ -631,20 +629,19 @@ const TravelTargetSelectionScreen = (props: {
   );
 };
 
-const TravelDimmer = (props: {
-  drone: DroneTravel,
-}, context) => {
+const TravelDimmer = (
+  props: {
+    drone: DroneTravel;
+  },
+  context
+) => {
   const { travel_time_left } = props.drone;
   return (
     <Section fill>
       <Dimmer>
         <Stack textAlign="center" vertical>
           <Stack.Item>
-            <Icon
-              color="yellow"
-              name="route"
-              size={10}
-            />
+            <Icon color="yellow" name="route" size={10} />
           </Stack.Item>
           <Stack.Item fontSize="18px" color="yellow">
             Travel Time: {formatTime(travel_time_left)}
@@ -655,24 +652,15 @@ const TravelDimmer = (props: {
   );
 };
 
-const TimeoutScreen = (props: {
-  drone: DroneBusy,
-}) => {
-  const {
-    wait_time_left,
-    wait_message,
-  } = props.drone;
+const TimeoutScreen = (props: { drone: DroneBusy }) => {
+  const { wait_time_left, wait_message } = props.drone;
 
   return (
     <Section fill>
       <Dimmer>
         <Stack textAlign="center" vertical>
           <Stack.Item>
-            <Icon
-              color="green"
-              name="cog"
-              size={10}
-            />
+            <Icon color="green" name="cog" size={10} />
           </Stack.Item>
           <Stack.Item fontSize="18px" color="green">
             {wait_message} ({formatTime(wait_time_left)})
@@ -683,23 +671,24 @@ const TimeoutScreen = (props: {
   );
 };
 
-const ExplorationScreen = (props: {
-  drone: DroneExploration & DroneData,
-}, context) => {
+const ExplorationScreen = (
+  props: {
+    drone: DroneExploration & DroneData;
+  },
+  context
+) => {
   const { act } = useBackend(context);
   const { drone } = props;
   const { site } = drone;
 
-  const [
-    TravelDimmerShown,
-    setTravelDimmerShown,
-  ] = useLocalState(context, 'TravelDimmerShown', false);
+  const [TravelDimmerShown, setTravelDimmerShown] = useLocalState(
+    context,
+    'TravelDimmerShown',
+    false
+  );
 
   if (TravelDimmerShown) {
-    return (<TravelTargetSelectionScreen
-      drone={drone}
-      showCancelButton
-    />);
+    return <TravelTargetSelectionScreen drone={drone} showCancelButton />;
   }
   return (
     <Section
@@ -715,38 +704,40 @@ const ExplorationScreen = (props: {
         <Stack.Item grow>
           <LabeledList>
             <LabeledList.Item label="Site">{site.name}</LabeledList.Item>
-            <LabeledList.Item label="Location">{site.coordinates}</LabeledList.Item>
-            <LabeledList.Item label="Description">{site.description}</LabeledList.Item>
+            <LabeledList.Item label="Location">
+              {site.coordinates}
+            </LabeledList.Item>
+            <LabeledList.Item label="Description">
+              {site.description}
+            </LabeledList.Item>
           </LabeledList>
         </Stack.Item>
         <Stack.Item align="center" grow>
-          <Button
-            content="Explore!"
-            onClick={() => act("explore")} />
+          <Button content="Explore!" onClick={() => act('explore')} />
         </Stack.Item>
-        {site.events.map(e => (
-          <Stack.Item
-            align="center"
-            key={site.ref}
-            grow>
+        {site.events.map((e) => (
+          <Stack.Item align="center" key={site.ref} grow>
             <Button
               content={capitalize(e.name)}
-              onClick={() => act("explore_event", { target_event: e.ref })} />
-          </Stack.Item>))}
+              onClick={() => act('explore_event', { target_event: e.ref })}
+            />
+          </Stack.Item>
+        ))}
         <Stack.Item align="center" grow>
-          <Button
-            content="Travel"
-            onClick={() => setTravelDimmerShown(true)} />
+          <Button content="Travel" onClick={() => setTravelDimmerShown(true)} />
         </Stack.Item>
       </Stack>
     </Section>
   );
 };
 
-const EventScreen = (props: {
-  drone: DroneData,
-  event: FullEventData,
-}, context) => {
+const EventScreen = (
+  props: {
+    drone: DroneData;
+    event: FullEventData;
+  },
+  context
+) => {
   const { act } = useBackend(context);
   const { drone, event } = props;
 
@@ -764,35 +755,37 @@ const EventScreen = (props: {
         <Stack.Item>
           <Stack fill>
             <Stack.Item>
-              <img src={resolveAsset(event.image)}
+              <img
+                src={resolveAsset(event.image)}
                 height="125px"
                 width="250px"
                 style={{
                   '-ms-interpolation-mode': 'nearest-neighbor',
-                }} />
+                }}
+              />
             </Stack.Item>
-            <Stack.Item >
-              <BlockQuote preserveWhitespace>
-                {event.description}
-              </BlockQuote>
+            <Stack.Item>
+              <BlockQuote preserveWhitespace>{event.description}</BlockQuote>
             </Stack.Item>
           </Stack>
         </Stack.Item>
         <Stack.Divider />
         <Stack.Item grow>
-          <Stack vertical fill >
+          <Stack vertical fill>
             <Stack.Item grow />
             <Stack.Item grow>
               <Button
                 content={event.action_text}
                 disabled={!event.action_enabled}
-                onClick={() => act("start_event")} />
+                onClick={() => act('start_event')}
+              />
             </Stack.Item>
             {!!event.skippable && (
               <Stack.Item mt={2}>
                 <Button
                   content={event.ignore_text}
-                  onClick={() => act("skip_event")} />
+                  onClick={() => act('skip_event')}
+                />
               </Stack.Item>
             )}
             <Stack.Item grow />
@@ -803,28 +796,31 @@ const EventScreen = (props: {
   );
 };
 
-export const AdventureScreen = (props: {
-  adventure_data: AdventureData,
-  drone_integrity: number,
-  drone_max_integrity: number,
-  hide_status?: boolean,
-}, context) => {
+export const AdventureScreen = (
+  props: {
+    adventure_data: AdventureData;
+    drone_integrity: number;
+    drone_max_integrity: number;
+    hide_status?: boolean;
+  },
+  context
+) => {
   const { act } = useBackend(context);
-  const {
-    adventure_data,
-    drone_integrity,
-    drone_max_integrity,
-  } = props;
+  const { adventure_data, drone_integrity, drone_max_integrity } = props;
   const rawData = adventure_data.raw_image;
   const imgSource = rawData ? rawData : resolveAsset(adventure_data.image);
   return (
     <Section
       fill
       title="Exploration"
-      buttons={!props.hide_status && <DroneStatus
-        drone_integrity={drone_integrity}
-        drone_max_integrity={drone_max_integrity}
-      />}>
+      buttons={
+        !props.hide_status && (
+          <DroneStatus
+            drone_integrity={drone_integrity}
+            drone_max_integrity={drone_max_integrity}
+          />
+      )
+      }>
       <Stack>
         <Stack.Item>
           <BlockQuote preserveWhitespace>
@@ -839,19 +835,23 @@ export const AdventureScreen = (props: {
             width="200px"
             style={{
               '-ms-interpolation-mode': 'nearest-neighbor',
-            }} />
+            }}
+          />
           <Stack vertical>
             <Stack.Divider />
             <Stack.Item grow />
-            {!!adventure_data.choices && adventure_data.choices.map(choice => (
-              <Stack.Item key={choice.key}>
-                <Button
-                  fluid
-                  content={choice.text}
-                  textAlign="center"
-                  onClick={() => act('adventure_choice', { choice: choice.key })} />
-              </Stack.Item>
-            ))}
+            {!!adventure_data.choices
+              && adventure_data.choices.map((choice) => (
+                <Stack.Item key={choice.key}>
+                  <Button
+                    fluid
+                    content={choice.text}
+                    textAlign="center"
+                    onClick={() =>
+                      act('adventure_choice', { choice: choice.key })}
+                  />
+                </Stack.Item>
+              ))}
             <Stack.Item grow />
           </Stack>
         </Stack.Item>
@@ -860,9 +860,7 @@ export const AdventureScreen = (props: {
   );
 };
 
-const DroneScreen = (props: {
-  drone: ActiveDrone & DroneData,
-}) => {
+const DroneScreen = (props: { drone: ActiveDrone & DroneData }) => {
   const { drone } = props;
 
   switch (drone.drone_status) {
@@ -872,16 +870,17 @@ const DroneScreen = (props: {
     case DroneStatusEnum.Travel:
       return <TravelTargetSelectionScreen drone={drone} />;
     case DroneStatusEnum.Adventure:
-      return (<AdventureScreen
-        adventure_data={drone.adventure_data}
-        drone_integrity={drone.drone_integrity}
-        drone_max_integrity={drone.drone_max_integrity}
-      />);
+      return (
+        <AdventureScreen
+          adventure_data={drone.adventure_data}
+          drone_integrity={drone.drone_integrity}
+          drone_max_integrity={drone.drone_max_integrity}
+        />
+      );
     case DroneStatusEnum.Exploration:
       if (drone.event) {
         return <EventScreen drone={drone} event={drone.event} />;
-      }
-      else {
+      } else {
         return <ExplorationScreen drone={drone} />;
       }
   }

--- a/tgui/packages/tgui/interfaces/ExoscannerConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ExoscannerConsole.tsx
@@ -3,23 +3,24 @@ import { BlockQuote, Box, Button, Icon, Modal, Section, LabeledList, NoticeBox, 
 import { Window } from '../layouts';
 import { formatTime } from '../format';
 
+
 type SiteData = {
-  name: string;
-  ref: string;
-  description: string;
-  distance: number;
-  band_info: Record<string, string>;
-  revealed: boolean;
-};
+  name: string,
+  ref: string,
+  description: string,
+  distance: number,
+  band_info: Record<string, string>,
+  revealed: boolean,
+}
 
 type ScanData = {
-  scan_power: number;
-  point_scan_eta: number;
-  deep_scan_eta: number;
-  point_scan_complete: boolean;
-  deep_scan_complete: boolean;
-  site_data: SiteData;
-};
+  scan_power: number,
+  point_scan_eta: number,
+  deep_scan_eta: number,
+  point_scan_complete: boolean,
+  deep_scan_complete: boolean
+  site_data: SiteData
+}
 
 const ScanFailedModal = (_, context) => {
   const { act } = useBackend(context);
@@ -30,11 +31,12 @@ const ScanFailedModal = (_, context) => {
           <Box color="bad">SCAN FAILURE!</Box>
         </Stack.Item>
         <Stack.Item>
-          <Button content="Confirm" onClick={() => act('confirm_fail')} />
+          <Button
+            content="Confirm"
+            onClick={() => act("confirm_fail")} />
         </Stack.Item>
       </Stack>
-    </Modal>
-  );
+    </Modal>);
 };
 
 const ScanSelectionSection = (_, context) => {
@@ -49,8 +51,8 @@ const ScanSelectionSection = (_, context) => {
   } = data;
   const site = site_data;
 
-  const point_cost = scan_power > 0 ? formatTime(point_scan_eta, 'short') : '∞';
-  const deep_cost = scan_power > 0 ? formatTime(deep_scan_eta, 'short') : '∞';
+  const point_cost = scan_power > 0 ? formatTime(point_scan_eta, "short") : "∞";
+  const deep_cost = scan_power > 0 ? formatTime(deep_scan_eta, "short") : "∞";
   const scan_available = !point_scan_complete || !deep_scan_complete;
   return (
     <Stack vertical fill>
@@ -61,22 +63,21 @@ const ScanSelectionSection = (_, context) => {
           buttons={
             <Button
               content="Back"
-              onClick={() => act('select_site', { 'site_ref': null })}
-            />
+              onClick={() => act("select_site", { "site_ref": null })} />
           }>
           <LabeledList>
             <LabeledList.Item label="Name">{site.name}</LabeledList.Item>
             <LabeledList.Item label="Description">
-              {site.revealed ? site.description : 'No Data'}
+              {site.revealed ? site.description : "No Data"}
             </LabeledList.Item>
-            <LabeledList.Item label="Distance">
-              {site.distance}
-            </LabeledList.Item>
+            <LabeledList.Item label="Distance">{site.distance}</LabeledList.Item>
             <LabeledList.Divider />
             <LabeledList.Item label="Spectrography Data" />
             <LabeledList.Divider />
-            {Object.keys(site.band_info).map((band) => (
-              <LabeledList.Item key={band} label={band}>
+            {Object.keys(site.band_info).map(band => (
+              <LabeledList.Item
+                key={band}
+                label={band}>
                 {site.band_info[band]}
               </LabeledList.Item>
             ))}
@@ -89,16 +90,17 @@ const ScanSelectionSection = (_, context) => {
             {!point_scan_complete && (
               <Section title="Point Scan">
                 <BlockQuote>
-                  Point scan performs rudimentary scan of the site, revealing
-                  its general characteristics.
+                  Point scan performs rudimentary scan of
+                  the site, revealing its general characteristics.
                 </BlockQuote>
                 <Box>
                   <Button
                     content="Scan"
                     disabled={scan_power <= 0}
-                    onClick={() => act('start_point_scan')}
-                  />
-                  <Box inline pl={3}>
+                    onClick={() => act("start_point_scan")} />
+                  <Box
+                    inline
+                    pl={3}>
                     Estimated Time: {point_cost}.
                   </Box>
                 </Box>
@@ -107,16 +109,17 @@ const ScanSelectionSection = (_, context) => {
             {!deep_scan_complete && (
               <Section title="Deep Scan">
                 <BlockQuote>
-                  Deep scan performs full scan of the site, revealing all
-                  details.
+                  Deep scan performs full scan
+                  of the site, revealing all details.
                 </BlockQuote>
                 <Box>
                   <Button
                     content="Scan"
                     disabled={scan_power <= 0}
-                    onClick={() => act('start_deep_scan')}
-                  />
-                  <Box inline pl={3}>
+                    onClick={() => act("start_deep_scan")} />
+                  <Box
+                    inline
+                    pl={3}>
                     Estimated Time: {deep_cost}.
                   </Box>
                 </Box>
@@ -130,51 +133,59 @@ const ScanSelectionSection = (_, context) => {
 };
 
 type ScanInProgressData = {
-  scan_time: number;
-  scan_power: number;
-  scan_description: string;
-};
+  scan_time: number,
+  scan_power: number,
+  scan_description: string,
+}
 
 const ScanInProgressModal = (_, context) => {
   const { act, data } = useBackend<ScanInProgressData>(context);
-  const { scan_time, scan_power, scan_description } = data;
+  const {
+    scan_time,
+    scan_power,
+    scan_description,
+  } = data;
 
   return (
     <Modal ml={1}>
       <NoticeBox>Scan in Progress!</NoticeBox>
       <Box color="danger" />
       <LabeledList>
-        <LabeledList.Item label="Scan summary">
+        <LabeledList.Item
+          label="Scan summary">
           {scan_description}
         </LabeledList.Item>
-        <LabeledList.Item label="Time left">
+        <LabeledList.Item
+          label="Time left">
           {formatTime(scan_time)}
         </LabeledList.Item>
-        <LabeledList.Item label="Scanning array power">
+        <LabeledList.Item
+          label="Scanning array power">
           {scan_power}
         </LabeledList.Item>
-        <LabeledList.Item label="Emergency Stop">
+        <LabeledList.Item
+          label="Emergency Stop">
           <Button.Confirm
             content="STOP SCAN"
             color="red"
             icon="times"
-            onClick={() => act('stop_scan')}
-          />
+            onClick={() => act("stop_scan")} />
         </LabeledList.Item>
       </LabeledList>
     </Modal>
   );
 };
 
+
 type ExoscannerConsoleData = {
-  scan_in_progress: boolean;
-  scan_power: number;
-  possible_sites: Array<SiteData>;
-  wide_scan_eta: number;
-  selected_site: string;
-  failed: boolean;
-  scan_conditions: Array<string>;
-};
+  scan_in_progress: boolean,
+  scan_power: number,
+  possible_sites: Array<SiteData>,
+  wide_scan_eta: number,
+  selected_site: string,
+  failed: boolean,
+  scan_conditions: Array<string>,
+}
 
 export const ExoscannerConsole = (_, context) => {
   const { act, data } = useBackend<ExoscannerConsoleData>(context);
@@ -192,32 +203,38 @@ export const ExoscannerConsole = (_, context) => {
 
   return (
     <Window width={550} height={600}>
-      {!!scan_in_progress && <ScanInProgressModal />}
-      {!!failed && <ScanFailedModal />}
+      {!!scan_in_progress && (
+        <ScanInProgressModal />
+      )}
+      {!!failed && (
+        <ScanFailedModal />
+      )}
       <Window.Content>
         <Stack vertical fill>
           <Stack.Item>
             <Section fill title="Available array power">
               <Stack>
                 <Stack.Item grow>
-                  {(scan_power > 0 && (
+                  {scan_power > 0 && (
                     <>
-                      <Box pr={1} inline fontSize={2}>
-                        {scan_power}
-                      </Box>
-                      <Icon name="satellite-dish" size={3} />
+                      <Box pr={1} inline fontSize={2}>{scan_power}</Box>
+                      <Icon
+                        name="satellite-dish"
+                        size={3} />
                     </>
-                  ))
-                    || 'No properly configured scanner arrays detected.'}
+                  ) || (
+                    "No properly configured scanner arrays detected."
+                  )}
                 </Stack.Item>
               </Stack>
               <Section title="Special Scan Condtions">
-                {scan_conditions
-                  && scan_conditions.map((condition) => (
-                    <NoticeBox key={condition} warning>
-                      {condition}
-                    </NoticeBox>
-                  ))}
+                {scan_conditions && scan_conditions.map(condition => (
+                  <NoticeBox
+                    key={condition}
+                    warning>
+                    {condition}
+                  </NoticeBox>
+                ))}
               </Section>
             </Section>
           </Stack.Item>
@@ -243,15 +260,12 @@ export const ExoscannerConsole = (_, context) => {
                   <Stack>
                     <Stack.Item>
                       <BlockQuote>
-                        Broad spectrum scan looking for anything not matching
-                        known start charts.
+                        Broad spectrum scan looking for
+                        anything not matching known start charts.
                       </BlockQuote>
                     </Stack.Item>
                     <Stack.Item>
-                      Cost estimate:{' '}
-                      {scan_power > 0
-                        ? formatTime(wide_scan_eta, 'short')
-                        : '∞ minutes'}
+                      Cost estimate: {scan_power > 0 ? formatTime(wide_scan_eta, "short") : "∞ minutes"}
                     </Stack.Item>
                   </Stack>
                 </Section>
@@ -264,18 +278,15 @@ export const ExoscannerConsole = (_, context) => {
                   buttons={
                     <Button
                       content="View Experiments"
-                      onClick={() => act('open_experiments')}
-                      icon="tasks"
-                    />
+                      onClick={() => act("open_experiments")}
+                      icon="tasks" />
                   }>
                   <Stack vertical>
-                    {possible_sites.map((site) => (
+                    {possible_sites.map(site => (
                       <Stack.Item key={site.ref}>
                         <Button
                           content={site.name}
-                          onClick={() =>
-                            act('select_site', { 'site_ref': site.ref })}
-                        />
+                          onClick={() => act("select_site", { "site_ref": site.ref })} />
                       </Stack.Item>
                     ))}
                   </Stack>

--- a/tgui/packages/tgui/interfaces/ExoscannerConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ExoscannerConsole.tsx
@@ -1,45 +1,43 @@
 import { useBackend } from '../backend';
-import { BlockQuote, Box, Button, Flex, Icon, Modal, Section, LabeledList, NoticeBox, Stack } from '../components';
+import { BlockQuote, Box, Button, Icon, Modal, Section, LabeledList, NoticeBox, Stack } from '../components';
 import { Window } from '../layouts';
 import { formatTime } from '../format';
 
-
 type SiteData = {
-  name: string,
-  ref: string,
-  description: string,
-  distance: number,
-  band_info: Record<string, string>,
-  revealed: boolean,
-}
-
-type ScanData = {
-  scan_power: number,
-  point_scan_eta: number,
-  deep_scan_eta: number,
-  point_scan_complete: boolean,
-  deep_scan_complete: boolean
-  site_data: SiteData
-}
-
-const ScanFailedModal = (props, context) => {
-  const { act, data } = useBackend(context);
-  return (
-    <Modal>
-      <Flex direction="column">
-        <Flex.Item>
-          <Box color="bad">SCAN FAILURE!</Box>
-        </Flex.Item>
-        <Flex.Item>
-          <Button
-            content="Confirm"
-            onClick={() => act("confirm_fail")} />
-        </Flex.Item>
-      </Flex>
-    </Modal>);
+  name: string;
+  ref: string;
+  description: string;
+  distance: number;
+  band_info: Record<string, string>;
+  revealed: boolean;
 };
 
-const ScanSelectionSection = (props, context) => {
+type ScanData = {
+  scan_power: number;
+  point_scan_eta: number;
+  deep_scan_eta: number;
+  point_scan_complete: boolean;
+  deep_scan_complete: boolean;
+  site_data: SiteData;
+};
+
+const ScanFailedModal = (_, context) => {
+  const { act } = useBackend(context);
+  return (
+    <Modal>
+      <Stack fill vertical>
+        <Stack.Item>
+          <Box color="bad">SCAN FAILURE!</Box>
+        </Stack.Item>
+        <Stack.Item>
+          <Button content="Confirm" onClick={() => act('confirm_fail')} />
+        </Stack.Item>
+      </Stack>
+    </Modal>
+  );
+};
+
+const ScanSelectionSection = (_, context) => {
   const { act, data } = useBackend<ScanData>(context);
   const {
     scan_power,
@@ -51,8 +49,8 @@ const ScanSelectionSection = (props, context) => {
   } = data;
   const site = site_data;
 
-  const point_cost = scan_power > 0 ? formatTime(point_scan_eta, "short") : "∞";
-  const deep_cost = scan_power > 0 ? formatTime(deep_scan_eta, "short") : "∞";
+  const point_cost = scan_power > 0 ? formatTime(point_scan_eta, 'short') : '∞';
+  const deep_cost = scan_power > 0 ? formatTime(deep_scan_eta, 'short') : '∞';
   const scan_available = !point_scan_complete || !deep_scan_complete;
   return (
     <Stack vertical fill>
@@ -63,21 +61,22 @@ const ScanSelectionSection = (props, context) => {
           buttons={
             <Button
               content="Back"
-              onClick={() => act("select_site", { "site_ref": null })} />
+              onClick={() => act('select_site', { 'site_ref': null })}
+            />
           }>
           <LabeledList>
             <LabeledList.Item label="Name">{site.name}</LabeledList.Item>
             <LabeledList.Item label="Description">
-              {site.revealed ? site.description : "No Data"}
+              {site.revealed ? site.description : 'No Data'}
             </LabeledList.Item>
-            <LabeledList.Item label="Distance">{site.distance}</LabeledList.Item>
+            <LabeledList.Item label="Distance">
+              {site.distance}
+            </LabeledList.Item>
             <LabeledList.Divider />
             <LabeledList.Item label="Spectrography Data" />
             <LabeledList.Divider />
-            {Object.keys(site.band_info).map(band => (
-              <LabeledList.Item
-                key={band}
-                label={band}>
+            {Object.keys(site.band_info).map((band) => (
+              <LabeledList.Item key={band} label={band}>
                 {site.band_info[band]}
               </LabeledList.Item>
             ))}
@@ -90,17 +89,16 @@ const ScanSelectionSection = (props, context) => {
             {!point_scan_complete && (
               <Section title="Point Scan">
                 <BlockQuote>
-                  Point scan performs rudimentary scan of
-                  the site, revealing its general characteristics.
+                  Point scan performs rudimentary scan of the site, revealing
+                  its general characteristics.
                 </BlockQuote>
                 <Box>
                   <Button
                     content="Scan"
                     disabled={scan_power <= 0}
-                    onClick={() => act("start_point_scan")} />
-                  <Box
-                    inline
-                    pl={3}>
+                    onClick={() => act('start_point_scan')}
+                  />
+                  <Box inline pl={3}>
                     Estimated Time: {point_cost}.
                   </Box>
                 </Box>
@@ -109,17 +107,16 @@ const ScanSelectionSection = (props, context) => {
             {!deep_scan_complete && (
               <Section title="Deep Scan">
                 <BlockQuote>
-                  Deep scan performs full scan
-                  of the site, revealing all details.
+                  Deep scan performs full scan of the site, revealing all
+                  details.
                 </BlockQuote>
                 <Box>
                   <Button
                     content="Scan"
                     disabled={scan_power <= 0}
-                    onClick={() => act("start_deep_scan")} />
-                  <Box
-                    inline
-                    pl={3}>
+                    onClick={() => act('start_deep_scan')}
+                  />
+                  <Box inline pl={3}>
                     Estimated Time: {deep_cost}.
                   </Box>
                 </Box>
@@ -133,61 +130,53 @@ const ScanSelectionSection = (props, context) => {
 };
 
 type ScanInProgressData = {
-  scan_time: number,
-  scan_power: number,
-  scan_description: string,
-}
+  scan_time: number;
+  scan_power: number;
+  scan_description: string;
+};
 
-const ScanInProgressModal = (props, context) => {
+const ScanInProgressModal = (_, context) => {
   const { act, data } = useBackend<ScanInProgressData>(context);
-  const {
-    scan_time,
-    scan_power,
-    scan_description,
-  } = data;
+  const { scan_time, scan_power, scan_description } = data;
 
   return (
     <Modal ml={1}>
       <NoticeBox>Scan in Progress!</NoticeBox>
       <Box color="danger" />
       <LabeledList>
-        <LabeledList.Item
-          label="Scan summary">
+        <LabeledList.Item label="Scan summary">
           {scan_description}
         </LabeledList.Item>
-        <LabeledList.Item
-          label="Time left">
+        <LabeledList.Item label="Time left">
           {formatTime(scan_time)}
         </LabeledList.Item>
-        <LabeledList.Item
-          label="Scanning array power">
+        <LabeledList.Item label="Scanning array power">
           {scan_power}
         </LabeledList.Item>
-        <LabeledList.Item
-          label="Emergency Stop">
+        <LabeledList.Item label="Emergency Stop">
           <Button.Confirm
             content="STOP SCAN"
             color="red"
             icon="times"
-            onClick={() => act("stop_scan")} />
+            onClick={() => act('stop_scan')}
+          />
         </LabeledList.Item>
       </LabeledList>
     </Modal>
   );
 };
 
-
 type ExoscannerConsoleData = {
-  scan_in_progress: boolean,
-  scan_power: number,
-  possible_sites: Array<SiteData>,
-  wide_scan_eta: number,
-  selected_site: string,
-  failed: boolean,
-  scan_conditions: Array<string>,
-}
+  scan_in_progress: boolean;
+  scan_power: number;
+  possible_sites: Array<SiteData>;
+  wide_scan_eta: number;
+  selected_site: string;
+  failed: boolean;
+  scan_conditions: Array<string>;
+};
 
-export const ExoscannerConsole = (props, context) => {
+export const ExoscannerConsole = (_, context) => {
   const { act, data } = useBackend<ExoscannerConsoleData>(context);
   const {
     scan_in_progress,
@@ -202,39 +191,33 @@ export const ExoscannerConsole = (props, context) => {
   const can_start_wide_scan = scan_power > 0;
 
   return (
-    <Window>
-      {!!scan_in_progress && (
-        <ScanInProgressModal />
-      )}
-      {!!failed && (
-        <ScanFailedModal />
-      )}
+    <Window width={550} height={600}>
+      {!!scan_in_progress && <ScanInProgressModal />}
+      {!!failed && <ScanFailedModal />}
       <Window.Content>
         <Stack vertical fill>
           <Stack.Item>
             <Section fill title="Available array power">
               <Stack>
                 <Stack.Item grow>
-                  {scan_power > 0 && (
+                  {(scan_power > 0 && (
                     <>
-                      <Box pr={1} inline fontSize={2}>{scan_power}</Box>
-                      <Icon
-                        name="satellite-dish"
-                        size={3} />
+                      <Box pr={1} inline fontSize={2}>
+                        {scan_power}
+                      </Box>
+                      <Icon name="satellite-dish" size={3} />
                     </>
-                  ) || (
-                    "No properly configured scanner arrays detected."
-                  )}
+                  ))
+                    || 'No properly configured scanner arrays detected.'}
                 </Stack.Item>
               </Stack>
               <Section title="Special Scan Condtions">
-                {scan_conditions && scan_conditions.map(condition => (
-                  <NoticeBox
-                    key={condition}
-                    warning>
-                    {condition}
-                  </NoticeBox>
-                ))}
+                {scan_conditions
+                  && scan_conditions.map((condition) => (
+                    <NoticeBox key={condition} warning>
+                      {condition}
+                    </NoticeBox>
+                  ))}
               </Section>
             </Section>
           </Stack.Item>
@@ -246,23 +229,29 @@ export const ExoscannerConsole = (props, context) => {
           {!selected_site && (
             <>
               <Stack.Item>
-                <Section fill title="Configure Wide Scan">
+                <Section
+                  buttons={
+                    <Button
+                      icon="search"
+                      disabled={!can_start_wide_scan}
+                      onClick={() => act('start_wide_scan')}>
+                      Scan
+                    </Button>
+                  }
+                  fill
+                  title="Configure Wide Scan">
                   <Stack>
                     <Stack.Item>
                       <BlockQuote>
-                        Broad spectrum scan looking for
-                        anything not matching known start charts.
+                        Broad spectrum scan looking for anything not matching
+                        known start charts.
                       </BlockQuote>
                     </Stack.Item>
                     <Stack.Item>
-                      Cost estimate: {scan_power > 0 ? formatTime(wide_scan_eta, "short") : "∞ minutes"}
-                    </Stack.Item>
-                    <Stack.Item>
-                      <Button
-                        mt={2}
-                        content="Scan"
-                        disabled={!can_start_wide_scan}
-                        onClick={() => act("start_wide_scan")} />
+                      Cost estimate:{' '}
+                      {scan_power > 0
+                        ? formatTime(wide_scan_eta, 'short')
+                        : '∞ minutes'}
                     </Stack.Item>
                   </Stack>
                 </Section>
@@ -275,15 +264,18 @@ export const ExoscannerConsole = (props, context) => {
                   buttons={
                     <Button
                       content="View Experiments"
-                      onClick={() => act("open_experiments")}
-                      icon="tasks" />
+                      onClick={() => act('open_experiments')}
+                      icon="tasks"
+                    />
                   }>
                   <Stack vertical>
-                    {possible_sites.map(site => (
+                    {possible_sites.map((site) => (
                       <Stack.Item key={site.ref}>
                         <Button
                           content={site.name}
-                          onClick={() => act("select_site", { "site_ref": site.ref })} />
+                          onClick={() =>
+                            act('select_site', { 'site_ref': site.ref })}
+                        />
                       </Stack.Item>
                     ))}
                   </Stack>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1. Exoscanner array console did not have a height / width set ( ͡° ͜ʖ ͡°)
2. Drone console had strange button placement / clipping issues

![1](https://user-images.githubusercontent.com/42397676/146690132-97eca25d-8130-4fc5-819e-fb52346aaaa2.png)
![2](https://user-images.githubusercontent.com/42397676/146690134-359e6cde-7b08-4e6e-8e69-9dff341830aa.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #62838
Fixes #63498
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Clipping and sizing issues on drone consoles have been fixed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
