### PR TITLE
Fixes tagger destinations

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -289,38 +289,14 @@ GLOBAL_LIST_INIT(scarySounds, list(
 //If you don't want to fuck up disposals, add to this list, and don't change the order.
 //If you insist on changing the order, you'll have to change every sort junction to reflect the new order. --Pete
 
-GLOBAL_LIST_INIT(TAGGERLOCATIONS, list(
-	"Atmospherics",
-	"Bar",
-	"Cargo Bay",
-	"CE Office",
-	"Chapel",
-	"Chemistry",
-	"CMO Office",
-	"Detective's Office",
-	"Disposals",
-	"Dormitories",
-	"Engineering",
-	"Experimentor Lab",
-	"Genetics",
-	"HoP Office",
-	"HoS Office",
-	"Hydroponics",
-	"Janitor Closet",
-	"Kitchen",
-	"Law Office",
-	"Library",
-	"Medbay",
-	"Ordnance",
-	"QM Office",
-	"RD Office",
-	"Research",
-	"Robotics",
-	"Security",
-	"Theatre",
-	"Virology",
-	"Xenobiology",
-))
+GLOBAL_LIST_INIT(TAGGERLOCATIONS, list("Disposals",
+	"Cargo Bay", "QM Office", "Engineering", "CE Office",
+	"Atmospherics", "Security", "HoS Office", "Medbay",
+	"CMO Office", "Chemistry", "Research", "RD Office",
+	"Robotics", "HoP Office", "Library", "Chapel", "Theatre",
+	"Bar", "Kitchen", "Hydroponics", "Janitor Closet","Genetics",
+	"Experimentor Lab", "Ordnance", "Dormitories", "Virology",
+	"Xenobiology", "Law Office","Detective's Office"))
 
 GLOBAL_LIST_INIT(station_prefixes, world.file2list("strings/station_prefixes.txt"))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#64018 completely fucked `TAGGERLOCATIONS`. This PR reverts the changes to the one and only valid order of the values.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Mailing crates is completely broken right now.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed delivery tagger destinations.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
