### PR TITLE
Fixes admin deadsay not showing up for admins in the lobby

### DIFF
--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -27,9 +27,9 @@
 	var/rendered = "<span class='game deadsay'>[span_prefix("DEAD:")] [span_name("[rank_name]([admin_name])")] says, <span class='message'>\"[emoji_parse(msg)]\"</span></span>"
 
 	for (var/mob/M in GLOB.player_list)
-		if(isnewplayer(M))
+		if(isnewplayer(M) && !M.client?.holder) // We want to make sure admins can see this when in the lobby too!
 			continue
-		if (M.stat == DEAD || (M.client.holder && (M.client.prefs.chat_toggles & CHAT_DEAD))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only give to Administrators and above
+		if (M.stat == DEAD || (M.client?.holder && (M.client?.prefs?.chat_toggles & CHAT_DEAD))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only given to Administrators and above
 			to_chat(M, rendered, confidential = TRUE)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Dsay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -27,9 +27,10 @@
 	var/rendered = "<span class='game deadsay'>[span_prefix("DEAD:")] [span_name("[rank_name]([admin_name])")] says, <span class='message'>\"[emoji_parse(msg)]\"</span></span>"
 
 	for (var/mob/M in GLOB.player_list)
-		if(isnewplayer(M) && !M.client?.holder) // We want to make sure admins can see this when in the lobby too!
+		var/admin_holder = M.client?.holder
+		if(isnewplayer(M) && !admin_holder) // We want to make sure admins can see this when in the lobby too!
 			continue
-		if (M.stat == DEAD || (M.client?.holder && (M.client?.prefs?.chat_toggles & CHAT_DEAD))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only given to Administrators and above
+		if (M.stat == DEAD || (admin_holder && (M.client?.prefs.chat_toggles & CHAT_DEAD))) //admins can toggle deadchat on and off. This is a proc in admin.dm and is only given to Administrators and above
 			to_chat(M, rendered, confidential = TRUE)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Dsay") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
## About The Pull Request
That's about it, really. I was tired of being able to see deadchat in the lobby, but I couldn't see my own deadsay messages because they're handled differently. This way, it should now work properly once again, and I'll be able to know when a message wasn't sent properly because the chat ate it :)

## Why It's Good For The Game
Less paranoia for admins is a good thing. Also, I added some null checks in there because it could potentially runtime on clients being null, so better be safe than sorry.

<details>
<summary>Here's a picture of me testing it.</summary>

![image](https://user-images.githubusercontent.com/58045821/147496929-a22fcb0f-97ea-40fb-b68c-41b2253b3072.png)
</details>

## Changelog

:cl: GoldenAlpharex
fix: Admin deadsay will now properly be sent to admins that are on the lobby screen, with their deadchat toggle turned on.
code: Admin deadsay shouldn't be as prone to cause small runtimes anymore.
/:cl:
