### PR TITLE
Fixes rust heretic ascension (from runtiming to hell) (and some other rusty hereticy issues)

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1969,6 +1969,9 @@
  * Override this if you want custom behaviour in whatever gets hit by the rust
  */
 /atom/proc/rust_heretic_act()
+	if(HAS_TRAIT(src, TRAIT_RUSTY))
+		return
+
 	AddElement(/datum/element/rust)
 
 /**

--- a/code/game/turfs/open/floor/iron_floor.dm
+++ b/code/game/turfs/open/floor/iron_floor.dm
@@ -17,10 +17,7 @@
 /turf/open/floor/iron/rust_heretic_act()
 	if(prob(70))
 		new /obj/effect/temp_visual/glowing_rune(src)
-	var/atom/changed_turf = ChangeTurf(/turf/open/floor/plating)
-	changed_turf.AddElement(/datum/element/rust)
-	return ..()
-
+	ChangeTurf(/turf/open/floor/plating/rust)
 
 /turf/open/floor/iron/update_icon_state()
 	if(broken || burnt)

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -212,16 +212,16 @@
 /**
  * #Rust spread datum
  *
- * Simple datum that automatically spreads rust around it
+ * Simple datum that automatically spreads rust around it.
  *
- * Simple implementation of automatically growing entity
+ * Simple implementation of automatically growing entity.
  */
 /datum/rust_spread
 	/// The rate of spread every tick.
 	var/spread_per_sec = 6
 	/// The very center of the spread.
 	var/turf/centre
-	/// Lazylist of turfs at the edge of our rust (but not yet rusted).
+	/// List of turfs at the edge of our rust (but not yet rusted).
 	var/list/edge_turfs = list()
 	/// List of all turfs we've afflicted.
 	var/list/rusted_turfs = list()
@@ -263,7 +263,8 @@
 /**
  * Compile turfs
  *
- * Recreates the edge_turfs list and the rusted_turfs list.
+ * Recreates the edge_turfs list.
+ * Updates the rusted_turfs list, in case any turfs within were un-rusted.
  */
 /datum/rust_spread/proc/compile_turfs()
 	edge_turfs.Cut()

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -281,5 +281,5 @@
 
 		for(var/turf/line_turf as anything in get_line(nearby_turf, centre))
 			if(get_dist(nearby_turf, line_turf) <= 1)
-				LAZYADD(edge_turfs, line_turf)
+				LAZYADD(edge_turfs, nearby_turf)
 		CHECK_TICK

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -217,9 +217,15 @@
  * Simple implementation of automatically growing entity
  */
 /datum/rust_spread
-	var/list/edge_turfs = list()
-	var/list/turfs = list()
+	/// The rate of spread every tick.
+	var/spread_per_sec = 6
+	/// The very center of the spread.
 	var/turf/centre
+	/// Lazylist of turfs at the edge of our rust (but not yet rusted).
+	var/list/edge_turfs
+	/// List of all turfs we've afflicted.
+	var/list/rusted_turfs = list()
+	/// Static blacklist of turfs we can't spread to.
 	var/static/list/blacklisted_turfs = typecacheof(list(
 		/turf/open/indestructible,
 		/turf/closed/indestructible,
@@ -227,54 +233,53 @@
 		/turf/open/lava,
 		/turf/open/chasm
 	))
-	var/spread_per_sec = 6
-
 
 /datum/rust_spread/New(loc)
-	. = ..()
 	centre = get_turf(loc)
 	centre.rust_heretic_act()
-	turfs += centre
-	START_PROCESSING(SSprocessing,src)
+	rusted_turfs += centre
+	START_PROCESSING(SSprocessing, src)
 
 /datum/rust_spread/Destroy(force, ...)
-	STOP_PROCESSING(SSprocessing,src)
+	centre = null
+	LAZYCLEARLIST(edge_turfs)
+	rusted_turfs.Cut()
+	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 
 /datum/rust_spread/process(delta_time)
-	var/spread_am = round(spread_per_sec * delta_time)
+	var/spread_amount = round(spread_per_sec * delta_time)
 
-	if(edge_turfs.len < spread_am)
+	if(LAZYLEN(edge_turfs) < spread_amount)
 		compile_turfs()
 
-	var/turf/rust_affected
-	for(var/i in 0 to spread_am)
-		if(!edge_turfs.len)
-			continue
-		rust_affected = pick(edge_turfs - turfs)
-		rust_affected.rust_heretic_act()
-		turfs += rust_affected
-
+	for(var/i in 0 to spread_amount)
+		if(!LAZYLEN(edge_turfs))
+			break
+		var/turf/afflicted_turf = pick(edge_turfs)
+		afflicted_turf.rust_heretic_act()
+		LAZYREMOVE(edge_turfs, afflicted_turf)
+		rusted_turfs |= afflicted_turf
 
 /**
  * Compile turfs
  *
- * Recreates all edge_turfs as well as normal turfs.
+ * Recreates the edge_turfs list and the rusted_turfs list.
  */
 /datum/rust_spread/proc/compile_turfs()
-	edge_turfs = list()
-	var/list/removal_list = list()
-	var/max_dist = 1
-	for(var/atom/turfie as anything in turfs)
-		if(!HAS_TRAIT(turfie, TRAIT_RUSTY))
-			removal_list += turfie
-		max_dist = max(max_dist, get_dist(turfie,centre) +1)
-	turfs -= removal_list
-	for(var/turfie in spiral_range_turfs(max_dist,centre,FALSE))
+	LAZYCLEARLIST(edge_turfs)
 
-		if(turfie in turfs || is_type_in_typecache(turfie,blacklisted_turfs))
+	var/max_dist = 1
+	for(var/turf/found_turf as anything in rusted_turfs)
+		if(!HAS_TRAIT(found_turf, TRAIT_RUSTY))
+			rusted_turfs -= found_turf
+		max_dist = max(max_dist, get_dist(found_turf, centre) + 1)
+
+	for(var/turf/nearby_turf as anything in spiral_range_turfs(max_dist, centre, FALSE))
+		if(nearby_turf in rusted_turfs || is_type_in_typecache(nearby_turf, blacklisted_turfs))
 			continue
-		for(var/line_turfie_owo in get_line(turfie,centre))
-			if(get_dist(turfie,line_turfie_owo) <= 1)
-				edge_turfs += turfie
+
+		for(var/turf/line_turf as anything in get_line(nearby_turf, centre))
+			if(get_dist(nearby_turf, line_turf) <= 1)
+				LAZYADD(edge_turfs, line_turf)
 		CHECK_TICK


### PR DESCRIPTION
## About The Pull Request

- Fixes the rust heretic ascension. Fixes #58846
- Prevents rust heretic act from re-applying rust element to atoms which already have it, causing a ton of signal override runtimes
- Fixes iron floor rust heretic act applying rust twice
- code improvements(?) for the rust spread datum
- handles references in rust spread datum `destroy()`. probably would never be destroyed but might as well prevent the funny deletes 

The rust spread datum probably performs very poorly. 

## Why It's Good For The Game

- Allows rust to spread forth again from the rune of rusty lads. Makes it cool again.

- ![image](https://user-images.githubusercontent.com/51863163/147920789-fdd2cf81-ddd3-490a-bfe4-e8dd49c4bbbc.png)

## Changelog

:cl: Melbert
fix: Rust heretic ascension spread rusts everywhere again.
/:cl:


