### PR TITLE
Replaces the passive janiborg cleaning with an active version 

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -28,6 +28,13 @@
 		toggle_headlamp(TRUE)
 	diag_hud_set_borgcell()
 
+#define CLEANING_MODE_POWER_DRAW 30
+/mob/living/silicon/robot/model/janitor/use_power(delta_time, times_fired)
+	. = ..()
+	if(cell?.charge && model.clean_on_move)
+		cell.use(CLEANING_MODE_POWER_DRAW)
+#undef CLEANING_MODE_POWER_DRAW
+
 /mob/living/silicon/robot/proc/handle_robot_hud_updates()
 	if(!client)
 		return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -717,11 +717,6 @@
 		for(var/trait in model.model_traits)
 			ADD_TRAIT(src, trait, MODEL_TRAIT)
 
-	if(model.clean_on_move)
-		AddElement(/datum/element/cleaning)
-	else
-		RemoveElement(/datum/element/cleaning)
-
 	hat_offset = model.hat_offset
 
 	INVOKE_ASYNC(src, .proc/updatename)

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -161,6 +161,11 @@
 /mob/living/silicon/robot/model/janitor
 	set_model = /obj/item/robot_model/janitor
 	icon_state = "janitor"
+	var/datum/action/jani_powers/jani_powers = new /datum/action/jani_powers
+
+/mob/living/silicon/robot/model/janitor/Initialize(mapload)
+	. = ..()
+	jani_powers.Grant(src)
 
 /mob/living/silicon/robot/model/medical
 	set_model = /obj/item/robot_model/medical

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -376,6 +376,7 @@
 	button_icon_state = "mop"
 
 /datum/action/jani_powers/Trigger()
+	. = ..()
 	var/mob/living/silicon/robot/janitor = owner
 	var/obj/item/robot_model/janitor_model = janitor.model
 	if (janitor_model.clean_on_move)

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -383,16 +383,30 @@
 	else
 		start_cleaning(janitor, janitor_model)
 
+/**
+ * stops the janiborg cleaning ability
+ *
+ * Arguments:
+ * * mob/living/silicon/robot/janitor - The cyborg
+ * * obj/item/robot_model/janitor_model - The cyborg's model
+ */
 /datum/action/jani_powers/proc/stop_cleaning(mob/living/silicon/robot/janitor, obj/item/robot_model/janitor_model)
 	janitor_model.clean_on_move = FALSE
 	janitor.RemoveElement(/datum/element/cleaning)
-	janitor.audible_message("[owner] ceases humming.", "[owner] ceases vibrating.")
+	janitor.audible_message(span_notice("[owner] ceases humming."), span_notice("[owner] ceases vibrating."))
 	janitor.remove_movespeed_modifier(/datum/movespeed_modifier/janiborg_cleaning)
 
+/**
+ * starts the janiborg cleaning ability
+ *
+ * Arguments:
+ * * mob/living/silicon/robot/janitor - The cyborg
+ * * obj/item/robot_model/janitor_model - The cyborg's model
+ */
 /datum/action/jani_powers/proc/start_cleaning(mob/living/silicon/robot/janitor, obj/item/robot_model/janitor_model)
 	janitor_model.clean_on_move = TRUE
 	janitor.AddElement(/datum/element/cleaning)
-	janitor.audible_message("[owner] begins to hum loudly!", "[owner] appears to vibrate slightly.")
+	janitor.audible_message(span_notice("[owner] begins to hum loudly!"), span_notice("[owner] appears to vibrate slightly."))
 	janitor.add_movespeed_modifier(/datum/movespeed_modifier/janiborg_cleaning)
 
 

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -396,6 +396,8 @@
 	janitor.audible_message(span_notice("[owner] ceases humming."), span_notice("[owner] ceases vibrating."))
 	janitor.remove_movespeed_modifier(/datum/movespeed_modifier/janiborg_cleaning)
 
+	animate(janitor, pixel_x = janitor.base_pixel_x, pixel_y = janitor.base_pixel_y, time = 2)
+
 /**
  * starts the janiborg cleaning ability
  *
@@ -408,6 +410,19 @@
 	janitor.AddElement(/datum/element/cleaning)
 	janitor.audible_message(span_notice("[owner] begins to hum loudly!"), span_notice("[owner] appears to vibrate slightly."))
 	janitor.add_movespeed_modifier(/datum/movespeed_modifier/janiborg_cleaning)
+
+	var/base_x = janitor.base_pixel_x
+	var/base_y = janitor.base_pixel_y
+	janitor.pixel_x = base_x + rand(-7, 7)
+	janitor.pixel_y = base_y + rand(-7, 7)
+	//Larger shake with more changes to start out, feels like "Revving"
+	var/x_offset = 0
+	var/y_offset = 0
+	animate(janitor, pixel_x = base_x, pixel_y = base_y, time = 1, loop = -1)
+	for(var/i in 1 to 100)
+		x_offset = base_x + rand(-2, 2)
+		y_offset = base_y + rand(-2, 2)
+		animate(pixel_x = x_offset, pixel_y = y_offset, time = 1)
 
 
 /obj/item/reagent_containers/spray/cyborg_drying

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -126,3 +126,6 @@
 
 /datum/movespeed_modifier/morph_disguised
 	multiplicative_slowdown = 1
+
+/datum/movespeed_modifier/janiborg_cleaning
+	multiplicative_slowdown = 5


### PR DESCRIPTION
## About The Pull Request
This removes the insanely overpowered passive ability for janiborgs to
immedaitely and inconsequentially cleanup messes, with an active
cleaning ability instead.
When the cleaning ability is activated it applies a heavy slowdown to the borg, as well as a consistent power draw.
The ability is given as an action button.

(Alternative to https://github.com/tgstation/tgstation/pull/64105)
(im 100% willing to change the numbers chosen for both slowdown and powerdraw if people feel they are too harsh/not harsh enough)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/16159590/149612036-0626c2c6-d6de-404e-96be-547d3b1de92f.png)

but more seriously:
The janiborg is a pretty unfair cyborg replacement for the janitor. If there is a janitor + janiborg on the station the janitor is essentially out of the job. The janitor must employ various different techniques to clean: some are time consuming, others are costly but quick. The janiborg on the otherhand just strolls through an area and cleans it immediately. It removes all of the substance from playing janitor, an already relatively low content job.
While I don't think outright removing the janiborg from the game would be a good idea as when theres no janitor, a cyborg replacement is very useful. But, I do believe that they are far too "powerful" when there are actual janitors around.
So i feel that making the instant cleaning at least have some drawback and added weight, won't just ruin a normal janitor's round.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Turns the janiborg's passive cleaning ability into an active one, requiring extra power and slower movement speeds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
