### PR TITLE
Expands Slapping: Facepalms and slapping people awake

### DIFF
--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -216,8 +216,7 @@
 /obj/item/slapper/attack(mob/living/slapped, mob/living/carbon/human/user)
 	if(ishuman(slapped))
 		var/mob/living/carbon/human/human_slapped = slapped
-		if(human_slapped.dna?.species)
-			human_slapped.dna.species.stop_wagging_tail(slapped)
+		human_slapped.dna?.species?.stop_wagging_tail(slapped)
 	user.do_attack_animation(slapped)
 
 	var/slap_volume = 50

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -238,18 +238,18 @@
 	else if(user.zone_selected == BODY_ZONE_HEAD || user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
 		if(user == slapped)
 			user.visible_message(
-				span_danger("[user] facepalms!"),
+				span_notice("[user] facepalms!"),
 				span_notice("You facepalm."),
 				span_hear("You hear a slap."),
-				)
+			)
 
 		else
 			if(slapped.IsSleeping() || slapped.IsUnconscious())
 				user.visible_message(
-					span_danger("[user] slaps [slapped] in the face, trying to wake [slapped.p_them()] up!"),
+					span_notice("[user] slaps [slapped] in the face, trying to wake [slapped.p_them()] up!"),
 					span_notice("You slap [slapped] in the face, trying to wake [slapped.p_them()] up!"),
 					span_hear("You hear a slap."),
-					)
+				)
 
 				// Worse than just help intenting people.
 				slapped.AdjustSleeping(-75)
@@ -260,12 +260,13 @@
 					span_danger("[user] slaps [slapped] in the face!"),
 					span_notice("You slap [slapped] in the face!"),
 					span_hear("You hear a slap."),
-					)
+				)
 	else
-		user.visible_message(span_danger("[user] slaps [slapped]!"),
+		user.visible_message(
+			span_danger("[user] slaps [slapped]!"),
 			span_notice("You slap [slapped]!"),
 			span_hear("You hear a slap."),
-			)
+		)
 	playsound(slapped, 'sound/weapons/slap.ogg', slap_volume, TRUE, -1)
 	return
 

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -227,7 +227,7 @@
 			span_notice("The nerve! You wind back your hand and smack [slapped] hard enough to knock [slapped.p_them()] over!"),
 			span_hear("You hear someone get the everloving shit smacked out of them!"),
 			ignored_mobs = slapped,
-			)
+		)
 		to_chat(slapped, span_userdanger("You see [user] scoff and pull back [user.p_their()] arm, then suddenly you're on the ground with an ungodly ringing in your ears!"))
 		slap_volume = 120
 		SEND_SOUND(slapped, sound('sound/weapons/flash_ring.ogg'))

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -213,35 +213,61 @@
 	/// How many smaller table smacks we can do before we're out
 	var/table_smacks_left = 3
 
-/obj/item/slapper/attack(mob/living/M, mob/living/carbon/human/user)
-	if(ishuman(M))
-		var/mob/living/carbon/human/L = M
-		if(L && L.dna && L.dna.species)
-			L.dna.species.stop_wagging_tail(M)
-	user.do_attack_animation(M)
+/obj/item/slapper/attack(mob/living/slapped, mob/living/carbon/human/user)
+	if(ishuman(slapped))
+		var/mob/living/carbon/human/human_slapped = slapped
+		if(human_slapped.dna?.species)
+			human_slapped.dna.species.stop_wagging_tail(slapped)
+	user.do_attack_animation(slapped)
 
 	var/slap_volume = 50
-	var/datum/status_effect/offering/kiss_check = M.has_status_effect(STATUS_EFFECT_OFFERING)
+	var/datum/status_effect/offering/kiss_check = slapped.has_status_effect(STATUS_EFFECT_OFFERING)
 	if(kiss_check && istype(kiss_check.offered_item, /obj/item/kisser) && (user in kiss_check.possible_takers))
-		user.visible_message(span_danger("[user] scoffs at [M]'s advance, winds up, and smacks [M.p_them()] hard to the ground!"),
-			span_notice("The nerve! You wind back your hand and smack [M] hard enough to knock [M.p_them()] over!"),
-			span_hear("You hear someone get the everloving shit smacked out of them!"), ignored_mobs = M)
-		to_chat(M, span_userdanger("You see [user] scoff and pull back [user.p_their()] arm, then suddenly you're on the ground with an ungodly ringing in your ears!"))
+		user.visible_message(
+			span_danger("[user] scoffs at [slapped]'s advance, winds up, and smacks [slapped.p_them()] hard to the ground!"),
+			span_notice("The nerve! You wind back your hand and smack [slapped] hard enough to knock [slapped.p_them()] over!"),
+			span_hear("You hear someone get the everloving shit smacked out of them!"),
+			ignored_mobs = slapped,
+			)
+		to_chat(slapped, span_userdanger("You see [user] scoff and pull back [user.p_their()] arm, then suddenly you're on the ground with an ungodly ringing in your ears!"))
 		slap_volume = 120
-		SEND_SOUND(M, sound('sound/weapons/flash_ring.ogg'))
-		shake_camera(M, 2, 2)
-		M.Paralyze(2.5 SECONDS)
-		M.add_confusion(7)
-		M.adjustStaminaLoss(40)
+		SEND_SOUND(slapped, sound('sound/weapons/flash_ring.ogg'))
+		shake_camera(slapped, 2, 2)
+		slapped.Paralyze(2.5 SECONDS)
+		slapped.add_confusion(7)
+		slapped.adjustStaminaLoss(40)
 	else if(user.zone_selected == BODY_ZONE_HEAD || user.zone_selected == BODY_ZONE_PRECISE_MOUTH)
-		user.visible_message(span_danger("[user] slaps [M] in the face!"),
-			span_notice("You slap [M] in the face!"),
-			span_hear("You hear a slap."))
+		if(user == slapped)
+			user.visible_message(
+				span_danger("[user] facepalms!"),
+				span_notice("You facepalm."),
+				span_hear("You hear a slap."),
+				)
+
+		else
+			if(slapped.IsSleeping() || slapped.IsUnconscious())
+				user.visible_message(
+					span_danger("[user] slaps [slapped] in the face, trying to wake [slapped.p_them()] up!"),
+					span_notice("You slap [slapped] in the face, trying to wake [slapped.p_them()] up!"),
+					span_hear("You hear a slap."),
+					)
+
+				// Worse than just help intenting people.
+				slapped.AdjustSleeping(-75)
+				slapped.AdjustUnconscious(-50)
+
+			else
+				user.visible_message(
+					span_danger("[user] slaps [slapped] in the face!"),
+					span_notice("You slap [slapped] in the face!"),
+					span_hear("You hear a slap."),
+					)
 	else
-		user.visible_message(span_danger("[user] slaps [M]!"),
-			span_notice("You slap [M]!"),
-			span_hear("You hear a slap."))
-	playsound(M, 'sound/weapons/slap.ogg', slap_volume, TRUE, -1)
+		user.visible_message(span_danger("[user] slaps [slapped]!"),
+			span_notice("You slap [slapped]!"),
+			span_hear("You hear a slap."),
+			)
+	playsound(slapped, 'sound/weapons/slap.ogg', slap_volume, TRUE, -1)
 	return
 
 /obj/item/slapper/attack_atom(obj/O, mob/living/user, params)


### PR DESCRIPTION
## About The Pull Request

- Slapping yourself while targeting the face will now deliver a facepalm.
- Slapping someone while targeting the face who's asleep or unconscious will wake them up slightly. It's worse than just using help intent but it's funnier. 

## Why It's Good For The Game

There's no facepalm emote for carbons. Wack. Allows humans to facepalm with a funny sound. 
Slapping people to wake them up is a classic time-honored tradition.

## Changelog

:cl: Melbert
expansion: Slapping yourself in the face now delivers a facepalm.
expansion: Slapping someone who's asleep in the face may wake them up faster.
/:cl:
