### PR TITLE
The medieval shuttle now only colors humans

### DIFF
--- a/code/game/machinery/teambuilder.dm
+++ b/code/game/machinery/teambuilder.dm
@@ -9,6 +9,8 @@
 	density = FALSE
 	can_buckle = FALSE
 	resistance_flags = INDESTRUCTIBLE // Just to be safe.
+	///Are non-humans allowed to use this?
+	var/humans_only = FALSE
 	///What color is your mob set to when crossed?
 	var/team_color = COLOR_WHITE
 	///What radio station is your radio set to when crossed (And human)?
@@ -28,6 +30,8 @@
 
 /obj/machinery/teambuilder/proc/on_entered(datum/source, atom/movable/AM)
 	SIGNAL_HANDLER
+	if(!ishuman(AM) && humans_only)
+		return
 	if(AM.get_filter("teambuilder"))
 		return
 	if(isliving(AM) && team_color)
@@ -42,11 +46,13 @@
 /obj/machinery/teambuilder/red
 	name = "Teambuilding Machine (Red)"
 	desc = "A machine that, when passed, colors you based on the color of your team. Go red team!"
+	humans_only = TRUE
 	team_color = COLOR_RED
 	team_radio = FREQ_CTF_RED
 
 /obj/machinery/teambuilder/blue
 	name = "Teambuilding Machine (Blue)"
 	desc = "A machine that, when passed, colors you based on the color of your team. Go blue team!"
+	humans_only = TRUE
 	team_color = COLOR_BLUE
 	team_radio = FREQ_CTF_BLUE


### PR DESCRIPTION
## About The Pull Request

This was made with hopes of keeping the admin-only powers of it, while also closing https://github.com/tgstation/tgstation/issues/58804

## Why It's Good For The Game

as mentioned, closes https://github.com/tgstation/tgstation/issues/58804

## Changelog

:cl:
fix: Revenants (and any other non human) will no longer turn red/blue from the medieval shuttle teambuilding machines.
/:cl: