### PR TITLE
Traitor objective logging + adds the objectives to the antag panel

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -144,6 +144,10 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
 	if (CONFIG_GET(flag/log_econ))
 		WRITE_LOG(GLOB.world_econ_log, "MONEY: [text]")
 
+/proc/log_traitor(text)
+	if (CONFIG_GET(flag/log_econ))
+		WRITE_LOG(GLOB.world_game_log, "TRAITOR: [text]")
+
 /proc/log_manifest(ckey, datum/mind/mind, mob/body, latejoin = FALSE)
 	if (CONFIG_GET(flag/log_manifest))
 		WRITE_LOG(GLOB.world_manifest_log, "[ckey] \\ [body.real_name] \\ [mind.assigned_role.title] \\ [mind.special_role ? mind.special_role : "NONE"] \\ [latejoin ? "LATEJOIN":"ROUNDSTART"]")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -611,6 +611,36 @@
 					message_admins("[key_name_admin(usr)] has unemag'ed [ai]'s Cyborgs.")
 					log_admin("[key_name(usr)] has unemag'ed [ai]'s Cyborgs.")
 
+	else if(href_list["edit_obj_tc"])
+		var/datum/traitor_objective/objective = locate(href_list["edit_obj_tc"])
+		if(!istype(objective))
+			return
+		var/telecrystal = input("Set new telecrystal reward for [objective.name]","Syndicate uplink", objective.telecrystal_reward) as null | num
+		if(isnull(telecrystal))
+			return
+		objective.telecrystal_reward = telecrystal
+		message_admins("[key_name_admin(usr)] changed [objective]'s telecrystal reward count to [telecrystal].")
+		log_admin("[key_name(usr)] changed [objective]'s telecrystal reward count to [telecrystal].")
+	else if(href_list["edit_obj_pr"])
+		var/datum/traitor_objective/objective = locate(href_list["edit_obj_pr"])
+		if(!istype(objective))
+			return
+		var/progression = input("Set new progression reward for [objective.name]","Syndicate uplink", objective.progression_reward) as null | num
+		if(isnull(progression))
+			return
+		objective.progression_reward = progression
+		message_admins("[key_name_admin(usr)] changed [objective]'s progression reward count to [progression].")
+		log_admin("[key_name(usr)] changed [objective]'s progression reward count to [progression].")
+	else if(href_list["fail_objective"])
+		var/datum/traitor_objective/objective = locate(href_list["fail_objective"])
+		if(!istype(objective))
+			return
+		objective.fail_objective()
+	else if(href_list["succeed_objective"])
+		var/datum/traitor_objective/objective = locate(href_list["succeed_objective"])
+		if(!istype(objective))
+			return
+		objective.succeed_objective()
 	else if (href_list["common"])
 		switch(href_list["common"])
 			if("undress")

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -635,11 +635,16 @@
 		var/datum/traitor_objective/objective = locate(href_list["fail_objective"])
 		if(!istype(objective))
 			return
+		var/performed = objective.objective_state == OBJECTIVE_STATE_INACTIVE? "skipped" : "failed"
+		message_admins("[key_name_admin(usr)] forcefully [performed] [objective].")
+		log_admin("[key_name(usr)] forcefully [performed] [objective].")
 		objective.fail_objective()
 	else if(href_list["succeed_objective"])
 		var/datum/traitor_objective/objective = locate(href_list["succeed_objective"])
 		if(!istype(objective))
 			return
+		message_admins("[key_name_admin(usr)] forcefully succeeded [objective].")
+		log_admin("[key_name(usr)] forcefully succeeded [objective].")
 		objective.succeed_objective()
 	else if (href_list["common"])
 		switch(href_list["common"])

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -80,16 +80,16 @@
 /datum/antagonist/traitor/proc/traitor_objective_to_html(datum/traitor_objective/to_display)
 	var/string = "[to_display.name]"
 	if(to_display.objective_state == OBJECTIVE_STATE_ACTIVE || to_display.objective_state == OBJECTIVE_STATE_INACTIVE)
-		string += " <a href='?src=[REF(owner)];edit_obj_tc=[REF(to_display)]>[to_display.telecrystal_reward] TC</a>"
-		string += " <a href='?src=[REF(owner)];edit_obj_pr=[REF(to_display)]>[to_display.progression_reward] PR</a>"
+		string += " <a href='?src=[REF(owner)];edit_obj_tc=[REF(to_display)]'>[to_display.telecrystal_reward] TC</a>"
+		string += " <a href='?src=[REF(owner)];edit_obj_pr=[REF(to_display)]'>[to_display.progression_reward] PR</a>"
 	else
-		string += " [to_display.telecrystal_reward] TC"
-		string += " [to_display.progression_reward] PR"
+		string += ", [to_display.telecrystal_reward] TC"
+		string += ", [to_display.progression_reward] PR"
 	if(to_display.objective_state == OBJECTIVE_STATE_ACTIVE)
-		string += " <a href='?src=[REF(owner)];fail_objective=[REF(to_display)]>Fail this objective</a>"
-		string += " <a href='?src=[REF(owner)];succeed_objective=[REF(to_display)]>Succeed this objective</a>"
+		string += " <a href='?src=[REF(owner)];fail_objective=[REF(to_display)]'>Fail this objective</a>"
+		string += " <a href='?src=[REF(owner)];succeed_objective=[REF(to_display)]'>Succeed this objective</a>"
 	if(to_display.objective_state == OBJECTIVE_STATE_INACTIVE)
-		string += " <a href='?src=[REF(owner)];fail_objective=[REF(to_display)]>Dispose of this objective</a>"
+		string += " <a href='?src=[REF(owner)];fail_objective=[REF(to_display)]'>Dispose of this objective</a>"
 
 	if(to_display.skipped)
 		string += " - <b>Skipped</b>"
@@ -106,17 +106,23 @@
 	var/result = ..()
 	if(!uplink_handler)
 		return result
-	result += "<i><b>Traitor specific objectives</b></i>:<br>"
+	result += "<i><b>Traitor specific objectives</b></i><br>"
 	result += "<i><b>Concluded Objectives</b></i>:<br>"
 	for(var/datum/traitor_objective/objective as anything in uplink_handler.completed_objectives)
 		result += "[traitor_objective_to_html(objective)]<br>"
+	if(!length(uplink_handler.completed_objectives))
+		result += "EMPTY<br>"
 	result += "<i><b>Ongoing Objectives</b></i>:<br>"
 	for(var/datum/traitor_objective/objective as anything in uplink_handler.active_objectives)
 		result += "[traitor_objective_to_html(objective)]<br>"
+	if(!length(uplink_handler.active_objectives))
+		result += "EMPTY<br>"
 	result += "<i><b>Potential Objectives</b></i>:<br>"
 	for(var/datum/traitor_objective/objective as anything in uplink_handler.potential_objectives)
 		result += "[traitor_objective_to_html(objective)]<br>"
-	result += "<br><a href='?src=[REF(owner)];common=1;give_objective=1'>Force add objective</a><br>"
+	if(!length(uplink_handler.potential_objectives))
+		result += "EMPTY<br>"
+	result += "<a href='?src=[REF(owner)];common=1;give_objective=1'>Force add objective</a><br>"
 	return result
 
 /datum/antagonist/traitor/on_removal()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -122,7 +122,7 @@
 		result += "[traitor_objective_to_html(objective)]<br>"
 	if(!length(uplink_handler.potential_objectives))
 		result += "EMPTY<br>"
-	result += "<a href='?src=[REF(owner)];common=1;give_objective=1'>Force add objective</a><br>"
+	result += "<a href='?src=[REF(owner)];common=give_objective'>Force add objective</a><br>"
 	return result
 
 /datum/antagonist/traitor/on_removal()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -77,6 +77,48 @@
 
 	return ..()
 
+/datum/antagonist/traitor/proc/traitor_objective_to_html(datum/traitor_objective/to_display)
+	var/string = "[to_display.name]"
+	if(to_display.objective_state == OBJECTIVE_STATE_ACTIVE || to_display.objective_state == OBJECTIVE_STATE_INACTIVE)
+		string += " <a href='?src=[REF(owner)];edit_obj_tc=[REF(to_display)]>[to_display.telecrystal_reward] TC</a>"
+		string += " <a href='?src=[REF(owner)];edit_obj_pr=[REF(to_display)]>[to_display.progression_reward] PR</a>"
+	else
+		string += " [to_display.telecrystal_reward] TC"
+		string += " [to_display.progression_reward] PR"
+	if(to_display.objective_state == OBJECTIVE_STATE_ACTIVE)
+		string += " <a href='?src=[REF(owner)];fail_objective=[REF(to_display)]>Fail this objective</a>"
+		string += " <a href='?src=[REF(owner)];succeed_objective=[REF(to_display)]>Succeed this objective</a>"
+	if(to_display.objective_state == OBJECTIVE_STATE_INACTIVE)
+		string += " <a href='?src=[REF(owner)];fail_objective=[REF(to_display)]>Dispose of this objective</a>"
+
+	if(to_display.skipped)
+		string += " - <b>Skipped</b>"
+	else if(to_display.objective_state == OBJECTIVE_STATE_FAILED)
+		string += " - <b><font color='red'>Failed</font></b>"
+	else if(to_display.objective_state == OBJECTIVE_STATE_INVALID)
+		string += " - <b>Invalidated</b>"
+	else if(to_display.objective_state == OBJECTIVE_STATE_COMPLETED)
+		string += " - <b><font color='green'>Succeeded</font></b>"
+
+	return string
+
+/datum/antagonist/traitor/antag_panel_objectives()
+	var/result = ..()
+	if(!uplink_handler)
+		return result
+	result += "<i><b>Traitor specific objectives</b></i>:<br>"
+	result += "<i><b>Concluded Objectives</b></i>:<br>"
+	for(var/datum/traitor_objective/objective as anything in uplink_handler.completed_objectives)
+		result += "[traitor_objective_to_html(objective)]<br>"
+	result += "<i><b>Ongoing Objectives</b></i>:<br>"
+	for(var/datum/traitor_objective/objective as anything in uplink_handler.active_objectives)
+		result += "[traitor_objective_to_html(objective)]<br>"
+	result += "<i><b>Potential Objectives</b></i>:<br>"
+	for(var/datum/traitor_objective/objective as anything in uplink_handler.potential_objectives)
+		result += "[traitor_objective_to_html(objective)]<br>"
+	result += "<br><a href='?src=[REF(owner)];common=1;give_objective=1'>Force add objective</a><br>"
+	return result
+
 /datum/antagonist/traitor/on_removal()
 	owner.special_role = null
 	return ..()

--- a/code/modules/antagonists/traitor/traitor_objective.dm
+++ b/code/modules/antagonists/traitor/traitor_objective.dm
@@ -233,7 +233,7 @@
 
 /datum/traitor_objective/proc/on_objective_taken(mob/user)
 	SStraitor.on_objective_taken(src)
-	log_traitor("[key_name(handler.owner)] has taken an objective: [objective.to_debug_string()]")
+	log_traitor("[key_name(handler.owner)] has taken an objective: [to_debug_string()]")
 
 /// Used for generating the UI buttons for the UI. Use ui_perform_action to respond to clicks.
 /datum/traitor_objective/proc/generate_ui_buttons(mob/user)

--- a/code/modules/antagonists/traitor/traitor_objective.dm
+++ b/code/modules/antagonists/traitor/traitor_objective.dm
@@ -233,6 +233,7 @@
 
 /datum/traitor_objective/proc/on_objective_taken(mob/user)
 	SStraitor.on_objective_taken(src)
+	log_traitor("[key_name(handler.owner)] has taken an objective: [objective.to_debug_string()]")
 
 /// Used for generating the UI buttons for the UI. Use ui_perform_action to respond to clicks.
 /datum/traitor_objective/proc/generate_ui_buttons(mob/user)

--- a/code/modules/antagonists/traitor/traitor_objective.dm
+++ b/code/modules/antagonists/traitor/traitor_objective.dm
@@ -153,7 +153,7 @@
 
 /// Converts the type into a useful debug string to be used for logging and debug display.
 /datum/traitor_objective/proc/to_debug_string()
-	return "[type] (Name: [name], TC: [telecrystal_reward], Progression: [progression_reward] Time of creation: [time_of_creation])"
+	return "[type] (Name: [name], TC: [telecrystal_reward], Progression: [progression_reward], Time of creation: [time_of_creation])"
 
 /datum/traitor_objective/proc/save_objective()
 	SSblackbox.record_feedback("associative", "traitor_objective", 1, get_log_data())

--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -118,6 +118,7 @@
 	if(!handle_duplicate(objective))
 		qdel(objective)
 		return
+	log_traitor("[key_name(handler.owner)] has received a potential objective: [objective.to_debug_string()]")
 	objective.original_progression = objective.progression_reward
 	objective.update_progression_reward()
 	potential_objectives += objective

--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -118,7 +118,7 @@
 	if(!handle_duplicate(objective))
 		qdel(objective)
 		return
-	log_traitor("[key_name(handler.owner)] has received a potential objective: [objective.to_debug_string()]")
+	log_traitor("[key_name(owner)] has received a potential objective: [objective.to_debug_string()]")
 	objective.original_progression = objective.progression_reward
 	objective.update_progression_reward()
 	potential_objectives += objective


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
See title
Adds logs for when an objective is added as a potential objective, taken as an active objective and on completion/failure. Also adds the new traitor objectives to the traitor panel.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Admins can see what objectives a traitor has taken, what objectives they have completed/failed/skipped and force succeed/fail them.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Added the objectives to the antag panel for admins.
admin: Added logs for when a player gets a potential objective, when a player takes an objective and when a player succeeds/fails an objective.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
