### PR TITLE
Binoculars work during spacedrifting.

### DIFF
--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -8,8 +8,9 @@
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
-	var/mob/listeningTo
+	/// The amount to increase the size of the FoV.
 	var/zoom_out_amt = 5.5
+	/// The amount displace the FoV in the direction the user is facing.
 	var/zoom_amt = 10
 
 /obj/item/binoculars/Initialize(mapload)
@@ -21,42 +22,62 @@
 	. = ..()
 	AddComponent(/datum/component/two_handed, force_unwielded=8, force_wielded=12)
 
-/obj/item/binoculars/Destroy()
-	listeningTo = null
-	return ..()
-
+/**
+ * Handles zooming the user out when they look through the binoculars.
+ *
+ * Arguments:
+ * - [source][/obj/item]: The source of the signal. Equivalent to src.
+ * - [user][/mob]: The mob that has wielded this pair of binoculars.
+ */
 /obj/item/binoculars/proc/on_wield(obj/item/source, mob/user)
 	SIGNAL_HANDLER
 
-	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/on_walk)
+	RegisterSignal(user, COMSIG_MOB_CLIENT_MOVED, .proc/on_walk)
 	RegisterSignal(user, COMSIG_ATOM_DIR_CHANGE, .proc/rotate)
-	listeningTo = user
 	user.visible_message(span_notice("[user] holds [src] up to [user.p_their()] eyes."), span_notice("You hold [src] up to your eyes."))
 	inhand_icon_state = "binoculars_wielded"
 	user.regenerate_icons()
 	user.client.view_size.zoomOut(zoom_out_amt, zoom_amt, user.dir)
 
-/obj/item/binoculars/proc/rotate(atom/thing, old_dir, new_dir)
-	SIGNAL_HANDLER
-
-	if(ismob(thing))
-		var/mob/lad = thing
-		lad.regenerate_icons()
-		lad.client.view_size.zoomOut(zoom_out_amt, zoom_amt, new_dir)
-
-/obj/item/binoculars/proc/on_walk()
-	SIGNAL_HANDLER
-
-	attack_self(listeningTo) //Yes I have sinned, why do you ask?
-
+/**
+ * Handles zooming the user back in when they lower the binoculars.
+ *
+ * Arguments:
+ * - [source][/obj/item]: The source of the signal. Equivalent to src.
+ * - [user][/mob]: The mob that has unwielded this pair of binoculars.
+ */
 /obj/item/binoculars/proc/on_unwield(obj/item/source, mob/user)
 	SIGNAL_HANDLER
 
-	if(listeningTo)
-		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
-		UnregisterSignal(user, COMSIG_ATOM_DIR_CHANGE)
-		listeningTo = null
+	UnregisterSignal(user, list(
+		COMSIG_MOB_CLIENT_MOVED,
+		COMSIG_ATOM_DIR_CHANGE,
+	))
 	user.visible_message(span_notice("[user] lowers [src]."), span_notice("You lower [src]."))
 	inhand_icon_state = "binoculars"
 	user.regenerate_icons()
 	user.client.view_size.zoomIn()
+
+
+/**
+ * Handles rotating the user's view when they turn while looking through the binoculars.
+ *
+ * Arguments:
+ * - [lad][/mob]: The source of the signal. The person using the binoculars.
+ * - old_dir: The direction the user was facing.
+ * - new_dir: The direction the user is now facing.
+ */
+/obj/item/binoculars/proc/rotate(mob/lad, old_dir, new_dir)
+	SIGNAL_HANDLER
+	lad.regenerate_icons()
+	lad.client.view_size.zoomOut(zoom_out_amt, zoom_amt, new_dir)
+
+/**
+ * Handles lowering the binoculars when the person using them tries to move.
+ *
+ * Arguments:
+ * - [user][/mob]: The mob using this pair of binoculars that moved.
+ */
+/obj/item/binoculars/proc/on_walk(mob/user)
+	SIGNAL_HANDLER
+	attack_self(user) //Yes I have sinned, why do you ask?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the signal binoculars listen to to make you lower them on movement to listen for _intentional_ movement.
This makes it possible to use them while drifting through space, which is one of the few places you'd actually want to use them.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pressing z while spacedrifting with the binoculars will no longer make the screen spaz out.
Also lets the item that lets you see what things are far away work in one of the few situations in which you don't know what's far away. (Space)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You will no longer be forced to lower binoculars while spacedrifting, making them actually usable in 0-gravity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
