### PR TITLE
Fixes pirates getting normal names + no antag status

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/pirate_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/pirate_roles.dm
@@ -21,8 +21,8 @@
 
 /obj/effect/mob_spawn/ghost_role/human/pirate/special(mob/living/spawned_mob, mob/mob_possessor)
 	. = ..()
-	mob_possessor.fully_replace_character_name(mob_possessor.real_name, generate_pirate_name(mob_possessor.gender))
-	mob_possessor.mind.add_antag_datum(/datum/antagonist/pirate)
+	spawned_mob.fully_replace_character_name(spawned_mob.real_name, generate_pirate_name(spawned_mob.gender))
+	spawned_mob.mind.add_antag_datum(/datum/antagonist/pirate)
 
 /obj/effect/mob_spawn/ghost_role/human/pirate/proc/generate_pirate_name(spawn_gender)
 	var/beggings = strings(PIRATE_NAMES_FILE, "beginnings")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There was the wrong variable being used on pirate post-spawning code that runtimed really hard.

## Why It's Good For The Game

fixes #63662
fixes #63564

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes pirates not getting their antag status, alongside a non-pirate name
/:cl:
