### PR TITLE
Rubbershot is now very bouncy

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -83,7 +83,7 @@
 	icon_state = "bshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_rubbershot
 	pellets = 6
-	variance = 25
+	variance = 20
 	custom_materials = list(/datum/material/iron=4000)
 
 /obj/item/ammo_casing/shotgun/incapacitate

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -367,6 +367,7 @@
 			decayedRange = max(0, decayedRange - reflect_range_decrease)
 			ricochet_chance *= ricochet_decay_chance
 			damage *= ricochet_decay_damage
+			stamina *= ricochet_decay_damage
 			range = decayedRange
 			if(hitscan)
 				store_hitscan_collision(point_cache)
@@ -862,10 +863,10 @@
 
 /**
  * Aims the projectile at a target.
- * 
+ *
  * Must be passed at least one of a target or a list of click parameters.
  * If only passed the click modifiers the source atom must be a mob with a client.
- * 
+ *
  * Arguments:
  * - [target][/atom]: (Optional) The thing that the projectile will be aimed at.
  * - [source][/atom]: The initial location of the projectile or the thing firing it.
@@ -911,7 +912,7 @@
 
 /**
  * Calculates the pixel offsets and angle that a projectile should be launched at.
- * 
+ *
  * Arguments:
  * - [source][/atom]: The thing that the projectile is being shot from.
  * - [target][/atom]: (Optional) The thing that the projectile is being shot at.
@@ -938,7 +939,7 @@
 
 	if(!ismob(source) || !LAZYACCESS(modifiers, SCREEN_LOC))
 		CRASH("Can't make trajectory calculations without a target or click modifiers and a client.")
-	
+
 	var/mob/user = source
 	if(!user.client)
 		CRASH("Can't make trajectory calculations without a target or click modifiers and a client.")

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -75,6 +75,15 @@
 	var/tile_dropoff = 0.45
 	var/tile_dropoff_s = 0.5
 
+/obj/projectile/bullet/pellet/Range()
+	..()
+	if(damage > 0)
+		damage -= tile_dropoff
+	if(stamina > 0)
+		stamina -= tile_dropoff_s
+	if(damage < 0 && stamina < 0)
+		qdel(src)
+
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
 	damage = 7.5
@@ -86,23 +95,30 @@
 	name = "rubbershot pellet"
 	damage = 3
 	stamina = 11
+	tile_dropoff_s = 0.25
 	sharpness = NONE
 	embedding = null
+	speed = 1.2
+	ricochets_max = 4
+	ricochet_chance = 120
+	ricochet_decay_chance = 0.9
+	ricochet_decay_damage = 0.8
+	ricochet_auto_aim_range = 2
+	ricochet_auto_aim_angle = 30
+	ricochet_incidence_leeway = 75
+	/// Subtracted from the ricochet chance for each tile traveled
+	var/tile_dropoff_ricochet = 4
+
+/obj/projectile/bullet/pellet/shotgun_rubbershot/Range()
+	if(ricochet_chance > 0)
+		ricochet_chance -= tile_dropoff_ricochet
+	. = ..()
 
 /obj/projectile/bullet/pellet/shotgun_incapacitate
 	name = "incapacitating pellet"
 	damage = 1
 	stamina = 6
 	embedding = null
-
-/obj/projectile/bullet/pellet/Range()
-	..()
-	if(damage > 0)
-		damage -= tile_dropoff
-	if(stamina > 0)
-		stamina -= tile_dropoff_s
-	if(damage < 0 && stamina < 0)
-		qdel(src)
 
 /obj/projectile/bullet/pellet/shotgun_improvised
 	tile_dropoff = 0.35 //Come on it does 6 damage don't be like that.

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -73,7 +73,7 @@
 
 /obj/projectile/bullet/pellet
 	var/tile_dropoff = 0.45
-	var/tile_dropoff_s = 0.5
+	var/tile_dropoff_s = 0.25
 
 /obj/projectile/bullet/pellet/Range()
 	..()
@@ -95,7 +95,6 @@
 	name = "rubbershot pellet"
 	damage = 3
 	stamina = 11
-	tile_dropoff_s = 0.25
 	sharpness = NONE
 	embedding = null
 	speed = 1.2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Shotguns have been butt for a while now and don't really have a niche that justifies their clunkiness compared to energy guns and disablers (can't affix tactical lights, have to carry extra ammo for it, can't pass through windows+grilles, must be two handed etc etc), so this PR aims to carve out a niche for them in a fun way that plays into the environments they're used in.

Rubbershot is now much bouncier, has a slightly tighter choke, and has less stamina damage drop off over range, though they also fly 50% slower than before. This way, shotguns will gain a niche in close quarters maint tunnels, where the walls act like a funnel to extend their range, while rifles and beam guns are still much more practical for open areas and general use. It also increases the funny side effect of being able to hit totally unintended bystanders/friendlies or even yourself if you're not careful (though it's still rubbershot so not like it'll do much damage).

[Here's a sample](https://streamable.com/o2wg8c)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives a reason to use shotguns that encourages people to take their environment into consideration in deciding whether to break one out. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ryll/Shaps
balance: Rubbershot is now much more bouncy than before, loses damage over range a bit slower, and has a somewhat tighter spread. Its pellets now also fly 50% slower.
fix: Bullets that deal both brute and stamina damage like .38 Rubber will now properly have both their brute and stamina damage reduced after each ricochet, instead of just the brute.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
