### PR TITLE
Fixes midi2piano

### DIFF
--- a/tools/midi2piano/midi2piano.py
+++ b/tools/midi2piano/midi2piano.py
@@ -54,6 +54,7 @@ def notenum2string(num, accidentals, octaves):
     names = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
     convert_table = {1:0, 3:1, 6:2, 8:3, 10:4}
     inclusion_table = {0:0, 2:1, 5:2, 7:3, 9:4}
+    correspondence_table = {0:1, 1:0, 2:3, 3:2, 5:6, 6:5, 7:8, 8:7, 9:10, 10:9}
 
     num += OCTAVE_KEYS * OCTAVE_TRANSPOSE
     octave = int(num / OCTAVE_KEYS)
@@ -68,6 +69,8 @@ def notenum2string(num, accidentals, octaves):
 
     accidental = (len(names[name_indx]) == 2)
     output_octaves[name_indx] = octave
+    if name_indx in correspondence_table:
+        output_octaves[correspondence_table[name_indx]] = octave
     add_n = False
 
     if accidental:


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Accidental and natural notes (C and C#, for example) now have the same current octave.
Midi patterns like A6,A#5,An6 now will output like A6,A#5,An6 as they should (not like A6,A#5,An, which in the game is equivalent to A6,A#5,An5).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->