### PR TITLE
Suffles around DeltaStation's Walls

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2546,7 +2546,6 @@
 /area/command/heads_quarters/rd)
 "aGo" = (
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/newscaster/directional/east,
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -2560,6 +2559,9 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "aGu" = (
@@ -7496,9 +7498,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "bEK" = (
@@ -83686,6 +83685,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
 "rWh" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

On the tin. This PR addresses a weird graphical bug that can show up ghosts/AIs/anything that can see the full game window by shuffling around the wall-pieces in DeltaStation's Bar. 

![image](https://user-images.githubusercontent.com/34697715/149270067-a6f7767a-18f0-4e82-80d8-574755a31643.png)

Pretty much like that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/149270089-6b0555d9-4f1d-4ca7-9846-a65c7da1a998.png)

This doesn't exactly look good when you have that bird-eye view.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Moved the poster and newscaster in the bar on Deltastation so they aren't ontop of other wall objects for ghosts/AIs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
