### PR TITLE
makes ai static into images added to obscured turfs to save on maptick

### DIFF
--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -383,13 +383,15 @@ DEFINE_BITFIELD(smoothing_junction, list(
 					var/mutable_appearance/underlay_appearance = mutable_appearance(layer = TURF_LAYER, plane = FLOOR_PLANE)
 					if(!neighbor_turf.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency))
 						neighbor_turf = get_step(src, turned_adjacency & (EAST|WEST))
+
 						if(!neighbor_turf.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency))
 							neighbor_turf = get_step(src, turned_adjacency)
+
 							if(!neighbor_turf.get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency))
 								if(!get_smooth_underlay_icon(underlay_appearance, src, turned_adjacency)) //if all else fails, ask our own turf
 									underlay_appearance.icon = DEFAULT_UNDERLAY_ICON
 									underlay_appearance.icon_state = DEFAULT_UNDERLAY_ICON_STATE
-					underlays = list(underlay_appearance)
+					underlays += underlay_appearance
 
 /turf/open/floor/set_smoothed_icon_state(new_junction)
 	if(broken || burnt)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -502,19 +502,12 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /turf/proc/visibilityChanged()
 	GLOB.cameranet.updateVisibility(src)
-	// The cameranet usually handles this for us, but if we've just been
-	// recreated we should make sure we have the cameranet vis_contents.
-	var/datum/camerachunk/C = GLOB.cameranet.chunkGenerated(x, y, z)
-	if(C)
-		if(C.obscuredTurfs[src])
-			vis_contents += GLOB.cameranet.vis_contents_opaque
-		else
-			vis_contents -= GLOB.cameranet.vis_contents_opaque
 
 /turf/proc/burn_tile()
+	return
 
 /turf/proc/is_shielded()
-
+	return
 
 /turf/contents_explosion(severity, target)
 	for(var/thing in contents)

--- a/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/cameranet.dm
@@ -7,25 +7,24 @@
 GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 
 /datum/cameranet
-	var/name = "Camera Net" // Name to show for VV and stat()
+	/// Name to show for VV and stat()
+	var/name = "Camera Net"
 
-	// The cameras on the map, no matter if they work or not. Updated in obj/machinery/camera.dm by New() and Del().
+	/// The cameras on the map, no matter if they work or not. Updated in obj/machinery/camera.dm by New() and Del().
 	var/list/cameras = list()
-	// The chunks of the map, mapping the areas that the cameras can see.
+	/// The chunks of the map, mapping the areas that the cameras can see.
 	var/list/chunks = list()
 	var/ready = 0
 
-	///this object is the static that ais see on obscured turfs, added to the turfs vis_contents
-	var/obj/effect/overlay/camera_static/vis_contents_opaque
-
-	///The image given to the effect in vis_contents on AI clients
+	///The image cloned by all chunk static images put onto turfs cameras cant see
 	var/image/obscured
 
 /datum/cameranet/New()
-	vis_contents_opaque = new /obj/effect/overlay/camera_static()
 
-	obscured = new('icons/effects/cameravis.dmi', vis_contents_opaque, null)
+	obscured = new('icons/effects/cameravis.dmi')
 	obscured.plane = CAMERA_STATIC_PLANE
+	obscured.appearance_flags = RESET_TRANSFORM | RESET_ALPHA | RESET_COLOR | KEEP_APART
+	obscured.override = TRUE
 
 /// Checks if a chunk has been Generated in x, y, z.
 /datum/cameranet/proc/chunkGenerated(x, y, z)
@@ -52,9 +51,6 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 	else
 		other_eyes = list()
 
-	if(C && use_static)
-		C.images += obscured
-
 	for(var/mob/camera/ai_eye/eye as anything in moved_eyes)
 		var/list/visibleChunks = list()
 		if(eye.loc)
@@ -78,11 +74,6 @@ GLOBAL_DATUM_INIT(cameranet, /datum/cameranet, new)
 
 		for(var/datum/camerachunk/chunk as anything in add)
 			chunk.add(eye)
-
-		if(!eye.visibleCameraChunks.len)
-			var/client/client = eye.GetViewerClient()
-			if(client && eye.use_static)
-				client.images -= obscured
 
 /// Updates the chunks that the turf is located in. Use this when obstacles are destroyed or when doors open.
 /datum/cameranet/proc/updateVisibility(atom/A, opacity_check = 1)

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -122,9 +122,6 @@
 	src.y = y
 	src.z = z
 
-	for(var/turf_num in 1 to 16 * 16)
-		inactive_static_images += new/image(GLOB.cameranet.obscured)
-
 	for(var/obj/machinery/camera/camera in urange(CHUNK_SIZE, locate(x + (CHUNK_SIZE / 2), y + (CHUNK_SIZE / 2), z)))
 		if(camera.can_use())
 			cameras += camera
@@ -135,6 +132,9 @@
 
 	for(var/turf/t as anything in block(locate(max(x, 1), max(y, 1), z), locate(min(x + CHUNK_SIZE - 1, world.maxx), min(y + CHUNK_SIZE - 1, world.maxy), z)))
 		turfs[t] = t
+
+	for(var/turf in turfs)//one for each 16x16 = 256 turfs this camera chunk encompasses
+		inactive_static_images += new/image(GLOB.cameranet.obscured)
 
 	for(var/obj/machinery/camera/camera as anything in cameras)
 		if(!camera)

--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -83,6 +83,13 @@
 	///turfs that we could see last update but cant see now
 	var/list/newly_obscured_turfs = visibleTurfs - updated_visible_turfs
 
+	for(var/mob/camera/ai_eye/client_eye as anything in seenby)
+		var/client/client = client_eye.ai?.client || client_eye.client
+		if(!client)
+			continue
+
+		client.images -= active_static_images
+
 	for(var/turf/visible_turf as anything in newly_visible_turfs)
 		var/image/static_image_to_deallocate = obscuredTurfs[visible_turf]
 		if(!static_image_to_deallocate)
@@ -95,7 +102,7 @@
 		obscuredTurfs -= visible_turf
 
 	for(var/turf/obscured_turf as anything in newly_obscured_turfs)
-		if(!obscuredTurfs[obscured_turf] || istype(obscured_turf, /turf/open/ai_visible))
+		if(obscuredTurfs[obscured_turf] || istype(obscured_turf, /turf/open/ai_visible))
 			continue
 
 		var/image/static_image_to_allocate = inactive_static_images[length(inactive_static_images)]
@@ -112,6 +119,14 @@
 	visibleTurfs = updated_visible_turfs
 
 	changed = FALSE
+
+	for(var/mob/camera/ai_eye/client_eye as anything in seenby)
+		var/client/client = client_eye.ai?.client || client_eye.client
+		if(!client)
+			continue
+
+		client.images += active_static_images
+
 
 /// Create a new camera chunk, since the chunks are made as they are needed.
 /datum/camerachunk/New(x, y, z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
for the past week and a half #63439 has been testmerged on manuel to test how much the static vis_contents objects on every turf not seeable by cameras affected maptick. i didnt expect it to make a big difference since ive tested shared vis_contents among thousands of movables in view and knew that they had much better maptick performance than unique vis_contents objects on every one, and the ai static is all done using one object. However, it did have a big effect, an effect that still probably needs another day or two to measure due to the averaging used in this graph: 
![Maptick Average by Server](https://user-images.githubusercontent.com/15794172/147533440-9ecb3722-ff99-4336-97b4-b3d61b8243c9.png)
manuel on average has gone from a maptick per person of around 0.55 to ~0.45, a full 0.1 reduction in maptick per person, which is incredibly significant. so i worked on a way to actually get rid of vis_contents ai static.

now every camera chunk has 256 (1 for each turf they encompass) images that represent the ai static. every obscured turf gets 1 of the images assigned to their loc and when a camera eye that can see static moves in range of a chunk, all the currently assigned images gets added to that clients images list, and when they leave sight of that camera chunk theyre removed. this has the benefit of having no added images to vis_contents driving up maptick for everyone else in the world. however this means that the images have to be added and subtracted when the eye moves around.

looking at profiles, moving (as a camera mob) around already generated chunks is around 2x more expensive than on master (/datum/camerachunk/proc/add() went from around 0.2 ms per call to around  0.5ms) it appears that updating the chunks is significantly cheaper though for some reason, maybe assigning image locs is much cheaper than adding and removing vis_contents. however this seems to only be for 

also probably fixes #38857 since all static no longer depends on one image being rendered by the client but i cant be sure since its hard to reproduce the issue
fixes #63869<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
while ai movement itself is more expensive, maptick is lower for every other player in the game which is worth the trade, especially as player count increases. the lower maptick per person gets the higher population our servers can support without time dilation, and less scaling time dilation per player. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: NanoTrasen has broken up the AI Static Union and thus AI static will no longer intermittently decide to stop working.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
