### PR TITLE
Maybe fixes podpeople cloning not properly working for objectives

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -144,7 +144,6 @@
 						if(!O.can_reenter_corpse)
 							break
 					make_podman = TRUE
-					ckey_holder = M.ckey
 					break
 
 	// No podman player, give one or two seeds.

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -123,7 +123,6 @@
 /obj/item/seeds/replicapod/harvest(mob/user) //now that one is fun -- Urist
 	var/obj/machinery/hydroponics/parent = loc
 	var/make_podman = FALSE
-	var/ckey_holder = null
 	var/list/result = list()
 	if(CONFIG_GET(flag/revival_pod_plants))
 		if(ckey)

--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -182,14 +182,11 @@
 	var/mob/living/carbon/human/podman = new /mob/living/carbon/human(parent.loc)
 
 	if(realName)
-		podman.real_name = realName
+		podman.fully_replace_character_name(null, realName)
 	else
 		podman.real_name = "Pod Person ([rand(1,999)])"
+
 	mind.transfer_to(podman)
-	if(ckey)
-		podman.ckey = ckey
-	else
-		podman.ckey = ckey_holder
 	podman.gender = blood_gender
 	podman.faction |= factions
 	if(!features["mcolor"])


### PR DESCRIPTION
## About The Pull Request

uses fully_replace_character_name() instead of just real_name

Also:
![image](https://user-images.githubusercontent.com/53777086/149677648-5c947c8c-ce92-4451-9aaa-98b453d367c2.png)

## Why It's Good For The Game

Not entirely sure, but this might fix https://github.com/tgstation/tgstation/issues/64133 (because the objective should update to say their podperson name, not that the round ended with them as the goal)

## Changelog

I am quite scared of adding 'fix' here since I don't know if this actually fixes the maroon objective. At most I think this is just 'code improvement'.