### PR TITLE
Updates Round End News Message for when Nuclear Operatives succeed to be more gender-neutral

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -590,7 +590,7 @@ SUBSYSTEM_DEF(ticker)
 		if(WIZARD_KILLED)
 			news_message = "Tensions have flared with the Space Wizard Federation following the death of one of their members aboard [decoded_station_name]."
 		if(STATION_NUKED)
-			news_message = "[decoded_station_name] activated its self-destruct device for unknown reasons. Attempts to clone the Captain so he can be arrested and executed are underway."
+			news_message = "[decoded_station_name] activated its self-destruct device for unknown reasons. Attempts to clone the Captain for arrest and execution are underway."
 		if(CLOCK_SUMMON)
 			news_message = "The garbled messages about hailing a mouse and strange energy readings from [decoded_station_name] have been discovered to be an ill-advised, if thorough, prank by a clown."
 		if(CLOCK_SILICONS)


### PR DESCRIPTION
## About The Pull Request

On the tin. Hopefully the comedic timing isn't TOO gadzonked from this, but I think it feels OK.

## Why It's Good For The Game

It just doesn't make sense to have the gender-neutral "he" for this game when you could have someone playing a female character (or anything else). I shrug my shoulders and ride off into the sunset.

## Changelog

:cl:
fix: The Nanotrasen News Network has updated their news tickers for when a station horrifically blows up to be more accommodating towards the person directly responsible for making sure it didn't horrifically blow up.
/:cl: