### PR TITLE
In Soviet Nanotransen, Tram consume you!

### DIFF
--- a/code/game/machinery/computer/tram_controls.dm
+++ b/code/game/machinery/computer/tram_controls.dm
@@ -4,7 +4,7 @@
 	icon_screen = "tram"
 	icon_keyboard = "atmos_key"
 	circuit = /obj/item/circuitboard/computer/tram_controls
-	flags_1 = NODECONSTRUCT_1 | SUPERMATTER_IGNORES_1 //What fun is it if we get consumed by the SM and can't move the tram anymore?
+	flags_1 = NODECONSTRUCT_1 | SUPERMATTER_IGNORES_1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 	light_color = LIGHT_COLOR_GREEN

--- a/code/game/machinery/computer/tram_controls.dm
+++ b/code/game/machinery/computer/tram_controls.dm
@@ -4,7 +4,7 @@
 	icon_screen = "tram"
 	icon_keyboard = "atmos_key"
 	circuit = /obj/item/circuitboard/computer/tram_controls
-	flags_1 = NODECONSTRUCT_1
+	flags_1 = NODECONSTRUCT_1 | SUPERMATTER_IGNORES_1 //What fun is it if we get consumed by the SM and can't move the tram anymore?
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
 	light_color = LIGHT_COLOR_GREEN

--- a/code/game/objects/structures/industrial_lift.dm
+++ b/code/game/objects/structures/industrial_lift.dm
@@ -6,6 +6,14 @@
 ///Collect and command
 /datum/lift_master
 	var/list/lift_platforms
+	var/list/ignored_smashthroughs = list(	//Typepath list of what to ignore smashing through, controls all lifts. Could be admemery?
+		/obj/machinery/power/supermatter_crystal,
+		/obj/structure/holosign
+	)
+
+/datum/lift_master/New(obj/structure/industrial_lift/lift_platform)
+	Rebuild_lift_plaform(lift_platform)
+	ignored_smashthroughs = typecacheof(ignored_smashthroughs)
 
 /datum/lift_master/Destroy()
 	for(var/l in lift_platforms)
@@ -14,8 +22,6 @@
 	lift_platforms = null
 	return ..()
 
-/datum/lift_master/New(obj/structure/industrial_lift/lift_platform)
-	Rebuild_lift_plaform(lift_platform)
 
 /datum/lift_master/proc/add_lift_platforms(obj/structure/industrial_lift/new_lift_platform)
 	if(new_lift_platform in lift_platforms)
@@ -234,7 +240,7 @@ GLOBAL_LIST_EMPTY(lifts)
 	else
 		destination = going
 	///handles any special interactions objects could have with the lift/tram, handled on the item itself	
-	SEND_SIGNAL(destination, COMSIG_TURF_INDUSTRIAL_LIFT_ENTER)
+	SEND_SIGNAL(destination, COMSIG_TURF_INDUSTRIAL_LIFT_ENTER, things_to_move)
 
 	if(istype(destination, /turf/closed/wall))
 		var/turf/closed/wall/C = destination
@@ -254,7 +260,7 @@ GLOBAL_LIST_EMPTY(lifts)
 		for(var/obj/structure/victim_structure in destination.contents)
 			if(QDELETED(victim_structure))
 				continue
-			if(!istype(victim_structure, /obj/structure/holosign) && victim_structure.layer >= LOW_OBJ_LAYER)
+			if(!is_type_in_typecache(victim_structure, lift_master_datum.ignored_smashthroughs) && victim_structure.layer >= LOW_OBJ_LAYER)
 				if(victim_structure.anchored && initial(victim_structure.anchored) == TRUE)
 					visible_message(span_danger("[src] smashes through [victim_structure]!"))
 					victim_structure.deconstruct(FALSE)
@@ -266,6 +272,8 @@ GLOBAL_LIST_EMPTY(lifts)
 		for(var/obj/machinery/victim_machine in destination.contents)
 			if(QDELETED(victim_machine))
 				continue
+			if(is_type_in_typecache(victim_machine, lift_master_datum.ignored_smashthroughs))
+				continue
 			if(istype(victim_machine, /obj/machinery/field)) //graceful break handles this scenario
 				continue
 			if(victim_machine.layer >= LOW_OBJ_LAYER) //avoids stuff that is probably flush with the ground
@@ -274,6 +282,8 @@ GLOBAL_LIST_EMPTY(lifts)
 				qdel(victim_machine)
 
 		for(var/mob/living/collided in destination.contents)
+			if(is_type_in_typecache(collided, lift_master_datum.ignored_smashthroughs))
+				continue
 			to_chat(collided, span_userdanger("[src] collides into you!"))
 			playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
 			var/damage = rand(5, 10)

--- a/code/game/objects/structures/industrial_lift.dm
+++ b/code/game/objects/structures/industrial_lift.dm
@@ -6,7 +6,8 @@
 ///Collect and command
 /datum/lift_master
 	var/list/lift_platforms
-	var/list/ignored_smashthroughs = list(	//Typepath list of what to ignore smashing through, controls all lifts. Could be admemery?
+	/// Typepath list of what to ignore smashing through, controls all lifts
+	var/list/ignored_smashthroughs = list(
 		/obj/machinery/power/supermatter_crystal,
 		/obj/structure/holosign
 	)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -487,12 +487,12 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	explode()
 
-//Consume things that run into the supermatter from the tram. The tram calls forceMove (doesn't call Bump/ed) and not Move, and I'm afraid changing it will do something chaotic
+/// Consume things that run into the supermatter from the tram. The tram calls forceMove (doesn't call Bump/ed) and not Move, and I'm afraid changing it will do something chaotic
 /obj/machinery/power/supermatter_crystal/proc/tram_contents_consume(datum/source, list/tram_contents)
 	SIGNAL_HANDLER
 
-	for(var/X in tram_contents)
-		Bumped(X)
+	for(var/atom/thing_to_consume as anything in tram_contents)
+		Bumped(thing_to_consume)
 
 /obj/machinery/power/supermatter_crystal/process_atmos()
 	if(!processes) //Just fuck me up bro

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -264,6 +264,11 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	AddElement(/datum/element/bsa_blocker)
 	RegisterSignal(src, COMSIG_ATOM_BSA_BEAM, .proc/call_explode)
 
+	var/static/list/loc_connections = list(
+		COMSIG_TURF_INDUSTRIAL_LIFT_ENTER = .proc/tram_contents_consume,
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)	//Speficially for the tram, hacky
+
 	soundloop = new(src, TRUE)
 	if(ispath(psyOverlay))
 		psyOverlay = new psyOverlay()
@@ -481,6 +486,13 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	SIGNAL_HANDLER
 
 	explode()
+
+//Consume things that run into the supermatter from the tram. The tram calls forceMove (doesn't call Bump/ed) and not Move, and I'm afraid changing it will do something chaotic
+/obj/machinery/power/supermatter_crystal/proc/tram_contents_consume(datum/source, list/tram_contents)
+	SIGNAL_HANDLER
+
+	for(var/X in tram_contents)
+		Bumped(X)
 
 /obj/machinery/power/supermatter_crystal/process_atmos()
 	if(!processes) //Just fuck me up bro


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stops the tram hilariously qdel-ing the SM, and now makes the SM consume the tram instead.

Adds a blacklist typepath var of things that all lifts/trams cannot interact with, which lift master datums use.
Also makes it so the tram control console cannot be consumed by the SM

## Why It's Good For The Game
Bug fix, but also this could be funny seeing someone drag the SM shard around

Turns this boring, sad thing...
![1](https://user-images.githubusercontent.com/26515331/147428211-d626e923-15bb-4e0a-8b3d-92d3e2469154.PNG)

Into this fun, exciting thing!
https://user-images.githubusercontent.com/26515331/147429544-ea0722bd-4a19-4404-bba9-3abb4fe5ad3f.mp4

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The tram can no longer consume and delete the Supermatter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
