### PR TITLE
Adds family objectives to the traitor panel (+ bonus fix)

### DIFF
--- a/code/modules/antagonists/gang/gang.dm
+++ b/code/modules/antagonists/gang/gang.dm
@@ -90,6 +90,7 @@
 	if(starter_gangster)
 		equip_gangster_in_inventory()
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/thatshowfamiliesworks.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
+	add_objectives()
 	..()
 
 /datum/antagonist/gang/on_removal()
@@ -115,6 +116,12 @@
 	if(starter_gangster)
 		package_spawner.Remove(owner.current)
 	..()
+
+/// Used to display gang objectives in the player's traitor panel
+/datum/antagonist/gang/proc/add_objectives()
+	var/datum/objective/objective = new ()
+	objective.explanation_text = my_gang.current_theme.gang_objectives[type]
+	objectives.Add(objective)
 
 /// Gives a gangster their equipment in their backpack and / or pockets.
 /datum/antagonist/gang/proc/equip_gangster_in_inventory()
@@ -284,9 +291,9 @@
 		/obj/item/clothing/under/suit/checkered,
 		/obj/item/toy/crayon/spraycan)
 	antag_hud_name = "Italian"
-	gang_team_type = /datum/team/gang/russian_mafia
+	gang_team_type = /datum/team/gang/italian_mob
 
-/datum/team/gang/russian_mafia/rename_gangster(datum/mind/gangster, original_name, starter_gangster)
+/datum/team/gang/italian_mob/rename_gangster(datum/mind/gangster, original_name, starter_gangster)
 	var/static/regex/last_name = new("\[^\\s-\]+$") //First word before whitespace or "-"
 	last_name.Find(original_name)
 	if(starter_gangster)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds family objectives to the traitor panel, and fixed a copy/paste error where Italian Mob got the Russian Mafia team datum. 
![image](https://user-images.githubusercontent.com/66640614/147446397-d4cc5cea-f229-4ec2-9433-ea2e7d3e29aa.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Easier for admins to tell what each player's family's objectives are without needing to use VV. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: italian mafioso now get their proper names
admin: admins can now view family objectives from the traitor panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
