### PR TITLE
Cleans up thief midround ruleset, adds a few more conditions

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -993,10 +993,16 @@
 	candidates = living_players
 	for(var/mob/living/carbon/human/candidate in candidates)
 		if( \
-			candidate.mind.has_antag_datum(antag_datum) \
+			//no bigger antagonists getting smaller role
+			player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0) \
+			//no dead people
 			|| candidate.stat == DEAD \
+			//no people who don't want it
 			|| !(ROLE_OPPORTUNIST in candidate.client?.prefs?.be_special) \
-			|| !candidate.mind.assigned_role \
+			//no non-station crew
+			|| candidate.mind.assigned_role.faction != FACTION_STATION \
+			//stops thief being added to admins messing around on centcom
+			|| is_centcom_level(candidate.z) \
 		)
 			candidates -= candidate
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -994,7 +994,7 @@
 	for(var/mob/living/carbon/human/candidate in candidates)
 		if( \
 			//no bigger antagonists getting smaller role
-			player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0) \
+			candidate.mind && (candidate.mind.special_role || candidate.mind.antag_datums?.len > 0) \
 			//no dead people
 			|| candidate.stat == DEAD \
 			//no people who don't want it


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Adds an antag datum check to the opportunist roll, so only nonantags can become thieves. Thieves can still roll for higher influence antagonists, though
- Adds a centcom zlevel check as well.
- Finally, adds comments on what each check is. Why not?

## Why It's Good For The Game

- antag datum check is to not waste potential thieves on antags with an already greater part of the game.
- the centcom check is so admins testing around don't waste rolls

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Antagonists cannot roll for thieves anymore, as you already have a larger amount of impact on the round than thief would give you.
admin: Admins no longer roll for thief while they sit around on centcom testing things.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
