### PR TITLE
Exploration Drone Launcher code update + hard-del (and other) fixes

### DIFF
--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -367,13 +367,14 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 		return ..()
 
 /obj/machinery/exodrone_launcher/crowbar_act(mob/living/user, obj/item/I)
-	. = ..()
-	if(fuel_canister)
-		to_chat(user, span_notice("You remove the fuel tank from [src]."))
-		fuel_canister.forceMove(drop_location())
-		fuel_canister = null
-		update_appearance(UPDATE_ICON)
-		return TRUE
+	if(!fuel_canister)
+		return
+
+	to_chat(user, span_notice("You remove the fuel tank from [src]."))
+	fuel_canister.forceMove(drop_location())
+	fuel_canister = null
+	update_appearance(UPDATE_ICON)
+	return TRUE
 
 /obj/machinery/exodrone_launcher/Destroy()
 	. = ..()

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -342,6 +342,7 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 /// Exploration drone launcher
 /obj/machinery/exodrone_launcher
 	name = "exploration drone launcher"
+	desc = "A launch pad designed to launch exploration drones into the great beyond."
 	icon = 'icons/obj/exploration.dmi'
 	icon_state = "launcher"
 	/// Loaded fuel pellet.
@@ -351,34 +352,36 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 	. = ..()
 	GLOB.exodrone_launchers += src
 
-/obj/machinery/exodrone_launcher/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/fuel_pellet))
+/obj/machinery/exodrone_launcher/attackby(obj/item/weapon, mob/living/user, params)
+	if(istype(weapon, /obj/item/fuel_pellet))
 		if(fuel_canister)
-			to_chat(user, span_warning("There's already a fuel tank inside [src]!"))
+			to_chat(user, span_warning("There's already fuel loaded inside [src]!"))
 			return TRUE
-		if(!user.transferItemToLoc(I, src))
+		if(!user.transferItemToLoc(weapon, src))
 			return
-		fuel_canister = I
+		fuel_canister = weapon
 		update_icon()
 		return TRUE
-	else if(istype(I,/obj/item/exodrone) && user.transferItemToLoc(I, drop_location()))
-		return TRUE
-	else
-		return ..()
 
-/obj/machinery/exodrone_launcher/crowbar_act(mob/living/user, obj/item/I)
+	if(istype(weapon, /obj/item/exodrone) && user.transferItemToLoc(weapon, drop_location()))
+		return TRUE
+
+	return ..()
+
+/obj/machinery/exodrone_launcher/crowbar_act(mob/living/user, obj/item/crowbar)
 	if(!fuel_canister)
 		return
 
-	to_chat(user, span_notice("You remove the fuel tank from [src]."))
+	to_chat(user, span_notice("You remove [fuel_canister] from [src]."))
 	fuel_canister.forceMove(drop_location())
 	fuel_canister = null
-	update_appearance(UPDATE_ICON)
+	update_icon()
 	return TRUE
 
 /obj/machinery/exodrone_launcher/Destroy()
-	. = ..()
 	GLOB.exodrone_launchers -= src
+	fuel_canister = null
+	return ..()
 
 /obj/machinery/exodrone_launcher/update_overlays()
 	. = ..()
@@ -391,6 +394,9 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 			if(FUEL_EXOTIC)
 				. += "launchpad_fuel_exotic"
 
+/*
+ * Gets the fuel travel coefficient for what type of fuel is within the launcher.
+ */
 /obj/machinery/exodrone_launcher/proc/get_fuel_coefficent()
 	if(!fuel_canister)
 		return
@@ -402,10 +408,19 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 		if(FUEL_EXOTIC)
 			return EXOTIC_FUEL_TIME_COST
 
+/*
+ * Use up some of the fuel within the launcher to power the drone.
+ *
+ * drone - the drone that's being fuelled by our launcher.
+ */
 /obj/machinery/exodrone_launcher/proc/fuel_up(obj/item/exodrone/drone)
 	drone.travel_cost_coeff = get_fuel_coefficent()
 	fuel_canister.use()
+	update_icon()
 
+/*
+ * Plays an effect on the pad, with a sound effect to boot.
+ */
 /obj/machinery/exodrone_launcher/proc/launch_effect()
 	playsound(src,'sound/effects/podwoosh.ogg',50, FALSE)
 	do_smoke(1,get_turf(src))
@@ -428,15 +443,17 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 
 /obj/item/fuel_pellet
 	name = "standard fuel pellet"
-	desc = "compressed fuel pellet for long-distance flight"
+	desc = "A compressed fuel pellet for long-distance drone flight."
 	icon = 'icons/obj/exploration.dmi'
 	icon_state = "fuel_basic"
+	/// The type of fuel this pellet has within.
 	var/fuel_type = FUEL_BASIC
+	/// The amount of uses left in this fuel pellet.
 	var/uses = 5
 
 /obj/item/fuel_pellet/use()
 	uses--
-	if(uses < 0)
+	if(uses <= 0)
 		qdel(src)
 
 /obj/item/fuel_pellet/advanced

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -380,7 +380,7 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 
 /obj/machinery/exodrone_launcher/Destroy()
 	GLOB.exodrone_launchers -= src
-	fuel_canister = null
+	QDEL_NULL(fuel_canister)
 	return ..()
 
 /obj/machinery/exodrone_launcher/update_overlays()

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -342,7 +342,7 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 /// Exploration drone launcher
 /obj/machinery/exodrone_launcher
 	name = "exploration drone launcher"
-	desc = "A launch pad designed to launch exploration drones into the great beyond."
+	desc = "A launch pad designed to send exploration drones into the great beyond."
 	icon = 'icons/obj/exploration.dmi'
 	icon_state = "launcher"
 	/// Loaded fuel pellet.

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -372,6 +372,8 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 		to_chat(user, span_notice("You remove the fuel tank from [src]."))
 		fuel_canister.forceMove(drop_location())
 		fuel_canister = null
+		update_appearance(UPDATE_ICON)
+		return TRUE
 
 /obj/machinery/exodrone_launcher/Destroy()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

- Fixes exploration drone launcher overlays not being updated properly when fuel is consumed / changes
- Fixes crowbarring out a fuel pellet not updating the sprite, also fixes crowbarring out a fuel pellet after-attacking the exo-drone launcher
- Fixes fuel pellets not getting deleted when empty
- Fixes exploration drone launchers hard-delling if broken with a fuel pellet within
- Corrected fuel pellet description grammer, and added a proper description to the exodrone launcher
- Improved the code + documentation in general (early returns, better vars)

## Why It's Good For The Game

Fuel pellets are very obtuse when working on exploration drones. Hopefully, a few of these fixes helps some of those clear up.

When fuel pellets run out of uses, they're intended to delete, but never did - meaning you held around a buncha empty fuel.
Trying to replace the fuel pellets was very confusing as the icon didn't update properly.

## Changelog

:cl: Melbert
fix: Exo-drone fuel pellets delete when empty.
fix: Exo-drone launchers now update their icon correctly when adding / removing fuel. Removing fuel with a crowbar also doesn't smack the launcher when done.
fix: Fixes a hard-del with the exo-drone launcher. 
/:cl:
