### PR TITLE
Miscellaneous projectile phasing fixes/tweaks + fixes a typo in the blastcannon projectile.

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -138,6 +138,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define PASSFLAPS (1<<9)
 #define PASSDOORS (1<<10)
 #define PASSVEHICLE (1<<11)
+#define PASSITEM (1<<12)
 
 //Movement Types
 #define GROUND (1<<0)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -5,6 +5,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	name = "item"
 	icon = 'icons/obj/items_and_weapons.dmi'
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
+	pass_flags_self = PASSITEM
 
 	/* !!!!!!!!!!!!!!! IMPORTANT !!!!!!!!!!!!!!
 

--- a/code/modules/projectiles/guns/special/blastcannon.dm
+++ b/code/modules/projectiles/guns/special/blastcannon.dm
@@ -294,8 +294,10 @@
 	icon_state = "blastwave"
 	damage = 0
 	nodamage = FALSE
+	flag = BOMB // Doesn't actually have any functional purpose. But it makes sense.
 	movement_type = FLYING
 	projectile_phasing = ALL // just blows up the turfs lmao
+	phasing_ignore_direct_target = TRUE // If we don't do this the blastcannon shot can be blocked by random items.
 	/// The maximum distance this will inflict [EXPLODE_DEVASTATE]
 	var/heavy_ex_range = 0
 	/// The maximum distance this will inflict [EXPLODE_HEAVY]
@@ -304,7 +306,7 @@
 	var/light_ex_range = 0
 
 /obj/projectile/blastwave/Initialize(mapload, heavy_ex_range, medium_ex_range, light_ex_range)
-	range = max(heavy_ex_range, medium_ex_range, light_range, 0)
+	range = max(heavy_ex_range, medium_ex_range, light_ex_range, 0)
 	src.heavy_ex_range = heavy_ex_range
 	src.medium_ex_range = medium_ex_range
 	src.light_ex_range = light_ex_range
@@ -323,7 +325,7 @@
 		SSexplosions.highturf += loc
 	else if(medium_ex_range)
 		SSexplosions.medturf += loc
-	else if(light_range)
+	else if(light_ex_range)
 		SSexplosions.lowturf += loc
 	else
 		qdel(src)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -587,7 +587,7 @@
  * Return PROJECTILE_DELETE_WITHOUT_HITTING to delete projectile without hitting at all!
  */
 /obj/projectile/proc/prehit_pierce(atom/A)
-	if((projectile_phasing & A.pass_flags_self) && (!phasing_ignore_direct_target || original != A))
+	if((projectile_phasing & A.pass_flags_self) && (phasing_ignore_direct_target || original != A))
 		return PROJECTILE_PIERCE_PHASE
 	if(projectile_piercing & A.pass_flags_self)
 		return PROJECTILE_PIERCE_HIT

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -11,7 +11,7 @@
 	icon_state = "gaussphase"
 	damage = 20
 	armour_penetration = 70
-	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
+	projectile_phasing =  PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
 
 // 7.62 (Nagant Rifle)
 

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -35,6 +35,7 @@
 	damage = 60
 	projectile_piercing = PASSMOB|PASSVEHICLE
 	projectile_phasing = ~(PASSMOB|PASSVEHICLE)
+	phasing_ignore_direct_target = TRUE
 	dismemberment = 0 //It goes through you cleanly.
 	paralyze = 0
 	breakthings = FALSE

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -33,8 +33,8 @@
 	name = "penetrator round"
 	icon_state = "gauss"
 	damage = 60
-	projectile_piercing = PASSMOB & PASSVEHICLE
-	projectile_phasing = (ALL & (~PASSMOB & ~PASSVEHICLE))
+	projectile_piercing = PASSMOB|PASSVEHICLE
+	projectile_phasing = ~(PASSMOB|PASSVEHICLE)
 	dismemberment = 0 //It goes through you cleanly.
 	paralyze = 0
 	breakthings = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Fixes a typo in the blastcannon projectile that made it use the `light_range` (how far it projects light) in place of the `light_ex_range` (the range at which it should apply the effects of a light explosion).
- Fixes an issue with projectile phasing when clicking on items.
  - Checking for phasing/penetration on directly targeted items was bugged in that for a projectile to phase/penetrate through something it had to share some flags with the targets `pass_flags_self`. For items this var is `NONE` and so directly clicking on an item makes the projectile hit it regardless of its phasing/penetrating state. This adds `PASSITEM` and gives it to items to fix this.
  - There was also a bug with the `phase_ignore_direct_target` check which made every projectile pass when it was `FALSE`. Since this contradicts the doc comment for the variable I have brought the behavior in line with the doc comment.
- Makes the blastcannon projectile pass through directly targeted objects as was intended.
- Unspaghettis some var definitions for phasing sniper rounds.
- Makes phasic carbine rounds actually use the projectile phasing system.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes blastcannon rounds to actually use the light explosion range they are provided with as they were intended to.
Makes accidentally clicking on a cigarette butt not eat 5-25 minutes of toxins work depending on your speed. (Cigarettes < Cuban Pete).
Makes the flag intended to make projectiles phase through their direct targets actually function as docced.
Brings phasic carbine rounds into compliance with the rest of the projectiles.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes blastcannons not actually having any light range regardless of the bomb they used.
fix: Fixes blastcannons being blocked by cigarette butts.
code: Unspaghettis some variable definitions.
code: Brings phasic carbine rounds into compliance with the rest of the projectiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
