### PR TITLE
Fixes not being able to say ahelp in dchat

### DIFF
--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -39,10 +39,10 @@
 				if(!mind.current.say(message))
 					to_chat(src, span_warning("Your linked body was unable to speak!"))
 		return
-	if(sanitize(message)[1] == "*")
-		message = copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN)
-		if(check_emote(message, forced))
-			return
+
+	message = copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN)
+	if(message[1] == "*" && check_emote(message, forced))
+		return
 
 	. = say_dead(message)
 

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -39,10 +39,10 @@
 				if(!mind.current.say(message))
 					to_chat(src, span_warning("Your linked body was unable to speak!"))
 		return
-
-	message = copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN)
-	if(check_emote(message, forced))
-		return
+	if(sanitize(message)[1] == "*")
+		message = copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN)
+		if(check_emote(message, forced))
+			return
 
 	. = say_dead(message)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently when checking for emotes as an observer, instead of checking for asterisk it just forces the first letter off and checks if the remaining string is an emote. Breaks saying ahelp since there is a `help` emote, and you can also run emotes if you just do something like `xspin` you will still spin.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes https://github.com/tgstation/tgstation/issues/62501
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Emotes will now parse properly in dchat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
