### PR TITLE
Circuit index-wise list setters

### DIFF
--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -341,6 +341,15 @@
 	id = "comp_filter_list"
 	build_path = /obj/item/circuit_component/filter_list
 
+/datum/design/component/index_setter
+	name = "Set List Element By Index"
+	id = "comp_list_index_set"
+	build_path = /obj/item/circuit_component/index_setter
+
+/datum/design/component/index_setter_assoc
+	name = "Set Assoc List Element By Index"
+	id = "comp_list_index_set_assoc"
+	build_path = /obj/item/circuit_component/index_setter/assoc_string
 
 /datum/design/compact_remote_shell
 	name = "Compact Remote Shell"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -243,6 +243,8 @@
 		"comp_light",
 		"comp_list_literal",
 		"comp_list_assoc_literal",
+		"comp_list_index_set",
+		"comp_list_index_set_assoc",
 		"comp_logic",
 		"comp_matscanner",
 		"comp_mmi",

--- a/code/modules/wiremod/components/list/index_setter.dm
+++ b/code/modules/wiremod/components/list/index_setter.dm
@@ -1,0 +1,69 @@
+/obj/item/circuit_component/index_setter
+	display_name = "Set List Element By Index"
+	desc = "A component that sets the value of a list at a given index."
+	category = "List"
+
+	/// The list type
+	var/datum/port/input/option/list_options
+
+	/// The input ports
+	var/datum/port/input/list_input_port
+	var/datum/port/input/new_element_value
+	var/datum/port/input/index_port
+
+	/// The list after setting the value
+	var/datum/port/output/list_output_port
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
+
+	var/index_type = PORT_TYPE_NUMBER
+
+/obj/item/circuit_component/index_setter/populate_options()
+	list_options = add_option_port("List Type", GLOB.wiremod_basic_types)
+
+/obj/item/circuit_component/index_setter/proc/make_list_ports()
+	list_input_port = add_input_port("List", PORT_TYPE_LIST(PORT_TYPE_ANY))
+	list_output_port = add_output_port("Modified List", PORT_TYPE_LIST(PORT_TYPE_ANY))
+
+/obj/item/circuit_component/index_setter/populate_ports()
+	index_port = add_input_port("Index", index_type)
+	new_element_value = add_input_port("New Value", PORT_TYPE_ANY)
+	make_list_ports()
+
+/obj/item/circuit_component/index_setter/pre_input_received(datum/port/input/port)
+	if(port == list_options)
+		var/new_type = list_options.value
+		list_input_port.set_datatype(PORT_TYPE_LIST(new_type))
+		list_output_port.set_datatype(PORT_TYPE_LIST(new_type))
+		new_element_value.set_datatype(new_type)
+
+/obj/item/circuit_component/index_setter/input_received(datum/port/input/port)
+
+	var/index = index_port.value
+	var/list/list_input = list_input_port.value
+
+	if(!list_input)
+		return
+
+	var/list/modified_list = deep_copy_list(list_input)
+
+	if(index > 0 && index <= modified_list.len)
+		modified_list[index] = new_element_value.value
+
+	list_output_port.set_output(modified_list)
+
+/obj/item/circuit_component/index_setter/assoc_string
+	display_name = "Set Assoc List Element By Index"
+	desc = "A component that can be used to set a row from a table. Modifies data from a key, value list."
+
+	index_type = PORT_TYPE_STRING
+
+/obj/item/circuit_component/index_setter/assoc_string/make_list_ports()
+	list_input_port = add_input_port("List", PORT_TYPE_ASSOC_LIST(PORT_TYPE_STRING, PORT_TYPE_ANY))
+	list_output_port = add_output_port("Modified List", PORT_TYPE_ASSOC_LIST(PORT_TYPE_STRING, PORT_TYPE_ANY))
+
+/obj/item/circuit_component/index_setter/assoc_string/pre_input_received(datum/port/input/port)
+	if(port == list_options)
+		var/new_type = list_options.value
+		list_input_port.set_datatype(PORT_TYPE_ASSOC_LIST(PORT_TYPE_STRING, new_type))
+		list_output_port.set_datatype(PORT_TYPE_ASSOC_LIST(PORT_TYPE_STRING, new_type))
+		new_element_value.set_datatype(new_type)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4059,6 +4059,7 @@
 #include "code\modules\wiremod\components\list\foreach.dm"
 #include "code\modules\wiremod\components\list\get_column.dm"
 #include "code\modules\wiremod\components\list\index.dm"
+#include "code\modules\wiremod\components\list\index_setter.dm"
 #include "code\modules\wiremod\components\list\index_table.dm"
 #include "code\modules\wiremod\components\list\list_literal.dm"
 #include "code\modules\wiremod\components\list\select.dm"


### PR DESCRIPTION
## About The Pull Request

Adds circuit components that set the value of a list by index. Given an input list, an index, and a value, these components will return a copy of the list with the value at the selected index replaced with the input value.

## Why It's Good For The Game

Adds an method for circuit list manipulation that's either difficult or impossible to perform with current components.
~~also I want to make buttbots but I needed this component to do that~~

## Changelog

:cl:
expansion: Adds circuit components to set the element of a list by index.
/:cl:

