### PR TITLE
Headrev preferences is now what matters when rolling headrev

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -368,7 +368,7 @@
 			var/list/datum/mind/nonhuman_promotable = list()
 			for(var/datum/mind/khrushchev in non_heads)
 				if(khrushchev.current && !khrushchev.current.incapacitated() && !HAS_TRAIT(khrushchev.current, TRAIT_RESTRAINED) && khrushchev.current.client)
-					if(ROLE_REV in khrushchev.current.client.prefs.be_special)
+					if(ROLE_REV_HEAD in khrushchev.current.client.prefs.be_special)
 						if(ishuman(khrushchev.current))
 							promotable += khrushchev
 						else


### PR DESCRIPTION
## About The Pull Request

Title. You now roll headrev depending on whether you have headrev in your preferences, rather than rev.

I was told this was QoL and to wait for feature freeze to end to PR this.

## Why It's Good For The Game

If you don't have your preferences to be a headrev, I don't think you want to be one.

## Changelog

:cl:
qol: Being promoted to a headrev now takes into account headrev preferences, rather than regular revolutionary.
/:cl: