### PR TITLE
Grammar fix: adminhelp

### DIFF
--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -103,7 +103,7 @@
 				continue //Don't show afk admins to adminwho
 			if(!C.holder.fakekey)
 				msg += "\t[C] is a [C.holder.rank]\n"
-		msg += span_info("Adminhelps are also sent through TGS to Discord. If no admins are available in game, sending an adminhelp might still be noticed and responded to.")
+		msg += span_info("Adminhelps are also sent through TGS services like IRC and Discord. If no admins are available in game, sending an adminhelp might still be noticed and responded to.")
 	to_chat(src, msg)
 
 #undef DEFAULT_WHO_CELLS_PER_ROW

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -103,7 +103,7 @@
 				continue //Don't show afk admins to adminwho
 			if(!C.holder.fakekey)
 				msg += "\t[C] is a [C.holder.rank]\n"
-		msg += span_info("Adminhelps are also sent through TGS services like IRC and Discord. If no admins are available in game, sending an adminhelp might still be noticed and responded to.")
+		msg += span_info("Adminhelps are also sent through TGS to services like IRC and Discord. If no admins are available in game, sending an adminhelp might still be noticed and responded to.")
 	to_chat(src, msg)
 
 #undef DEFAULT_WHO_CELLS_PER_ROW

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -103,7 +103,7 @@
 				continue //Don't show afk admins to adminwho
 			if(!C.holder.fakekey)
 				msg += "\t[C] is a [C.holder.rank]\n"
-		msg += span_info("Adminhelps are also sent through TGS to services like IRC and Discord. If no admins are available in game adminhelp anyways and an admin will see it and respond.")
+		msg += span_info("Adminhelps are also sent through TGS to Discord. If no admins are available in game, sending an adminhelp might still be noticed and responded to.")
 	to_chat(src, msg)
 
 #undef DEFAULT_WHO_CELLS_PER_ROW


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
>Adminhelps are also sent through TGS to services like IRC and Discord. If no admins are available in game adminhelp anyways and an admin will see it and respond.
 
to: 
>Adminhelps are also sent through TGS to Discord. If no admins are available in game, sending an adminhelp might still be noticed and responded to.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A comma would be better there, and we don't even use IRC
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Admin help info is now slightly more readable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
