### PR TITLE
Replaces the Crème de Menthe in Quadruple Sec with Grenadine because mint with triple citrus tastes awful and Grenadine = RED

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -469,7 +469,7 @@
 
 /datum/chemical_reaction/drink/quadruplesec
 	results = list(/datum/reagent/consumable/ethanol/quadruple_sec = 15)
-	required_reagents = list(/datum/reagent/consumable/ethanol/triple_sec = 5, /datum/reagent/consumable/triple_citrus = 5, /datum/reagent/consumable/ethanol/creme_de_menthe = 5)
+	required_reagents = list(/datum/reagent/consumable/ethanol/triple_sec = 5, /datum/reagent/consumable/triple_citrus = 5, /datum/reagent/consumable/grenadine = 5)
 	mix_message = "The snap of a taser emanates clearly from the mixture as it settles."
 	mix_sound = 'sound/weapons/taser.ogg'
 	reaction_tags = REACTION_TAG_DRINK | REACTION_TAG_EASY | REACTION_TAG_OTHER


### PR DESCRIPTION
## About The Pull Request

Replaces the Crème de Menthe in Quadruple Sec with Grenadine because mint with triple citrus tastes awful and Grenadine = RED

## Why It's Good For The Game

I'm drinking this right now and it's great

## Changelog

:cl:
balance: Replaces the Crème de Menthe in Quadruple Sec with Grenadine because mint with triple citrus tastes awful and Grenadine turns drinks red
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
