### PR TITLE
Heirlooms now reveal themselves on examine regardless of role, status or ownership.

### DIFF
--- a/code/datums/components/heirloom.dm
+++ b/code/datums/components/heirloom.dm
@@ -14,11 +14,13 @@
 /datum/component/heirloom/proc/examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
+	var/datum/antagonist/obsessed/creeper = user.mind.has_antag_datum(/datum/antagonist/obsessed)
+
 	if(user.mind == owner)
 		examine_list += span_notice("It is your precious [family_name] family heirloom. Keep it safe!")
-	else if(isobserver(user))
-		examine_list += span_notice("It is the [family_name] family heirloom, belonging to [owner].")
-	else
+	else if(creeper)
 		var/datum/antagonist/obsessed/creeper = user.mind.has_antag_datum(/datum/antagonist/obsessed)
 		if(creeper && creeper.trauma.obsession == owner)
 			examine_list += span_nicegreen("This must be [owner]'s family heirloom! It smells just like them...")
+	else
+		examine_list += span_notice("It is the [family_name] family heirloom, belonging to [owner].")

--- a/code/datums/components/heirloom.dm
+++ b/code/datums/components/heirloom.dm
@@ -18,9 +18,7 @@
 
 	if(user.mind == owner)
 		examine_list += span_notice("It is your precious [family_name] family heirloom. Keep it safe!")
-	else if(creeper)
-		var/datum/antagonist/obsessed/creeper = user.mind.has_antag_datum(/datum/antagonist/obsessed)
-		if(creeper && creeper.trauma.obsession == owner)
-			examine_list += span_nicegreen("This must be [owner]'s family heirloom! It smells just like them...")
+	else if(creeper && creeper.trauma.obsession == owner)
+		examine_list += span_nicegreen("This must be [owner]'s family heirloom! It smells just like them...")
 	else
 		examine_list += span_notice("It is the [family_name] family heirloom, belonging to [owner].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Heirlooms can be seen by everyone on examine.

## Why It's Good For The Game

It has become more and more important as time goes on to be able to identify what is and is not an heirloom. The advantages are more health around the chronicler and obsessed antagonists

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Heirlooms are now visible to everyone on examine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
