### PR TITLE
Fixes spidercharges blowing up anywhere

### DIFF
--- a/code/modules/ninja/ninja_explosive.dm
+++ b/code/modules/ninja/ninja_explosive.dm
@@ -17,12 +17,7 @@
 	if(!ninja_antag)
 		to_chat(user, span_notice("While it appears normal, you can't seem to detonate the charge."))
 		return
-	var/datum/objective/plant_explosive/objective = locate() in ninja_antag.objectives
-	if(!objective)
-		to_chat(user, span_notice("You can't seem to activate the charge.  It's location-locked, but you don't know where to detonate it."))
-		return
-	if(objective.detonation_location != get_area(user))
-		to_chat(user, span_notice("This isn't the location you're supposed to use this!"))
+	if (!check_loc(user, ninja_antag))
 		return
 	detonator = user
 	return ..()
@@ -33,5 +28,24 @@
 	if(!detonator)
 		return
 	var/datum/antagonist/ninja/ninja_antag = detonator.mind.has_antag_datum(/datum/antagonist/ninja)
+	//buuuuuuuuuuuuuuut the c4 may have moved
+	if(!check_loc(detonator, ninja_antag))
+		return
 	var/datum/objective/plant_explosive/objective = locate() in ninja_antag.objectives
 	objective.completed = TRUE
+
+/obj/item/grenade/c4/ninja/proc/check_loc(mob/user, datum/antagonist/ninja/ninja_antag)
+	var/datum/objective/plant_explosive/objective = locate() in ninja_antag.objectives
+	if(!objective)
+		if (active)
+			say("Invalid location!")
+		else
+			to_chat(user, span_notice("You can't seem to activate the charge.  It's location-locked, but you don't know where to detonate it."))
+		return FALSE
+	if(objective.detonation_location != get_area(user))
+		if (active)
+			say("Invalid location!")
+		else
+			to_chat(user, span_notice("This isn't the location you're supposed to use this!"))
+		return FALSE
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/63635
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the spider charge should only be blowing up in the given location
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Spidercharges can now only be blown up in their intended location.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
