### PR TITLE
Stops silicons from opening circuit airlocks by bumping them open

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -75,6 +75,9 @@
 #define COMSIG_OBJ_ALLOWED "door_try_to_activate"
 	#define COMPONENT_OBJ_ALLOW (1<<0)
 
+#define COMSIG_AIRLOCK_SHELL_ALLOWED "airlock_shell_try_allowed"
+	#define COMPONENT_AIRLOCK_SHELL_ALLOW (1<<0)
+
 // /obj/machinery/door/airlock signals
 
 //from /obj/machinery/door/airlock/open(): (forced)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -246,7 +246,8 @@
 	else if(I.tool_behaviour == TOOL_WELDER)
 		try_to_weld(I, user, params)
 		return TRUE
-	else if((!(I.item_flags & NOBLUDGEON) && !user.combat_mode) && try_to_activate_door(user))
+	else if(!(I.item_flags & NOBLUDGEON) && !user.combat_mode)
+		try_to_activate_door(user)
 		return TRUE
 	return ..()
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -246,8 +246,7 @@
 	else if(I.tool_behaviour == TOOL_WELDER)
 		try_to_weld(I, user, params)
 		return TRUE
-	else if(!(I.item_flags & NOBLUDGEON) && !user.combat_mode)
-		try_to_activate_door(user)
+	else if((!(I.item_flags & NOBLUDGEON) && !user.combat_mode) && try_to_activate_door(user))
 		return TRUE
 	return ..()
 

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -31,6 +31,8 @@
 	return FALSE
 
 /obj/machinery/door/airlock/shell/allowed(mob/user)
+	if(SEND_SIGNAL(src, COMSIG_OBJ_ALLOWED, user) & COMPONENT_OBJ_ALLOW)
+		return TRUE
 	return isAdminGhostAI(user)
 
 /obj/machinery/door/airlock/shell/set_wires()

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -31,7 +31,7 @@
 	return FALSE
 
 /obj/machinery/door/airlock/shell/allowed(mob/user)
-	if(SEND_SIGNAL(src, COMSIG_OBJ_ALLOWED, user) & COMPONENT_OBJ_ALLOW)
+	if(SEND_SIGNAL(src, COMSIG_AIRLOCK_SHELL_ALLOWED, user) & COMPONENT_AIRLOCK_SHELL_ALLOW)
 		return TRUE
 	return isAdminGhostAI(user)
 

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -30,6 +30,9 @@
 /obj/machinery/door/airlock/shell/canAIHack(mob/user)
 	return FALSE
 
+/obj/machinery/door/airlock/shell/allowed(mob/user)
+	return isAdminGhostAI(user)
+
 /obj/machinery/door/airlock/shell/set_wires()
 	return new /datum/wires/airlock/shell(src)
 

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -156,12 +156,12 @@
 	. = ..()
 	if(istype(shell, /obj/machinery/door/airlock))
 		attached_airlock = shell
-		RegisterSignal(shell, COMSIG_OBJ_ALLOWED, .proc/handle_allowed)
+		RegisterSignal(shell, COMSIG_AIRLOCK_SHELL_ALLOWED , .proc/handle_allowed)
 
 /obj/item/circuit_component/airlock_access_event/unregister_shell(atom/movable/shell)
 	attached_airlock = null
 	UnregisterSignal(shell, list(
-		COMSIG_OBJ_ALLOWED,
+		COMSIG_AIRLOCK_SHELL_ALLOWED ,
 	))
 	return ..()
 
@@ -193,4 +193,4 @@
 		return
 
 	if(result["should_open"])
-		return COMPONENT_OBJ_ALLOW
+		return COMPONENT_AIRLOCK_SHELL_ALLOW 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>Removed from current PR, part of the pre-split PR, see #63914 </summary>
Allows people to put integrated circuits and swipe their IDs to lock circuit airlocks without having to use combat mode in an extremely unintuitive way. (What used to happen: the check below would return true and end the attackby proc call before the attackby signal was called unless combat mode was on)

```
else if(!(I.item_flags & NOBLUDGEON) && !user.combat_mode)
	try_to_activate_door(user)
	return TRUE
```
</details>
Prevents silicons from easily opening circuit airlocks by simply bumping them open 
(This happened as airlock/bumpopen(mob/user) called door/proc/bumpopen(mob/user) which called door/allowed(mob/user) which calls obj/allowed(mob/user) which checks for silicons before it checks for check_access)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
~~The former makes circuit airlocks impossible to use without knowing "use combat mode to get it to work",~~ the latter I assume is unintended since canAIControl was overrided.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Prevents silicons from opening circuit airlocks by walking through them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
