### PR TITLE
Fixes the antag panel not being removed on mind loss 

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -164,7 +164,7 @@
 	antag_hud = new_character.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/antagonist_hud, "combo_hud", src)
 	for(var/a in antag_datums) //Makes sure all antag datums effects are applied in the new body
 		var/datum/antagonist/A = a
-		A.on_body_transfer(old_current, current)
+		A.on_body_transfer(current)
 	if(iscarbon(new_character))
 		var/mob/living/carbon/C = new_character
 		C.last_mind = src

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -71,6 +71,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	GLOB.antagonists -= src
 	if(owner)
 		LAZYREMOVE(owner.antag_datums, src)
+		UnregisterSignal(owner, COMSIG_MIND_TRANSFERRED)
 	QDEL_NULL(team_hud_ref)
 	owner = null
 	return ..()

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -65,8 +65,6 @@ GLOBAL_LIST_EMPTY(antagonists)
 	GLOB.antagonists += src
 	typecache_datum_blacklist = typecacheof(typecache_datum_blacklist)
 
-	RegisterSignal(owner, COMSIG_MIND_TRANSFERRED, .proc/on_body_removal)
-
 /datum/antagonist/Destroy()
 	GLOB.antagonists -= src
 	if(owner)
@@ -181,6 +179,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	if(!soft_antag && owner.current.stat != DEAD && owner.current.client)
 		owner.current.add_to_current_living_antags()
 
+	RegisterSignal(owner, COMSIG_MIND_TRANSFERRED, .proc/on_body_removal)
 	SEND_SIGNAL(owner, COMSIG_ANTAGONIST_GAINED, src)
 
 /**

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	GLOB.antagonists += src
 	typecache_datum_blacklist = typecacheof(typecache_datum_blacklist)
 
-	RegisterSignal(owner.current, COMSIG_CARBON_LOSE_ORGAN, .proc/on_body_removal)
+	RegisterSignal(owner, COMSIG_MIND_TRANSFERRED, .proc/on_body_removal)
 
 /datum/antagonist/Destroy()
 	GLOB.antagonists -= src
@@ -90,11 +90,9 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/antagonist/proc/specialization(datum/mind/new_owner)
 	return src
 
-/datum/antagonist/proc/on_body_removal(mob/living/old_body, obj/item/organ/organ)
+/datum/antagonist/proc/on_body_removal(datum/mind, mob/living/old_body)
 	SIGNAL_HANDLER
 
-	if (!istype(organ, /obj/item/organ/brain))
-		return FALSE
 	remove_innate_effects(old_body)
 	if(!soft_antag && old_body && old_body.stat != DEAD && !LAZYLEN(old_body.mind?.antag_datums))
 		old_body.remove_from_current_living_antags()

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -90,7 +90,14 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/antagonist/proc/specialization(datum/mind/new_owner)
 	return src
 
-/datum/antagonist/proc/on_body_removal(datum/mind, mob/living/old_body)
+/**
+ * Called on the owners mind transfer, to remove actions and effects from the original body
+ *
+ * Arguments:
+ * * datum/mind/mind - The owners mind
+ * * mob/living/old_body - The owners old body
+ */
+/datum/antagonist/proc/on_body_removal(datum/mind/mind, mob/living/old_body)
 	SIGNAL_HANDLER
 
 	remove_innate_effects(old_body)
@@ -99,8 +106,6 @@ GLOBAL_LIST_EMPTY(antagonists)
 	var/datum/action/antag_info/info_button = info_button_ref?.resolve()
 	if(info_button)
 		info_button.Remove(old_body)
-	return TRUE
-
 
 ///Called by the transfer_to() mind proc after the mind (mind.current and new_character.mind) has moved but before the player (key and client) is transfered.
 /datum/antagonist/proc/on_body_transfer(mob/living/new_body)

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -23,9 +23,12 @@
 /datum/antagonist/ashwalker/get_team()
 	return ashie_team
 
-/datum/antagonist/ashwalker/on_body_transfer(mob/living/old_body, mob/living/new_body)
+/datum/antagonist/ashwalker/on_body_removal(mob/living/old_body)
 	. = ..()
 	UnregisterSignal(old_body, COMSIG_MOB_EXAMINATE)
+
+/datum/antagonist/ashwalker/on_body_transfer(mob/living/new_body)
+	. = ..()
 	RegisterSignal(new_body, COMSIG_MOB_EXAMINATE, .proc/on_examinate)
 
 /datum/antagonist/ashwalker/on_gain()

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -23,7 +23,7 @@
 /datum/antagonist/ashwalker/get_team()
 	return ashie_team
 
-/datum/antagonist/ashwalker/on_body_removal(mob/living/old_body)
+/datum/antagonist/ashwalker/on_body_removal(datum/mind/mind, mob/living/old_body)
 	. = ..()
 	UnregisterSignal(old_body, COMSIG_MOB_EXAMINATE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Since action buttons are stored on the mob, they must be manually removed. These are removed on body transfer, however the proc for that is not *always* called, (i.e. mind swap), so this ensures that it always does by removing it anytime the mind has been transfered.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
these panels should be removed...

Tested on surgery and mind swap spell, both work
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Antag panels will no longer remain on bodies after the mind has been taken out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
