### PR TITLE
APOTHEOSIS! now forces you standing when you're in the death animation as a plasma skeleton.

### DIFF
--- a/code/datums/martial/plasma_fist.dm
+++ b/code/datums/martial/plasma_fist.dm
@@ -113,8 +113,8 @@
 	plasma_power = 1 //just in case there is any clever way to cause it to happen again
 
 /datum/martial_art/plasma_fist/proc/Apotheosis_end(mob/living/dying)
-	if (ishuman(user))
-		var/mob/living/carbon/human/dying_human = user
+	if(ishuman(dying))
+		var/mob/living/carbon/human/dying_human = dying
 		REMOVE_TRAIT(dying_human, TRAIT_FORCED_STANDING, type)
 		dying_human.dna.species.species_traits -= TRAIT_BOMBIMMUNE
 	if(dying.stat == DEAD)

--- a/code/datums/martial/plasma_fist.dm
+++ b/code/datums/martial/plasma_fist.dm
@@ -89,6 +89,7 @@
 	if (ishuman(user))
 		var/mob/living/carbon/human/human_attacker = user
 		human_attacker.set_species(/datum/species/plasmaman)
+		ADD_TRAIT(human_attacker, TRAIT_FORCED_STANDING, type)
 		human_attacker.dna.species.species_traits += TRAIT_BOMBIMMUNE
 		human_attacker.unequip_everything()
 		human_attacker.underwear = "Nude"
@@ -112,9 +113,10 @@
 	plasma_power = 1 //just in case there is any clever way to cause it to happen again
 
 /datum/martial_art/plasma_fist/proc/Apotheosis_end(mob/living/dying)
-	var/datum/dna/dna = dying.has_dna()
-	if (dna?.species)
-		dna.species.species_traits -= TRAIT_BOMBIMMUNE
+	if (ishuman(user))
+		var/mob/living/carbon/human/dying_human = user
+		REMOVE_TRAIT(dying_human, TRAIT_FORCED_STANDING, type)
+		dying_human.dna.species.species_traits -= TRAIT_BOMBIMMUNE
 	if(dying.stat == DEAD)
 		return
 	dying.death()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

APOTHEOSIS! adds the forcestanding trait when you perform APOTHEOSIS! during the animation where you exploded all your skin off and are just standing there moments before death.

## Why It's Good For The Game

I used to not need this but the resting rework made it so, so the cool standing at the center of an explosion before dropping dead is now proper

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: APOTHEOSIS! now forces you standing during your death animation, restoring the old (not forced) standing when I originally added APOTHEOSIS!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
