### PR TITLE
Security Gas Masks no longer have the FOV effect

### DIFF
--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	var/safety = TRUE
 
 /obj/item/clothing/mask/gas/sechailer/init_fov()
-  return
+	return
 
 /obj/item/clothing/mask/gas/sechailer/swat
 	name = "\improper SWAT mask"

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -62,6 +62,9 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	var/broken_hailer = FALSE
 	var/safety = TRUE
 
+/obj/item/clothing/mask/gas/sechailer/init_fov()
+  return
+
 /obj/item/clothing/mask/gas/sechailer/swat
 	name = "\improper SWAT mask"
 	desc = "A close-fitting tactical mask with an especially aggressive Compli-o-nator 3000."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

After a lot of arguing with maintainers for a solid thirty minutes, it's finally here. This uses the init_call to prevent the FOV effect happening in security gas masks (this same init is called for the Clown and Mime masks, and I believe it is much similar to the tint=0 edit that Ghilker had to do before we killed that implementation of tint).

Fixes #63531.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

IT DOESN'T COVER YOUR EYES WHY WOULD THIS TRIGGER THE FOV I CAN SEE SIR PLEASE COME ON 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
fix: Security Gas Masks now no longer trigger the FOV effect. Anti-coners shall rejoice.
/:cl: