### PR TITLE
Enables the GPS and Quantum Pad on Ancient Protolathes.

### DIFF
--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -68,7 +68,7 @@
 	name = "Quantum Spin Inverter"
 	desc = "An experimental device that is able to swap the locations of two entities by switching their particles' spin values. Must be linked to another device to function."
 	id = "swapper"
-	build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 1000, /datum/material/bluespace = 2000, /datum/material/gold = 1500, /datum/material/silver = 1000)
 	build_path = /obj/item/swapper
 	category = list("Bluespace Designs")

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -38,7 +38,7 @@
 	name = "GPS Device"
 	desc = "Little thingie that can track its position at all times."
 	id = "telesci_gps"
-	build_type = PROTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 1000)
 	build_path = /obj/item/gps
 	category = list("Bluespace Designs")
@@ -68,7 +68,7 @@
 	name = "Quantum Spin Inverter"
 	desc = "An experimental device that is able to swap the locations of two entities by switching their particles' spin values. Must be linked to another device to function."
 	id = "swapper"
-	build_type = PROTOLATHE
+	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 1000, /datum/material/bluespace = 2000, /datum/material/gold = 1500, /datum/material/silver = 1000)
 	build_path = /obj/item/swapper
 	category = list("Bluespace Designs")

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -95,7 +95,6 @@
 	name = "Machine Design (Quantum Pad Board)"
 	desc = "The circuit board for a quantum telepad."
 	id = "quantumpad"
-	build_type = IMPRINTER
 	build_path = /obj/item/circuitboard/machine/quantumpad
 	category = list ("Teleportation Machinery")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Okay, so. I wanted to make a mapping PR, but I decided to do this instead. Iunno, reasons.
Ancient Protolathes were added to the game to prevent ghostroles from shitting on-station and straying too far from their intended bounds. (Also to partially dissuade station players from looting them, though that very much still happens.) Sounds good, right? Except... there are still ways around the limitations, to the point it just becomes an annoyance rather than a proper security measure.
This PR reverts two choice designs that were disabled - GPS Units and Quantum Pads. I'll explain why briefly:

GPS Units:
GPS units are obtainable by anyone who has access to a mining equipment vendor, (Survival pod has a GPS unit that can be obtained inhand with just a wrench) or a robotics setup with modsuit (MODSUIT GPS). Basically, everyone except lavaland syndicate roles, and they broadcast a GPS signal as-is.

Quantum Pads:
Eigenstasium Lockers are obtainable by anyone with a chemistry set and function near identically - perhaps even better than Quantum Pads depending on use case. **Note that I have opted _not_ to enable spin inverters as well for fear of abuse, even though golems can obtain near-equivalents in the red and blue cube.**
Also, Quantum Keycards were printable, so maybe this one was an oversight maybe hopefully, I dunno.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
While I respect why they were disabled originally, fact is simply that it's ended up as a minor annoyance to actual use and won't stop someone actually dedicated to abusing either item or their equivalents.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Ghostroles can now natively print quantum pads and GPS units from their lathes, rather than having to use workarounds with mining equipment vendors or chemistry. Quantum Spin Inverters, Teleporters, and Bluespace Launchpads are still only obtainable on-station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
