### PR TITLE
output direction change for mech fabs

### DIFF
--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -112,6 +112,17 @@
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Storing up to <b>[rmat.local_size]</b> material units.<br>Material consumption at <b>[component_coeff*100]%</b>.<br>Build time reduced by <b>[100-time_coeff*100]%</b>.")
+	if(panel_open)
+		. += span_notice("Alt-click to rotate the output direction.")
+
+/obj/machinery/mecha_part_fabricator/AltClick(mob/user)
+	. = ..()
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
+	if(panel_open)
+		dir = turn(dir, -90)
+		to_chat(user, span_notice("You change [src]'s output direction to [dir2text(dir)]."))
+		return TRUE
 
 /**
  * Generates an info list for a given part.

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -121,7 +121,7 @@
 		return
 	if(panel_open)
 		dir = turn(dir, -90)
-		to_chat(user, span_notice("You change [src]'s output direction to [dir2text(dir)]."))
+		balloon_alert(user, "rotated to [dir2text(dir)].")
 		return TRUE
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this adds the ability to change the output direction (the direction) of the mech fabricator using alt-click whilst it has its wire panel open.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Certain maps have a dir for the mech fabricator that prints in that dir; however, if it were to be destroyed, you can't change its dir whatsoever. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can now rotate the direction of the mecha fab if its wire panel is open
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
