### PR TITLE
Radio jammers now jam PDA messaging

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -788,6 +788,12 @@ GLOBAL_LIST_EMPTY(PDAs)
 	if((last_text && world.time < last_text + 10) || (everyone && last_everyone && world.time < last_everyone + PDA_SPAM_DELAY))
 		return FALSE
 
+	var/turf/position = get_turf(src)
+	for(var/obj/item/jammer/jammer as anything in GLOB.active_jammers)
+		var/turf/jammer_turf = get_turf(jammer)
+		if(position?.z == jammer_turf.z && (get_dist(position, jammer_turf) <= jammer.range))
+			return FALSE
+
 	var/list/filter_result = CAN_BYPASS_FILTER(user) ? null : is_ic_filtered_for_pdas(message)
 	if (filter_result)
 		REPORT_CHAT_FILTER_TO_USER(user, filter_result)


### PR DESCRIPTION
## About The Pull Request

As title

## Why It's Good For The Game
PDAs also rely on telecomms and this makes sense
Prevents cheesing the item meant to prevent you for calling for help with another radio device used to call for help

## Changelog
:cl:
qol: Radio jammers will now also jam PDA messaging.
/:cl:
