### PR TITLE
Fix to other forms of death not showing up on crew monitor w/ maxed out vitals

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -130,12 +130,15 @@ const CrewTableEntry = (props, context) => {
         {name}{assignment !== undefined ? ` (${assignment})` : ""}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
-        {(life_status ? <ColorBox color={healthToColor(
-          oxydam,
-          toxdam,
-          burndam,
-          brutedam)} />
-          : <ColorBox color={'#ed2814'} />)}
+        {life_status ? (
+          <ColorBox color={healthToColor(
+            oxydam,
+            toxdam,
+            burndam,
+            brutedam)} />
+         ) : (
+           <ColorBox color={'#ed2814'} />
+         )}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {oxydam !== undefined ? (

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -130,12 +130,12 @@ const CrewTableEntry = (props, context) => {
         {name}{assignment !== undefined ? ` (${assignment})` : ""}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
-        <ColorBox
-          color={healthToColor(
-            oxydam,
-            toxdam,
-            burndam,
-            brutedam)} />
+        {(life_status ? <ColorBox color={healthToColor(
+          oxydam,
+          toxdam,
+          burndam,
+          brutedam)} />
+          : <ColorBox color={'#ed2814'} />)}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {oxydam !== undefined ? (

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -131,11 +131,12 @@ const CrewTableEntry = (props, context) => {
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {life_status ? (
-          <ColorBox color={healthToColor(
-            oxydam,
-            toxdam,
-            burndam,
-            brutedam)} />
+          <ColorBox
+            color={healthToColor(
+              oxydam,
+              toxdam,
+              burndam,
+              brutedam)} />
          ) : (
            <ColorBox color={'#ed2814'} />
          )}

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -137,9 +137,9 @@ const CrewTableEntry = (props, context) => {
               toxdam,
               burndam,
               brutedam)} />
-         ) : (
-           <ColorBox color={'#ed2814'} />
-         )}
+        ) : (
+          <ColorBox color={'#ed2814'} />
+        )}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {oxydam !== undefined ? (


### PR DESCRIPTION
## About The Pull Request

Fix to where decapitation, or other forms of being dead, such as being braindead, does not show up on crew monitors when sensors are maxed out.

BEFORE:
![image](https://user-images.githubusercontent.com/68792662/148555090-19836091-b87a-4b3b-90ac-bfd10f479104.png)
![image](https://user-images.githubusercontent.com/68792662/148554984-4a6b3d6d-8be1-4fb8-8bd8-2fcf7dc71022.png)

NOW:
![image](https://user-images.githubusercontent.com/68792662/148551280-913f8522-23ca-488c-b09f-f8b25a12d379.png)
![image](https://user-images.githubusercontent.com/68792662/148551293-14293792-7d3b-4bd4-ab2b-ee89378aae89.png)


## Why It's Good For The Game

If, for example, someone is braindead, it will not show up on crew monitors if their vitals aren't maxed out. This is bad and stupid. Same with any other type of organ damage, it'll only show up as green. 
Why?
Due to it only calculating the combination of oxygen damage, toxin damage, brute damage, and burn damage, the previous code combined them to make separate damage levels.
This seemed like a good idea- until I noticed there's no detection for straight-up death.

## Changelog
:cl:
fix: Fix to where other forms of being dead (ie decapitation/braindeath) now shows up on crew monitors when vitals are available via the red square.
/:cl: