### PR TITLE
Adds circuit USB for reflectors

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -32,6 +32,10 @@
 
 	if(admin)
 		can_rotate = FALSE
+	
+	AddComponent(/datum/component/usb_port, list(
+		/obj/item/circuit_component/reflector,
+	))
 
 /obj/structure/reflector/examine(mob/user)
 	. = ..()
@@ -256,3 +260,30 @@
 		return
 	else
 		return ..()
+
+//	USB
+
+/obj/item/circuit_component/reflector
+	display_name = "Reflector"
+	desc = "Allows to adjust the angle of a reflector."
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL
+	
+	///angle the reflector will be set to at trigger unless locked
+	var/datum/port/input/angle
+	
+	var/obj/structure/reflector/attached_reflector
+
+/obj/item/circuit_component/reflector/populate_ports()
+	angle = add_input_port("Angle", PORT_TYPE_NUMBER)
+
+/obj/item/circuit_component/reflector/register_usb_parent(atom/movable/parent)
+	. = ..()
+	if(istype(parent, /obj/structure/reflector))
+		attached_reflector = parent
+
+/obj/item/circuit_component/reflector/unregister_usb_parent(atom/movable/parent)
+	attached_reflector = null
+	return ..()
+
+/obj/item/circuit_component/reflector/input_received(datum/port/input/port)
+	attached_reflector?.set_angle(angle.value)

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -265,7 +265,7 @@
 
 /obj/item/circuit_component/reflector
 	display_name = "Reflector"
-	desc = "Allows to adjust the angle of a reflector."
+	desc = "Allows you to adjust the angle of a reflector."
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL
 	
 	///angle the reflector will be set to at trigger unless locked


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reflectors get USB ports. You can put in an angle and, if the reflector is unlocked, it goes to that angle when the component is triggered.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fun new uses for circuits! Fun new uses for the trig module!! We love lasers!!!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Reflectors have been slotted with USB ports.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
