### PR TITLE
Fixes the HoS in Mafia Not Being Able to Cancel Their Ability

### DIFF
--- a/code/modules/mafia/roles.dm
+++ b/code/modules/mafia/roles.dm
@@ -522,6 +522,8 @@
 /datum/mafia_role/hos/handle_action(datum/mafia_controller/game,action,datum/mafia_role/target)
 	if(execute_target == target)
 		to_chat(body,span_warning("You have decided against executing tonight."))
+		execute_target = null
+		return
 	to_chat(body,span_warning("You have decided to execute [target.body.real_name] tonight."))
 	execute_target = target
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I added a null and an early return on the target selection thing for the HoS in mafia. I lost a game of mafia for the station by meme selecting someone on n2 and then couldn't cancel it and I killed the chaplain. Whenever I clicked the execute button a second time to cancel it, it displayed the unselect messages and then the reselect message and kept them as my target.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The other people in the mafia game got mad at me in Dchat afterwards and it felt bad man.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The HoS in mafia can now properly unselect their target for the night.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
