### PR TITLE
Adds blood brother teammates to antag info

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -5,6 +5,7 @@
 	var/special_role = ROLE_BROTHER
 	antag_hud_name = "brother"
 	hijack_speed = 0.5
+	ui_name = "AntagInfoBrother"
 	suicide_cry = "FOR MY BROTHER!!"
 	var/datum/team/brother_team/team
 	antag_moodlet = /datum/mood_event/focused
@@ -110,6 +111,13 @@
 	T.update_name()
 	message_admins("[key_name_admin(admin)] made [key_name_admin(new_owner)] and [key_name_admin(bro)] into blood brothers.")
 	log_admin("[key_name(admin)] made [key_name(new_owner)] and [key_name(bro)] into blood brothers.")
+
+/datum/antagonist/brother/ui_static_data(mob/user)
+	var/list/data = list()
+	data["antag_name"] = name
+	data["objectives"] = get_objectives()
+	data["brothers"] = get_brother_names()
+	return data
 
 /datum/team/brother_team
 	name = "brotherhood"

--- a/tgui/packages/tgui/interfaces/AntagInfoBrother.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoBrother.tsx
@@ -1,0 +1,67 @@
+import { useBackend } from '../backend';
+import { Section, Stack } from '../components';
+import { BooleanLike } from 'common/react';
+import { Window } from '../layouts';
+
+type Objective = {
+  count: number;
+  name: string;
+  explanation: string;
+  complete: BooleanLike;
+  was_uncompleted: BooleanLike;
+  reward: number;
+}
+
+type Info = {
+  antag_name: string;
+  objectives: Objective[];
+  brothers: string;
+};
+
+export const AntagInfoBrother = (props, context) => {
+  const { data } = useBackend<Info>(context);
+  const {
+    antag_name,
+    brothers,
+  } = data;
+  return (
+    <Window
+      width={620}
+      height={250}>
+      <Window.Content>
+        <Section scrollable fill>
+          <Stack vertical>
+            <Stack.Item textColor="red" fontSize="20px">
+              You are the {antag_name} of {brothers}!
+            </Stack.Item>
+            <Stack.Item>
+              <ObjectivePrintout />
+            </Stack.Item>
+          </Stack>
+        </Section>
+      </Window.Content>
+    </Window>
+  );
+};
+
+const ObjectivePrintout = (props, context) => {
+  const { data } = useBackend<Info>(context);
+  const {
+    objectives,
+  } = data;
+  return (
+    <Stack vertical>
+      <Stack.Item bold>
+        Your objectives:
+      </Stack.Item>
+      <Stack.Item>
+        {!objectives && "None!"
+        || objectives.map(objective => (
+          <Stack.Item key={objective.count}>
+            #{objective.count}: {objective.explanation}
+          </Stack.Item>
+        )) }
+      </Stack.Item>
+    </Stack>
+  );
+};


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes blood brother antag info display the names of their blood brothers.

![image](https://user-images.githubusercontent.com/5479091/149637286-2af10156-ebad-4faa-8aea-40cb26c6f1bd.png)

## Why It's Good For The Game

Fixes #64009

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Blood brothers will now be told who their teammates are in their antagonist info window.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
