### PR TITLE
Deltastation Botany Critical Fix

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -71017,12 +71017,15 @@
 "oto" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
-	name = "Hydroponics Desk";
-	req_access_txt = "35"
+	name = "Hydroponics Desk"
 	},
 /obj/machinery/door/firedoor,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/machinery/door/window/westleft{
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "otz" = (
@@ -93582,10 +93585,6 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "uBi" = (
-/obj/machinery/door/window/eastleft{
-	name = "Hydroponics Biogenerator";
-	req_access_txt = "35"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/item/folder/white{
@@ -93593,6 +93592,13 @@
 	pixel_y = 2
 	},
 /obj/item/folder/yellow,
+/obj/machinery/door/window/westright{
+	name = "Hydroponics Desk";
+	req_access_txt = "35"
+	},
+/obj/machinery/door/window/eastleft{
+	name = "Hydroponics Desk"
+	},
 /turf/open/floor/plating,
 /area/service/hydroponics)
 "uBn" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -71016,9 +71016,6 @@
 /area/service/abandoned_gambling_den/gaming)
 "oto" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	name = "Hydroponics Desk"
-	},
 /obj/machinery/door/firedoor,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -93595,9 +93592,6 @@
 /obj/machinery/door/window/westright{
 	name = "Hydroponics Desk";
 	req_access_txt = "35"
-	},
-/obj/machinery/door/window/eastleft{
-	name = "Hydroponics Desk"
 	},
 /turf/open/floor/plating,
 /area/service/hydroponics)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Never in my life have I seen a change as critically demanded as this. The fact that this hasn't been fixed yet is tantamount to disgrace. The Deltastation Botany desk windoors were on the WRONG SIDE.
EDIT: Only one set of inner windoors w/ botany access required to open them.

Before:
![aaa10](https://user-images.githubusercontent.com/73589390/148715165-b25c44c0-359e-45a7-a95c-ba19511831b7.png)
After:
![aaa10](https://user-images.githubusercontent.com/73589390/148789195-d7e505d0-3345-489b-ac2a-a286b82af7d3.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Botany can't put things on their desk to display without every assistant having a way to get into botany. Now, botanists have a helpful windoor to keep back the masses demanding their very cool weed. Also, MrMelbert intended for the windows to be on this side.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Deltastation's Hydroponics Desk now has proper windoors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
