### PR TITLE
Makes blackmarket uplinks not runtime and get broken at mapload

### DIFF
--- a/code/modules/cargo/blackmarket/blackmarket_uplink.dm
+++ b/code/modules/cargo/blackmarket/blackmarket_uplink.dm
@@ -16,6 +16,14 @@
 
 /obj/item/blackmarket_uplink/Initialize(mapload)
 	. = ..()
+	// We don't want to go through this at mapload because the SSblackmarket isn't initialized yet.
+	if(mapload)
+		return
+
+	update_viewing_category()
+
+/// Simple internal proc for updating the viewing_category variable.
+/obj/item/blackmarket_uplink/proc/update_viewing_category()
 	if(accessible_markets.len)
 		viewing_market = accessible_markets[1]
 		var/list/categories = SSblackmarket.markets[viewing_market].categories
@@ -54,6 +62,9 @@
 	to_chat(user, span_notice("You withdraw [amount_to_remove] credits into a holochip."))
 
 /obj/item/blackmarket_uplink/ui_interact(mob/user, datum/tgui/ui)
+	if(!viewing_category)
+		update_viewing_category()
+
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "BlackMarketUplink", name)


### PR DESCRIPTION
## About The Pull Request
Basically they runtimed at mapload because they would try to access SSblackmarket, which wasn't initialized yet. Now, if it's mapload, it'll do that upon the first use of the item instead (tested and it works).

## Why It's Good For The Game
Less runtimes == better, plus this allows people to use them in ruins or whatever if they want to.

## Changelog

:cl: GoldenAlpharex
fix: The blackmarket uplink shouldn't run into issues loading the different categories of items it can order when it was created during mapload.
/:cl:
