### PR TITLE
Krav maga message display adjustment

### DIFF
--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -172,7 +172,7 @@
 		playsound(defender, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
 		defender.apply_damage(rand(10, 15), STAMINA, affecting, armor_block)
 		log_combat(attacker, defender, "stomped nonlethally")
-	if(prob(defender.getStaminaLoss()) && !defender.stat >= UNCONSCIOUS)
+	if(prob(defender.getStaminaLoss()) && defender.stat < UNCONSCIOUS)
 		defender.visible_message(span_warning("[defender] sputters and recoils in pain!"), span_userdanger("You recoil in pain as you are jabbed in a nerve!"))
 		defender.drop_all_held_items()
 	return TRUE

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -67,114 +67,114 @@
 	legsweep.Remove(owner)
 	lungpunch.Remove(owner)
 
-/datum/martial_art/krav_maga/proc/check_streak(mob/living/A, mob/living/D)
+/datum/martial_art/krav_maga/proc/check_streak(mob/living/attacker, mob/living/defender)
 	switch(streak)
 		if("neck_chop")
 			streak = ""
-			neck_chop(A,D)
+			neck_chop(attacker, defender)
 			return TRUE
 		if("leg_sweep")
 			streak = ""
-			leg_sweep(A,D)
+			leg_sweep(attacker, defender)
 			return TRUE
 		if("quick_choke")//is actually lung punch
 			streak = ""
-			quick_choke(A,D)
+			quick_choke(attacker, defender)
 			return TRUE
 	return FALSE
 
-/datum/martial_art/krav_maga/proc/leg_sweep(mob/living/A, mob/living/D)
-	if(D.stat || D.IsParalyzed())
+/datum/martial_art/krav_maga/proc/leg_sweep(mob/living/attacker, mob/living/defender)
+	if(defender.stat || defender.IsParalyzed())
 		return FALSE
-	var/obj/item/bodypart/affecting = D.get_bodypart(BODY_ZONE_CHEST)
-	var/armor_block = D.run_armor_check(affecting, MELEE)
-	D.visible_message(span_warning("[A] leg sweeps [D]!"), \
-					span_userdanger("Your legs are sweeped by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, A)
-	to_chat(A, span_danger("You leg sweep [D]!"))
-	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
-	D.apply_damage(rand(20,30), STAMINA, affecting, armor_block)
-	D.Knockdown(60)
-	log_combat(A, D, "leg sweeped")
+	var/obj/item/bodypart/affecting = defender.get_bodypart(BODY_ZONE_CHEST)
+	var/armor_block = defender.run_armor_check(affecting, MELEE)
+	defender.visible_message(span_warning("[attacker] leg sweeps [defender]!"), \
+					span_userdanger("Your legs are sweeped by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
+	to_chat(attacker, span_danger("You leg sweep [defender]!"))
+	playsound(get_turf(attacker), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
+	defender.apply_damage(rand(20, 30), STAMINA, affecting, armor_block)
+	defender.Knockdown(60)
+	log_combat(attacker, defender, "leg sweeped")
 	return TRUE
 
-/datum/martial_art/krav_maga/proc/quick_choke(mob/living/A, mob/living/D)//is actually lung punch
-	D.visible_message(span_warning("[A] pounds [D] on the chest!"), \
-					span_userdanger("Your chest is slammed by [A]! You can't breathe!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-	to_chat(A, span_danger("You pound [D] on the chest!"))
-	playsound(get_turf(A), 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-	if(D.losebreath <= 10)
-		D.losebreath = clamp(D.losebreath + 5, 0, 10)
-	D.adjustOxyLoss(10)
-	log_combat(A, D, "quickchoked")
+/datum/martial_art/krav_maga/proc/quick_choke(mob/living/attacker, mob/living/defender)//is actually lung punch
+	defender.visible_message(span_warning("[attacker] pounds [defender] on the chest!"), \
+					span_userdanger("Your chest is slammed by [attacker]! You can't breathe!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+	to_chat(attacker, span_danger("You pound [defender] on the chest!"))
+	playsound(get_turf(attacker), 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
+	if(defender.losebreath <= 10)
+		defender.losebreath = clamp(defender.losebreath + 5, 0, 10)
+	defender.adjustOxyLoss(10)
+	log_combat(attacker, defender, "quickchoked")
 	return TRUE
 
-/datum/martial_art/krav_maga/proc/neck_chop(mob/living/A, mob/living/D)
-	D.visible_message(span_warning("[A] karate chops [D]'s neck!"), \
-					span_userdanger("Your neck is karate chopped by [A], rendering you unable to speak!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-	to_chat(A, span_danger("You karate chop [D]'s neck, rendering [D.p_them()] unable to speak!"))
-	playsound(get_turf(A), 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-	D.apply_damage(5, A.get_attack_type())
-	if (iscarbon(D))
-		var/mob/living/carbon/carbon_defender = D
+/datum/martial_art/krav_maga/proc/neck_chop(mob/living/attacker, mob/living/defender)
+	defender.visible_message(span_warning("[attacker] karate chops [defender]'s neck!"), \
+					span_userdanger("Your neck is karate chopped by [attacker], rendering you unable to speak!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+	to_chat(attacker, span_danger("You karate chop [defender]'s neck, rendering [defender.p_them()] unable to speak!"))
+	playsound(get_turf(attacker), 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
+	defender.apply_damage(5, attacker.get_attack_type())
+	if (iscarbon(defender))
+		var/mob/living/carbon/carbon_defender = defender
 		if(carbon_defender.silent <= 10)
 			carbon_defender.silent = clamp(carbon_defender.silent + 10, 0, 10)
-	log_combat(A, D, "neck chopped")
+	log_combat(attacker, defender, "neck chopped")
 	return TRUE
 
-/datum/martial_art/krav_maga/grab_act(mob/living/A, mob/living/D)
-	if(check_streak(A,D))
+/datum/martial_art/krav_maga/grab_act(mob/living/attacker, mob/living/defender)
+	if(check_streak(attacker, defender))
 		return TRUE
-	log_combat(A, D, "grabbed (Krav Maga)")
+	log_combat(attacker, defender, "grabbed (Krav Maga)")
 	..()
 
-/datum/martial_art/krav_maga/harm_act(mob/living/A, mob/living/D)
-	if(check_streak(A,D))
+/datum/martial_art/krav_maga/harm_act(mob/living/attacker, mob/living/defender)
+	if(check_streak(attacker, defender))
 		return TRUE
-	log_combat(A, D, "punched")
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
-	var/armor_block = D.run_armor_check(affecting, MELEE)
+	log_combat(attacker, defender, "punched")
+	var/obj/item/bodypart/affecting = defender.get_bodypart(ran_zone(attacker.zone_selected))
+	var/armor_block = defender.run_armor_check(affecting, MELEE)
 	var/picked_hit_type = pick("punch", "kick")
 	var/bonus_damage = 0
-	if(D.body_position == LYING_DOWN)
+	if(defender.body_position == LYING_DOWN)
 		bonus_damage += 5
 		picked_hit_type = "stomp"
-	D.apply_damage(rand(5,10) + bonus_damage, A.get_attack_type(), affecting, armor_block)
+	defender.apply_damage(rand(5, 10) + bonus_damage, attacker.get_attack_type(), affecting, armor_block)
 	if(picked_hit_type == "kick" || picked_hit_type == "stomp")
-		A.do_attack_animation(D, ATTACK_EFFECT_KICK)
-		playsound(get_turf(D), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
+		attacker.do_attack_animation(defender, ATTACK_EFFECT_KICK)
+		playsound(get_turf(defender), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
 	else
-		A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-		playsound(get_turf(D), 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-	D.visible_message(span_danger("[A] [picked_hit_type]s [D]!"), \
-					span_userdanger("You're [picked_hit_type]ed by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-	to_chat(A, span_danger("You [picked_hit_type] [D]!"))
-	log_combat(A, D, "[picked_hit_type] with [name]")
+		attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
+		playsound(get_turf(defender), 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
+	defender.visible_message(span_danger("[attacker] [picked_hit_type]s [defender]!"), \
+					span_userdanger("You're [picked_hit_type]ed by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+	to_chat(attacker, span_danger("You [picked_hit_type] [defender]!"))
+	log_combat(attacker, defender, "[picked_hit_type] with [name]")
 	return TRUE
 
-/datum/martial_art/krav_maga/disarm_act(mob/living/A, mob/living/D)
-	if(check_streak(A,D))
+/datum/martial_art/krav_maga/disarm_act(mob/living/attacker, mob/living/defender)
+	if(check_streak(attacker, defender))
 		return TRUE
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
-	var/armor_block = D.run_armor_check(affecting, MELEE)
-	if(D.body_position == STANDING_UP)
-		D.visible_message(span_danger("[A] reprimands [D]!"), \
-					span_userdanger("You're slapped by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-		to_chat(A, span_danger("You jab [D]!"))
-		A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-		playsound(D, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-		D.apply_damage(rand(5,10), STAMINA, affecting, armor_block)
-		log_combat(A, D, "punched nonlethally")
-	if(D.body_position == LYING_DOWN)
-		D.visible_message(span_danger("[A] reprimands [D]!"), \
-					span_userdanger("You're manhandled by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-		to_chat(A, span_danger("You stomp [D]!"))
-		A.do_attack_animation(D, ATTACK_EFFECT_KICK)
-		playsound(D, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-		D.apply_damage(rand(10,15), STAMINA, affecting, armor_block)
-		log_combat(A, D, "stomped nonlethally")
-	if(prob(D.getStaminaLoss()))
-		D.visible_message(span_warning("[D] sputters and recoils in pain!"), span_userdanger("You recoil in pain as you are jabbed in a nerve!"))
-		D.drop_all_held_items()
+	var/obj/item/bodypart/affecting = defender.get_bodypart(ran_zone(attacker.zone_selected))
+	var/armor_block = defender.run_armor_check(affecting, MELEE)
+	if(defender.body_position == STANDING_UP)
+		defender.visible_message(span_danger("[attacker] reprimands [defender]!"), \
+					span_userdanger("You're slapped by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+		to_chat(attacker, span_danger("You jab [defender]!"))
+		attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
+		playsound(defender, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
+		defender.apply_damage(rand(5, 10), STAMINA, affecting, armor_block)
+		log_combat(attacker, defender, "punched nonlethally")
+	if(defender.body_position == LYING_DOWN)
+		defender.visible_message(span_danger("[attacker] reprimands [defender]!"), \
+					span_userdanger("You're manhandled by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+		to_chat(attacker, span_danger("You stomp [defender]!"))
+		attacker.do_attack_animation(defender, ATTACK_EFFECT_KICK)
+		playsound(defender, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
+		defender.apply_damage(rand(10, 15), STAMINA, affecting, armor_block)
+		log_combat(attacker, defender, "stomped nonlethally")
+	if(prob(defender.getStaminaLoss()) && !defender.stat >= UNCONSCIOUS)
+		defender.visible_message(span_warning("[defender] sputters and recoils in pain!"), span_userdanger("You recoil in pain as you are jabbed in a nerve!"))
+		defender.drop_all_held_items()
 	return TRUE
 
 //Krav Maga Gloves


### PR DESCRIPTION
## About The Pull Request

You wouldn't sputter and recoil in pain when heavily incapacitated or dead. (relevant code on ln 175)

Also very minor code tweaks like removing single letter vars, and a few commas without spaces after them.

## Why It's Good For The Game

Muh immersion.

## Changelog
:cl:
fix: Disarming a heavily incapacitated person with krav maga will no longer make them recoil in pain.
/:cl: