### PR TITLE
Fixes brainwash ui clipping issue

### DIFF
--- a/tgui/packages/tgui/interfaces/AntagInfoBrainwashed.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoBrainwashed.tsx
@@ -16,7 +16,7 @@ type Info = {
   objectives: Objective[];
 };
 
-export const AntagInfoBrainwashed = (props, context) => {
+export const AntagInfoBrainwashed = () => {
   return (
     <Window
       width={400}
@@ -32,7 +32,7 @@ export const AntagInfoBrainwashed = (props, context) => {
           top="42%"
           left="26%" />
         <Section fill>
-          <Stack align="baseline" vertical fill>
+          <Stack vertical fill textAlign="center">
             <Stack.Item fontFamily="Wingdings">
               Hey, no! Stop translating this!
             </Stack.Item>
@@ -42,11 +42,11 @@ export const AntagInfoBrainwashed = (props, context) => {
             <Stack.Item mt={-0.25} fontSize="20px">
               It is focusing on a single purpose...
             </Stack.Item>
-            <Stack.Item mt={1.5} grow >
+            <Stack.Item mt={3.5} grow>
               <ObjectivePrintout />
             </Stack.Item>
-            <Stack.Item fontSize="20px">
-              Follow the Directives, at any cost!
+            <Stack.Item fontSize="20px" textColor="#61e4b9">
+              Follow the directives at any cost!
             </Stack.Item>
             <Stack.Item fontFamily="Wingdings">
               You ruined my cool font effect.
@@ -58,24 +58,24 @@ export const AntagInfoBrainwashed = (props, context) => {
   );
 };
 
-const ObjectivePrintout = (props, context) => {
+const ObjectivePrintout = (_, context) => {
   const { data } = useBackend<Info>(context);
   const {
     objectives,
   } = data;
   return (
-    <Stack vertical>
-      <Stack.Item bold>
+    <Stack fill vertical>
+      <Stack.Item bold textColor="#61e4b9">
         Your current objectives:
       </Stack.Item>
-      <Stack.Item>
+      <Stack.Item textAlign="left">
         {!objectives && "None!"
         || objectives.map(objective => (
           <>
             <Stack.Item key={objective.count}>
-              #{objective.count}: {objective.explanation}
+              {objective.count}. {objective.explanation}
             </Stack.Item>
-            <Stack.Item textColor="red">
+            <Stack.Item bold textColor="red">
               This Directive must be followed.
             </Stack.Item>
           </>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Got brainwashed the other day and noticed that the text clips over the window. Fixed it, added a couple more colors (#61e4b9 is the inverse of the header color). Cleaned up nicely.

![1](https://user-images.githubusercontent.com/42397676/147712936-fc0a8237-5d91-49e6-a771-749df30a27a5.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a clipping issue with the brainwash objective text. Brainwashed victims can now properly lead longer objectives about the clown being a zombie, etc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
