### PR TITLE
Adds an error for compiling with broken BYOND versions.

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -70,6 +70,12 @@
 #error You need version 514.1556 or higher
 #endif
 
+#if (DM_VERSION == 514 && DM_BUILD > 1571)
+#error Your version of BYOND currently has a crashing issue that will prevent you from running Dream Daemon test servers.
+#error We require users to test their content, so an inability to test means we cannot allow the compile.
+#error Please consider downgrading to 514.1571.
+#endif
+
 //Additional code for the above flags.
 #ifdef TESTING
 #warn compiling in TESTING mode. testing() debug messages will be visible.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -72,7 +72,7 @@
 
 #if (DM_VERSION == 514 && DM_BUILD > 1571)
 #error Your version of BYOND currently has a crashing issue that will prevent you from running Dream Daemon test servers.
-#error We require users to test their content, so an inability to test means we cannot allow the compile.
+#error We require developers to test their content, so an inability to test means we cannot allow the compile.
 #error Please consider downgrading to 514.1571.
 #endif
 

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -70,10 +70,10 @@
 #error You need version 514.1556 or higher
 #endif
 
-#if (DM_VERSION == 514 && DM_BUILD > 1571)
+#if (DM_VERSION == 514 && DM_BUILD > 1575)
 #error Your version of BYOND currently has a crashing issue that will prevent you from running Dream Daemon test servers.
 #error We require developers to test their content, so an inability to test means we cannot allow the compile.
-#error Please consider downgrading to 514.1571.
+#error Please consider downgrading to 514.1575 or lower.
 #endif
 
 //Additional code for the above flags.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -70,7 +70,7 @@
 #error You need version 514.1556 or higher
 #endif
 
-#if (DM_VERSION == 514 && DM_BUILD > 1575)
+#if (DM_VERSION == 514 && DM_BUILD > 1575 && DM_BUILD <= 1577)
 #error Your version of BYOND currently has a crashing issue that will prevent you from running Dream Daemon test servers.
 #error We require developers to test their content, so an inability to test means we cannot allow the compile.
 #error Please consider downgrading to 514.1575 or lower.


### PR DESCRIPTION
Versions above ~~1571~~1575 currently crash Dream Daemon during lighting, and devs keep running into this and getting confused while trying to test.