### PR TITLE
Removes an unused var on Armour

### DIFF
--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -16,7 +16,6 @@
 	var/fire
 	var/acid
 	var/wound
-	var/consume
 
 /datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, fire = 0, acid = 0, wound = 0)
 	src.melee = melee
@@ -28,7 +27,6 @@
 	src.fire = fire
 	src.acid = acid
 	src.wound = wound
-	src.consume = melee
 	tag = ARMORID
 
 /datum/armor/proc/modifyRating(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, fire = 0, acid = 0, wound = 0)


### PR DESCRIPTION
## About The Pull Request

I don't know what the consume var is supposed to do, but it isn't used at all, so I don't see why we should keep it.

## Why It's Good For The Game

Removes an unused thing that does absolutely nothing.
Armor datum is used a lot so having this unused var on every single one probably isn't helpful.

## Changelog

Not needed.