### PR TITLE
Stops garment bags from stacking clothes on top of eachother (saves accessories)

### DIFF
--- a/code/game/objects/items/storage/garment.dm
+++ b/code/game/objects/items/storage/garment.dm
@@ -34,12 +34,13 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.display_numerical_stacking = FALSE
 	STR.max_combined_w_class = 200
 	STR.max_items = 15
 	STR.insert_preposition = "in"
 	STR.set_holdable(list(
-		/obj/item/clothing
-		))
+		/obj/item/clothing,
+	))
 
 /obj/item/storage/bag/garment/captain/PopulateContents()
 	new /obj/item/clothing/under/rank/captain(src)


### PR DESCRIPTION
## About The Pull Request

Stops adding clothes to a garment bag from stacking on top of eachother, and by extension stops accessories on an accessory from deleting itself.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/63589 
Garment bags are closer to backpacks than mining satchels, so it makes more sense for them to act like those instead. It also makes it easier to tell how much space you got left in the bag.

## Changelog

:cl:
fix: accessories on clothes placed inside garment bags will no longer delete themselves.
/:cl: