### PR TITLE
Fixes a missed arg pass in cult scribe component

### DIFF
--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -111,7 +111,7 @@
 	if(!target.has_reagent(/datum/reagent/water/holywater))
 		return
 
-	INVOKE_ASYNC(src, .proc/do_purge_holywater, user)
+	INVOKE_ASYNC(src, .proc/do_purge_holywater, target, user)
 
 /*
  * Signal proc for [COMSIG_ITEM_ATTACK_OBJ].


### PR DESCRIPTION
## About The Pull Request

`do_purge_holywater` should be passed target and user, but was only passed user, causing it to runtime. This fixes that.

## Why It's Good For The Game

Fixes cult purging from runtiming.
- [x] I tested this PR

## Changelog

:cl: Melbert
fix: Fixes cult dagger error with holywater purging.
/:cl:

