### PR TITLE
Remove the auto updating in the orbit menu and bring back manual refresh

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -1,20 +1,6 @@
 GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 
 /datum/orbit_menu
-	/// Serialised list of all valid POIs. Master list that holds all POIs from all other lists.
-	var/list/pois = list()
-	/// Serialised list of all alive POIs.
-	var/list/alive = list()
-	/// Serialised list of all antagonist POIs.
-	var/list/antagonists = list()
-	/// Serialised list of all dead mob POIs.
-	var/list/dead = list()
-	/// Serialised list of all observers POIS.
-	var/list/ghosts = list()
-	/// Serialised list of all non-mob POIs.
-	var/list/misc = list()
-	/// Serialised list of all POIS without a mind.
-	var/list/npcs = list()
 
 /datum/orbit_menu/ui_state(mob/user)
 	return GLOB.observer_state
@@ -49,40 +35,25 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 			if (auto_observe)
 				user.do_observe(poi)
 			return TRUE
-
-/datum/orbit_menu/ui_data(mob/user)
-	var/list/data = list()
-
-	update_poi_list()
-
-	data["alive"] = alive
-	data["antagonists"] = antagonists
-	data["dead"] = dead
-	data["ghosts"] = ghosts
-	data["misc"] = misc
-	data["npcs"] = npcs
-
-	return data
+		if ("refresh")
+			update_static_data(usr, ui)
+			return TRUE
 
 /datum/orbit_menu/ui_assets()
 	return list(
 		get_asset_datum(/datum/asset/simple/orbit),
 	)
 
-/// Fully updates the list of POIs.
-/datum/orbit_menu/proc/update_poi_list()
+/datum/orbit_menu/ui_static_data(mob/user)
 	var/list/new_mob_pois = SSpoints_of_interest.get_mob_pois(CALLBACK(src, .proc/validate_mob_poi), append_dead_role = FALSE)
 	var/list/new_other_pois = SSpoints_of_interest.get_other_pois()
 
-	pois.Cut()
-
-	alive.Cut()
-	antagonists.Cut()
-	dead.Cut()
-	ghosts.Cut()
-	npcs.Cut()
-
-	misc.Cut()
+	var/list/alive = list()
+	var/list/antagonists = list()
+	var/list/dead = list()
+	var/list/ghosts = list()
+	var/list/misc = list()
+	var/list/npcs = list()
 
 	for(var/name in new_mob_pois)
 		var/list/serialized = list()
@@ -92,8 +63,6 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		var/poi_ref = REF(mob_poi)
 		serialized["ref"] = poi_ref
 		serialized["name"] = name
-
-		pois[poi_ref] = mob_poi
 
 		if(isobserver(mob_poi))
 			var/number_of_orbiters = length(mob_poi.get_all_orbiters())
@@ -128,16 +97,21 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 			alive += list(serialized)
 
 	for(var/name in new_other_pois)
-		var/list/serialized = list()
-
 		var/atom/atom_poi = new_other_pois[name]
 
-		var/poi_ref = REF(atom_poi)
-		serialized["ref"] = poi_ref
-		serialized["name"] = name
+		misc += list(list(
+			"ref" = REF(atom_poi),
+			"name" = name,
+		))
 
-		pois[poi_ref] = atom_poi
-		misc += list(serialized)
+	return list(
+		"alive" = alive,
+		"antagonists" = antagonists,
+		"dead" = dead,
+		"ghosts" = ghosts,
+		"misc" = misc,
+		"npcs" = npcs,
+	)
 
 /// Shows the UI to the specified user.
 /datum/orbit_menu/proc/show(mob/user)

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -161,6 +161,15 @@ export const Orbit = (props, context) => {
                 icon={autoObserve ? "toggle-on" : "toggle-off"}
                 onClick={() => setAutoObserve(!autoObserve)} />
             </Flex.Item>
+            <Flex.Item>
+              <Button
+                inline
+                color="transparent"
+                tooltip="Refresh"
+                tooltipPosition="bottom-start"
+                icon="sync-alt"
+                onClick={() => act("refresh")} />
+            </Flex.Item>
           </Flex>
         </Section>
         {antagonists.length > 0 && (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the auto-updating in the orbit menu and brings back the original manual refresh.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
1. It's really bad UX, and makes orbiting around a pain since their observer counts constantly update. Names constantly swap back and forth, especially as other ghosts orbit.
2. It's apparently really slow, because it happens on ui_data. I think Lemon said this anyway

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Restored the original manual refresh for the orbit menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
