### PR TITLE
Removes stray <b> from cult objective

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -434,7 +434,7 @@
 	update_explanation_text()
 
 /datum/objective/eldergod/update_explanation_text()
-	explanation_text = "Summon Nar'Sie by invoking the rune 'Summon Nar'Sie'. <b>The summoning can only be accomplished in [english_list(summon_spots)] - where the veil is weak enough for the ritual to begin.</b>"
+	explanation_text = "Summon Nar'Sie by invoking the rune 'Summon Nar'Sie'. The summoning can only be accomplished in [english_list(summon_spots)] - where the veil is weak enough for the ritual to begin."
 
 /datum/objective/eldergod/check_completion()
 	if(killed)


### PR DESCRIPTION
## About The Pull Request

<b> and </b> here actually show up in game when looking at the objectives, which isn't what it's supposed to do. I don't see any reason to keep it around, either, ever since they were moved to the new antag ui.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/62934

## Changelog

:cl:
spellcheck: Removed a visible b> from Cult's objective text.
/:cl: