### PR TITLE
Spacevine text + colors

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -563,7 +563,7 @@
 	if(!isspaceturf(stepturf) && stepturf.Enter(src))
 		var/obj/structure/spacevine/spot_taken = locate() in stepturf //Locates any vine on target turf. Calls that vine "spot_taken".
 		var/datum/spacevine_mutation/vine_eating/eating = locate() in mutations //Locates the vine eating trait in our own seed and calls it E.
-		if(!spot_taken || (eating && (spot_taken && !spot_taken.mutations.Find(eating)))) //Proceed if there isn't a vine on the target turf, OR we have vine eater AND target vine is from our seed and doesn't. Vines from other seeds are eaten regardless.
+		if(!spot_taken || (eating && (spot_taken && !spot_taken.mutations?.Find(eating)))) //Proceed if there isn't a vine on the target turf, OR we have vine eater AND target vine is from our seed and doesn't. Vines from other seeds are eaten regardless.
 			if(master)
 				for(var/datum/spacevine_mutation/mutation in mutations)
 					mutation.on_spread(src, stepturf) //Only do the on_spread proc if it actually spreads.

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -143,7 +143,7 @@
 
 /datum/spacevine_mutation/aggressive_spread  //very OP, but im out of other ideas currently
 	name = "Aggressive spreading"
-	hue = "#1F441E"
+	hue = "#316b2f"
 	severity = 3
 	quality = NEGATIVE
 
@@ -251,7 +251,7 @@
 
 /datum/spacevine_mutation/plasma_eater
 	name = "Plasma consuming"
-	hue = "#54436B"
+	hue = "#9074b6"
 	severity = 3
 	quality = POSITIVE
 

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/spacevine
-	name = "Spacevine"
+	name = "Space vines"
 	typepath = /datum/round_event/spacevine
 	weight = 15
 	max_occurrences = 3
@@ -11,18 +11,18 @@
 /datum/round_event/spacevine/start()
 	var/list/turfs = list() //list of all the empty floor turfs in the hallway areas
 
-	var/obj/structure/spacevine/SV = new()
+	var/obj/structure/spacevine/vine = new()
 
-	for(var/area/hallway/A in world)
-		for(var/turf/F in A)
-			if(F.Enter(SV))
-				turfs += F
+	for(var/area/hallway/area in world)
+		for(var/turf/floor in area)
+			if(floor.Enter(vine))
+				turfs += floor
 
-	qdel(SV)
+	qdel(vine)
 
-	if(turfs.len) //Pick a turf to spawn at if we can
-		var/turf/T = pick(turfs)
-		new /datum/spacevine_controller(T, list(pick(subtypesof(/datum/spacevine_mutation))), rand(10,100), rand(1,6), src) //spawn a controller at turf with randomized stats and a single random mutation
+	if(length(turfs)) //Pick a turf to spawn at if we can
+		var/turf/floor = pick(turfs)
+		new /datum/spacevine_controller(floor, list(pick(subtypesof(/datum/spacevine_mutation))), rand(10,100), rand(1,6), src) //spawn a controller at turf with randomized stats and a single random mutation
 
 
 /datum/spacevine_mutation
@@ -50,13 +50,13 @@
 /datum/spacevine_mutation/proc/on_death(obj/structure/spacevine/holder)
 	return
 
-/datum/spacevine_mutation/proc/on_hit(obj/structure/spacevine/holder, mob/hitter, obj/item/I, expected_damage)
+/datum/spacevine_mutation/proc/on_hit(obj/structure/spacevine/holder, mob/hitter, obj/item/item, expected_damage)
 	. = expected_damage
 
 /datum/spacevine_mutation/proc/on_cross(obj/structure/spacevine/holder, mob/crosser)
 	return
 
-/datum/spacevine_mutation/proc/on_chem(obj/structure/spacevine/holder, datum/reagent/R)
+/datum/spacevine_mutation/proc/on_chem(obj/structure/spacevine/holder, datum/reagent/chem)
 	return
 
 /datum/spacevine_mutation/proc/on_eat(obj/structure/spacevine/holder, mob/living/eater)
@@ -71,12 +71,12 @@
 /datum/spacevine_mutation/proc/on_explosion(severity, target, obj/structure/spacevine/holder)
 	return
 
-/datum/spacevine_mutation/aggressive_spread/proc/aggrospread_act(obj/structure/spacevine/S, mob/living/M)
+/datum/spacevine_mutation/aggressive_spread/proc/aggrospread_act(obj/structure/spacevine/vine, mob/living/M)
 	return
 
 /datum/spacevine_mutation/light
-	name = "light"
-	hue = "#ffff00"
+	name = "Light"
+	hue = "#FFEAC9"
 	quality = POSITIVE
 	severity = 4
 
@@ -85,8 +85,8 @@
 		holder.set_light(severity, 0.3)
 
 /datum/spacevine_mutation/toxicity
-	name = "toxic"
-	hue = "#ff00ff"
+	name = "Toxic"
+	hue = "#9B3675"
 	severity = 10
 	quality = NEGATIVE
 
@@ -101,9 +101,9 @@
 	if(!isvineimmune(eater))
 		eater.adjustToxLoss(5)
 
-/datum/spacevine_mutation/explosive  //OH SHIT IT CAN CHAINREACT RUN!!!
-	name = "explosive"
-	hue = "#ff0000"
+/datum/spacevine_mutation/explosive  // JC IT'S A BOMB
+	name = "Explosive"
+	hue = "#D83A56"
 	quality = NEGATIVE
 	severity = 2
 
@@ -114,26 +114,26 @@
 		. = 1
 		QDEL_IN(holder, 5)
 
-/datum/spacevine_mutation/explosive/on_death(obj/structure/spacevine/holder, mob/hitter, obj/item/I)
+/datum/spacevine_mutation/explosive/on_death(obj/structure/spacevine/holder, mob/hitter, obj/item/item)
 	explosion(holder, light_impact_range = severity, adminlog = FALSE)
 
 /datum/spacevine_mutation/fire_proof
-	name = "fire proof"
-	hue = "#ff8888"
+	name = "Fire proof"
+	hue = "#FF616D"
 	quality = MINOR_NEGATIVE
 
 /datum/spacevine_mutation/fire_proof/process_temperature(obj/structure/spacevine/holder, temp, volume)
 	return 1
 
-/datum/spacevine_mutation/fire_proof/on_hit(obj/structure/spacevine/holder, mob/hitter, obj/item/I, expected_damage)
-	if(I && I.damtype == BURN)
+/datum/spacevine_mutation/fire_proof/on_hit(obj/structure/spacevine/holder, mob/hitter, obj/item/item, expected_damage)
+	if(item && item.damtype == BURN)
 		. = 0
 	else
 		. = expected_damage
 
 /datum/spacevine_mutation/vine_eating
-	name = "vine eating"
-	hue = "#ff7700"
+	name = "Vine eating"
+	hue = "#F4A442"
 	quality = MINOR_NEGATIVE
 
 /// Destroys any vine on spread-target's tile. The checks for if this should be done are in the spread() proc.
@@ -142,58 +142,58 @@
 		qdel(prey)
 
 /datum/spacevine_mutation/aggressive_spread  //very OP, but im out of other ideas currently
-	name = "aggressive spreading"
-	hue = "#333333"
+	name = "Aggressive spreading"
+	hue = "#1F441E"
 	severity = 3
 	quality = NEGATIVE
 
 /// Checks mobs on spread-target's turf to see if they should be hit by a damaging proc or not.
-/datum/spacevine_mutation/aggressive_spread/on_spread(obj/structure/spacevine/holder, turf/target, mob/living)
-	for(var/mob/living/M in target)
-		if(!isvineimmune(M) && M.stat != DEAD) // Don't kill immune creatures. Dead check to prevent log spam when a corpse is trapped between vine eaters.
-			aggrospread_act(holder, M)
+/datum/spacevine_mutation/aggressive_spread/on_spread(obj/structure/spacevine/holder, turf/turf, mob/living)
+	for(var/mob/living/victim in turf)
+		if(!isvineimmune(victim) && victim.stat != DEAD) // Don't kill immune creatures. Dead check to prevent log spam when a corpse is trapped between vine eaters.
+			aggrospread_act(holder, victim)
 
 /// What happens if an aggr spreading vine buckles a mob.
 /datum/spacevine_mutation/aggressive_spread/on_buckle(obj/structure/spacevine/holder, mob/living/buckled)
 	aggrospread_act(holder, buckled)
 
 /// Hurts mobs. To be used when a vine with aggressive spread mutation spreads into the mob's tile or buckles them.
-/datum/spacevine_mutation/aggressive_spread/aggrospread_act(obj/structure/spacevine/S, mob/living/M)
-	var/mob/living/carbon/C = M //If the mob is carbon then it now also exists as a "C", and not just an M.
-	if(istype(C)) //If the mob (M) is a carbon subtype (C) we move on to pick a more complex damage proc, with damage zones, wounds and armor mitigation.
+/datum/spacevine_mutation/aggressive_spread/aggrospread_act(obj/structure/spacevine/vine, mob/living/living_mob)
+	var/mob/living/carbon/victim = living_mob //If the mob is carbon then it now also exists as a victim, and not just an living mob.
+	if(istype(victim)) //If the mob (M) is a carbon subtype (C) we move on to pick a more complex damage proc, with damage zones, wounds and armor mitigation.
 		var/obj/item/bodypart/limb = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD, BODY_ZONE_CHEST) //Picks a random bodypart. Does not runtime even if it's missing.
-		var/armor = C.run_armor_check(limb, MELEE, null, null) //armor = the armor value of that randomly chosen bodypart. Nulls to not print a message, because it would still print on pierce.
-		var/datum/spacevine_mutation/thorns/T = locate() in S.mutations //Searches for the thorns mutation in the "mutations"-list inside obj/structure/spacevine, and defines T if it finds it.
-		if(T && (prob(40))) //If we found the thorns mutation there is now a chance to get stung instead of lashed or smashed.
-			C.apply_damage(50, BRUTE, def_zone = limb, wound_bonus = rand(-20,10), sharpness = SHARP_POINTY) //This one gets a bit lower damage because it ignores armor.
-			C.Stun(1 SECONDS) //Stopped in place for a moment.
-			playsound(M, 'sound/weapons/pierce.ogg', 50, TRUE, -1)
-			M.visible_message(span_danger("[M] is nailed by a sharp thorn!"), \
+		var/armor = victim.run_armor_check(limb, MELEE, null, null) //armor = the armor value of that randomly chosen bodypart. Nulls to not print a message, because it would still print on pierce.
+		var/datum/spacevine_mutation/thorns/thorn = locate() in vine.mutations //Searches for the thorns mutation in the "mutations"-list inside obj/structure/spacevine, and defines T if it finds it.
+		if(thorn && (prob(40))) //If we found the thorns mutation there is now a chance to get stung instead of lashed or smashed.
+			victim.apply_damage(50, BRUTE, def_zone = limb, wound_bonus = rand(-20,10), sharpness = SHARP_POINTY) //This one gets a bit lower damage because it ignores armor.
+			victim.Stun(1 SECONDS) //Stopped in place for a moment.
+			playsound(living_mob, 'sound/weapons/pierce.ogg', 50, TRUE, -1)
+			living_mob.visible_message(span_danger("[living_mob] is nailed by a sharp thorn!"), \
 			span_userdanger("You are nailed by a sharp thorn!"))
-			log_combat(S, M, "aggressively pierced") //"Aggressively" for easy ctrl+F'ing in the attack logs.
+			log_combat(vine, living_mob, "aggressively pierced") //"Aggressively" for easy ctrl+F'ing in the attack logs.
 		else
 			if(prob(80))
-				C.apply_damage(60, BRUTE, def_zone = limb, blocked = armor, wound_bonus = rand(-20,10), sharpness = SHARP_EDGED)
-				C.Knockdown(2 SECONDS)
-				playsound(M, 'sound/weapons/whip.ogg', 50, TRUE, -1)
-				M.visible_message(span_danger("[M] is lacerated by an outburst of vines!"), \
+				victim.apply_damage(60, BRUTE, def_zone = limb, blocked = armor, wound_bonus = rand(-20,10), sharpness = SHARP_EDGED)
+				victim.Knockdown(2 SECONDS)
+				playsound(victim, 'sound/weapons/whip.ogg', 50, TRUE, -1)
+				living_mob.visible_message(span_danger("[living_mob] is lacerated by an outburst of vines!"), \
 				span_userdanger("You are lacerated by an outburst of vines!"))
-				log_combat(S, M, "aggressively lacerated")
+				log_combat(vine, living_mob, "aggressively lacerated")
 			else
-				C.apply_damage(60, BRUTE, def_zone = limb, blocked = armor, wound_bonus = rand(-20,10), sharpness = NONE)
-				C.Knockdown(3 SECONDS)
-				var/atom/throw_target = get_edge_target_turf(C, get_dir(S, get_step_away(C, S)))
-				C.throw_at(throw_target, 3, 6)
-				playsound(M, 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
-				M.visible_message(span_danger("[M] is smashed by a large vine!"), \
+				victim.apply_damage(60, BRUTE, def_zone = limb, blocked = armor, wound_bonus = rand(-20,10), sharpness = NONE)
+				victim.Knockdown(3 SECONDS)
+				var/atom/throw_target = get_edge_target_turf(living_mob, get_dir(vine, get_step_away(living_mob, vine)))
+				victim.throw_at(throw_target, 3, 6)
+				playsound(victim, 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
+				living_mob.visible_message(span_danger("[living_mob] is smashed by a large vine!"), \
 				span_userdanger("You are smashed by a large vine!"))
-				log_combat(S, M, "aggressively smashed")
+				log_combat(vine, living_mob, "aggressively smashed")
 	else //Living but not a carbon? Maybe a silicon? Can't be wounded so have a big chunk of simple bruteloss with no special effects. They can be entangled.
-		M.adjustBruteLoss(75)
-		playsound(M, 'sound/weapons/whip.ogg', 50, TRUE, -1)
-		M.visible_message(span_danger("[M] is brutally threshed by [S]!"), \
-		span_userdanger("You are brutally threshed by [S]!"))
-		log_combat(S, M, "aggressively spread into") //You aren't being attacked by the vines. You just happen to stand in their way.
+		living_mob.adjustBruteLoss(75)
+		playsound(living_mob, 'sound/weapons/whip.ogg', 50, TRUE, -1)
+		living_mob.visible_message(span_danger("[living_mob] is brutally threshed by [vine]!"), \
+		span_userdanger("You are brutally threshed by [vine]!"))
+		log_combat(vine, living_mob, "aggressively spread into") //You aren't being attacked by the vines. You just happen to stand in their way.
 
 /datum/spacevine_mutation/transparency
 	name = "transparent"
@@ -205,86 +205,86 @@
 	holder.alpha = 125
 
 /datum/spacevine_mutation/oxy_eater
-	name = "oxygen consuming"
-	hue = "#ffff88"
+	name = "Oxygen consuming"
+	hue = "#28B5B5"
 	severity = 3
 	quality = NEGATIVE
 
 /datum/spacevine_mutation/oxy_eater/process_mutation(obj/structure/spacevine/holder)
-	var/turf/open/floor/T = holder.loc
-	if(istype(T))
-		var/datum/gas_mixture/GM = T.air
-		if(!GM.gases[/datum/gas/oxygen])
+	var/turf/open/floor/turf = holder.loc
+	if(istype(turf))
+		var/datum/gas_mixture/gas_mix = turf.air
+		if(!gas_mix.gases[/datum/gas/oxygen])
 			return
-		GM.gases[/datum/gas/oxygen][MOLES] = max(GM.gases[/datum/gas/oxygen][MOLES] - severity * holder.energy, 0)
-		GM.garbage_collect()
+		gas_mix.gases[/datum/gas/oxygen][MOLES] = max(gas_mix.gases[/datum/gas/oxygen][MOLES] - severity * holder.energy, 0)
+		gas_mix.garbage_collect()
 
 /datum/spacevine_mutation/nitro_eater
-	name = "nitrogen consuming"
-	hue = "#8888ff"
+	name = "Nitrogen consuming"
+	hue = "#FF7B54"
 	severity = 3
 	quality = NEGATIVE
 
 /datum/spacevine_mutation/nitro_eater/process_mutation(obj/structure/spacevine/holder)
-	var/turf/open/floor/T = holder.loc
-	if(istype(T))
-		var/datum/gas_mixture/GM = T.air
-		if(!GM.gases[/datum/gas/nitrogen])
+	var/turf/open/floor/turf = holder.loc
+	if(istype(turf))
+		var/datum/gas_mixture/gas_mix = turf.air
+		if(!gas_mix.gases[/datum/gas/nitrogen])
 			return
-		GM.gases[/datum/gas/nitrogen][MOLES] = max(GM.gases[/datum/gas/nitrogen][MOLES] - severity * holder.energy, 0)
-		GM.garbage_collect()
+		gas_mix.gases[/datum/gas/nitrogen][MOLES] = max(gas_mix.gases[/datum/gas/nitrogen][MOLES] - severity * holder.energy, 0)
+		gas_mix.garbage_collect()
 
 /datum/spacevine_mutation/carbondioxide_eater
 	name = "CO2 consuming"
-	hue = "#00ffff"
+	hue = "#798777"
 	severity = 3
 	quality = POSITIVE
 
 /datum/spacevine_mutation/carbondioxide_eater/process_mutation(obj/structure/spacevine/holder)
-	var/turf/open/floor/T = holder.loc
-	if(istype(T))
-		var/datum/gas_mixture/GM = T.air
-		if(!GM.gases[/datum/gas/carbon_dioxide])
+	var/turf/open/floor/turf = holder.loc
+	if(istype(turf))
+		var/datum/gas_mixture/gas_mix = turf.air
+		if(!gas_mix.gases[/datum/gas/carbon_dioxide])
 			return
-		GM.gases[/datum/gas/carbon_dioxide][MOLES] = max(GM.gases[/datum/gas/carbon_dioxide][MOLES] - severity * holder.energy, 0)
-		GM.garbage_collect()
+		gas_mix.gases[/datum/gas/carbon_dioxide][MOLES] = max(gas_mix.gases[/datum/gas/carbon_dioxide][MOLES] - severity * holder.energy, 0)
+		gas_mix.garbage_collect()
 
 /datum/spacevine_mutation/plasma_eater
-	name = "plasma consuming"
-	hue = "#ffbbff"
+	name = "Plasma consuming"
+	hue = "#54436B"
 	severity = 3
 	quality = POSITIVE
 
 /datum/spacevine_mutation/plasma_eater/process_mutation(obj/structure/spacevine/holder)
-	var/turf/open/floor/T = holder.loc
-	if(istype(T))
-		var/datum/gas_mixture/GM = T.air
-		if(!GM.gases[/datum/gas/plasma])
+	var/turf/open/floor/turf = holder.loc
+	if(istype(turf))
+		var/datum/gas_mixture/gas_mix = turf.air
+		if(!gas_mix.gases[/datum/gas/plasma])
 			return
-		GM.gases[/datum/gas/plasma][MOLES] = max(GM.gases[/datum/gas/plasma][MOLES] - severity * holder.energy, 0)
-		GM.garbage_collect()
+		gas_mix.gases[/datum/gas/plasma][MOLES] = max(gas_mix.gases[/datum/gas/plasma][MOLES] - severity * holder.energy, 0)
+		gas_mix.garbage_collect()
 
 /datum/spacevine_mutation/thorns
-	name = "thorny"
-	hue = "#666666"
+	name = "Thorny"
+	hue = "#9ECCA4"
 	severity = 10
 	quality = NEGATIVE
 
 /datum/spacevine_mutation/thorns/on_cross(obj/structure/spacevine/holder, mob/living/crosser)
 	if(prob(severity) && istype(crosser) && !isvineimmune(crosser))
-		var/mob/living/M = crosser
-		M.adjustBruteLoss(5)
-		to_chat(M, span_alert("You cut yourself on the thorny vines."))
+		var/mob/living/victim = crosser
+		victim.adjustBruteLoss(5)
+		to_chat(victim, span_danger("You cut yourself on the thorny vines."))
 
-/datum/spacevine_mutation/thorns/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/I, expected_damage)
+/datum/spacevine_mutation/thorns/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/item, expected_damage)
 	if(prob(severity) && istype(hitter) && !isvineimmune(hitter))
-		var/mob/living/M = hitter
-		M.adjustBruteLoss(5)
-		to_chat(M, span_alert("You cut yourself on the thorny vines."))
+		var/mob/living/victim = hitter
+		victim.adjustBruteLoss(5)
+		to_chat(victim, span_danger("You cut yourself on the thorny vines."))
 	. = expected_damage
 
 /datum/spacevine_mutation/woodening
-	name = "hardened"
+	name = "Hardened"
 	hue = "#997700"
 	quality = NEGATIVE
 
@@ -293,15 +293,15 @@
 		holder.set_density(TRUE)
 	holder.modify_max_integrity(100)
 
-/datum/spacevine_mutation/woodening/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/I, expected_damage)
-	if(I?.get_sharpness())
+/datum/spacevine_mutation/woodening/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/item, expected_damage)
+	if(item?.get_sharpness())
 		. = expected_damage * 0.5
 	else
 		. = expected_damage
 
 /datum/spacevine_mutation/flowering
-	name = "flowering"
-	hue = "#0A480D"
+	name = "Flowering"
+	hue = "#66DE93"
 	quality = NEGATIVE
 	severity = 10
 
@@ -313,10 +313,9 @@
 	if(prob(25))
 		holder.entangle(crosser)
 
-
 // SPACE VINES (Note that this code is very similar to Biomass code)
 /obj/structure/spacevine
-	name = "space vines"
+	name = "space vine"
 	desc = "An extremely expansionistic species of vine."
 	icon = 'icons/effects/spacevines.dmi'
 	icon_state = "Light1"
@@ -328,6 +327,7 @@
 	max_integrity = 50
 	var/energy = 0
 	var/datum/spacevine_controller/master = null
+	/// List of mutations for a specific vine
 	var/list/mutations = list()
 
 /obj/structure/spacevine/Initialize(mapload)
@@ -345,14 +345,16 @@
 		. += "This vine has no mutations."
 		return
 	var/text = "This vine has the following mutations:\n"
-	for(var/datum/spacevine_mutation/SM as anything in mutations)
-		text += "| [SM.name] "
-	text += "|"dw
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		if(mutation.name == "transparent") /// Transparent has no hue
+			text += "<font color='#F7F7E8'>Transparent</font> "
+		else
+			text += "<font color='[mutation.hue]'>[mutation.name]</font> "
 	. += text
 
 /obj/structure/spacevine/Destroy()
-	for(var/datum/spacevine_mutation/SM in mutations)
-		SM.on_death(src)
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		mutation.on_death(src)
 	if(master)
 		master.VineDestroyed(src)
 	mutations = list()
@@ -361,31 +363,31 @@
 		unbuckle_all_mobs(force=1)
 	return ..()
 
-/obj/structure/spacevine/proc/on_chem_effect(datum/reagent/R)
+/obj/structure/spacevine/proc/on_chem_effect(datum/reagent/chem)
 	var/override = 0
-	for(var/datum/spacevine_mutation/SM in mutations)
-		override += SM.on_chem(src, R)
-	if(!override && istype(R, /datum/reagent/toxin/plantbgone))
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		override += mutation.on_chem(src, chem)
+	if(!override && istype(chem, /datum/reagent/toxin/plantbgone))
 		if(prob(50))
 			qdel(src)
 
 /obj/structure/spacevine/proc/eat(mob/eater)
 	var/override = 0
-	for(var/datum/spacevine_mutation/SM in mutations)
-		override += SM.on_eat(src, eater)
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		override += mutation.on_eat(src, eater)
 	if(!override)
 		qdel(src)
 
-/obj/structure/spacevine/attacked_by(obj/item/I, mob/living/user)
-	var/damage_dealt = I.force
-	if(I.get_sharpness())
+/obj/structure/spacevine/attacked_by(obj/item/item, mob/living/user)
+	var/damage_dealt = item.force
+	if(item.get_sharpness())
 		damage_dealt *= 4
-	if(I.damtype == BURN)
+	if(item.damtype == BURN)
 		damage_dealt *= 4
 
-	for(var/datum/spacevine_mutation/SM in mutations)
-		damage_dealt = SM.on_hit(src, user, I, damage_dealt) //on_hit now takes override damage as arg and returns new value for other mutations to permutate further
-	take_damage(damage_dealt, I.damtype, MELEE, 1)
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		damage_dealt = mutation.on_hit(src, user, item, damage_dealt) //on_hit now takes override damage as arg and returns new value for other mutations to permutate further
+	take_damage(damage_dealt, item.damtype, MELEE, 1)
 
 /obj/structure/spacevine/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
@@ -397,23 +399,23 @@
 		if(BURN)
 			playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
 
-/obj/structure/spacevine/proc/on_entered(datum/source, atom/movable/AM)
+/obj/structure/spacevine/proc/on_entered(datum/source, atom/movable/movable)
 	SIGNAL_HANDLER
-	if(!isliving(AM))
+	if(!isliving(movable))
 		return
-	for(var/datum/spacevine_mutation/SM in mutations)
-		SM.on_cross(src, AM)
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		mutation.on_cross(src, movable)
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/structure/spacevine/attack_hand(mob/user, list/modifiers)
-	for(var/datum/spacevine_mutation/SM in mutations)
-		SM.on_hit(src, user)
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		mutation.on_hit(src, user)
 	user_unbuckle_mob(user, user)
 	. = ..()
 
 /obj/structure/spacevine/attack_paw(mob/living/user, list/modifiers)
-	for(var/datum/spacevine_mutation/SM in mutations)
-		SM.on_hit(src, user)
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		mutation.on_hit(src, user)
 	user_unbuckle_mob(user,user)
 
 /obj/structure/spacevine/attack_alien(mob/living/user, list/modifiers)
@@ -430,9 +432,9 @@
 /datum/spacevine_controller/New(turf/location, list/muts, potency, production, datum/round_event/event = null)
 	vines = list()
 	growth_queue = list()
-	var/obj/structure/spacevine/SV = spawn_spacevine_piece(location, null, muts)
-	if (event)
-		event.announce_to_ghosts(SV)
+	var/obj/structure/spacevine/vine = spawn_spacevine_piece(location, null, muts)
+	if(event)
+		event.announce_to_ghosts(vine)
 	START_PROCESSING(SSobj, src)
 	vine_mutations_list = list()
 	init_subtypes(/datum/spacevine_mutation/, vine_mutations_list)
@@ -460,37 +462,38 @@
 	return ..()
 
 /datum/spacevine_controller/proc/spawn_spacevine_piece(turf/location, obj/structure/spacevine/parent, list/muts)
-	var/obj/structure/spacevine/SV = new(location)
-	growth_queue += SV
-	vines += SV
-	SV.master = src
-	if(muts?.len)
-		for(var/datum/spacevine_mutation/M in muts)
-			M.add_mutation_to_vinepiece(SV)
+	var/obj/structure/spacevine/vine = new(location)
+	growth_queue += vine
+	vines += vine
+	vine.master = src
+	if(length(muts))
+		for(var/datum/spacevine_mutation/mutation in muts)
+			mutation.add_mutation_to_vinepiece(vine)
 	if(parent)
-		SV.mutations |= parent.mutations
+		vine.mutations |= parent.mutations
 		var/parentcolor = parent.atom_colours[FIXED_COLOUR_PRIORITY]
-		SV.add_atom_colour(parentcolor, FIXED_COLOUR_PRIORITY)
+		vine.add_atom_colour(parentcolor, FIXED_COLOUR_PRIORITY)
 		if(prob(mutativeness))
-			var/datum/spacevine_mutation/random_mutate = pick(vine_mutations_list - SV.mutations)
-			random_mutate.add_mutation_to_vinepiece(SV)
+			var/datum/spacevine_mutation/random_mutate = pick(vine_mutations_list - vine.mutations)
+			random_mutate.add_mutation_to_vinepiece(vine)
 
-	for(var/datum/spacevine_mutation/SM in SV.mutations)
-		SM.on_birth(SV)
-	location.Entered(SV, null)
-	return SV
+	for(var/datum/spacevine_mutation/mutation in vine.mutations)
+		mutation.on_birth(vine)
+	location.Entered(vine, null)
+	return vine
 
-/datum/spacevine_controller/proc/VineDestroyed(obj/structure/spacevine/S)
-	S.master = null
-	vines -= S
-	growth_queue -= S
-	if(!vines.len)
-		var/obj/item/seeds/kudzu/KZ = new(S.loc)
-		KZ.mutations |= S.mutations
-		KZ.set_potency(mutativeness * 10)
-		KZ.set_production(11 - (spread_cap / initial(spread_cap)) * 5) //Reverts spread_cap formula so resulting seed gets original production stat or equivalent back.
+/datum/spacevine_controller/proc/VineDestroyed(obj/structure/spacevine/vine)
+	vine.master = null
+	vines -= vine
+	growth_queue -= vine
+	if(!length(vines))
+		var/obj/item/seeds/kudzu/seed = new(vine.loc)
+		seed.mutations |= vine.mutations
+		seed.set_potency(mutativeness * 10)
+		seed.set_production(11 - (spread_cap / initial(spread_cap)) * 5) //Reverts spread_cap formula so resulting seed gets original production stat or equivalent back.
 		qdel(src)
 
+/// Life cycle of a space vine
 /datum/spacevine_controller/process(delta_time)
 	if(!LAZYLEN(vines))
 		qdel(src) //space vines exterminated. Remove the controller
@@ -499,30 +502,31 @@
 		qdel(src) //Sanity check
 		return
 
-	var/length = round(clamp(delta_time * 0.5 * vines.len / spread_multiplier, 1, spread_cap))
-	var/i = 0
+	var/length = round(clamp(delta_time * 0.5 * length(vines) / spread_multiplier, 1, spread_cap))
+	var/index = 0
 	var/list/obj/structure/spacevine/queue_end = list()
 
-	for(var/obj/structure/spacevine/SV in growth_queue)
-		if(QDELETED(SV))
+	for(var/obj/structure/spacevine/vine in growth_queue)
+		if(QDELETED(vine))
 			continue
-		i++
-		queue_end += SV
-		growth_queue -= SV
-		for(var/datum/spacevine_mutation/SM in SV.mutations)
-			SM.process_mutation(SV)
-		if(SV.energy < 2) //If tile isn't fully grown
+		index++
+		queue_end += vine
+		growth_queue -= vine
+		for(var/datum/spacevine_mutation/mutation in vine.mutations)
+			mutation.process_mutation(vine)
+		if(vine.energy < 2) //If tile isn't fully grown
 			if(DT_PROB(10, delta_time))
-				SV.grow()
+				vine.grow()
 		else //If tile is fully grown
-			SV.entangle_mob()
+			vine.entangle_mob()
 
-		SV.spread()
-		if(i >= length)
+		vine.spread()
+		if(index >= length)
 			break
 
 	growth_queue = growth_queue + queue_end
 
+/// Updates the icon as the space vine grows
 /obj/structure/spacevine/proc/grow()
 	if(!energy)
 		src.icon_state = pick("Med1", "Med2", "Med3")
@@ -532,44 +536,46 @@
 		src.icon_state = pick("Hvy1", "Hvy2", "Hvy3")
 		energy = 2
 
-	for(var/datum/spacevine_mutation/SM in mutations)
-		SM.on_grow(src)
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		mutation.on_grow(src)
 
+/// Buckles mobs trying to pass through it
 /obj/structure/spacevine/proc/entangle_mob()
 	if(!has_buckled_mobs() && prob(25))
-		for(var/mob/living/V in src.loc)
-			entangle(V)
+		for(var/mob/living/victim in src.loc)
+			entangle(victim)
 			if(has_buckled_mobs())
 				break //only capture one mob at a time
 
-/obj/structure/spacevine/proc/entangle(mob/living/V)
-	if(!V || isvineimmune(V))
+/obj/structure/spacevine/proc/entangle(mob/living/victim)
+	if(!victim || isvineimmune(victim))
 		return
-	for(var/datum/spacevine_mutation/SM in mutations)
-		SM.on_buckle(src, V)
-	if((V.stat != DEAD) && (V.buckled != src)) //not dead or captured
-		to_chat(V, span_danger("The vines [pick("wind", "tangle", "tighten")] around you!"))
-		buckle_mob(V, 1)
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		mutation.on_buckle(src, victim)
+	if((victim.stat != DEAD) && (victim.buckled != src)) //not dead or captured
+		to_chat(victim, span_userdanger("The vines [pick("wind", "tangle", "tighten")] around you!"))
+		buckle_mob(victim, 1)
 
 /// Finds a target tile to spread to. If checks pass it will spread to it and also proc on_spread on target.
 /obj/structure/spacevine/proc/spread()
 	var/direction = pick(GLOB.cardinals)
-	var/turf/stepturf = get_step(src,direction)
+	var/turf/stepturf = get_step(src, direction)
 	if(!isspaceturf(stepturf) && stepturf.Enter(src))
 		var/obj/structure/spacevine/spot_taken = locate() in stepturf //Locates any vine on target turf. Calls that vine "spot_taken".
-		var/datum/spacevine_mutation/vine_eating/E = locate() in mutations //Locates the vine eating trait in our own seed and calls it E.
-		if(!spot_taken || (E && (spot_taken && !spot_taken.mutations.Find(E)))) //Proceed if there isn't a vine on the target turf, OR we have vine eater AND target vine is from our seed and doesn't. Vines from other seeds are eaten regardless.
+		var/datum/spacevine_mutation/vine_eating/eating = locate() in mutations //Locates the vine eating trait in our own seed and calls it E.
+		if(!spot_taken || (eating && (spot_taken && !spot_taken.mutations.Find(eating)))) //Proceed if there isn't a vine on the target turf, OR we have vine eater AND target vine is from our seed and doesn't. Vines from other seeds are eaten regardless.
 			if(master)
-				for(var/datum/spacevine_mutation/SM in mutations)
-					SM.on_spread(src, stepturf) //Only do the on_spread proc if it actually spreads.
+				for(var/datum/spacevine_mutation/mutation in mutations)
+					mutation.on_spread(src, stepturf) //Only do the on_spread proc if it actually spreads.
 					stepturf = get_step(src,direction) //in case turf changes, to make sure no runtimes happen
 				master.spawn_spacevine_piece(stepturf, src)
 
+/// Destroying an explosive vine sets off a chain reaction
 /obj/structure/spacevine/ex_act(severity, target)
-	var/i
-	for(var/datum/spacevine_mutation/SM in mutations)
-		i += SM.on_explosion(severity, target, src)
-	if(!i && prob(34 * severity))
+	var/index
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		index += mutation.on_explosion(severity, target, src)
+	if(!index && prob(34 * severity))
 		qdel(src)
 
 /obj/structure/spacevine/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
@@ -577,8 +583,8 @@
 
 /obj/structure/spacevine/atmos_expose(datum/gas_mixture/air, exposed_temperature)
 	var/volume = air.return_volume()
-	for(var/datum/spacevine_mutation/SM in mutations)
-		if(SM.process_temperature(src, exposed_temperature, volume)) //If it's ever true we're safe
+	for(var/datum/spacevine_mutation/mutation in mutations)
+		if(mutation.process_temperature(src, exposed_temperature, volume)) //If it's ever true we're safe
 			return
 	qdel(src)
 
@@ -587,9 +593,13 @@
 	if(isvineimmune(mover))
 		return TRUE
 
-/proc/isvineimmune(atom/A)
-	if(isliving(A))
-		var/mob/living/M = A
-		if(("vines" in M.faction) || ("plants" in M.faction))
+/**
+ * Used to determine whether the mob is immune to actions by the vine.
+ * Use cases: Stops vine from attacking itself, other plants.
+ */
+/proc/isvineimmune(atom/target)
+	if(isliving(target))
+		var/mob/living/victim = target
+		if(("vines" in victim.faction) || ("plants" in victim.faction))
 			return TRUE
 	return FALSE

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -76,7 +76,7 @@
 
 /datum/spacevine_mutation/light
 	name = "Light"
-	hue = "#FFEAC9"
+	hue = "#B2EA70"
 	quality = POSITIVE
 	severity = 4
 
@@ -345,9 +345,9 @@
 		. += "This vine has no mutations."
 		return
 	var/text = "This vine has the following mutations:\n"
-	for(var/datum/spacevine_mutation/mutation in mutations)
+	for(var/datum/spacevine_mutation/mutation as anything in mutations)
 		if(mutation.name == "transparent") /// Transparent has no hue
-			text += "<font color='#F7F7E8'>Transparent</font> "
+			text += "<font color='#346751'>Transparent</font> "
 		else
 			text += "<font color='[mutation.hue]'>[mutation.name]</font> "
 	. += text

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -341,14 +341,13 @@
 
 /obj/structure/spacevine/examine(mob/user)
 	. = ..()
-	var/text = "This one is a"
-	if(mutations.len)
-		for(var/A in mutations)
-			var/datum/spacevine_mutation/SM = A
-			text += " [SM.name]"
-	else
-		text += " normal"
-	text += " vine."
+	if(!length(mutations))
+		. += "This vine has no mutations."
+		return
+	var/text = "This vine has the following mutations:\n"
+	for(var/datum/spacevine_mutation/SM as anything in mutations)
+		text += "| [SM.name] "
+	text += "|"dw
 	. += text
 
 /obj/structure/spacevine/Destroy()

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/spacevine
-	name = "Space vines"
+	name = "Space Vines"
 	typepath = /datum/round_event/spacevine
 	weight = 15
 	max_occurrences = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I always found reading the info text for space vines difficult, it would be something like
>This one is a oxygen consuming vine eating toxic plasma consuming light explosive vine

And it just felt half-assed. I went through spacevine.dm, 
- removed single letter var names
- updated the colors to match nature palettes from colorhunt.co
- changed how mutations are listed in chat, they now also use the hue of the mutation itself
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
flavor really, and code readability
here are some using the new tints:
![Screenshot 2022-01-03 151125](https://user-images.githubusercontent.com/42397676/147990848-c2f09658-7e3a-4f1c-8c09-d6490f203a79.png)

here is a regular and mutated vine exam text:
![2](https://user-images.githubusercontent.com/42397676/147990860-39d56056-a1dd-4353-9702-654cf74c49d1.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Space vine code is cleaned up slightly.
refactor: Space vines now use more flowery, easier to see colors.
refactor: Space vine examination text is now easier to read.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
