### PR TITLE
Adds better examine text to catwalk plating

### DIFF
--- a/code/game/turfs/open/floor/catwalk_plating.dm
+++ b/code/game/turfs/open/floor/catwalk_plating.dm
@@ -32,12 +32,11 @@
 /turf/open/floor/catwalk_floor/examine(mob/user)
 	. = ..()
 
-	switch(covered)
-		if(TRUE)
-			. += span_notice("You can <b>unscrew</b> it to reveal the contents beneath.")
-		else
-			. += span_notice("You can <b>screw</b> it to hide the contents beneath.")
-			. += span_notice("There's a <b>small crack</b> on the edge of it.")
+	if(covered)
+		. += span_notice("You can <b>unscrew</b> it to reveal the contents beneath.")
+	else
+		. += span_notice("You can <b>screw</b> it to hide the contents beneath.")
+		. += span_notice("There's a <b>small crack</b> on the edge of it.")
 
 /turf/open/floor/catwalk_floor/screwdriver_act(mob/living/user, obj/item/tool)
 	. = ..()

--- a/code/game/turfs/open/floor/catwalk_plating.dm
+++ b/code/game/turfs/open/floor/catwalk_plating.dm
@@ -31,13 +31,13 @@
 
 /turf/open/floor/catwalk_floor/examine(mob/user)
 	. = ..()
-	. += span_notice("There's a <b>small crack</b> on the edge of it.")
 
 	switch(covered)
 		if(TRUE)
 			. += span_notice("You can <b>unscrew</b> it to reveal the contents beneath.")
 		else
 			. += span_notice("You can <b>screw</b> it to hide the contents beneath.")
+			. += span_notice("There's a <b>small crack</b> on the edge of it.")
 
 /turf/open/floor/catwalk_floor/screwdriver_act(mob/living/user, obj/item/tool)
 	. = ..()

--- a/code/game/turfs/open/floor/catwalk_plating.dm
+++ b/code/game/turfs/open/floor/catwalk_plating.dm
@@ -29,6 +29,16 @@
 	underlays += catwalk_underlays[catwalk_type]
 	update_appearance()
 
+/turf/open/floor/catwalk_floor/examine(mob/user)
+	. = ..()
+	. += span_notice("There's a <b>small crack</b> on the edge of it.")
+
+	switch(covered)
+		if(TRUE)
+			. += span_notice("You can <b>unscrew</b> it to reveal the contents beneath.")
+		else
+			. += span_notice("You can <b>screw</b> it to hide the contents beneath.")
+
 /turf/open/floor/catwalk_floor/screwdriver_act(mob/living/user, obj/item/tool)
 	. = ..()
 	covered = !covered
@@ -43,6 +53,7 @@
 		plane = GAME_PLANE
 		icon_state = "[catwalk_type]_above"
 	user.balloon_alert(user, "[!covered ? "cover removed" : "cover added"]")
+	tool.play_tool_sound(src)
 	update_appearance()
 
 /turf/open/floor/catwalk_floor/crowbar_act(mob/user, obj/item/crowbar)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Informs players that you can unscrew catwalk plating to access the pipes / cables below instead of pulling it up.
Also plays the screwdriver sound when screwed with.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Minor nitpick / grammar thing since other types of tiling display how to pull it up.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Adds text to let players know that you can unscrew catwalk plating.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
