### PR TITLE
Moves the CentComm ERT Bay Status Screen

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -602,9 +602,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/centcom/briefing)
 "cE" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -602,6 +602,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/status_display{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/briefing)
 "cE" = (
@@ -15046,13 +15049,6 @@
 /obj/item/canvas/twentythree_twentythree,
 /turf/open/floor/catwalk_floor,
 /area/centcom/holding)
-"Sz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron,
-/area/centcom/supplypod/loading/ert)
 "SD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -52865,7 +52861,7 @@ px
 mD
 pD
 pX
-Sz
+pX
 pX
 rb
 oe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It moves it to the other side of the wall (as displayed in the image below), so the game stops sending the obj (the screen) on the turf in the ERT bay. There's no real reason for the ERT bay to have that screen because you're only ever in there for an admin event (hopefully), and I don't really see how another reminder of the time until the round ends is of much use in that scenario. The only thing it seems to be good for is accidentally sending the station/someone else a screen that can't be removed from wherever you drop it.

![image](https://user-images.githubusercontent.com/34697715/148160748-992bcf9c-a9e0-40b4-960c-0746ff356185.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's the most annoying thing in the word when you want to send a Supply Pod from the CentComm ERT Bay, yet instead of having your omega-Death trooper show up, the crew gets a fucking screen that tells them how much time they have until they can get out of the station. This will reduce that headache for myself, and hopefully others.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The status screen in the ERT Bay in CentComm has been moved to the other side of the wall because we accidentally kept sending them down and the crew would keep selling them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
