### PR TITLE
Fixes bad hop path in mail

### DIFF
--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -76,7 +76,7 @@
 		undershirt = /datum/sprite_accessory/undershirt/ian
 
 //only pet worth reviving
-/datum/job/hop/get_mail_goodies(mob/recipient)
+/datum/job/head_of_personnel/get_mail_goodies(mob/recipient)
 	. = ..()
 	// Strange Reagent if the pet is dead.
 	for(var/mob/living/simple_animal/pet/dog/corgi/ian/staff_pet in GLOB.dead_mob_list)


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/53777086/147253435-c3d93a47-7335-4b1b-ad1a-cb440f2528c9.png)

## Why It's Good For The Game

``/datum/job/hop`` isn't real, they cant hurt you
``/datum/job/hop``:

## Changelog

:cl:
fix: The HoP will now get strange reagent in the mail if Ian is dead, as originally intended.
/:cl: