### PR TITLE
Add accessibility label, for the same GBP as a fix

### DIFF
--- a/.github/gbp.toml
+++ b/.github/gbp.toml
@@ -2,6 +2,7 @@ no_balance_label = "GBP: No Update"
 reset_label = "GBP: Reset"
 
 [points]
+"Accessibility" = 3
 "Administration" = 2
 "Atomic" = 2
 "Balance/Rebalance" = -8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Adds an Accessibility label. This label should be added for any feature that improves the experience for people with disabilities.

This includes, but is not limited to:
- Adding visual/auditory feedback for which there previously was none (such as adding a balloon alert where the only other feedback was a sound)
- Adding captions, such as to AI vox, ambience, etc
- Adding colorblind options, or otherwise making features not rely on colors (such as pipes, slimes, etc)
- Adding more keyboard navigation to UIs, such that a mouse is not as required
- Reducing flashing/bright lights for those with epilepsy

This *does not* include:
- General QoL, such as replacing chat messages with balloon alerts
- Making the game generally easier to do weird interactions with. This is considered bettering *approachability*, not necessarily *accessibility*

...though many changes that improve QoL can easily improve accessibility.

For further reading, [the Game Accessibility Guidelines](http://gameaccessibilityguidelines.com/) are a very interesting resource to go through.