### PR TITLE
Refactors pricetag component: no getcomponent, no ugly signals, fixes cubes a bit

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -197,13 +197,18 @@
 #define COMSIG_OBJ_ATTEMPT_CHARGE_CHANGE "obj_attempt_simple_charge_change"
 
 // /obj/item signals for economy
+///called before an item is sold by the exports system.
+#define COMSIG_ITEM_PRE_EXPORT "item_pre_sold"
+	/// Stops the item from exporting, so you can handle it manually.
+	#define COMPONENT_STOP_EXPORT (1<<0)
 ///called when an item is sold by the exports subsystem
-#define COMSIG_ITEM_SOLD "item_sold"
+#define COMSIG_ITEM_EXPORTED "item_sold"
+	/// The item was added to the report manually via signal and shouldn't be done in sell_object()
+	#define COMPONENT_ADDED_TO_REPORT (1<<0)
 ///called when a wrapped up structure is opened by hand
 #define COMSIG_STRUCTURE_UNWRAPPED "structure_unwrapped"
 ///called when a wrapped up item is opened by hand
 #define COMSIG_ITEM_UNWRAPPED "item_unwrapped"
-	#define COMSIG_ITEM_SPLIT_VALUE  (1<<0)
 ///called when getting the item's exact ratio for cargo's profit.
 #define COMSIG_ITEM_SPLIT_PROFIT "item_split_profits"
 ///called when getting the item's exact ratio for cargo's profit, without selling the item.

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -199,12 +199,12 @@
 // /obj/item signals for economy
 ///called before an item is sold by the exports system.
 #define COMSIG_ITEM_PRE_EXPORT "item_pre_sold"
-	/// Stops the item from exporting, so you can handle it manually.
+	/// Stops the export from calling sell_object() on the item, so you can handle it manually.
 	#define COMPONENT_STOP_EXPORT (1<<0)
 ///called when an item is sold by the exports subsystem
 #define COMSIG_ITEM_EXPORTED "item_sold"
-	/// The item was added to the report manually via signal and shouldn't be done in sell_object()
-	#define COMPONENT_ADDED_TO_REPORT (1<<0)
+	/// Stops the export from adding the export information to the report, so you can handle it manually.
+	#define COMPONENT_STOP_REPORT (1<<0)
 ///called when a wrapped up structure is opened by hand
 #define COMSIG_STRUCTURE_UNWRAPPED "structure_unwrapped"
 ///called when a wrapped up item is opened by hand

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -204,7 +204,7 @@
 ///called when an item is sold by the exports subsystem
 #define COMSIG_ITEM_EXPORTED "item_sold"
 	/// Stops the export from adding the export information to the report, so you can handle it manually.
-	#define COMPONENT_STOP_REPORT (1<<0)
+	#define COMPONENT_STOP_EXPORT_REPORT (1<<0)
 ///called when a wrapped up structure is opened by hand
 #define COMSIG_STRUCTURE_UNWRAPPED "structure_unwrapped"
 ///called when a wrapped up item is opened by hand

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -500,6 +500,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_NO_IMMOBILIZE "no_immobilize"
 /// Prevents stripping this equipment
 #define TRAIT_NO_STRIP "no_strip"
+/// Disallows this item from being pricetagged with a barcode
+#define TRAIT_NO_BARCODES "no_barcode"
 
 //quirk traits
 #define TRAIT_ALCOHOL_TOLERANCE "alcohol_tolerance"

--- a/code/datums/components/pricetag.dm
+++ b/code/datums/components/pricetag.dm
@@ -64,14 +64,15 @@
 	for(var/datum/bank_account/payee as anything in payees)
 		// Every payee with a ratio gets a cut based on the item's total value
 		var/payee_cut = round(item_value * payees[payee])
-		overall_item_price -= payee_cut
+		// And of course, the cut is removed from what cargo gets. (But not below zero, just in case)
+		overall_item_price = max(0, overall_item_price - payee_cut)
 
 		payee.adjust_money(payee_cut)
 		payee.bank_card_talk("Sale of [source] recorded. [payee_cut] credits added to account.")
 
-	// Update the report with the modified value here
+	// Update the report with the modified final price
 	report.total_value[export] += overall_item_price
 	report.total_amount[export] += export.get_amount(source) * export.amount_report_multiplier
 
 	// And ensure we don't double-add to the report
-	return COMPONENT_ADDED_TO_REPORT
+	return COMPONENT_STOP_REPORT

--- a/code/datums/components/pricetag.dm
+++ b/code/datums/components/pricetag.dm
@@ -75,4 +75,4 @@
 	report.total_amount[export] += export.get_amount(source) * export.amount_report_multiplier
 
 	// And ensure we don't double-add to the report
-	return COMPONENT_STOP_REPORT
+	return COMPONENT_STOP_EXPORT_REPORT

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -337,7 +337,7 @@
 	bounty_holder_account = holder_id.registered_account
 	name = "\improper [bounty_value] cr [name]"
 	desc += " The sales tag indicates it was <i>[bounty_holder] ([bounty_holder_job])</i>'s reward for completing the <i>[bounty_name]</i> bounty."
-	AddComponent(/datum/component/pricetag, holder_id.registered_account, holder_cut)
+	AddComponent(/datum/component/pricetag, holder_id.registered_account, holder_cut, FALSE)
 	AddComponent(/datum/component/gps, "[src]")
 	START_PROCESSING(SSobj, src)
 	COOLDOWN_START(src, next_nag_time, nag_cooldown)

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -275,6 +275,7 @@
 
 /obj/item/bounty_cube/Initialize(mapload)
 	. = ..()
+	ADD_TRAIT(src, TRAIT_NO_BARCODES, INNATE_TRAIT) // Don't allow anyone to override our pricetag component with a barcode
 	radio = new(src)
 	radio.keyslot = new radio_key
 	radio.set_listening(FALSE)
@@ -284,7 +285,7 @@
 /obj/item/bounty_cube/Destroy()
 	UnregisterSignal(radio, COMSIG_ITEM_PRE_EXPORT)
 	QDEL_NULL(radio)
-	. = ..()
+	return ..()
 
 /obj/item/bounty_cube/examine()
 	. = ..()
@@ -294,15 +295,18 @@
 		. += span_notice("Scan this in the cargo shuttle with an export scanner to register your bank account for the <b>[bounty_value * handler_tip]</b> credit handling tip.")
 
 /*
- * Signal proc for [COMSIG_ITEM_EXPORTED].
+ * Signal proc for [COMSIG_ITEM_EXPORTED], registered on the internal radio.
  *
- * Deletes the internal radio before it's sold - no free 4 credits for you!
+ * Deletes the internal radio before being exported,
+ * to stop it from bring counted as an export.
+ *
+ * No 4 free credits for you!
  */
 /obj/item/bounty_cube/proc/on_export(datum/source)
 	SIGNAL_HANDLER
 
 	QDEL_NULL(radio)
-	return COMPONENT_STOP_EXPORT // deletes the radio and stops it from bring counted as an export
+	return COMPONENT_STOP_EXPORT // stops the radio from exporting, not the cube
 
 /obj/item/bounty_cube/process(delta_time)
 	//if our nag cooldown has finished and we aren't on Centcom or in transit, then nag

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -279,8 +279,10 @@
 	radio.keyslot = new radio_key
 	radio.set_listening(FALSE)
 	radio.recalculateChannels()
+	RegisterSignal(radio, COMSIG_ITEM_PRE_EXPORT, .proc/on_export)
 
 /obj/item/bounty_cube/Destroy()
+	UnregisterSignal(radio, COMSIG_ITEM_PRE_EXPORT)
 	QDEL_NULL(radio)
 	. = ..()
 
@@ -290,6 +292,17 @@
 		. += span_notice("<b>[time2text(next_nag_time - world.time,"mm:ss")]</b> remains until <b>[bounty_value * speed_bonus]</b> credit speedy delivery bonus lost.")
 	if(handler_tip && !bounty_handler_account)
 		. += span_notice("Scan this in the cargo shuttle with an export scanner to register your bank account for the <b>[bounty_value * handler_tip]</b> credit handling tip.")
+
+/*
+ * Signal proc for [COMSIG_ITEM_EXPORTED].
+ *
+ * Deletes the internal radio before it's sold - no free 4 credits for you!
+ */
+/obj/item/bounty_cube/proc/on_export(datum/source)
+	SIGNAL_HANDLER
+
+	QDEL_NULL(radio)
+	return COMPONENT_STOP_EXPORT // deletes the radio and stops it from bring counted as an export
 
 /obj/item/bounty_cube/process(delta_time)
 	//if our nag cooldown has finished and we aren't on Centcom or in transit, then nag

--- a/code/modules/cargo/export_scanner.dm
+++ b/code/modules/cargo/export_scanner.dm
@@ -29,6 +29,7 @@
 		var/mob/living/carbon/human/scan_human = user
 		if(istype(O, /obj/item/bounty_cube))
 			var/obj/item/bounty_cube/cube = O
+			var/datum/bank_account/scanner_account = scan_human.get_bank_account()
 
 			if(!istype(get_area(cube), /area/shuttle/supply))
 				to_chat(user, span_warning("Shuttle placement not detected. Handling tip not registered."))
@@ -36,12 +37,10 @@
 			else if(cube.bounty_handler_account)
 				to_chat(user, span_warning("Bank account for handling tip already registered!"))
 
-			else if(scan_human.get_bank_account() && cube.GetComponent(/datum/component/pricetag))
-				var/datum/component/pricetag/pricetag = cube.GetComponent(/datum/component/pricetag)
+			else if(scanner_account)
+				cube.AddComponent(/datum/component/pricetag, scanner_account, cube.handler_tip)
 
-				cube.bounty_handler_account = scan_human.get_bank_account()
-				pricetag.payees[cube.bounty_handler_account] += cube.handler_tip
-
+				cube.bounty_handler_account = scanner_account
 				cube.bounty_handler_account.bank_card_talk("Bank account for [price ? "<b>[price * cube.handler_tip]</b> credit " : ""]handling tip successfully registered.")
 
 				if(cube.bounty_holder_account != cube.bounty_handler_account) //No need to send a tracking update to the person scanning it

--- a/code/modules/cargo/export_scanner.dm
+++ b/code/modules/cargo/export_scanner.dm
@@ -38,7 +38,7 @@
 				to_chat(user, span_warning("Bank account for handling tip already registered!"))
 
 			else if(scanner_account)
-				cube.AddComponent(/datum/component/pricetag, scanner_account, cube.handler_tip)
+				cube.AddComponent(/datum/component/pricetag, scanner_account, cube.handler_tip, FALSE)
 
 				cube.bounty_handler_account = scanner_account
 				cube.bounty_handler_account.bank_card_talk("Bank account for [price ? "<b>[price * cube.handler_tip]</b> credit " : ""]handling tip successfully registered.")

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -26,7 +26,7 @@ Then the player gets the profit from selling his own wasted time.
 	var/list/total_value = list() //export instance => total value of sold objects
 
 // external_report works as "transaction" object, pass same one in if you're doing more than one export in single go
-/proc/export_item_and_contents(atom/movable/AM, apply_elastic = TRUE, delete_unsold = TRUE, dry_run=FALSE, datum/export_report/external_report)
+/proc/export_item_and_contents(atom/movable/AM, apply_elastic = TRUE, delete_unsold = TRUE, dry_run = FALSE, datum/export_report/external_report)
 	if(!GLOB.exports_list.len)
 		setupExports()
 
@@ -43,7 +43,7 @@ Then the player gets the profit from selling his own wasted time.
 		var/sold = FALSE
 		for(var/datum/export/export as anything in GLOB.exports_list)
 			if(export.applies_to(thing, apply_elastic))
-				if(SEND_SIGNAL(thing, COMSIG_ITEM_PRE_EXPORT) & COMPONENT_STOP_EXPORT)
+				if(!dry_run && (SEND_SIGNAL(thing, COMSIG_ITEM_PRE_EXPORT) & COMPONENT_STOP_EXPORT))
 					continue
 				sold = export.sell_object(thing, report, dry_run, apply_elastic)
 				report.exported_atoms += " [thing.name]"

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -44,7 +44,7 @@ Then the player gets the profit from selling his own wasted time.
 		for(var/datum/export/export as anything in GLOB.exports_list)
 			if(export.applies_to(thing, apply_elastic))
 				if(!dry_run && (SEND_SIGNAL(thing, COMSIG_ITEM_PRE_EXPORT) & COMPONENT_STOP_EXPORT))
-					continue
+					break
 				sold = export.sell_object(thing, report, dry_run, apply_elastic)
 				report.exported_atoms += " [thing.name]"
 				break

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -151,7 +151,7 @@ Then the player gets the profit from selling his own wasted time.
 		export_result = SEND_SIGNAL(sold_item, COMSIG_ITEM_EXPORTED, src, report, export_value)
 
 	// If the signal handled adding it to the report, don't do it now
-	if(!(export_result & COMPONENT_ADDED_TO_REPORT))
+	if(!(export_result & COMPONENT_STOP_REPORT))
 		report.total_value[src] += export_value
 		report.total_amount[src] += export_amount * amount_report_multiplier
 

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -151,7 +151,7 @@ Then the player gets the profit from selling his own wasted time.
 		export_result = SEND_SIGNAL(sold_item, COMSIG_ITEM_EXPORTED, src, report, export_value)
 
 	// If the signal handled adding it to the report, don't do it now
-	if(!(export_result & COMPONENT_STOP_REPORT))
+	if(!(export_result & COMPONENT_STOP_EXPORT_REPORT))
 		report.total_value[src] += export_value
 		report.total_amount[src] += export_amount * amount_report_multiplier
 

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -30,8 +30,6 @@ Then the player gets the profit from selling his own wasted time.
 	if(!GLOB.exports_list.len)
 		setupExports()
 
-	var/profit_ratio = 1 //Percentage that gets sent to the seller, rest goes to cargo.
-
 	var/list/contents = AM.get_all_contents()
 
 	var/datum/export_report/report = external_report
@@ -45,12 +43,14 @@ Then the player gets the profit from selling his own wasted time.
 		var/sold = FALSE
 		for(var/datum/export/export as anything in GLOB.exports_list)
 			if(export.applies_to(thing, apply_elastic))
-				sold = export.sell_object(thing, report, dry_run, apply_elastic, profit_ratio)
+				if(SEND_SIGNAL(thing, COMSIG_ITEM_PRE_EXPORT) & COMPONENT_STOP_EXPORT)
+					continue
+				sold = export.sell_object(thing, report, dry_run, apply_elastic)
 				report.exported_atoms += " [thing.name]"
 				break
 		if(!dry_run && (sold || delete_unsold))
 			if(ismob(thing))
-				thing.investigate_log("deleted through cargo export",INVESTIGATE_CARGO)
+				thing.investigate_log("deleted through cargo export", INVESTIGATE_CARGO)
 			to_delete += thing
 
 	for(var/atom/movable/thing as anything in to_delete)
@@ -136,31 +136,29 @@ Then the player gets the profit from selling his own wasted time.
  * get_cost, get_amount and applies_to do not neccesary mean a successful sale.
  *
  */
-/datum/export/proc/sell_object(obj/O, datum/export_report/report, dry_run = TRUE, apply_elastic = TRUE)
+/datum/export/proc/sell_object(obj/sold_item, datum/export_report/report, dry_run = TRUE, apply_elastic = TRUE)
 	///This is the value of the object, as derived from export datums.
-	var/the_cost = get_cost(O, apply_elastic)
+	var/export_value = get_cost(sold_item, apply_elastic)
 	///Quantity of the object in question.
-	var/amount = get_amount(O)
-	///Utilized in the pricetag component. Splits the object's profit when it has a pricetag by the specified amount.
-	var/profit_ratio = 0
+	var/export_amount = get_amount(sold_item)
 
-	if(amount <=0 || (the_cost <=0 && !allow_negative_cost))
+	if(export_amount <= 0 || (export_value <= 0 && !allow_negative_cost))
 		return FALSE
-	if(dry_run == FALSE)
-		if(SEND_SIGNAL(O, COMSIG_ITEM_SOLD, item_value = get_cost(O, apply_elastic)) & COMSIG_ITEM_SPLIT_VALUE)
-			profit_ratio = SEND_SIGNAL(O, COMSIG_ITEM_SPLIT_PROFIT_DRY)
-			the_cost = the_cost * ((100 - profit_ratio) * 0.01)
-	else
-		profit_ratio = SEND_SIGNAL(O, COMSIG_ITEM_SPLIT_PROFIT)
-		the_cost = the_cost * ((100 - profit_ratio) * 0.01)
-	report.total_value[src] += the_cost
 
-	report.total_amount[src] += amount*amount_report_multiplier
+	// If we're not doing a dry run, send COMSIG_ITEM_EXPORTED to the sold item
+	var/export_result
+	if(!dry_run)
+		export_result = SEND_SIGNAL(sold_item, COMSIG_ITEM_EXPORTED, src, report, export_value)
+
+	// If the signal handled adding it to the report, don't do it now
+	if(!(export_result & COMPONENT_ADDED_TO_REPORT))
+		report.total_value[src] += export_value
+		report.total_amount[src] += export_amount * amount_report_multiplier
 
 	if(!dry_run)
 		if(apply_elastic)
-			cost *= NUM_E**(-1*k_elasticity*amount) //marginal cost modifier
-		SSblackbox.record_feedback("nested tally", "export_sold_cost", 1, list("[O.type]", "[the_cost]"))
+			cost *= NUM_E**(-1 * k_elasticity * export_amount) //marginal cost modifier
+		SSblackbox.record_feedback("nested tally", "export_sold_cost", 1, list("[sold_item.type]", "[export_value]"))
 	return TRUE
 
 // Total printout for the cargo console.

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -114,9 +114,10 @@
 		sticker.payments_acc = tagger.payments_acc	//new tag gets the tagger's current account.
 		sticker.cut_multiplier = tagger.cut_multiplier	//same, but for the percentage taken.
 
-		var/list/wrap_contents = src.get_all_contents()
-		for(var/obj/I in wrap_contents)
-			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, tagger.cut_multiplier)
+		for(var/obj/wrapped_item in get_all_contents())
+			if(HAS_TRAIT(wrapped_item, TRAIT_NO_BARCODES))
+				continue
+			wrapped_item.AddComponent(/datum/component/pricetag, sticker.payments_acc, tagger.cut_multiplier)
 		var/overlaystring = "[icon_state]_tag"
 		if(giftwrapped)
 			overlaystring = copytext(overlaystring, 5)
@@ -133,9 +134,10 @@
 			to_chat(user, span_warning("For some reason, you can't attach [W]!"))
 			return
 		sticker = stickerA
-		var/list/wrap_contents = src.get_all_contents()
-		for(var/obj/I in wrap_contents)
-			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, sticker.cut_multiplier)
+		for(var/obj/wrapped_item in get_all_contents())
+			if(HAS_TRAIT(wrapped_item, TRAIT_NO_BARCODES))
+				continue
+			wrapped_item.AddComponent(/datum/component/pricetag, sticker.payments_acc, sticker.cut_multiplier)
 		var/overlaystring = "[icon_state]_tag"
 		if(giftwrapped)
 			overlaystring = copytext_char(overlaystring, 5) //5 == length("gift") + 1
@@ -307,9 +309,10 @@
 		sticker.payments_acc = tagger.payments_acc	//new tag gets the tagger's current account.
 		sticker.cut_multiplier = tagger.cut_multiplier	//as above, as before.
 
-		var/list/wrap_contents = src.get_all_contents()
-		for(var/obj/I in wrap_contents)
-			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, tagger.cut_multiplier)
+		for(var/obj/wrapped_item in get_all_contents())
+			if(HAS_TRAIT(wrapped_item, TRAIT_NO_BARCODES))
+				continue
+			wrapped_item.AddComponent(/datum/component/pricetag, sticker.payments_acc, tagger.cut_multiplier)
 		var/overlaystring = "[icon_state]_tag"
 		if(giftwrapped)
 			overlaystring = copytext(overlaystring, 5)
@@ -327,9 +330,10 @@
 			to_chat(user, span_warning("For some reason, you can't attach [W]!"))
 			return
 		sticker = stickerA
-		var/list/wrap_contents = src.get_all_contents()
-		for(var/obj/I in wrap_contents)
-			I.AddComponent(/datum/component/pricetag, sticker.payments_acc, sticker.cut_multiplier)
+		for(var/obj/wrapped_item in get_all_contents())
+			if(HAS_TRAIT(wrapped_item, TRAIT_NO_BARCODES))
+				continue
+			wrapped_item.AddComponent(/datum/component/pricetag, sticker.payments_acc, sticker.cut_multiplier)
 		var/overlaystring = "[icon_state]_tag"
 		if(giftwrapped)
 			overlaystring = copytext_char(overlaystring, 5) //5 == length("gift") + 1


### PR DESCRIPTION
## About The Pull Request

- Refactors the pricetag component
- Removes a getcomponent for the pricetag component in cube export handling (replaced with inherit component behavior)
- Removes some nasty signals which were effectively just `send signal, get 1`
- Deletes the internal radio within bounty cubes from before exporting
- Disallows bounty cubes from being barcoded with `TRAIT_NO_BARCODES`
- Prevents bounty cube pricetag component from being deleted by unwrapping

Closes #63921 technically

## Why It's Good For The Game

I went on a massive rabbit hole looking at #63921 . It was caused by progression traitors but progression traitors caused it in a very dumb way.

It removed a named argument from a signal (which turns out works, TIL), which broke how it was used. This was because the signal proc never had `datum/source` passed which was very silly and incorrect

But the further I looked the more confused me, some signals were outdated and no-longer needed, some signals were very ugly getters from the component which was bad

Also bounty cubes used a getcomponent which is sad so I changed the component to `COMPONENT_DUPE_UNIQUE_PASSARGS` to pass it that way

Also also I found in testing that the internal radio of bounty cubes counted as exports so I added a little signal to prevent that for fun. You never know when someone wants to export radios in the future and cries that cubes export their internal radio.

Also also also I was pointed to an oversight with cubes that allow you to re-wrap them to get a higher pricetag value. Prevents that with a trait, `TRAIT_NO_BARCODES`. This additionally fixes an exploit that allows you to wrap and unwrap a bounty cube to delete the original pricetag component.

## Changelog

:cl: Melbert
fix: Wrapping a bounty cube then unwrapping it no longer scams the owner out of a cut
fix: Wrapping a bounty cube then applying a barcode no longer grants a bigger cut than deserved, or steals money from the original owner
fix: The internal radio within bounty cubes is no longer exported. Every bounty cube sold gave cargo an extra FOUR credits. How much extra money was gained by radios alone?
refactor: Refactored Pricetag component, less getcomponent and ugly signals, more sanity, harder to break
/:cl:

