### PR TITLE
Ash drake shapeshifting now converts health, fixes 60567

### DIFF
--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -136,7 +136,6 @@
 	name = "Dragon Form"
 	desc = "Take on the shape a lesser ash drake."
 	invocation = "RAAAAAAAAWR!"
-	convert_damage = TRUE
 
 
 	shapeshift_type = /mob/living/simple_animal/hostile/megafauna/dragon/lesser

--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -136,7 +136,7 @@
 	name = "Dragon Form"
 	desc = "Take on the shape a lesser ash drake."
 	invocation = "RAAAAAAAAWR!"
-	convert_damage = FALSE
+	convert_damage = TRUE
 
 
 	shapeshift_type = /mob/living/simple_animal/hostile/megafauna/dragon/lesser


### PR DESCRIPTION
Miners shouldn't have 2 healthbars considering they are also super stocked on armor fixes #60567


:cl: Improvedname
fix: Ash drake shapeshift now converts your health like shapeshifting is supposed to
/:cl:
