### PR TITLE
Fixes drones being able to place their tools into storage containers

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -113,6 +113,12 @@
 	else
 		..()
 
+/mob/living/simple_animal/drone/transferItemToLoc(obj/item/item, newloc, force, silent)
+	. = ..()
+	for (var/tool in internal_storage)
+		if (istype(item, tool))
+			return FALSE
+
 /mob/living/simple_animal/drone/getarmor(def_zone, type)
 	var/armorval = 0
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -114,10 +114,7 @@
 		..()
 
 /mob/living/simple_animal/drone/transferItemToLoc(obj/item/item, newloc, force, silent)
-	. = ..()
-	for (var/tool in internal_storage)
-		if (istype(item, tool))
-			return FALSE
+	return item in internal_storage && ..()
 
 /mob/living/simple_animal/drone/getarmor(def_zone, type)
 	var/armorval = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
drones were able to put their tools into things such as microwaves, toolboxes... sort of
it's loc was still in the drone, but it was able to moved around and indirectly interacted with OUTSIDE of the drone

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes https://github.com/tgstation/tgstation/issues/63723
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Drone tools can no longer be removed from the drone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
