### PR TITLE
Converts atmos, disposal, and transit tube pipedispensers to tgui

### DIFF
--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -103,15 +103,15 @@
 						if(!verify_recipe(GLOB.disposal_pipe_recipes, p_type))
 							return
 						
-						var/obj/structure/disposalconstruct/C = new (loc, p_type)
-						if(!C.can_place())
+						var/obj/structure/disposalconstruct/disposal_out = new (loc, p_type)
+						if(!disposal_out.can_place())
 							to_chat(usr, span_warning("There's not enough room to build that here!"))
-							qdel(C)
+							qdel(disposal_out)
 							return
 						
-						C.add_fingerprint(usr)
-						C.update_appearance()
-						C.setDir(params["pipe_dir"])
+						disposal_out.add_fingerprint(usr)
+						disposal_out.update_appearance()
+						disposal_out.setDir(params["pipe_dir"])
 						wait = world.time + 1 SECONDS
 				if(TRANSIT_PIPEDISPENSER)
 					if(wait < world.time)
@@ -122,10 +122,10 @@
 						if(!verify_recipe(GLOB.transit_tube_recipes, p_type))
 							return
 						
-						var/obj/structure/c_transit_tube/tube = new p_type(loc)
-						tube.add_fingerprint(usr)
-						tube.update_appearance()
-						tube.setDir(params["pipe_dir"])
+						var/obj/structure/c_transit_tube/tube_out = new p_type(loc)
+						tube_out.add_fingerprint(usr)
+						tube_out.update_appearance()
+						tube_out.setDir(params["pipe_dir"])
 						wait = world.time + 1 SECONDS
 		if("piping_layer")
 			piping_layer = text2num(params["piping_layer"])
@@ -211,4 +211,6 @@
 	desc = "Dispenses pipes that will move beings around."
 	category = TRANSIT_PIPEDISPENSER
 
-
+#undef ATMOS_PIPEDISPENSER
+#undef DISPOSAL_PIPEDISPENSER
+#undef TRANSIT_PIPEDISPENSER

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -71,15 +71,16 @@
 			switch(category)
 				if(ATMOS_PIPEDISPENSER)
 					if(wait < world.time)
-						var/rec = GLOB.atmos_pipe_recipes[params["category"]][params["pipe_type"]].type
-						var/p_type = GLOB.atmos_pipe_recipes[params["category"]][params["pipe_type"]].id
+						var/datum/pipe_info/info = GLOB.atmos_pipe_recipes[params["category"]][params["pipe_type"]]
+						var/recipe_type = info.type
+						var/p_type = info.id
 						
 						// No spawning arbitrary paths (literally 1984)
 						if(!verify_recipe(GLOB.atmos_pipe_recipes, p_type))
 							return
 						
 						// If this is a meter, make that.
-						if(rec == /datum/pipe_info/meter)
+						if(recipe_type == /datum/pipe_info/meter)
 							new /obj/item/pipe_meter(loc)
 							wait = world.time + 1 SECONDS
 							return
@@ -95,7 +96,8 @@
 						wait = world.time + 1 SECONDS
 				if(DISPOSAL_PIPEDISPENSER)
 					if(wait < world.time)
-						var/p_type = GLOB.disposal_pipe_recipes[params["category"]][params["pipe_type"]].id
+						var/datum/pipe_info/info = GLOB.disposal_pipe_recipes[params["category"]][params["pipe_type"]]
+						var/p_type = info.id
 						
 						// No spawning arbitrary paths (literally 1984)
 						if(!verify_recipe(GLOB.disposal_pipe_recipes, p_type))
@@ -113,7 +115,8 @@
 						wait = world.time + 1 SECONDS
 				if(TRANSIT_PIPEDISPENSER)
 					if(wait < world.time)
-						var/p_type = GLOB.transit_tube_recipes[params["category"]][params["pipe_type"]].id
+						var/datum/pipe_info/info = GLOB.transit_tube_recipes[params["category"]][params["pipe_type"]]
+						var/p_type = info.id
 						
 						// No spawning arbitrary paths (literally 1984)
 						if(!verify_recipe(GLOB.transit_tube_recipes, p_type))

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -68,30 +68,62 @@
 			paint_color = params["paint_color"]
 		
 		if("pipe_type")
-			if(wait < world.time)
-				var/rec = GLOB.atmos_pipe_recipes[params["category"]][params["pipe_type"]].type
-				var/p_type = GLOB.atmos_pipe_recipes[params["category"]][params["pipe_type"]].id
-				
-				// No spawning arbitrary paths (literally 1984)
-				if(!verify_recipe(GLOB.atmos_pipe_recipes, p_type))
-					return
-				
-				// If this is a meter, make that.
-				if(rec == /datum/pipe_info/meter)
-					new /obj/item/pipe_meter(loc)
-					wait = world.time + 1 SECONDS
-					return
-				
-				// Otherwise, make a pipe/device
-				var/p_dir = params["pipe_dir"]
-				var/obj/item/pipe/pipe_out = new (loc, p_type, p_dir)
-				pipe_out.p_init_dir = p_init_dir
-				pipe_out.pipe_color = GLOB.pipe_paint_colors[paint_color]
-				pipe_out.add_atom_colour(GLOB.pipe_paint_colors[paint_color], FIXED_COLOUR_PRIORITY)
-				pipe_out.set_piping_layer(piping_layer)
-				pipe_out.add_fingerprint(usr)
-				wait = world.time + 1 SECONDS
-		
+			switch(category)
+				if(ATMOS_PIPEDISPENSER)
+					if(wait < world.time)
+						var/rec = GLOB.atmos_pipe_recipes[params["category"]][params["pipe_type"]].type
+						var/p_type = GLOB.atmos_pipe_recipes[params["category"]][params["pipe_type"]].id
+						
+						// No spawning arbitrary paths (literally 1984)
+						if(!verify_recipe(GLOB.atmos_pipe_recipes, p_type))
+							return
+						
+						// If this is a meter, make that.
+						if(rec == /datum/pipe_info/meter)
+							new /obj/item/pipe_meter(loc)
+							wait = world.time + 1 SECONDS
+							return
+						
+						// Otherwise, make a pipe/device
+						var/p_dir = params["pipe_dir"]
+						var/obj/item/pipe/pipe_out = new (loc, p_type, p_dir)
+						pipe_out.p_init_dir = p_init_dir
+						pipe_out.pipe_color = GLOB.pipe_paint_colors[paint_color]
+						pipe_out.add_atom_colour(GLOB.pipe_paint_colors[paint_color], FIXED_COLOUR_PRIORITY)
+						pipe_out.set_piping_layer(piping_layer)
+						pipe_out.add_fingerprint(usr)
+						wait = world.time + 1 SECONDS
+				if(DISPOSAL_PIPEDISPENSER)
+					if(wait < world.time)
+						var/p_type = GLOB.disposal_pipe_recipes[params["category"]][params["pipe_type"]].id
+						
+						// No spawning arbitrary paths (literally 1984)
+						if(!verify_recipe(GLOB.disposal_pipe_recipes, p_type))
+							return
+						
+						var/obj/structure/disposalconstruct/C = new (loc, p_type)
+						if(!C.can_place())
+							to_chat(usr, span_warning("There's not enough room to build that here!"))
+							qdel(C)
+							return
+						
+						C.add_fingerprint(usr)
+						C.update_appearance()
+						C.setDir(params["pipe_dir"])
+						wait = world.time + 1 SECONDS
+				if(TRANSIT_PIPEDISPENSER)
+					if(wait < world.time)
+						var/p_type = GLOB.transit_tube_recipes[params["category"]][params["pipe_type"]].id
+						
+						// No spawning arbitrary paths (literally 1984)
+						if(!verify_recipe(GLOB.transit_tube_recipes, p_type))
+							return
+						
+						var/obj/structure/c_transit_tube/tube = new p_type(loc)
+						tube.add_fingerprint(usr)
+						tube.update_appearance()
+						tube.setDir(params["pipe_dir"])
+						wait = world.time + 1 SECONDS
 		if("piping_layer")
 			piping_layer = text2num(params["piping_layer"])
 		
@@ -165,28 +197,6 @@
 
 	qdel(pipe)
 
-/obj/machinery/pipedispenser/disposal/ui_act(action, params)
-	switch(action)
-		if("pipe_type")
-			if(wait < world.time)
-				var/p_type = GLOB.disposal_pipe_recipes[params["category"]][params["pipe_type"]].id
-				
-				// No spawning arbitrary paths (literally 1984)
-				if(!verify_recipe(GLOB.disposal_pipe_recipes, p_type))
-					return
-				
-				var/obj/structure/disposalconstruct/C = new (loc, p_type)
-				if(!C.can_place())
-					to_chat(usr, span_warning("There's not enough room to build that here!"))
-					qdel(C)
-					return
-				
-				C.add_fingerprint(usr)
-				C.update_appearance()
-				C.setDir(params["pipe_dir"])
-				
-				wait = world.time + 1 SECONDS
-	return TRUE
 
 //transit tube dispenser
 //inherit disposal for the dragging proc
@@ -198,22 +208,4 @@
 	desc = "Dispenses pipes that will move beings around."
 	category = TRANSIT_PIPEDISPENSER
 
-
-/obj/machinery/pipedispenser/disposal/transit_tube/ui_act(action, params)
-	switch(action)
-		if("pipe_type")
-			if(wait < world.time)
-				var/p_type = GLOB.transit_tube_recipes[params["category"]][params["pipe_type"]].id
-				
-				// No spawning arbitrary paths (literally 1984)
-				if(!verify_recipe(GLOB.transit_tube_recipes, p_type))
-					return
-				
-				var/obj/structure/c_transit_tube/tube = new p_type(loc)
-				tube.add_fingerprint(usr)
-				tube.update_appearance()
-				tube.setDir(params["pipe_dir"])
-				
-				wait = world.time + 1 SECONDS
-	return TRUE
 

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -85,17 +85,6 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/dirtype = PIPE_BENDABLE
 	var/all_layers
 
-/datum/pipe_info/proc/Render(dispenser)
-	var/dat = "<li><a href='?src=[REF(dispenser)]&[Params()]'>[name]</a></li>"
-
-	// Stationary pipe dispensers don't allow you to pre-select pipe directions.
-	// This makes it impossble to spawn bent versions of bendable pipes.
-	// We add a "Bent" pipe type with a preset diagonal direction to work around it.
-	if(istype(dispenser, /obj/machinery/pipedispenser) && (dirtype == PIPE_BENDABLE || dirtype == /obj/item/pipe/binary/bendable))
-		dat += "<li><a href='?src=[REF(dispenser)]&[Params()]&dir=[NORTHEAST]'>Bent [name]</a></li>"
-
-	return dat
-
 /datum/pipe_info/proc/Params()
 	return ""
 

--- a/tgui/packages/tgui/interfaces/PipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/PipeDispenser.js
@@ -17,7 +17,7 @@ const ICON_BY_CATEGORY_NAME = {
 const ColorSection = (props, context) => {
   const { act, data } = useBackend(context);
   const {
-    selected_color
+    selected_color,
   } = data;
   return (
     <Section>

--- a/tgui/packages/tgui/interfaces/PipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/PipeDispenser.js
@@ -1,4 +1,3 @@
-import { classes } from 'common/react';
 import { multiline } from 'common/string';
 import { useBackend, useLocalState } from '../backend';
 import { Box, Button, ColorBox, LabeledList, Section, Stack, Tabs } from '../components';
@@ -18,9 +17,7 @@ const ICON_BY_CATEGORY_NAME = {
 const ColorSection = (props, context) => {
   const { act, data } = useBackend(context);
   const {
-    category: rootCategoryIndex,
-    selected_color,
-    mode,
+    selected_color
   } = data;
   return (
     <Section>
@@ -52,7 +49,6 @@ const ColorSection = (props, context) => {
 const LayerSection = (props, context) => {
   const { act, data } = useBackend(context);
   const {
-    category: rootCategoryIndex,
     piping_layer,
   } = data;
   return (
@@ -108,6 +104,7 @@ const PipeTypeSection = (props, context) => {
           title={recipe.pipe_name}
           onClick={() => act('pipe_type', {
             pipe_type: recipe.pipe_index,
+            pipe_dir: recipe.dir,
             category: shownCategory.cat_name,
           })} />
       ))}
@@ -118,9 +115,6 @@ const PipeTypeSection = (props, context) => {
 const SmartPipeBlockSection = (props, context) => {
   const { act, data } = useBackend(context);
   const init_directions = data.init_directions || [];
-  const {
-    category: rootCategoryIndex,
-  } = data;
   return (
     <Section height={7.5}>
       <Stack fill vertical textAlign="center">

--- a/tgui/packages/tgui/interfaces/PipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/PipeDispenser.js
@@ -1,73 +1,7 @@
-import { multiline } from 'common/string';
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, ColorBox, LabeledList, Section, Stack, Tabs } from '../components';
+import { Button, LabeledList, Section, Stack, Tabs } from '../components';
 import { Window } from '../layouts';
-
-const ICON_BY_CATEGORY_NAME = {
-  'Atmospherics': 'wrench',
-  'Disposals': 'trash-alt',
-  'Transit Tubes': 'bus',
-  'Pipes': 'grip-lines',
-  'Disposal Pipes': 'grip-lines',
-  'Devices': 'microchip',
-  'Heat Exchange': 'thermometer-half',
-  'Station Equipment': 'microchip',
-};
-
-const ColorSection = (props, context) => {
-  const { act, data } = useBackend(context);
-  const {
-    selected_color,
-  } = data;
-  return (
-    <Section>
-      <LabeledList>
-        <LabeledList.Item
-          label="Color">
-          <Box
-            inline
-            width="64px"
-            color={data.paint_colors[selected_color]}>
-            {selected_color}
-          </Box>
-          {Object.keys(data.paint_colors)
-            .map(colorName => (
-              <ColorBox
-                key={colorName}
-                ml={1}
-                color={data.paint_colors[colorName]}
-                onClick={() => act('color', {
-                  paint_color: colorName,
-                })} />
-            ))}
-        </LabeledList.Item>
-      </LabeledList>
-    </Section>
-  );
-};
-
-const LayerSection = (props, context) => {
-  const { act, data } = useBackend(context);
-  const {
-    piping_layer,
-  } = data;
-  return (
-    <Section fill width={7.5}>
-      <Stack vertical mb={1}>
-        {[1, 2, 3, 4, 5].map(layer => (
-          <Stack.Item my={0} key={layer}>
-            <Button.Checkbox
-              checked={layer === piping_layer}
-              content={'Layer ' + layer}
-              onClick={() => act('piping_layer', {
-                piping_layer: layer,
-              })} />
-          </Stack.Item>
-        ))}
-      </Stack>
-    </Section>
-  );
-};
+import { ICON_BY_CATEGORY_NAME, ColorItem, LayerSelect, SmartPipeBlockSection } from './RapidPipeDispenser';
 
 const PipeTypeSection = (props, context) => {
   const { act, data } = useBackend(context);
@@ -112,70 +46,6 @@ const PipeTypeSection = (props, context) => {
   );
 };
 
-const SmartPipeBlockSection = (props, context) => {
-  const { act, data } = useBackend(context);
-  const init_directions = data.init_directions || [];
-  return (
-    <Section height={7.5}>
-      <Stack fill vertical textAlign="center">
-        <Stack.Item basis={1.5}>
-          <Stack>
-            <Stack.Item>
-              <Button
-                color="transparent"
-                icon="info"
-                tooltipPosition="right"
-                tooltip={multiline`
-                This is a panel for blocking certain connection
-                directions for the smart pipes.
-                The button in the center resets to
-                default (all directions can connect)`} />
-            </Stack.Item>
-            <Stack.Item>
-              <Button icon="arrow-up"
-                disabled={!!data.smart_pipe}
-                selected={init_directions["north"]}
-                onClick={() => act('init_dir_setting', {
-                  dir_flag: "north",
-                })} />
-            </Stack.Item>
-          </Stack>
-        </Stack.Item>
-        <Stack.Item basis={1.5}>
-          <Stack fill>
-            <Stack.Item>
-              <Button icon="arrow-left"
-                selected={init_directions["west"]}
-                onClick={() => act('init_dir_setting', {
-                  dir_flag: "west",
-                })} />
-            </Stack.Item>
-            <Stack.Item grow>
-              <Button icon="circle"
-                onClick={() => act('init_reset', {
-                })} />
-            </Stack.Item>
-            <Stack.Item>
-              <Button icon="arrow-right"
-                selected={init_directions["east"]}
-                onClick={() => act('init_dir_setting', {
-                  dir_flag: "east",
-                })} />
-            </Stack.Item>
-          </Stack>
-        </Stack.Item>
-        <Stack.Item grow>
-          <Button icon="arrow-down"
-            selected={init_directions["south"]}
-            onClick={() => act('init_dir_setting', {
-              dir_flag: "south",
-            })} />
-        </Stack.Item>
-      </Stack>
-    </Section>
-  );
-};
-
 export const PipeDispenser = (props, context) => {
   const { act, data } = useBackend(context);
   const {
@@ -189,7 +59,11 @@ export const PipeDispenser = (props, context) => {
         <Stack fill vertical>
           {rootCategoryIndex === 0 && (
             <Stack.Item>
-              <ColorSection />
+              <Section>
+                <LabeledList>
+                  <ColorItem />
+                </LabeledList>
+              </Section>
             </Stack.Item>
           )}
           <Stack.Item grow>
@@ -201,7 +75,9 @@ export const PipeDispenser = (props, context) => {
                       <SmartPipeBlockSection />
                     </Stack.Item>
                     <Stack.Item grow>
-                      <LayerSection />
+                      <Section fill width={7.5}>
+                        <LayerSelect />
+                      </Section>
                     </Stack.Item>
                   </Stack>
                 </Stack.Item>

--- a/tgui/packages/tgui/interfaces/PipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/PipeDispenser.js
@@ -1,0 +1,226 @@
+import { classes } from 'common/react';
+import { multiline } from 'common/string';
+import { useBackend, useLocalState } from '../backend';
+import { Box, Button, ColorBox, LabeledList, Section, Stack, Tabs } from '../components';
+import { Window } from '../layouts';
+
+const ICON_BY_CATEGORY_NAME = {
+  'Atmospherics': 'wrench',
+  'Disposals': 'trash-alt',
+  'Transit Tubes': 'bus',
+  'Pipes': 'grip-lines',
+  'Disposal Pipes': 'grip-lines',
+  'Devices': 'microchip',
+  'Heat Exchange': 'thermometer-half',
+  'Station Equipment': 'microchip',
+};
+
+const ColorSection = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    category: rootCategoryIndex,
+    selected_color,
+    mode,
+  } = data;
+  return (
+    <Section>
+      <LabeledList>
+        <LabeledList.Item
+          label="Color">
+          <Box
+            inline
+            width="64px"
+            color={data.paint_colors[selected_color]}>
+            {selected_color}
+          </Box>
+          {Object.keys(data.paint_colors)
+            .map(colorName => (
+              <ColorBox
+                key={colorName}
+                ml={1}
+                color={data.paint_colors[colorName]}
+                onClick={() => act('color', {
+                  paint_color: colorName,
+                })} />
+            ))}
+        </LabeledList.Item>
+      </LabeledList>
+    </Section>
+  );
+};
+
+const LayerSection = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    category: rootCategoryIndex,
+    piping_layer,
+  } = data;
+  return (
+    <Section fill width={7.5}>
+      {rootCategoryIndex === 0 && (
+        <Stack vertical mb={1}>
+          {[1, 2, 3, 4, 5].map(layer => (
+            <Stack.Item my={0} key={layer}>
+              <Button.Checkbox
+                checked={layer === piping_layer}
+                content={'Layer ' + layer}
+                onClick={() => act('piping_layer', {
+                  piping_layer: layer,
+                })} />
+            </Stack.Item>
+          ))}
+        </Stack>
+      )}
+    </Section>
+  );
+};
+
+const PipeTypeSection = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    categories = [],
+  } = data;
+  const [
+    categoryName,
+    setCategoryName,
+  ] = useLocalState(context, 'categoryName');
+  const shownCategory = categories
+    .find(category => category.cat_name === categoryName)
+    || categories[0];
+  return (
+    <Section fill scrollable>
+      <Tabs>
+        {categories.map((category, i) => (
+          <Tabs.Tab
+            fluid
+            key={category.cat_name}
+            icon={ICON_BY_CATEGORY_NAME[category.cat_name]}
+            selected={category.cat_name === shownCategory.cat_name}
+            onClick={() => setCategoryName(category.cat_name)}>
+            {category.cat_name}
+          </Tabs.Tab>
+        ))}
+      </Tabs>
+      {shownCategory?.recipes.map(recipe => (
+        <Button
+          key={recipe.pipe_index}
+          fluid
+          ellipsis
+          content={recipe.pipe_name}
+          title={recipe.pipe_name}
+          onClick={() => act('pipe_type', {
+            pipe_type: recipe.pipe_index,
+            category: shownCategory.cat_name,
+          })} />
+      ))}
+    </Section>
+  );
+};
+
+const SmartPipeBlockSection = (props, context) => {
+  const { act, data } = useBackend(context);
+  const init_directions = data.init_directions || [];
+  const {
+    category: rootCategoryIndex,
+  } = data;
+  return (
+    <Section height={7.5}>
+      <Stack fill vertical textAlign="center">
+        <Stack.Item basis={1.5}>
+          <Stack>
+            <Stack.Item>
+              <Button
+                color="transparent"
+                icon="info"
+                tooltipPosition="right"
+                tooltip={multiline`
+                This is a panel for blocking certain connection
+                directions for the smart pipes.
+                The button in the center resets to
+                default (all directions can connect)`} />
+            </Stack.Item>
+            <Stack.Item>
+              <Button icon="arrow-up"
+                disabled={!!data.smart_pipe}
+                selected={init_directions["north"]}
+                onClick={() => act('init_dir_setting', {
+                  dir_flag: "north",
+                })} />
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
+        <Stack.Item basis={1.5}>
+          <Stack fill>
+            <Stack.Item>
+              <Button icon="arrow-left"
+                selected={init_directions["west"]}
+                onClick={() => act('init_dir_setting', {
+                  dir_flag: "west",
+                })} />
+            </Stack.Item>
+            <Stack.Item grow>
+              <Button icon="circle"
+                onClick={() => act('init_reset', {
+                })} />
+            </Stack.Item>
+            <Stack.Item>
+              <Button icon="arrow-right"
+                selected={init_directions["east"]}
+                onClick={() => act('init_dir_setting', {
+                  dir_flag: "east",
+                })} />
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
+        <Stack.Item grow>
+          <Button icon="arrow-down"
+            selected={init_directions["south"]}
+            onClick={() => act('init_dir_setting', {
+              dir_flag: "south",
+            })} />
+        </Stack.Item>
+      </Stack>
+    </Section>
+  );
+};
+
+export const PipeDispenser = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    category: rootCategoryIndex,
+  } = data;
+  return (
+    <Window
+      width={450}
+      height={575}>
+      <Window.Content>
+        <Stack fill vertical>
+          {rootCategoryIndex === 0 && (
+            <Stack.Item>
+              <ColorSection />
+            </Stack.Item>
+          )}
+          <Stack.Item grow>
+            <Stack fill>
+              {rootCategoryIndex === 0 && (
+                <Stack.Item>
+                  <Stack vertical fill>
+                    <Stack.Item>
+                      <SmartPipeBlockSection />
+                    </Stack.Item>
+                    <Stack.Item grow>
+                      <LayerSection />
+                    </Stack.Item>
+                  </Stack>
+                </Stack.Item>
+              )}
+              <Stack.Item grow>
+                <PipeTypeSection />
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/PipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/PipeDispenser.js
@@ -57,20 +57,18 @@ const LayerSection = (props, context) => {
   } = data;
   return (
     <Section fill width={7.5}>
-      {rootCategoryIndex === 0 && (
-        <Stack vertical mb={1}>
-          {[1, 2, 3, 4, 5].map(layer => (
-            <Stack.Item my={0} key={layer}>
-              <Button.Checkbox
-                checked={layer === piping_layer}
-                content={'Layer ' + layer}
-                onClick={() => act('piping_layer', {
-                  piping_layer: layer,
-                })} />
-            </Stack.Item>
-          ))}
-        </Stack>
-      )}
+      <Stack vertical mb={1}>
+        {[1, 2, 3, 4, 5].map(layer => (
+          <Stack.Item my={0} key={layer}>
+            <Button.Checkbox
+              checked={layer === piping_layer}
+              content={'Layer ' + layer}
+              onClick={() => act('piping_layer', {
+                piping_layer: layer,
+              })} />
+          </Stack.Item>
+        ))}
+      </Stack>
     </Section>
   );
 };

--- a/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
+++ b/tgui/packages/tgui/interfaces/RapidPipeDispenser.js
@@ -10,7 +10,7 @@ const ROOT_CATEGORIES = [
   'Transit Tubes',
 ];
 
-const ICON_BY_CATEGORY_NAME = {
+export const ICON_BY_CATEGORY_NAME = {
   'Atmospherics': 'wrench',
   'Disposals': 'trash-alt',
   'Transit Tubes': 'bus',
@@ -40,65 +40,148 @@ const TOOLS = [
   },
 ];
 
-const SelectionSection = (props, context) => {
+export const ColorItem = (props, context) => {
   const { act, data } = useBackend(context);
   const {
-    category: rootCategoryIndex,
     selected_color,
+  } = data;
+  return (
+    <LabeledList.Item
+      label="Color">
+      <Box
+        inline
+        width="64px"
+        color={data.paint_colors[selected_color]}>
+        {selected_color}
+      </Box>
+      {Object.keys(data.paint_colors)
+        .map(colorName => (
+          <ColorBox
+            key={colorName}
+            ml={1}
+            color={data.paint_colors[colorName]}
+            onClick={() => act('color', {
+              paint_color: colorName,
+            })} />
+        ))}
+    </LabeledList.Item>
+  );
+};
+
+const ModeItem = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
     mode,
   } = data;
   return (
+    <LabeledList.Item label="Modes">
+      <Stack fill>
+        {TOOLS.map(tool => (
+          <Stack.Item grow key={tool.bitmask}>
+            <Button.Checkbox
+              checked={mode & tool.bitmask}
+              fluid
+              content={tool.name}
+              onClick={() => act('mode', {
+                mode: tool.bitmask,
+              })} />
+          </Stack.Item>
+        ))}
+      </Stack>
+    </LabeledList.Item>
+  );
+};
+
+const CategoryItem = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    category: rootCategoryIndex,
+  } = data;
+  return (
+    <LabeledList.Item
+      label="Category">
+      {ROOT_CATEGORIES.map((categoryName, i) => (
+        <Button
+          key={categoryName}
+          selected={rootCategoryIndex === i}
+          icon={ICON_BY_CATEGORY_NAME[categoryName]}
+          color="transparent"
+          onClick={() => act('category', { category: i })} >
+          {categoryName}
+        </Button>
+      ))}
+    </LabeledList.Item>
+  );
+};
+
+const SelectionSection = (props, context) => {
+  const { act, data } = useBackend(context);
+  return (
     <Section>
       <LabeledList>
-        <LabeledList.Item
-          label="Category">
-          {ROOT_CATEGORIES.map((categoryName, i) => (
-            <Button
-              key={categoryName}
-              selected={rootCategoryIndex === i}
-              icon={ICON_BY_CATEGORY_NAME[categoryName]}
-              color="transparent"
-              onClick={() => act('category', { category: i })} >
-              {categoryName}
-            </Button>
-          ))}
-        </LabeledList.Item>
-        <LabeledList.Item label="Modes">
-          <Stack fill>
-            {TOOLS.map(tool => (
-              <Stack.Item grow key={tool.bitmask}>
-                <Button.Checkbox
-                  checked={mode & tool.bitmask}
-                  fluid
-                  content={tool.name}
-                  onClick={() => act('mode', {
-                    mode: tool.bitmask,
-                  })} />
-              </Stack.Item>
-            ))}
-          </Stack>
-        </LabeledList.Item>
-        <LabeledList.Item
-          label="Color">
-          <Box
-            inline
-            width="64px"
-            color={data.paint_colors[selected_color]}>
-            {selected_color}
-          </Box>
-          {Object.keys(data.paint_colors)
-            .map(colorName => (
-              <ColorBox
-                key={colorName}
-                ml={1}
-                color={data.paint_colors[colorName]}
-                onClick={() => act('color', {
-                  paint_color: colorName,
-                })} />
-            ))}
-        </LabeledList.Item>
+        <CategoryItem />
+        <ModeItem />
+        <ColorItem />
       </LabeledList>
     </Section>
+  );
+};
+
+export const LayerSelect = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    piping_layer,
+  } = data;
+  return (
+    <Stack vertical mb={1}>
+      {[1, 2, 3, 4, 5].map(layer => (
+        <Stack.Item my={0} key={layer}>
+          <Button.Checkbox
+            checked={layer === piping_layer}
+            content={'Layer ' + layer}
+            onClick={() => act('piping_layer', {
+              piping_layer: layer,
+            })} />
+        </Stack.Item>
+      ))}
+    </Stack>
+  );
+};
+
+const PreviewSelect = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    category: rootCategoryIndex,
+  } = data;
+  const previews = data.preview_rows.flatMap(row => row.previews);
+  return (
+    <Box width="120px">
+      {previews.map(preview => (
+        <Button
+          ml={0}
+          key={preview.dir}
+          title={preview.dir_name}
+          selected={preview.selected}
+          style={{
+            width: '40px',
+            height: '40px',
+            padding: 0,
+          }}
+          onClick={() => act('setdir', {
+            dir: preview.dir,
+            flipped: preview.flipped,
+          })}>
+          <Box
+            className={classes([
+              'pipes32x32',
+              preview.dir + '-' + preview.icon_state,
+            ])}
+            style={{
+              transform: 'scale(1.5) translate(9.5%, 9.5%)',
+            }} />
+        </Button>
+      ))}
+    </Box>
   );
 };
 
@@ -112,46 +195,9 @@ const LayerSection = (props, context) => {
   return (
     <Section fill width={7.5}>
       {rootCategoryIndex === 0 && (
-        <Stack vertical mb={1}>
-          {[1, 2, 3, 4, 5].map(layer => (
-            <Stack.Item my={0} key={layer}>
-              <Button.Checkbox
-                checked={layer === piping_layer}
-                content={'Layer ' + layer}
-                onClick={() => act('piping_layer', {
-                  piping_layer: layer,
-                })} />
-            </Stack.Item>
-          ))}
-        </Stack>
+        <LayerSelect />
       )}
-      <Box width="120px">
-        {previews.map(preview => (
-          <Button
-            ml={0}
-            key={preview.dir}
-            title={preview.dir_name}
-            selected={preview.selected}
-            style={{
-              width: '40px',
-              height: '40px',
-              padding: 0,
-            }}
-            onClick={() => act('setdir', {
-              dir: preview.dir,
-              flipped: preview.flipped,
-            })}>
-            <Box
-              className={classes([
-                'pipes32x32',
-                preview.dir + '-' + preview.icon_state,
-              ])}
-              style={{
-                transform: 'scale(1.5) translate(9.5%, 9.5%)',
-              }} />
-          </Button>
-        ))}
-      </Box>
+      <PreviewSelect />
     </Section>
   );
 };
@@ -199,14 +245,14 @@ const PipeTypeSection = (props, context) => {
   );
 };
 
-const SmartPipeBlockSection = (props, context) => {
+export const SmartPipeBlockSection = (props, context) => {
   const { act, data } = useBackend(context);
   const init_directions = data.init_directions || [];
   const {
     category: rootCategoryIndex,
   } = data;
   return (
-    <Section>
+    <Section height={7.5}>
       <Stack fill vertical textAlign="center">
         <Stack.Item basis={1.5}>
           <Stack>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Converts atmos, disposal, and transit tube pipedispenser (the stationary ones) dialogs to tgui.
- Creates the PipeDispenser react component
- removes the now unneeded Render proc for pipe_info
- removes old traditional ui procs
- gives atmos pipedispensers the ability to color pipes and dispense smart pipes
- Decomposes RapidPipeDispenser component a bit, to make the resuse of stuff like the color picker easier.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

tgui good.

Also this now allows the atmos pipedispensers to take advantage of pipe colors and smart pipes.

![tgui](https://user-images.githubusercontent.com/12129109/148272983-21e92db7-d8e6-4d74-b1f8-e6551741aa1c.PNG)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: stationary pipe dispensers now take advantage of tgui
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
