### PR TITLE
Fixes eigenstasium teleporting undroppable items

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -350,7 +350,7 @@
 				owner.Knockdown(10)
 			var/list/items = list()
 			for (var/obj/item/item in owner.get_contents())
-				if ((item & DROPDEL) || HAS_TRAIT(item, TRAIT_NODROP)) // can't teleport these kinds of items
+				if ((item.item_flags & DROPDEL) || HAS_TRAIT(item, TRAIT_NODROP)) // can't teleport these kinds of items
 					continue
 				items.Add(item)
 			if(!LAZYLEN(items))

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -348,8 +348,10 @@
 				to_chat(owner, span_userdanger("You start to convlse violently as you feel your consciousness merges across realities, your possessions flying wildy off your body!"))
 				owner.Jitter(200)
 				owner.Knockdown(10)
+			var/list/possible_items = owner.get_contents()
 			var/list/items = list()
-			for (var/obj/item/item in owner.get_contents())
+			for (var/i in 1 to 10)
+				var/obj/item/item = possible_items[i]
 				if ((item.item_flags & DROPDEL) || HAS_TRAIT(item, TRAIT_NODROP)) // can't teleport these kinds of items
 					continue
 				items.Add(item)

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -348,13 +348,19 @@
 				to_chat(owner, span_userdanger("You start to convlse violently as you feel your consciousness merges across realities, your possessions flying wildy off your body!"))
 				owner.Jitter(200)
 				owner.Knockdown(10)
-			var/list/possible_items = owner.get_contents()
+
 			var/list/items = list()
-			for (var/i in 1 to 10)
-				var/obj/item/item = possible_items[i]
+			var/max_loop
+			if (length(owner.get_contents()) >= 10)
+				max_loop = 10
+			else
+				max_loop = length(owner.get_contents())
+			for (var/i in 1 to max_loop)
+				var/obj/item/item = owner.get_contents()[i]
 				if ((item.item_flags & DROPDEL) || HAS_TRAIT(item, TRAIT_NODROP)) // can't teleport these kinds of items
 					continue
 				items.Add(item)
+
 			if(!LAZYLEN(items))
 				return ..()
 			var/obj/item/item = pick(items)

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -348,7 +348,11 @@
 				to_chat(owner, span_userdanger("You start to convlse violently as you feel your consciousness merges across realities, your possessions flying wildy off your body!"))
 				owner.Jitter(200)
 				owner.Knockdown(10)
-			var/items = owner.get_contents()
+			var/list/items = list()
+			for (var/obj/item/item in owner.get_contents())
+				if ((item & DROPDEL) || HAS_TRAIT(item, TRAIT_NODROP)) // can't teleport these kinds of items
+					continue
+				items.Add(item)
 			if(!LAZYLEN(items))
 				return ..()
 			var/obj/item/item = pick(items)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/62661
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

`max_loop` is used in the case where there are more than 10 objects in a mob's contents, so that it isn't looping through a needlessly large amount of items

## Why It's Good For The Game
It was teleporting implants and NODROP items out of your inventory and that shouldn't be happening
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Eigenstasium will no longer teleport undroppable items out of your inventory.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
