### PR TITLE
 Fixes opening storage containers in a locker (or other container) via right click.

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -869,7 +869,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(!user.CanReach(parent))
 		to_chat(user, span_alert("You can't quite reach into [parent]!"))
 		return FALSE
-	if(!isliving(user) || !user.CanReach(parent) || user.incapacitated())
+	if(!isliving(user) || user.incapacitated())
 		return FALSE
 	if(locked)
 		to_chat(user, span_warning("[parent] seems to be locked!"))

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -867,7 +867,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 /datum/component/storage/proc/open_storage(mob/user)
 	if(!user.CanReach(parent))
-		to_chat(user, span_alert("You can't quite reach into [parent]!"))
+		user.balloon_alert(user, "can't reach!")
 		return FALSE
 	if(!isliving(user) || user.incapacitated())
 		return FALSE

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -866,6 +866,9 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 
 /datum/component/storage/proc/open_storage(mob/user)
+	if(!user.CanReach(parent))
+		to_chat(user, span_alert("You can't quite reach into [parent]!"))
+		return FALSE
 	if(!isliving(user) || !user.CanReach(parent) || user.incapacitated())
 		return FALSE
 	if(locked)
@@ -891,6 +894,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	if(open_storage(user))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+		return COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN
 
 /datum/component/storage/proc/on_open_storage_attackby(datum/source, obj/item/weapon, mob/user, params)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an oversight in the storage component which allowed you to open and interact with storage containers while you couldn't actually reach them (using right click).
Right click was calling attack hand afterwards, which was just nullifying the fact that we already tried to open the container.
Aswell, provides some feedback for the player.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You aren't supposed to be able to access storage containers whilst in a container.
This is indicated by the fact that a storage container open on your hud will close, upon entering. Aswell as the fact that you can't open a bag through any other method except right clicking.

Closes https://github.com/tgstation/tgstation/issues/60170
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Can no longer open storage containers in a locker (or other container) via right click.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
