### PR TITLE
Re-adds holopad back to the security meeting area on MetaStation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -60449,7 +60449,7 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "thJ" = (
-/obj/machinery/holopad,
+/obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "thR" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -60448,6 +60448,10 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/service/janitor)
+"thJ" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "thR" = (
 /obj/machinery/food_cart,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -105053,7 +105057,7 @@ jLR
 mVh
 lyV
 nnS
-cpe
+thJ
 cpe
 cVD
 eCu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

On the tin. All I could find was the 2018 High-Resolution of MetaStation on the wiki, which displays the following:

![image](https://user-images.githubusercontent.com/34697715/148155867-79056a1c-a553-4207-bf7f-632e7f0b5a45.png)

Which shows off a holopad. I believe when they re-did Security, they seem to have dropped the placement of a new holopad here. This PR adds a holopad in roughly the same area.

![image](https://user-images.githubusercontent.com/34697715/148155958-151fead6-ef71-4228-8db3-97bf9e3dc785.png)

Right there (in our modern 2022 version), to be exact.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I like having the AI be able to scream at security as they plot ways to kill the clown in that grand hall of theirs. I also see no reason why it should have been removed.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The holopad is now back in Security's meeting room on MetaStation! Silicon lovers and cold-callers rejoice!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
