### PR TITLE
Hopefully fixes another source of long timer singlecaps

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -166,6 +166,15 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
 	if(message_admins)
 		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(user)] " : ""][details][bomb ? " [bomb.name] at [ADMIN_VERBOSEJMP(bomb)]": ""][additional_details ? " [additional_details]" : ""].")
 
+/// Logs the contents of the gasmix to the game log, prefixed by text
+/proc/log_atmos(text, datum/gas_mixture/mix)
+	var/message = text
+	message += "TEMP=[mix.temperature],MOL=[mix.total_moles()],VOL=[mix.volume]"
+	for(var/key in mix.gases)
+		var/list/gaslist = mix.gases[key]
+		message += "[gaslist[GAS_META][META_GAS_ID]]=[gaslist[MOLES]];"
+	log_game(message)
+
 /proc/log_say(text)
 	if (CONFIG_GET(flag/log_say))
 		WRITE_LOG(GLOB.world_game_log, "SAY: [text]")

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -320,7 +320,7 @@
 
 		// As of writing this this is calibrated to maxcap at 140L and 160atm.
 		var/power = (air_contents.volume * (pressure - TANK_FRAGMENT_PRESSURE)) / TANK_FRAGMENT_SCALE
-		log_atmos("[src.type] exploded with a power of [power] and a mix of ", air_contents)
+		log_atmos("[type] exploded with a power of [power] and a mix of ", air_contents)
 		dyn_explosion(src, power, flash_range = 1.5, ignorecap = FALSE)
 	return ..()
 

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -318,9 +318,9 @@
 		air_contents.react(src)
 		pressure = air_contents.return_pressure()
 
-		log_atmos("[src.type] exploded with a mix of ", air_contents)
 		// As of writing this this is calibrated to maxcap at 140L and 160atm.
 		var/power = (air_contents.volume * (pressure - TANK_FRAGMENT_PRESSURE)) / TANK_FRAGMENT_SCALE
+		log_atmos("[src.type] exploded with a power of [power] and a mix of ", air_contents)
 		dyn_explosion(src, power, flash_range = 1.5, ignorecap = FALSE)
 	return ..()
 

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -318,6 +318,7 @@
 		air_contents.react(src)
 		pressure = air_contents.return_pressure()
 
+		log_atmos("[src.type] exploded with a mix of ", air_contents)
 		// As of writing this this is calibrated to maxcap at 140L and 160atm.
 		var/power = (air_contents.volume * (pressure - TANK_FRAGMENT_PRESSURE)) / TANK_FRAGMENT_SCALE
 		dyn_explosion(src, power, flash_range = 1.5, ignorecap = FALSE)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -486,7 +486,8 @@
 /datum/gas_reaction/bzformation/init_reqs()
 	requirements = list(
 		/datum/gas/nitrous_oxide = 10,
-		/datum/gas/plasma = 10
+		/datum/gas/plasma = 10,
+		"MAX_TEMP" = T20C + 20 // Yes, someone used this as a bomb timer. I hate players
 	)
 
 /datum/gas_reaction/bzformation/react(datum/gas_mixture/air)
@@ -494,6 +495,7 @@
 	var/temperature = air.temperature
 	var/pressure = air.return_pressure()
 	var/old_heat_capacity = air.heat_capacity()
+	// This slows down in relation to pressure, very quickly. Please don't expect it to be anything more then a snail
 	var/reaction_efficency = min(1 / ((pressure / (0.1 * ONE_ATMOSPHERE)) * (max(cached_gases[/datum/gas/plasma][MOLES] / cached_gases[/datum/gas/nitrous_oxide][MOLES], 1))), cached_gases[/datum/gas/nitrous_oxide][MOLES], cached_gases[/datum/gas/plasma][MOLES] * INVERSE(2))
 	var/energy_released = 2 * reaction_efficency * FIRE_CARBON_ENERGY_RELEASED
 	if ((cached_gases[/datum/gas/nitrous_oxide][MOLES] - reaction_efficency < 0 )|| (cached_gases[/datum/gas/plasma][MOLES] - (2 * reaction_efficency) < 0) || energy_released <= 0) //Shouldn't produce gas from nothing.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Very similar to 87fbe4c (#62415)

Got a ping from mothblocks complaining about "Mass bombing" and "Unplayable rounds" on sybil, caused by long timer singlecaps.
I'm like 90% sure they're using bz's slow heating to achieve this. So I'm just gonna cap bz production at 20 degrees above room temp. It's not like you're going to be doing fabrication at this temperature anyway, so this isn't horribly impactful.

For the curious among you, bz scales its temperature increase inversely to its pressure, among other factors.
This scaling is VERY harsh, so at high pressures it barely creates any heat at all. This is useful for generating horribly long delays

Adds gasmix logging to tank explosions
Hopefully this will be useful if I ever keel over and die someday

## Why It's Good For The Game

Insert discussion of single caps, cursed problems, and salt prs here. 
You know if you guys weren't absolute chodes about this stuff I wouldn't even notice

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed another source of long timer singlecaps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
