### PR TITLE
Fixes pixel-specific aiming.

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -862,10 +862,10 @@
 
 /**
  * Aims the projectile at a target.
- * 
+ *
  * Must be passed at least one of a target or a list of click parameters.
  * If only passed the click modifiers the source atom must be a mob with a client.
- * 
+ *
  * Arguments:
  * - [target][/atom]: (Optional) The thing that the projectile will be aimed at.
  * - [source][/atom]: The initial location of the projectile or the thing firing it.
@@ -890,6 +890,8 @@
 	trajectory_ignore_forcemove = FALSE
 
 	starting = source_loc
+	pixel_x = source.pixel_x
+	pixel_y = source.pixel_y
 	original = target
 	if(length(modifiers))
 		var/list/calculated = calculate_projectile_angle_and_pixel_offsets(source, target_loc && target, modifiers)
@@ -911,7 +913,7 @@
 
 /**
  * Calculates the pixel offsets and angle that a projectile should be launched at.
- * 
+ *
  * Arguments:
  * - [source][/atom]: The thing that the projectile is being shot from.
  * - [target][/atom]: (Optional) The thing that the projectile is being shot at.
@@ -919,26 +921,22 @@
  * - [modifiers][/list]: A list of click parameters used to modify the shot angle.
  */
 /proc/calculate_projectile_angle_and_pixel_offsets(atom/source, atom/target, modifiers)
-	var/p_x = 0
-	var/p_y = 0
 	var/angle = 0
-	if(LAZYACCESS(modifiers, ICON_X))
-		p_x += text2num(LAZYACCESS(modifiers, ICON_X))
-	if(LAZYACCESS(modifiers, ICON_Y))
-		p_y += text2num(LAZYACCESS(modifiers, ICON_Y))
+	var/p_x = LAZYACCESS(modifiers, ICON_X) ? text2num(LAZYACCESS(modifiers, ICON_X)) : world.icon_size / 2 // ICON_(X|Y) are measured from the bottom left corner of the icon.
+	var/p_y = LAZYACCESS(modifiers, ICON_Y) ? text2num(LAZYACCESS(modifiers, ICON_Y)) : world.icon_size / 2 // This centers the target if modifiers aren't passed.
 
 	if(target)
 		var/turf/source_loc = get_turf(source)
 		var/turf/target_loc = get_turf(target)
-		var/dx = ((target_loc.x - source_loc.x) * world.icon_size) + target.pixel_x
-		var/dy = ((target_loc.y - source_loc.y) * world.icon_size) + target.pixel_y
+		var/dx = ((target_loc.x - source_loc.x) * world.icon_size) + (target.pixel_x - source.pixel_x) + (p_x - (world.icon_size / 2))
+		var/dy = ((target_loc.y - source_loc.y) * world.icon_size) + (target.pixel_y - source.pixel_y) + (p_y - (world.icon_size / 2))
 
 		angle = ATAN2(dy, dx)
 		return list(angle, p_x, p_y)
 
 	if(!ismob(source) || !LAZYACCESS(modifiers, SCREEN_LOC))
 		CRASH("Can't make trajectory calculations without a target or click modifiers and a client.")
-	
+
 	var/mob/user = source
 	if(!user.client)
 		CRASH("Can't make trajectory calculations without a target or click modifiers and a client.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There used to be code that was supposed to let you shoot at the individual pixels of your target.
It was broken and was causing bullets to drift off-center at long ranges and zooms.
I tried to fix it and accidentally wound up removing the ability to target individual pixels.
This reimplements the pixel targeting without the aim drift bug.

`GBP_NO_UPDATE` please.
This PR is also baked into #63859 so that PR should close this one if it's merged first.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lets people be slightly more precise with their shots.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Guns can once again target individual pixels rather than always shooting at the center of their target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
