### PR TITLE
TramStation Area Renaming - Laundry Room

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -40,7 +40,7 @@
 "aau" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aaB" = (
 /turf/closed/wall,
 /area/maintenance/port/central)
@@ -446,7 +446,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "adS" = (
 /turf/closed/wall,
 /area/maintenance/starboard/central)
@@ -681,7 +681,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "afG" = (
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
@@ -696,7 +696,7 @@
 /obj/structure/bedsheetbin,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "afI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -1380,7 +1380,7 @@
 	},
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "ajU" = (
 /obj/structure/railing/corner,
 /turf/open/floor/glass,
@@ -1480,7 +1480,7 @@
 	},
 /obj/structure/closet/wardrobe/grey,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aku" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "medcell";
@@ -2022,7 +2022,7 @@
 /obj/structure/closet/boxinggloves,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "anG" = (
 /turf/closed/wall,
 /area/hallway/primary/tram/left)
@@ -2539,7 +2539,7 @@
 	},
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aqV" = (
 /obj/structure/ladder,
 /turf/open/floor/iron/white,
@@ -2579,7 +2579,7 @@
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "ari" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 4
@@ -2695,7 +2695,7 @@
 	},
 /obj/machinery/vending/clothing,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "arJ" = (
 /obj/structure/table/wood/fancy,
 /obj/item/flashlight/lantern,
@@ -3807,7 +3807,7 @@
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "ayb" = (
 /obj/machinery/field/generator,
 /obj/effect/turf_decal/stripes/line,
@@ -3865,7 +3865,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "ayt" = (
 /turf/open/openspace,
 /area/hallway/primary/tram/right)
@@ -4025,7 +4025,7 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "azr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -4210,7 +4210,7 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aAk" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -4369,7 +4369,7 @@
 	name = "Laundromat"
 	},
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aBy" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -4723,7 +4723,7 @@
 	},
 /obj/machinery/vending/modularpc,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aDH" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -4733,7 +4733,7 @@
 	},
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aDI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -4922,7 +4922,7 @@
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aEB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron,
@@ -6538,7 +6538,7 @@
 /obj/structure/closet/wardrobe/black,
 /obj/item/clothing/shoes/jackboots,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aRL" = (
 /turf/closed/wall,
 /area/maintenance/starboard/secondary)
@@ -6568,7 +6568,7 @@
 /area/construction/mining/aux_base)
 "aRW" = (
 /turf/closed/wall,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aRX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -6867,7 +6867,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aUJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6886,7 +6886,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aUW" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -7258,7 +7258,7 @@
 /obj/structure/closet/wardrobe/green,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "aZb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -14670,7 +14670,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "dLp" = (
 /obj/structure/chair/pew/right{
 	dir = 4
@@ -14946,7 +14946,7 @@
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/effect/spawner/random/clothing/costume,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "dTm" = (
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
@@ -15743,7 +15743,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "efY" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/yellow,
@@ -16781,7 +16781,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "evi" = (
 /turf/closed/wall,
 /area/security/warden)
@@ -17529,7 +17529,7 @@
 /obj/effect/landmark/start/hangover,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "eLR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/cable,
@@ -28970,7 +28970,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "iOw" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -34484,7 +34484,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "kTU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -40090,7 +40090,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "mWR" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -43392,7 +43392,7 @@
 /obj/structure/closet/masks,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "ogL" = (
 /obj/structure/railing{
 	dir = 1
@@ -49636,7 +49636,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "qqR" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -50913,7 +50913,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "qSj" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -56816,7 +56816,7 @@
 /obj/structure/chair/stool/directional/west,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "tad" = (
 /obj/structure/chair{
 	dir = 1
@@ -58248,7 +58248,7 @@
 /obj/structure/closet/athletic_mixed,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "tzE" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Server Access";
@@ -67542,7 +67542,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "xaO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -70095,7 +70095,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
-/area/commons/locker)
+/area/commons/dorms/laundry)
 "xTU" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/item/stack/sheet/iron,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes the area turfs for the once "Locker Room" on TramStation to the newly added "Laundry Room" area turf definition.

![image](https://user-images.githubusercontent.com/34697715/149860418-0ad8b94d-5e00-4229-b8ea-d47d7f5d262b.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I feel like this name is a tad more descriptive of the function of this room on TramStation than the previous "Locker Room". I checked the other maps as well to see if they had discrete areas for laundry, but they all seemed to be integrated in the larger dorms/toilet room area.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The Laundry Room on TramStation is now called a Laundry Room. Rejoice!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
