### PR TITLE
Fixes zombie powder and stomach

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -244,6 +244,8 @@
 	exposed_mob.adjustOxyLoss(0.5*REM, 0)
 	if(methods & INGEST)
 		var/datum/reagent/toxin/zombiepowder/zombiepowder = exposed_mob?.getorganslot(ORGAN_SLOT_STOMACH).reagents.has_reagent(/datum/reagent/toxin/zombiepowder)
+		if(!istype(zombiepowder))
+			zombiepowder = exposed_mob.reagents.has_reagent(/datum/reagent/toxin/zombiepowder)
 		if(istype(zombiepowder))
 			zombiepowder.fakedeath_active = TRUE
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -243,7 +243,7 @@
 	. = ..()
 	exposed_mob.adjustOxyLoss(0.5*REM, 0)
 	if(methods & INGEST)
-		var/datum/reagent/toxin/zombiepowder/zombiepowder = exposed_mob.reagents.has_reagent(/datum/reagent/toxin/zombiepowder)
+		var/datum/reagent/toxin/zombiepowder/zombiepowder = exposed_mob?.getorganslot(ORGAN_SLOT_STOMACH).reagents.has_reagent(/datum/reagent/toxin/zombiepowder)
 		if(istype(zombiepowder))
 			zombiepowder.fakedeath_active = TRUE
 


### PR DESCRIPTION
Ingestable reagent get sent into stomach so the check needs to ask stomach too


:cl:

fix: Zombie powder now properly works when ingested

/:cl:
