### PR TITLE
Binary key no longer tells players to shout at coders

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -11,15 +11,18 @@
 
 /obj/item/encryptionkey/Initialize(mapload)
 	. = ..()
-	if(!channels.len)
-		desc = "An encryption key for a radio headset.  Has no special codes in it. You should probably tell a coder!"
+	if(!channels.len && !translate_binary)
+		desc += " Has no special codes in it. You should probably tell a coder!"
 
 /obj/item/encryptionkey/examine(mob/user)
 	. = ..()
-	if(LAZYLEN(channels))
+	if(LAZYLEN(channels) || translate_binary)
 		var/list/examine_text_list = list()
 		for(var/i in channels)
 			examine_text_list += "[GLOB.channel_tokens[i]] - [lowertext(i)]"
+
+		if(translate_binary)
+			examine_text_list += "[GLOB.channel_tokens[MODE_BINARY]] - [MODE_BINARY]"
 
 		. += span_notice("It can access the following channels; [jointext(examine_text_list, ", ")].")
 


### PR DESCRIPTION
## About The Pull Request

The binary encryption key no longer erroneously tells examiners to yell at coders.

It instead now tells the examiner how to access the binary channel, like other encryption keys do for their channels.

## Why It's Good For The Game

Not really sure how it's been 4 years and a commonly purchased traitor item has had a "yell at coders" description that no one's reported. Maybe they thought it was intended? 

## Changelog

:cl: Melbert
fix: Updated the binary key's description / examine text to actually describe its abilities.
/:cl:
