### PR TITLE
Slightly* buffs Maint Drones

### DIFF
--- a/code/datums/components/shy.dm
+++ b/code/datums/components/shy.dm
@@ -20,7 +20,7 @@
 	/// What was our last result?
 	var/last_result = FALSE
 
-/datum/component/shy/Initialize(mob_whitelist, shy_range, message, dead_shy, dead_shy_immediate machine_whitelist)
+/datum/component/shy/Initialize(mob_whitelist, shy_range, message, dead_shy, dead_shy_immediate, machine_whitelist)
 	if(!ismob(parent))
 		return COMPONENT_INCOMPATIBLE
 	src.mob_whitelist = mob_whitelist

--- a/code/datums/components/shy.dm
+++ b/code/datums/components/shy.dm
@@ -13,7 +13,7 @@
 	var/message = "You find yourself too shy to do that around %TARGET!"
 	/// Are you shy around a dead body?
 	var/dead_shy = FALSE
-	/// If dead_shy is false and this is true, you're only shy when next to a dead target
+	/// If dead_shy is false and this is true, you're only shy when right next to a dead target
 	var/dead_shy_immediate = TRUE
 	/// Invalidate last_result at this time
 	COOLDOWN_DECLARE(result_cooldown)
@@ -84,7 +84,9 @@
 			if(!is_type_in_typecache(person, mob_whitelist))
 				continue
 			if(person.stat == DEAD && !dead_shy)
-				if(!dead_shy_immediate || !owner.DirectAccess(person))
+				if(!dead_shy_immediate)
+					continue
+				else if(!owner.DirectAccess(person))
 					continue
 			to_chat(owner, span_warning("[replacetext(message, "%TARGET", person)]"))
 			result = TRUE

--- a/code/datums/components/shy.dm
+++ b/code/datums/components/shy.dm
@@ -13,12 +13,14 @@
 	var/message = "You find yourself too shy to do that around %TARGET!"
 	/// Are you shy around a dead body?
 	var/dead_shy = FALSE
+	/// If dead_shy is false and this is true, you're only shy when next to a dead target
+	var/dead_shy_immediate = TRUE
 	/// Invalidate last_result at this time
 	COOLDOWN_DECLARE(result_cooldown)
 	/// What was our last result?
 	var/last_result = FALSE
 
-/datum/component/shy/Initialize(mob_whitelist, shy_range, message, dead_shy, machine_whitelist)
+/datum/component/shy/Initialize(mob_whitelist, shy_range, message, dead_shy, dead_shy_immediate machine_whitelist)
 	if(!ismob(parent))
 		return COMPONENT_INCOMPATIBLE
 	src.mob_whitelist = mob_whitelist
@@ -28,6 +30,8 @@
 		src.message = message
 	if(dead_shy)
 		src.dead_shy = dead_shy
+	if(dead_shy_immediate)
+		src.dead_shy_immediate = dead_shy_immediate
 	if(machine_whitelist)
 		src.machine_whitelist = machine_whitelist
 
@@ -75,10 +79,16 @@
 
 	if(length(strangers) && locate(/mob/living) in strangers)
 		for(var/mob/living/person in strangers)
-			if(person != owner && !is_type_in_typecache(person, mob_whitelist) && (person.stat != DEAD || dead_shy))
-				to_chat(owner, span_warning("[replacetext(message, "%TARGET", person)]"))
-				result = TRUE
-				break
+			if(person == owner)
+				continue
+			if(!is_type_in_typecache(person, mob_whitelist))
+				continue
+			if(person.stat == DEAD && !dead_shy)
+				if(!dead_shy_immediate || !owner.DirectAccess(person))
+					continue
+			to_chat(owner, span_warning("[replacetext(message, "%TARGET", person)]"))
+			result = TRUE
+			break
 
 	last_result = result
 	COOLDOWN_START(src, result_cooldown, SHY_COMPONENT_CACHE_TIME)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -338,7 +338,7 @@
 	var/static/list/not_shy_of = typecacheof(list(/mob/living/simple_animal/drone, /mob/living/simple_animal/bot))
 	if(shy)
 		ADD_TRAIT(src, TRAIT_PACIFISM, DRONE_SHY_TRAIT)
-		LoadComponent(/datum/component/shy, not_shy_of, 3, "Your laws prevent this action near %TARGET.", TRUE, shy_machine_whitelist)
+		LoadComponent(/datum/component/shy, not_shy_of, shy_range=3, "Your laws prevent this action near %TARGET.", dead_shy=FALSE, dead_shy_immediate=TRUE, shy_machine_whitelist)
 		LoadComponent(/datum/component/shy_in_room, drone_bad_areas, "Touching anything in %ROOM could break your laws.")
 		LoadComponent(/datum/component/technoshy, 1 MINUTES, "%TARGET was touched by a being recently, using it could break your laws.")
 		LoadComponent(/datum/component/itempicky, drone_good_items, "Using %TARGET could break your laws.")

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -338,7 +338,7 @@
 	var/static/list/not_shy_of = typecacheof(list(/mob/living/simple_animal/drone, /mob/living/simple_animal/bot))
 	if(shy)
 		ADD_TRAIT(src, TRAIT_PACIFISM, DRONE_SHY_TRAIT)
-		LoadComponent(/datum/component/shy, not_shy_of, shy_range=3, "Your laws prevent this action near %TARGET.", dead_shy=FALSE, dead_shy_immediate=TRUE, shy_machine_whitelist)
+		LoadComponent(/datum/component/shy, mob_whitelist=not_shy_of, shy_range=3, message="Your laws prevent this action near %TARGET.", dead_shy=FALSE, dead_shy_immediate=TRUE, machine_whitelist=shy_machine_whitelist)
 		LoadComponent(/datum/component/shy_in_room, drone_bad_areas, "Touching anything in %ROOM could break your laws.")
 		LoadComponent(/datum/component/technoshy, 1 MINUTES, "%TARGET was touched by a being recently, using it could break your laws.")
 		LoadComponent(/datum/component/itempicky, drone_good_items, "Using %TARGET could break your laws.")

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -20,8 +20,8 @@
 	icon_state = "drone_maint_grey"
 	icon_living = "drone_maint_grey"
 	icon_dead = "drone_maint_dead"
-	health = 30
-	maxHealth = 30
+	health = 45
+	maxHealth = 45
 	unsuitable_atmos_damage = 0
 	minbodytemp = 0
 	maxbodytemp = 0
@@ -296,7 +296,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	Stun(100)
+	Stun(70)
 	to_chat(src, span_danger("<b>ER@%R: MME^RY CO#RU9T!</b> R&$b@0tin)..."))
 	if(severity == 1)
 		adjustBruteLoss(heavy_emp_damage)
@@ -338,9 +338,9 @@
 	var/static/list/not_shy_of = typecacheof(list(/mob/living/simple_animal/drone, /mob/living/simple_animal/bot))
 	if(shy)
 		ADD_TRAIT(src, TRAIT_PACIFISM, DRONE_SHY_TRAIT)
-		LoadComponent(/datum/component/shy, not_shy_of, 4, "Your laws prevent this action near %TARGET.", TRUE, shy_machine_whitelist)
+		LoadComponent(/datum/component/shy, not_shy_of, 3, "Your laws prevent this action near %TARGET.", TRUE, shy_machine_whitelist)
 		LoadComponent(/datum/component/shy_in_room, drone_bad_areas, "Touching anything in %ROOM could break your laws.")
-		LoadComponent(/datum/component/technoshy, 5 MINUTES, "%TARGET was touched by a being recently, using it could break your laws.")
+		LoadComponent(/datum/component/technoshy, 1 MINUTES, "%TARGET was touched by a being recently, using it could break your laws.")
 		LoadComponent(/datum/component/itempicky, drone_good_items, "Using %TARGET could break your laws.")
 		RegisterSignal(src, COMSIG_TRY_USE_MACHINE, .proc/blacklist_on_try_use_machine)
 		RegisterSignal(src, COMSIG_TRY_WIRES_INTERACT, .proc/blacklist_on_try_wires_interact)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1. Increases drone health from 30 to 45, making it harder to instantly die from some things
2. Lowers the range that drones can't do interactions from 4 tiles to 3 tiles
3. Lowers stun time from 10 seconds to 7 seconds when EMP'd
4. Wait time for when a mob has recently interacted with something has been decreased from 5 minutes to 1 minute
5. Drones can now build near dead mobs, but not interact when right next to them (to prevent pulling)

Also adds a new argument for the shy component that allows interacting near dead bodies, but not right on top of them

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is mainly for the QOL of Drones. I know "maint" is implied in the name of drones, but it sucks that you have to hide in maint for half the shift while all the airlocks are being opened by everyone, being unable to fix the station from explosions. Also even though the range was 4 tiles for interacting next to living mobs, it seemed a bit excessive when you tried to do stuff.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: Maintenance Drone health changed from 30 to 45
balance: Maintenance Drone stun times from getting EMP'd reduced from 10 seconds to 7 seconds
qol: Maintenance Drones can now interact near dead bodies
qol: Maintenance Drones don't have to wait 5 minutes to open an airlock when someone recently did it. Now they have to wait 1 minute.
qol: Changed distance Maintenance Drones aren't allowed to interact with anything from a nearby mob from 4 tiles to 3 tiles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
