### PR TITLE
makes staff's balloon alert over the user instead of the wand

### DIFF
--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -75,7 +75,7 @@
 	. = ..()
 	if(!is_wizard_or_friend(user))
 		to_chat(user, span_hypnophrase("<span style='font-size: 24px'>The staff feels weaker as you touch it</span>"))
-		balloon_alert(user, "the staff feels weaker as you touch it")
+		user.balloon_alert(user, "the staff feels weaker as you touch it")
 
 /obj/item/gun/magic/staff/healing/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

When a non-wiz picks up a staff, you get a balloon alert that it feels weak.
One problem:
![image](https://user-images.githubusercontent.com/53777086/146959395-e240966c-b80a-46ce-8bf8-a55644283478.png)

## Why It's Good For The Game

Bug fix, balloon alert now works properly.
Closes https://github.com/tgstation/tgstation/issues/62477

## Changelog

:cl:
fix: Balloon alerts when picking up staffs as a non wizard now properly appears over the player's head.
/:cl: