### PR TITLE
Implements small labels to abductor glands to see what they do. Part 2.

### DIFF
--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -6,7 +6,7 @@
 	status = ORGAN_ROBOTIC
 	organ_flags = NONE
 	beating = TRUE
-	var/true_name = "baseline placebo referencer"
+	var/abductor_hint = "baseline placebo referencer"
 
 	/// The minimum time between activations
 	var/cooldown_low = 30 SECONDS
@@ -30,7 +30,7 @@
 /obj/item/organ/heart/gland/examine(mob/user)
 	. = ..()
 	if((user.mind && HAS_TRAIT(user.mind, TRAIT_ABDUCTOR_SCIENTIST_TRAINING)) || isobserver(user))
-		. += span_notice("It is \a [true_name].")
+		. += span_notice("It is \a [abductor_hint]")
 
 /obj/item/organ/heart/gland/proc/ownerCheck()
 	if(ishuman(owner))

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -6,6 +6,7 @@
 	status = ORGAN_ROBOTIC
 	organ_flags = NONE
 	beating = TRUE
+	/// Shows name of the gland as well as a description of what it does upon examination by abductor scientists and observers.
 	var/abductor_hint = "baseline placebo referencer"
 
 	/// The minimum time between activations

--- a/code/modules/antagonists/abductor/equipment/glands/access.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/access.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/access
-	true_name = "anagraphic electro-scrambler"
+	true_name = "anagraphic electro-scrambler. After it activates, makes the abductee have intrinsic all access."
 	cooldown_low = 600
 	cooldown_high = 1200
 	uses = 1

--- a/code/modules/antagonists/abductor/equipment/glands/access.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/access.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/access
-	true_name = "anagraphic electro-scrambler. After it activates, makes the abductee have intrinsic all access."
+	true_name = "anagraphic electro-scrambler. After it activates, makes the abductee have intrinsic all access"
 	cooldown_low = 600
 	cooldown_high = 1200
 	uses = 1

--- a/code/modules/antagonists/abductor/equipment/glands/access.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/access.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/access
-	true_name = "anagraphic electro-scrambler. After it activates, makes the abductee have intrinsic all access"
+	abductor_hint = "anagraphic electro-scrambler. After it activates, grants the abductee intrinsic all access."
 	cooldown_low = 600
 	cooldown_high = 1200
 	uses = 1

--- a/code/modules/antagonists/abductor/equipment/glands/blood.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/blood.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/blood
-	true_name = "pseudonuclear hemo-destabilizer. Periodically randomizes the abductee's bloodtype into a random reagent"
+	abductor_hint = "pseudonuclear hemo-destabilizer. Periodically randomizes the abductee's bloodtype into a random reagent."
 	cooldown_low = 1200
 	cooldown_high = 1800
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/blood.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/blood.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/blood
-	true_name = "pseudonuclear hemo-destabilizer. Periodically randomizes the abductee's bloodtype into a random reagent."
+	true_name = "pseudonuclear hemo-destabilizer. Periodically randomizes the abductee's bloodtype into a random reagent"
 	cooldown_low = 1200
 	cooldown_high = 1800
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/blood.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/blood.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/blood
-	true_name = "pseudonuclear hemo-destabilizer"
+	true_name = "pseudonuclear hemo-destabilizer. Periodically randomizes the abductee's bloodtype into a random reagent."
 	cooldown_low = 1200
 	cooldown_high = 1800
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/chem.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/chem.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/chem
-	true_name = "intrinsic pharma-provider. The abductee constantly produces random chemicals inside their bloodstream. They also quickly regenerate toxin damage."
+	true_name = "intrinsic pharma-provider. The abductee constantly produces random chemicals inside their bloodstream. They also quickly regenerate toxin damage"
 	cooldown_low = 50
 	cooldown_high = 50
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/chem.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/chem.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/chem
-	true_name = "intrinsic pharma-provider"
+	true_name = "intrinsic pharma-provider. The abductee constantly produces random chemicals inside their bloodstream. They also quickly regenerate toxin damage."
 	cooldown_low = 50
 	cooldown_high = 50
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/chem.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/chem.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/chem
-	true_name = "intrinsic pharma-provider. The abductee constantly produces random chemicals inside their bloodstream. They also quickly regenerate toxin damage"
+	abductor_hint = "intrinsic pharma-provider. The abductee constantly produces random chemicals inside their bloodstream. They also quickly regenerate toxin damage."
 	cooldown_low = 50
 	cooldown_high = 50
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/egg.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/egg.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/egg
-	true_name = "roe/enzymatic synthesizer"
+	true_name = "roe/enzymatic synthesizer. Makes the abductee lay eggs filled with random reagents."
 	cooldown_low = 300
 	cooldown_high = 400
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/egg.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/egg.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/egg
-	true_name = "roe/enzymatic synthesizer. Makes the abductee lay eggs filled with random reagents."
+	true_name = "roe/enzymatic synthesizer. Makes the abductee lay eggs filled with random reagents"
 	cooldown_low = 300
 	cooldown_high = 400
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/egg.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/egg.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/egg
-	true_name = "roe/enzymatic synthesizer. Makes the abductee lay eggs filled with random reagents"
+	abductor_hint = "roe/enzymatic synthesizer. The abductee will periodically lay eggs filled with random reagents."
 	cooldown_low = 300
 	cooldown_high = 400
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/electric.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/electric.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/electric
-	true_name = "electron accumulator/discharger"
+	true_name = "electron accumulator/discharger. The abductee becomes fully immune to electric shocks. Additionally, they will randomly discharge electric bolts."
 	cooldown_low = 800
 	cooldown_high = 1200
 	icon_state = "species"

--- a/code/modules/antagonists/abductor/equipment/glands/electric.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/electric.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/electric
-	true_name = "electron accumulator/discharger. The abductee becomes fully immune to electric shocks. Additionally, they will randomly discharge electric bolts."
+	true_name = "electron accumulator/discharger. The abductee becomes fully immune to electric shocks. Additionally, they will randomly discharge electric bolts"
 	cooldown_low = 800
 	cooldown_high = 1200
 	icon_state = "species"

--- a/code/modules/antagonists/abductor/equipment/glands/electric.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/electric.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/electric
-	true_name = "electron accumulator/discharger. The abductee becomes fully immune to electric shocks. Additionally, they will randomly discharge electric bolts"
+	abductor_hint = "electron accumulator/discharger. The abductee becomes fully immune to electric shocks. Additionally, they will randomly discharge electric bolts."
 	cooldown_low = 800
 	cooldown_high = 1200
 	icon_state = "species"

--- a/code/modules/antagonists/abductor/equipment/glands/heal.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/heal.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/heal
-	true_name = "organic replicator. If organs, chest or or limbs are too damaged or robotic, they will be forcefully rejected and replacements will grow out instead. If having low blood, over 40 toxin damage, or at least 10u toxins in bloodstream, the blood will be rejected (by vomit) and replaced with healthy blood. Also rejects implants such as mindshield implants."
+	true_name = "organic replicator. If organs, chest or or limbs are too damaged or robotic, they will be forcefully rejected and replacements will grow out instead. If having low blood, over 40 toxin damage, or at least 10u toxins in bloodstream, the blood will be rejected (by vomit) and replaced with healthy blood. Also rejects implants such as mindshield implants"
 	cooldown_low = 200
 	cooldown_high = 400
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/heal.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/heal.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/heal
-	true_name = "organic replicator. If organs, chest or or limbs are too damaged or robotic, they will be forcefully rejected and replacements will grow out instead. If having low blood, moderate toxin damage, or at least mild toxins in bloodstream, the blood will be rejected (by vomit) and replaced with healthy blood. Also rejects implants such as mindshield implants"
+	abductor_hint = "organic replicator. Forcibly ejects damaged and robotic organs from the abductee and regenerates them. Additionally, forcibly removes reagents (via vomit) from the abductee if they have moderate toxin damage or poison within the bloodstream, and regenerates blood to a healthy threshold if too low. The abductee will also reject implants such as mindshields."
 	cooldown_low = 200
 	cooldown_high = 400
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/heal.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/heal.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/heal
-	true_name = "organic replicator"
+	true_name = "organic replicator. If organs, chest or or limbs are too damaged or robotic, they will be forcefully rejected and replacements will grow out instead. If having low blood, over 40 toxin damage, or at least 10u toxins in bloodstream, the blood will be rejected (by vomit) and replaced with healthy blood. Also rejects implants such as mindshield implants."
 	cooldown_low = 200
 	cooldown_high = 400
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/heal.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/heal.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/heal
-	true_name = "organic replicator. If organs, chest or or limbs are too damaged or robotic, they will be forcefully rejected and replacements will grow out instead. If having low blood, over 40 toxin damage, or at least 10u toxins in bloodstream, the blood will be rejected (by vomit) and replaced with healthy blood. Also rejects implants such as mindshield implants"
+	true_name = "organic replicator. If organs, chest or or limbs are too damaged or robotic, they will be forcefully rejected and replacements will grow out instead. If having low blood, moderate toxin damage, or at least mild toxins in bloodstream, the blood will be rejected (by vomit) and replaced with healthy blood. Also rejects implants such as mindshield implants"
 	cooldown_low = 200
 	cooldown_high = 400
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/mindshock
-	true_name = "neural crosstalk uninhibitor"
+	true_name = "neural crosstalk uninhibitor. Makes the abductee emit a disrupting psychic wave every so often. This will either stun, cause hallucinations or deal random brain damage to people nearby."
 	cooldown_low = 400
 	cooldown_high = 700
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/mindshock
-	true_name = "neural crosstalk uninhibitor. Makes the abductee emit a disrupting psychic wave every so often. This will either stun, cause hallucinations or deal random brain damage to people nearby."
+	true_name = "neural crosstalk uninhibitor. Makes the abductee emit a disrupting psychic wave every so often. This will either stun, cause hallucinations or deal random brain damage to people nearby"
 	cooldown_low = 400
 	cooldown_high = 700
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/mindshock.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/mindshock
-	true_name = "neural crosstalk uninhibitor. Makes the abductee emit a disrupting psychic wave every so often. This will either stun, cause hallucinations or deal random brain damage to people nearby"
+	abductor_hint = "neural crosstalk uninhibitor. The abductee emits a disrupting psychic wave every so often. This will either stun, cause hallucinations or deal random brain damage to people nearby."
 	cooldown_low = 400
 	cooldown_high = 700
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/plasma.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/plasma.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/plasma
-	true_name = "effluvium sanguine-synonym emitter"
+	true_name = "effluvium sanguine-synonym emitter. Makes the abductee emit a disrupting psychic wave every so often. This will either stun, cause hallucinations or deal random brain damage to people nearby."
 	cooldown_low = 1200
 	cooldown_high = 1800
 	icon_state = "slime"

--- a/code/modules/antagonists/abductor/equipment/glands/plasma.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/plasma.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/plasma
-	true_name = "effluvium sanguine-synonym emitter. Makes the abductee emit a disrupting psychic wave every so often. This will either stun, cause hallucinations or deal random brain damage to people nearby."
+	true_name = "effluvium sanguine-synonym emitter. Makes the abductee emit a disrupting psychic wave every so often. This will either stun, cause hallucinations or deal random brain damage to people nearby"
 	cooldown_low = 1200
 	cooldown_high = 1800
 	icon_state = "slime"

--- a/code/modules/antagonists/abductor/equipment/glands/plasma.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/plasma.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/plasma
-	true_name = "effluvium sanguine-synonym emitter. Makes the abductee emit a disrupting psychic wave every so often. This will either stun, cause hallucinations or deal random brain damage to people nearby"
+	abductor_hint = "effluvium sanguine-synonym emitter. The abductee randomly emits clouds of plasma."
 	cooldown_low = 1200
 	cooldown_high = 1800
 	icon_state = "slime"

--- a/code/modules/antagonists/abductor/equipment/glands/quantum.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/quantum.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/quantum
-	true_name = "quantic de-observation matrix. Periodically links with a random person in view, then the abductee later swaps positions with that person"
+	abductor_hint = "quantic de-observation matrix. Periodically links with a random person in view, then the abductee later swaps positions with that person."
 	cooldown_low = 150
 	cooldown_high = 150
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/quantum.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/quantum.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/quantum
-	true_name = "quantic de-observation matrix"
+	true_name = "quantic de-observation matrix. Periodically links with a random person in view, then the abductee later swaps positions with that person."
 	cooldown_low = 150
 	cooldown_high = 150
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/quantum.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/quantum.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/quantum
-	true_name = "quantic de-observation matrix. Periodically links with a random person in view, then the abductee later swaps positions with that person."
+	true_name = "quantic de-observation matrix. Periodically links with a random person in view, then the abductee later swaps positions with that person"
 	cooldown_low = 150
 	cooldown_high = 150
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/slime.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/slime.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/slime
-	true_name = "gastric animation galvanizer. The abductee occasionally vomits slimes. Slimes will no longer attack the abductee"
+	abductor_hint = "gastric animation galvanizer. The abductee occasionally vomits slimes. Slimes will no longer attack the abductee."
 	cooldown_low = 600
 	cooldown_high = 1200
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/slime.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/slime.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/slime
-	true_name = "gastric animation galvanizer"
+	true_name = "gastric animation galvanizer. The abductee occasionally vomits slimes. Slimes will no longer attack the abductee."
 	cooldown_low = 600
 	cooldown_high = 1200
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/slime.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/slime.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/slime
-	true_name = "gastric animation galvanizer. The abductee occasionally vomits slimes. Slimes will no longer attack the abductee."
+	true_name = "gastric animation galvanizer. The abductee occasionally vomits slimes. Slimes will no longer attack the abductee"
 	cooldown_low = 600
 	cooldown_high = 1200
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/spider.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/spider.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/spiderman
-	true_name = "araneae cloister accelerator. Makes the abductee exhale spider pheromones and spawn spiderlings"
+	abductor_hint = "araneae cloister accelerator. The abductee occasionally exhales spider pheromones and will spawn spiderlings."
 	cooldown_low = 450
 	cooldown_high = 900
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/spider.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/spider.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/spiderman
-	true_name = "araneae cloister accelerator"
+	true_name = "araneae cloister accelerator. Makes the abductee exhale spider pheromones and spawn spiderlings."
 	cooldown_low = 450
 	cooldown_high = 900
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/spider.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/spider.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/spiderman
-	true_name = "araneae cloister accelerator. Makes the abductee exhale spider pheromones and spawn spiderlings."
+	true_name = "araneae cloister accelerator. Makes the abductee exhale spider pheromones and spawn spiderlings"
 	cooldown_low = 450
 	cooldown_high = 900
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/transform.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/transform.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/transform
-	true_name = "anthropmorphic transmorphosizer. Makes the abductee occasionally change appearance and species"
+	abductor_hint = "anthropmorphic transmorphosizer. The abductee will occasionally change appearance and species."
 	cooldown_low = 900
 	cooldown_high = 1800
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/transform.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/transform.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/transform
-	true_name = "anthropmorphic transmorphosizer"
+	true_name = "anthropmorphic transmorphosizer. Makes the abductee occasionally change appearance and species."
 	cooldown_low = 900
 	cooldown_high = 1800
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/transform.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/transform.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/transform
-	true_name = "anthropmorphic transmorphosizer. Makes the abductee occasionally change appearance and species."
+	true_name = "anthropmorphic transmorphosizer. Makes the abductee occasionally change appearance and species"
 	cooldown_low = 900
 	cooldown_high = 1800
 	uses = -1

--- a/code/modules/antagonists/abductor/equipment/glands/trauma.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/trauma.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/trauma
-	true_name = "white matter randomiser"
+	true_name = "white matter randomiser. The abductee occasionally gains a random brain trauma, up to five times. The traumas can range from basic to deep-rooted."
 	cooldown_low = 800
 	cooldown_high = 1200
 	uses = 5

--- a/code/modules/antagonists/abductor/equipment/glands/trauma.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/trauma.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/trauma
-	true_name = "white matter randomiser. The abductee occasionally gains a random brain trauma, up to five times. The traumas can range from basic to deep-rooted"
+	abductor_hint = "white matter randomiser. The abductee occasionally gains a random brain trauma, up to five times. The traumas can range from basic to deep-rooted."
 	cooldown_low = 800
 	cooldown_high = 1200
 	uses = 5

--- a/code/modules/antagonists/abductor/equipment/glands/trauma.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/trauma.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/trauma
-	true_name = "white matter randomiser. The abductee occasionally gains a random brain trauma, up to five times. The traumas can range from basic to deep-rooted."
+	true_name = "white matter randomiser. The abductee occasionally gains a random brain trauma, up to five times. The traumas can range from basic to deep-rooted"
 	cooldown_low = 800
 	cooldown_high = 1200
 	uses = 5

--- a/code/modules/antagonists/abductor/equipment/glands/ventcrawl.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/ventcrawl.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/ventcrawling
-	true_name = "pliant cartilage enabler. Allows the abductee to crawl through vents without trouble"
+	abductor_hint = "pliant cartilage enabler. The abductee can crawl through vents without trouble."
 	cooldown_low = 1800
 	cooldown_high = 2400
 	uses = 1

--- a/code/modules/antagonists/abductor/equipment/glands/ventcrawl.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/ventcrawl.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/ventcrawling
-	true_name = "pliant cartilage enabler"
+	true_name = "pliant cartilage enabler. Allows the abductee to crawl through vents without trouble."
 	cooldown_low = 1800
 	cooldown_high = 2400
 	uses = 1

--- a/code/modules/antagonists/abductor/equipment/glands/ventcrawl.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/ventcrawl.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/ventcrawling
-	true_name = "pliant cartilage enabler. Allows the abductee to crawl through vents without trouble."
+	true_name = "pliant cartilage enabler. Allows the abductee to crawl through vents without trouble"
 	cooldown_low = 1800
 	cooldown_high = 2400
 	uses = 1

--- a/code/modules/antagonists/abductor/equipment/glands/viral.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/viral.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/viral
-	true_name = "contamination incubator"
+	true_name = "contamination incubator. Makes the abductee carrier of a random advanced disease - abductee is NOT affected."
 	cooldown_low = 1800
 	cooldown_high = 2400
 	uses = 1

--- a/code/modules/antagonists/abductor/equipment/glands/viral.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/viral.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/viral
-	true_name = "contamination incubator. Makes the abductee carrier of a random advanced disease - abductee is NOT affected"
+	abductor_hint = "contamination incubator. The abductee becomes a carrier of a random advanced disease - of which they are unaffected by."
 	cooldown_low = 1800
 	cooldown_high = 2400
 	uses = 1

--- a/code/modules/antagonists/abductor/equipment/glands/viral.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/viral.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/heart/gland/viral
-	true_name = "contamination incubator. Makes the abductee carrier of a random advanced disease - abductee is NOT affected."
+	true_name = "contamination incubator. Makes the abductee carrier of a random advanced disease - abductee is NOT affected"
 	cooldown_low = 1800
 	cooldown_high = 2400
 	uses = 1


### PR DESCRIPTION
## About The Pull Request

Abductors and observers will now be able to see what organ's do upon shift-clicking them. Uhhh, mothblocks was racist towards Australians and the AEST so I GUESS I had to remake this.

## Why It's Good For The Game

Uhhh, who the fuck thought having to check the wiki for every organ was a good idea? This allows for a better experience for abductor scientists and curious ghosts wanting to see what happens next.

## Changelog

:cl:
qol: Adds descriptions to abductor glands upon shiftclick. 
/:cl: