### PR TITLE
Fixes a bug with windoor examination text + refactor

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -50,7 +50,7 @@
 			. += span_notice("Due to a security threat, its access requirements have been lifted!")
 		else
 			. += span_notice("In the event of a red alert, its access requirements will automatically lift.")
-	. += span_notice("Its maintenance panel is <b>screwed</b> in place.")
+	. += span_notice("Its maintenance panel is [panel_open ? "open" : "<b>screwed</b> in place"].")
 
 /obj/machinery/door/check_access_list(list/access_list)
 	if(red_alert_access && SSsecurity_level.current_level >= SEC_LEVEL_RED)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -235,69 +235,68 @@
 		desc += "<BR>[span_warning("Its access panel is smoking slightly.")]"
 		open(2)
 
-/obj/machinery/door/window/attackby(obj/item/I, mob/living/user, params)
-
-	if(operating)
+/obj/machinery/door/window/screwdriver_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(flags_1 & NODECONSTRUCT_1)
 		return
-
+	if(density || operating)
+		to_chat(user, span_warning("You need to open the door to access the maintenance panel!"))
+		return
 	add_fingerprint(user)
-	if(!(flags_1&NODECONSTRUCT_1))
-		if(I.tool_behaviour == TOOL_SCREWDRIVER)
-			if(density || operating)
-				to_chat(user, span_warning("You need to open the door to access the maintenance panel!"))
-				return
-			I.play_tool_sound(src)
-			panel_open = !panel_open
-			to_chat(user, span_notice("You [panel_open ? "open":"close"] the maintenance panel of the [name]."))
-			return
+	tool.play_tool_sound(src)
+	panel_open = !panel_open
+	to_chat(user, span_notice("You [panel_open ? "open" : "close"] the maintenance panel."))
+	return TRUE
 
-		if(I.tool_behaviour == TOOL_CROWBAR)
-			if(panel_open && !density && !operating)
-				user.visible_message(span_notice("[user] removes the electronics from the [name]."), \
-					span_notice("You start to remove electronics from the [name]..."))
-				if(I.use_tool(src, user, 40, volume=50))
-					if(panel_open && !density && !operating && loc)
-						var/obj/structure/windoor_assembly/WA = new /obj/structure/windoor_assembly(loc)
-						switch(base_state)
-							if("left")
-								WA.facing = "l"
-							if("right")
-								WA.facing = "r"
-							if("leftsecure")
-								WA.facing = "l"
-								WA.secure = TRUE
-							if("rightsecure")
-								WA.facing = "r"
-								WA.secure = TRUE
-						WA.set_anchored(TRUE)
-						WA.state= "02"
-						WA.setDir(dir)
-						WA.update_appearance()
-						WA.created_name = name
-
-						if(obj_flags & EMAGGED)
-							to_chat(user, span_warning("You discard the damaged electronics."))
-							qdel(src)
-							return
-
-						to_chat(user, span_notice("You remove the airlock electronics."))
-
-						var/obj/item/electronics/airlock/ae
-						if(!electronics)
-							ae = new/obj/item/electronics/airlock(drop_location())
-							if(req_one_access)
-								ae.one_access = 1
-								ae.accesses = req_one_access
-							else
-								ae.accesses = req_access
-						else
-							ae = electronics
-							electronics = null
-							ae.forceMove(drop_location())
-
-						qdel(src)
-				return
-	return ..()
+/obj/machinery/door/window/crowbar_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(flags_1 & NODECONSTRUCT_1)
+		return
+	if(!panel_open || density || operating)
+		return
+	add_fingerprint(user)
+	user.visible_message(span_notice("[user] removes the electronics from the [name]."), \
+	span_notice("You start to remove electronics from the [name]..."))
+	if(!tool.use_tool(src, user, 40, volume=50))
+		return
+	if(!panel_open || density || operating || !loc)
+		return
+	var/obj/structure/windoor_assembly/windoor_assembly = new /obj/structure/windoor_assembly(loc)
+	switch(base_state)
+		if("left")
+			windoor_assembly.facing = "l"
+		if("right")
+			windoor_assembly.facing = "r"
+		if("leftsecure")
+			windoor_assembly.facing = "l"
+			windoor_assembly.secure = TRUE
+		if("rightsecure")
+			windoor_assembly.facing = "r"
+			windoor_assembly.secure = TRUE
+	windoor_assembly.set_anchored(TRUE)
+	windoor_assembly.state= "02"
+	windoor_assembly.setDir(dir)
+	windoor_assembly.update_appearance()
+	windoor_assembly.created_name = name
+	if(obj_flags & EMAGGED)
+		to_chat(user, span_warning("You discard the damaged electronics."))
+		qdel(src)
+		return
+	to_chat(user, span_notice("You remove the airlock electronics."))
+	var/obj/item/electronics/airlock/dropped_electronics
+	if(!electronics)
+		dropped_electronics = new/obj/item/electronics/airlock(drop_location())
+		if(req_one_access)
+			dropped_electronics.one_access = 1
+			dropped_electronics.accesses = req_one_access
+		else
+			dropped_electronics.accesses = req_access
+	else
+		dropped_electronics = electronics
+		electronics = null
+		dropped_electronics.forceMove(drop_location())
+		qdel(src)
+	return TRUE
 
 /obj/machinery/door/window/interact(mob/user) //for sillycones
 	try_to_activate_door(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Windoors would display "the maintenance panel is screwed in place" regardless of whether you had screwdrivered it open
- The code was pretty dated
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #36482
Refactor for readable code
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Windoor exam text now properly displays whether the panel is open.
refactor: Windoor tool_act code is updated to the latest century.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
