### PR TITLE
Completely removes Clown and Janitor borg modules for completely 100% replacing the jobs they were assigned to instead of supplementing and supporting them, along with adding an extra clown slot to make up for the reduction in clowns

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -165,83 +165,6 @@
 		R.model.basic_modules += S
 		R.model.add_module(S, FALSE, TRUE)
 
-/obj/item/borg/upgrade/tboh
-	name = "janitor cyborg trash bag of holding"
-	desc = "A trash bag of holding replacement for the janiborg's standard trash bag."
-	icon_state = "cyborg_upgrade3"
-	require_model = TRUE
-	model_type = list(/obj/item/robot_model/janitor)
-	model_flags = BORG_MODEL_JANITOR
-
-/obj/item/borg/upgrade/tboh/action(mob/living/silicon/robot/R)
-	. = ..()
-	if(.)
-		for(var/obj/item/storage/bag/trash/cyborg/TB in R.model.modules)
-			R.model.remove_module(TB, TRUE)
-
-		var/obj/item/storage/bag/trash/bluespace/cyborg/B = new /obj/item/storage/bag/trash/bluespace/cyborg(R.model)
-		R.model.basic_modules += B
-		R.model.add_module(B, FALSE, TRUE)
-
-/obj/item/borg/upgrade/tboh/deactivate(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if(.)
-		for(var/obj/item/storage/bag/trash/bluespace/cyborg/B in R.model.modules)
-			R.model.remove_module(B, TRUE)
-
-		var/obj/item/storage/bag/trash/cyborg/TB = new (R.model)
-		R.model.basic_modules += TB
-		R.model.add_module(TB, FALSE, TRUE)
-
-/obj/item/borg/upgrade/amop
-	name = "janitor cyborg advanced mop"
-	desc = "An advanced mop replacement for the janiborg's standard mop."
-	icon_state = "cyborg_upgrade3"
-	require_model = TRUE
-	model_type = list(/obj/item/robot_model/janitor)
-	model_flags = BORG_MODEL_JANITOR
-
-/obj/item/borg/upgrade/amop/action(mob/living/silicon/robot/R)
-	. = ..()
-	if(.)
-		for(var/obj/item/mop/cyborg/M in R.model.modules)
-			R.model.remove_module(M, TRUE)
-
-		var/obj/item/mop/advanced/cyborg/mop = new /obj/item/mop/advanced/cyborg(R.model)
-		R.model.basic_modules += mop
-		R.model.add_module(mop, FALSE, TRUE)
-
-/obj/item/borg/upgrade/amop/deactivate(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if(.)
-		for(var/obj/item/mop/advanced/cyborg/A in R.model.modules)
-			R.model.remove_module(A, TRUE)
-
-		var/obj/item/mop/cyborg/M = new (R.model)
-		R.model.basic_modules += M
-		R.model.add_module(M, FALSE, TRUE)
-
-/obj/item/borg/upgrade/prt
-	name = "janitor cyborg plating repair tool"
-	desc = "A tiny heating device to repair burnt and damaged hull platings with."
-	icon_state = "cyborg_upgrade3"
-	require_model = TRUE
-	model_type = list(/obj/item/robot_model/janitor)
-	model_flags = BORG_MODEL_JANITOR
-
-/obj/item/borg/upgrade/prt/action(mob/living/silicon/robot/R)
-	. = ..()
-	if(.)
-		var/obj/item/cautery/prt/P = new (R.model)
-		R.model.basic_modules += P
-		R.model.add_module(P, FALSE, TRUE)
-
-/obj/item/borg/upgrade/prt/deactivate(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if(.)
-		for(var/obj/item/cautery/prt/P in R.model.modules)
-			R.model.remove_module(P, TRUE)
-
 /obj/item/borg/upgrade/syndicate
 	name = "illegal equipment module"
 	desc = "Unlocks the hidden, deadlier functions of a cyborg."
@@ -667,12 +590,6 @@
 	. = ..()
 	if(. && new_model)
 		R.model.transform_to(new_model)
-
-/obj/item/borg/upgrade/transform/clown
-	name = "borg model picker (Clown)"
-	desc = "Allows you to to turn a cyborg into a clown, honk."
-	icon_state = "cyborg_upgrade3"
-	new_model = /obj/item/robot_model/clown
 
 /obj/item/borg/upgrade/circuit_app
 	name = "circuit manipulation apparatus"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -645,34 +645,6 @@
 		if (E)
 			R.model.remove_module(E, TRUE)
 
-/obj/item/borg/upgrade/broomer
-	name = "experimental push broom"
-	desc = "An experimental push broom used for efficiently pushing refuse."
-	icon_state = "cyborg_upgrade3"
-	require_model = TRUE
-	model_type = list(/obj/item/robot_model/janitor)
-	model_flags = BORG_MODEL_JANITOR
-
-/obj/item/borg/upgrade/broomer/action(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if (!.)
-		return
-	var/obj/item/pushbroom/cyborg/BR = locate() in R.model.modules
-	if (BR)
-		to_chat(user, span_warning("This janiborg is already equipped with an experimental broom!"))
-		return FALSE
-	BR = new(R.model)
-	R.model.basic_modules += BR
-	R.model.add_module(BR, FALSE, TRUE)
-
-/obj/item/borg/upgrade/broomer/deactivate(mob/living/silicon/robot/R, user = usr)
-	. = ..()
-	if (!.)
-		return
-	var/obj/item/pushbroom/cyborg/BR = locate() in R.model.modules
-	if (BR)
-		R.model.remove_module(BR, TRUE)
-
 ///This isn't an upgrade or part of the same path, but I'm gonna just stick it here because it's a tool used on cyborgs.
 //A reusable tool that can bring borgs back to life. They gotta be repaired first, though.
 /obj/item/borg_restart_board

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -3,8 +3,8 @@
 	description = "Entertain the crew, make bad jokes, go on a holy quest to find bananium, HONK!"
 	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
 	exp_granted_type = EXP_TYPE_CREW

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -169,7 +169,6 @@
 		"Engineering" = /obj/item/robot_model/engineering,
 		"Medical" = /obj/item/robot_model/medical,
 		"Miner" = /obj/item/robot_model/miner,
-		"Janitor" = /obj/item/robot_model/janitor,
 		"Service" = /obj/item/robot_model/service,
 	)
 	if(!CONFIG_GET(flag/disable_peaceborg))

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -150,17 +150,9 @@
 	. = ..()
 	INVOKE_ASYNC(model, /obj/item/robot_model.proc/transform_to, set_model, TRUE)
 
-/mob/living/silicon/robot/model/clown
-	set_model = /obj/item/robot_model/clown
-	icon_state = "clown"
-
 /mob/living/silicon/robot/model/engineering
 	set_model = /obj/item/robot_model/engineering
 	icon_state = "engineer"
-
-/mob/living/silicon/robot/model/janitor
-	set_model = /obj/item/robot_model/janitor
-	icon_state = "janitor"
 
 /mob/living/silicon/robot/model/medical
 	set_model = /obj/item/robot_model/medical

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -276,33 +276,6 @@
 		return FALSE
 	return TRUE
 
-/obj/item/robot_model/clown
-	name = "Clown"
-	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
-		/obj/item/toy/crayon/rainbow,
-		/obj/item/instrument/bikehorn,
-		/obj/item/stamp/clown,
-		/obj/item/bikehorn,
-		/obj/item/bikehorn/airhorn,
-		/obj/item/paint/anycolor,
-		/obj/item/soap/nanotrasen,
-		/obj/item/pneumatic_cannon/pie/selfcharge/cyborg,
-		/obj/item/razor, //killbait material
-		/obj/item/lipstick/purple,
-		/obj/item/reagent_containers/spray/waterflower/cyborg,
-		/obj/item/borg/cyborghug/peacekeeper,
-		/obj/item/borg/lollipop/clown,
-		/obj/item/picket_sign/cyborg,
-		/obj/item/reagent_containers/borghypo/clown,
-		/obj/item/extinguisher/mini)
-	emag_modules = list(
-		/obj/item/reagent_containers/borghypo/clown/hacked,
-		/obj/item/reagent_containers/spray/waterflower/cyborg/hacked)
-	model_select_icon = "service"
-	cyborg_base_icon = "clown"
-	hat_offset = -2
-
 /obj/item/robot_model/engineering
 	name = "Engineering"
 	basic_modules = list(
@@ -334,54 +307,6 @@
 	model_select_icon = "engineer"
 	model_traits = list(TRAIT_NEGATES_GRAVITY)
 	hat_offset = -4
-
-/obj/item/robot_model/janitor
-	name = "Janitor"
-	basic_modules = list(
-		/obj/item/assembly/flash/cyborg,
-		/obj/item/screwdriver/cyborg,
-		/obj/item/crowbar/cyborg,
-		/obj/item/stack/tile/iron/base/cyborg,
-		/obj/item/soap/nanotrasen,
-		/obj/item/storage/bag/trash/cyborg,
-		/obj/item/melee/flyswatter,
-		/obj/item/extinguisher/mini,
-		/obj/item/mop/cyborg,
-		/obj/item/reagent_containers/glass/bucket,
-		/obj/item/paint/paint_remover,
-		/obj/item/lightreplacer/cyborg,
-		/obj/item/holosign_creator/janibarrier,
-		/obj/item/reagent_containers/spray/cyborg_drying)
-	radio_channels = list(RADIO_CHANNEL_SERVICE)
-	emag_modules = list(/obj/item/reagent_containers/spray/cyborg_lube)
-	cyborg_base_icon = "janitor"
-	model_select_icon = "janitor"
-	hat_offset = -5
-	clean_on_move = TRUE
-
-/obj/item/reagent_containers/spray/cyborg_drying
-	name = "drying agent spray"
-	color = "#A000A0"
-	list_reagents = list(/datum/reagent/drying_agent = 250)
-
-/obj/item/reagent_containers/spray/cyborg_lube
-	name = "lube spray"
-	list_reagents = list(/datum/reagent/lube = 250)
-
-/obj/item/robot_model/janitor/respawn_consumable(mob/living/silicon/robot/cyborg, coeff = 1)
-	..()
-	var/obj/item/lightreplacer/light_replacer = locate(/obj/item/lightreplacer) in basic_modules
-	if(light_replacer)
-		for(var/charge in 1 to coeff)
-			light_replacer.Charge(cyborg)
-
-	var/obj/item/reagent_containers/spray/cyborg_drying/drying_agent = locate(/obj/item/reagent_containers/spray/cyborg_drying) in basic_modules
-	if(drying_agent)
-		drying_agent.reagents.add_reagent(/datum/reagent/drying_agent, 5 * coeff)
-
-	var/obj/item/reagent_containers/spray/cyborg_lube/lube = locate(/obj/item/reagent_containers/spray/cyborg_lube) in emag_modules
-	if(lube)
-		lube.reagents.add_reagent(/datum/reagent/lube, 2 * coeff)
 
 /obj/item/robot_model/medical
 	name = "Medical"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -796,15 +796,6 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
-/datum/design/borg_transform_clown
-	name = "Cyborg Upgrade (Clown Model)"
-	id = "borg_transform_clown"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/transform/clown
-	materials = list(/datum/material/iron = 15000, /datum/material/glass = 15000, /datum/material/bananium = 1000)
-	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
-
 /datum/design/borg_upgrade_selfrepair
 	name = "Cyborg Upgrade (Self-repair)"
 	id = "borg_upgrade_selfrepair"
@@ -847,33 +838,6 @@
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/processor
 	materials = list(/datum/material/iron = 5000, /datum/material/glass = 4000, /datum/material/silver = 4000)
-	construction_time = 40
-	category = list("Cyborg Upgrade Modules")
-
-/datum/design/borg_upgrade_trashofholding
-	name = "Cyborg Upgrade (Trash Bag of Holding)"
-	id = "borg_upgrade_trashofholding"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/tboh
-	materials = list(/datum/material/gold = 2000, /datum/material/uranium = 1000)
-	construction_time = 40
-	category = list("Cyborg Upgrade Modules")
-
-/datum/design/borg_upgrade_advancedmop
-	name = "Cyborg Upgrade (Advanced Mop)"
-	id = "borg_upgrade_advancedmop"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/amop
-	materials = list(/datum/material/iron = 2000, /datum/material/glass = 2000)
-	construction_time = 40
-	category = list("Cyborg Upgrade Modules")
-
-/datum/design/borg_upgrade_prt
-	name = "Cyborg Upgrade (Plating Repair Tool)"
-	id = "borg_upgrade_prt"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/prt
-	materials = list(/datum/material/iron = 2500, /datum/material/glass = 750) //same price as a cautery
 	construction_time = 40
 	category = list("Cyborg Upgrade Modules")
 

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -896,15 +896,6 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
-/datum/design/borg_upgrade_broomer
-	name = "Cyborg Upgrade (Experimental Push Broom)"
-	id = "borg_upgrade_broomer"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/broomer
-	materials = list(/datum/material/iron = 4000, /datum/material/glass = 500)
-	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
-
 //Misc
 /datum/design/mecha_tracking
 	name = "Exosuit Tracker (Exosuit Tracking Beacon)"

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -21,7 +21,7 @@ Cook=2,1
 Botanist=3,2
 Janitor=2,1
 
-Clown=1,1
+Clown=2,2
 Mime=1,1
 Curator=1,1
 Lawyer=2,2


### PR DESCRIPTION
## About The Pull Request

Completely removes Clown and Janitor borg modules for completely 100% replacing the jobs they were assigned to instead of supplementing and supporting them

Adds another Clown slot at the request of @Kylerace 

## Why It's Good For The Game
![149504733-17fe7d0a-7e4a-43f0-8f9a-a00de8a3bbdc](https://user-images.githubusercontent.com/4081722/149549146-2b6bdafe-ff96-4b62-911b-e2426bf33c04.png)
![149473017-b7e56931-e751-4f5d-9374-1767f9427a22 (1)](https://user-images.githubusercontent.com/4081722/149549154-fcf5076b-a912-4c28-8656-23f5beb830f2.png)

janiborgs and clown borgs suck and, by merely existing on the station, completely obsolete their human/lizard/felinid/moth/plasmaman/ethereal counterparts

they're bad cyborg modules on that alone

to make up for the reduction in clowns, and to ensure everything is perfectly balanced as all things should be, the clown job has been given another slot at maintainer request

## Changelog

:cl:
del: Completely removes Clown and Janitor borg modules
add: another clown slot
/:cl:
