### PR TITLE
Fixes loading shells with their own initial circuits

### DIFF
--- a/code/modules/wiremod/components/admin/save_shell.dm
+++ b/code/modules/wiremod/components/admin/save_shell.dm
@@ -28,7 +28,12 @@
 
 /obj/item/circuit_component/save_shell/proc/on_post_load(datum/source)
 	SIGNAL_HANDLER
-	loaded_shell.AddComponent(/datum/component/shell, starting_circuit = parent)
+	var/datum/component/shell/shell_component = loaded_shell.GetComponent(/datum/component/shell)
+	if(!istype(shell_component))
+		loaded_shell.AddComponent(/datum/component/shell, starting_circuit = parent)
+	else
+		QDEL_NULL(shell_component.attached_circuit)
+		shell_component.attach_circuit(parent)
 	on_loaded.set_output(COMPONENT_SIGNAL)
 
 /obj/item/circuit_component/save_shell/proc/on_pre_save_to_json(datum/source, list/general_data)


### PR DESCRIPTION
## About The Pull Request

Attempting to load a BCI or circuit MODsuit module with the save shell component yields an empty circuit. This PR fixes that by making the save shell component check for and delete any pre-existing circuit in the loaded shell.

## Why It's Good For The Game

Reduces some of the hassle involved in loading certain kinds of admin circuits.

## Changelog

:cl:
admin: The Save Shell admin circuit component now properly loads circuits that use a BCI or MODsuit module as their shell.
/:cl:
