### PR TITLE
Medical HUDs no longer show viruses.

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -11,7 +11,7 @@
 	for(var/datum/atom_hud/data/human/hud in GLOB.huds)
 		hud.add_to_hud(src)
 
-/atom/proc/remove_from_all_data_huds()
+/atom/proc/remove_from_all_data_huds()f
 	for(var/datum/atom_hud/data/hud in GLOB.huds)
 		hud.remove_from_hud(src)
 
@@ -188,7 +188,6 @@ Medical HUD! Basic mode needs suit sensors on.
 /mob/living/carbon/med_hud_set_status()
 	var/image/holder = hud_list[STATUS_HUD]
 	var/icon/I = icon(icon, icon_state, dir)
-	var/virus_threat = check_virus()
 	holder.pixel_y = I.Height() - world.icon_size
 	if(HAS_TRAIT(src, TRAIT_XENO_HOST))
 		holder.icon_state = "hudxeno"
@@ -198,23 +197,7 @@ Medical HUD! Basic mode needs suit sensors on.
 		else
 			holder.icon_state = "huddead"
 	else
-		switch(virus_threat)
-			if(DISEASE_SEVERITY_BIOHAZARD)
-				holder.icon_state = "hudill5"
-			if(DISEASE_SEVERITY_DANGEROUS)
-				holder.icon_state = "hudill4"
-			if(DISEASE_SEVERITY_HARMFUL)
-				holder.icon_state = "hudill3"
-			if(DISEASE_SEVERITY_MEDIUM)
-				holder.icon_state = "hudill2"
-			if(DISEASE_SEVERITY_MINOR)
-				holder.icon_state = "hudill1"
-			if(DISEASE_SEVERITY_NONTHREAT)
-				holder.icon_state = "hudill0"
-			if(DISEASE_SEVERITY_POSITIVE)
-				holder.icon_state = "hudbuff"
-			if(null)
-				holder.icon_state = "hudhealthy"
+		holder.icon_state = "hudhealthy"
 
 
 /***********************************************

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -11,7 +11,7 @@
 	for(var/datum/atom_hud/data/human/hud in GLOB.huds)
 		hud.add_to_hud(src)
 
-/atom/proc/remove_from_all_data_huds()f
+/atom/proc/remove_from_all_data_huds()
 	for(var/datum/atom_hud/data/hud in GLOB.huds)
 		hud.remove_from_hud(src)
 


### PR DESCRIPTION
## About The Pull Request

Medical HUDs no longer show viruses.

## Why It's Good For The Game

Viruses are really, really, really, really easy to spot and find by medbay. You don't need to check for symptoms before investigating, you don't need to figure out if that coughing is bad lungs or a virus, you just wait to see the funny hud icon that tells you all you need to know about a virus(how dangerous it is).

Frankly, it is to the point of not needing a virologist or any virology equipment at all for 99% of virus outbreaks, let alone sentient diseases.

Making doctors have to actually keep an eye out for symptoms should make viruses more interesting mechanically beyond "did i see the funny face icon or not".

## Changelog

:cl:
balance: Medical HUDs no longer show viruses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
