### PR TITLE
Standardizes + Adds some more variety to the ninja / traitor communications console hack 

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -769,6 +769,8 @@
 #define MIN_GHOSTS_FOR_PIRATES 4
 /// The minimum number of ghosts / observers to have the chance of spawning fugitives.
 #define MIN_GHOSTS_FOR_FUGITIVES 6
+/// The maximum percentage of the population to be ghosts before we no longer have the chance of spawning Sleeper Agents.
+#define MAX_PERCENT_GHOSTS_FOR_SLEEPER 0.2
 /// The amount of threat injected by a hack, if chosen.
 #define HACK_THREAT_INJECTION_AMOUNT 15
 
@@ -793,8 +795,8 @@
 	// Fugitives require empty space for the hunter's ship, and ghosts for both fugitives and hunters (Please no waldo)
 	if(SSmapping.empty_space && (num_ghosts >= MIN_GHOSTS_FOR_FUGITIVES))
 		hack_options += HACK_FUGITIVES
-	// If less than 20% of the population is ghosts, consider sleeper agents
-	if(num_ghosts < (length(GLOB.clients) * 0.2))
+	// If less than a certain percent of the population is ghosts, consider sleeper agents
+	if(num_ghosts < (length(GLOB.clients) * MAX_PERCENT_GHOSTS_FOR_SLEEPER))
 		hack_options += HACK_SLEEPER
 
 	var/picked_option = pick(hack_options)
@@ -868,6 +870,7 @@
 
 #undef MIN_GHOSTS_FOR_PIRATES
 #undef MIN_GHOSTS_FOR_FUGITIVES
+#undef MAX_PERCENT_GHOSTS_FOR_SLEEPER
 #undef HACK_THREAT_INJECTION_AMOUNT
 
 /datum/comm_message

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -782,7 +782,7 @@
  */
 /obj/machinery/computer/communications/proc/hack_console(mob/living/hacker)
 	// All hack results we'll choose from.
-	var/list/hack_options = list(HACK_SLEEPER, HACK_THREAT)
+	var/list/hack_options = list(HACK_THREAT)
 
 	// If we have a certain amount of ghosts, we'll add some more !!fun!! options to the list
 	var/num_ghosts = length(GLOB.current_observers_list) + length(GLOB.dead_player_list)
@@ -793,10 +793,9 @@
 	// Fugitives require empty space for the hunter's ship, and ghosts for both fugitives and hunters (Please no waldo)
 	if(SSmapping.empty_space && (num_ghosts >= MIN_GHOSTS_FOR_FUGITIVES))
 		hack_options += HACK_FUGITIVES
-
-	// If more than 10% of the population is ghosts, let's not even consider sleeper agents - they want ghost roles
-	if(num_ghosts >= (length(GLOB.clients) / 10))
-		hack_options -= HACK_SLEEPER
+	// If less than 20% of the population is ghosts, consider sleeper agents
+	if(num_ghosts < (length(GLOB.clients) * 0.2))
+		hack_options += HACK_SLEEPER
 
 	var/picked_option = pick(hack_options)
 	message_admins("[ADMIN_LOOKUPFLW(hacker)] hacked a [name] located at [ADMIN_VERBOSEJMP(src)], resulting in: [picked_option]!")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -794,8 +794,8 @@
 	if(SSmapping.empty_space && (num_ghosts >= MIN_GHOSTS_FOR_FUGITIVES))
 		hack_options += HACK_FUGITIVES
 
-	// If we have a really good amount of ghosts, let's not even consider sleeper agents - they want ghost roles
-	if(num_ghosts > 8)
+	// If more than 10% of the population is ghosts, let's not even consider sleeper agents - they want ghost roles
+	if(num_ghosts >= (length(GLOB.clients) / 10))
 		hack_options -= HACK_SLEEPER
 
 	var/picked_option = pick(hack_options)
@@ -808,7 +808,7 @@
 				)
 
 			var/datum/round_event_control/pirates/pirate_event = locate() in SSevents.control
-			if(!fugitive_event)
+			if(!pirate_event)
 				CRASH("hack_console() attempted to run pirates, but could not find an event controller!")
 			addtimer(CALLBACK(pirate_event, /datum/round_event_control.proc/runEvent), rand(20 SECONDS, 1 MINUTES))
 
@@ -828,6 +828,11 @@
 				"Attention crew, it appears that someone on your station has shifted your orbit into more dangerous territory.",
 				"[command_name()] High-Priority Update"
 				)
+
+			for(var/mob/crew_member as anything in GLOB.player_list)
+				if(!is_station_level(crew_member.z))
+					continue
+				shake_camera(crew_member, 15, 1)
 
 			var/datum/game_mode/dynamic/dynamic = SSticker.mode
 			dynamic.create_threat(HACK_THREAT_INJECTION_AMOUNT)

--- a/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
+++ b/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
@@ -37,11 +37,11 @@
 		return
 	if(!istype(target))
 		return
-	target.AI_notify_hack()
 	INVOKE_ASYNC(src, .proc/begin_hack, user, target)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /datum/traitor_objective/hack_comm_console/proc/begin_hack(mob/user, obj/machinery/computer/communications/target)
+	target.AI_notify_hack()
 	if(!do_after(user, 30 SECONDS, target))
 		return
 	succeed_objective()

--- a/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
+++ b/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
@@ -45,6 +45,4 @@
 	if(!do_after(user, 30 SECONDS, target))
 		return
 	succeed_objective()
-	priority_announce("Attention crew, it appears that someone on your station has made unexpected communication with a syndicate ship in nearby space.", "[command_name()] High-Priority Update")
-	var/datum/round_event_control/pirates/pirate_event = new/datum/round_event_control/pirates
-	pirate_event.runEvent()
+	target.hack_console(user)

--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -176,17 +176,16 @@
 	if(machine_stat & (NOPOWER|BROKEN))
 		return
 	AI_notify_hack()
-	if(do_after(ninja, 300))
-		priority_announce("Attention crew, it appears that someone on your station has made unexpected communication with a syndicate ship in nearby space.", "[command_name()] High-Priority Update")
-		var/datum/round_event_control/pirates/pirate_event = new/datum/round_event_control/pirates
-		pirate_event.runEvent()
-		ninja_gloves.communication_console_hack_success = TRUE
-		var/datum/antagonist/ninja/ninja_antag = ninja.mind.has_antag_datum(/datum/antagonist/ninja)
-		if(!ninja_antag)
-			return
-		var/datum/objective/terror_message/objective = locate() in ninja_antag.objectives
-		if(objective)
-			objective.completed = TRUE
+	if(!do_after(ninja, 30 SECONDS, src))
+		return
+	hack_console(ninja)
+	ninja_gloves.communication_console_hack_success = TRUE
+	var/datum/antagonist/ninja/ninja_antag = ninja.mind.has_antag_datum(/datum/antagonist/ninja)
+	if(!ninja_antag)
+		return
+	var/datum/objective/terror_message/objective = locate() in ninja_antag.objectives
+	if(objective)
+		objective.completed = TRUE
 
 //AIRLOCK//
 /obj/machinery/door/airlock/ninjadrain_act(obj/item/clothing/suit/space/space_ninja/ninja_suit, mob/living/carbon/human/ninja, obj/item/clothing/gloves/space_ninja/ninja_gloves)


### PR DESCRIPTION
## About The Pull Request

- Standardizes the two functions of hacking the communications console between ninjas and traitors. The code was copy pasted for some reason.
- Adds in 3 new options for hack results, resulting in 4 total:
  - If there are >4 ghosts and the map is in space, it can summon Pirates
  - If there are >6 ghosts and the map is in space, it can summon Fugitives
  - If less than 20% of the players are ghosts, it can inject 1-3 Syndicate Sleeper Agents into the crew
  - Lastly, it can flat inject 15 threat into the round. (the "default" option)

## Why It's Good For The Game

With the removal of Swarmers, ONLY pirates could be summoned by antagonists using a communications console. Now I like pirates, but the lack of variety is shameful.

So, I added a few other options to the pool to pick from:

- Pirates remain an option of course, they're great
- Fugitives were added if there are a good amount of ghosts
  - Fugitives have the power to cause a lot of problems but are rare and seem to only ever trigger when there's no ghosts, here's hoping that this gives them a little bit of showtime
- Sleeper Agents
  - If there aren't a whole lotta ghosts, Sleeper Agents are a good replacement for some people to cause problems
- Flat +15 threat (can be tweaked)
  - Threat can be used later to buy an antag to pose a moderate threat, like abductors or aliens
  - Why not just put the threats in the pool? I found it not as thematically appropriate for someone hacking a console to trigger "alien infestation" or whatever - so, I left the contents of the pool to be things that seem fitting

## Changelog

:cl: Melbert
expansion: Ninja / traitor comms hacking can now summon a wider variety of antags: Pirates, Fugitives, More traitors, or a flat dynamic threat increase!
/:cl:

