### PR TITLE
Bumps bootstrapped python version to 3.7.9

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -18,4 +18,4 @@ export NODE_VERSION_PRECISE=16.13.1
 export SPACEMAN_DMM_VERSION=suite-1.7.1
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.6.8
+export PYTHON_VERSION=3.7.9

--- a/tools/bootstrap/python37._pth
+++ b/tools/bootstrap/python37._pth
@@ -1,4 +1,4 @@
-python36.zip
+python37.zip
 .
 ..\..\..
 

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -50,7 +50,7 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 
 	# Copy a ._pth file without "import site" commented, so pip will work
-	Copy-Item "$Bootstrap/python36._pth" $PythonDir `
+	Copy-Item "$Bootstrap/python37._pth" $PythonDir `
 		-ErrorAction Stop
 
 	Remove-Item $Archive


### PR DESCRIPTION
Fixes #64243 

From quick test all our helper scripts work fine on 3.7.
Why 3.7.9 instead of latest 3.7.12 ? Embed zips for these versions are missing from python.org ftp. (They apparently do not ship binaries for security-fix only releases)