### PR TITLE
Fixes simplebots taking damage when using tools on them.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -407,23 +407,22 @@
 				if (paicard)
 					user.visible_message(span_notice("[user] uses [attacking_item] to pull [paicard] out of [initial(src.name)]!"),span_notice("You pull [paicard] out of [initial(src.name)] with [attacking_item]."))
 					ejectpai(user)
-	else
+	else if(attacking_item.tool_behaviour == TOOL_WELDER && !user.combat_mode)
 		user.changeNext_move(CLICK_CD_MELEE)
-		if(attacking_item.tool_behaviour == TOOL_WELDER && !user.combat_mode)
-			if(health >= maxHealth)
-				to_chat(user, span_warning("[src] does not need a repair!"))
-				return
-			if(!(bot_cover_flags & BOT_COVER_OPEN))
-				to_chat(user, span_warning("Unable to repair with the maintenance panel closed!"))
-				return
+		if(health >= maxHealth)
+			to_chat(user, span_warning("[src] does not need a repair!"))
+			return
+		if(!(bot_cover_flags & BOT_COVER_OPEN))
+			to_chat(user, span_warning("Unable to repair with the maintenance panel closed!"))
+			return
 
-			if(attacking_item.use_tool(src, user, 0, volume=40))
-				adjustHealth(-10)
-				user.visible_message(span_notice("[user] repairs [src]!"),span_notice("You repair [src]."))
-		else
-			if(attacking_item.force) //if force is non-zero
-				do_sparks(5, TRUE, src)
-	..()
+		if(attacking_item.use_tool(src, user, 0, volume=40))
+			adjustHealth(-10)
+			user.visible_message(span_notice("[user] repairs [src]!"),span_notice("You repair [src]."))
+	else
+		if(attacking_item.force) //if force is non-zero
+			do_sparks(5, TRUE, src)
+		..()
 
 /mob/living/simple_animal/bot/bullet_act(obj/projectile/Proj, def_zone, piercing_hit = FALSE)
 	if(Proj && (Proj.damage_type == BRUTE || Proj.damage_type == BURN))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes simplebots (floorbots, firebots, etc.) getting harmed when using tools on them (screwdriver to unscrew their panel, welder to heal), making it impossible to heal them with welders, among other issues.

## Why It's Good For The Game

Bugs are bad.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Simplebots can now have tools used on them without injuring them in the process.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
