### PR TITLE
Purified shades get converted to shades if they get converted & related fixes

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -576,6 +576,7 @@
 	[IRON_TO_CONSTRUCT_SHELL_CONVERSION] iron into a construct shell\n
 	Living cyborgs into constructs after a delay\n
 	Cyborg shells into construct shells\n
+	Purified soulstones (and any shades inside) into cultist soulstones\n
 	Airlocks into brittle runed airlocks after a delay (harm intent)"}
 
 /obj/item/melee/blood_magic/construction/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
@@ -652,6 +653,12 @@
 			else
 				channeling = FALSE
 				return
+		else if(istype(target,/obj/item/soulstone))
+			var/obj/item/soulstone/candidate = target
+			if(candidate.corrupt())
+				uses--
+				to_chat(user, span_warning("You corrupt [candidate]!"))
+				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
 		else
 			to_chat(user, span_warning("The spell will not work on [target]!"))
 			return

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -178,7 +178,7 @@
 
 /datum/action/innate/cult/blood_spell/construction
 	name = "Twisted Construction"
-	desc = "Empowers your hand to corrupt certain metalic objects.<br><u>Converts:</u><br>Plasteel into runed metal<br>50 metal into a construct shell<br>Living cyborgs into constructs after a delay<br>Cyborg shells into construct shells<br>Airlocks into brittle runed airlocks after a delay (harm intent)"
+	desc = "Empowers your hand to corrupt certain metalic objects.<br><u>Converts:</u><br>Plasteel into runed metal<br>50 metal into a construct shell<br>Living cyborgs into constructs after a delay<br>Cyborg shells into construct shells<br>Purified soulstones (and any shades inside) into cultist soulstones<br>Airlocks into brittle runed airlocks after a delay (harm intent)"
 	button_icon_state = "transmute"
 	magic_path = "/obj/item/melee/blood_magic/construction"
 	health_cost = 12

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -283,6 +283,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 		H.cultslurring = 0
 		if(prob(1) || SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
 			H.say("You son of a bitch! I'm in.", forced = "That son of a bitch! They're in.")
+	if(isshade(convertee))
+		convertee.icon_state = "shade_cult"
+		convertee.name = convertee.real_name
 	return TRUE
 
 /obj/effect/rune/convert/proc/do_sacrifice(mob/living/sacrificial, list/invokers)

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -52,7 +52,7 @@
 		mob_cultist.mind.remove_antag_datum(/datum/antagonist/cult)
 	for(var/mob/living/simple_animal/shade/sharded_shade in src)
 		sharded_shade.icon_state = "ghost1"
-		sharded_shade.name = "Purified [initial(sharded_shade.name)]"
+		sharded_shade.name = "Purified [sharded_shade.real_name]"
 	exorcist.visible_message(span_notice("[exorcist] purifies [src]!"))
 	UnregisterSignal(src, COMSIG_BIBLE_SMACKED)
 
@@ -197,7 +197,7 @@
 			if(THEME_HOLY)
 				icon_state = "purified_soulstone"
 				A.icon_state = "shade_holy"
-				A.name = "Purified [initial(A.name)]"
+				A.name = "Purified [A.real_name]"
 				A.loot = list(/obj/item/ectoplasm/angelic)
 			if(THEME_WIZARD)
 				icon_state = "mystic_soulstone"

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -56,6 +56,28 @@
 	exorcist.visible_message(span_notice("[exorcist] purifies [src]!"))
 	UnregisterSignal(src, COMSIG_BIBLE_SMACKED)
 
+/**
+ * corrupt: turns the soulstone into a cult one and turns the occupant shade, if any, into a cultist
+ */
+/obj/item/soulstone/proc/corrupt()
+	if(theme == THEME_CULT)
+		return FALSE
+	required_role = null
+	theme = THEME_CULT
+	icon_state = "soulstone"
+	for(var/mob/shade_to_convert in contents)
+		if(!shade_to_convert.mind)
+			continue
+		icon_state = "soulstone2"
+		if(IS_CULTIST(shade_to_convert))
+			continue
+		shade_to_convert.mind.add_antag_datum(/datum/antagonist/cult)
+	for(var/mob/living/simple_animal/shade/sharded_shade in src)
+		sharded_shade.icon_state = "shade_cult"
+		sharded_shade.name = sharded_shade.real_name
+	RegisterSignal(src, COMSIG_BIBLE_SMACKED)
+	return TRUE
+
 /obj/item/soulstone/proc/role_check(mob/who)
 	return required_role ? (who.mind && who.mind.has_antag_datum(required_role, TRUE)) : TRUE
 
@@ -288,7 +310,7 @@
 		icon_state = "mystic_soulstone2"
 	if(theme == THEME_CULT)
 		icon_state = "soulstone2"
-	name = "soulstone: Shade of [shade.real_name]"
+	name = "soulstone: [shade.real_name]"
 	to_chat(shade, span_notice("Your soul has been captured by [src]. Its arcane energies are reknitting your ethereal form."))
 	if(user != shade)
 		to_chat(user, "[span_info("<b>Capture successful!</b>:")] [shade.real_name]'s soul has been captured and stored within [src].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1) Purified shades now get converted to shades (mainly name & icon change) if they get converted to cult
2) Using twisted construction on a non-cult soulstone now makes it a cult soulstone (including converting any shade inside to a cult shade if any shades are inside)
3) Fixes a bug found during testing where soulstones with a shade that has been recaptured would say "soulstone: Shade of Shade of [NAME]", caused due to real_name already being "Shade of [NAME]".
4) Purified shades now show who they were prior to being captured.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Purified shades probably should not be able to be cult. Also some of the other issues with shades in general ground during testing were annoying.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Purified shades now show who they were prior to becoming a shade.
fix: Purified shades that get converted to shades now become regular cult shades.
qol: Purified soulstones (and the shades inside) can now directly be converted into cult soulstones (and cult shades) with Twisted Construction.
spellcheck: "Shade of" does not get duplicated anymore for soulstones under certain conditions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
