### PR TITLE
Makes it clear that the health sensor cannot be activated while unsecured

### DIFF
--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -74,5 +74,5 @@
 	if (secured)
 		to_chat(user, span_notice("You toggle [src] [src.scanning ? "off" : "on"]."))
 	else
-		to_chat(user, span_warning("This must be secured first!"))
+		to_chat(user, span_warning("This device must be secured first!"))
 	toggle_scan()

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -72,7 +72,7 @@
 /obj/item/assembly/health/attack_self(mob/user)
 	. = ..()
 	if (secured)
-		to_chat(user, span_notice("You toggle [src] [src.scanning ? "off" : "on"]."))
+		balloon_alert(user, "scanning [scanning ? "disabled" : "enabled"]")
 	else
-		to_chat(user, span_warning("This device must be secured first!"))
+		balloon_alert(user, span_warning("secure it first!"))
 	toggle_scan()

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -71,5 +71,8 @@
 
 /obj/item/assembly/health/attack_self(mob/user)
 	. = ..()
-	to_chat(user, span_notice("You toggle [src] [src.scanning ? "off" : "on"]."))
+	if (secured)
+		to_chat(user, span_notice("You toggle [src] [src.scanning ? "off" : "on"]."))
+	else
+		to_chat(user, span_warning("This must be secured first!"))
 	toggle_scan()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Closes https://github.com/tgstation/tgstation/issues/55369
the health assembly is a little confusing
if you unsecure it, and attempt to turn it on, it will continuously say that you just turned it on
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
less confusing
sorry if this is bikeshedding

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The health sensor's status is now more clear when unsecured.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
