### PR TITLE
Various suicide_act() things

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -79,3 +79,6 @@
 //from /mob/living/carbon/human/proc/check_shields(): (atom/hit_by, damage, attack_text, attack_type, armour_penetration)
 #define COMSIG_HUMAN_CHECK_SHIELDS "human_check_shields"
 	#define SHIELD_BLOCK (1<<0)
+
+///From mob/living/carbon/human/suicide()
+#define COMSIG_HUMAN_SUICIDE "human_suicide_act"

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -580,6 +580,25 @@
 	owner.forceMove(box)
 	owner.playsound_local(box, 'sound/misc/box_deploy.ogg', 50, TRUE)
 
+/datum/action/item_action/agent_box/Grant(mob/M)
+	..()
+	if(owner)
+		RegisterSignal(owner, COMSIG_HUMAN_SUICIDE, .proc/suicide_act)
+
+/datum/action/item_action/agent_box/Remove(mob/M)
+	if(owner)
+		UnregisterSignal(owner, COMSIG_HUMAN_SUICIDE)
+	..()
+
+/datum/action/item_action/agent_box/proc/suicide_act(datum/source)
+	if(istype(owner.loc, /obj/structure/closet/cardboard/agent))
+		var/obj/structure/closet/cardboard/agent/box = owner.loc
+		owner.playsound_local(box, 'sound/misc/box_deploy.ogg', 50, TRUE)
+		box.open()
+		owner.visible_message(span_suicide("[owner] falls out of [box]! It looks like [owner.p_they()] committed suicide!"))
+		owner.throw_at(get_turf(owner))
+		return OXYLOSS
+
 //Preset for spells
 /datum/action/spell_action
 	check_flags = NONE

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -75,6 +75,7 @@
 
 /obj/item/toy/crayon/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is jamming [src] up [user.p_their()] nose and into [user.p_their()] brain. It looks like [user.p_theyre()] trying to commit suicide!"))
+	user.add_atom_colour(paint_color)
 	return (BRUTELOSS|OXYLOSS)
 
 /obj/item/toy/crayon/Initialize(mapload)

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -108,3 +108,10 @@
 	if(!preserved_food)
 		AddComponent(/datum/component/decomposition, mapload, decomp_req_handle, decomp_flags = foodtypes, decomp_result = decomp_type, ant_attracting = ant_attracting)
 
+/obj/item/food/suicide_act(mob/user, show_message=TRUE)
+	if(show_message)
+		user.visible_message(span_suicide("[user] [pick("gobbles up", "consumes", "munches", "devours")] [src] in one bite! It looks like [user.p_theyre()] trying to commit suicide!"))
+	for(var/datum/reagent/R in reagents.reagent_list)
+		user.reagents.add_reagent(R.type, R.volume)
+	qdel(src)
+	return OXYLOSS

--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -297,6 +297,13 @@
 	foodtypes = GRAIN | MEAT | DAIRY
 	venue_value = FOOD_PRICE_EXOTIC
 
+/obj/item/food/burger/superbite/suicide_act(mob/user, show_message=TRUE)
+	user.visible_message(span_suicide("[user] starts to eat [src] in one bite, it looks like [user.p_theyre()] trying to commit suicide!"))
+	var/datum/component/edible/C = GetComponent(/datum/component/edible)
+	if(!C)
+		return OXYLOSS
+	C.TakeBite(user, user)
+
 /obj/item/food/burger/fivealarm
 	name = "five alarm burger"
 	desc = "HOT! HOT!"

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -445,6 +445,11 @@
 	/// The amount to metabolize per second
 	var/metabolization_amount = REAGENTS_METABOLISM / 2
 
+/obj/item/food/bubblegum/suicide_act(mob/user, show_message=FALSE)
+	user.visible_message(span_suicide("[user] swallows [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+	..()
+	return TOXLOSS
+
 /obj/item/food/bubblegum/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/chewable, metabolization_amount = metabolization_amount)
@@ -469,6 +474,7 @@
 	food_reagents = list(/datum/reagent/blood = 15)
 	tastes = list("hell" = 1)
 	metabolization_amount = REAGENTS_METABOLISM
+	var/list/hallucination_lines = list("I AM IMMORTAL.", "I SHALL TAKE YOUR WORLD.", "I SEE YOU.", "YOU CANNOT ESCAPE ME FOREVER.", "NOTHING CAN HOLD ME.")
 
 /obj/item/food/bubblegum/bubblegum/process()
 	. = ..()
@@ -499,9 +505,13 @@
 		return
 	if(prob(15))
 		new /datum/hallucination/oh_yeah(victim)
-		to_chat(victim, span_colossus("<b>[pick("I AM IMMORTAL.", "I SHALL TAKE YOUR WORLD.", "I SEE YOU.", "YOU CANNOT ESCAPE ME FOREVER.", "NOTHING CAN HOLD ME.")]</b>"))
+		to_chat(victim, span_colossus("<b>[pick(hallucination_lines)]</b>"))
 	else
 		to_chat(victim, span_warning("[pick("You hear faint whispers.", "You smell ash.", "You feel hot.", "You hear a roar in the distance.")]"))
+
+/obj/item/food/bubblegum/bubblegum/suicide_act(mob/user, show_message=FALSE)
+	. = ..()
+	user.say(";[pick(hallucination_lines)]")
 
 /obj/item/food/gumball
 	name = "gumball"

--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -24,7 +24,6 @@
 	. = ..()
 	go_invisible()
 
-
 /obj/structure/closet/cardboard/agent/open(mob/living/user, force = FALSE)
 	. = ..()
 	qdel(src)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -845,6 +845,14 @@
 	else
 		return ..()
 
+/obj/item/storage/box/clown/suicide_act(mob/user)
+	user.visible_message(span_suicide("[user] opens [src] and gets consumed by [src.p_them()]! It looks like [user.p_theyre()] trying to commit suicide!"))
+	playsound(user, 'sound/misc/scary_horn.ogg', 70, TRUE)
+	var/obj/item/clothing/head/mob_holder/M = new(src, user)
+	user.loc = M
+	M.desc = "It's [user.real_name]! It looks like they committed suicide!"
+	return OXYLOSS
+
 //////
 /obj/item/storage/box/hug/medical/PopulateContents()
 	new /obj/item/stack/medical/bruise_pack(src)

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -35,6 +35,25 @@
 	new /obj/item/stamp/law(src)
 	..()
 
+/obj/item/storage/briefcase/suicide_act(mob/user)
+	var/list/papers_found = list()
+	var/turf/T = get_turf(src)
+	for(var/atom/A in contents)
+		if(istype(A, /obj/item/paper) || istype(A, /obj/item/paperplane))
+			papers_found += A
+	if(!LAZYLEN(papers_found) || !T)
+		user.visible_message(span_suicide("[user] bashes [user.p_them()]self in the head with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+		return BRUTELOSS
+
+	user.visible_message(span_suicide("[user] opens [src] and all of [user.p_their()] papers fly out!"))
+	for(var/obj/item/I in papers_found)
+		I.throw_at(get_ranged_target_turf(T, pick(GLOB.modulo_angle_to_dir), 2))
+	sleep(1 SECONDS)
+	user.set_suicide(FALSE)	//Just temporary, because say() whispers if you're trying to suicide for some reason
+	user.say("ARGGHH, HOW WILL I GET THIS WORK DONE NOW?!!")
+	user.visible_message(span_suicide("[user] looks overwhelmed with paperwork! It looks like [user.p_theyre()] trying to commit suicide!"))
+	return OXYLOSS
+
 /obj/item/storage/briefcase/sniperbundle
 	desc = "Its label reads \"genuine hardened Captain leather\", but suspiciously has no other tags or branding. Smells like L'Air du Temps."
 	force = 10

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -80,6 +80,33 @@
 	if(use_charge)
 		return ..()
 
+/obj/item/melee/touch_attack/mansus_fist/suicide_act(mob/user)
+	. = FIRELOSS
+	user.visible_message(span_suicide("[user] covers [user.p_their()] face with [user.p_their()] sickly-looking hand! It looks like [user.p_theyre()] trying to commit suicide!"))
+	var/mob/living/carbon/C = user	//iscarbon already used in spell's parent
+	var/datum/antagonist/heretic/cultie = C.mind.has_antag_datum(/datum/antagonist/heretic)
+	var/list/knowledge = cultie.get_all_knowledge()
+	var/escape_our_torment = 0
+	while(C.stat == CONSCIOUS)
+		if(escape_our_torment > 20)	//Stops us from infinitely stunning ourselves if we're just not taking the damage
+			return
+		if(prob(70))
+			C.adjustFireLoss(20)
+			playsound(C, 'sound/effects/wounds/sizzle1.ogg', 70, TRUE)
+			if(prob(50))
+				C.emote("scream")
+				C.stuttering += 13
+
+		for(var/X in knowledge)
+			var/datum/eldritch_knowledge/EK = knowledge[X]
+			EK.on_mansus_grasp(C, C)
+
+		C.adjustBruteLoss(10)
+		C.AdjustKnockdown(5 SECONDS)
+		C.adjustStaminaLoss(80)
+		escape_our_torment++
+		sleep(0.4 SECONDS)
+
 /obj/effect/proc_holder/spell/aoe_turf/rust_conversion
 	name = "Aggressive Spread"
 	desc = "Spreads rust onto nearby surfaces."

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -35,8 +35,10 @@
 			return
 		set_suicide(TRUE) //need to be called before calling suicide_act as fuck knows what suicide_act will do with your suicider
 		var/obj/item/held_item = get_active_held_item()
-		if(held_item)
-			var/damagetype = held_item.suicide_act(src)
+		var/damagetype = SEND_SIGNAL(src, COMSIG_HUMAN_SUICIDE)
+		if(held_item || damagetype)
+			if(!damagetype && held_item)
+				damagetype = held_item.suicide_act(src)
 			if(damagetype)
 				if(damagetype & SHAME)
 					adjustStaminaLoss(200)

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -41,6 +41,20 @@
 	to_chat(user, span_warning("PZZTTPFFFT"))
 	desc = "[desc] The display is flickering slightly."
 
+/obj/item/clothing/glasses/hud/suicide_act(mob/user)
+	if(user.is_blind() || !isliving(user))
+		return ..()
+	var/mob/living/L = user
+	user.visible_message(span_suicide("[user] looks through [src] and looks overwhelmed with the information! It looks like [user.p_theyre()] trying to commit suicide!"))
+	if(L.getOrganLoss(ORGAN_SLOT_BRAIN) >= 150)
+		var/mob/thing = pick((/mob in view()) - user)
+		if(thing)
+			user.say("VALID MAN IS WANTER, ARREST HE!!")
+			user.pointed(thing)
+		else
+			user.say("WHY IS THERE A BAR ON MY HEAD?!!")
+	return OXYLOSS
+
 /obj/item/clothing/glasses/hud/health
 	name = "health scanner HUD"
 	desc = "A heads-up display that scans the humanoids in view and provides accurate data about their health status."

--- a/code/modules/clothing/head/tinfoilhat.dm
+++ b/code/modules/clothing/head/tinfoilhat.dm
@@ -24,6 +24,8 @@
 		QDEL_NULL(paranoia)
 	paranoia = new()
 
+	RegisterSignal(user, COMSIG_HUMAN_SUICIDE, .proc/suicide_act)
+
 	user.gain_trauma(paranoia, TRAUMA_RESILIENCE_MAGIC)
 	to_chat(user, span_warning("As you don the foiled hat, an entire world of conspiracy theories and seemingly insane ideas suddenly rush into your mind. What you once thought unbelievable suddenly seems.. undeniable. Everything is connected and nothing happens just by accident. You know too much and now they're out to get you. "))
 
@@ -49,6 +51,7 @@
 	if(!isliving(loc) || !paranoia)
 		return
 	var/mob/living/target = loc
+	UnregisterSignal(target, COMSIG_HUMAN_SUICIDE)
 	if(target.get_item_by_slot(ITEM_SLOT_HEAD) != src)
 		return
 	QDEL_NULL(paranoia)
@@ -67,3 +70,22 @@
 	. = ..()
 	if(!warped)
 		warp_up()
+
+/obj/item/clothing/head/foilhat/suicide_act(mob/living/user)
+	user.visible_message(span_suicide("[user] gets a crazed look in [user.p_their()] eyes! [capitalize(user.p_they())] [user.p_have()] witnessed the truth, and try to commit suicide!"))
+	var/conspiracy_line = pick(list(
+		";THEY'RE HIDING CAMERAS IN THE CEILINGS! THEY WITNESS EVERYTHING WE DO!!",
+		";HOW CAN I LIVE IN A WORLD WHERE MY FATE AND EXISTANCE IS DECIDED BY A GROUP OF INDIVIDUALS?!!",
+		";THEY'RE TOYING WITH ALL OF YOUR MINDS AND TREATING YOU AS EXPERIMENTS!!",
+		";THEY HIRE ASSISTANTS WITHOUT DOING BACKGROUND CHECKS!!",
+		";WE LIVE IN A ZOO AND WE ARE THE ONES BEING OBSERVED!!",
+		";WE REPEAT OUR LIVES DAILY WITHOUT FURTHER QUESTIONS!!"
+	))
+	user.say(conspiracy_line)
+	var/obj/item/organ/brain/B = user.getorganslot(ORGAN_SLOT_BRAIN)
+	if(B)
+		B.damage = BRAIN_DAMAGE_DEATH
+		user.death(FALSE)
+		user.ghostize(FALSE)
+		return MANUAL_SUICIDE
+	return OXYLOSS

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1969,6 +1969,9 @@
 /mob/living/proc/will_escape_storage()
 	return FALSE
 
+/mob/living/carbon/human/will_escape_storage()
+	return TRUE
+
 /// Sets the mob's hunger levels to a safe overall level. Useful for TRAIT_NOHUNGER species changes.
 /mob/living/proc/set_safe_hunger_level()
 	// Nutrition reset and alert clearing.

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -324,6 +324,12 @@
 				to_chat(user, span_warning("You don't have enough units of that chemical to modify the bee's DNA!"))
 	..()
 
+/obj/item/queen_bee/suicide_act(mob/user)
+	user.visible_message(span_suicide("[user] eats [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+	user.say("IT'S HIP TO EAT BEES!")
+	qdel(src)
+	return TOXLOSS
+
 /obj/item/queen_bee/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_QUEEN_BEE, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds suicide_act interactions with various items.
* Food can be eaten in one bite, except for the super bite burger
* The clown box eats you
* Magnus Grasp claws out your eyes
* Eating Bubblegum will make him scream out of you
* Become a true conspiracy nut with the tinfoil hat
* Show your love for work when the papers in your suitcase fly everywhere
* Be hip, eat a bee

Also adds a special case in calling a new signal that works on non-held items
* Fling yourself out of a stealth implant box
* That's about it, except the tinfoil hat is also the case here


Because why not?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

:cl:
add: Various items provide special texts when suiciding with them.
add: Unique text is shown when suiciding with food, a clown box, bubblegum, bubblegum bubblegum, bees, tinfoil hats, suitcases, Magnus's Grasp, and even when inside a stealth implant box.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
