### PR TITLE
Adds a color matrix layer to GAGS

### DIFF
--- a/code/datums/greyscale/_greyscale_config.dm
+++ b/code/datums/greyscale/_greyscale_config.dm
@@ -279,7 +279,7 @@
 			layer_icon = GenerateLayerGroup(colors, layer, render_steps)
 			layer = layer[1] // When there are multiple layers in a group like this we use the first one's blend mode
 		else
-			layer_icon = layer.Generate(colors, render_steps)
+			layer_icon = layer.Generate(colors, render_steps, new_icon)
 
 		if(!new_icon)
 			new_icon = layer_icon

--- a/code/datums/greyscale/_greyscale_config.dm
+++ b/code/datums/greyscale/_greyscale_config.dm
@@ -239,8 +239,7 @@
 
 	var/icon/icon_bundle = GenerateBundle(color_string, last_external_icon=last_external_icon)
 	icon_bundle = fcopy_rsc(icon_bundle)
-	if(!nocache)
-		icon_cache[key] = icon_bundle
+	icon_cache[key] = icon_bundle
 	var/icon/output = icon(icon_bundle)
 	return output
 

--- a/code/datums/greyscale/json_reader.dm
+++ b/code/datums/greyscale/json_reader.dm
@@ -31,6 +31,27 @@
 		new_values += new_value
 	return new_values
 
+/datum/json_reader/color_matrix/ReadJson(list/value)
+	if(!istype(value))
+		CRASH("Expected a list but got [value]")
+	if(length(value) > 5 || length(value) < 4)
+		CRASH("Color matrix must contain 4 or 5 rows")
+	var/list/new_values = list()
+	for(var/list/row in value)
+		var/list/interpreted_row = list()
+		if(!istype(row) || length(row) != 4)
+			stack_trace("Expected list to contain further row lists with exactly 4 entries")
+			interpreted_row = list(0, 0, 0, 0, 0)
+			continue
+		for(var/number in row)
+			if(!isnum(number))
+				stack_trace("Each color matrix row must only contain numbers")
+				interpreted_row += 0
+			else
+				interpreted_row += number
+		new_values += interpreted_row
+	return new_values
+
 /datum/json_reader/blend_mode
 	var/static/list/blend_modes = list(
 		"add" = ICON_ADD,

--- a/code/datums/greyscale/json_reader.dm
+++ b/code/datums/greyscale/json_reader.dm
@@ -41,7 +41,7 @@
 		var/list/interpreted_row = list()
 		if(!istype(row) || length(row) != 4)
 			stack_trace("Expected list to contain further row lists with exactly 4 entries")
-			interpreted_row = list(0, 0, 0, 0, 0)
+			interpreted_row = list(0, 0, 0, 0)
 			continue
 		for(var/number in row)
 			if(!isnum(number))

--- a/code/datums/greyscale/layer.dm
+++ b/code/datums/greyscale/layer.dm
@@ -149,8 +149,8 @@
 	var/icon/generated_icon
 	if(render_steps)
 		var/list/reference_data = list()
-		generated_icon = reference_type.GenerateBundle(colors, reference_data)
+		generated_icon = reference_type.GenerateBundle(colors, reference_data, new_icon)
 		render_steps += reference_data[icon_state]
 	else
-		generated_icon = reference_type.Generate(colors.Join())
+		generated_icon = reference_type.Generate(colors.Join(), new_icon)
 	return icon(generated_icon, icon_state)

--- a/code/datums/greyscale/layer.dm
+++ b/code/datums/greyscale/layer.dm
@@ -66,18 +66,19 @@
 
 /// Used to actualy create the layer using the given colors
 /// Do not override, use InternalGenerate instead
-/datum/greyscale_layer/proc/Generate(list/colors, list/render_steps)
+/datum/greyscale_layer/proc/Generate(list/colors, list/render_steps, icon/new_icon)
 	var/list/processed_colors = list()
 	for(var/i in color_ids)
 		if(isnum(i))
 			processed_colors += colors[i]
 		else
 			processed_colors += i
-	return InternalGenerate(processed_colors, render_steps)
+	var/icon/copy_of_new_icon = icon(new_icon) // Layers shouldn't be modifying it directly, this is just for them to reference
+	return InternalGenerate(processed_colors, render_steps, copy_of_new_icon)
 
 /// Override this to implement layers.
 /// The colors var will only contain colors that this layer is configured to use.
-/datum/greyscale_layer/proc/InternalGenerate(list/colors, list/render_steps)
+/datum/greyscale_layer/proc/InternalGenerate(list/colors, list/render_steps, icon/new_icon)
 
 ////////////////////////////////////////////////////////
 // Subtypes
@@ -103,11 +104,25 @@
 	. = ..()
 	required_values[NAMEOF(src, icon_state)] = /datum/json_reader/text
 
-/datum/greyscale_layer/icon_state/InternalGenerate(list/colors, list/render_steps)
+/datum/greyscale_layer/icon_state/InternalGenerate(list/colors, list/render_steps, icon/new_icon)
 	. = ..()
-	var/icon/new_icon = icon(icon)
+	var/icon/generated_icon = icon(icon)
 	if(length(colors))
-		new_icon.Blend(colors[1], ICON_MULTIPLY)
+		generated_icon.Blend(colors[1], ICON_MULTIPLY)
+	return generated_icon
+
+/// A layer to modify the previous layer's colors with a color matrix
+/datum/greyscale_layer/color_matrix
+	layer_type = "color_matrix"
+	var/list/color_matrix
+
+/datum/greyscale_layer/color_matrix/GetExpectedValues(list/required_values, list/optional_values)
+	. = ..()
+	required_values[NAMEOF(src, color_matrix)] = /datum/json_reader/color_matrix
+
+/datum/greyscale_layer/color_matrix/InternalGenerate(list/colors, list/render_steps, icon/new_icon)
+	. = ..()
+	new_icon.MapColors(arglist(color_matrix))
 	return new_icon
 
 /// A layer created by using another greyscale icon's configuration
@@ -130,7 +145,7 @@
 	if(!reference_type.icon_states[icon_state])
 		CRASH("[src] expects icon_state '[icon_state]' but referenced configuration '[reference_type]' does not have it.")
 
-/datum/greyscale_layer/reference/InternalGenerate(list/colors, list/render_steps)
+/datum/greyscale_layer/reference/InternalGenerate(list/colors, list/render_steps, icon/new_icon)
 	var/icon/generated_icon
 	if(render_steps)
 		var/list/reference_data = list()


### PR DESCRIPTION
## About The Pull Request

No actual player facing changes here. Requested long ago and I finally got around to implementing it, the color matrix filter allows for more complex effects to be done in GAGS than could previously be supported, this is mostly for reusable effects or post processing to be applied after the colors have been filled in but has a variety of uses. As an example, here's the color matrix layer configured to turn a colored sprite greyscale.

```
{
	"type": "color_matrix",
	"blend_mode": "overlay",
	"color_matrix": [
		[0.3, 0.3, 0.3, 0],
		[0.59, 0.59, 0.59, 0],
		[0.11, 0.11, 0.11, 0],
		[0, 0, 0, 1],
		[0, 0, 0, 0]
	]
}
```

![image](https://user-images.githubusercontent.com/1234602/148673132-fc49eaee-4fac-4a09-901d-4d4cb99a2169.png)

The way it works here is it takes the previous layer's sprite and modifies it then overlays it, functionally recoloring the previous layer. You could use other blend modes if you want to say darken a sprite instead, use the multiply blend mode instead and you get this.

![image](https://user-images.githubusercontent.com/1234602/148673171-96925aca-4eda-48ae-bbcc-86d79893e25b.png)
