### PR TITLE
Fix antag info panel on body loss, also some sanity

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -143,7 +143,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	if(!owner.current)
 		CRASH("[src] ran on_gain() on a mind without a mob")
 	if(ui_name)//in the future, this should entirely replace greet.
-		info_button = new(owner.current, src)
+		info_button = new(src)
 		info_button.Grant(owner.current)
 	if(!silent)
 		greet()
@@ -479,31 +479,27 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/action/antag_info
 	name = "Open Antag Information:"
 	button_icon_state = "round_end"
-	/// The antag datum that this button interacts with.
-	var/datum/antagonist/antag_datum
 
-/datum/action/antag_info/New(Target, datum/antagonist/antag_datum)
+/datum/action/antag_info/New(Target)
 	. = ..()
-	src.antag_datum = antag_datum
-	name += " [antag_datum.name]"
-
-/datum/action/antag_info/Destroy()
-	antag_datum = null
-	return ..()
+	name += " [target]"
 
 /datum/action/antag_info/Trigger()
 	. = ..()
 	if(!.)
 		return
 
-	antag_datum.ui_interact(owner)
+	target.ui_interact(owner)
 
 /datum/action/antag_info/IsAvailable()
+	if(!target)
+		stack_trace("[type] was used without a target antag datum!")
+		return FALSE
 	. = ..()
 	if(!.)
 		return
-	if(!antag_datum)
+	if(!owner.mind)
 		return FALSE
-	if(!(antag_datum in owner.mind.antag_datums))
+	if(!(target in owner.mind.antag_datums))
 		return FALSE
 	return TRUE

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -94,6 +94,8 @@ GLOBAL_LIST_EMPTY(antagonists)
 	remove_innate_effects(old_body)
 	if(!soft_antag && old_body && old_body.stat != DEAD && !LAZYLEN(old_body.mind?.antag_datums))
 		old_body.remove_from_current_living_antags()
+	info_button.Remove(old_body)
+	info_button.Grant(new_body)
 	apply_innate_effects(new_body)
 	if(!soft_antag && new_body.stat != DEAD)
 		new_body.add_to_current_living_antags()
@@ -477,6 +479,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/action/antag_info
 	name = "Open Antag Information:"
 	button_icon_state = "round_end"
+	/// The antag datum that this button interacts with.
 	var/datum/antagonist/antag_datum
 
 /datum/action/antag_info/New(Target, datum/antagonist/antag_datum)
@@ -484,9 +487,23 @@ GLOBAL_LIST_EMPTY(antagonists)
 	src.antag_datum = antag_datum
 	name += " [antag_datum.name]"
 
+/datum/action/antag_info/Destroy()
+	antag_datum = null
+	return ..()
+
 /datum/action/antag_info/Trigger()
-	if(antag_datum)
-		antag_datum.ui_interact(owner)
+	. = ..()
+	if(!.)
+		return
+
+	antag_datum.ui_interact(owner)
 
 /datum/action/antag_info/IsAvailable()
+	. = ..()
+	if(!.)
+		return
+	if(!antag_datum)
+		return FALSE
+	if(!(antag_datum in owner.mind.antag_datums))
+		return FALSE
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

- Losing your body as an antag will correctly remove the antag info panel from the body
- Gaining a new body as an antag will give the panel to the new body
- Adds some sanity checks to ensure no one who doesn't need to be seeing the panel can use it

Fixes #63303

## Why It's Good For The Game

You can see your objectives after being brain transplanted as an antag

## Changelog

:cl: Melbert
fix: Antag info ui carries over to a fresh body correctly
/:cl:

