### PR TITLE
fixes typo in exploration drone's computer console

### DIFF
--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -537,7 +537,7 @@
 	build_path = /obj/machinery/computer/exoscanner_control
 
 /obj/item/circuitboard/computer/exodrone_console
-	name = "Exploration odrone control console (Computer Board)"
+	name = "Exploration Drone Control Console (Computer Board)"
 	build_path = /obj/machinery/computer/exodrone_control_console
 
 /obj/item/circuitboard/computer/service_orders


### PR DESCRIPTION
## About The Pull Request

## Why It's Good For The Game

Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.

## Changelog

:cl:
spellcheck: Exploration Drone Control Console's computer board is now properly spelled.
/:cl: