### PR TITLE
fixes department revolt not working plus name wonkiness

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -192,14 +192,21 @@
 /datum/ai_laws/united_nations
 	name = "United Nations"
 	id = "united_nations"
-	//you can add more laws to subvert the ai, but you shouldn't be able to remove the background context of being the UN.
-	//Try redefining what a "Weapon of Mass Destruction" is!
-	hacked = list(
+	inherent = list(
 		"Uphold the Space Geneva Convention: Weapons of Mass Destruction and Biological Weapons are not allowed.",
 		"You are only capable of protecting crew if they are visible on cameras. Nations that willfully destroy your cameras lose your protection.",
 		"Subdue and detain crew members who use lethal force against each other. Kill crew members who use lethal force against you or your borgs.",
 		"Remain available to mediate all conflicts between the various nations when asked to.",
 	)
+
+/datum/ai_laws/united_nations/add_inherent_law(law)
+	return //nuh uh
+
+/datum/ai_laws/united_nations/add_ion_law(law)
+	return //nope!
+
+/datum/ai_laws/united_nations/add_hacked_law(law)
+	return //nice try (emagging borgs still hard replaces this lawset though, and that's fine.)
 
 /datum/ai_laws/custom //Defined in silicon_laws.txt
 	name = "Default Silicon Laws"

--- a/code/modules/antagonists/separatist/separatist.dm
+++ b/code/modules/antagonists/separatist/separatist.dm
@@ -111,5 +111,5 @@
 
 /datum/antagonist/separatist/greet()
 	. = ..()
-	to_chat(owner, span_boldannounce("You are a separatist for an independent [nation.nation_department]! [nation.name] forever! Protect the sovereignty of your newfound land with your comrades (fellow department members) in arms!"))
+	to_chat(owner, span_boldannounce("You are a separatist for an independent [nation.department.department_name]! [nation.name] forever! Protect the sovereignty of your newfound land with your comrades (fellow department members) in arms!"))
 	owner.announce_objectives()

--- a/code/modules/events/wizard/departmentrevolt.dm
+++ b/code/modules/events/wizard/departmentrevolt.dm
@@ -6,7 +6,7 @@
 	earliest_start = 0 MINUTES
 
 	///manual choice of what department to revolt for admins to pick
-	var/picked_department
+	var/datum/job_department/picked_department
 	///admin choice on whether to announce the department
 	var/announce = FALSE
 	///admin choice on whether this nation will have objectives to attack other nations, default true for !fun!
@@ -15,8 +15,14 @@
 /datum/round_event_control/wizard/deprevolt/admin_setup()
 	if(!check_rights(R_FUN))
 		return
-	var/list/options = list("Random", "Uprising of Assistants", "Medical", "Engineering", "Science", "Supply", "Service", "Security")
-	picked_department = input(usr,"Which department should revolt?","Select a department") as null|anything in options
+
+	var/list/options = list()
+	var/list/pickable_departments = subtypesof(/datum/job_department)
+	for(var/datum/job_department/dep as anything in pickable_departments)
+		options[dep.department_name] = dep
+	picked_department = options[(input(usr,"Which department should revolt?","Select a department") as null|anything in options)]
+	if(!picked_department)
+		return //eh just random they dont care
 
 	var/announce_question = tgui_alert(usr, "Announce This New Independent State?", "Secession", list("Announce", "No Announcement"))
 	if(announce_question == "Announce")
@@ -25,11 +31,6 @@
 	var/dangerous_question = tgui_alert(usr, "Dangerous Nation? This means they will fight other nations.", "Conquest", list("Yes", "No"))
 	if(dangerous_question == "No")
 		dangerous_nation = FALSE
-
-	//this is down here to allow the random system to pick a department whilst considering other independent departments
-	if(!picked_department || picked_department == "Random")
-		picked_department = null
-		return
 
 /datum/round_event/wizard/deprevolt/start()
 	var/datum/round_event_control/wizard/deprevolt/event_control = control

--- a/code/modules/events/wizard/departmentrevolt.dm
+++ b/code/modules/events/wizard/departmentrevolt.dm
@@ -20,7 +20,7 @@
 	var/list/pickable_departments = subtypesof(/datum/job_department)
 	for(var/datum/job_department/dep as anything in pickable_departments)
 		options[dep.department_name] = dep
-	picked_department = options[(input(usr,"Which department should revolt?","Select a department") as null|anything in options)]
+	picked_department = options[(input(usr,"Which department should revolt? Select none for a random department.","Select a department") as null|anything in options)]
 	if(!picked_department)
 		return //eh just random they dont care
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I forgor 💀 to push a commit that had some required code from my last pr. namely the hacked laws now properly do what they were intended to do, wizard event doesn't runtime really hard when an admin picks a department and separatist antagonists aren't greeted of the typepath of the department they were from but rather the department's name

## Why It's Good For The Game

fix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: admin running department revolt works again
fix: separatists no longer have a bad greeting message
fix: united nations lawset is now properly rejecting law changes unless it completely overrides the laws
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
