### PR TITLE
Make objectives actually fail when they should

### DIFF
--- a/code/modules/antagonists/traitor/components/traitor_objective_helpers.dm
+++ b/code/modules/antagonists/traitor/components/traitor_objective_helpers.dm
@@ -42,7 +42,7 @@
 /datum/component/traitor_objective_register/proc/on_fail(datum/traitor_objective/source)
 	SIGNAL_HANDLER
 	var/datum/traitor_objective/objective = parent
-	objective.succeed_objective()
+	objective.fail_objective(penalty)
 
 /datum/component/traitor_objective_register/proc/on_success()
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
https://github.com/tgstation/tgstation/blob/975830a242ca554138d6a3f1821e886aca7e62ef/code/modules/antagonists/traitor/components/traitor_objective_helpers.dm#L42-L45

Yeah... Fixes #64040 and also any other case this was used which also includes QDELETING the calling card for the assassination objective, or the bug for the bug object, or the brainwashing disk for the brainwashing objective...
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Certain traitor objectives now fail when they are supposed to instead of unintentionally succeeding, most notably when objective-critical items are destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
