### PR TITLE
Fixes windoor electronics removal

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -295,7 +295,7 @@
 		dropped_electronics = electronics
 		electronics = null
 		dropped_electronics.forceMove(drop_location())
-		qdel(src)
+	qdel(src)
 	return TRUE
 
 /obj/machinery/door/window/interact(mob/user) //for sillycones


### PR DESCRIPTION
## About The Pull Request

Correctly indents a qdel adjusted in https://github.com/tgstation/tgstation/pull/63690, meaning windoors will be deleted once their electronics are removed. This prevents you from making infinite electronics & assemblies from the same windoor.

Fixes https://github.com/tgstation/tgstation/issues/64069

## Why It's Good For The Game

Bugfix

## Changelog
:cl:
fix: Windoors can now have their electronics removed without creating infinite assemblies.
/:cl: