### PR TITLE
Fix AI restorer not deleting AIs when destroyed

### DIFF
--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -133,9 +133,8 @@
 /obj/machinery/computer/aifixer/Destroy()
 	if(occupier)
 		QDEL_NULL(occupier)
-	..()
+	return ..()
 
 /obj/machinery/computer/aifixer/on_deconstruction()
 	if(occupier)
 		QDEL_NULL(occupier)
-	..()

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -133,3 +133,4 @@
 /obj/machinery/computer/aifixer/on_deconstruction()
 	if(occupier)
 		QDEL_NULL(occupier)
+	..()

--- a/code/game/machinery/computer/aifixer.dm
+++ b/code/game/machinery/computer/aifixer.dm
@@ -130,6 +130,11 @@
 		else if (!occupier)
 			to_chat(user, span_alert("ERROR: Unable to locate artificial intelligence."))
 
+/obj/machinery/computer/aifixer/Destroy()
+	if(occupier)
+		QDEL_NULL(occupier)
+	..()
+
 /obj/machinery/computer/aifixer/on_deconstruction()
 	if(occupier)
 		QDEL_NULL(occupier)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #42262

The AI restorer computer now destroys the AI inside it if the computer is destroyed for whatever reason.  Please note that this computer is different from the modular one.  The AI card does not get inserted into the computer, rather the AI gets downloaded to the computer so it is not possible to return the AI to the card. (the modular one has the card inserted)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

One more bug down.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix AIs inside a AI restorer computer now die if the computer is destroyed while they are inside it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
