### PR TITLE
Fixes abysmal signposting on a dangerous stage hazard in the Hot Springs Ice Box ruin.

### DIFF
--- a/code/modules/ruins/icemoonruin_code/hotsprings.dm
+++ b/code/modules/ruins/icemoonruin_code/hotsprings.dm
@@ -11,6 +11,12 @@
  */
 
 /turf/open/water/cursed_spring
+	name = "transforming spring"
+	color = "#CBC3E3"
+	light_color = "#CBC3E3"
+	light_range = 3
+	light_power = 1.75
+	light_on = TRUE
 	baseturfs = /turf/open/water/cursed_spring
 	planetary_atmos = TRUE
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS


### PR DESCRIPTION
## About The Pull Request

Fixes abysmal signposting on a dangerous stage hazard in the Hot Springs Ice Box ruin.

## Why It's Good For The Game

It is extremely easy to completely miss the note at this ruin explaining the water transforms you before you stumble in and turn into a cow or a chicken or a plasmaman by accident. The water now being purple and glowing illuminates the note, along with providing people who miss the note somehow/can't find the note due to someone moving it to know something might be up with the water.

Maintainer suggested:
![Discord_w6LkgytU2T](https://user-images.githubusercontent.com/4081722/147320922-3f255fa4-5caa-4379-82c9-4a71c1dc3388.png)

## Changelog

:cl:
fix: Fixes abysmal signposting on a dangerous stage hazard in the Hot Springs Ice Box ruin.
/:cl: