### PR TITLE
Fixes Modular Map Loading Runtimes

### DIFF
--- a/code/modules/mapping/modular_map_loader/README.md
+++ b/code/modules/mapping/modular_map_loader/README.md
@@ -12,7 +12,7 @@ This root object handled picking and loading in map modules. It has two variable
 
 * `var/config_file` - A string, points to a TOML configuration file, which is used to hold the information necessary to pull the correct map files and place them on the correct roots. This will be the same for all roots on a map.
 * `var/key` - A string, used to pull a list of `.dmm` files from the configuration file.
-* `load_map()` - Called asynchronously in the root's `Initialize()`. This proc creates a new instance of `/datum/map_template/map_module`, ingests the configuration file `config_file` points to, and picks a `.dmm` file path which maps to the root's `key`, by picking a random filename from among those which `key` maps to, and appending it to a folder path. This file path is passed into the map templace instance's `load()`, and the template takes over.
+* `load_map()` - Called asynchronously in the root's `New()`. This proc creates a new instance of `/datum/map_template/map_module`, ingests the configuration file `config_file` points to, and picks a `.dmm` file path which maps to the root's `key`, by picking a random filename from among those which `key` maps to, and appending it to a folder path. This file path is passed into the map templace instance's `load()`, and the template takes over. This proc is called on `New()` and not `Initialize()` for reasons due to the init order to prevent runtime errors.
 
 ### /datum/map_template/map_module
 

--- a/code/modules/mapping/modular_map_loader/README.md
+++ b/code/modules/mapping/modular_map_loader/README.md
@@ -12,7 +12,9 @@ This root object handled picking and loading in map modules. It has two variable
 
 * `var/config_file` - A string, points to a TOML configuration file, which is used to hold the information necessary to pull the correct map files and place them on the correct roots. This will be the same for all roots on a map.
 * `var/key` - A string, used to pull a list of `.dmm` files from the configuration file.
-* `load_map()` - Called asynchronously in the root's `New()`. This proc creates a new instance of `/datum/map_template/map_module`, ingests the configuration file `config_file` points to, and picks a `.dmm` file path which maps to the root's `key`, by picking a random filename from among those which `key` maps to, and appending it to a folder path. This file path is passed into the map templace instance's `load()`, and the template takes over. This proc is called on `New()` and not `Initialize()` for reasons due to the init order to prevent runtime errors.
+* `load_map()` - Called asynchronously in the root's `Initialize()`. This proc creates a new instance of `/datum/map_template/map_module`, ingests the configuration file `config_file` points to, and picks a `.dmm` file path which maps to the root's `key`, by picking a random filename from among those which `key` maps to, and appending it to a folder path. This file path is passed into the map templace instance's `load()`, and the template takes over.
+
+INITIALIZE_IMMEDIATE is used to ensure the ruins are loaded at the right time to avoid runtime errors related to lighting.
 
 ### /datum/map_template/map_module
 

--- a/code/modules/mapping/modular_map_loader/modular_map_loader.dm
+++ b/code/modules/mapping/modular_map_loader/modular_map_loader.dm
@@ -11,7 +11,7 @@
 	/// Key used to look up the appropriate map paths in the associated .toml file
 	var/key = null
 
-/obj/modular_map_root/Initialize(mapload)
+/obj/modular_map_root/New()
 	. = ..()
 	INVOKE_ASYNC(src, .proc/load_map)
 

--- a/code/modules/mapping/modular_map_loader/modular_map_loader.dm
+++ b/code/modules/mapping/modular_map_loader/modular_map_loader.dm
@@ -11,7 +11,9 @@
 	/// Key used to look up the appropriate map paths in the associated .toml file
 	var/key = null
 
-/obj/modular_map_root/New()
+INITIALIZE_IMMEDIATE(/obj/modular_map_root)
+
+/obj/modular_map_root/Initialize(mapload)
 	. = ..()
 	INVOKE_ASYNC(src, .proc/load_map)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves the modmap root object's load_map() call to New(). This changes something about where it falls in init order that stops it from causing a flood of lighting runtimes. Don't ask my why, it just does.

## Why It's Good For The Game

Fixes #64192

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Eliminated a runtime error related to Modular Map Loading
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
