### PR TITLE
burning things moving over a bonfire sets the bonfire on fire

### DIFF
--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -119,11 +119,13 @@
 
 /obj/structure/bonfire/proc/on_entered(datum/source, atom/movable/entered)
 	SIGNAL_HANDLER
-	if(burning & !grill)
-		bonfire_burn()
+	if(burning)
+		if(grill)
+			bonfire_burn()
+		return
 
 	//Not currently burning, let's see if we can ignite it.
-	else if(isliving(entered))
+	if(isliving(entered))
 		var/mob/living/burning_body = entered
 		if(burning_body.on_fire)
 			start_burning()

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -120,7 +120,7 @@
 /obj/structure/bonfire/proc/on_entered(datum/source, atom/movable/entered)
 	SIGNAL_HANDLER
 	if(burning)
-		if(grill)
+		if(!grill)
 			bonfire_burn()
 		return
 

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -119,7 +119,10 @@
 
 /obj/structure/bonfire/proc/on_entered(datum/source, atom/movable/entered)
 	SIGNAL_HANDLER
-	if(isliving(entered))
+	if(burning & !grill)
+		bonfire_burn()
+	//Not currently burning, let's see if we can ignite it.
+	else if(isliving(entered))
 		var/mob/living/burning_body = entered
 		if(burning_body.on_fire)
 			start_burning()
@@ -127,9 +130,6 @@
 	else if(entered.resistance_flags & ON_FIRE)
 		start_burning()
 		visible_message(span_notice("[entered] runs over [src], starting it's fire!"))
-
-	if(burning & !grill)
-		bonfire_burn()
 
 /obj/structure/bonfire/proc/bonfire_burn(delta_time = 2)
 	var/turf/current_location = get_turf(src)

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -121,15 +121,17 @@
 	SIGNAL_HANDLER
 	if(burning & !grill)
 		bonfire_burn()
+
 	//Not currently burning, let's see if we can ignite it.
 	else if(isliving(entered))
 		var/mob/living/burning_body = entered
 		if(burning_body.on_fire)
 			start_burning()
-			visible_message(span_notice("[entered] runs over [src], starting it's fire!"))
+			visible_message(span_notice("[entered] runs over [src], starting its fire!"))
+
 	else if(entered.resistance_flags & ON_FIRE)
 		start_burning()
-		visible_message(span_notice("[entered] runs over [src], starting it's fire!"))
+		visible_message(span_notice("[entered]'s fire speads to [src], setting it ablaze!"))
 
 /obj/structure/bonfire/proc/bonfire_burn(delta_time = 2)
 	var/turf/current_location = get_turf(src)

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -119,6 +119,15 @@
 
 /obj/structure/bonfire/proc/on_entered(datum/source, atom/movable/entered)
 	SIGNAL_HANDLER
+	if(isliving(entered))
+		var/mob/living/burning_body = entered
+		if(burning_body.on_fire)
+			start_burning()
+			visible_message(span_notice("[entered] runs over [src], starting it's fire!"))
+	else if(entered.resistance_flags & ON_FIRE)
+		start_burning()
+		visible_message(span_notice("[entered] runs over [src], starting it's fire!"))
+
 	if(burning & !grill)
 		bonfire_burn()
 


### PR DESCRIPTION
## About The Pull Request

A living thing on fire, or any atom on fire, will light a bonfire when moving over it.

## Why It's Good For The Game

It's better consistency, as bonfires already set things that walk over it on fire, no reason why the opposite shouldn't additionally be the case.
Closes https://github.com/tgstation/tgstation/issues/62963

## Changelog

:cl:
fix: Things on fire moving over a bonfire will now ignite its flame
/:cl: