### PR TITLE
Bounty Hunters as ERTs + Flame Id

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -101,3 +101,13 @@
 	mission = "Create entertainment for the crew."
 	polldesc = "a Code Rainbow Nanotrasen Emergency Response Party"
 	code = "Rainbow"
+
+/datum/ert/bounty_hunters
+	roles = list(/datum/antagonist/ert/bounty_armor, /datum/antagonist/ert/bounty_hook, /datum/antagonist/ert/bounty_synth)
+	leader_role = /datum/antagonist/ert/bounty_armor
+	teamsize = 3
+	opendoors = FALSE
+	rename_team = "Bounty Hunters"
+	mission = "Assist the station in catching perps, dead or alive."
+	polldesc = "a Centcom-hired bounty hunting gang"
+	random_names = FALSE

--- a/code/datums/id_trim/centcom.dm
+++ b/code/datums/id_trim/centcom.dm
@@ -38,6 +38,11 @@
 
 	access |= SSid_access.get_flag_access_list(ACCESS_FLAG_COMMON)
 
+/// Trim for Bounty Hunters hired by centcom.
+/datum/id_trim/centcom/bounty_hunter
+	access = list(ACCESS_CENT_GENERAL)
+	assignment = "Bounty Hunter"
+
 /// Trim for Centcom Bartenders.
 /datum/id_trim/centcom/bartender
 	access = list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING, ACCESS_CENT_BAR)

--- a/code/datums/id_trim/outfits.dm
+++ b/code/datums/id_trim/outfits.dm
@@ -40,3 +40,7 @@
 /datum/id_trim/tunnel_clown/New()
 	. = ..()
 	access |= SSid_access.get_region_access_list(list(REGION_ALL_STATION))
+
+/// Trim for Bounty Hunters NOT hired by centcom. (?)
+/datum/id_trim/bounty_hunter
+	assignment = "Bounty Hunter"

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -209,6 +209,18 @@
 	if(istype(new_team))
 		ert_team = new_team
 
+/datum/antagonist/ert/bounty_armor
+	role = "Armored Bounty Hunter"
+	outfit = /datum/outfit/bountyarmor/ert
+
+/datum/antagonist/ert/bounty_hook
+	role = "Hookgun Bounty Hunter"
+	outfit = /datum/outfit/bountyarmor/ert
+
+/datum/antagonist/ert/bounty_synth
+	role = "Synthetic Bounty Hunter"
+	outfit = /datum/outfit/bountysynth/ert
+
 /datum/antagonist/ert/proc/forge_objectives()
 	if(ert_team)
 		objectives |= ert_team.objectives

--- a/code/modules/antagonists/fugitive/fugitive_outfits.dm
+++ b/code/modules/antagonists/fugitive/fugitive_outfits.dm
@@ -141,7 +141,6 @@
 	if(visualsOnly)
 		return
 	var/obj/item/card/id/W = H.wear_id
-	W.assignment = "Bounty Hunter"
 	W.registered_name = H.real_name
 	W.update_label()
 	W.update_icon()
@@ -171,7 +170,6 @@
 	synthetic_appearance.assume_disguise(synthetic_appearance, H)
 	H.update_hair()
 	var/obj/item/card/id/W = H.wear_id
-	W.assignment = "Bounty Hunter"
 	W.registered_name = H.real_name
 	W.update_label()
 	W.update_icon()

--- a/code/modules/antagonists/fugitive/fugitive_outfits.dm
+++ b/code/modules/antagonists/fugitive/fugitive_outfits.dm
@@ -108,7 +108,7 @@
 	glasses = /obj/item/clothing/glasses/sunglasses/gar
 	ears = /obj/item/radio/headset
 	r_pocket = /obj/item/restraints/handcuffs/cable
-	id = /obj/item/card/id/advanced
+	id = /obj/item/card/id/advanced/bountyhunter
 	l_hand = /obj/item/tank/internals/plasma/full
 	r_hand = /obj/item/flamethrower/full/tank
 
@@ -116,7 +116,6 @@
 	if(visualsOnly)
 		return
 	var/obj/item/card/id/W = H.wear_id
-	W.assignment = "Bounty Hunter"
 	W.registered_name = H.real_name
 	W.update_label()
 	W.update_icon()
@@ -131,7 +130,7 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	mask = /obj/item/clothing/mask/scarecrow
 	r_pocket = /obj/item/restraints/handcuffs/cable
-	id = /obj/item/card/id/advanced
+	id = /obj/item/card/id/advanced/bountyhunter
 	r_hand = /obj/item/gun/ballistic/shotgun/hook
 
 	backpack_contents = list(
@@ -156,7 +155,7 @@
 	glasses = /obj/item/clothing/glasses/eyepatch
 	r_pocket = /obj/item/restraints/handcuffs/cable
 	ears = /obj/item/radio/headset
-	id = /obj/item/card/id/advanced
+	id = /obj/item/card/id/advanced/bountyhunter
 	r_hand = /obj/item/storage/firstaid/regular
 	l_hand = /obj/item/pinpointer/shuttle
 
@@ -176,3 +175,22 @@
 	W.registered_name = H.real_name
 	W.update_label()
 	W.update_icon()
+
+//ids and ert code
+
+/obj/item/card/id/advanced/bountyhunter
+	assignment = "Bounty Hunter"
+	icon_state = "card_flames" //oh SHIT
+	trim = /datum/id_trim/bounty_hunter
+
+/datum/outfit/bountyarmor/ert
+	id = /obj/item/card/id/advanced/bountyhunter/ert
+
+/datum/outfit/bountyhook/ert
+	id = /obj/item/card/id/advanced/bountyhunter/ert
+
+/datum/outfit/bountysynth/ert
+	id = /obj/item/card/id/advanced/bountyhunter/ert
+
+/obj/item/card/id/advanced/bountyhunter/ert
+	trim = /datum/id_trim/centcom/bounty_hunter


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bounty Hunters can now be called as ERTs, to which they will spawn at centcom with proper access. Also, the bounty hunters now get flame ids, because they think they're that cool.

## Why It's Good For The Game

Bounty Hunters are really fitting for admin erts, but I never bothered to throw them in until now. Also, it was a good opportunity to fuck off with all that id label BS

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Bounty Hunters can now be called via admin ert
expansion: Oh, and they have cool flame ids as well!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
