### PR TITLE
Fix card decks hard deleting due to playing cards holding a reference to them.

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -834,10 +834,10 @@
 	if(parentdeck)
 		UnregisterSignal(parentdeck, COMSIG_PARENT_QDELETING)
 
-	parentdeck = new_parent_deck
-
-	if(parentdeck)
+	if(new_parent_deck)
 		RegisterSignal(parentdeck, COMSIG_PARENT_QDELETING, .proc/on_parent_deck_deletion)
+
+	parentdeck = new_parent_deck
 
 /**
  * Nulls the parent deck when the parent deck is deleted to avoid hard dels from hanging references.
@@ -845,7 +845,7 @@
 /obj/item/toy/cards/proc/on_parent_deck_deletion(obj/item/toy/cards/deck/source)
 	SIGNAL_HANDLER
 
-	parentdeck = null
+	set_parent_deck(null)
 
 /obj/item/toy/cards/deck
 	name = "deck of cards"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -834,10 +834,10 @@
 	if(parentdeck)
 		UnregisterSignal(parentdeck, COMSIG_PARENT_QDELETING)
 
-	if(new_parent_deck)
-		RegisterSignal(parentdeck, COMSIG_PARENT_QDELETING, .proc/on_parent_deck_deletion)
-
 	parentdeck = new_parent_deck
+
+	if(parentdeck)
+		RegisterSignal(parentdeck, COMSIG_PARENT_QDELETING, .proc/on_parent_deck_deletion)
 
 /**
  * Nulls the parent deck when the parent deck is deleted to avoid hard dels from hanging references.
@@ -845,7 +845,7 @@
 /obj/item/toy/cards/proc/on_parent_deck_deletion(obj/item/toy/cards/deck/source)
 	SIGNAL_HANDLER
 
-	set_parent_deck(null)
+	parentdeck = null
 
 /obj/item/toy/cards/deck
 	name = "deck of cards"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1099,7 +1099,7 @@
 
 		user.visible_message(span_notice("[user] adds a card to [user.p_their()] hand."), span_notice("You add the [cardname] to your hand."))
 	else
-		new_cardhand.parentdeck = WEAKREF(parentdeck)
+		new_cardhand.parentdeck = parentdeck
 		new_cardhand.apply_card_vars(new_cardhand, src)
 		to_chat(user, span_notice("You combine the cards into a hand."))
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -726,12 +726,14 @@
 	var/list/card_attack_verb_continuous = list("attacks")
 	var/list/card_attack_verb_simple = list("attack")
 
+
 /obj/item/toy/cards/Initialize(mapload)
 	. = ..()
 	if(card_attack_verb_continuous)
 		card_attack_verb_continuous = string_list(card_attack_verb_continuous)
 	if(card_attack_verb_simple)
 		card_attack_verb_simple = string_list(card_attack_verb_simple)
+
 
 /obj/item/toy/cards/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] is slitting [user.p_their()] wrists with \the [src]! It looks like [user.p_they()] [user.p_have()] a crummy hand!"))
@@ -824,29 +826,6 @@
 	update_appearance()
 	return card_to_draw
 
-/**
- * Sets the parent deck for this card, registering a signal to clear references on the parent deck's deletion.
- *
- * Arguments:
- * * new_parent_deck - New deck to set as a parent.
- */
-/obj/item/toy/cards/proc/set_parent_deck(obj/item/toy/cards/deck/new_parent_deck)
-	if(parentdeck)
-		UnregisterSignal(parentdeck, COMSIG_PARENT_QDELETING)
-
-	parentdeck = new_parent_deck
-
-	if(parentdeck)
-		RegisterSignal(parentdeck, COMSIG_PARENT_QDELETING, .proc/on_parent_deck_deletion)
-
-/**
- * Nulls the parent deck when the parent deck is deleted to avoid hard dels from hanging references.
- */
-/obj/item/toy/cards/proc/on_parent_deck_deletion(obj/item/toy/cards/deck/source)
-	SIGNAL_HANDLER
-
-	parentdeck = null
-
 /obj/item/toy/cards/deck
 	name = "deck of cards"
 	desc = "A deck of space-grade playing cards."
@@ -879,7 +858,7 @@
 	if(holo)
 		holo.spawned += card_to_add
 	card_to_add.cardname = name
-	card_to_add.set_parent_deck(src)
+	card_to_add.parentdeck = src
 	card_to_add.apply_card_vars(card_to_add, src)
 	return card_to_add
 
@@ -1120,7 +1099,7 @@
 
 		user.visible_message(span_notice("[user] adds a card to [user.p_their()] hand."), span_notice("You add the [cardname] to your hand."))
 	else
-		new_cardhand.set_parent_deck(parentdeck)
+		new_cardhand.parentdeck = parentdeck
 		new_cardhand.apply_card_vars(new_cardhand, src)
 		to_chat(user, span_notice("You combine the cards into a hand."))
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -715,7 +715,7 @@
 	resistance_flags = FLAMMABLE
 	max_integrity = 50
 	///The parent deck of the cards
-	var/parentdeck = null
+	var/datum/weakref/parentdeck
 	///Artistic style of the deck
 	var/deckstyle = "nanotrasen"
 	var/card_hitsound = null
@@ -769,7 +769,7 @@
 	if (istype(src, /obj/item/toy/cards/cardhand))
 		to_cardhand = TRUE
 
-	if ((card_to_add.parentdeck != src.parentdeck) && (card_to_add.parentdeck != src))
+	if ((card_to_add.parentdeck != src.parentdeck) && (card_to_add.parentdeck != WEAKREF(src)))
 		to_chat(user, span_warning("You can't mix cards from other decks!"))
 		return
 	if (!user.temporarilyRemoveItemFromInventory(card_to_add))
@@ -858,7 +858,7 @@
 	if(holo)
 		holo.spawned += card_to_add
 	card_to_add.cardname = name
-	card_to_add.parentdeck = src
+	card_to_add.parentdeck = WEAKREF(src)
 	card_to_add.apply_card_vars(card_to_add, src)
 	return card_to_add
 
@@ -1099,7 +1099,7 @@
 
 		user.visible_message(span_notice("[user] adds a card to [user.p_their()] hand."), span_notice("You add the [cardname] to your hand."))
 	else
-		new_cardhand.parentdeck = parentdeck
+		new_cardhand.parentdeck = WEAKREF(parentdeck)
 		new_cardhand.apply_card_vars(new_cardhand, src)
 		to_chat(user, span_notice("You combine the cards into a hand."))
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -726,14 +726,12 @@
 	var/list/card_attack_verb_continuous = list("attacks")
 	var/list/card_attack_verb_simple = list("attack")
 
-
 /obj/item/toy/cards/Initialize(mapload)
 	. = ..()
 	if(card_attack_verb_continuous)
 		card_attack_verb_continuous = string_list(card_attack_verb_continuous)
 	if(card_attack_verb_simple)
 		card_attack_verb_simple = string_list(card_attack_verb_simple)
-
 
 /obj/item/toy/cards/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] is slitting [user.p_their()] wrists with \the [src]! It looks like [user.p_they()] [user.p_have()] a crummy hand!"))
@@ -826,6 +824,29 @@
 	update_appearance()
 	return card_to_draw
 
+/**
+ * Sets the parent deck for this card, registering a signal to clear references on the parent deck's deletion.
+ *
+ * Arguments:
+ * * new_parent_deck - New deck to set as a parent.
+ */
+/obj/item/toy/cards/proc/set_parent_deck(obj/item/toy/cards/deck/new_parent_deck)
+	if(parentdeck)
+		UnregisterSignal(parentdeck, COMSIG_PARENT_QDELETING)
+
+	parentdeck = new_parent_deck
+
+	if(parentdeck)
+		RegisterSignal(parentdeck, COMSIG_PARENT_QDELETING, .proc/on_parent_deck_deletion)
+
+/**
+ * Nulls the parent deck when the parent deck is deleted to avoid hard dels from hanging references.
+ */
+/obj/item/toy/cards/proc/on_parent_deck_deletion(obj/item/toy/cards/deck/source)
+	SIGNAL_HANDLER
+
+	parentdeck = null
+
 /obj/item/toy/cards/deck
 	name = "deck of cards"
 	desc = "A deck of space-grade playing cards."
@@ -858,7 +879,7 @@
 	if(holo)
 		holo.spawned += card_to_add
 	card_to_add.cardname = name
-	card_to_add.parentdeck = src
+	card_to_add.set_parent_deck(src)
 	card_to_add.apply_card_vars(card_to_add, src)
 	return card_to_add
 
@@ -1099,7 +1120,7 @@
 
 		user.visible_message(span_notice("[user] adds a card to [user.p_their()] hand."), span_notice("You add the [cardname] to your hand."))
 	else
-		new_cardhand.parentdeck = parentdeck
+		new_cardhand.set_parent_deck(parentdeck)
 		new_cardhand.apply_card_vars(new_cardhand, src)
 		to_chat(user, span_notice("You combine the cards into a hand."))
 

--- a/code/modules/games/cas.dm
+++ b/code/modules/games/cas.dm
@@ -73,7 +73,7 @@
 	H.buffertext = choice.name
 	H.icon_state = choice.card_icon
 	H.card_face = choice.card_icon
-	H.parentdeck = src
+	H.parentdeck = WEAKREF(src)
 	src.cards -= choice
 	H.pickup(user)
 	user.put_in_hands(H)

--- a/code/modules/games/cas.dm
+++ b/code/modules/games/cas.dm
@@ -57,26 +57,26 @@
 		cards += P
 	shuffle_inplace(cards) // distribute blank cards throughout deck
 
-/obj/item/toy/cards/deck/cas/draw_card(mob/living/user)
+/obj/item/toy/cards/deck/cas/draw_card(mob/user)
 	if(isliving(user))
-		var/mob/living/living_user = user
-		if(!(living_user.mobility_flags & MOBILITY_PICKUP))
+		var/mob/living/L = user
+		if(!(L.mobility_flags & MOBILITY_PICKUP))
 			return
 	if(cards.len == 0)
 		to_chat(user, span_warning("There are no more cards to draw!"))
 		return
-	var/obj/item/toy/cards/singlecard/cas/new_cas_card = new/obj/item/toy/cards/singlecard/cas(user.loc)
+	var/obj/item/toy/cards/singlecard/cas/H = new/obj/item/toy/cards/singlecard/cas(user.loc)
 	var/datum/playingcard/choice = cards[1]
 	if (choice.name == "Blank Card")
-		new_cas_card.blank = 1
-	new_cas_card.name = choice.name
-	new_cas_card.buffertext = choice.name
-	new_cas_card.icon_state = choice.card_icon
-	new_cas_card.card_face = choice.card_icon
-	new_cas_card.set_parent_deck(src)
-	cards -= choice
-	new_cas_card.pickup(user)
-	user.put_in_hands(new_cas_card)
+		H.blank = 1
+	H.name = choice.name
+	H.buffertext = choice.name
+	H.icon_state = choice.card_icon
+	H.card_face = choice.card_icon
+	H.parentdeck = src
+	src.cards -= choice
+	H.pickup(user)
+	user.put_in_hands(H)
 	user.visible_message(span_notice("[user] draws a card from the deck."), span_notice("You draw a card from the deck."))
 	update_appearance()
 

--- a/code/modules/games/cas.dm
+++ b/code/modules/games/cas.dm
@@ -57,26 +57,26 @@
 		cards += P
 	shuffle_inplace(cards) // distribute blank cards throughout deck
 
-/obj/item/toy/cards/deck/cas/draw_card(mob/user)
+/obj/item/toy/cards/deck/cas/draw_card(mob/living/user)
 	if(isliving(user))
-		var/mob/living/L = user
-		if(!(L.mobility_flags & MOBILITY_PICKUP))
+		var/mob/living/living_user = user
+		if(!(living_user.mobility_flags & MOBILITY_PICKUP))
 			return
 	if(cards.len == 0)
 		to_chat(user, span_warning("There are no more cards to draw!"))
 		return
-	var/obj/item/toy/cards/singlecard/cas/H = new/obj/item/toy/cards/singlecard/cas(user.loc)
+	var/obj/item/toy/cards/singlecard/cas/new_cas_card = new/obj/item/toy/cards/singlecard/cas(user.loc)
 	var/datum/playingcard/choice = cards[1]
 	if (choice.name == "Blank Card")
-		H.blank = 1
-	H.name = choice.name
-	H.buffertext = choice.name
-	H.icon_state = choice.card_icon
-	H.card_face = choice.card_icon
-	H.parentdeck = src
-	src.cards -= choice
-	H.pickup(user)
-	user.put_in_hands(H)
+		new_cas_card.blank = 1
+	new_cas_card.name = choice.name
+	new_cas_card.buffertext = choice.name
+	new_cas_card.icon_state = choice.card_icon
+	new_cas_card.card_face = choice.card_icon
+	new_cas_card.set_parent_deck(src)
+	cards -= choice
+	new_cas_card.pickup(user)
+	user.put_in_hands(new_cas_card)
 	user.visible_message(span_notice("[user] draws a card from the deck."), span_notice("You draw a card from the deck."))
 	update_appearance()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

For (as of the time of writing) unknown reasons, CI is intermittently failing on playing cards holding references to their parent decks when the parent decks are deleted.

![image](https://user-images.githubusercontent.com/24975989/149124528-13d1a63a-4407-496d-9f14-68d845d7b52f.png)

While we haven't yet figured out why the failures are intermittent, I suspect there's some non-deterministic method of processing the del queue or something else where sometimes the card is deleted first (no problem!) and sometimes a parent deck is deleted before all cards that reference it (problem!).

In the meantime, the root cause of the hard del itself is that cards never let go of any references they hold to their parent deck once set.

![image](https://user-images.githubusercontent.com/24975989/149125080-4e89bdd1-b10c-431c-9ccf-65e91282c3d1.png)

Two solutions. One, weakref. The other, single handler on parent deck qdeletion.

I chose the signal handler route arbitrarily, implementing a setter to handle the registering and unregistering of signals as necessary and a handler to null the parent deck as necessary.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes the hard del causing the CI issue. Why the hard del is only intermittently happening on CI is an investigation for far smarter people than I.

No player-facing changes.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->