### PR TITLE
Make tactical turtleneck dyeable

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -46,6 +46,7 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		DYE_RD = /obj/item/clothing/under/rank/rnd/research_director/skirt,
 		DYE_CMO = /obj/item/clothing/under/rank/medical/chief_medical_officer/skirt,
 		DYE_PRISONER = /obj/item/clothing/under/rank/prisoner/skirt,
+		DYE_SYNDICATE = /obj/item/clothing/under/syndicate/skirt,
 	),
 	DYE_REGISTRY_GLOVES = list(
 		DYE_RED = /obj/item/clothing/gloves/color/red,
@@ -127,7 +128,7 @@ GLOBAL_LIST_INIT(dye_registry, list(
 		DYE_SYNDICATE = /obj/item/bedsheet/syndie,
 		DYE_CENTCOM = /obj/item/bedsheet/centcom
 	),
-		DYE_REGISTRY_DOUBLE_BEDSHEET = list(
+	DYE_REGISTRY_DOUBLE_BEDSHEET = list(
 		DYE_RED = /obj/item/bedsheet/red/double,
 		DYE_ORANGE = /obj/item/bedsheet/orange/double,
 		DYE_YELLOW = /obj/item/bedsheet/yellow/double,

--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -8,6 +8,7 @@
 	alt_covers_chest = TRUE
 	icon = 'icons/obj/clothing/under/syndicate.dmi'
 	worn_icon = 'icons/mob/clothing/under/syndicate.dmi'
+	dying_key = DYE_REGISTRY_UNDER
 
 /obj/item/clothing/under/syndicate/skirt
 	name = "tactical skirtleneck"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does what it says on the tin.
Also makes it so you can dye a skirt into a tactical skritleneck.
Also fixes some indentation in `washing_machine.dm`.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fixes  #33653

According to the issue, it was intended that you should be able to do this. There is some value in allowing people to dispose of syndicate gear in a constructive way, and allowing traitors to waste a telecrystal to make a cool sweater.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Can now dye tactical turtlenecks (and skritlenecks) to other jumpsuits (or jumpskirts), and vice versa.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
