### PR TITLE
Dehardcodes hulk lost on crit number

### DIFF
--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -66,7 +66,7 @@
 			arm.force_wound_upwards(/datum/wound/blunt/moderate)
 
 /datum/mutation/human/hulk/on_life(delta_time, times_fired)
-	if(owner.health < 0)
+	if(owner.health < owner.crit_threshold)
 		on_losing(owner)
 		to_chat(owner, span_danger("You suddenly feel very weak."))
 


### PR DESCRIPTION
## About The Pull Request

Changes the number hulk checks for being lost when you enter crit from a hardcoded `0` value to the owner's critical health threshold.

Crit-threshold can be modified - primarily, by sanity (increased if you're insane, decreased if you're **very** sane). 
Because this was hardcoded as 0, you'd sometimes end up keeping hulk when you should lose it, and (rarely, due to the hulk moodlet) losing hulk when you should keep it. 

(I wanted to change this from `on_life()` to `COMSIG_MOB_STATCHANGE`, but apparently some brain traumas like Tenacity prevent statchange signals from being sent. damn it all)

## Why It's Good For The Game

Consistency - you lose hulk when you enter soft crit, so it should be lost on the same number used to determine soft crit.

## Changelog

:cl: Melbert
fix: Hulk is removed more consistently when the user actually enters soft crit.
/:cl:
