### PR TITLE
Buffs soil by +5 max nutriment

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -937,7 +937,7 @@
 	flags_1 = NODECONSTRUCT_1
 	unwrenchable = FALSE
 	self_sustaining_overlay_icon_state = null
-	maxnutri = 10
+	maxnutri = 15
 
 /obj/machinery/hydroponics/soil/update_icon(updates=ALL)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Increases the max nutriment for soil to 15 from 10

## Why It's Good For The Game

For the longest time soil had a bugged max capacity of 20 instead of the intended 10. I fixed that, but 10 is a bit low IMO, given the way botany functions (scales based on how much fertilizer you use). So, a little bit of wiggle-room will help ghetto / prisoner / public botany a bit.

## Changelog

:cl:  Melbert
balance: Buffed hydroponics dirt tray's capacity to 15u.
/:cl:

