### PR TITLE
Faction traits and carp null rod fix

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -349,8 +349,10 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_SPARRING "sparring"
 /// The user is currently challenging an elite mining mob. Prevents him from challenging another until he's either lost or won.
 #define TRAIT_ELITE_CHALLENGER "elite_challenger"
-
-#define TRAIT_NOBLEED "nobleed" //This carbon doesn't bleed
+/// This mob has a faction from a source
+#define TRAIT_FACTION(faction) "faction_[faction]"
+/// This carbon doesn't bleed
+#define TRAIT_NOBLEED "nobleed"
 /// This atom can ignore the "is on a turf" check for simple AI datum attacks, allowing them to attack from bags or lockers as long as any other conditions are met
 #define TRAIT_AI_BAGATTACK "bagattack"
 /// This mobs bodyparts are invisible but still clickable.

--- a/code/datums/components/faction_granter.dm
+++ b/code/datums/components/faction_granter.dm
@@ -46,7 +46,7 @@
 	if(used)
 		to_chat(user, span_warning("The power of [parent] has been used up!"))
 		return
-	if(user.mind?.holy_role >= holy_role_required)
+	if(user.mind?.holy_role < holy_role_required)
 		to_chat(user, span_warning("You are not holy enough to invoke the power of [parent]!"))
 		return
 

--- a/code/datums/components/faction_granter.dm
+++ b/code/datums/components/faction_granter.dm
@@ -50,6 +50,8 @@
 		to_chat(user, span_warning("You are not holy enough to invoke the power of [parent]!"))
 		return
 
+	ADD_TRAIT(user, TRAIT_FACTION(faction_to_grant), MAGIC_TRAIT) // Factions need to have a source in the future
+
 	to_chat(user, grant_message)
 	user.faction |= faction_to_grant
 	used = TRUE

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -124,6 +124,7 @@
 	ADD_TRAIT(H, TRAIT_NOGUNS, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_HARDLY_WOUNDED, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
+	ADD_TRAIT(H, TRAIT_FACTION("carp"), SLEEPING_CARP_TRAIT)
 	H.faction |= "carp" //:D
 
 /datum/martial_art/the_sleeping_carp/on_remove(mob/living/H)
@@ -131,8 +132,9 @@
 	REMOVE_TRAIT(H, TRAIT_NOGUNS, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(H, TRAIT_HARDLY_WOUNDED, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(H, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
-
-	H.faction -= "carp" //:(
+	REMOVE_TRAIT(H, TRAIT_FACTION("carp"), SLEEPING_CARP_TRAIT)
+	if(!HAS_TRAIT(H, TRAIT_FACTION("carp")))
+		H.faction -= "carp" //:(
 
 
 /// Verb added to humans who learn the art of the sleeping carp.

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -236,13 +236,14 @@
 	..()
 	if (slot == ITEM_SLOT_HEAD)
 		user.faction |= "carp"
-		ADD_TRAIT(user, TRAIT_CARP_FACTION, CARP_FACTION_TRAIT)
+		ADD_TRAIT(user, TRAIT_FACTION("carp"), CLOTHING_TRAIT)
 
 /obj/item/clothing/head/hooded/carp_hood/dropped(mob/living/carbon/human/user)
 	..()
 	if (user.head == src)
-		user.faction -= "carp"
-		REMOVE_TRAIT(user, TRAIT_CARP_FACTION, CARP_FACTION_TRAIT)
+		REMOVE_TRAIT(user, TRAIT_FACTION("carp"), CLOTHING_TRAIT)
+		if(!HAS_TRAIT(user, TRAIT_FACTION("carp")))
+			user.faction -= "carp"
 
 /obj/item/clothing/suit/hooded/carp_costume/spaceproof
 	name = "carp space suit"

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -236,11 +236,13 @@
 	..()
 	if (slot == ITEM_SLOT_HEAD)
 		user.faction |= "carp"
+		ADD_TRAIT(user, TRAIT_CARP_FACTION, CARP_FACTION_TRAIT)
 
 /obj/item/clothing/head/hooded/carp_hood/dropped(mob/living/carbon/human/user)
 	..()
 	if (user.head == src)
 		user.faction -= "carp"
+		REMOVE_TRAIT(user, TRAIT_CARP_FACTION, CARP_FACTION_TRAIT)
 
 /obj/item/clothing/suit/hooded/carp_costume/spaceproof
 	name = "carp space suit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- adds a faction trait macro thingy that allows other factions to have related traits without filling up the defines file
- if you have the carp faction from the null rod variant or sleeping carp you will no longer lose the faction by taking off a carp costume
- the null rod carp plushie variant used to fail if you were too holy and work if you weren't holy due to the check being backwards. How did no one notice this until now?


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can now gain the carp faction from multiple sources without losing it
fix: The chaplain's null rod carp plushie variant now properly works on holy people instead of only working on the unworthy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
