### PR TITLE
Borgs can now interact with recharging stations in low-power mode

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -277,8 +277,8 @@
 	queueAlarm("--- [alarm_type] alarm in [source_area.name] has been cleared.", alarm_type, FALSE)
 
 /mob/living/silicon/robot/can_interact_with(atom/A)
-	if (A == modularInterface)
-		return TRUE //bypass for borg tablets
+	if ((A == modularInterface) || (istype(A, /obj/machinery/recharge_station)))
+		return TRUE //bypass for borg tablets and recharging stations
 	if (low_power_mode)
 		return FALSE
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, if a cyborg loses power or has a new power cell upgraded with no charge, they can move TO a recharging station but cannot click on it to close it around them and begin charging. This minor code change effectively allows borgs with no power to interact with a recharging station, allowing them to begin recharging themselves if, for example, the Roboticist upgrades them with a completely drained power cell and then walks off, leaving the borg to seek out someone that just needs to click once on the recharging station to get power flowing again.

In case any more convincing is needed:

Without any power, borgs are able to:
1. Talk freely, locally on the radio, or in Robotic chat
2. Move anywhere
3. Climb tables
4. Pull objects
5. Interact with their tablet/modular interface - Check diagnostics, view upgrades
6. State laws
7. Use/toggle sensor overlay (health, Sechud)
8. Toggle combat mode (but cannot attack)
9. Interact with radio settings
10. Interact with camera - Take pictures and print images

...So then why not be able to click on only a recharging station and nothing else? No other machines, no doors, no mobs, nothing. Hell, take away all of the above except for moving freely, and a single click on a recharging station can bring it all back.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Borgs can now interact with recharging stations in low-power mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
