### PR TITLE
Skateboard content expansion pack

### DIFF
--- a/code/datums/elements/food/processable.dm
+++ b/code/datums/elements/food/processable.dm
@@ -28,7 +28,7 @@
 	. = ..()
 	UnregisterSignal(target, list(COMSIG_ATOM_TOOL_ACT(tool_behaviour), COMSIG_PARENT_EXAMINE))
 
-/datum/element/processable/proc/try_process(datum/source, mob/living/user, list/mutable_recipes)
+/datum/element/processable/proc/try_process(datum/source, mob/living/user, obj/item/I, list/mutable_recipes)
 	SIGNAL_HANDLER
 
 	mutable_recipes += list(list(TOOL_PROCESSING_RESULT = result_atom_type, TOOL_PROCESSING_AMOUNT = amount_created, TOOL_PROCESSING_TIME = time_to_process))

--- a/code/datums/elements/food/processable.dm
+++ b/code/datums/elements/food/processable.dm
@@ -28,7 +28,7 @@
 	. = ..()
 	UnregisterSignal(target, list(COMSIG_ATOM_TOOL_ACT(tool_behaviour), COMSIG_PARENT_EXAMINE))
 
-/datum/element/processable/proc/try_process(datum/source, mob/living/user, obj/item/I, list/mutable_recipes)
+/datum/element/processable/proc/try_process(datum/source, mob/living/user, list/mutable_recipes)
 	SIGNAL_HANDLER
 
 	mutable_recipes += list(list(TOOL_PROCESSING_RESULT = result_atom_type, TOOL_PROCESSING_AMOUNT = amount_created, TOOL_PROCESSING_TIME = time_to_process))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1395,7 +1395,7 @@
 			if(TOOL_ANALYZER)
 				act_result = analyzer_act(user, tool)
 	else
-		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_SECONDARY_TOOL_ACT(tool_type), user, tool)
+		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_SECONDARY_TOOL_ACT(tool_type), user)
 		if(signal_result & COMPONENT_BLOCK_TOOL_ATTACK) // The COMSIG_ATOM_TOOL_ACT signal is blocking the act
 			return TOOL_ACT_SIGNAL_BLOCKING
 		switch(tool_type)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1395,7 +1395,7 @@
 			if(TOOL_ANALYZER)
 				act_result = analyzer_act(user, tool)
 	else
-		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_SECONDARY_TOOL_ACT(tool_type), user)
+		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_SECONDARY_TOOL_ACT(tool_type), user, tool)
 		if(signal_result & COMPONENT_BLOCK_TOOL_ATTACK) // The COMSIG_ATOM_TOOL_ACT signal is blocking the act
 			return TOOL_ACT_SIGNAL_BLOCKING
 		switch(tool_type)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1367,7 +1367,7 @@
  *
  * Must return  parent proc ..() in the end if overridden
  */
-/atom/proc/tool_act(mob/living/user, obj/item/tool, tool_type, is_right_clicking, instant_proccess = FALSE)
+/atom/proc/tool_act(mob/living/user, obj/item/tool, tool_type, is_right_clicking
 	var/act_result
 	var/signal_result
 	if(!is_right_clicking) // Left click first for sensibility
@@ -1376,7 +1376,7 @@
 		if(signal_result & COMPONENT_BLOCK_TOOL_ATTACK) // The COMSIG_ATOM_TOOL_ACT signal is blocking the act
 			return TOOL_ACT_SIGNAL_BLOCKING
 		if(processing_recipes.len)
-			process_recipes(user, tool, processing_recipes, instant_proccess)
+			process_recipes(user, tool, processing_recipes)
 		if(QDELETED(tool))
 			return TRUE
 		switch(tool_type)
@@ -1417,16 +1417,16 @@
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 
-/atom/proc/process_recipes(mob/living/user, obj/item/processed_object, list/processing_recipes, instant_proccess = FALSE)
+/atom/proc/process_recipes(mob/living/user, obj/item/processed_object, list/processing_recipes)
 	//Only one recipe? use the first
 	if(processing_recipes.len == 1)
-		StartProcessingAtom(user, processed_object, processing_recipes[1], instant_proccess)
+		StartProcessingAtom(user, processed_object, processing_recipes[1])
 		return
 	//Otherwise, select one with a radial
-	ShowProcessingGui(user, processed_object, processing_recipes, instant_proccess)
+	ShowProcessingGui(user, processed_object, processing_recipes)
 
 ///Creates the radial and processes the selected option
-/atom/proc/ShowProcessingGui(mob/living/user, obj/item/processed_object, list/possible_options, instant_proccess = FALSE)
+/atom/proc/ShowProcessingGui(mob/living/user, obj/item/processed_object, list/possible_options)
 	var/list/choices_to_options = list() //Dict of object name | dict of object processing settings
 	var/list/choices = list()
 
@@ -1438,13 +1438,11 @@
 
 	var/pick = show_radial_menu(user, src, choices, radius = 36, require_near = TRUE)
 
-	StartProcessingAtom(user, processed_object, choices_to_options[pick], instant_proccess)
+	StartProcessingAtom(user, processed_object, choices_to_options[pick])
 
 
-/atom/proc/StartProcessingAtom(mob/living/user, obj/item/process_item, list/chosen_option, instant_proccess = FALSE)
+/atom/proc/StartProcessingAtom(mob/living/user, obj/item/process_item, list/chosen_option)
 	var/processing_time = chosen_option[TOOL_PROCESSING_TIME]
-	if(instant_proccess)
-		processing_time = 0
 	else
 		to_chat(user, span_notice("You start working on [src]."))
 	if(process_item.use_tool(src, user, processing_time, volume=50))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1372,7 +1372,7 @@
 	var/signal_result
 	if(!is_right_clicking) // Left click first for sensibility
 		var/list/processing_recipes = list() //List of recipes that can be mutated by sending the signal
-		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(tool_type), user, tool, processing_recipes)
+		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(tool_type), user, processing_recipes)
 		if(signal_result & COMPONENT_BLOCK_TOOL_ATTACK) // The COMSIG_ATOM_TOOL_ACT signal is blocking the act
 			return TOOL_ACT_SIGNAL_BLOCKING
 		if(processing_recipes.len)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1372,7 +1372,7 @@
 	var/signal_result
 	if(!is_right_clicking) // Left click first for sensibility
 		var/list/processing_recipes = list() //List of recipes that can be mutated by sending the signal
-		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(tool_type), user, tool, processing_recipes, tool)
+		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(tool_type), user, tool, processing_recipes)
 		if(signal_result & COMPONENT_BLOCK_TOOL_ATTACK) // The COMSIG_ATOM_TOOL_ACT signal is blocking the act
 			return TOOL_ACT_SIGNAL_BLOCKING
 		if(processing_recipes.len)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1372,7 +1372,7 @@
 	var/signal_result
 	if(!is_right_clicking) // Left click first for sensibility
 		var/list/processing_recipes = list() //List of recipes that can be mutated by sending the signal
-		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(tool_type), user, processing_recipes)
+		signal_result = SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(tool_type), user, tool, processing_recipes, tool)
 		if(signal_result & COMPONENT_BLOCK_TOOL_ATTACK) // The COMSIG_ATOM_TOOL_ACT signal is blocking the act
 			return TOOL_ACT_SIGNAL_BLOCKING
 		if(processing_recipes.len)
@@ -1443,7 +1443,7 @@
 
 /atom/proc/StartProcessingAtom(mob/living/user, obj/item/process_item, list/chosen_option)
 	var/processing_time = chosen_option[TOOL_PROCESSING_TIME]
-		to_chat(user, span_notice("You start working on [src]."))
+	to_chat(user, span_notice("You start working on [src]."))
 	if(process_item.use_tool(src, user, processing_time, volume=50))
 		var/atom/atom_to_create = chosen_option[TOOL_PROCESSING_RESULT]
 		var/list/atom/created_atoms = list()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1367,7 +1367,7 @@
  *
  * Must return  parent proc ..() in the end if overridden
  */
-/atom/proc/tool_act(mob/living/user, obj/item/tool, tool_type, is_right_clicking
+/atom/proc/tool_act(mob/living/user, obj/item/tool, tool_type, is_right_clicking)
 	var/act_result
 	var/signal_result
 	if(!is_right_clicking) // Left click first for sensibility
@@ -1443,7 +1443,6 @@
 
 /atom/proc/StartProcessingAtom(mob/living/user, obj/item/process_item, list/chosen_option)
 	var/processing_time = chosen_option[TOOL_PROCESSING_TIME]
-	else
 		to_chat(user, span_notice("You start working on [src]."))
 	if(process_item.use_tool(src, user, processing_time, volume=50))
 		var/atom/atom_to_create = chosen_option[TOOL_PROCESSING_RESULT]

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -94,6 +94,12 @@
 	if(!iscarbon(rider) || rider.getStaminaLoss() >= 100 || grinding || iscarbon(bumped_thing))
 		var/atom/throw_target = get_edge_target_turf(rider, pick(GLOB.cardinals))
 		unbuckle_mob(rider)
+		if((istype(bumped_thing, /obj/machinery/disposal/bin)))
+			rider.Paralyze(8 SECONDS)
+			rider.forceMove(bumped_thing)
+			src.forceMove(bumped_thing)
+			visible_message(span_danger("[src] crashes into [bumped_thing], and gets dumped straight into it!"))
+			return
 		rider.throw_at(throw_target, 3, 2)
 		var/head_slot = rider.get_item_by_slot(ITEM_SLOT_HEAD)
 		if(!head_slot || !(istype(head_slot,/obj/item/clothing/head/helmet) || istype(head_slot,/obj/item/clothing/head/hardhat)))
@@ -108,10 +114,10 @@
 				grinding_mulitipler = 2
 			victim.Knockdown(4 * grinding_mulitipler SECONDS)
 			victim.Paralyze(1 * grinding_mulitipler SECONDS)
-		else
-			var/backdir = turn(dir, 180)
-			step(src, backdir)
-			rider.spin(4, 1)
+	else
+		var/backdir = turn(dir, 180)
+		step(src, backdir)
+		rider.spin(4, 1)
 
 ///Moves the vehicle forward and if it lands on a table, repeats
 /obj/vehicle/ridden/scooter/skateboard/proc/grind()
@@ -155,7 +161,7 @@
 					victim.apply_damage(damage = 25, damagetype = BRUTE, def_zone = body_part, wound_bonus = 20)
 					victim.Paralyze(1.5 SECONDS)
 					skater.adjustStaminaLoss(instability)
-					victim.visible_message(span_danger("[victim] strait up gets grinded into the ground by [skater]'s [src]! Radical!"))
+					victim.visible_message(span_danger("[victim] straight up gets grinded into the ground by [skater]'s [src]! Radical!"))
 		for(var/obj/item/cut_thing in location)
 			var/cut_holder = new/obj/item/knife(null) // The lore implications is that when a skateboard runs over cheese, it summons a knife from the shadow realm to cut it
 			cut_thing.tool_act(skater, cut_holder, TOOL_KNIFE, instant_proccess = TRUE)

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -150,18 +150,18 @@
 
 		for(var/mob/living/carbon/victim in location)
 			if(victim.body_position == LYING_DOWN)
-				var/total_brute = victim.getBruteLoss()
 				playsound(location, 'sound/items/trayhit2.ogg', 40)
-					var/body_part = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_CHEST)
-					victim.apply_damage(damage = 25, damagetype = BRUTE, def_zone = body_part, wound_bonus = 20)
-					victim.Paralyze(1.5 SECONDS)
-					skater.adjustStaminaLoss(instability)
-					victim.visible_message(span_danger("[victim] straight up gets grinded into the ground by [skater]'s [src]! Radical!"))
+				var/body_part = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_CHEST)
+				victim.apply_damage(damage = 25, damagetype = BRUTE, def_zone = body_part, wound_bonus = 20)
+				victim.Paralyze(1.5 SECONDS)
+				skater.adjustStaminaLoss(instability)
+				victim.visible_message(span_danger("[victim] straight up gets grinded into the ground by [skater]'s [src]! Radical!"))
 		for(var/obj/item/cut_thing in location)
-			var/cut_holder = new/obj/item/knife(null) // The lore implications is that when a skateboard runs over cheese, it summons a knife from the shadow realm to cut it
-			cut_thing.tool_act(skater, cut_holder, TOOL_KNIFE, instant_proccess = TRUE)
-			qdel(cut_holder) // and then disapears the knife back to where it came from.
 	addtimer(CALLBACK(src, .proc/grind), 1)
+
+			//var/cut_holder = new/obj/item/knife(null) // The lore implications is that when a skateboard runs over cheese, it summons a knife from the shadow realm to cut it
+			//cut_thing.tool_act(skater, cut_holder, TOOL_KNIFE, instant_proccess = TRUE)
+			//qdel(cut_holder) // and then disapears the knife back to where it came from.
 
 /obj/vehicle/ridden/scooter/skateboard/MouseDrop(atom/over_object)
 	. = ..()

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -113,7 +113,6 @@
 			if(grinding)
 				grinding_mulitipler = 2
 			victim.Knockdown(4 * grinding_mulitipler SECONDS)
-			victim.Paralyze(1 * grinding_mulitipler SECONDS)
 	else
 		var/backdir = turn(dir, 180)
 		step(src, backdir)
@@ -153,10 +152,6 @@
 			if(victim.body_position == LYING_DOWN)
 				var/total_brute = victim.getBruteLoss()
 				playsound(location, 'sound/items/trayhit2.ogg', 40)
-				if(victim.stat == DEAD && total_brute >= 175)
-					victim.gib() // Beaten and brutalised, your body gives up
-					playsound(victim, 'sound/effects/splat.ogg', 50)
-				else
 					var/body_part = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_CHEST)
 					victim.apply_damage(damage = 25, damagetype = BRUTE, def_zone = body_part, wound_bonus = 20)
 					victim.Paralyze(1.5 SECONDS)

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -97,7 +97,7 @@
 		if((istype(bumped_thing, /obj/machinery/disposal/bin)))
 			rider.Paralyze(8 SECONDS)
 			rider.forceMove(bumped_thing)
-			src.forceMove(bumped_thing)
+			forceMove(bumped_thing)
 			visible_message(span_danger("[src] crashes into [bumped_thing], and gets dumped straight into it!"))
 			return
 		rider.throw_at(throw_target, 3, 2)

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -147,18 +147,18 @@
 		if(prob(25))
 			location.hotspot_expose(1000,1000)
 			sparks.start() //the most radical way to start plasma fires
+	for(var/mob/living/carbon/victim in location)
+		if(victim.body_position == LYING_DOWN)
+			playsound(location, 'sound/items/trayhit2.ogg', 40)
+			var/body_part = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_CHEST)
+			victim.apply_damage(damage = 25, damagetype = BRUTE, def_zone = body_part, wound_bonus = 20)
+			victim.Paralyze(1.5 SECONDS)
+			skater.adjustStaminaLoss(instability)
+			victim.visible_message(span_danger("[victim] straight up gets grinded into the ground by [skater]'s [src]! Radical!"))
 
-		for(var/mob/living/carbon/victim in location)
-			if(victim.body_position == LYING_DOWN)
-				playsound(location, 'sound/items/trayhit2.ogg', 40)
-				var/body_part = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_CHEST)
-				victim.apply_damage(damage = 25, damagetype = BRUTE, def_zone = body_part, wound_bonus = 20)
-				victim.Paralyze(1.5 SECONDS)
-				skater.adjustStaminaLoss(instability)
-				victim.visible_message(span_danger("[victim] straight up gets grinded into the ground by [skater]'s [src]! Radical!"))
-		for(var/obj/item/cut_thing in location)
 	addtimer(CALLBACK(src, .proc/grind), 1)
 
+			//for(var/obj/item/cut_thing in location)
 			//var/cut_holder = new/obj/item/knife(null) // The lore implications is that when a skateboard runs over cheese, it summons a knife from the shadow realm to cut it
 			//cut_thing.tool_act(skater, cut_holder, TOOL_KNIFE, instant_proccess = TRUE)
 			//qdel(cut_holder) // and then disapears the knife back to where it came from.

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -155,13 +155,7 @@
 			victim.Paralyze(1.5 SECONDS)
 			skater.adjustStaminaLoss(instability)
 			victim.visible_message(span_danger("[victim] straight up gets grinded into the ground by [skater]'s [src]! Radical!"))
-
 	addtimer(CALLBACK(src, .proc/grind), 1)
-
-			//for(var/obj/item/cut_thing in location)
-			//var/cut_holder = new/obj/item/knife(null) // The lore implications is that when a skateboard runs over cheese, it summons a knife from the shadow realm to cut it
-			//cut_thing.tool_act(skater, cut_holder, TOOL_KNIFE, instant_proccess = TRUE)
-			//qdel(cut_holder) // and then disapears the knife back to where it came from.
 
 /obj/vehicle/ridden/scooter/skateboard/MouseDrop(atom/over_object)
 	. = ..()

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -297,7 +297,7 @@
 			return
 		var/mob/living/rider = owner
 		var/turf/landing_turf = get_step(vehicle.loc, vehicle.dir)
-		rider.adjustStaminaLoss(vehicle.instability*0.5)
+		rider.adjustStaminaLoss(vehicle.instability* 0.75)
 		if (rider.getStaminaLoss() >= 100)
 			vehicle.obj_flags &= ~CAN_BE_HIT
 			playsound(src, 'sound/effects/bang.ogg', 20, TRUE)

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -298,7 +298,7 @@
 			return
 		var/mob/living/rider = owner
 		var/turf/landing_turf = get_step(vehicle.loc, vehicle.dir)
-		rider.adjustStaminaLoss(vehicle.instability*2)
+		rider.adjustStaminaLoss(vehicle.instability*0.5)
 		if (rider.getStaminaLoss() >= 100)
 			vehicle.obj_flags &= ~CAN_BE_HIT
 			playsound(src, 'sound/effects/bang.ogg', 20, TRUE)

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -287,11 +287,10 @@
 	name = "Ollie"
 	desc = "Get some air! Land on a table to do a gnarly grind."
 	button_icon_state = "skateboard_ollie"
-	///Cooldown to next jump
-	var/next_ollie
+	check_flags = AB_CHECK_CONSCIOUS
 
 /datum/action/vehicle/ridden/scooter/skateboard/ollie/Trigger(trigger_flags)
-	if(world.time > next_ollie)
+	if(..())
 		var/obj/vehicle/ridden/scooter/skateboard/vehicle = vehicle_target
 		vehicle.obj_flags |= BLOCK_Z_OUT_DOWN
 		if (vehicle.grinding)

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -290,7 +290,8 @@
 	check_flags = AB_CHECK_CONSCIOUS
 
 /datum/action/vehicle/ridden/scooter/skateboard/ollie/Trigger(trigger_flags)
-	if(..())
+	. = ..()
+	if(.)
 		var/obj/vehicle/ridden/scooter/skateboard/vehicle = vehicle_target
 		vehicle.obj_flags |= BLOCK_Z_OUT_DOWN
 		if (vehicle.grinding)

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -250,3 +250,4 @@ If you're bleeding, you can apply pressure to the limb by grabbing yourself whil
 Laying down will help slow down bloodloss. Death will halt it entirely.
 ♪ Hey, have you ever tried appending the % character before your messages when speaking in-game? ♫
 @You can use the |, + and _ characters to emphasize parts of what you say in-game (e.g. say"my _ass_ |is| +heavy+." will be outputted as "my <u>ass</u> <i>is</i> <b>heavy</b>."). You can also escape these emphasizers by appending backslashes before them (e.g. say"1\+2\+3" will come out as "1+2+3" and not "1\<b>2\</b>3").
+If you knock into somebody while doing a wicked grind on a skateboard, they will be floored for double the time. Radical!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
(Drafted because working on balance and looking for more rad ideas)

Makes skateboarding a hell of a lot cooler,


Lowers stamina cost for ollieing and grinding.
Makes collisions with other carbons always result in a wipeout no matter your stamina damage, colliding with a carbon will stun and knock them down for a short time (Stunned for the quarter of the length the skater is, and knockdown for have the length) The time is doubled if you collide with them while they are performing a sick grind.

Additionally grinding on top of stuff now has more functionality.
Grinding over a person that is laying down will deal significant damage with a high chance to wound at the cost of the skaters' stamina. For this to happen the person has to be laying down on the table, if they are standing they will simply collide as normal.
You can grind into a disposals bin.
Fixed action buttons always being red
 fixed being able to ollie while unconscious/dead
Grinding over an object that is cuttable with a knife will lead to that item getting instantly cut! This includes cheese.

- [x]  Implement further suggestions for grind functionality
- [x] Fix some known skateboard bugs
- [x] Tweak some stamina cost numbers, maybe stun times
- [x] Make a better changelog
- [x] Record a video where my character doesn't randomly turn invisible because of a memory shortage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
https://user-images.githubusercontent.com/55666666/150283992-ecf731bc-6c2b-4100-bb38-52966ec05822.mp4

https://user-images.githubusercontent.com/55666666/150379153-ab268574-2c78-48fb-a09f-7d93237d83bc.mp4


https://user-images.githubusercontent.com/55666666/150401922-c89ae889-e1e0-4a18-b60c-c9f9ba6a2d7d.mp4



<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: itseasytosee
expansion: Skateboards have been made considerably more radical
expansion: While grinding on a table with a skateboard, if you grind on top of somebody you are likely to hurt them quite badly 
expansion: Colliding with another person will now always result in a crash, in which the person hit gets knocked over as well as the skater (protip: crash into someone while grind to double the stun time!)
expansion: Colliding with a disposal unit while grinding will result in you getting dunked in! Wack!
fix: fixed some skateboard related bugs, including the action button for ollieing always being red, and being able to ollie while dead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
