### PR TITLE
Fixes connect_range to work from the get-go

### DIFF
--- a/code/datums/components/connect_range.dm
+++ b/code/datums/components/connect_range.dm
@@ -23,6 +23,7 @@
 	if(!isatom(tracked) || isarea(tracked) || range < 0)
 		return COMPONENT_INCOMPATIBLE
 	src.connections = connections
+	src.range = range
 	set_tracked(tracked)
 	src.works_in_containers = works_in_containers
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The #62755 cleanup apparently failed to test if the `connect_range` component actually works with a range bigger than 0 the first time it's added, as `Initialize()` doesn't actually set `range`, leaving it as null (treated as 0 in the code, rather than a runtime apparently).

This is why stacking machines in Recycling have been doing exactly jack all for the past few weeks.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Stacking machines tossing the scrap back into the silo is nice.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
fix: The connect_range component now works correctly, meaning stacking machines in Recycling now pick up stacks again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
