### PR TITLE
Fixes a missing initialize flag set in oranges_ear

### DIFF
--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -37,6 +37,9 @@
 
 /mob/oranges_ear/Initialize(mapload)
 	SHOULD_CALL_PARENT(FALSE)
+	if(flags_1 & INITIALIZED_1)
+		stack_trace("Warning: [src]([type]) initialized multiple times!")
+	flags_1 |= INITIALIZED_1
 	return INITIALIZE_HINT_NORMAL
 
 /mob/oranges_ear/Destroy(force)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm pretty sure this was unintended, and it sets me off

## Why It's Good For The Game

Honestly close to net neutral, I won't see oranges ear failing to init in Display Initialize() Log anymore