### PR TITLE
Makes donksofts consistent with the rest of the vending machines.

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -513,8 +513,10 @@
 	var/static/list/vending_names_paths = list(
 		/obj/machinery/vending/boozeomat = "Booze-O-Mat",
 		/obj/machinery/vending/coffee = "Solar's Best Hot Drinks",
+		/obj/machinery/vending/donksofttoyvendor = "Donksoft Toy Vendor",
 		/obj/machinery/vending/snack = "Getmore Chocolate Corp",
 		/obj/machinery/vending/cola = "Robust Softdrinks",
+		/obj/machinery/vending/toyliberationstation = "Syndicate Donksoft Toy Vendor",
 		/obj/machinery/vending/cigarette = "ShadyCigs Deluxe",
 		/obj/machinery/vending/games = "\improper Good Clean Fun",
 		/obj/machinery/vending/autodrobe = "AutoDrobe",
@@ -553,7 +555,8 @@
 		/obj/machinery/vending/security = "SecTech",
 		/obj/machinery/vending/modularpc = "Deluxe Silicate Selections",
 		/obj/machinery/vending/tool = "YouTool",
-		/obj/machinery/vending/custom = "Custom Vendor")
+		/obj/machinery/vending/custom = "Custom Vendor",
+	)
 
 /obj/item/circuitboard/machine/vendor/screwdriver_act(mob/living/user, obj/item/tool)
 	var/static/list/display_vending_names_paths
@@ -577,19 +580,10 @@
 			break
 	return ..()
 
-/obj/item/circuitboard/machine/vending/donksofttoyvendor
-	name = "Donksoft Toy Vendor (Machine Board)"
-	build_path = /obj/machinery/vending/donksofttoyvendor
-	req_components = list(
-		/obj/item/stack/sheet/glass = 1,
-		/obj/item/vending_refill/donksoft = 1)
-
-/obj/item/circuitboard/machine/vending/syndicatedonksofttoyvendor
-	name = "Syndicate Donksoft Toy Vendor (Machine Board)"
-	build_path = /obj/machinery/vending/toyliberationstation
-	req_components = list(
-		/obj/item/stack/sheet/glass = 1,
-		/obj/item/vending_refill/donksoft = 1)
+///Used to print donksoft toy vendors through illegal tech.
+/obj/item/circuitboard/machine/vendor/donksofttoyvendor/Initialize(mapload)
+	. = ..()
+	set_type(/obj/machinery/vending/donksofttoyvendor)
 
 /obj/item/circuitboard/machine/bountypad
 	name = "Civilian Bounty Pad (Machine Board)"

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -528,7 +528,7 @@
 	name = "Machine Design (Donksoft Toy Vendor Board)"
 	desc = "The circuit board for a Donksoft Toy Vendor."
 	id = "donksofttoyvendor"
-	build_path = /obj/item/circuitboard/machine/vending/donksofttoyvendor
+	build_path = /obj/item/circuitboard/machine/vendor/donksofttoyvendor
 	category = list ("Misc. Machinery")
 
 

--- a/code/modules/vending/liberation_toy.dm
+++ b/code/modules/vending/liberation_toy.dm
@@ -35,5 +35,5 @@
 	light_mask = "donksoft-light-mask"
 
 /obj/item/vending_refill/syndicate_donksoft
-	machine_name = "Donksoft Toy Vendor"
+	machine_name = "Syndicate Donksoft Toy Vendor"
 	icon_state = "refill_donksoft"

--- a/code/modules/vending/liberation_toy.dm
+++ b/code/modules/vending/liberation_toy.dm
@@ -6,7 +6,6 @@
 	product_slogans = "Get your cool toys today!;Trigger a valid hunter today!;Quality toy weapons for cheap prices!;Give them to HoPs for all access!;Give them to HoS to get permabrigged!"
 	product_ads = "Feel robust with your toys!;Express your inner child today!;Toy weapons don't kill people, but valid hunters do!;Who needs responsibilities when you have toy weapons?;Make your next murder FUN!"
 	vend_reply = "Come back for more!"
-	circuit = /obj/item/circuitboard/machine/vending/syndicatedonksofttoyvendor
 	products = list(
 		/obj/item/gun/ballistic/automatic/toy/unrestricted = 10,
 		/obj/item/gun/ballistic/automatic/pistol/toy = 10,
@@ -29,8 +28,12 @@
 	)
 	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 100, ACID = 50)
 	resistance_flags = FIRE_PROOF
-	refill_canister = /obj/item/vending_refill/donksoft
+	refill_canister = /obj/item/vending_refill/syndicate_donksoft
 	default_price = PAYCHECK_HARD
 	extra_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_SRV
 	light_mask = "donksoft-light-mask"
+
+/obj/item/vending_refill/syndicate_donksoft
+	machine_name = "Donksoft Toy Vendor"
+	icon_state = "refill_donksoft"

--- a/code/modules/vending/toys.dm
+++ b/code/modules/vending/toys.dm
@@ -7,7 +7,6 @@
 	product_ads = "Feel robust with your toys!;Express your inner child today!;Toy weapons don't kill people, but valid hunters do!;Who needs responsibilities when you have toy weapons?;Make your next murder FUN!"
 	vend_reply = "Come back for more!"
 	light_mask = "donksoft-light-mask"
-	circuit = /obj/item/circuitboard/machine/vending/donksofttoyvendor
 	products = list(
 		/obj/item/gun/ballistic/automatic/toy/unrestricted = 10,
 		/obj/item/gun/ballistic/automatic/pistol/toy = 10,


### PR DESCRIPTION
## About The Pull Request

- adds a new donksoft refill unit for the syndicate version
- changes donksofts to use the new vending system

## Why It's Good For The Game

Donksoft vendors are subtypes of ``/obj/item/circuitboard/machine/vending``, something that DOESN'T EXIST.
This makes it more consistent with the rest, and to prevent getting the syndicate version being gained through smuggler satchels, made a new subtype of the refill unit for them.

## Changelog

:cl:
fix: Donksoft vendors are now consistent with the other vending machines, therefore you can now screwdriver machines to relabel them to Donksoft and vice versa.
/:cl: