### PR TITLE
The Detective can now print .38 Rubber at the Security Protolathe.

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -39,6 +39,16 @@
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/c38_rubber
+	name = "Speed Loader (.38 Rubber)"
+	desc = "Designed to quickly reload revolvers. Rubber bullets are bouncy and less-than-lethal."
+	id = "c38_rubber"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 20000)
+	build_path = /obj/item/ammo_box/c38/match/bouncy
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
 /datum/design/rubbershot/sec
 	id = "sec_rshot"
 	build_type = PROTOLATHE | AWAY_LATHE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -16,6 +16,7 @@
 		"basic_scanning",
 		"bepis",
 		"bucket",
+		"c38_rubber",
 		"c-reader",
 		"circuit_imprinter",
 		"circuit_imprinter_offstation",
@@ -28,9 +29,11 @@
 		"doppler_array",
 		"experi_scanner",
 		"experimentor",
+		"gas_filter",
 		"handlabel",
 		"mechfab",
 		"micro_mani",
+		"oven_tray",
 		"packagewrap",
 		"paystand",
 		"plasmaglass",
@@ -41,6 +44,7 @@
 		"plastic_spoon",
 		"plastitanium",
 		"plastitaniumglass",
+		"plasmaman_gas_filter",
 		"rdconsole",
 		"rdserver",
 		"rdservercontrol",
@@ -55,10 +59,6 @@
 		"space_heater",
 		"tech_disk",
 		"titaniumglass",
-		"gas_filter",
-		"plasmaman_gas_filter",
-		"oven_tray",
-		"c38_rubber",
 	)
 
 /datum/techweb_node/mmi

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -57,7 +57,8 @@
 		"titaniumglass",
 		"gas_filter",
 		"plasmaman_gas_filter",
-		"oven_tray"
+		"oven_tray",
+		"c38_rubber"
 	)
 
 /datum/techweb_node/mmi

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -58,7 +58,7 @@
 		"gas_filter",
 		"plasmaman_gas_filter",
 		"oven_tray",
-		"c38_rubber"
+		"c38_rubber",
 	)
 
 /datum/techweb_node/mmi


### PR DESCRIPTION
## About The Pull Request

The Detective can now print .38 Rubber at the Security Protolathe.

## Why It's Good For The Game

We frown on Security players killing people they could have apprehended, and Detectives especially so get more scrutiny due to the inherent lethality of their revolver. We shouldn't punish Detectives who choose to keep their revolver configured for .38 and want to detain rather than kill by restricting their access to less-than-lethal rounds.

Technically speaking, the Detective has no ranged option other than his revolver except on maps where the security locker room door is misconfigured and he can purchase Energy Bolas from the vendor. Which, once again, is a result of misconfigured door access. The Lawyer could walk in and buy energy bolas on those maps.

As such, we shouldn't require the Detective to spend 130 credits every time he needs to reload his gun if he wants to not immediately murder people, especially given that killing the wrong person can land you in some serious shit with admins.

## Changelog

:cl:
balance: The Detective can now print .38 Rubber at the Security Protolathe.
/:cl: