### PR TITLE
Circuit assemblies can be attached to wires

### DIFF
--- a/code/modules/wiremod/shell/assembly.dm
+++ b/code/modules/wiremod/shell/assembly.dm
@@ -7,6 +7,7 @@
 	name = "circuit assembly"
 	desc = "A small electronic device that can house an integrated circuit."
 	icon_state = "wiremod"
+	attachable = TRUE
 
 /obj/item/assembly/wiremod/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

I didn't know about the existence of the `attachable` var for assemblies, and that it needed to be set to `TRUE` to make them attachable to wires.

## Why It's Good For The Game

It was always my intention for the assembly shell to be attached to wires.

## Changelog

:cl:
fix: The assembly shell can now be attached to wires as intended
/:cl:
