### PR TITLE
Refactors and adds an Internal Affairs Dynamic ruleset.

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -114,6 +114,9 @@ GLOBAL_LIST_INIT(heretic_start_knowledge,list(/datum/eldritch_knowledge/spell/ba
 ///File to the malf flavor
 #define MALFUNCTION_FLAVOR_FILE "antagonist_flavor/malfunction_flavor.json"
 
+///File to the IAA flavor
+#define IAA_FLAVOR_FILE "antagonist_flavor/internalaffair_flavor.json"
+
 ///employers that are from the syndicate
 GLOBAL_LIST_INIT(syndicate_employers, list(
 	"Animal Rights Consortium",
@@ -131,7 +134,6 @@ GLOBAL_LIST_INIT(nanotrasen_employers, list(
 	"Champions of Evil",
 	"Corporate Climber",
 	"Gone Postal",
-	"Internal Affairs Agent",
 	"Legal Trouble",
 ))
 
@@ -151,7 +153,6 @@ GLOBAL_LIST_INIT(normal_employers, list(
 	"Cybersun Industries",
 	"Donk Corporation",
 	"Gorlex Marauders",
-	"Internal Affairs Agent",
 	"Legal Trouble",
 	"MI13",
 	"Waffle Corporation",

--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -13,6 +13,7 @@
 #define ROLE_CULTIST "Cultist"
 #define ROLE_FAMILIES "Gangster"
 #define ROLE_HERETIC "Heretic"
+#define ROLE_INTERNAL_AFFAIRS "Internal Affairs Agent"
 #define ROLE_MALF "Malf AI"
 #define ROLE_MONKEY "Monkey"
 #define ROLE_OPERATIVE "Operative"
@@ -63,7 +64,6 @@
 #define ROLE_DRONE "Drone"
 #define ROLE_DEATHSQUAD "Deathsquad"
 #define ROLE_LAVALAND "Lavaland"
-#define ROLE_INTERNAL_AFFAIRS "Internal Affairs Agent"
 
 #define ROLE_POSITRONIC_BRAIN "Positronic Brain"
 #define ROLE_FREE_GOLEM "Free Golem"
@@ -111,6 +111,7 @@ GLOBAL_LIST_INIT(special_roles, list(
 	ROLE_CULTIST = 14,
 	ROLE_FAMILIES = 0,
 	ROLE_HERETIC = 0,
+	ROLE_INTERNAL_AFFAIRS = 0,
 	ROLE_MALF = 0,
 	ROLE_MONKEY = 0,
 	ROLE_OPERATIVE = 14,

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -87,6 +87,66 @@
 		LAZYADDASSOC(SSjob.dynamic_forced_occupations, new_malf, "AI")
 	return TRUE
 
+//////////////////////////////////////////////
+//                                          //
+//            INTERNAL AFFAIRS              //
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/roundstart/internal_affairs
+	name = "Internal Affairs"
+	antag_flag = ROLE_INTERNAL_AFFAIRS
+	antag_datum = /datum/antagonist/traitor/internal_affairs
+	protected_roles = list(JOB_CAPTAIN, JOB_HEAD_OF_SECURITY, JOB_WARDEN, JOB_SECURITY_OFFICER, JOB_DETECTIVE, JOB_PRISONER)
+	restricted_roles = list(JOB_AI, JOB_CYBORG)
+	required_candidates = 6
+	weight = 4
+	cost = 8
+	scaling_cost = 2
+	requirements = list(8,8,8,8,8,8,8,8,8,8)
+	antag_cap = list("denominator" = 24, "offset" = 3)
+	///List of all IAAs, inserted in the correct order to assign eachother as objectives of one another.
+	var/list/target_list = list()
+
+/datum/dynamic_ruleset/roundstart/internal_affairs/pre_execute(population)
+	. = ..()
+	var/num_traitors = get_antag_cap(population)
+	for(var/affair_number = 1 to num_traitors)
+		if(candidates.len <= 0)
+			break
+		var/mob/M = pick_n_take(candidates)
+		assigned += M.mind
+		M.mind.restricted_roles = restricted_roles
+		GLOB.pre_setup_antags += M.mind
+
+	//We assign all IAAs their position in the list to later assign them as objectives of one another.
+	var/list_position = 0
+	for(var/datum/mind/iaa_minds in assigned)
+		list_position++
+		if(list_position + 1 > assigned.len)
+			list_position = 0
+		target_list[iaa_minds] = assigned[list_position+1]
+	return TRUE
+
+/datum/dynamic_ruleset/roundstart/internal_affairs/execute()
+	. = ..()
+	if(!.)
+		return FALSE
+
+	// We do get_antag_minds as they have already been removed from 'assigned'.
+	for(var/datum/mind/assigned_traitors as anything in get_antag_minds(/datum/antagonist/traitor/internal_affairs))
+		var/datum/antagonist/traitor/internal_affairs/iaa_datum = assigned_traitors.has_antag_datum(/datum/antagonist/traitor/internal_affairs)
+		if(target_list.len && target_list[assigned_traitors])
+			var/datum/mind/target_mind = target_list[assigned_traitors]
+
+			var/datum/objective/assassinate/internal/kill_objective = new
+			kill_objective.owner = assigned_traitors
+			kill_objective.target = target_mind
+			kill_objective.update_explanation_text()
+			iaa_datum.objectives += kill_objective
+
+	return TRUE
+
 //////////////////////////////////////////
 //                                      //
 //           BLOOD BROTHERS             //

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -100,7 +100,7 @@
 	protected_roles = list(JOB_CAPTAIN, JOB_HEAD_OF_SECURITY, JOB_WARDEN, JOB_SECURITY_OFFICER, JOB_DETECTIVE, JOB_PRISONER)
 	restricted_roles = list(JOB_AI, JOB_CYBORG)
 	required_candidates = 6
-	weight = 4
+	weight = 0
 	cost = 8
 	scaling_cost = 2
 	requirements = list(8,8,8,8,8,8,8,8,8,8)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -192,8 +192,8 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 
 /datum/objective/assassinate
 	name = "assasinate"
-	var/target_role_type=FALSE
 	martyr_compatible = TRUE
+	var/target_role_type = FALSE
 
 
 /datum/objective/assassinate/check_completion()
@@ -210,12 +210,15 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 	admin_simple_target_pick(admin)
 
 /datum/objective/assassinate/internal
-	var/stolen = FALSE //Have we already eliminated this target?
+	///Have we already eliminated this target?
+	var/stolen = FALSE
 
 /datum/objective/assassinate/internal/update_explanation_text()
 	..()
-	if(target && !target.current)
-		explanation_text = "Assassinate [target.name], who was obliterated"
+	if(target && target.current)
+		explanation_text = "Assassinate [target.name], the [!target_role_type ? target.assigned_role.title : target.special_role]."
+	else
+		explanation_text = "Assassinate [target.name], who has been obliterated."
 
 /datum/objective/mutiny
 	name = "mutiny"

--- a/code/modules/antagonists/traitor/IAA/agent_pinpointer.dm
+++ b/code/modules/antagonists/traitor/IAA/agent_pinpointer.dm
@@ -13,9 +13,13 @@
 	duration = -1
 	tick_interval = PINPOINTER_PING_TIME
 	alert_type = /atom/movable/screen/alert/status_effect/agent_pinpointer
+	///The minimum range to start pointing towards your target.
 	var/minimum_range = PINPOINTER_MINIMUM_RANGE
+	///How fuzzy will the pinpointer be, messing with it pointing to your target.
 	var/range_fuzz_factor = PINPOINTER_EXTRA_RANDOM_RANGE
+	///The range until you're considered 'close'
 	var/range_mid = 8
+	///The range until you're considered 'too far away'
 	var/range_far = 16
 	///The target we are pointing towards, refreshes every tick.
 	var/mob/scan_target

--- a/code/modules/antagonists/traitor/IAA/agent_pinpointer.dm
+++ b/code/modules/antagonists/traitor/IAA/agent_pinpointer.dm
@@ -1,0 +1,74 @@
+#define PINPOINTER_MINIMUM_RANGE 15
+#define PINPOINTER_EXTRA_RANDOM_RANGE 10
+#define PINPOINTER_PING_TIME (4 SECONDS)
+
+/atom/movable/screen/alert/status_effect/agent_pinpointer
+	name = "Internal Affairs Integrated Pinpointer"
+	desc = "Even stealthier than a normal implant."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "pinon"
+
+/datum/status_effect/agent_pinpointer
+	id = "agent_pinpointer"
+	duration = -1
+	tick_interval = PINPOINTER_PING_TIME
+	alert_type = /atom/movable/screen/alert/status_effect/agent_pinpointer
+	var/minimum_range = PINPOINTER_MINIMUM_RANGE
+	var/range_fuzz_factor = PINPOINTER_EXTRA_RANDOM_RANGE
+	var/range_mid = 8
+	var/range_far = 16
+	///The target we are pointing towards, refreshes every tick.
+	var/mob/scan_target
+
+/datum/status_effect/agent_pinpointer/tick()
+	if(!owner)
+		qdel(src)
+		return
+	scan_for_target()
+	point_to_target()
+
+///Show the distance and direction of a scanned target
+/datum/status_effect/agent_pinpointer/proc/point_to_target()
+	if(!scan_target)
+		linked_alert.icon_state = "pinonnull"
+		return
+
+	var/turf/here = get_turf(owner)
+	var/turf/there = get_turf(scan_target)
+
+	if(here.z != there.z)
+		linked_alert.icon_state = "pinonnull"
+		return
+	if(get_dist_euclidian(here,there) <= minimum_range + rand(0, range_fuzz_factor))
+		linked_alert.icon_state = "pinondirect"
+		return
+	linked_alert.setDir(get_dir(here, there))
+
+	var/dist = (get_dist(here, there))
+	if(dist >= 1 && dist <= range_mid)
+		linked_alert.icon_state = "pinonclose"
+	else if(dist > range_mid && dist <= range_far)
+		linked_alert.icon_state = "pinonmedium"
+	else if(dist > range_far)
+		linked_alert.icon_state = "pinonfar"
+
+///Attempting to locate a nearby target to scan and point towards.
+/datum/status_effect/agent_pinpointer/proc/scan_for_target()
+	scan_target = null
+	if(!owner && !owner.mind)
+		return
+	for(var/datum/objective/assassinate/internal/objective_datums as anything in owner.mind.get_all_objectives())
+		if(!objective_datums.target || !objective_datums.target.current || objective_datums.target.current.stat == DEAD)
+			continue
+		var/mob/tracked_target = objective_datums.target.current
+		//JUUUST in case.
+		if(!tracked_target)
+			continue
+
+		//Catch the first one we find, then stop. We want to point to the most recent one we've got.
+		scan_target = tracked_target
+		break
+
+#undef PINPOINTER_EXTRA_RANDOM_RANGE
+#undef PINPOINTER_MINIMUM_RANGE
+#undef PINPOINTER_PING_TIME

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -12,8 +12,6 @@
 	should_give_codewords = FALSE
 	///List of all targets we have stolen thus far.
 	var/list/datum/mind/targets_stolen = list()
-	///The crime we've committed, used for flavortext.
-	var/crime
 
 /datum/antagonist/traitor/internal_affairs/on_gain()
 	. = ..()
@@ -51,7 +49,7 @@
 
 /datum/antagonist/traitor/internal_affairs/greet()
 	. = ..()
-	crime = pick(
+	var/crime = pick(
 		"distribution of contraband",
 		"unauthorized erotic action on duty",
 		"embezzlement",

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -10,6 +10,7 @@
 	job_rank = ROLE_INTERNAL_AFFAIRS
 	preview_outfit = /datum/outfit/internal_affair_agent
 	should_give_codewords = FALSE
+
 	///List of all targets we have stolen thus far.
 	var/list/datum/mind/targets_stolen = list()
 

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -1,247 +1,209 @@
-#define PINPOINTER_MINIMUM_RANGE 15
-#define PINPOINTER_EXTRA_RANDOM_RANGE 10
-#define PINPOINTER_PING_TIME 40
-#define PROB_ACTUAL_TRAITOR 20
-#define TRAITOR_AGENT_ROLE "Syndicate External Affairs Agent"
+///External Affairs is basically a default Traitor
+#define ROLE_EXTERNAL_AFFAIRS "External Affairs Agent"
+///The chance you have of rolling EAA
+#define EXTERNAL_CHANCE 20
 
 /datum/antagonist/traitor/internal_affairs
 	name = "\improper Internal Affairs Agent"
-	employer = "Nanotrasen"
-	suicide_cry = "FOR THE COMPANY!!"
-	var/special_role = "internal affairs agent"
-	var/syndicate = FALSE
-	var/last_man_standing = FALSE
-	var/list/datum/mind/targets_stolen
-
-/datum/antagonist/traitor/internal_affairs/New()
-	. = ..()
-	LAZYADD(targets_stolen, src)
-
-/datum/antagonist/traitor/internal_affairs/proc/give_pinpointer()
-	if(!owner)
-		CRASH("Antag datum with no owner.")
-
-	if(owner.current)
-		owner.current.apply_status_effect(/datum/status_effect/agent_pinpointer)
-
-/datum/antagonist/traitor/internal_affairs/apply_innate_effects()
-	. = ..()
-
-	if(!owner)
-		CRASH("Antag datum with no owner.")
-
-	if(owner.current)
-		give_pinpointer(owner.current)
-
-/datum/antagonist/traitor/internal_affairs/remove_innate_effects()
-	. = ..()
-
-	if(!owner)
-		CRASH("Antag datum with no owner.")
-
-	if(owner.current)
-		owner.current.remove_status_effect(/datum/status_effect/agent_pinpointer)
+	roundend_category = "internal affairs agents"
+	suicide_cry = "FOR THE CORPORATION!!"
+	job_rank = ROLE_INTERNAL_AFFAIRS
+	preview_outfit = /datum/outfit/internal_affair_agent
+	should_give_codewords = FALSE
+	///List of all targets we have stolen thus far.
+	var/list/datum/mind/targets_stolen = list()
+	///The crime we've committed, used for flavortext.
+	var/crime
 
 /datum/antagonist/traitor/internal_affairs/on_gain()
-	START_PROCESSING(SSprocessing, src)
 	. = ..()
+	RegisterSignal(owner.current, COMSIG_LIVING_REVIVE, .proc/on_revive)
+	RegisterSignal(owner.current, COMSIG_LIVING_DEATH, .proc/on_death)
+
 /datum/antagonist/traitor/internal_affairs/on_removal()
-	STOP_PROCESSING(SSprocessing,src)
+	UnregisterSignal(owner.current, COMSIG_LIVING_DEATH)
+	UnregisterSignal(owner.current, COMSIG_LIVING_REVIVE)
+	return ..()
+
+/datum/antagonist/traitor/internal_affairs/apply_innate_effects(mob/living/mob_override)
 	. = ..()
-/datum/antagonist/traitor/internal_affairs/process()
-	iaa_process()
+	var/mob/living/datum_owner = mob_override || owner.current
+	datum_owner.apply_status_effect(/datum/status_effect/agent_pinpointer)
 
-/datum/status_effect/agent_pinpointer
-	id = "agent_pinpointer"
-	duration = -1
-	tick_interval = PINPOINTER_PING_TIME
-	alert_type = /atom/movable/screen/alert/status_effect/agent_pinpointer
-	var/minimum_range = PINPOINTER_MINIMUM_RANGE
-	var/range_fuzz_factor = PINPOINTER_EXTRA_RANDOM_RANGE
-	var/mob/scan_target = null
-	var/range_mid = 8
-	var/range_far = 16
+/datum/antagonist/traitor/internal_affairs/remove_innate_effects(mob/living/mob_override)
+	var/mob/living/datum_owner = mob_override || owner.current
+	datum_owner.remove_status_effect(/datum/status_effect/agent_pinpointer)
+	return ..()
 
-/atom/movable/screen/alert/status_effect/agent_pinpointer
-	name = "Internal Affairs Integrated Pinpointer"
-	desc = "Even stealthier than a normal implant."
-	icon = 'icons/obj/device.dmi'
-	icon_state = "pinon"
+/// Affairs Agents can only roll Internal or External, rather than the normal factions.
+/datum/antagonist/traitor/internal_affairs/pick_employer()
+	var/faction = prob(EXTERNAL_CHANCE) ? ROLE_EXTERNAL_AFFAIRS : ROLE_INTERNAL_AFFAIRS
 
-/datum/status_effect/agent_pinpointer/proc/point_to_target() //If we found what we're looking for, show the distance and direction
-	if(!scan_target)
-		linked_alert.icon_state = "pinonnull"
-		return
-	var/turf/here = get_turf(owner)
-	var/turf/there = get_turf(scan_target)
-	if(here.z != there.z)
-		linked_alert.icon_state = "pinonnull"
-		return
-	if(get_dist_euclidian(here,there)<=minimum_range + rand(0, range_fuzz_factor))
-		linked_alert.icon_state = "pinondirect"
+	employer = faction
+
+	traitor_flavor = strings(IAA_FLAVOR_FILE, employer)
+
+	// External Affairs get an additional objective, done here since objectives are already assigned
+	if(employer == ROLE_EXTERNAL_AFFAIRS)
+		owner.special_role = ROLE_EXTERNAL_AFFAIRS
+		should_give_codewords = TRUE
+		objectives += forge_single_generic_objective()
+
+/datum/antagonist/traitor/internal_affairs/greet()
+	. = ..()
+	crime = pick(
+		"distribution of contraband",
+		"unauthorized erotic action on duty",
+		"embezzlement",
+		"piloting under the influence",
+		"dereliction of duty",
+		"syndicate collaboration",
+		"mutiny",
+		"multiple homicides",
+		"corporate espionage",
+		"receiving bribes",
+		"malpractice",
+		"worship of prohibited life forms",
+		"possession of profane texts",
+		"murder",
+		"arson",
+		"insulting their manager",
+		"grand theft",
+		"conspiracy",
+		"attempting to unionize",
+		"vandalism",
+		"gross incompetence",
+	)
+
+	if(employer == ROLE_EXTERNAL_AFFAIRS)
+		to_chat(owner.current, span_userdanger("Your target has been framed for [crime], and you have been tasked with eliminating them to prevent them defending themselves in court."))
 	else
-		linked_alert.setDir(get_dir(here, there))
-		var/dist = (get_dist(here, there))
-		if(dist >= 1 && dist <= range_mid)
-			linked_alert.icon_state = "pinonclose"
-		else if(dist > range_mid && dist <= range_far)
-			linked_alert.icon_state = "pinonmedium"
-		else if(dist > range_far)
-			linked_alert.icon_state = "pinonfar"
+		to_chat(owner.current, span_userdanger("Your target is suspected of [crime], and you have been tasked with eliminating them by any means necessary to avoid a costly and embarrassing public trial."))
 
-/datum/status_effect/agent_pinpointer/proc/scan_for_target()
-	scan_target = null
-	if(owner)
-		if(owner.mind)
-			for(var/datum/objective/objective_ in owner.mind.get_all_objectives())
-				if(!is_internal_objective(objective_))
-					continue
-				var/datum/objective/assassinate/internal/objective = objective_
-				var/mob/current = objective.target.current
-				if(current&&current.stat!=DEAD)
-					scan_target = current
+	to_chat(owner.current, span_userdanger("Finally, watch your back. Your target has friends in high places, and intel suggests someone may have taken out a contract of their own to protect them."))
+	owner.announce_objectives()
+
+/// We handle this in the dynamic ruleset instead.
+/datum/antagonist/traitor/internal_affairs/forge_traitor_objectives()
+	return
+
+/// All IAA's have to escape until they're the very last alive.
+/datum/antagonist/traitor/internal_affairs/forge_ending_objective()
+	ending_objective = new /datum/objective/escape
+	ending_objective.owner = owner
+	objectives += ending_objective
+
+/// When an IAA is revived, their hunter(s) have to kill them again
+/datum/antagonist/traitor/internal_affairs/proc/on_revive()
+	SIGNAL_HANDLER
+
+	for(var/datum/mind/internal_minds as anything in get_antag_minds(/datum/antagonist/traitor/internal_affairs))
+		for(var/datum/objective/assassinate/internal/internal_objectives as anything in internal_minds.get_all_objectives())
+			if(!internal_objectives.target || internal_objectives.target != owner)
+				continue
+			if(internal_objectives.check_completion())
+				CRASH("[src] ran on_revive but still completed an objective.")
+			to_chat(internal_minds.current, span_userdanger("Your sensors tell you that [internal_objectives.target.current.real_name], one of the targets you were meant to have killed, pulled one over on you, and is still alive - do the job properly this time!"))
+			internal_objectives.stolen = FALSE
+			objectives -= internal_objectives
+
+///When an IAA dies, their hunter completes their objective and inherits their targets
+/datum/antagonist/traitor/internal_affairs/proc/on_death()
+	SIGNAL_HANDLER
+
+	for(var/datum/mind/internal_minds as anything in get_antag_minds(/datum/antagonist/traitor/internal_affairs))
+		if(!internal_minds.current || internal_minds.current.stat == DEAD)
+			continue
+		for(var/datum/objective/assassinate/internal/internal_objectives as anything in internal_minds.get_all_objectives())
+			if(!internal_objectives.target || internal_objectives.target != owner)
+				continue
+			if(!internal_objectives.check_completion())
+				CRASH("[src] ran on_death and failed to complete an objective.")
+			if(internal_objectives.stolen)
 				break
+			var/datum/antagonist/traitor/internal_affairs/iaa_datum = internal_minds.has_antag_datum(/datum/antagonist/traitor/internal_affairs)
+			//This is on the TARGET's IAA datum, NOT ours.
+			iaa_datum.steal_targets(internal_objectives.target)
+			internal_objectives.stolen = TRUE
+			break
 
-/datum/status_effect/agent_pinpointer/tick()
-	if(!owner)
-		qdel(src)
+/// Upon killing a target, we steal their target, to continue the cycle.
+/datum/antagonist/traitor/internal_affairs/proc/steal_targets(datum/mind/victim)
+	if(!owner.current || owner.current.stat == DEAD)
 		return
-	scan_for_target()
-	point_to_target()
 
+	to_chat(owner.current, span_userdanger("Target eliminated: [victim.current]"))
+	for(var/datum/objective/assassinate/internal/objective as anything in victim.get_all_objectives())
+		if(!objective.target || objective.target == owner)
+			continue
+		if(targets_stolen.Find(objective.target) == 0)
+			var/datum/objective/assassinate/internal/new_objective = new
+			new_objective.owner = owner
+			new_objective.target = objective.target
+			new_objective.update_explanation_text()
+			objectives += new_objective
 
-/proc/is_internal_objective(datum/objective/O)
-	return (istype(O, /datum/objective/assassinate/internal)||istype(O, /datum/objective/destroy/internal))
+			owner.announce_objectives()
+			objective.stolen = TRUE
 
-/datum/antagonist/traitor/proc/replace_escape_objective()
-	if(!owner)
-		CRASH("Antag datum with no owner.")
-	if(!objectives.len)
+			targets_stolen += objective.target
+			var/status_text = objective.check_completion() ? "neutralised" : "active"
+			to_chat(owner.current, span_userdanger("New target added to database: [objective.target.current] ([status_text])"))
+
+	check_last_man_standing()
+
+/// Check all our internal objectives, if one fails, return. Otherwise, we're the last man standing.
+/datum/antagonist/traitor/internal_affairs/proc/check_last_man_standing()
+	for(var/datum/objective/assassinate/internal/objective as anything in owner.get_all_objectives())
+		if(!istype(objective, /datum/objective/assassinate/internal))
+			continue
+		if(!objective.check_completion())
+			return
+	if(employer == ROLE_EXTERNAL_AFFAIRS)
+		to_chat(owner.current, span_userdanger("All the loyalist agents are dead, and no more is required of you. Die a glorious death, agent."))
+	else
+		to_chat(owner.current, span_userdanger("All the other agents are dead, and you're the last loose end. Stage a Syndicate terrorist attack to cover up for today's events. You no longer have any limits on collateral damage."))
+
+	replace_escape_objective()
+	make_iaa_unrevivable()
+
+/// Upon becoming the last man standing, all other IAA's become unrevivable
+/datum/antagonist/traitor/internal_affairs/proc/make_iaa_unrevivable()
+	for(var/datum/mind/internal_minds as anything in get_antag_minds(/datum/antagonist/traitor/internal_affairs))
+		var/mob/living/carbon/agents = internal_minds.current
+		if(istype(agents) && agents.stat == DEAD)
+			agents.makeUncloneable()
+			ADD_TRAIT(agents, TRAIT_DEFIB_BLACKLISTED, REF(src))
+			agents.med_hud_set_status()
+
+/// When you are the final IAA, your 'Escape' objective is replaced with Die a Glorious Death
+/datum/antagonist/traitor/internal_affairs/proc/replace_escape_objective()
+	if(!owner || !objectives.len)
 		return
-	for (var/objective in objectives)
-		if(!(istype(objective, /datum/objective/escape) || istype(objective, /datum/objective/survive/malf)))
+	for(var/datum/objective/objective as anything in owner.get_all_objectives())
+		if(!istype(objective, /datum/objective/escape) && !istype(objective, /datum/objective/survive))
 			continue
 		objectives -= objective
 
 	var/datum/objective/martyr/martyr_objective = new
 	martyr_objective.owner = owner
 	objectives += martyr_objective
-
-/datum/antagonist/traitor/proc/reinstate_escape_objective()
-	if(!owner)
-		CRASH("Antag datum with no owner.")
-	if(!objectives.len)
-		return
-	for (var/objective in objectives)
-		if(!istype(objective, /datum/objective/martyr))
-			continue
-		objectives -= objective
-
-/datum/antagonist/traitor/internal_affairs/reinstate_escape_objective()
-	..()
-	for (var/datum/objective/martyr/martyr_objective in objectives)
-		objectives -= martyr_objective
-
-	var/datum/objective/escape_objective = new /datum/objective/escape()
-	escape_objective.owner = owner
-	objectives += escape_objective
-
-/datum/antagonist/traitor/internal_affairs/proc/steal_targets(datum/mind/victim)
-	if(!owner.current||owner.current.stat==DEAD)
-		return
-	to_chat(owner.current, span_userdanger("Target eliminated: [victim.name]"))
-	for(var/objective_ in victim.get_all_objectives())
-		if(istype(objective_, /datum/objective/assassinate/internal))
-			var/datum/objective/assassinate/internal/objective = objective_
-			if(objective.target==owner)
-				continue
-			else if(targets_stolen.Find(objective.target) == 0)
-				var/datum/objective/assassinate/internal/new_objective = new
-				new_objective.owner = owner
-				new_objective.target = objective.target
-				new_objective.update_explanation_text()
-				objectives += new_objective
-				targets_stolen += objective.target
-				var/status_text = objective.check_completion() ? "neutralised" : "active"
-				to_chat(owner.current, span_userdanger("New target added to database: [objective.target.name] ([status_text])"))
-		else if(istype(objective_, /datum/objective/destroy/internal))
-			var/datum/objective/destroy/internal/objective = objective_
-			var/datum/objective/destroy/internal/new_objective = new
-			if(objective.target==owner)
-				continue
-			else if(targets_stolen.Find(objective.target) == 0)
-				new_objective.owner = owner
-				new_objective.target = objective.target
-				new_objective.update_explanation_text()
-				objectives += new_objective
-				targets_stolen += objective.target
-				var/status_text = objective.check_completion() ? "neutralised" : "active"
-				to_chat(owner.current, span_userdanger("New target added to database: [objective.target.name] ([status_text])"))
-	last_man_standing = TRUE
-	for(var/objective_ in objectives)
-		if(!is_internal_objective(objective_))
-			continue
-		var/datum/objective/assassinate/internal/objective = objective_
-		if(!objective.check_completion())
-			last_man_standing = FALSE
-			return
-	if(last_man_standing)
-		if(syndicate)
-			to_chat(owner.current,span_userdanger("All the loyalist agents are dead, and no more is required of you. Die a glorious death, agent."))
-		else
-			to_chat(owner.current,span_userdanger("All the other agents are dead, and you're the last loose end. Stage a Syndicate terrorist attack to cover up for today's events. You no longer have any limits on collateral damage."))
-		replace_escape_objective(owner)
-
-/datum/antagonist/traitor/internal_affairs/proc/iaa_process()
-	if(!owner)
-		CRASH("Antag datum with no owner.")
-	if(owner.current && owner.current.stat != DEAD)
-		for(var/objective_ in objectives)
-			if(!is_internal_objective(objective_))
-				continue
-			var/datum/objective/assassinate/internal/objective = objective_
-			if(!objective.target)
-				continue
-			if(objective.check_completion())
-				if(objective.stolen)
-					continue
-				else
-					steal_targets(objective.target)
-					objective.stolen = TRUE
-			else
-				if(objective.stolen)
-					var/fail_msg = span_userdanger("Your sensors tell you that [objective.target.current.real_name], one of the targets you were meant to have killed, pulled one over on you, and is still alive - do the job properly this time! ")
-					if(last_man_standing)
-						if(syndicate)
-							fail_msg += span_userdanger(" You no longer have permission to die. ")
-						else
-							fail_msg += span_userdanger(" The truth could still slip out!</font><B><font size=5 color=red> Cease any terrorist actions as soon as possible, unneeded property damage or loss of employee life will lead to your contract being terminated.")
-						reinstate_escape_objective(owner)
-						last_man_standing = FALSE
-					to_chat(owner.current, fail_msg)
-					objective.stolen = FALSE
-
-/datum/antagonist/traitor/internal_affairs/forge_traitor_objectives()
-	var/datum/objective/escape_objective = new /datum/objective/escape()
-	escape_objective.owner = owner
-	objectives += escape_objective
-
-/datum/antagonist/traitor/internal_affairs/greet()
-	. = ..()
-	var/crime = pick("distribution of contraband" , "unauthorized erotic action on duty", "embezzlement", "piloting under the influence", "dereliction of duty", "syndicate collaboration", "mutiny", "multiple homicides", "corporate espionage", "receiving bribes", "malpractice", "worship of prohibited life forms", "possession of profane texts", "murder", "arson", "insulting their manager", "grand theft", "conspiracy", "attempting to unionize", "vandalism", "gross incompetence")
-	if(syndicate)
-		to_chat(owner.current, span_userdanger("Your target has been framed for [crime], and you have been tasked with eliminating them to prevent them defending themselves in court."))
-		to_chat(owner.current, "<span class='warningplain'><B><font size=5 color=red>Any damage you cause will be a further embarrassment to Nanotrasen, so you have no limits on collateral damage.</font></B></span>")
-		to_chat(owner.current, span_userdanger("You have been provided with a standard uplink to accomplish your task."))
-	else
-		to_chat(owner.current, span_userdanger("Your target is suspected of [crime], and you have been tasked with eliminating them by any means necessary to avoid a costly and embarrassing public trial."))
-		to_chat(owner.current, "<span class='warningplain'><B><font size=5 color=red>While you have a license to kill, unneeded property damage or loss of employee life will lead to your contract being terminated.</font></B></span>")
-		to_chat(owner.current, span_userdanger("For the sake of plausible deniability, you have been equipped with an array of captured Syndicate weaponry available via uplink."))
-
-	to_chat(owner.current, span_userdanger("Finally, watch your back. Your target has friends in high places, and intel suggests someone may have taken out a contract of their own to protect them."))
 	owner.announce_objectives()
 
-#undef PROB_ACTUAL_TRAITOR
-#undef PINPOINTER_EXTRA_RANDOM_RANGE
-#undef PINPOINTER_MINIMUM_RANGE
-#undef PINPOINTER_PING_TIME
+/datum/outfit/internal_affair_agent
+	name = "IAA (Preview only)"
+
+	uniform = /obj/item/clothing/under/rank/centcom/officer
+	head = /obj/item/clothing/head/centhat
+	glasses = /obj/item/clothing/glasses/sunglasses
+	r_hand = /obj/item/melee/energy/sword
+
+/datum/outfit/internal_affair_agent/post_equip(mob/living/carbon/human/owner, visualsOnly)
+	var/obj/item/melee/energy/sword/sword = locate() in owner.held_items
+	sword.icon_state = "e_sword_on_blue"
+	sword.worn_icon_state = "e_sword_on_blue"
+
+	owner.update_inv_hands()
+
+#undef EXTERNAL_CHANCE
+#undef ROLE_EXTERNAL_AFFAIRS

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -61,11 +61,7 @@
 		forge_traitor_objectives()
 		forge_ending_objective()
 
-	var/faction = prob(75) ? FACTION_SYNDICATE : FACTION_NANOTRASEN
-
-	pick_employer(faction)
-
-	traitor_flavor = strings(TRAITOR_FLAVOR_FILE, employer)
+	pick_employer()
 
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/tatoralert.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
 
@@ -75,7 +71,9 @@
 	owner.special_role = null
 	return ..()
 
-/datum/antagonist/traitor/proc/pick_employer(faction)
+/datum/antagonist/traitor/proc/pick_employer()
+	var/faction = prob(75) ? FACTION_SYNDICATE : FACTION_NANOTRASEN
+
 	var/list/possible_employers = list()
 	possible_employers.Add(GLOB.syndicate_employers, GLOB.nanotrasen_employers)
 
@@ -90,6 +88,8 @@
 		if(FACTION_NANOTRASEN)
 			possible_employers -= GLOB.syndicate_employers
 	employer = pick(possible_employers)
+
+	traitor_flavor = strings(TRAITOR_FLAVOR_FILE, employer)
 
 /// Generates a complete set of traitor objectives up to the traitor objective limit, including non-generic objectives such as martyr and hijack.
 /datum/antagonist/traitor/proc/forge_traitor_objectives()

--- a/strings/antagonist_flavor/internalaffair_flavor.json
+++ b/strings/antagonist_flavor/internalaffair_flavor.json
@@ -1,0 +1,18 @@
+{
+	"Internal Affairs Agent": {
+		"introduction": "You are the Internal Affairs Agent.",
+		"allies": "Eliminate your targets by any means necessary to avoid a costly and embarrassing public trial.",
+		"goal": "While you have a license to kill, unneeded property damage or loss of employee life will lead to your contract being terminated.",
+		"uplink": "For the sake of plausible deniability, you have been equipped with an array of captured Syndicate weaponry available via uplink.",
+		"roundend_report": "was an Internal Affairs Agent.",
+		"ui_theme": "ntos"
+	},
+	"External Affairs Agent": {
+		"introduction": "You are the External Affairs Agent.",
+		"allies": "Eliminate your targets by any means necessary to deny them a chance at defending themselves in court.",
+		"goal": "Any damage you cause will be a further embarrassment to Nanotrasen, so you have no limits on collateral damage.",
+		"uplink": "You have been provided with a standard uplink to accomplish your task.",
+		"roundend_report": "was an External Affairs Agent!",
+		"ui_theme": "syndicate"
+	}
+}

--- a/strings/antagonist_flavor/traitor_flavor.json
+++ b/strings/antagonist_flavor/traitor_flavor.json
@@ -63,14 +63,6 @@
         "ui_theme": "syndicate",
         "uplink": "You have been provided with a standard uplink to accomplish your task."
     },
-    "Internal Affairs Agent": {
-        "allies": "Death to the Syndicate. Killing infiltrators is a whole different kind of internal affair we fully approve of dealing with.",
-        "goal": "While you have a license to kill, unneeded property damage or loss of employee life will lead to your contract being terminated.",
-        "introduction": "You are the Internal Affairs Agent.",
-        "roundend_report": "was part of Nanotrasen Internal Affairs.",
-        "ui_theme": "ntos",
-        "uplink": "For the sake of plausible deniability, you have been equipped with an array of captured Syndicate weaponry available via uplink."
-    },
     "Legal Trouble": {
         "allies": "Death to the Syndicate.",
         "goal": "Try to finish your to-do list, and don't get caught. If they find out what you're actually doing, this scandal will go galactic.",

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2046,6 +2046,7 @@
 #include "code\modules\antagonists\traitor\equipment\contractor.dm"
 #include "code\modules\antagonists\traitor\equipment\Malf_Modules.dm"
 #include "code\modules\antagonists\traitor\equipment\module_picker.dm"
+#include "code\modules\antagonists\traitor\IAA\agent_pinpointer.dm"
 #include "code\modules\antagonists\traitor\IAA\internal_affairs.dm"
 #include "code\modules\antagonists\valentines\heartbreaker.dm"
 #include "code\modules\antagonists\valentines\valentine.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/internal_affairs.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/internal_affairs.ts
@@ -1,0 +1,19 @@
+import { Antagonist, Category } from "../base";
+import { multiline } from "common/string";
+import { TRAITOR_MECHANICAL_DESCRIPTION } from "./traitor";
+
+const InternalAffairsAgent: Antagonist = {
+  key: "internalaffairsagent",
+  name: "Internal Affairs Agent",
+  description: [
+    multiline`
+      Sent by either Nanotrasen or the Syndicate, find and kill your target,
+      but watch your back, as someone is hunting you too.
+    `,
+
+    TRAITOR_MECHANICAL_DESCRIPTION,
+  ],
+  category: Category.Roundstart,
+};
+
+export default InternalAffairsAgent;


### PR DESCRIPTION
## About The Pull Request

Re-adds IAA as they were when they were last removed, with a new added idea

Once an IAA kills another IAA, they will inherit their targets. Once you are the last IAA, you will gain Die a Glorious Death objective, and all other IAAs will become unrevivable as not to fuck over your glorious death.

This is a complete overhaul of IAA AND their pinpointer (which is also used by Changelings' pheremone receptors), moving it into a separate file as well because I found it was fitting.

This does NOT bring back AI IAAs, as I did not want to go through the effort of re-adding something I didn't even like. It can be done by someone else if they want AI IAAs that much.

This is their prefs menu:
![iaa](https://user-images.githubusercontent.com/53777086/148497417-a4e4a840-c9b5-4812-bf6a-4f24ec97289e.png)

## Why It's Good For The Game

This antag has been sitting unused for a good while thanks to no one wanting to patch it up for Dynamic. This fixes the main problems there was with it to fit it in with Dynamic's gameplay. I don't know how much I have to explain myself here, as I feel this antagonist is kinda 'grandfathered' in since it was a gamemode and is still in the code, unlike say, Devils.

## Changelog

:cl:
refactor: Internal Affairs Agents (the Antagonist) has been completely re-factored for Dynamic mode. This means that IAAs are no longer Traitor flavortext, but a full Antagonist working for Nanotrasen.
/:cl: