### PR TITLE
Fixed two issues w/ TGUI text entry

### DIFF
--- a/code/modules/tgui/tgui_input_text.dm
+++ b/code/modules/tgui/tgui_input_text.dm
@@ -32,7 +32,10 @@
 			else
 				return stripped_input(user, message, title, default, max_length)
 		else
-			return input(user, message, title, default) as text|null
+			if(multiline)
+				return input(user, message, title, default) as message|null
+			else
+				return input(user, message, title, default) as text|null
 	var/datum/tgui_input_text/text_input = new(user, message, title, default, max_length, multiline, encode, timeout)
 	text_input.ui_interact(user)
 	text_input.wait()

--- a/code/modules/tgui/tgui_input_text.dm
+++ b/code/modules/tgui/tgui_input_text.dm
@@ -183,8 +183,9 @@
 			return TRUE
 
 /datum/tgui_input_text/proc/set_entry(entry)
-	var/converted_entry = encode ? html_encode(entry) : entry
-	src.entry = trim(converted_entry, max_length)
+	if(entry)
+		var/converted_entry = encode ? html_encode(entry) : entry
+		src.entry = trim(converted_entry, max_length)
 
 /**
  * # async tgui_input_text

--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -40,7 +40,7 @@ export const TextInputModal = (_, context) => {
   };
   // Dynamically changes the window height based on the message.
   const windowHeight
-    = 127
+    = 125
     + Math.ceil(message.length / 3)
     + (multiline || input.length >= 30 ? 75 : 0)
     + (message.length && large_buttons ? 5 : 0);
@@ -63,7 +63,7 @@ export const TextInputModal = (_, context) => {
             <Stack.Item>
               <Box color="label">{message}</Box>
             </Stack.Item>
-            <Stack.Item grow mb={0.7}>
+            <Stack.Item grow>
               <InputArea input={input} onType={onType} />
             </Stack.Item>
             <Stack.Item pl={!large_buttons && 5} pr={!large_buttons && 5}>
@@ -81,16 +81,25 @@ export const TextInputModal = (_, context) => {
 
 /** Gets the user input and invalidates if there's a constraint. */
 const InputArea = (props, context) => {
-  const { data } = useBackend<TextInputData>(context);
-  const { max_length } = data;
+  const { act, data } = useBackend<TextInputData>(context);
+  const { max_length, multiline } = data;
   const { input, onType } = props;
 
   return (
     <TextArea
       autoFocus
       autoSelect
-      height="100%"
+      height={multiline || input.length >= 30 ? "100%" : "1.8rem"}
       maxLength={max_length}
+      onKeyDown={(event) => {
+        const keyCode = window.event ? event.which : event.keyCode;
+        if (keyCode === KEY_ENTER) {
+          act('submit', { entry: input });
+        }
+        if (keyCode === KEY_ESCAPE) {
+          act('cancel');
+        }
+      }}
       onInput={(_, value) => onType(value)}
       placeholder="Type something..."
       value={input}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tgui input text apparently would still affix a blank, but not null, entry when user hits cancel
Another primarily visual issue: Pressing enter briefly created a newline in input
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed an issue where cancelling out of tgui input text didn't count as null/no entry. You can now properly cancel out of succumb, etc.
fix: Pressing enter on tgui input text will no longer briefly create a new line.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
