### PR TITLE
Makes destination tagger UI use alphabetical order

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -412,7 +412,7 @@
 	switch(action)
 		if("change")
 			var/new_tag = round(text2num(params["index"]))
-			if(new_tag == currTag)
+			if(new_tag == currTag || new_tag < 1 || new_tag > length(GLOB.TAGGERLOCATIONS))
 				return
 			currTag = new_tag
 	return TRUE

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -358,6 +358,7 @@
 	worn_icon_state = "cargotagger"
 	var/currTag = 0 //Destinations are stored in code\globalvars\lists\flavor_misc.dm
 	var/locked_destination = FALSE //if true, users can't open the destination tag window to prevent changing the tagger's current destination
+	var/sort_list_mode = "STANDARD" // Mode to sort destinations by. Other values defined and used inside TGUI.
 	w_class = WEIGHT_CLASS_TINY
 	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
@@ -402,6 +403,7 @@
 	var/list/data = list()
 	data["locations"] = GLOB.TAGGERLOCATIONS
 	data["currentTag"] = currTag
+	data["sortListMode"] = sort_list_mode
 	return data
 
 /** User clicks a button on the tagger */
@@ -409,11 +411,17 @@
 	. = ..()
 	if(.)
 		return
-	if(action != "change")
-		return
-	if(round(text2num(params["index"])) == currTag)
-		return
-	currTag = round(text2num(params["index"]))
+	switch(action)
+		if("change")
+			var/new_tag = round(text2num(params["index"]))
+			if(new_tag == currTag)
+				return
+			currTag = new_tag
+		if("sort_list")
+			var/new_sort_mode = params["mode"]
+			if(new_sort_mode == sort_list_mode)
+				return
+			sort_list_mode = new_sort_mode
 	return TRUE
 
 /obj/item/sales_tagger

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -358,7 +358,6 @@
 	worn_icon_state = "cargotagger"
 	var/currTag = 0 //Destinations are stored in code\globalvars\lists\flavor_misc.dm
 	var/locked_destination = FALSE //if true, users can't open the destination tag window to prevent changing the tagger's current destination
-	var/sort_list_mode = "STANDARD" // Mode to sort destinations by. Other values defined and used inside TGUI.
 	w_class = WEIGHT_CLASS_TINY
 	inhand_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
@@ -403,7 +402,6 @@
 	var/list/data = list()
 	data["locations"] = GLOB.TAGGERLOCATIONS
 	data["currentTag"] = currTag
-	data["sortListMode"] = sort_list_mode
 	return data
 
 /** User clicks a button on the tagger */
@@ -417,11 +415,6 @@
 			if(new_tag == currTag)
 				return
 			currTag = new_tag
-		if("sort_list")
-			var/new_sort_mode = params["mode"]
-			if(new_sort_mode == sort_list_mode)
-				return
-			sort_list_mode = new_sort_mode
 	return TRUE
 
 /obj/item/sales_tagger

--- a/tgui/packages/tgui/interfaces/DestinationTagger.tsx
+++ b/tgui/packages/tgui/interfaces/DestinationTagger.tsx
@@ -1,19 +1,10 @@
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
-import { Stack, Section, Button, Divider } from '../components';
-
-/**
- * The sorting mode for the destination list. See sortDestinations()
- */
-enum SortMode {
-  SM_DEFAULT = "STANDARD", // By code
-  SM_ALPHABETICAL = "ALPHABETICAL", // By name
-}
+import { Stack, Section, Button } from '../components';
 
 type DestinationTaggerData = {
   locations: string[];
   currentTag: number;
-  sortListMode: SortMode;
 };
 
 /**
@@ -24,27 +15,27 @@ type DestinationInfo = {
   sorting_id: number;
 };
 
-const sortDestinations
-  = (locations: string[], mode: SortMode): DestinationInfo[] => {
-    const clean_destinations = locations.map((name, index) => ({
+/**
+ * Sort destinations in alphabetical order,
+ * and wrap them in a way that preserves what ID to return.
+ * @param locations The raw, official list of destination tags.
+ * @returns The alphetically sorted list of destinations.
+ */
+const sortDestinations = (locations: string[]): DestinationInfo[] => {
+  return locations
+    .map((name, index) => ({
       name: name.toUpperCase(),
       sorting_id: index + 1,
-    }));
-
-    switch (mode) {
-      case SortMode.SM_ALPHABETICAL:
-        return clean_destinations.sort((a, b) => a.name.localeCompare(b.name));
-      default:
-        return clean_destinations;
-    }
-  };
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+};
 
 export const DestinationTagger = (props, context) => {
   const { act, data } = useBackend<DestinationTaggerData>(context);
-  const { locations, currentTag, sortListMode } = data;
+  const { locations, currentTag } = data;
 
   return (
-    <Window theme="retro" title="TagMaster 2.4" width={420} height={530}>
+    <Window theme="retro" title="TagMaster 2.4" width={420} height={500}>
       <Window.Content>
         <Stack fill vertical>
           <Stack.Item grow>
@@ -56,34 +47,18 @@ export const DestinationTagger = (props, context) => {
                   ? 'Please Select A Location'
                   : `Current Destination: ${locations[currentTag - 1]}`
               }>
-              {Object.values(SortMode).map((modeName) => {
+              {sortDestinations(locations).map((location) => {
                 return (
                   <Button.Checkbox
-                    checked={sortListMode === modeName}
+                    checked={currentTag === location.sorting_id}
                     height={2}
-                    key={modeName}
-                    onClick={() => act('sort_list', { mode: modeName })}
-                    width={15} >
-                    {modeName}
+                    key={location.sorting_id}
+                    onClick={() => act('change', { index: location.sorting_id })}
+                    width={15}>
+                    {location.name}
                   </Button.Checkbox>
                 );
               })}
-
-              <Divider />
-
-              {sortDestinations(locations, sortListMode)
-                .map((location) => {
-                  return (
-                    <Button.Checkbox
-                      checked={currentTag === location.sorting_id}
-                      height={2}
-                      key={location.sorting_id}
-                      onClick={() => act('change', { index: location.sorting_id })}
-                      width={15}>
-                      {location.name}
-                    </Button.Checkbox>
-                  );
-                })}
             </Section>
           </Stack.Item>
         </Stack>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Inspired by a recent bugfix, I made the Destination Tagger UI sort the items alphabetically.

I originally just replaced it with a `tgui_input_list_async()`, but there's something charming about this chunky remote control interface.

I also cleaned up the code a little bit.

![image](https://user-images.githubusercontent.com/1185434/150672843-2f6e0e1b-9795-4136-9441-565d9b24ed35.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People likely find it difficult to find destinations quickly in this interface, so this probably helps. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
qol: The destination tagger UI now shows its items in alphabetical order (intentionally).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
