### PR TITLE
removes opening new CE job slots

### DIFF
--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -14,13 +14,13 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	program_icon = "address-book"
 
 	var/change_position_cooldown = 30
-	//Jobs you cannot open new positions for
+	///Jobs blacklisted from having their slots edited.
 	var/list/blacklisted = list(
 		JOB_CAPTAIN,
 		JOB_HEAD_OF_PERSONNEL,
 		JOB_HEAD_OF_SECURITY,
 		JOB_RESEARCH_DIRECTOR,
-		JOB_CHIEF_MEDICAL_OFFICER,
+		JOB_CHIEF_ENGINEER,
 		JOB_CHIEF_MEDICAL_OFFICER,
 		JOB_AI,
 		JOB_CYBORG,


### PR DESCRIPTION
## About The Pull Request

15/15 Chief Engineer slots have been taken.

## Why It's Good For The Game

bug fix

## Changelog

:cl:
fix: The HoP can no longer open CE job slots again.
/:cl:
