### PR TITLE
Allows cyborgs to quicken their self untip time with roleplay

### DIFF
--- a/code/datums/components/tippable.dm
+++ b/code/datums/components/tippable.dm
@@ -238,4 +238,4 @@
 	self_untip_timer = addtimer(CALLBACK(src, .proc/right_self, user), time_left / 2, TIMER_UNIQUE | TIMER_STOPPABLE)
 	roleplayed = TRUE
 
-	to_chat(user, span_notice("Your emotion has empowered you! You can now right yourself faster!"))
+	to_chat(user, span_notice("Your frustration has empowered you! You can now right yourself faster!"))

--- a/code/datums/components/tippable.dm
+++ b/code/datums/components/tippable.dm
@@ -16,6 +16,8 @@
 	var/datum/callback/post_tipped_callback
 	/// Callback to additional behavior after being untipped.
 	var/datum/callback/post_untipped_callback
+	/// Callback to any extra roleplay behaviour
+	var/datum/callback/roleplay_callback
 	///The timer given until they untip themselves
 	var/self_untip_timer
 
@@ -35,6 +37,7 @@
 	datum/callback/post_untipped_callback,
 	roleplay_friendly = FALSE,
 	roleplay_emotes,
+	datum/callback/roleplay_callback,
 )
 
 	if(!isliving(parent))
@@ -48,6 +51,7 @@
 	src.post_untipped_callback = post_untipped_callback
 	src.roleplay_friendly = roleplay_friendly
 	src.roleplay_emotes = roleplay_emotes
+	src.roleplay_callback = roleplay_callback
 
 /datum/component/tippable/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND_SECONDARY, .proc/interact_with_tippable)
@@ -65,6 +69,8 @@
 		QDEL_NULL(post_tipped_callback)
 	if(post_untipped_callback)
 		QDEL_NULL(post_untipped_callback)
+	if(roleplay_callback)
+		QDEL_NULL(roleplay_callback)
 	return ..()
 
 /*
@@ -235,7 +241,6 @@
 		return
 	var/time_left = timeleft(self_untip_timer)
 	deltimer(self_untip_timer)
-	self_untip_timer = addtimer(CALLBACK(src, .proc/right_self, user), time_left / 2, TIMER_UNIQUE | TIMER_STOPPABLE)
+	self_untip_timer = addtimer(CALLBACK(src, .proc/right_self, user), time_left * 0.75, TIMER_UNIQUE | TIMER_STOPPABLE)
 	roleplayed = TRUE
-
-	to_chat(user, span_notice("Your frustration has empowered you! You can now right yourself faster!"))
+	roleplay_callback?.Invoke(user)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -11,7 +11,8 @@
 		post_tipped_callback = CALLBACK(src, .proc/after_tip_over), \
 		post_untipped_callback = CALLBACK(src, .proc/after_righted), \
 		roleplay_friendly = TRUE, \
-		roleplay_emotes = list(/datum/emote/silicon/buzz, /datum/emote/silicon/buzz2, /datum/emote/living/beep))
+		roleplay_emotes = list(/datum/emote/silicon/buzz, /datum/emote/silicon/buzz2, /datum/emote/living/beep), \
+		roleplay_callback = CALLBACK(src, .proc/untip_roleplay))
 
 	wires = new /datum/wires/robot(src)
 	AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
@@ -1003,3 +1004,6 @@
 	var/datum/job/cyborg/cyborg_job_ref = SSjob.GetJobType(/datum/job/cyborg)
 
 	.[cyborg_job_ref.title] = minutes
+
+/mob/living/silicon/robot/proc/untip_roleplay()
+	to_chat(src, span_notice("Your frustration has empowered you! You can now right yourself faster!"))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -9,7 +9,9 @@
 		untip_time = 2 SECONDS, \
 		self_right_time = 60 SECONDS, \
 		post_tipped_callback = CALLBACK(src, .proc/after_tip_over), \
-		post_untipped_callback = CALLBACK(src, .proc/after_righted))
+		post_untipped_callback = CALLBACK(src, .proc/after_righted), \
+		roleplay_friendly = TRUE, \
+		roleplay_emotes = list(/datum/emote/silicon/buzz, /datum/emote/silicon/buzz2, /datum/emote/living/beep))
 
 	wires = new /datum/wires/robot(src)
 	AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/16159590/150043669-8470a5c1-6ea4-4c7f-a747-5cd9ebddee65.png)
(halves their untip timer when they emote, only works once)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
borgs should be encouraged for roleplaying their anger at being tipped
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Borgs can halve their selfuntip time with the power of roleplay.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
