### PR TITLE
Fixes the mess between ROLE_REV and ROLE_REV_HEAD

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -142,7 +142,6 @@ GLOBAL_LIST_INIT(special_roles, list(
 	ROLE_SYNDICATE_INFILTRATOR = 0,
 
 	// I'm not too sure why these are here, but they're not moving.
-	ROLE_REV = 14,
 	ROLE_PAI = 0,
 	ROLE_SENTIENCE = 0,
 ))

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -79,7 +79,7 @@
 	persistent = TRUE
 	antag_datum = /datum/antagonist/rev/head
 	antag_flag = ROLE_PROVOCATEUR
-	antag_flag_override = ROLE_REV
+	antag_flag_override = ROLE_REV_HEAD
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -473,7 +473,7 @@
 	name = "Revolution"
 	persistent = TRUE
 	antag_flag = ROLE_REV_HEAD
-	antag_flag_override = ROLE_REV
+	antag_flag_override = ROLE_REV_HEAD
 	antag_datum = /datum/antagonist/rev/head
 	minimum_required_age = 14
 	restricted_roles = list(

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -162,6 +162,7 @@
 /datum/antagonist/rev/head
 	name = "\improper Head Revolutionary"
 	antag_hud_name = "rev_head"
+	job_rank = ROLE_REV_HEAD
 
 	preview_outfit = /datum/outfit/revolutionary
 
@@ -368,7 +369,7 @@
 			var/list/datum/mind/nonhuman_promotable = list()
 			for(var/datum/mind/khrushchev in non_heads)
 				if(khrushchev.current && !khrushchev.current.incapacitated() && !HAS_TRAIT(khrushchev.current, TRAIT_RESTRAINED) && khrushchev.current.client)
-					if(ROLE_REV in khrushchev.current.client.prefs.be_special)
+					if(ROLE_REV_HEAD in khrushchev.current.client.prefs.be_special)
 						if(ishuman(khrushchev.current))
 							promotable += khrushchev
 						else

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -369,7 +369,7 @@
 			var/list/datum/mind/nonhuman_promotable = list()
 			for(var/datum/mind/khrushchev in non_heads)
 				if(khrushchev.current && !khrushchev.current.incapacitated() && !HAS_TRAIT(khrushchev.current, TRAIT_RESTRAINED) && khrushchev.current.client)
-					if(ROLE_REV_HEAD in khrushchev.current.client.prefs.be_special)
+					if((ROLE_REV_HEAD in khrushchev.current.client.prefs.be_special) || (ROLE_PROVOCATEUR in khrushchev.current.client.prefs.be_special))
 						if(ishuman(khrushchev.current))
 							promotable += khrushchev
 						else

--- a/code/modules/client/preferences/migrations/tgui_prefs_migration.dm
+++ b/code/modules/client/preferences/migrations/tgui_prefs_migration.dm
@@ -43,6 +43,8 @@
 	// "Familes [sic] Antagonists" was the old name of the catch-all.
 	migrate_antagonist("Familes Antagonists", list(ROLE_FAMILIES, ROLE_FAMILY_HEAD_ASPIRANT))
 
+// If you have an antagonist enabled, it will add the alternative preferences for said antag in be_special
+// will_exist is the role we check if enabled, to_add list is the antagonists we add onto the be_special list
 /datum/preferences/proc/migrate_antagonist(will_exist, list/to_add)
 	if (will_exist in be_special)
 		for (var/add in to_add)

--- a/code/modules/client/preferences/migrations/tgui_prefs_migration.dm
+++ b/code/modules/client/preferences/migrations/tgui_prefs_migration.dm
@@ -43,8 +43,8 @@
 	// "Familes [sic] Antagonists" was the old name of the catch-all.
 	migrate_antagonist("Familes Antagonists", list(ROLE_FAMILIES, ROLE_FAMILY_HEAD_ASPIRANT))
 
-// If you have an antagonist enabled, it will add the alternative preferences for said antag in be_special
-// will_exist is the role we check if enabled, to_add list is the antagonists we add onto the be_special list
+// If you have an antagonist enabled, it will add the alternative preferences for said antag in be_special.
+// will_exist is the role we check if enabled, to_add list is the antagonists we add onto the be_special list.
 /datum/preferences/proc/migrate_antagonist(will_exist, list/to_add)
 	if (will_exist in be_special)
 		for (var/add in to_add)


### PR DESCRIPTION
## About The Pull Request

If you are banned from Head revolutionary:
- You can roll Head rev in dynamic, as it checks for being banned from Rev, not Headrev
- You can still be a headrev, as headrevs are still Revs in job_rank (which is what gets used for banning)
- You can still be promoted to headrev, as it only checks revs in your preferences, not headrevs (revs not even being a preference option, only headrevs are)

If you are banned from REGULAR revolutionary:
- You cannot roll headrev
- You can't be promoted to headrev (though being converted to regular rev solves that)

## Why It's Good For The Game

Fixes this god damn mess, and also makes being promoted to headrevs, optional.

## Changelog

:cl:
qol: People who don't have head revolutionary enabled in their preference, will no longer be promoted to head revolutionaries by force.
fix: People banned from head revolutionary will no longer roll Head revolutionary.
/:cl: