### PR TITLE
[I DED] Adds an important step to the SM sliver theft guide.

### DIFF
--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -144,6 +144,7 @@
 /obj/item/paper/guides/antag/supermatter_sliver
 	info = "How to safely extract a supermatter sliver:<br>\
 	<ul>\
+	<li>You must have active magnetic anchoring at all times near an active supermatter crystal.</li>\
 	<li>Approach an active supermatter crystal with radiation shielded personal protective equipment. DO NOT MAKE PHYSICAL CONTACT.</li>\
 	<li>Use a supermatter scalpel (provided) to slice off a sliver of the crystal.</li>\
 	<li>Use supermatter extraction tongs (also provided) to safely pick up the sliver you sliced off.</li>\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the titles says. Adds a step on the sliver steal paper reminding you to wear magboots in the chamber.

## Why It's Good For The Game

**DID YOU KNOW THE SUPERMATTER PULLS YOU IN?**
If you haven't played Engineering in the last three years, you may find this out the hard way!!

Considering this feature isn't even documented on the wiki, the only way to learn this knowledge is to die to it (and realize that blaming airflow isn't actually the fault). People who aren't engineers trying to steal it should at least get a hint that they need an item to even enter the supermatter chamber and not die instantly.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Traitors trying to steal a supermatter sliver should be reminded that magboots are required near an active supermatter at all times.
/:cl: