### PR TITLE
Restores missing xmas tree on tram

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -37429,6 +37429,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/bar)
+"mbQ" = (
+/obj/effect/spawner/xmastree,
+/turf/open/floor/carpet,
+/area/service/chapel)
 "mcb" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -94278,7 +94282,7 @@ avP
 avP
 avP
 oOc
-avP
+mbQ
 avP
 avP
 avP


### PR DESCRIPTION
## About The Pull Request
Skyrockets tramstation's chaos factor by placing an xmas tree in Chapel.

## Why It's Good For The Game
makes the hell that is tramstation that much more bearable 
mmmiracles if that was your intent for tram to never have an xmas tree feel free to scream

## Changelog
:cl:
fix: plopped an xmas tree in tramsation's chapel
/:cl:
