### PR TITLE
statues now have the monster jaunting ability.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -53,8 +53,6 @@
 
 	var/cannot_be_seen = 1
 	var/mob/living/creator = null
-	///ability to phase in and out when unseen.
-	var/datum/action/innate/creature/teleport/teleport
 
 // No movement while seen code.
 
@@ -65,7 +63,7 @@
 	mob_spell_list += new /obj/effect/proc_holder/spell/aoe_turf/flicker_lights(src)
 	mob_spell_list += new /obj/effect/proc_holder/spell/aoe_turf/blindness(src)
 	mob_spell_list += new /obj/effect/proc_holder/spell/targeted/night_vision(src)
-	teleport = new
+	var/datum/action/innate/creature/teleport/teleport = new
 	teleport.Grant(src)
 
 	// Set creator

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -53,7 +53,7 @@
 
 	var/cannot_be_seen = 1
 	var/mob/living/creator = null
-	//ability to phase in and out when unseen.
+	///ability to phase in and out when unseen.
 	var/datum/action/innate/creature/teleport/teleport
 
 // No movement while seen code.

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -53,8 +53,8 @@
 
 	var/cannot_be_seen = 1
 	var/mob/living/creator = null
-
-
+	//ability to phase in and out when unseen.
+	var/datum/action/innate/creature/teleport/teleport
 
 // No movement while seen code.
 
@@ -65,6 +65,8 @@
 	mob_spell_list += new /obj/effect/proc_holder/spell/aoe_turf/flicker_lights(src)
 	mob_spell_list += new /obj/effect/proc_holder/spell/aoe_turf/blindness(src)
 	mob_spell_list += new /obj/effect/proc_holder/spell/targeted/night_vision(src)
+	teleport = new
+	teleport.Grant(src)
 
 	// Set creator
 	if(creator)

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -63,7 +63,7 @@
 	mob_spell_list += new /obj/effect/proc_holder/spell/aoe_turf/flicker_lights(src)
 	mob_spell_list += new /obj/effect/proc_holder/spell/aoe_turf/blindness(src)
 	mob_spell_list += new /obj/effect/proc_holder/spell/targeted/night_vision(src)
-	var/datum/action/innate/creature/teleport/teleport = new
+	var/datum/action/innate/creature/teleport/teleport = new(src)
 	teleport.Grant(src)
 
 	// Set creator


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

statues now have the ability netherworld link monsters have, which is to phase out and in when unseen.

## Why It's Good For The Game

statues are currently solved by walling them in, which is one of the worst ways a monster is defeated in this game. the alternate is allowing the statue to break down walls, which would be FAR worse. this is a sister pr to #64047, as that pr adds a new defeat condition for statues.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Statues can now phase around when unseen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
