### PR TITLE
Traitor Roboticists can now purchase the Springlock MODsuit Module from the uplink, due to being the man behind the slaughter.

### DIFF
--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -247,6 +247,7 @@
 	mod.activation_step_time *= 10
 	
 /obj/item/mod/module/springlock/bite_of_87/on_suit_activation()
+	..()
 	var/list/all_parts = mod.mod_parts.Copy() + mod 
 	for(var/obj/item/part in all_parts) // turns the suit yellow
 		part.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -232,13 +232,15 @@
 	REMOVE_TRAIT(mod.wearer, TRAIT_NOSLIPWATER, MOD_TRAIT)
 	
 /obj/item/mod/module/springlock/bite_of_87
-	name = "MOD DNA lock module"
-	desc = "A module which engages with the various locks and seals tied to the suit's systems, \
-		enabling it to only be worn by someone corresponding with the user's exact DNA profile; \
-		however, this incredibly sensitive module is shorted out by EMPs. Luckily, cloning has been outlawed."
-	icon_state = "dnalock"
-	complexity = 2 // for all intents and purposes, looks like a real DNA lock module
-	use_power_cost = DEFAULT_CHARGE_DRAIN * 3
+	
+/obj/item/mod/module/springlock/bite_of_87/Initialize(mapload)
+	. = ..()
+	var/obj/item/mod/module/dna_lock/the_dna_lock_behind_the_slaughter = /obj/item/mod/module/dna_lock
+	name = initial(the_dna_lock_behind_the_slaughter.name)
+	desc = initial(the_dna_lock_behind_the_slaughter.desc)
+	icon_state = initial(the_dna_lock_behind_the_slaughter.icon_state)
+	complexity = initial(the_dna_lock_behind_the_slaughter.complexity)
+	use_power_cost = initial(the_dna_lock_behind_the_slaughter.use_power_cost)
 
 /obj/item/mod/module/springlock/bite_of_87/on_install()
 	mod.activation_step_time *= 0.1
@@ -248,9 +250,10 @@
 	
 /obj/item/mod/module/springlock/bite_of_87/on_suit_activation()
 	..()
-	var/list/all_parts = mod.mod_parts.Copy() + mod 
-	for(var/obj/item/part in all_parts) // turns the suit yellow
-		part.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
-		part.add_atom_colour("#b17f00", FIXED_COLOUR_PRIORITY)
-	mod.wearer.remove_atom_colour(WASHABLE_COLOUR_PRIORITY) // turns purple guy purple
-	mod.wearer.add_atom_colour("#704b96", FIXED_COLOUR_PRIORITY)
+	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS] || prob(1))
+		var/list/all_parts = mod.mod_parts.Copy() + mod 
+		for(var/obj/item/part in all_parts) // turns the suit yellow
+			part.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
+			part.add_atom_colour("#b17f00", FIXED_COLOUR_PRIORITY)
+		mod.wearer.remove_atom_colour(WASHABLE_COLOUR_PRIORITY) // turns purple guy purple
+		mod.wearer.add_atom_colour("#704b96", FIXED_COLOUR_PRIORITY)

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -248,8 +248,8 @@
 	
 /obj/item/mod/module/springlock/bite_of_87/on_suit_activation()
 	var/list/all_parts = mod.mod_parts.Copy() + mod 
-	for(var/obj/item/part as anything in all_parts) // turns the suit yellow
+	for(var/obj/item/part in all_parts) // turns the suit yellow
 		part.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
 		part.add_atom_colour("#b17f00", FIXED_COLOUR_PRIORITY)
-	part.remove_atom_colour(WASHABLE_COLOUR_PRIORITY) // turns purple guy purple
-	part.add_atom_colour("#704b96", FIXED_COLOUR_PRIORITY)
+	mod.wearer.remove_atom_colour(WASHABLE_COLOUR_PRIORITY) // turns purple guy purple
+	mod.wearer.add_atom_colour("#704b96", FIXED_COLOUR_PRIORITY)

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -230,3 +230,26 @@
 
 /obj/item/mod/module/noslip/on_suit_deactivation()
 	REMOVE_TRAIT(mod.wearer, TRAIT_NOSLIPWATER, MOD_TRAIT)
+	
+/obj/item/mod/module/springlock/bite_of_87
+	name = "MOD DNA lock module"
+	desc = "A module which engages with the various locks and seals tied to the suit's systems, \
+		enabling it to only be worn by someone corresponding with the user's exact DNA profile; \
+		however, this incredibly sensitive module is shorted out by EMPs. Luckily, cloning has been outlawed."
+	icon_state = "dnalock"
+	complexity = 2 // for all intents and purposes, looks like a real DNA lock module
+	use_power_cost = DEFAULT_CHARGE_DRAIN * 3
+
+/obj/item/mod/module/springlock/bite_of_87/on_install()
+	mod.activation_step_time *= 0.1
+
+/obj/item/mod/module/springlock/bite_of_87/on_uninstall()
+	mod.activation_step_time *= 10
+	
+/obj/item/mod/module/springlock/bite_of_87/on_suit_activation()
+	var/list/all_parts = mod.mod_parts.Copy() + mod 
+	for(var/obj/item/part as anything in all_parts) // turns the suit yellow
+		part.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
+		part.add_atom_colour("#b17f00", FIXED_COLOUR_PRIORITY)
+	part.remove_atom_colour(WASHABLE_COLOUR_PRIORITY) // turns purple guy purple
+	part.add_atom_colour("#704b96", FIXED_COLOUR_PRIORITY)

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -155,6 +155,16 @@
 	restricted_roles = list(JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_ROBOTICIST)
 	cost = 5
 
+/datum/uplink_item/role_restricted/springlock_module
+	name = "Springlock MODSuit Module"
+	desc = "A module that spans the entire size of the MOD unit, sitting under the outer shell. \
+		This mechanical exoskeleton pushes out of the way when the user enters and it helps in booting \
+		up, but was taken out of modern suits because of the springlock's tendency to \"snap\" back \
+		into place when exposed to humidity. You know what it's like to have an entire exoskeleton enter you?"
+	item = /obj/item/mod/module/springlock
+	restricted_roles = list(JOB_ROBOTICIST)
+	cost = 2
+
 /datum/uplink_item/role_restricted/reverse_revolver
 	name = "Reverse Revolver"
 	desc = "A revolver that always fires at its user. \"Accidentally\" drop your weapon, then watch as the greedy corporate pigs blow their own brains all over the wall. \

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -156,13 +156,15 @@
 	cost = 5
 
 /datum/uplink_item/role_restricted/springlock_module
-	name = "Springlock MODsuit Module"
+	name = "Heavily Modified Springlock MODsuit Module"
 	desc = "A module that spans the entire size of the MOD unit, sitting under the outer shell. \
 		This mechanical exoskeleton pushes out of the way when the user enters and it helps in booting \
 		up, but was taken out of modern suits because of the springlock's tendency to \"snap\" back \
-		into place when exposed to humidity. You know what it's like to have an entire exoskeleton enter you?"
-	item = /obj/item/mod/module/springlock
-	restricted_roles = list(JOB_ROBOTICIST)
+		into place when exposed to humidity. You know what it's like to have an entire exoskeleton enter you? \
+		This version of the module has been modified to allow for near instant activation of the MODsuit. \
+		Useful for quickly getting your MODsuit on/off, or for taking care of a target via a tragic accident."
+	item = /obj/item/mod/module/springlock/bite_of_87
+	restricted_roles = list(JOB_ROBOTICIST, JOB_RESEARCH_DIRECTOR)
 	cost = 2
 
 /datum/uplink_item/role_restricted/reverse_revolver

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -156,7 +156,7 @@
 	cost = 5
 
 /datum/uplink_item/role_restricted/springlock_module
-	name = "Springlock MODSuit Module"
+	name = "Springlock MODsuit Module"
 	desc = "A module that spans the entire size of the MOD unit, sitting under the outer shell. \
 		This mechanical exoskeleton pushes out of the way when the user enters and it helps in booting \
 		up, but was taken out of modern suits because of the springlock's tendency to \"snap\" back \


### PR DESCRIPTION
## About The Pull Request

Traitor Roboticists can now purchase the Springlock MODsuit Module from the uplink, due to being the man behind the slaughter.

## Why It's Good For The Game

![Purple_man](https://user-images.githubusercontent.com/4081722/150035820-457fd888-24a0-460f-88e5-e3590ed4b721.png)


## Changelog

:cl:
add: Traitor Roboticists can now purchase the Springlock MODsuit Module from the uplink.
add: This version of the Springlock MODsuit Module activates way, way faster.
/:cl:
