### PR TITLE
(Finally) Fixes dirt piles being able to hold double expected capactity of reagents. 

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -57,7 +57,7 @@
 /obj/machinery/hydroponics/Initialize(mapload)
 	//ALRIGHT YOU DEGENERATES. YOU HAD REAGENT HOLDERS FOR AT LEAST 4 YEARS AND NONE OF YOU MADE HYDROPONICS TRAYS HOLD NUTRIENT CHEMS INSTEAD OF USING "Points".
 	//SO HERE LIES THE "nutrilevel" VAR. IT'S DEAD AND I PUT IT OUT OF IT'S MISERY. USE "reagents" INSTEAD. ~ArcaneMusic, accept no substitutes.
-	create_reagents(20)
+	create_reagents(maxnutri)
 	reagents.add_reagent(/datum/reagent/plantnutriment/eznutriment, 10) //Half filled nutrient trays for dirt trays to have more to grow with in prison/lavaland.
 	. = ..()
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -16,7 +16,7 @@
 	///How many units of nutrients will be drained in the tray.
 	var/nutridrain = 1
 	///The maximum nutrient of water in the tray
-	var/maxnutri = 10
+	var/maxnutri = 20
 	///The amount of pests in the tray (max 10)
 	var/pestlevel = 0
 	///The amount of weeds in the tray (max 10)
@@ -933,6 +933,7 @@
 	flags_1 = NODECONSTRUCT_1
 	unwrenchable = FALSE
 	self_sustaining_overlay_icon_state = null
+	maxnutri = 10
 
 /obj/machinery/hydroponics/soil/update_icon(updates=ALL)
 	. = ..()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -15,7 +15,7 @@
 	var/maxwater = 100
 	///How many units of nutrients will be drained in the tray.
 	var/nutridrain = 1
-	///The maximum nutrient of water in the tray
+	///The maximum nutrient reagent container size of the tray.
 	var/maxnutri = 20
 	///The amount of pests in the tray (max 10)
 	var/pestlevel = 0


### PR DESCRIPTION
## About The Pull Request

I'm sorry, botanist players. It had to be done eventually...

Fixes:
![image](https://user-images.githubusercontent.com/51863163/146877223-673f75da-9861-439a-861d-7de905f14a12.png)

Dehardcodes the 20 reagent container size from hydroponics trays. Now, it grabs from `maxnutri`. Adjusts the default maxnutri values to accommodate, but no actual change. (For construct-able trays, this value is set to 20 with its initial parts.)

## Why It's Good For The Game

For... over a year and a half now, dirt piles could hold 20/10 nutriments in their reagent container.
This does nerf prison botany, public botany (on some maps), and lavaland botany. If it's TOO bad, it can definitely be buffed up a bit in the future.

## Changelog

:cl: Melbert
fix: Dirt piles can no longer exceed their maximum reagent capacity by 10. Sorry prison botanists. 
/:cl:

