### PR TITLE
Biogenerator and kitchen-botany access on Delta

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -40823,7 +40823,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/biogenerator,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "gBM" = (
@@ -102336,7 +102336,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "wWB" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -6600,14 +6600,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/hydroponics/glass{
-	name = "Hydroponics";
-	req_access_txt = "35"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/hydroponics/glass{
+	name = "Hydroponics";
+	req_one_access_txt = "35;28"
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bxp" = (
@@ -40816,7 +40816,6 @@
 /turf/open/floor/iron/large,
 /area/service/hydroponics)
 "gBp" = (
-/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -40824,6 +40823,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/biogenerator,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "gBM" = (
@@ -102336,6 +102336,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "wWB" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cooks can now enter botany on Deltastation, same way they can do on Meta. Also, they get one extra biogenerator.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Usually the cook was able to enter botany somehow. On the recent Delta rework cook lost his pass to botany, which made it an incredible pain in the ass when there was no botanist present or when the cook wanted to shout at botanists to make him some plants directly in their faces. I'm sorry, botanists.

Also, a biogenerator closer to kitchen will help to provide those enormous amounts of food that the crew of a station as big as Delta consume.

## Changelog

:cl:
qol: Chef can now enter botany on Delta. Also, there's a new biogenerator there.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
