### PR TITLE
Redoes the walls in DeltaStation's Pharmacy

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -20107,7 +20107,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "dbc" = (
@@ -20613,6 +20612,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/medical/pharmacy)
 "dcU" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -20107,6 +20107,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "dbc" = (
@@ -20127,6 +20128,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "dbd" = (
@@ -20145,11 +20148,9 @@
 /turf/open/floor/iron,
 /area/medical/pharmacy)
 "dbg" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "dbh" = (
@@ -20583,13 +20584,13 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "dcO" = (
@@ -20612,7 +20613,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/medical/pharmacy)
 "dcU" = (
@@ -20944,6 +20944,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "den" = (
@@ -20969,6 +20970,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "deq" = (
@@ -45201,6 +45203,20 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"hHJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/medical/pharmacy)
 "hHL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61600,6 +61616,7 @@
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
 "lYb" = (
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "lYe" = (
@@ -69572,6 +69589,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "ods" = (
@@ -103050,6 +103068,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"xfe" = (
+/obj/machinery/newscaster/directional/east,
+/turf/closed/wall,
+/area/medical/pharmacy)
 "xfl" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -146918,7 +146940,7 @@ our
 eSk
 hVx
 wSx
-mOg
+pxG
 dbc
 lYb
 dem
@@ -147178,7 +147200,7 @@ iuE
 qDR
 dbd
 dcP
-den
+hHJ
 den
 mKh
 dir
@@ -147948,7 +147970,7 @@ eXB
 eCr
 pxG
 dbg
-dgZ
+den
 dgZ
 dgZ
 dgZ
@@ -148464,7 +148486,7 @@ pxG
 pxG
 pxG
 pxG
-pxG
+xfe
 dhb
 diu
 ndH


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

DeltaStation's pharmacy has weird clipping issues with the walls, where a player could see items placed on the same wall, but on opposite sides due to how the windows lined up.

![image](https://user-images.githubusercontent.com/34697715/149068173-593134a9-36ad-4d84-9042-2520aa5f8431.png)

Like such. This PR replaces a window (inconsequential), and moves around the APC and Newscaster in the Pharmacy just to abate the issue of how that all rolls out. There's also a new light there to compensate for the window removal.

Before:

![image](https://user-images.githubusercontent.com/34697715/149223167-595c812d-e965-4d61-a29e-420d09f38e5a.png)

After:

![image](https://user-images.githubusercontent.com/34697715/149222972-3278176f-29a2-4d93-8c67-cc9473a24724.png)

The turf the newscaster is now on was associated to an Evacuation Status Display, but the pharmacy already has one on the wall just across the room, so I don't think there should be any reservations getting rid of that one.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The way we have seeing stuff programmed is that two things on opposite sides would still show up on turfs if you looked at it juuuust the right way (albeit very uncommon), this PR just nullifies that happening in DeltaStation's Pharmacy. Wall space was at a premium, and adding another wall to just thin it out should make everything look and be a lot simpler.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: DeltaStation's Pharmacy has gotten some minor refurbishment, replacing a window for a wall to slam more equipment on it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
