### PR TITLE
Resolves some changeling monkey business 

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -202,7 +202,7 @@
 	thepower.on_purchase(owner.current)//Grant() is ran in this proc, see changeling_powers.dm
 
 /datum/antagonist/changeling/proc/readapt()
-	if(!ishuman(owner.current))
+	if(!ishuman(owner.current) || ismonkey(owner.current))
 		to_chat(owner.current, span_warning("We can't remove our evolutions in this form!"))
 		return
 	if(HAS_TRAIT_FROM(owner.current, TRAIT_DEATHCOMA, CHANGELING_TRAIT))
@@ -265,7 +265,7 @@
 		if(verbose)
 			to_chat(user, span_warning("[target]'s body is ruined beyond usability!"))
 		return
-	if(!ishuman(target))//Absorbing monkeys is entirely possible, but it can cause issues with transforming. That's what lesser form is for anyway!
+	if(!ishuman(target) || ismonkey(target))//Absorbing monkeys is entirely possible, but it can cause issues with transforming. That's what lesser form is for anyway!
 		if(verbose)
 			to_chat(user, span_warning("We could gain no benefit from absorbing a lesser creature."))
 		return

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -11,7 +11,7 @@
 	var/chemical_cost = 0 // negative chemical cost is for passive abilities (chemical glands)
 	var/dna_cost = -1 //cost of the sting in dna points. 0 = auto-purchase (see changeling.dm), -1 = cannot be purchased
 	var/req_dna = 0  //amount of dna needed to use this ability. Changelings always have atleast 1
-	var/req_human = 0 //if you need to be human to use this ability
+	var/req_human = FALSE //if you need to be human to use this ability
 	var/req_absorbs = 0 //similar to req_dna, but only gained from absorbing, not DNA sting
 	///Maximum stat before the ability is blocked. For example, `UNCONSCIOUS` prevents it from being used when in hard crit or dead, while `DEAD` allows the ability to be used on any stat values.
 	var/req_stat = CONSCIOUS
@@ -64,10 +64,9 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 /datum/action/changeling/proc/sting_feedback(mob/user, mob/target)
 	return FALSE
 
-//Fairly important to remember to return 1 on success >.<
-
+// Fairly important to remember to return 1 on success >.< // Return TRUE not 1 >.<
 /datum/action/changeling/proc/can_sting(mob/living/user, mob/target)
-	if(!ishuman(user)) //typecast everything from mob to carbon from this point onwards
+	if(!can_be_used_by(user))
 		return FALSE
 	var/datum/antagonist/changeling/c = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(c.chem_charges < chemical_cost)
@@ -88,10 +87,11 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 	return TRUE
 
 /datum/action/changeling/proc/can_be_used_by(mob/user)
-	if(!user || QDELETED(user))
+	if(QDELETED(user))
 		return FALSE
 	if(!ishuman(user))
 		return FALSE
-	if(req_human && !ishuman(user))
+	if(req_human && ismonkey(user))
+		to_chat(user, span_warning("This ability requires you be in human form!"))
 		return FALSE
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -4,7 +4,7 @@
 	button_icon_state = "absorb_dna"
 	chemical_cost = 0
 	dna_cost = 0
-	req_human = 1
+	req_human = TRUE
 	///if we're currently absorbing, used for sanity
 	var/is_absorbing = FALSE
 

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -5,7 +5,7 @@
 	button_icon_state = "adrenaline"
 	chemical_cost = 30
 	dna_cost = 2
-	req_human = 1
+	req_human = TRUE
 	req_stat = UNCONSCIOUS
 
 //Recover from stuns.

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -5,7 +5,7 @@
 	button_icon_state = "biodegrade"
 	chemical_cost = 30 //High cost to prevent spam
 	dna_cost = 2
-	req_human = 1
+	req_human = TRUE
 
 /datum/action/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
 	var/used = FALSE // only one form of shackles removed per use

--- a/code/modules/antagonists/changeling/powers/chameleon_skin.dm
+++ b/code/modules/antagonists/changeling/powers/chameleon_skin.dm
@@ -5,10 +5,10 @@
 	button_icon_state = "chameleon_skin"
 	dna_cost = 2
 	chemical_cost = 25
-	req_human = 1
+	req_human = TRUE
 
 /datum/action/changeling/chameleon_skin/sting_action(mob/user)
-	var/mob/living/carbon/human/H = user //SHOULD always be human, because req_human = 1
+	var/mob/living/carbon/human/H = user //SHOULD always be human, because req_human = TRUE
 	if(!istype(H)) // req_human could be done in can_sting stuff.
 		return
 	..()

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -5,7 +5,7 @@
 	button_icon_state = "last_resort"
 	chemical_cost = 20
 	dna_cost = 1
-	req_human = 1
+	req_human = TRUE
 
 /datum/action/changeling/headcrab/sting_action(mob/living/user)
 	set waitfor = FALSE

--- a/code/modules/antagonists/changeling/powers/humanform.dm
+++ b/code/modules/antagonists/changeling/powers/humanform.dm
@@ -27,8 +27,28 @@
 	to_chat(user, span_notice("We transform our appearance."))
 	..()
 	changeling.purchasedpowers -= src
+	Remove(user)
 
 	var/newmob = user.humanize()
 
 	changeling.transform(newmob, chosen_prof)
+	return TRUE
+
+// Subtype used when a changeling uses lesser form.
+/datum/action/changeling/humanform/from_monkey
+	desc = "We change back into a human. Costs 5 chemicals."
+
+/datum/action/changeling/humanform/from_monkey/sting_action(mob/living/carbon/user)
+	. = ..()
+	if(!.)
+		return
+
+	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
+	var/datum/action/changeling/lesserform/monkey_form_ability = new()
+	changeling.purchasedpowers += monkey_form_ability
+
+	monkey_form_ability.Grant(user)
+
+	// Delete ourselves when we're done.
+	qdel(src)
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -5,7 +5,7 @@
 	button_icon_state = "lesser_form"
 	chemical_cost = 5
 	dna_cost = 1
-	req_human = 1
+	req_human = TRUE
 
 //Transform into a monkey.
 /datum/action/changeling/lesserform/sting_action(mob/living/carbon/human/user)
@@ -16,4 +16,13 @@
 
 	user.monkeyize()
 
+	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
+	var/datum/action/changeling/humanform/from_monkey/human_form_ability = new()
+	changeling.purchasedpowers += human_form_ability
+	changeling.purchasedpowers -= src
+
+	Remove(user)
+	human_form_ability.Grant(user)
+
+	qdel(src)
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -5,7 +5,7 @@
 	helptext = "Will turn your voice into the name that you enter. We must constantly expend chemicals to maintain our form like this."
 	chemical_cost = 0//constant chemical drain hardcoded
 	dna_cost = 1
-	req_human = 1
+	req_human = TRUE
 
 // Fake Voice
 /datum/action/changeling/mimicvoice/sting_action(mob/user)

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -141,7 +141,7 @@
 	button_icon_state = "armblade"
 	chemical_cost = 20
 	dna_cost = 2
-	req_human = 1
+	req_human = TRUE
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
 
@@ -227,7 +227,7 @@
 	button_icon_state = "tentacle"
 	chemical_cost = 10
 	dna_cost = 2
-	req_human = 1
+	req_human = TRUE
 	weapon_type = /obj/item/gun/magic/tentacle
 	weapon_name_simple = "tentacle"
 	silent = TRUE
@@ -406,7 +406,7 @@
 	button_icon_state = "organic_shield"
 	chemical_cost = 20
 	dna_cost = 1
-	req_human = 1
+	req_human = TRUE
 
 	weapon_type = /obj/item/shield/changeling
 	weapon_name_simple = "shield"
@@ -460,7 +460,7 @@
 	button_icon_state = "organic_suit"
 	chemical_cost = 20
 	dna_cost = 2
-	req_human = 1
+	req_human = TRUE
 
 	suit_type = /obj/item/clothing/suit/space/changeling
 	helmet_type = /obj/item/clothing/head/helmet/space/changeling
@@ -521,7 +521,7 @@
 	button_icon_state = "chitinous_armor"
 	chemical_cost = 20
 	dna_cost = 1
-	req_human = 1
+	req_human = TRUE
 	recharge_slowdown = 0.125
 
 	suit_type = /obj/item/clothing/suit/armor/changeling

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -5,7 +5,7 @@
 	button_icon_state = "resonant_shriek"
 	chemical_cost = 20
 	dna_cost = 1
-	req_human = 1
+	req_human = TRUE
 
 //A flashy ability, good for crowd control and sowing chaos.
 /datum/action/changeling/resonant_shriek/sting_action(mob/user)

--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -8,7 +8,7 @@
 	button_icon_state = "strained_muscles"
 	chemical_cost = 0
 	dna_cost = 1
-	req_human = 1
+	req_human = TRUE
 	var/stacks = 0 //Increments every 5 seconds; damage increases over time
 	active = FALSE //Whether or not you are a hedgehog
 

--- a/code/modules/antagonists/changeling/powers/transform.dm
+++ b/code/modules/antagonists/changeling/powers/transform.dm
@@ -5,7 +5,7 @@
 	chemical_cost = 5
 	dna_cost = 0
 	req_dna = 1
-	req_human = 1
+	req_human = TRUE
 
 /obj/item/clothing/glasses/changeling
 	name = "flesh"


### PR DESCRIPTION
## About The Pull Request

Fixes #56069

Abilities that require human now check for `!ismonkey()` instead of `ishuman()`. 
Cleaned up a bit of the code around it. Replaces `0/1` with `true/false`.

The proc `can_be_used_by()` was literally never called anywhere.

## Why It's Good For The Game

~~No more~~ Less ling monkey mess.

## Changelog

:cl: Melbert
fix: Changeling abilities unusable in lesser form are unusuable as a monkey again.
fix: Changelings can no longer unintentionally take DNA from monkeys.
fix: Changeling lesser form now toggles between "lesser form" and "human form" when used. 
/:cl:
