### PR TITLE
Fixes Mark of Ash and debuffs Mask of Madness to compensate

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -448,7 +448,7 @@
 
 /datum/status_effect/eldritch/ash/on_creation(mob/living/new_owner, _repetition = 5)
 	. = ..()
-	repetitions = min(1,_repetition)
+	repetitions = max(1,_repetition)
 
 /datum/status_effect/eldritch/ash/on_effect()
 	if(iscarbon(owner))

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -253,24 +253,24 @@
 	if((IS_HERETIC(local_user) || IS_HERETIC_MONSTER(local_user)) && HAS_TRAIT(src,TRAIT_NODROP))
 		REMOVE_TRAIT(src, TRAIT_NODROP, CLOTHING_TRAIT)
 
-	for(var/mob/living/carbon/human/human_in_range in spiral_range(9,local_user))
-		if(IS_HERETIC(human_in_range) || IS_HERETIC_MONSTER(human_in_range))
+	for(var/mob/living/carbon/human/human_in_view in view(6,local_user))
+		if(IS_HERETIC(human_in_view) || IS_HERETIC_MONSTER(human_in_view) || human_in_view.is_blind())
 			continue
 
-		SEND_SIGNAL(human_in_range,COMSIG_VOID_MASK_ACT,rand(-2,-20)*delta_time)
+		SEND_SIGNAL(human_in_view,COMSIG_VOID_MASK_ACT,rand(-2,-20)*delta_time)
 
 		if(DT_PROB(60,delta_time))
-			human_in_range.hallucination += 5
-
-		if(DT_PROB(40,delta_time))
-			human_in_range.Jitter(5)
+			human_in_view.hallucination += 5
 
 		if(DT_PROB(30,delta_time))
-			human_in_range.emote(pick("giggle","laugh"))
-			human_in_range.adjustStaminaLoss(10)
+			human_in_view.Jitter(5)
 
-		if(DT_PROB(25,delta_time))
-			human_in_range.Dizzy(5)
+		if(DT_PROB(30,delta_time))
+			human_in_view.emote(pick("giggle","laugh"))
+			human_in_view.adjustStaminaLoss(8)
+
+		if(DT_PROB(20,delta_time))
+			human_in_view.Dizzy(5)
 
 /obj/item/melee/rune_carver
 	name = "Carving Knife"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Initially this was just a fix PR to address #63605, however after speaking to Edge, it turns out it was not only broken but extremely underpowered compared to how it was intended to work. As a result of fixing the aforementioned issue, this is how it will work now:

- Mark of Ash will be applied to a target hit by the mansus grasp of a heretic that has unlocked it.
- Upon being hit with the Ashen Blade while this effect is active, they will be dealt 50 stamina damage and 25 burn damage. 
- The mark will then end on the user and be spread to everyone standing within one tile of them. 
- The stamina damage dealt upon hitting a marked target with the Ashen Blade will be reduced by 10 and the burn damage by 5 each time the mark jumps down to a minimum of 10 stamina and 5 burn.

Since this is incredibly more powerful compared to the broken 10 stam 5 burn and nothing or even healing after jumps, the mask of madness has been changed in the following ways:

- It is now only effective on people that the wearer can see within 6 tiles of them and that aren't blind, compared to a 9 tile spiral range that ignored sight from either party. 
- It's stamina damage has been reduced by 20%
- The probability of inflicting Jitter has been reduced by 10% per tick to 30%
- The probability of inflicting Dizzy has been reduced by 5% per tick to 20%

Many thanks to Edge for telling me how the code was originally meant to work, cause I was stuck trying to fix it backwards for quite a while.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes a bug and compensates the subsequent imbalance.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Mark of Ash now works as intended
bal: Mark of ash has been massively buffed as a result of the fix
bal: Mask of Madness is debuffed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
