### PR TITLE
Adjusts dismemberment message

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -20,6 +20,7 @@
 #define span_blueteamradio(str) ("<span class='blueteamradio'>" + str + "</span>")
 #define span_bold(str) ("<span class='bold'>" + str + "</span>")
 #define span_boldannounce(str) ("<span class='boldannounce'>" + str + "</span>")
+#define span_bolddanger(str) ("<span class='bolddanger'>" + str + "</span>")
 #define span_boldnotice(str) ("<span class='boldnotice'>" + str + "</span>")
 #define span_boldwarning(str) ("<span class='boldwarning'>" + str + "</span>")
 #define span_centcomradio(str) ("<span class='centcomradio'>" + str + "</span>")

--- a/code/datums/wounds/loss.dm
+++ b/code/datums/wounds/loss.dm
@@ -44,9 +44,9 @@
 			if(WOUND_BURN)
 				occur_text = "is completely incinerated, falling to dust!"
 
-	var/msg = "<span class='bolddanger'>[victim]'s [dismembered_part.name] [occur_text]!</span>"
+	var/msg = span_bolddanger("[victim]'s [dismembered_part.name] [occur_text]")
 
-	victim.visible_message(msg, span_userdanger("Your [dismembered_part.name] [self_msg ? self_msg : occur_text]!"))
+	victim.visible_message(msg, span_userdanger("Your [dismembered_part.name] [self_msg ? self_msg : occur_text]"))
 
 	set_limb(dismembered_part)
 	second_wind()

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -411,6 +411,11 @@ em {
   font-size: 185%;
 }
 
+.bolddanger {
+  color: #c51e1e;
+  font-weight: bold;
+}
+
 .danger {
   color: #c51e1e;
 }


### PR DESCRIPTION
## About The Pull Request

Removes some exclamation marks from the dismemberment message.
Also creates `span_bolddanger()`, why not while I'm there.

## Why It's Good For The Game

This is most likely not intended, and is a little overenthusiastic.
![image](https://user-images.githubusercontent.com/8881105/149684387-2086c21f-158f-47bd-876d-6fa10e410946.png)

## Changelog
:cl:
spellcheck: Removed a duplicate exclamation mark from the dismemberment message.
/:cl: