### PR TITLE
Fixes a supermatter runtime. Also fixes an airlock runtime.

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -170,14 +170,13 @@
 	if(operating)
 		return
 	add_fingerprint(user)
-	if(!requiresID())
-		user = null
+	if(!density || (obj_flags & EMAGGED))
+		return
 
-	if(density && !(obj_flags & EMAGGED))
-		if(allowed(user))
-			open()
-		else
-			do_animate("deny")
+	if(requiresID() && allowed(user))
+		open()
+	else
+		do_animate("deny")
 
 /obj/machinery/door/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -4,7 +4,7 @@
 	if(SEND_SIGNAL(src, COMSIG_OBJ_ALLOWED, accessor) & COMPONENT_OBJ_ALLOW)
 		return TRUE
 	//check if it doesn't require any access at all
-	if(src.check_access(null))
+	if(check_access(null))
 		return TRUE
 	if(issilicon(accessor))
 		if(ispAI(accessor))

--- a/code/modules/power/supermatter/supermatter_radiation.dm
+++ b/code/modules/power/supermatter/supermatter_radiation.dm
@@ -35,7 +35,14 @@
 	// At the "normal" N2 power output (with max integrity), this is 0.7, which is enough to be stopped
 	// by the walls or the radation shutters.
 	// As integrity does down, rads go up.
-	var/threshold = (THRESHOLD_EQUATION_SLOPE * power_factor + 1) ** ((1 / integrity) ** INTEGRITY_EXPONENTIAL_DEGREE)
+	var/threshold
+	switch(integrity)
+		if(0)
+			threshold = power_factor ? 0 : 1
+		if(1)
+			threshold = (THRESHOLD_EQUATION_SLOPE * power_factor + 1)
+		else
+			threshold = (THRESHOLD_EQUATION_SLOPE * power_factor + 1) ** ((1 / integrity) ** INTEGRITY_EXPONENTIAL_DEGREE)
 
 	// Calculating chance is done entirely on integrity, so that actively delaminating SMs feel more dangerous
 	var/chance = (CHANCE_EQUATION_SLOPE * (1 - integrity)) + RADIATION_CHANCE_AT_FULL_INTEGRITY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It turns out that when the supermatter is about to explode it spams a div/0 runtime instead of emitting rads. This fixes that.
This also fixes a runtime caused by attempting to walk through an airlock with a cut ID wire since it came up in testing.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less runtimes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The supermatter will once again emit radiation when it is about to explode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
