### PR TITLE
Fixes kudzu not spreading much

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -531,6 +531,7 @@
 	//We can only do so much work per process, but we still want to process everything at some point
 	//So we shift the queue a bit
 	growth_queue += queue_end
+	queue_end = list()
 
 /// Updates the icon as the space vine grows
 /obj/structure/spacevine/proc/grow()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When I touched kudzu code in my harddel pr f8aad14ae87c73edb7c4cba8644cbdd6977cd8d9 (#63877) I was trying to
prevent the queue_end list holding onto a ref of something that was deleted from the growth_queue list mid
process

To achieve this, I made queue_end a var on the vine controller itself. In my hubris however I neglected to
**clear** it when the process was completed. So it would just keep slowly ballooning in size. This caused the
kudzu to not spread at all, and also lead to harddels, kinda defeating the point of the change.

This rectifies that issue


## Why It's Good For The Game

Fixes #64091 
Fixes #64080 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Kudzu will spread properly now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
