### PR TITLE
Natural Insecticide now graftable

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -18,7 +18,6 @@
 	genes = list(/datum/plant_gene/trait/preserved)
 	mutatelist = list(/obj/item/seeds/poppy/geranium, /obj/item/seeds/poppy/lily)
 	reagents_add = list(/datum/reagent/medicine/c2/libital = 0.2, /datum/reagent/consumable/nutriment = 0.05)
-	graft_gene = /datum/plant_gene/trait/preserved
 
 /obj/item/food/grown/poppy
 	seed = /obj/item/seeds/poppy
@@ -111,6 +110,7 @@
 	mutatelist = null
 	rarity = 15
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05, /datum/reagent/fuel/oil = 0.05)
+	graft_gene = /datum/plant_gene/trait/preserved
 
 ///Fraxinella Flowers.
 /obj/item/food/grown/poppy/geranium/fraxinella

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -18,6 +18,7 @@
 	genes = list(/datum/plant_gene/trait/preserved)
 	mutatelist = list(/obj/item/seeds/poppy/geranium, /obj/item/seeds/poppy/lily)
 	reagents_add = list(/datum/reagent/medicine/c2/libital = 0.2, /datum/reagent/consumable/nutriment = 0.05)
+	graft_gene = /datum/plant_gene/trait/preserved
 
 /obj/item/food/grown/poppy
 	seed = /obj/item/seeds/poppy


### PR DESCRIPTION
## About The Pull Request

Makes the 'Natural Insecticide' trait found in fraxinella graftable.

## Why It's Good For The Game

Food decomposition/ants are a very interesting addition to the game, but disproportionally affect hydroponics. The stated intent of it was to get people to not leave food lying around. However, while many botany plants may technically be classified as food, they are often associated with other types of projects. Additionally, due to bulk harvesting and different plant strains belonging to the same species, simply putting the plants on a table or in the fridge often isn't a satisfactory solution. Having to constantly keep numerous samples from decomposing while doing multiple/complex projects can be tedious.

Seeing as how certain flowers already naturally resist decomposition/ants, and that transferring plant traits is a staple of botany mechanics already, adding the ability to transfer this protection to other plants seems like a reasonable in-universe way of giving botanists more quality of life options in this regard, while leaving most of the other aspects of decomposition/ant related content unmolested.

## Changelog

:cl:
qol: The fraxinella flower is now more willing to share its protection against the insect menace.
/:cl:
