### PR TITLE
Replaces the powergame crowbar accidentally mapped into icebox mining

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -15397,7 +15397,7 @@
 /obj/effect/turf_decal/tile/dark,
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/rack,
-/obj/item/crowbar/large/heavy,
+/obj/item/crowbar/large/old,
 /turf/open/floor/iron,
 /area/mine/living_quarters)
 "Yn" = (

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -60,6 +60,17 @@
 	force = 20
 	icon_state = "crowbar_powergame"
 
+/obj/item/crowbar/large/old
+	name = "old crowbar"
+	desc = "It's an old crowbar. Much larger than the pocket sized ones, carrying a lot more heft. They don't make 'em like they used to."
+	throwforce = 10
+	throw_speed = 2
+
+/obj/item/crowbar/large/old/Initialize()
+	. = ..()
+	if(prob(50))
+		icon_state = "crowbar_powergame"
+
 /obj/item/crowbar/power
 	name = "jaws of life"
 	desc = "A set of jaws of life, compressed through the magic of science."


### PR DESCRIPTION
## About The Pull Request

Removes the 20 force powergame crowbar mapped into icebox mining by mistake and replaces it with a (comparatively much weaker) 12 force, normal sized "old crowbar". 
Adds a new subtype of large crowbar to retain some soul. 

![image](https://user-images.githubusercontent.com/51863163/150631232-5b6dd823-b274-4874-8091-e7d71944a70a.png)

not even sure if this is technically a fix or balance, since it wasn't meant to be placed in the first place. 

## Why It's Good For The Game

free 20 force weapon in public mining goes brrrrr

## Changelog

:cl: Melbert
fix: the powergame crowbar has been lifted out of icebox mining and replaced with a more sane crowbar
/:cl:

