### PR TITLE
Fixes assigning timers to prisoner IDs (for Tramstation)

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -989,7 +989,7 @@
 		to_chat(user, "Restating prisoner ID to default parameters.")
 		return
 	var/choice = tgui_input_number(user, "Sentence time in seconds", "Sentencing")
-	if(isnull(time_to_assign) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+	if(isnull(choice) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		return
 	time_to_assign = round(choice)
 	to_chat(user, "You set the sentence time to [time_to_assign] seconds.")


### PR DESCRIPTION
## About The Pull Request

TGUI conversion broke it, I assume. This fixes it.
I don't understand how this hasn't even been reported yet, isn't Tramstation in rotation??

## Why It's Good For The Game

Tramstation's Brig can now ACTUALLY be used

## Changelog

:cl:
fix: Assigning timers on people's IDs now work properly, yay Tramstation Brig!
/:cl: