### PR TITLE
chisel, bane of statues

### DIFF
--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -285,6 +285,8 @@
 	. = ..()
 	AddElement(/datum/element/eyestab)
 	AddElement(/datum/element/wall_engraver)
+	//deals 200 damage to statues, meaning you can actually kill one in ~250 hits
+	AddElement(/datum/element/bane, /mob/living/simple_animal/hostile/statue, damage_multiplier = 40)
 
 /obj/item/chisel/Destroy()
 	prepared_block = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Chisels now deal 40x more damage to statue mobs.

## Why It's Good For The Game

Back in the day you could deal extra damage to statues by pickaxing them. At some point this was lost but we have a funnier and more accurate thing to make the bane of statues, along with elementization to make it incredibly easy to apply.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: chisels are now the animated statue's bane.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
