### PR TITLE
Reduces the temperature increase caused by the virus plasma and weakened virus plasma chemical reactions

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -187,10 +187,12 @@
 /datum/chemical_reaction/virus_food_plasma
 	results = list(/datum/reagent/toxin/plasma/plasmavirusfood = 1)
 	required_reagents = list(/datum/reagent/toxin/plasma = 1, /datum/reagent/consumable/virus_food = 1)
+	thermic_constant = 20 // To avoid the plasma boiling
 
 /datum/chemical_reaction/virus_food_plasma_synaptizine
 	results = list(/datum/reagent/toxin/plasma/plasmavirusfood/weak = 2)
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 1, /datum/reagent/toxin/plasma/plasmavirusfood = 1)
+	thermic_constant = 20 // To avoid the plasma boiling
 
 /datum/chemical_reaction/virus_food_mutagen_sugar
 	results = list(/datum/reagent/toxin/mutagen/mutagenvirusfood/sugar = 2)


### PR DESCRIPTION
## About The Pull Request

Lowers the thermic constant for the virus plasma and weak virus plasma recipes from the default 50 to 20
Fixes https://github.com/tgstation/tgstation/issues/63944

## Why It's Good For The Game

Plasmaflooding viro when trying to just do your job is not fun.

Technically this is also an issue in any reaction needing plasma, but all drinks already have a thermic constant of 0 and temperature is something chemists should be managing anyway.
Seems a little unfair to apply that to the viro, though.

## Changelog
:cl:
fix: Trying to make weak virus plasma will no longer plasmaflood virology.
/:cl: