### PR TITLE
Logs turning RD consoles on/off via RD server controller

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -76,8 +76,9 @@
 	set_machine_stat(machine_stat & ~EMPED)
 	refresh_working()
 
-/obj/machinery/rnd/server/proc/toggle_disable()
+/obj/machinery/rnd/server/proc/toggle_disable(mob/user)
 	research_disabled = !research_disabled
+	log_game("[key_name(user)] [research_disabled ? "shut off" : "turned on"] [src] at [loc_name(user)]")
 	refresh_working()
 
 /obj/machinery/rnd/server/proc/get_env_temp()
@@ -151,7 +152,7 @@
 	if (href_list["toggle"])
 		if(allowed(usr) || obj_flags & EMAGGED)
 			var/obj/machinery/rnd/server/S = locate(href_list["toggle"]) in SSresearch.servers
-			S.toggle_disable()
+			S.toggle_disable(usr)
 		else
 			to_chat(usr, span_danger("Access Denied."))
 


### PR DESCRIPTION
## About The Pull Request

Title, adds logs to game.log for when someone remotely shuts RD servers off.

![image](https://user-images.githubusercontent.com/53777086/147836984-9e32e30a-dd79-45cc-a0ef-1e420025459b.png)

## Why It's Good For The Game

It is hard for me to find a reason for RD servers to suddenly shut down, and only today found out that the servers can remotely shut them off. I think them being logged could help in the future, if not finding out someone did shut it off that way (not sure how many people do that), then at least ruling out a possible way for me to track down.

## Changelog

:cl:
admin: RD server controllers now log remotely shutting off/turning on RD servers.
/:cl:
