### PR TITLE
Removes some unobtainable/unused reagents that people and admins hardly care about

### DIFF
--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -775,7 +775,7 @@
 	hardcore_value = 3
 	processing_quirk = TRUE
 	var/list/allergies = list()
-	var/list/blacklist = list(/datum/reagent/medicine/c2,/datum/reagent/medicine/epinephrine,/datum/reagent/medicine/adminordrazine,/datum/reagent/medicine/omnizine/godblood,/datum/reagent/medicine/cordiolis_hepatico,/datum/reagent/medicine/synaphydramine,/datum/reagent/medicine/diphenhydramine)
+	var/list/blacklist = list(/datum/reagent/medicine/c2,/datum/reagent/medicine/epinephrine,/datum/reagent/medicine/adminordrazine,/datum/reagent/medicine/omnizine/godblood,/datum/reagent/medicine/cordiolis_hepatico,/datum/reagent/medicine/diphenhydramine)
 	var/allergy_string
 
 /datum/quirk/item_quirk/allergic/add_unique()

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -626,7 +626,7 @@
 	icon_state = "vodkabottle"
 	list_reagents = list()
 	var/list/accelerants = list( /datum/reagent/consumable/ethanol, /datum/reagent/fuel, /datum/reagent/clf3, /datum/reagent/phlogiston,
-							/datum/reagent/napalm, /datum/reagent/hellwater, /datum/reagent/toxin/plasma, /datum/reagent/toxin/spore_burning)
+							/datum/reagent/napalm, /datum/reagent/hellwater, /datum/reagent/toxin/plasma)
 	var/active = FALSE
 
 /obj/item/reagent_containers/food/drinks/bottle/molotov/CheckParts(list/parts_list)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -132,25 +132,6 @@
 		. = TRUE
 	..()
 
-/datum/reagent/medicine/synaphydramine
-	name = "Diphen-Synaptizine"
-	description = "Reduces drowsiness, hallucinations, and Histamine from body."
-	color = "#EC536D" // rgb: 236, 83, 109
-	ph = 5.2
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-
-/datum/reagent/medicine/synaphydramine/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.adjust_drowsyness(-5 * REM * delta_time)
-	if(holder.has_reagent(/datum/reagent/toxin/mindbreaker))
-		holder.remove_reagent(/datum/reagent/toxin/mindbreaker, 5 * REM * delta_time)
-	if(holder.has_reagent(/datum/reagent/toxin/histamine))
-		holder.remove_reagent(/datum/reagent/toxin/histamine, 5 * REM * delta_time)
-	M.hallucination = max(M.hallucination - (10 * REM * delta_time), 0)
-	if(DT_PROB(16, delta_time))
-		M.adjustToxLoss(1, 0)
-		. = TRUE
-	..()
-
 /datum/reagent/medicine/cryoxadone
 	name = "Cryoxadone"
 	description = "A chemical mixture with almost magical healing powers. Its main limitation is that the patient's body temperature must be under 270K for it to metabolise correctly."

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -748,21 +748,6 @@
 	if(reac_volume >= 1)//This prevents microdosing from infecting masses of people
 		exposed_mob.ForceContractDisease(new /datum/disease/transformation/morph(), FALSE, TRUE)
 
-/datum/reagent/serotrotium
-	name = "Serotrotium"
-	description = "A chemical compound that promotes concentrated production of the serotonin neurotransmitter in humans."
-	color = "#202040" // rgb: 20, 20, 40
-	metabolization_rate = 0.25 * REAGENTS_METABOLISM
-	taste_description = "bitterness"
-	ph = 10
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-
-/datum/reagent/serotrotium/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	if(ishuman(M))
-		if(DT_PROB(3.5, delta_time))
-			M.emote(pick("twitch","drool","moan","gasp"))
-	..()
-
 /datum/reagent/oxygen
 	name = "Oxygen"
 	description = "A colorless, odorless gas. Grows on trees but is still pretty valuable."

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -413,20 +413,6 @@
 	C.blur_eyes(3 * REM * delta_time)
 	return ..()
 
-/datum/reagent/toxin/spore_burning
-	name = "Burning Spore Toxin"
-	description = "A natural toxin produced by blob spores that induces combustion in its victim."
-	color = "#9ACD32"
-	toxpwr = 0.5
-	taste_description = "burning"
-	ph = 13
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
-
-/datum/reagent/toxin/spore_burning/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	M.adjust_fire_stacks(2 * REM * delta_time)
-	M.IgniteMob()
-	return ..()
-
 /datum/reagent/toxin/chloralhydrate
 	name = "Chloral Hydrate"
 	description = "A powerful sedative that induces confusion and drowsiness before putting its target to sleep."
@@ -1081,26 +1067,6 @@
 /datum/reagent/toxin/acid/nitracid/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.adjustFireLoss((volume/10) * REM * normalise_creation_purity() * delta_time, FALSE) //here you go nervar
 	. = TRUE
-	..()
-
-/datum/reagent/toxin/delayed
-	name = "Toxin Microcapsules"
-	description = "Causes heavy toxin damage after a brief time of inactivity."
-	reagent_state = LIQUID
-	metabolization_rate = 0 //stays in the system until active.
-	var/actual_metaboliztion_rate = REAGENTS_METABOLISM
-	toxpwr = 0
-	var/actual_toxpwr = 5
-	var/delay = 30
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
-
-/datum/reagent/toxin/delayed/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	if(current_cycle > delay)
-		holder.remove_reagent(type, actual_metaboliztion_rate * M.metabolism_efficiency * delta_time)
-		M.adjustToxLoss(actual_toxpwr * REM * delta_time, 0)
-		if(DT_PROB(5, delta_time))
-			M.Paralyze(20)
-		. = TRUE
 	..()
 
 /datum/reagent/toxin/mimesbane


### PR DESCRIPTION
## About The Pull Request
See the title. I'm removing some reagents of low interest that can't be found in game short of strange seeds RNG and proc calling or var editing. This should have minimal impact to the game thanks to the sheer amount of carpet, crayon, food and useless  drink reagents (some of which, especially older ones, have awful glass sprites).

## Why It's Good For The Game
Cleaning up the repo a little bit.

## Changelog

:cl:
del: Removed some unobtainable/unused reagents that people and admins hardly care about: Diphen-Synaptizine, Serotrotrium, Burning Spore Toxin and Toxin Microcapsules.
/:cl:
