### PR TITLE
Dyed objects are more obviously dyed

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -246,8 +246,8 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	inhand_y_dimension = initial(target_type.inhand_y_dimension)
 	//indicate that this is a dyed object rather than the real thing
 	name = "dyed [initial(name)]"
-	var/dyed_warning = "[p_they(TRUE)] [p_have()] been dyed to resemble"
-	desc = "[initial(desc)] [dyed_warning] [initial(target_type.name)]."
+	var/dyed_warning = "[p_they(TRUE)] [p_have()] been dyed to resemble [initial(target_type.name)]."
+	desc = "[initial(desc)] [dyed_warning]"
 	return target_type //successfully "appearance copy" dyed something; returns the target type as a hacky way of extending
 
 //what happens to this object when washed inside a washing machine

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -246,7 +246,7 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	inhand_y_dimension = initial(target_type.inhand_y_dimension)
 	//indicate that this is a dyed object rather than the real thing
 	name = "dyed [initial(name)]"
-	var/dyed_warning = gender == PLURAL ? "They have been dyed to resemble" : "It has been dyed to resemble a"
+	var/dyed_warning = "[p_they(TRUE)] [p_have()] been dyed to resemble"
 	desc = "[initial(desc)] [dyed_warning] [initial(target_type.name)]."
 	return target_type //successfully "appearance copy" dyed something; returns the target type as a hacky way of extending
 

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -244,8 +244,10 @@ GLOBAL_LIST_INIT(dye_registry, list(
 	worn_icon_state = initial(target_type.worn_icon_state)
 	inhand_x_dimension = initial(target_type.inhand_x_dimension)
 	inhand_y_dimension = initial(target_type.inhand_y_dimension)
-	name = initial(target_type.name)
-	desc = "[initial(target_type.desc)] The colors look a little dodgy."
+	//indicate that this is a dyed object rather than the real thing
+	name = "dyed [initial(name)]"
+	var/dyed_warning = gender == PLURAL ? "They have been dyed to resemble" : "It has been dyed to resemble a"
+	desc = "[initial(desc)] [dyed_warning] [initial(target_type.name)]."
 	return target_type //successfully "appearance copy" dyed something; returns the target type as a hacky way of extending
 
 //what happens to this object when washed inside a washing machine


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes dyeing such that when an object is dyed it maintains its old name with an added "dyed" prefix.
It also keeps its old description, with an added warning telling the player what object it is dyed to look like.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fixes #62564

Dyeing an object does not actually change the type of the object. This can lead to confusion, as seen in #62564. This change will make it more clear that the actual type of the object did not change.
The dyed prefix will make it possible for players to tell a suit is dyed just by examining it.
This makes hiding a jumpsuit with armor by dyeing it more noticeable. (E.g. A security officer's jumpsuit dyed with a blue crayon will appear to the examiner as a "dyed security officer's jumpsuit" rather than simply a "blue jumpsuit")

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Dyed objects now keep their original name with a "dyed" prefix, as well as keeping their original description with an added sentence to indicate what the object is dyed to look like.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
