### PR TITLE
Fixes gang induction, birdboat vomit, sentient disease actions, and an ooze action

### DIFF
--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -781,13 +781,15 @@
 	background_icon_state = our_proc_holder.action_background_icon_state
 	button.name = name
 
-/datum/action/cooldown/spell_like/Trigger()
-	if(!..())
+/datum/action/cooldown/spell_like/Activate(atom/activate_target)
+	if(!target)
 		return FALSE
-	if(target)
-		var/obj/effect/proc_holder/our_proc_holder = target
-		our_proc_holder.Click()
-		return TRUE
+
+	StartCooldown(10 SECONDS)
+	var/obj/effect/proc_holder/our_proc_holder = target
+	our_proc_holder.Click()
+	StartCooldown()
+	return TRUE
 
 //Stickmemes
 /datum/action/item_action/stickmen

--- a/code/modules/antagonists/gang/gang.dm
+++ b/code/modules/antagonists/gang/gang.dm
@@ -249,8 +249,7 @@
 	owner.visible_message(
 		span_notice("[human_owner] is offering to induct people into the Family."),
 		span_notice("You offer to induct people into the Family."),
-		null,
-		2,
+		vision_distance = 2,
 		)
 	if(human_owner.has_status_effect(STATUS_EFFECT_HANDSHAKE))
 		return FALSE
@@ -258,8 +257,7 @@
 		owner.visible_message(
 			span_danger("[human_owner] offers to induct people into the Family, but nobody was around."),
 			span_warning("You offer to induct people into the Family, but nobody is around."),
-			null,
-			2,
+			vision_distance = 2,
 			)
 		return FALSE
 

--- a/code/modules/antagonists/gang/gang.dm
+++ b/code/modules/antagonists/gang/gang.dm
@@ -219,17 +219,24 @@
 	/// The family antagonist datum of the "owner" of this action.
 	var/datum/antagonist/gang/my_gang_datum
 
-/datum/action/cooldown/spawn_induction_package/Trigger()
-	if(!..())
-		return FALSE
-	if(!IsAvailable())
-		return FALSE
+/datum/action/cooldown/spawn_induction_package/Activate(atom/target)
 	if(!my_gang_datum)
+		CRASH("[type] was created without a linked gang datum!")
+
+	if(!ishuman(owner))
 		return FALSE
-	if(!istype(owner, /mob/living/carbon/human))
-		return FALSE
-	var/mob/living/carbon/human/H = owner
-	if(H.stat)
+
+	StartCooldown(10 SECONDS)
+	offer_handshake()
+	StartCooldown()
+	return TRUE
+
+/*
+ * Equip a handshake slapper and offer it to people nearby.
+ */
+/datum/action/cooldown/spawn_induction_package/proc/offer_handshake()
+	var/mob/living/carbon/human/human_owner = owner
+	if(human_owner.stat != CONSCIOUS || human_owner.incapacitated())
 		return FALSE
 
 	var/obj/item/slapper/secret_handshake/secret_handshake_item = new(owner)
@@ -239,17 +246,24 @@
 		qdel(secret_handshake_item)
 		to_chat(owner, span_warning("You're incapable of performing a handshake in your current state."))
 		return FALSE
-	owner.visible_message(span_notice("[src] is offering to induct people into the Family."),
-		span_notice("You offer to induct people into the Family."), null, 2)
-	if(H.has_status_effect(STATUS_EFFECT_HANDSHAKE))
+	owner.visible_message(
+		span_notice("[human_owner] is offering to induct people into the Family."),
+		span_notice("You offer to induct people into the Family."),
+		null,
+		2,
+		)
+	if(human_owner.has_status_effect(STATUS_EFFECT_HANDSHAKE))
 		return FALSE
 	if(!(locate(/mob/living/carbon) in orange(1, owner)))
-		owner.visible_message(span_danger("[src] offers to induct people into the Family, but nobody was around."), \
-			span_warning("You offer to induct people into the Family, but nobody is around."), null, 2)
+		owner.visible_message(
+			span_danger("[human_owner] offers to induct people into the Family, but nobody was around."),
+			span_warning("You offer to induct people into the Family, but nobody is around."),
+			null,
+			2,
+			)
 		return FALSE
 
-	H.apply_status_effect(STATUS_EFFECT_HANDSHAKE, secret_handshake_item)
-	StartCooldown()
+	human_owner.apply_status_effect(STATUS_EFFECT_HANDSHAKE, secret_handshake_item)
 	return TRUE
 
 /datum/antagonist/gang/russian_mafia

--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -246,14 +246,16 @@
 	icon_icon = 'icons/mob/animal.dmi'
 	cooldown_time = 250
 
-/datum/action/cooldown/vomit/Trigger()
-	if(!..())
-		return FALSE
+/datum/action/cooldown/vomit/Activate(atom/target)
 	if(!istype(owner, /mob/living/simple_animal/hostile/retaliate/goose/vomit))
 		return FALSE
-	var/mob/living/simple_animal/hostile/retaliate/goose/vomit/vomit = owner
-	if(!vomit.vomiting)
-		vomit.vomit_prestart(vomit.vomitTimeBonus + 25)
-		vomit.vomitCoefficient = 1
-		vomit.vomitTimeBonus = 0
+
+	StartCooldown(10 SECONDS)
+	var/mob/living/simple_animal/hostile/retaliate/goose/vomit/probably_birdboat = owner
+	if(!probably_birdboat.vomiting)
+		probably_birdboat.vomit_prestart(probably_birdboat.vomitTimeBonus + 25)
+		probably_birdboat.vomitCoefficient = 1
+		probably_birdboat.vomitTimeBonus = 0
+
+	StartCooldown()
 	return TRUE

--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -153,10 +153,16 @@
 	return (ooze.ooze_nutrition >= nutrition_cost && !active)
 
 ///Give the mob a speed boost, heat it up every second, and end the ability in 6 seconds
-/datum/action/cooldown/metabolicboost/Trigger()
-	. = ..()
-	if(!.)
-		return
+/datum/action/cooldown/metabolicboost/Activate(atom/target)
+	StartCooldown(10 SECONDS)
+	trigger_boost()
+	StartCooldown()
+	return TRUE
+
+/*
+ * Actually trigger the boost.
+ */
+/datum/action/cooldown/metabolicboost/proc/trigger_boost()
 	var/mob/living/simple_animal/hostile/ooze/ooze = owner
 	ooze.add_movespeed_modifier(/datum/movespeed_modifier/metabolicboost)
 	var/timerid = addtimer(CALLBACK(src, .proc/HeatUp), 1 SECONDS, TIMER_STOPPABLE | TIMER_LOOP) //Heat up every second


### PR DESCRIPTION
## About The Pull Request

In the wake of the actions PR it seems as if a lot of these cooldown actions should have been converted to `Activate()` and not `Trigger()` because `Activate()` returns `null` on the default implementation which prevents `Trigger()` from running and AHHH

Converts a bunch of `Trigger()` to `Activate()`

I'm gonna be honest I have no idea why it does the `startCooldown(10 seconds)`, `startCooldown()` thing, all of the megafauna actions seem to do it so it seemed right

Fixes #63764

## Why It's Good For The Game

A lot of actions work again!

## Changelog

:cl: Melbert
fix: Fixes gang induction, sentient disease abilities, birdboat's vomit button, and the ooze's boost button
/:cl:

