### PR TITLE
Fixes an oversight in database code and cleans up telemetry

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -74,12 +74,12 @@ SUBSYSTEM_DEF(dbcore)
 		queries_current = queries_active.Copy()
 		processing_queries = all_queries.Copy()
 
-	for(var/I in processing_queries)
-		var/datum/db_query/Q = I
-		if(world.time - Q.last_activity_time > (5 MINUTES))
+	while(length(processing_queries))
+		var/datum/db_query/query = popleft(processing_queries)
+		if(world.time - query.last_activity_time > (5 MINUTES))
 			message_admins("Found undeleted query, please check the server logs and notify coders.")
-			log_sql("Undeleted query: \"[Q.sql]\" LA: [Q.last_activity] LAT: [Q.last_activity_time]")
-			qdel(Q)
+			log_sql("Undeleted query: \"[query.sql]\" LA: [Q.last_activity] LAT: [query.last_activity_time]")
+			qdel(query)
 		if(MC_TICK_CHECK)
 			return
 

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -78,7 +78,7 @@ SUBSYSTEM_DEF(dbcore)
 		var/datum/db_query/query = popleft(processing_queries)
 		if(world.time - query.last_activity_time > (5 MINUTES))
 			message_admins("Found undeleted query, please check the server logs and notify coders.")
-			log_sql("Undeleted query: \"[query.sql]\" LA: [Q.last_activity] LAT: [query.last_activity_time]")
+			log_sql("Undeleted query: \"[query.sql]\" LA: [query.last_activity] LAT: [query.last_activity_time]")
 			qdel(query)
 		if(MC_TICK_CHECK)
 			return

--- a/code/modules/tgui_panel/telemetry.dm
+++ b/code/modules/tgui_panel/telemetry.dm
@@ -92,7 +92,7 @@
 			query_data += list(list(
 				"telemetry_ckey" = row["ckey"],
 				"address" = row["address"],
-				"computer_id" = row["computer_id"]
+				"computer_id" = row["computer_id"],
 			))
 
 		if (row["ckey"] in our_known_alts)
@@ -134,6 +134,7 @@
 			"telemetry_ckey" = query_data["telemetry_ckey"],
 			"address" = query_data["address"],
 			"computer_id" = query_data["computer_id"], 
-			"round_id" = GLOB.round_id
+			"round_id" = GLOB.round_id,
 		))
 		query.Execute()
+		qdel(query)

--- a/code/modules/tgui_panel/telemetry.dm
+++ b/code/modules/tgui_panel/telemetry.dm
@@ -76,7 +76,7 @@
 
 	var/list/found
 
-	var/list/insert_queries = list()
+	var/list/query_data = list()
 
 	for(var/i in 1 to len)
 		if(QDELETED(client))
@@ -89,28 +89,10 @@
 			return
 
 		if (!isnull(GLOB.round_id))
-			insert_queries += SSdbcore.NewQuery({"
-				INSERT INTO [format_table_name("telemetry_connections")] (
-					ckey,
-					telemetry_ckey,
-					address,
-					computer_id,
-					first_round_id,
-					latest_round_id
-				) VALUES(
-					:ckey,
-					:telemetry_ckey,
-					INET_ATON(:address),
-					:computer_id,
-					:round_id,
-					:round_id
-				) ON DUPLICATE KEY UPDATE latest_round_id = :round_id
-			"}, list(
-				"ckey" = ckey,
+			query_data += list(list(
 				"telemetry_ckey" = row["ckey"],
 				"address" = row["address"],
-				"computer_id" = row["computer_id"],
-				"round_id" = GLOB.round_id,
+				"computer_id" = row["computer_id"]
 			))
 
 		if (row["ckey"] in our_known_alts)
@@ -130,7 +112,28 @@
 		log_suspicious_login(msg, access_log_mirror = FALSE)
 
 	// Only log them all at the end, since it's not as important as reporting an evader
-	for (var/datum/db_query/insert_query as anything in insert_queries)
-		insert_query.Execute()
-
-	QDEL_LIST(insert_queries)
+	for (var/one_query as anything in query_data)
+		var/datum/db_query/query = SSdbcore.NewQuery({"
+			INSERT INTO [format_table_name("telemetry_connections")] (
+				ckey,
+				telemetry_ckey,
+				address,
+				computer_id,
+				first_round_id,
+				latest_round_id
+			) VALUES(
+				:ckey,
+				:telemetry_ckey,
+				INET_ATON(:address),
+				:computer_id,
+				:round_id,
+				:round_id
+			) ON DUPLICATE KEY UPDATE latest_round_id = :round_id
+		"}, list(
+			"ckey" = ckey,
+			"telemetry_ckey" = query_data["telemetry_ckey"],
+			"address" = query_data["address"],
+			"computer_id" = query_data["computer_id"], 
+			"round_id" = GLOB.round_id
+		))
+		query.Execute()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As it is right now, we never actually clear the temporary list processing_queries
So if the subsystem is for some reason unable to complete a run, we will just whip right back around to it again
If it's been long enough, this could even cause horrific log spam. There was just now a manuel round with roughly 30k undeleted query errors. not good.

But what was actually not deleting you may ask?
Well

When you **create** a db request, a 5 minute timer starts. after those 5 minutes are up, the request is qdeleted by the db subsystem
This is to prevent the creation of unused requests, and to handle requests that are never cleaned up

Telemetry code was creating all of its db requests inside a for loop that could check tick, and then later
attempting to call them in series

Since requests by default sleep, this almost always lead to undeleted queries, which harddel'd given long enough periods

I've fixed this by moving the data gathering away from the query creation

## Why is it good for the game

I was working on atmos code, happy, safe in my delusion, when suddenly I got a ping from tattle freaking out over 200 undeleted queries a second
This resolves that issue, so I can once again live in peace 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Telemetry code will spam you with undeleted query logs much less often now!
server: Improved how the db subsystem handles undeleted queries, should never have an incident like that again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
