### PR TITLE
Rebalances the stun arm for the engineering borg

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -8,7 +8,7 @@
 /obj/item/borg/stun
 	name = "electrically-charged arm"
 	icon_state = "elecarm"
-	var/charge_cost = 30
+	var/charge_cost = 1000
 
 /obj/item/borg/stun/attack(mob/living/M, mob/living/user)
 	if(ishuman(M))


### PR DESCRIPTION
## Why It's Good For The Game
This hasn't been touched in a number of years, and has drifted over time
out of sync with battery values, this aligns it to the stunbaton cost

Engineering borgs would do well to avoid spamming this at risk of ending
up out of power and dead in the water.

Also incentivises malfunctioning AI's to stay under the radar until they
have better batteries in their borgs.

## Changelog
:cl: oranges
balance: The engineering borg stun arm malfunction module has been rebalanced to use more power
/:cl:
