### PR TITLE
Fixes zombie powder

### DIFF
--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -557,7 +557,7 @@
 		tod = null
 
 /// Induces fake death on a living mob.
-/mob/living/proc/fakedeath(source, comatose = FALSE, silent = FALSE)
+/mob/living/proc/fakedeath(source, silent = FALSE)
 	if(stat == DEAD)
 		return
 	if(!silent)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -556,8 +556,8 @@
 	if(stat != DEAD)
 		tod = null
 
-
-/mob/living/proc/fakedeath(source, silent = FALSE)
+/// Induces fake death on a living mob.
+/mob/living/proc/fakedeath(source, comatose = FALSE, silent = FALSE)
 	if(stat == DEAD)
 		return
 	if(!silent)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -40,7 +40,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/datum/reagents/holder = null
 	/// LIQUID, SOLID, GAS
 	var/reagent_state = LIQUID
-	/// special data associated with this like viruses etc
+	/// Special data associated with the reagent that will be passed on upon transfer to a new holder.
 	var/list/data
 	/// increments everytime on_mob_life is called
 	var/current_cycle = 0

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -225,31 +225,30 @@
 	toxpwr = 0.5
 	taste_description = "death"
 	penetrates_skin = NONE
-	var/fakedeath_active = FALSE
 	ph = 13
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/toxin/zombiepowder/on_mob_metabolize(mob/living/L)
-	..()
-	ADD_TRAIT(L, TRAIT_FAKEDEATH, type)
-	if(fakedeath_active)
-		L.fakedeath(type)
-
-/datum/reagent/toxin/zombiepowder/on_mob_end_metabolize(mob/living/L)
-	L.cure_fakedeath(type)
-	..()
-
-/datum/reagent/toxin/zombiepowder/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
+/datum/reagent/toxin/zombiepowder/on_mob_metabolize(mob/living/holder_mob)
 	. = ..()
-	exposed_mob.adjustOxyLoss(0.5*REM, 0)
-	if(methods & INGEST)
-		var/datum/reagent/toxin/zombiepowder/zombiepowder = exposed_mob.reagents.has_reagent(/datum/reagent/toxin/zombiepowder)
-		if(istype(zombiepowder))
-			zombiepowder.fakedeath_active = TRUE
+	holder_mob.adjustOxyLoss(0.5*REM, 0)
+	if(data?["method"] & INGEST)
+		holder_mob.fakedeath(type)
+
+/datum/reagent/toxin/zombiepowder/on_mob_end_metabolize(mob/living/holder_mob)
+	holder_mob.cure_fakedeath(type)
+	return ..()
+
+/datum/reagent/toxin/zombiepowder/on_transfer(atom/target_atom, methods, trans_volume)
+	. = ..()
+	var/datum/reagent/zombiepowder = target_atom.reagents.has_reagent(/datum/reagent/toxin/zombiepowder)
+	if(!zombiepowder || !(methods & INGEST))
+		return
+	LAZYINITLIST(zombiepowder.data)
+	zombiepowder.data["method"] |= INGEST
 
 /datum/reagent/toxin/zombiepowder/on_mob_life(mob/living/M, delta_time, times_fired)
 	..()
-	if(fakedeath_active)
+	if(HAS_TRAIT(M, TRAIT_FAKEDEATH) && HAS_TRAIT(M, TRAIT_DEATHCOMA))
 		return TRUE
 	switch(current_cycle)
 		if(1 to 5)
@@ -259,7 +258,6 @@
 		if(5 to 8)
 			M.adjustStaminaLoss(40 * REM * delta_time, 0)
 		if(9 to INFINITY)
-			fakedeath_active = TRUE
 			M.fakedeath(type)
 
 /datum/reagent/toxin/ghoulpowder


### PR DESCRIPTION
## About The Pull Request
Fixed zombie powder not working.
Fixes #54959

It doesn't work because `expose_mob` checks for the mob directly but not the stomach, when it fails to find one `fakedeath_active` on the reagent isn't updated and `on_mob_metabolize` will trigger without allowing the fakedeath proc to fire. Problem also arise if you continue to ingest more zombie powder while it is already metabolized, since it will set the `fakedeath` var to TRUE  bypassing the cycle switch to make you fall down after some ticks. A very funny case all around.

Probably should add a bit of information to the previous PR fixing this in case zombie powder breaks again in the future. It used to cause permastuns because there are cases when a mob was exposed, (previously) inducing fakedeath, but the powder never reached the liver, not allowing it to be metabolized and fatally, not allowing it to be end_metabolized.

Oh and you wont get the dead on medical hud thingy anymore while the reagent is metabolizing. Only when fakedeath has triggered.

## Why It's Good For The Game
Fix

## Changelog
:cl:
fix: fixed zombie powder not sleeping you on ingestion and on further ingestion.
/:cl: