### PR TITLE
Mops no longer wet the turf when you refill them from the mop bucket

### DIFF
--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -20,6 +20,7 @@
 			to_chat(user, span_notice("You wet [I] in [src]."))
 			playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
 			update_appearance()
+		return TRUE //Stop the click handling chain so the mop after attack doesn't proc and you don't wet the turf the bucket is on
 	else
 		. = ..()
 		update_appearance()


### PR DESCRIPTION
We stop the afterattack chain proccing by returning true from attackby.

:cl:
fix: Fixed mops wetting the turf when you refill them from the mop bucket I'm oranges and I don't put changelogs on my PRs
/:cl: