### PR TITLE
Thermite exploit fix

### DIFF
--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -60,7 +60,7 @@
 		amount += newC.amount
 	else
 		amount += _amount
-	if (thermite_timer) // prevent people from skipping a shorter timer
+	if (thermite_timer) // prevent people from skipping a longer timer
 		deltimer(burn_timer)
 		var/fakefire
 		for (var/obj/effect/overlay/thermite/fire in parent)

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -3,6 +3,7 @@
 	var/amount
 	var/burn_require
 	var/overlay
+	var/burn_timer
 
 	var/static/list/blacklist = typecacheof(list(
 		/turf/open/lava,
@@ -59,13 +60,19 @@
 		amount += newC.amount
 	else
 		amount += _amount
+	if (thermite_timer) // prevent people from skipping a shorter timer
+		deltimer(burn_timer)
+		var/fakefire
+		for (var/obj/effect/overlay/thermite/fire in parent)
+			fakefire = fire
+		burn_timer = addtimer(CALLBACK(src, .proc/burn_parent, fakefire, usr), min(amount * 0.35 SECONDS, 20 SECONDS), TIMER_STOPPABLE)
 
 /datum/component/thermite/proc/thermite_melt(mob/user)
 	var/turf/master = parent
 	master.cut_overlay(overlay)
 	playsound(master, 'sound/items/welder.ogg', 100, TRUE)
 	var/obj/effect/overlay/thermite/fakefire = new(master)
-	addtimer(CALLBACK(src, .proc/burn_parent, fakefire, user), min(amount * 0.35 SECONDS, 20 SECONDS))
+	burn_timer = addtimer(CALLBACK(src, .proc/burn_parent, fakefire, user), min(amount * 0.35 SECONDS, 20 SECONDS), TIMER_STOPPABLE)
 	UnregisterFromParent()
 
 /datum/component/thermite/proc/burn_parent(datum/fakefire, mob/user)

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -60,7 +60,7 @@
 		amount += newC.amount
 	else
 		amount += _amount
-	if (thermite_timer) // prevent people from skipping a longer timer
+	if (burn_timer) // prevent people from skipping a longer timer
 		deltimer(burn_timer)
 		var/fakefire
 		for (var/obj/effect/overlay/thermite/fire in parent)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/51565
currently you can skip the long timer of a full 50u thermite burn by throwing 10u on, igniting it, and then throwing the other 40u of thermite on

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Exploits are bad kids

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes an exploit with thermite burn times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
