### PR TITLE
Removes MS13

### DIFF
--- a/html/changelogs/archive/2022-01.yml
+++ b/html/changelogs/archive/2022-01.yml
@@ -59,8 +59,6 @@
   Wallem:
   - qol: Stasis beds put food in stasis as well, preventing decomposition.
 2022-01-04:
-  AndrewL97:
-  - server: MS13 is the best
   Deek-Za:
   - imageadd: Added sprites for cargo cap when flipped
   Fikou, modified sprites from Onule, descriptions by Nerevar and Halcyon:


### PR DESCRIPTION
## About The Pull Request

Worst downstream now.

## Why It's Good For The Game

Because MS13 is a downstream and the only good downstream is mine, this is fact not opinion sorry.

## Changelog

Nothing that should be mentioned in changelog.
