### PR TITLE
Don't eat camera upgrades when applied in assembly

### DIFF
--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -236,6 +236,14 @@
 	forceMove(C)
 	C.setDir(src.dir)
 
+	// Add upgrades
+	if(xray_module)
+		C.upgrades += CAMERA_UPGRADE_XRAY
+	if(emp_module)
+		C.upgrades += CAMERA_UPGRADE_EMP_PROOF
+	if(proxy_module)
+		C.upgrades += CAMERA_UPGRADE_MOTION
+
 	C.network = tempnetwork
 	var/area/A = get_area(src)
 	C.c_tag = "[A.name] ([rand(1, 999)])"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Security camera assemblies with upgrades lose them when finished and turned into a camera. This fixes that.

How has this bug been around since mid 2018? Does really no-one ever assemble cameras with upgrades?

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix. Also pleases our AI overlord.

Fixes #38591

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: mozi_h
fix: camera upgrades applied to an assembly will no longer be eaten by the void
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
