### PR TITLE
Suicided bodies can be used for brain transplants (and other brain-suicide interaction fixes)

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -56,7 +56,12 @@
 		else
 			C.key = brainmob.key
 
+		C.set_suicide(brainmob.suiciding)
+
 		QDEL_NULL(brainmob)
+
+	else
+		C.set_suicide(suicided)
 
 	for(var/X in traumas)
 		var/datum/brain_trauma/BT = X


### PR DESCRIPTION
Non-suicide brains put into suicide bodies will mark the body as no longer a suicide. This means that non-suicide brains put into suicided bodies can be revived. Conversely, suicided brains put into non-suicided bodies are visibly shown as suicided, and therefore unreviveable.

## Why It's Good For The Game

Fixes #62409

## Changelog

:cl:
fix: Non-suicided brains put into suicided bodies will no longer be marked as suicided. Consequentially, said suicided bodies can be used for brain transplants.
/:cl:
