### PR TITLE
Nerfs atmos gas mask

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -100,7 +100,6 @@
 	icon_state = "gas_atmos"
 	inhand_icon_state = "gas_atmos"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 20, ACID = 10)
-	w_class = WEIGHT_CLASS_SMALL
 	permeability_coefficient = 0.001
 	resistance_flags = FIRE_PROOF
 	max_filters = 3


### PR DESCRIPTION
## About The Pull Request

Makes the atmos gas mask normal size, in line with every other of its type.

## Why It's Good For The Game

Having one mask be objectively better than its counterparts for no apparent reason is bizarre. It already gives you pepper protection and is fireproof.

## Changelog
:cl:
balance: Atmospheric gas masks are now normal-sized, the same as other full-face gas masks.
/:cl: