### PR TITLE
Fixes MODsuit DNA scanner runtimes

### DIFF
--- a/code/modules/mod/mod_actions.dm
+++ b/code/modules/mod/mod_actions.dm
@@ -97,7 +97,7 @@
 	var/mob/pinner
 
 /datum/action/item_action/mod/pinned_module/New(Target, obj/item/mod/module/linked_module, mob/user)
-	if(user == mod.ai)
+	if(user == mod?.ai)
 		ai_action = TRUE
 	..()
 	module = linked_module

--- a/code/modules/mod/mod_actions.dm
+++ b/code/modules/mod/mod_actions.dm
@@ -97,7 +97,7 @@
 	var/mob/pinner
 
 /datum/action/item_action/mod/pinned_module/New(Target, obj/item/mod/module/linked_module, mob/user)
-	if(user == mod?.ai)
+	if(user == mod.ai)
 		ai_action = TRUE
 	..()
 	module = linked_module

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -571,10 +571,13 @@
 	. = ..()
 	on_emag(src, user, emag_card)
 
-/obj/item/mod/module/dna_lock/proc/dna_check()
-	if(!dna || (mod.wearer.has_dna() && mod.wearer.dna.unique_enzymes == dna))
+/obj/item/mod/module/dna_lock/proc/dna_check(mob/user)
+	if(!iscarbon(user))
+		return FALSE
+	var/mob/living/carbon/carbon_user = user
+	if(!dna  || (carbon_user.has_dna() && carbon_user.dna.unique_enzymes == dna))
 		return TRUE
-	balloon_alert(mod.wearer, "dna locked!")
+	balloon_alert(user, "dna locked!")
 	return FALSE
 
 /obj/item/mod/module/dna_lock/proc/on_emp(datum/source, severity)
@@ -587,16 +590,16 @@
 
 	dna = null
 
-/obj/item/mod/module/dna_lock/proc/on_mod_activation(datum/source)
+/obj/item/mod/module/dna_lock/proc/on_mod_activation(datum/source, mob/user)
 	SIGNAL_HANDLER
 
-	if(!dna_check())
+	if(!dna_check(user))
 		return MOD_CANCEL_ACTIVATE
 
-/obj/item/mod/module/dna_lock/proc/on_mod_removal(datum/source)
+/obj/item/mod/module/dna_lock/proc/on_mod_removal(datum/source, mob/user)
 	SIGNAL_HANDLER
 
-	if(!dna_check())
+	if(!dna_check(user))
 		return MOD_CANCEL_REMOVAL
 
 //Plasma Stabilizer


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The modsuit DNA lock seemed to lack sanity and only cared about whoever wore it, even though it's called when manipulating the modules inside the suit.
This PR deals with that and fixes the action buttons so they actually work, instead of just generating a runtime
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less runtimes is always good, and fixing features that don't work is dandy
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Modsuits DNA lock module will no longer stop you from changing up the suit's modules while not worn, even if you are it's rightfull owner.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
