### PR TITLE
makes rust visible again

### DIFF
--- a/code/datums/elements/rust.dm
+++ b/code/datums/elements/rust.dm
@@ -13,7 +13,7 @@
 	if(!isatom(target))
 		return COMPONENT_INCOMPATIBLE
 	if(!rust_overlay)
-		rust_overlay = image(rust_icon, rust_icon)
+		rust_overlay = image(rust_icon, rust_icon_state)
 	ADD_TRAIT(target, TRAIT_RUSTY, ELEMENT_TRAIT(type))
 	RegisterSignal(target, COMSIG_ATOM_UPDATE_OVERLAYS, .proc/apply_rust_overlay)
 	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/handle_examine)
@@ -35,7 +35,7 @@
 
 /datum/element/rust/proc/apply_rust_overlay(atom/parent_atom, list/overlays)
 	SIGNAL_HANDLER
-	overlays |= rust_overlay
+	overlays += rust_overlay
 
 /// Because do_after sleeps we register the signal here and defer via an async call
 /datum/element/rust/proc/secondary_tool_act(atom/source, mob/user, obj/item/item)


### PR DESCRIPTION
## About The Pull Request

you can see rust again

- Passes icon_state to the `image()` generation, which it DIDN'T DO
- consistency in adding of overlay operation

fixes #61421
probably fixes #60652

## Why It's Good For The Game

makes kilo ugly again

## Changelog

:cl: Melbert
fix:  You can see rust again
/:cl:
