### PR TITLE
Makes spirit holding call async

### DIFF
--- a/code/datums/components/spirit_holding.dm
+++ b/code/datums/components/spirit_holding.dm
@@ -56,8 +56,7 @@
 
 	attempting_awakening = TRUE
 	to_chat(awakener, span_notice("You attempt to wake the spirit of [parent]..."))
-
-	var/mob/dead/observer/candidates = poll_ghost_candidates("Do you want to play as the spirit of [awakener.real_name]'s blade?", ROLE_PAI, FALSE, 100, POLL_IGNORE_POSSESSED_BLADE)
+	var/mob/dead/observer/candidates = INVOKE_ASYNC(src, .proc/poll_ghost_candidates, "Do you want to play as the spirit of [awakener.real_name]'s blade?", ROLE_PAI, FALSE, 100, POLL_IGNORE_POSSESSED_BLADE)
 	if(!LAZYLEN(candidates))
 		to_chat(awakener, span_warning("[parent] is dormant. Maybe you can try again later."))
 		attempting_awakening = FALSE
@@ -70,19 +69,24 @@
 	bound_spirit = new(parent)
 	bound_spirit.ckey = chosen_spirit.ckey
 	bound_spirit.fully_replace_character_name(null, "The spirit of [parent]")
+	INVOKE_ASYNC(src, .proc/offer_ghost_rename)
 	bound_spirit.status_flags |= GODMODE
 	bound_spirit.copy_languages(awakener, LANGUAGE_MASTER) //Make sure the sword can understand and communicate with the awakener.
 	bound_spirit.update_atom_languages()
 	bound_spirit.grant_all_languages(FALSE, FALSE, TRUE) //Grants omnitongue
-	var/input = sanitize_name(tgui_input_text(bound_spirit, "What are you named?", "Spectral Nomenclature", max_length = MAX_NAME_LEN))
-	if(parent && input)
-		parent = input
-		bound_spirit.fully_replace_character_name(null, "The spirit of [input]")
-
 	//Add new signals for parent and stop attempting to awaken
 	RegisterSignal(parent, COMSIG_ATOM_RELAYMOVE, .proc/block_buckle_message)
 	RegisterSignal(parent, COMSIG_BIBLE_SMACKED, .proc/on_bible_smacked)
 	attempting_awakening = FALSE
+
+/datum/component/spirit_holding/proc/offer_ghost_rename()
+	if(!parent)
+		return
+	var/input = INVOKE_ASYNC(src, .proc/tgui_input_text, bound_spirit, "What are you named?", "Spectral Nomenclature", null, MAX_NAME_LEN)
+	if(sanitize_name(input))
+		parent = input
+		bound_spirit.fully_replace_character_name(null, "The spirit of [input]")
+
 
 ///signal fired from a mob moving inside the parent
 /datum/component/spirit_holding/proc/block_buckle_message(datum/source, mob/living/user, direction)


### PR DESCRIPTION
## About The Pull Request

I've literally been unable to figure out why spirit holding doesn't work properly (if more than 1 person says yes to become the blade, the extra ghosts who said yes will become a godmoded shade at the debug centcom room, able to go to the station WHILE GODMODED), but this is one of my assumptions.

- attempt_spirit_awaken is called by a signal invoking async, but nothing there uses invoke_async itself, so if you just move attempt_spirit_awaken to on_attack_self, this happens
![image](https://user-images.githubusercontent.com/53777086/147975089-5d2eed46-f373-49c4-8443-945602a820e6.png)

I assume it's still a problem regardless of where it is, but there's nothing telling you it's an actual error since its not on the proc the signal is registered to, so it lets it happen anyways, and doesn't work properly in-game.

I sadly cannot test this in-game as it requires 3 people.

## Why It's Good For The Game

please please please please please please please let it work this time

## Changelog

I don't even know if this fixes spirit holding or not.
