### PR TITLE
Make more use of <tool>_act

### DIFF
--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -53,20 +53,23 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 	GLOB.announcement_systems -= src //"OH GOD WHY ARE THERE 100,000 LISTED ANNOUNCEMENT SYSTEMS?!!"
 	return ..()
 
-/obj/machinery/announcement_system/attackby(obj/item/P, mob/user, params)
-	if(P.tool_behaviour == TOOL_SCREWDRIVER)
-		P.play_tool_sound(src)
-		panel_open = !panel_open
-		to_chat(user, span_notice("You [panel_open ? "open" : "close"] the maintenance hatch of [src]."))
-		update_appearance()
-	else if(default_deconstruction_crowbar(P))
-		return
-	else if(P.tool_behaviour == TOOL_MULTITOOL && panel_open && (machine_stat & BROKEN))
-		to_chat(user, span_notice("You reset [src]'s firmware."))
-		set_machine_stat(machine_stat & ~BROKEN)
-		update_appearance()
-	else
-		return ..()
+/obj/machinery/announcement_system/screwdriver_act(mob/living/user, obj/item/tool)
+	tool.play_tool_sound(src)
+	panel_open = !panel_open
+	to_chat(user, span_notice("You [panel_open ? "open" : "close"] the maintenance hatch of [src]."))
+	update_appearance()
+	return TRUE
+
+/obj/machinery/announcement_system/crowbar_act(mob/living/user, obj/item/tool)
+	if(default_deconstruction_crowbar(tool))
+		return TRUE
+
+/obj/machinery/announcement_system/multitool_act(mob/living/user, obj/item/tool)
+	if(!panel_open || !(machine_stat & BROKEN))
+		return FALSE
+	to_chat(user, span_notice("You reset [src]'s firmware."))
+	set_machine_stat(machine_stat & ~BROKEN)
+	update_appearance()
 
 /obj/machinery/announcement_system/proc/CompileText(str, user, rank) //replaces user-given variables with actual thingies.
 	str = replacetext(str, "%PERSON", "[user]")

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -59,16 +59,17 @@
 	if(board)
 		. += "button-board"
 
-/obj/machinery/button/attackby(obj/item/W, mob/living/user, params)
-	if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(panel_open || allowed(user))
-			default_deconstruction_screwdriver(user, "button-open", "[skin]",W)
-			update_appearance()
-		else
-			to_chat(user, span_alert("Maintenance Access Denied."))
-			flick("[skin]-denied", src)
-		return
+/obj/machinery/button/screwdriver_act(mob/living/user, obj/item/tool)
+	if(panel_open || allowed(user))
+		default_deconstruction_screwdriver(user, "button-open", "[skin]", tool)
+		update_appearance()
+	else
+		to_chat(user, span_alert("Maintenance Access Denied."))
+		flick("[skin]-denied", src)
 
+	return TRUE
+
+/obj/machinery/button/attackby(obj/item/W, mob/living/user, params)
 	if(panel_open)
 		if(!device && istype(W, /obj/item/assembly))
 			if(!user.transferItemToLoc(W, src))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -762,6 +762,26 @@
 	else
 		updateDialog()
 
+/obj/machinery/door/airlock/screwdriver_act(mob/living/user, obj/item/tool)
+	. = TRUE
+	if(panel_open && detonated)
+		to_chat(user, span_warning("[src] has no maintenance panel!"))
+		return
+	panel_open = !panel_open
+	to_chat(user, span_notice("You [panel_open ? "open":"close"] the maintenance panel of the airlock."))
+	tool.play_tool_sound(src)
+	update_appearance()
+
+/obj/machinery/door/airlock/wirecutter_act(mob/living/user, obj/item/tool)
+	if(user.CanReach(src))
+		user.visible_message(span_notice("[user] cuts down [note] from [src]."), span_notice("You remove [note] from [src]."))
+	else //telekinesis
+		visible_message(span_notice("[tool] cuts down [note] from [src]."))
+	tool.play_tool_sound(src)
+	note.forceMove(tool.drop_location())
+	note = null
+	update_appearance()
+
 
 /obj/machinery/door/airlock/attackby(obj/item/C, mob/user, params)
 	if(!issilicon(user) && !isAdminGhostAI(user))
@@ -885,23 +905,6 @@
 											span_notice("You cut through \the [src]'s outer grille."))
 						security_level = AIRLOCK_SECURITY_PLASTEEL_O
 					return
-	if(C.tool_behaviour == TOOL_SCREWDRIVER)
-		if(panel_open && detonated)
-			to_chat(user, span_warning("[src] has no maintenance panel!"))
-			return
-		panel_open = !panel_open
-		to_chat(user, span_notice("You [panel_open ? "open":"close"] the maintenance panel of the airlock."))
-		C.play_tool_sound(src)
-		update_appearance()
-	else if((C.tool_behaviour == TOOL_WIRECUTTER) && note)
-		if(user.CanReach(src))
-			user.visible_message(span_notice("[user] cuts down [note] from [src]."), span_notice("You remove [note] from [src]."))
-		else //telekinesis
-			visible_message(span_notice("[C] cuts down [note] from [src]."))
-		C.play_tool_sound(src)
-		note.forceMove(C.drop_location())
-		note = null
-		update_appearance()
 	else if(is_wire_tool(C) && panel_open)
 		attempt_wire_interaction(user)
 		return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -773,14 +773,18 @@
 	update_appearance()
 
 /obj/machinery/door/airlock/wirecutter_act(mob/living/user, obj/item/tool)
-	if(user.CanReach(src))
-		user.visible_message(span_notice("[user] cuts down [note] from [src]."), span_notice("You remove [note] from [src]."))
-	else //telekinesis
-		visible_message(span_notice("[tool] cuts down [note] from [src]."))
-	tool.play_tool_sound(src)
-	note.forceMove(tool.drop_location())
-	note = null
-	update_appearance()
+	if(note)
+		if(user.CanReach(src))
+			user.visible_message(span_notice("[user] cuts down [note] from [src]."), span_notice("You remove [note] from [src]."))
+		else //telekinesis
+			visible_message(span_notice("[tool] cuts down [note] from [src]."))
+		tool.play_tool_sound(src)
+		note.forceMove(tool.drop_location())
+		note = null
+		update_appearance()
+		return TRUE
+	else
+		return FALSE
 
 
 /obj/machinery/door/airlock/attackby(obj/item/C, mob/user, params)

--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -117,6 +117,16 @@
 
 	efficiency = (cap + 1) * 0.5 //used in the amount of charge in power cell uses
 
+/obj/machinery/electrolyzer/screwdriver_act(mob/living/user, obj/item/tool)
+	tool.play_tool_sound(src, 50)
+	panel_open = !panel_open
+	user.visible_message(span_notice("\The [user] [panel_open ? "opens" : "closes"] the hatch on \the [src]."), span_notice("You [panel_open ? "open" : "close"] the hatch on \the [src]."))
+	update_appearance()
+	return TRUE
+
+/obj/machinery/electrolyzer/crowbar_act(mob/living/user, obj/item/tool)
+	return default_deconstruction_crowbar(tool)
+
 /obj/machinery/electrolyzer/attackby(obj/item/I, mob/user, params)
 	add_fingerprint(user)
 	if(default_unfasten_wrench(user, I))
@@ -136,13 +146,6 @@
 		user.visible_message(span_notice("\The [user] inserts a power cell into \the [src]."), span_notice("You insert the power cell into \the [src]."))
 		SStgui.update_uis(src)
 
-		return
-	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		panel_open = !panel_open
-		user.visible_message(span_notice("\The [user] [panel_open ? "opens" : "closes"] the hatch on \the [src]."), span_notice("You [panel_open ? "open" : "close"] the hatch on \the [src]."))
-		update_appearance()
-		return
-	if(default_deconstruction_crowbar(I))
 		return
 	return ..()
 

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -96,17 +96,16 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/sparker, 26)
 		return FALSE
 	return ..()
 
-/obj/machinery/sparker/attackby(obj/item/W, mob/user, params)
-	if (W.tool_behaviour == TOOL_SCREWDRIVER)
-		add_fingerprint(user)
-		disable = !disable
-		if (disable)
-			user.visible_message(span_notice("[user] disables \the [src]!"), span_notice("You disable the connection to \the [src]."))
-		if (!disable)
-			user.visible_message(span_notice("[user] reconnects \the [src]!"), span_notice("You fix the connection to \the [src]."))
-		update_appearance()
-	else
-		return ..()
+/obj/machinery/sparker/screwdriver_act(mob/living/user, obj/item/tool)
+	add_fingerprint(user)
+	tool.play_tool_sound(src, 50)
+	disable = !disable
+	if (disable)
+		user.visible_message(span_notice("[user] disables \the [src]!"), span_notice("You disable the connection to \the [src]."))
+	if (!disable)
+		user.visible_message(span_notice("[user] reconnects \the [src]!"), span_notice("You fix the connection to \the [src]."))
+	update_appearance()
+	return TRUE
 
 /obj/machinery/sparker/attack_ai()
 	if (anchored)

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -96,17 +96,18 @@
 	icon_state = "[base_icon_state][open]"
 	return ..()
 
+/obj/machinery/navbeacon/screwdriver_act(mob/living/user, obj/item/tool)
+	add_fingerprint(user)
+	open = !open
+	user.visible_message(span_notice("[user] [open ? "opens" : "closes"] the beacon's cover."), span_notice("You [open ? "open" : "close"] the beacon's cover."))
+	update_appearance()
+	tool.play_tool_sound(src, 50)
+	return TRUE
+
 /obj/machinery/navbeacon/attackby(obj/item/I, mob/user, params)
 	var/turf/T = loc
 	if(T.underfloor_accessibility < UNDERFLOOR_INTERACTABLE)
 		return // prevent intraction when T-scanner revealed
-
-	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		open = !open
-
-		user.visible_message(span_notice("[user] [open ? "opens" : "closes"] the beacon's cover."), span_notice("You [open ? "open" : "close"] the beacon's cover."))
-
-		update_appearance()
 
 	else if (istype(I, /obj/item/card/id)||istype(I, /obj/item/pda))
 		if(open)

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -409,28 +409,32 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/requests_console, 30)
 		Radio.set_frequency(radio_freq)
 		Radio.talk_into(src, "[alert]: <i>[message]</i>", radio_freq)
 
-/obj/machinery/requests_console/attackby(obj/item/O, mob/user, params)
-	if(O.tool_behaviour == TOOL_CROWBAR)
-		if(open)
-			to_chat(user, span_notice("You close the maintenance panel."))
-			open = FALSE
-		else
-			to_chat(user, span_notice("You open the maintenance panel."))
-			open = TRUE
-		update_appearance()
-		return
-	if(O.tool_behaviour == TOOL_SCREWDRIVER)
-		if(open)
-			hackState = !hackState
-			if(hackState)
-				to_chat(user, span_notice("You modify the wiring."))
-			else
-				to_chat(user, span_notice("You reset the wiring."))
-			update_appearance()
-		else
-			to_chat(user, span_warning("You must open the maintenance panel first!"))
-		return
+/obj/machinery/requests_console/crowbar_act(mob/living/user, obj/item/tool)
 
+	tool.play_tool_sound(src, 50)
+	if(open)
+		to_chat(user, span_notice("You close the maintenance panel."))
+		open = FALSE
+	else
+		to_chat(user, span_notice("You open the maintenance panel."))
+		open = TRUE
+	update_appearance()
+	return TRUE
+
+/obj/machinery/requests_console/screwdriver_act(mob/living/user, obj/item/tool)
+	if(open)
+		hackState = !hackState
+		if(hackState)
+			to_chat(user, span_notice("You modify the wiring."))
+		else
+			to_chat(user, span_notice("You reset the wiring."))
+		update_appearance()
+		tool.play_tool_sound(src, 50)
+	else
+		to_chat(user, span_warning("You must open the maintenance panel first!"))
+	return TRUE
+
+/obj/machinery/requests_console/attackby(obj/item/O, mob/user, params)
 	var/obj/item/card/id/ID = O.GetID()
 	if(ID)
 		if(screen == REQ_SCREEN_AUTHENTICATE)

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -191,8 +191,10 @@
 		to_chat(user, span_notice("You open the panel and expose the wiring."))
 	else
 		to_chat(user, span_notice("You close the panel."))
+	return TRUE
 
 /obj/machinery/shieldgen/wrench_act(mob/living/user, obj/item/tool)
+	. = TRUE
 	if(locked)
 		to_chat(user, span_warning("The bolts are covered! Unlocking this would retract the covers."))
 		return

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -184,15 +184,33 @@
 			to_chat(user, span_warning("The device must first be secured to the floor!"))
 	return
 
+/obj/machinery/shieldgen/screwdriver_act(mob/living/user, obj/item/tool)
+	tool.play_tool_sound(src, 100)
+	panel_open = !panel_open
+	if(panel_open)
+		to_chat(user, span_notice("You open the panel and expose the wiring."))
+	else
+		to_chat(user, span_notice("You close the panel."))
+
+/obj/machinery/shieldgen/wrench_act(mob/living/user, obj/item/tool)
+	if(locked)
+		to_chat(user, span_warning("The bolts are covered! Unlocking this would retract the covers."))
+		return
+	if(!anchored && !isinspace())
+		tool.play_tool_sound(src, 100)
+		to_chat(user, span_notice("You secure \the [src] to the floor!"))
+		set_anchored(TRUE)
+	else if(anchored)
+		tool.play_tool_sound(src, 100)
+		to_chat(user, span_notice("You unsecure \the [src] from the floor!"))
+		if(active)
+			to_chat(user, span_notice("\The [src] shuts off!"))
+			shields_down()
+		set_anchored(FALSE)
+
+
 /obj/machinery/shieldgen/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		W.play_tool_sound(src, 100)
-		panel_open = !panel_open
-		if(panel_open)
-			to_chat(user, span_notice("You open the panel and expose the wiring."))
-		else
-			to_chat(user, span_notice("You close the panel."))
-	else if(istype(W, /obj/item/stack/cable_coil) && (machine_stat & BROKEN) && panel_open)
+	if(istype(W, /obj/item/stack/cable_coil) && (machine_stat & BROKEN) && panel_open)
 		var/obj/item/stack/cable_coil/coil = W
 		if (coil.get_amount() < 1)
 			to_chat(user, span_warning("You need one length of cable to repair [src]!"))
@@ -206,22 +224,6 @@
 			set_machine_stat(machine_stat & ~BROKEN)
 			to_chat(user, span_notice("You repair \the [src]."))
 			update_appearance()
-
-	else if(W.tool_behaviour == TOOL_WRENCH)
-		if(locked)
-			to_chat(user, span_warning("The bolts are covered! Unlocking this would retract the covers."))
-			return
-		if(!anchored && !isinspace())
-			W.play_tool_sound(src, 100)
-			to_chat(user, span_notice("You secure \the [src] to the floor!"))
-			set_anchored(TRUE)
-		else if(anchored)
-			W.play_tool_sound(src, 100)
-			to_chat(user, span_notice("You unsecure \the [src] from the floor!"))
-			if(active)
-				to_chat(user, span_notice("\The [src] shuts off!"))
-				shields_down()
-			set_anchored(FALSE)
 
 	else if(W.GetID())
 		if(allowed(user) && !(obj_flags & EMAGGED))

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -57,30 +57,32 @@
 	else
 		to_chat(user, span_warning("You need to screw \the [src] to the floor first!"))
 
-/obj/machinery/power/singularity_beacon/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_WRENCH)
-		if(active)
-			to_chat(user, span_warning("You need to deactivate \the [src] first!"))
-			return
+/obj/machinery/power/singularity_beacon/wrench_act(mob/living/user, obj/item/tool)
+	. = TRUE
+	if(active)
+		to_chat(user, span_warning("You need to deactivate \the [src] first!"))
+		return
 
-		if(anchored)
-			set_anchored(FALSE)
-			to_chat(user, span_notice("You unbolt \the [src] from the floor and detach it from the cable."))
-			disconnect_from_network()
+	if(anchored)
+		tool.play_tool_sound(src, 50)
+		set_anchored(FALSE)
+		to_chat(user, span_notice("You unbolt \the [src] from the floor and detach it from the cable."))
+		disconnect_from_network()
+		return
+	else
+		if(!connect_to_network())
+			to_chat(user, span_warning("\The [src] must be placed over an exposed, powered cable node!"))
 			return
-		else
-			if(!connect_to_network())
-				to_chat(user, span_warning("\The [src] must be placed over an exposed, powered cable node!"))
-				return
-			set_anchored(TRUE)
-			to_chat(user, span_notice("You bolt \the [src] to the floor and attach it to the cable."))
-			return
-	else if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		user.visible_message( \
+		tool.play_tool_sound(src, 50)
+		set_anchored(TRUE)
+		to_chat(user, span_notice("You bolt \the [src] to the floor and attach it to the cable."))
+		return
+
+/obj/machinery/power/singularity_beacon/screwdriver_act(mob/living/user, obj/item/tool)
+	user.visible_message( \
 			"[user] messes with \the [src] for a bit.", \
 			span_notice("You can't fit the screwdriver into \the [src]'s bolts! Try using a wrench."))
-	else
-		return ..()
+	return TRUE
 
 /obj/machinery/power/singularity_beacon/Destroy()
 	if(active)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -164,7 +164,7 @@
 	to_chat(user, span_notice("You start to cut [src] apart..."))
 	if(tool.use_tool(src, user, 20, volume=50, amount=5)) // uses up 5 fuel
 		to_chat(user, span_notice("You cut [src] apart."))
-		new /obj/item/stack/sheet/plasteel( loc, 5)
+		new /obj/item/stack/sheet/plasteel(loc, 5)
 		qdel(src)
 	return TRUE
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -110,45 +110,70 @@
 	else
 		. = timer_set
 
-/obj/machinery/syndicatebomb/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_WRENCH && can_unanchor)
-		if(!anchored)
-			if(!isturf(loc) || isspaceturf(loc))
-				to_chat(user, span_notice("The bomb must be placed on solid ground to attach it."))
-			else
-				to_chat(user, span_notice("You firmly wrench the bomb to the floor."))
-				I.play_tool_sound(src)
-				set_anchored(TRUE)
-				if(active)
-					to_chat(user, span_notice("The bolts lock in place."))
+/obj/machinery/syndicatebomb/wrench_act(mob/living/user, obj/item/tool)
+	if(!can_unanchor)
+		return FALSE
+	if(!anchored)
+		if(!isturf(loc) || isspaceturf(loc))
+			to_chat(user, span_notice("The bomb must be placed on solid ground to attach it."))
 		else
-			if(!active)
-				to_chat(user, span_notice("You wrench the bomb from the floor."))
-				I.play_tool_sound(src)
-				set_anchored(FALSE)
-			else
-				to_chat(user, span_warning("The bolts are locked down!"))
+			to_chat(user, span_notice("You firmly wrench the bomb to the floor."))
+			tool.play_tool_sound(src)
+			set_anchored(TRUE)
+			if(active)
+				to_chat(user, span_notice("The bolts lock in place."))
+	else
+		if(!active)
+			to_chat(user, span_notice("You wrench the bomb from the floor."))
+			tool.play_tool_sound(src)
+			set_anchored(FALSE)
+		else
+			to_chat(user, span_warning("The bolts are locked down!"))
 
-	else if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		open_panel = !open_panel
-		update_appearance()
-		to_chat(user, span_notice("You [open_panel ? "open" : "close"] the wire panel."))
+	return TRUE
 
-	else if(is_wire_tool(I) && open_panel)
+/obj/machinery/syndicatebomb/screwdriver_act(mob/living/user, obj/item/tool)
+	tool.play_tool_sound(src, 50)
+	open_panel = !open_panel
+	update_appearance()
+	to_chat(user, span_notice("You [open_panel ? "open" : "close"] the wire panel."))
+	return TRUE
+
+/obj/machinery/syndicatebomb/crowbar_act(mob/living/user, obj/item/tool)
+	. = TRUE
+	if(open_panel && wires.is_all_cut())
+		if(payload)
+			tool.play_tool_sound(src, 25) // sshhh
+			to_chat(user, span_notice("You carefully pry out [payload]."))
+			payload.forceMove(drop_location())
+			payload = null
+		else
+			to_chat(user, span_warning("There isn't anything in here to remove!"))
+	else if (open_panel)
+		to_chat(user, span_warning("The wires connecting the shell to the explosives are holding it down!"))
+	else
+		to_chat(user, span_warning("The cover is screwed on, it won't pry off!"))
+
+/obj/machinery/syndicatebomb/welder_act(mob/living/user, obj/item/tool)
+	if(payload || !wires.is_all_cut() || !open_panel)
+		return FALSE
+
+	if(!tool.tool_start_check(user, amount=5))  //uses up 5 fuel
+		return TRUE
+
+	to_chat(user, span_notice("You start to cut [src] apart..."))
+	if(tool.use_tool(src, user, 20, volume=50, amount=5)) // uses up 5 fuel
+		to_chat(user, span_notice("You cut [src] apart."))
+		new /obj/item/stack/sheet/plasteel( loc, 5)
+		qdel(src)
+	return TRUE
+
+
+/obj/machinery/syndicatebomb/attackby(obj/item/I, mob/user, params)
+
+	if(is_wire_tool(I) && open_panel)
 		wires.interact(user)
 
-	else if(I.tool_behaviour == TOOL_CROWBAR)
-		if(open_panel && wires.is_all_cut())
-			if(payload)
-				to_chat(user, span_notice("You carefully pry out [payload]."))
-				payload.forceMove(drop_location())
-				payload = null
-			else
-				to_chat(user, span_warning("There isn't anything in here to remove!"))
-		else if (open_panel)
-			to_chat(user, span_warning("The wires connecting the shell to the explosives are holding it down!"))
-		else
-			to_chat(user, span_warning("The cover is screwed on, it won't pry off!"))
 	else if(istype(I, /obj/item/bombcore))
 		if(!payload)
 			if(!user.transferItemToLoc(I, src))
@@ -157,22 +182,10 @@
 			to_chat(user, span_notice("You place [payload] into [src]."))
 		else
 			to_chat(user, span_warning("[payload] is already loaded into [src]! You'll have to remove it first."))
-	else if(I.tool_behaviour == TOOL_WELDER)
-		if(payload || !wires.is_all_cut() || !open_panel)
-			return
-
-		if(!I.tool_start_check(user, amount=5))  //uses up 5 fuel
-			return
-
-		to_chat(user, span_notice("You start to cut [src] apart..."))
-		if(I.use_tool(src, user, 20, volume=50, amount=5)) //uses up 5 fuel
-			to_chat(user, span_notice("You cut [src] apart."))
-			new /obj/item/stack/sheet/plasteel( loc, 5)
-			qdel(src)
 	else
 		var/old_integ = atom_integrity
 		. = ..()
-		if((old_integ > atom_integrity) && active  && (payload in src))
+		if((old_integ > atom_integrity) && active && (payload in src))
 			to_chat(user, span_warning("That seems like a really bad idea..."))
 
 /obj/machinery/syndicatebomb/interact(mob/user)

--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -39,13 +39,12 @@
 	var/customjob = "Admin"
 	var/custommessage = "This is a test, please ignore."
 
-
-/obj/machinery/computer/message_monitor/attackby(obj/item/O, mob/living/user, params)
-	if(O.tool_behaviour == TOOL_SCREWDRIVER && (obj_flags & EMAGGED))
+/obj/machinery/computer/message_monitor/screwdriver_act(mob/living/user, obj/item/I)
+	if(obj_flags & EMAGGED)
 		//Stops people from just unscrewing the monitor and putting it back to get the console working again.
 		to_chat(user, span_warning("It is too hot to mess with!"))
-	else
-		return ..()
+		return TRUE
+	return ..()
 
 /obj/machinery/computer/message_monitor/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -45,6 +45,40 @@
 
 	active = FALSE
 
+/obj/item/rcl/screwdriver_act(mob/living/user, obj/item/tool)
+	if(!loaded)
+		return FALSE
+	. = TRUE
+	if(ghetto && prob(10)) //Is it a ghetto RCL? If so, give it a 10% chance to fall apart
+		to_chat(user, span_warning("You attempt to loosen the securing screws on the side, but it falls apart!"))
+		while(loaded.amount > 30) //There are only two kinds of situations: "nodiff" (60,90), or "diff" (31-59, 61-89)
+			var/diff = loaded.amount % 30
+			if(diff)
+				loaded.use(diff)
+				new /obj/item/stack/pipe_cleaner_coil(get_turf(user), diff)
+			else
+				loaded.use(30)
+				new /obj/item/stack/pipe_cleaner_coil(get_turf(user), 30)
+		qdel(src)
+		return
+
+	tool.play_tool_sound(src)
+	to_chat(user, span_notice("You loosen the securing screws on the side, allowing you to lower the guiding edge and retrieve the wires."))
+	while(loaded.amount > 30) //There are only two kinds of situations: "nodiff" (60,90), or "diff" (31-59, 61-89)
+		var/diff = loaded.amount % 30
+		if(diff)
+			loaded.use(diff)
+			new /obj/item/stack/pipe_cleaner_coil(get_turf(user), diff)
+		else
+			loaded.use(30)
+			new /obj/item/stack/pipe_cleaner_coil(get_turf(user), 30)
+	loaded.max_amount = initial(loaded.max_amount)
+	if(!user.put_in_hands(loaded))
+		loaded.forceMove(get_turf(user))
+
+	loaded = null
+	update_appearance()
+
 /obj/item/rcl/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/stack/pipe_cleaner_coil))
 		var/obj/item/stack/pipe_cleaner_coil/C = W
@@ -66,37 +100,6 @@
 			return
 		update_appearance()
 		to_chat(user, span_notice("You add the pipe cleaners to [src]. It now contains [loaded.amount]."))
-	else if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(!loaded)
-			return
-		if(ghetto && prob(10)) //Is it a ghetto RCL? If so, give it a 10% chance to fall apart
-			to_chat(user, span_warning("You attempt to loosen the securing screws on the side, but it falls apart!"))
-			while(loaded.amount > 30) //There are only two kinds of situations: "nodiff" (60,90), or "diff" (31-59, 61-89)
-				var/diff = loaded.amount % 30
-				if(diff)
-					loaded.use(diff)
-					new /obj/item/stack/pipe_cleaner_coil(get_turf(user), diff)
-				else
-					loaded.use(30)
-					new /obj/item/stack/pipe_cleaner_coil(get_turf(user), 30)
-			qdel(src)
-			return
-
-		to_chat(user, span_notice("You loosen the securing screws on the side, allowing you to lower the guiding edge and retrieve the wires."))
-		while(loaded.amount > 30) //There are only two kinds of situations: "nodiff" (60,90), or "diff" (31-59, 61-89)
-			var/diff = loaded.amount % 30
-			if(diff)
-				loaded.use(diff)
-				new /obj/item/stack/pipe_cleaner_coil(get_turf(user), diff)
-			else
-				loaded.use(30)
-				new /obj/item/stack/pipe_cleaner_coil(get_turf(user), 30)
-		loaded.max_amount = initial(loaded.max_amount)
-		if(!user.put_in_hands(loaded))
-			loaded.forceMove(get_turf(user))
-
-		loaded = null
-		update_appearance()
 	else
 		..()
 

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -926,42 +926,39 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	user.visible_message(span_suicide("[user] is puffin hard on dat vape, [user.p_they()] trying to join the vape life on a whole notha plane!"))//it doesn't give you cancer, it is cancer
 	return (TOXLOSS|OXYLOSS)
 
-/obj/item/clothing/mask/vape/attackby(obj/item/O, mob/user, params)
-	if(O.tool_behaviour == TOOL_SCREWDRIVER)
-		if(!screw)
-			screw = TRUE
-			to_chat(user, span_notice("You open the cap on [src]."))
-			reagents.flags |= OPENCONTAINER
-			if(obj_flags & EMAGGED)
-				add_overlay("vapeopen_high")
-			else if(super)
-				add_overlay("vapeopen_med")
-			else
-				add_overlay("vapeopen_low")
+/obj/item/clothing/mask/vape/screwdriver_act(mob/living/user, obj/item/tool)
+	if(!screw)
+		screw = TRUE
+		to_chat(user, span_notice("You open the cap on [src]."))
+		reagents.flags |= OPENCONTAINER
+		if(obj_flags & EMAGGED)
+			add_overlay("vapeopen_high")
+		else if(super)
+			add_overlay("vapeopen_med")
 		else
-			screw = FALSE
-			to_chat(user, span_notice("You close the cap on [src]."))
-			reagents.flags &= ~(OPENCONTAINER)
+			add_overlay("vapeopen_low")
+	else
+		screw = FALSE
+		to_chat(user, span_notice("You close the cap on [src]."))
+		reagents.flags &= ~(OPENCONTAINER)
+		cut_overlays()
+
+/obj/item/clothing/mask/vape/multitool_act(mob/living/user, obj/item/tool)
+	. = TRUE
+	if(screw && !(obj_flags & EMAGGED))//also kinky
+		if(!super)
 			cut_overlays()
-
-	if(O.tool_behaviour == TOOL_MULTITOOL)
-		if(screw && !(obj_flags & EMAGGED))//also kinky
-			if(!super)
-				cut_overlays()
-				super = TRUE
-				to_chat(user, span_notice("You increase the voltage of [src]."))
-				add_overlay("vapeopen_med")
-			else
-				cut_overlays()
-				super = FALSE
-				to_chat(user, span_notice("You decrease the voltage of [src]."))
-				add_overlay("vapeopen_low")
-
-		if(screw && (obj_flags & EMAGGED))
-			to_chat(user, span_warning("[src] can't be modified!"))
+			super = TRUE
+			to_chat(user, span_notice("You increase the voltage of [src]."))
+			add_overlay("vapeopen_med")
 		else
-			..()
+			cut_overlays()
+			super = FALSE
+			to_chat(user, span_notice("You decrease the voltage of [src]."))
+			add_overlay("vapeopen_low")
 
+	if(screw && (obj_flags & EMAGGED))
+		to_chat(user, span_warning("[src] can't be modified!"))
 
 /obj/item/clothing/mask/vape/emag_act(mob/user)// I WON'T REGRET WRITTING THIS, SURLY.
 	if(screw)

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -132,6 +132,15 @@
 			var/atom/movable/screen/inventory/hand/H = over_object
 			M.putItemFromInventoryInHandIfPossible(src, H.held_index)
 
+/obj/item/defibrillator/screwdriver_act(mob/living/user, obj/item/tool)
+	if(cell)
+		cell.update_appearance()
+		cell.forceMove(get_turf(src))
+		cell = null
+		tool.play_tool_sound(src, 50)
+		to_chat(user, span_notice("You remove the cell from [src]."))
+		update_power()
+
 /obj/item/defibrillator/attackby(obj/item/W, mob/user, params)
 	if(W == paddles)
 		toggle_paddles()
@@ -147,13 +156,6 @@
 				return
 			cell = W
 			to_chat(user, span_notice("You install a cell in [src]."))
-			update_power()
-	else if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(cell)
-			cell.update_appearance()
-			cell.forceMove(get_turf(src))
-			cell = null
-			to_chat(user, span_notice("You remove the cell from [src]."))
 			update_power()
 	else
 		return ..()

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -39,6 +39,14 @@
 	. = ..()
 	diode = new /obj/item/stock_parts/micro_laser/ultra
 
+/obj/item/laser_pointer/screwdriver_act(mob/living/user, obj/item/tool)
+	if(diode)
+		tool.play_tool_sound(src)
+		to_chat(user, span_notice("You remove the [diode.name] from \the [src]."))
+		diode.forceMove(drop_location())
+		diode = null
+		return TRUE
+
 /obj/item/laser_pointer/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/stock_parts/micro_laser))
 		if(!diode)
@@ -48,12 +56,6 @@
 			to_chat(user, span_notice("You install a [diode.name] in [src]."))
 		else
 			to_chat(user, span_warning("[src] already has a diode installed!"))
-
-	else if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(diode)
-			to_chat(user, span_notice("You remove the [diode.name] from \the [src]."))
-			diode.forceMove(drop_location())
-			diode = null
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -74,35 +74,34 @@
 	update_appearance()
 	set_light(0)
 
-/obj/item/powersink/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_WRENCH)
-		if(mode == DISCONNECTED)
-			var/turf/T = loc
-			if(isturf(T) && T.underfloor_accessibility >= UNDERFLOOR_INTERACTABLE)
-				attached = locate() in T
-				if(!attached)
-					to_chat(user, span_warning("\The [src] must be placed over an exposed, powered cable node!"))
-				else
-					set_mode(CLAMPED_OFF)
-					user.visible_message( \
-						"[user] attaches \the [src] to the cable.", \
-						span_notice("You bolt \the [src] into the floor and connect it to the cable."),
-						span_hear("You hear some wires being connected to something."))
-			else
+/obj/item/powersink/wrench_act(mob/living/user, obj/item/tool)
+	. = TRUE
+	if(mode == DISCONNECTED)
+		var/turf/T = loc
+		if(isturf(T) && T.underfloor_accessibility >= UNDERFLOOR_INTERACTABLE)
+			attached = locate() in T
+			if(!attached)
 				to_chat(user, span_warning("\The [src] must be placed over an exposed, powered cable node!"))
+			else
+				set_mode(CLAMPED_OFF)
+				user.visible_message( \
+					"[user] attaches \the [src] to the cable.", \
+					span_notice("You bolt \the [src] into the floor and connect it to the cable."),
+					span_hear("You hear some wires being connected to something."))
 		else
-			set_mode(DISCONNECTED)
-			user.visible_message( \
-				"[user] detaches \the [src] from the cable.", \
-				span_notice("You unbolt \the [src] from the floor and detach it from the cable."),
-				span_hear("You hear some wires being disconnected from something."))
-
-	else if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		user.visible_message( \
-			"[user] messes with \the [src] for a bit.", \
-			span_notice("You can't fit the screwdriver into \the [src]'s bolts! Try using a wrench."))
+			to_chat(user, span_warning("\The [src] must be placed over an exposed, powered cable node!"))
 	else
-		return ..()
+		set_mode(DISCONNECTED)
+		user.visible_message( \
+			"[user] detaches \the [src] from the cable.", \
+			span_notice("You unbolt \the [src] from the floor and detach it from the cable."),
+			span_hear("You hear some wires being disconnected from something."))
+
+/obj/item/powersink/screwdriver_act(mob/living/user, obj/item/tool)
+	user.visible_message( \
+		"[user] messes with \the [src] for a bit.", \
+		span_notice("You can't fit the screwdriver into \the [src]'s bolts! Try using a wrench."))
+	return TRUE
 
 /obj/item/powersink/attack_paw(mob/user, list/modifiers)
 	return

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -305,6 +305,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 	else
 		to_chat(user, span_warning("This headset doesn't have any unique encryption keys! How useless..."))
+	tool.play_tool_sound(src, 10)
 	return TRUE
 
 /obj/item/radio/headset/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -286,29 +286,31 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	keyslot2 = new /obj/item/encryptionkey/ai
 	command = TRUE
 
+/obj/item/radio/headset/screwdriver_act(mob/living/user, obj/item/tool)
+	user.set_machine(src)
+	if(keyslot || keyslot2)
+		for(var/ch_name in channels)
+			SSradio.remove_object(src, GLOB.radiochannels[ch_name])
+			secure_radio_connections[ch_name] = null
+
+		if(keyslot)
+			user.put_in_hands(keyslot)
+			keyslot = null
+		if(keyslot2)
+			user.put_in_hands(keyslot2)
+			keyslot2 = null
+
+		recalculateChannels()
+		to_chat(user, span_notice("You pop out the encryption keys in the headset."))
+
+	else
+		to_chat(user, span_warning("This headset doesn't have any unique encryption keys! How useless..."))
+	return TRUE
+
 /obj/item/radio/headset/attackby(obj/item/W, mob/user, params)
 	user.set_machine(src)
 
-	if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(keyslot || keyslot2)
-			for(var/ch_name in channels)
-				SSradio.remove_object(src, GLOB.radiochannels[ch_name])
-				secure_radio_connections[ch_name] = null
-
-			if(keyslot)
-				user.put_in_hands(keyslot)
-				keyslot = null
-			if(keyslot2)
-				user.put_in_hands(keyslot2)
-				keyslot2 = null
-
-			recalculateChannels()
-			to_chat(user, span_notice("You pop out the encryption keys in the headset."))
-
-		else
-			to_chat(user, span_warning("This headset doesn't have any unique encryption keys! How useless..."))
-
-	else if(istype(W, /obj/item/encryptionkey))
+	if(istype(W, /obj/item/encryptionkey))
 		if(keyslot && keyslot2)
 			to_chat(user, span_warning("The headset can't hold another key!"))
 			return

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -31,32 +31,31 @@
 	else
 		. += span_notice("It's <i>unscrewed</i> from the wall, and can be <b>detached</b>.")
 
-/obj/item/radio/intercom/attackby(obj/item/I, mob/living/user, params)
-	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		if(unscrewed)
-			user.visible_message(span_notice("[user] starts tightening [src]'s screws..."), span_notice("You start screwing in [src]..."))
-			if(I.use_tool(src, user, 30, volume=50))
-				user.visible_message(span_notice("[user] tightens [src]'s screws!"), span_notice("You tighten [src]'s screws."))
-				unscrewed = FALSE
-		else
-			user.visible_message(span_notice("[user] starts loosening [src]'s screws..."), span_notice("You start unscrewing [src]..."))
-			if(I.use_tool(src, user, 40, volume=50))
-				user.visible_message(span_notice("[user] loosens [src]'s screws!"), span_notice("You unscrew [src], loosening it from the wall."))
-				unscrewed = TRUE
+/obj/item/radio/intercom/screwdriver_act(mob/living/user, obj/item/tool)
+	if(unscrewed)
+		user.visible_message(span_notice("[user] starts tightening [src]'s screws..."), span_notice("You start screwing in [src]..."))
+		if(tool.use_tool(src, user, 30, volume=50))
+			user.visible_message(span_notice("[user] tightens [src]'s screws!"), span_notice("You tighten [src]'s screws."))
+			unscrewed = FALSE
+	else
+		user.visible_message(span_notice("[user] starts loosening [src]'s screws..."), span_notice("You start unscrewing [src]..."))
+		if(tool.use_tool(src, user, 40, volume=50))
+			user.visible_message(span_notice("[user] loosens [src]'s screws!"), span_notice("You unscrew [src], loosening it from the wall."))
+			unscrewed = TRUE
+	return TRUE
+
+/obj/item/radio/intercom/wrench_act(mob/living/user, obj/item/tool)
+	. = TRUE
+	if(!unscrewed)
+		to_chat(user, span_warning("You need to unscrew [src] from the wall first!"))
 		return
-	else if(I.tool_behaviour == TOOL_WRENCH)
-		if(!unscrewed)
-			to_chat(user, span_warning("You need to unscrew [src] from the wall first!"))
-			return
-		user.visible_message(span_notice("[user] starts unsecuring [src]..."), span_notice("You start unsecuring [src]..."))
-		I.play_tool_sound(src)
-		if(I.use_tool(src, user, 80))
-			user.visible_message(span_notice("[user] unsecures [src]!"), span_notice("You detach [src] from the wall."))
-			playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
-			new/obj/item/wallframe/intercom(get_turf(src))
-			qdel(src)
-		return
-	return ..()
+	user.visible_message(span_notice("[user] starts unsecuring [src]..."), span_notice("You start unsecuring [src]..."))
+	tool.play_tool_sound(src)
+	if(tool.use_tool(src, user, 80))
+		user.visible_message(span_notice("[user] unsecures [src]!"), span_notice("You detach [src] from the wall."))
+		playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
+		new/obj/item/wallframe/intercom(get_turf(src))
+		qdel(src)
 
 /**
  * Override attack_tk_grab instead of attack_tk because we actually want attack_tk's

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -422,12 +422,13 @@
 	else if(icon_state == "[initial_icon_state]_reverse") //so flipping doesn't overwrite an unexpected icon_state (e.g. an admin's)
 		icon_state = initial_icon_state
 
-/obj/item/tape/attackby(obj/item/I, mob/user, params)
-	if(unspooled && (I.tool_behaviour == TOOL_SCREWDRIVER))
-		to_chat(user, span_notice("You start winding the tape back in..."))
-		if(I.use_tool(src, user, 120))
-			to_chat(user, span_notice("You wind the tape back in."))
-			respool()
+/obj/item/tape/screwdriver_act(mob/living/user, obj/item/tool)
+	if(!unspooled)
+		return FALSE
+	to_chat(user, span_notice("You start winding the tape back in..."))
+	if(tool.use_tool(src, user, 120))
+		to_chat(user, span_notice("You wind the tape back in."))
+		respool()
 
 //Random colour tapes
 /obj/item/tape/random

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -89,9 +89,9 @@
 
 /obj/item/flamethrower/wrench_act(mob/living/user, obj/item/tool)
 	. = TRUE
-	tool.play_tool_sound(src)
 	if(status)
 		return FALSE
+	tool.play_tool_sound(src)
 	var/turf/T = get_turf(src)
 	if(weldtool)
 		weldtool.forceMove(T)
@@ -106,7 +106,7 @@
 	qdel(src)
 
 /obj/item/flamethrower/screwdriver_act(mob/living/user, obj/item/tool)
-	if(!igniter || lit)
+	if(igniter && !lit)
 		tool.play_tool_sound(src)
 		status = !status
 		to_chat(user, span_notice("[igniter] is now [status ? "secured" : "unsecured"]!"))

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -87,29 +87,34 @@
 			log_combat(user, target, "flamethrowered", src)
 			flame_turf(turflist)
 
-/obj/item/flamethrower/attackby(obj/item/W, mob/user, params)
-	if(W.tool_behaviour == TOOL_WRENCH && !status)//Taking this apart
-		var/turf/T = get_turf(src)
-		if(weldtool)
-			weldtool.forceMove(T)
-			weldtool = null
-		if(igniter)
-			igniter.forceMove(T)
-			igniter = null
-		if(ptank)
-			ptank.forceMove(T)
-			ptank = null
-		new /obj/item/stack/rods(T)
-		qdel(src)
-		return
+/obj/item/flamethrower/wrench_act(mob/living/user, obj/item/tool)
+	. = TRUE
+	tool.play_tool_sound(src)
+	if(status)
+		return FALSE
+	var/turf/T = get_turf(src)
+	if(weldtool)
+		weldtool.forceMove(T)
+		weldtool = null
+	if(igniter)
+		igniter.forceMove(T)
+		igniter = null
+	if(ptank)
+		ptank.forceMove(T)
+		ptank = null
+	new /obj/item/stack/rods(T)
+	qdel(src)
 
-	else if(W.tool_behaviour == TOOL_SCREWDRIVER && igniter && !lit)
+/obj/item/flamethrower/screwdriver_act(mob/living/user, obj/item/tool)
+	if(!igniter || lit)
+		tool.play_tool_sound(src)
 		status = !status
 		to_chat(user, span_notice("[igniter] is now [status ? "secured" : "unsecured"]!"))
 		update_appearance()
-		return
+		return TRUE
 
-	else if(isigniter(W))
+/obj/item/flamethrower/attackby(obj/item/W, mob/user, params)
+	if(isigniter(W))
 		var/obj/item/assembly/igniter/I = W
 		if(I.secured)
 			return

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -99,26 +99,53 @@
 	if(stage == GRENADE_WIRED)
 		wires.interact(user)
 
+/obj/item/grenade/chem_grenade/screwdriver_act(mob/living/user, obj/item/tool)
+	if(stage == GRENADE_WIRED)
+		if(beakers.len)
+			stage_change(GRENADE_READY)
+			to_chat(user, span_notice("You lock the [initial(name)] assembly."))
+			tool.play_tool_sound(src, 25)
+		else
+			to_chat(user, span_warning("You need to add at least one beaker before locking the [initial(name)] assembly!"))
+	else if(stage == GRENADE_READY)
+		det_time = det_time == 50 ? 30 : 50 //toggle between 30 and 50
+		if(landminemode)
+			landminemode.time = det_time * 0.1 //overwrites the proxy sensor activation timer
+
+		to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
+	else
+		to_chat(user, span_warning("You need to add a wire!"))
+
+	return TRUE
+
+/obj/item/grenade/chem_grenade/screwdriver_act(mob/living/user, obj/item/tool)
+	. = TRUE
+	if(stage == GRENADE_READY && !active)
+		stage_change(GRENADE_WIRED)
+		to_chat(user, span_notice("You unlock the [initial(name)] assembly."))
+
+/obj/item/grenade/chem_grenade/wrench_act(mob/living/user, obj/item/tool)
+	if(stage != GRENADE_WIRED)
+		return FALSE
+	if(beakers.len)
+		for(var/obj/beaker in beakers)
+			beaker.forceMove(drop_location())
+			if(!beaker.reagents)
+				continue
+			var/reagent_list = pretty_string_from_reagent_list(beaker.reagents)
+			user.log_message("removed [beaker] ([reagent_list]) from [src]", LOG_GAME)
+		beakers = list()
+		to_chat(user, span_notice("You open the [initial(name)] assembly and remove the payload."))
+		return
+	tool.play_tool_sound(src)
+	wires.detach_assembly(wires.get_wire(1))
+	new /obj/item/stack/cable_coil(get_turf(src), 1)
+	stage_change(GRENADE_EMPTY)
+	to_chat(user, span_notice("You remove the activation mechanism from the [initial(name)] assembly."))
+
 /obj/item/grenade/chem_grenade/attackby(obj/item/item, mob/user, params)
 	if(istype(item, /obj/item/assembly) && stage == GRENADE_WIRED)
 		wires.interact(user)
-	if(item.tool_behaviour == TOOL_SCREWDRIVER)
-		if(stage == GRENADE_WIRED)
-			if(beakers.len)
-				stage_change(GRENADE_READY)
-				to_chat(user, span_notice("You lock the [initial(name)] assembly."))
-				item.play_tool_sound(src, 25)
-			else
-				to_chat(user, span_warning("You need to add at least one beaker before locking the [initial(name)] assembly!"))
-		else if(stage == GRENADE_READY)
-			det_time = det_time == 50 ? 30 : 50 //toggle between 30 and 50
-			if(landminemode)
-				landminemode.time = det_time * 0.1 //overwrites the proxy sensor activation timer
-
-			to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
-		else
-			to_chat(user, span_warning("You need to add a wire!"))
-		return
 	else if(stage == GRENADE_WIRED && is_type_in_list(item, allowed_containers))
 		. = TRUE //no afterattack
 		if(is_type_in_list(item, banned_containers))
@@ -147,26 +174,6 @@
 		else
 			to_chat(user, span_warning("You need one length of coil to wire the assembly!"))
 			return
-
-	else if(stage == GRENADE_READY && item.tool_behaviour == TOOL_WIRECUTTER && !active)
-		stage_change(GRENADE_WIRED)
-		to_chat(user, span_notice("You unlock the [initial(name)] assembly."))
-
-	else if(stage == GRENADE_WIRED && item.tool_behaviour == TOOL_WRENCH)
-		if(beakers.len)
-			for(var/obj/beaker in beakers)
-				beaker.forceMove(drop_location())
-				if(!beaker.reagents)
-					continue
-				var/reagent_list = pretty_string_from_reagent_list(beaker.reagents)
-				user.log_message("removed [beaker] ([reagent_list]) from [src]", LOG_GAME)
-			beakers = list()
-			to_chat(user, span_notice("You open the [initial(name)] assembly and remove the payload."))
-			return
-		wires.detach_assembly(wires.get_wire(1))
-		new /obj/item/stack/cable_coil(get_turf(src), 1)
-		stage_change(GRENADE_EMPTY)
-		to_chat(user, span_notice("You remove the activation mechanism from the [initial(name)] assembly."))
 	else
 		return ..()
 

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -100,6 +100,7 @@
 		wires.interact(user)
 
 /obj/item/grenade/chem_grenade/screwdriver_act(mob/living/user, obj/item/tool)
+	. = TRUE
 	if(stage == GRENADE_WIRED)
 		if(beakers.len)
 			stage_change(GRENADE_READY)
@@ -112,17 +113,19 @@
 		if(landminemode)
 			landminemode.time = det_time * 0.1 //overwrites the proxy sensor activation timer
 
+		tool.play_tool_sound(src, 25)
 		to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
 	else
 		to_chat(user, span_warning("You need to add a wire!"))
 
 	return TRUE
 
-/obj/item/grenade/chem_grenade/screwdriver_act(mob/living/user, obj/item/tool)
-	. = TRUE
+/obj/item/grenade/chem_grenade/wirecutter_act(mob/living/user, obj/item/tool)
 	if(stage == GRENADE_READY && !active)
+		tool.play_tool_sound(src)
 		stage_change(GRENADE_WIRED)
 		to_chat(user, span_notice("You unlock the [initial(name)] assembly."))
+		return TRUE
 
 /obj/item/grenade/chem_grenade/wrench_act(mob/living/user, obj/item/tool)
 	if(stage != GRENADE_WIRED)

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -144,26 +144,32 @@
 		var/mob/mob = loc
 		mob.dropItemToGround(src)
 
-/obj/item/grenade/attackby(obj/item/weapon, mob/user, params)
+/obj/item/grenade/screwdriver_act(mob/living/user, obj/item/tool)
 	if(active)
-		return ..()
+		return FALSE
+	if(change_det_time())
+		tool.play_tool_sound(src)
+		to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
+		return TRUE
 
-	if(weapon.tool_behaviour == TOOL_MULTITOOL)
-		var/newtime = tgui_input_list(user, "Please enter a new detonation time", "Detonation Timer", list("Instant", 3, 4, 5))
-		if (isnull(newtime))
-			return
-		if(!user.canUseTopic(src, BE_CLOSE))
-			return
-		if(newtime == "Instant" && change_det_time(0))
-			to_chat(user, span_notice("You modify the time delay. It's set to be instantaneous."))
-			return
-		newtime = round(newtime)
-		if(change_det_time(newtime))
-			to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
+/obj/item/grenade/multitool_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(active)
+		return FALSE
+
+	. = TRUE
+
+	var/newtime = tgui_input_list(user, "Please enter a new detonation time", "Detonation Timer", list("Instant", 3, 4, 5))
+	if (isnull(newtime))
 		return
-	else if(weapon.tool_behaviour == TOOL_SCREWDRIVER)
-		if(change_det_time())
-			to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
+	if(newtime == "Instant" && change_det_time(0))
+		to_chat(user, span_notice("You modify the time delay. It's set to be instantaneous."))
+		return
+	newtime = round(newtime)
+	if(change_det_time(newtime))
+		to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
 
 /obj/item/grenade/proc/change_det_time(time) //Time uses real time.
 	. = TRUE

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -34,10 +34,12 @@
 	target = null
 	return ..()
 
+/obj/item/grenade/c4/screwdriver_act(mob/living/user, obj/item/tool)
+	to_chat(user, span_notice("The wire panel can be accessed without a screwdriver."))
+	return TRUE
+
 /obj/item/grenade/c4/attackby(obj/item/item, mob/user, params)
-	if(item.tool_behaviour == TOOL_SCREWDRIVER)
-		to_chat(user, span_notice("The wire panel can be accessed without a screwdriver."))
-	else if(is_wire_tool(item))
+	if(is_wire_tool(item))
 		wires.interact(user)
 	else
 		return ..()

--- a/code/game/objects/items/inducer.dm
+++ b/code/game/objects/items/inducer.dm
@@ -59,20 +59,21 @@
 		return TRUE
 	return FALSE
 
+/obj/item/inducer/screwdriver_act(mob/living/user, obj/item/tool)
+	. = TRUE
+	tool.play_tool_sound(src)
+	if(!opened)
+		to_chat(user, span_notice("You unscrew the battery compartment."))
+		opened = TRUE
+		update_appearance()
+		return
+	else
+		to_chat(user, span_notice("You close the battery compartment."))
+		opened = FALSE
+		update_appearance()
+		return
 
 /obj/item/inducer/attackby(obj/item/W, mob/user)
-	if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		W.play_tool_sound(src)
-		if(!opened)
-			to_chat(user, span_notice("You unscrew the battery compartment."))
-			opened = TRUE
-			update_appearance()
-			return
-		else
-			to_chat(user, span_notice("You close the battery compartment."))
-			opened = FALSE
-			update_appearance()
-			return
 	if(istype(W, /obj/item/stock_parts/cell))
 		if(opened)
 			if(!cell)

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -427,6 +427,10 @@
 	else
 		. += span_warning("\The [src] does not have a power source installed.")
 
+/obj/item/melee/baton/security/screwdriver_act(mob/living/user, obj/item/tool)
+	tryremovecell(user)
+	return TRUE
+
 /obj/item/melee/baton/security/attackby(obj/item/item, mob/user, params)
 	if(istype(item, /obj/item/stock_parts/cell))
 		var/obj/item/stock_parts/cell/active_cell = item
@@ -441,9 +445,6 @@
 			cell = item
 			to_chat(user, span_notice("You install a cell in [src]."))
 			update_appearance()
-
-	else if(item.tool_behaviour == TOOL_SCREWDRIVER)
-		tryremovecell(user)
 	else
 		return ..()
 

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -428,7 +428,8 @@
 		. += span_warning("\The [src] does not have a power source installed.")
 
 /obj/item/melee/baton/security/screwdriver_act(mob/living/user, obj/item/tool)
-	tryremovecell(user)
+	if(tryremovecell(user))
+		tool.play_tool_sound(src)
 	return TRUE
 
 /obj/item/melee/baton/security/attackby(obj/item/item, mob/user, params)
@@ -452,6 +453,8 @@
 	if(cell && can_remove_cell)
 		cell.forceMove(drop_location())
 		to_chat(user, span_notice("You remove the cell from [src]."))
+		return TRUE
+	return FALSE
 
 /obj/item/melee/baton/security/attack_self(mob/user)
 	if(cell?.charge >= cell_hit_cost)

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -70,6 +70,23 @@
 		out += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it.")
 	. += out.Join("\n")
 
+/obj/item/pneumatic_cannon/screwdriver_act(mob/living/user, obj/item/tool)
+	if(tank)
+		tool.play_tool_sound(src)
+		updateTank(tank, 1, user)
+
+/obj/item/pneumatic_cannon/wrench_act(mob/living/user, obj/item/tool)
+	playsound(src, 'sound/items/ratchet.ogg', 50, TRUE)
+	switch(pressureSetting)
+		if(1)
+			pressureSetting = 2
+		if(2)
+			pressureSetting = 3
+		if(3)
+			pressureSetting = 1
+	to_chat(user, span_notice("You tweak \the [src]'s pressure output to [pressureSetting]."))
+	return TRUE
+
 /obj/item/pneumatic_cannon/attackby(obj/item/W, mob/living/user, params)
 	if(user.combat_mode)
 		return ..()
@@ -92,9 +109,6 @@
 			if(3)
 				pressureSetting = 1
 		to_chat(user, span_notice("You tweak \the [src]'s pressure output to [pressureSetting]."))
-	else if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(tank)
-			updateTank(tank, 1, user)
 	else if(loadedWeightClass >= maxWeightClass)
 		to_chat(user, span_warning("\The [src] can't hold any more items!"))
 	else if(isitem(W))

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -74,6 +74,7 @@
 	if(tank)
 		tool.play_tool_sound(src)
 		updateTank(tank, 1, user)
+	return TRUE
 
 /obj/item/pneumatic_cannon/wrench_act(mob/living/user, obj/item/tool)
 	playsound(src, 'sound/items/ratchet.ogg', 50, TRUE)

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -28,6 +28,22 @@
 	if(tank)
 		. += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it.")
 
+/obj/item/melee/powerfist/wrench_act(mob/living/user, obj/item/tool)
+	switch(fisto_setting)
+		if(1)
+			fisto_setting = 2
+		if(2)
+			fisto_setting = 3
+		if(3)
+			fisto_setting = 1
+	tool.play_tool_sound(src)
+	to_chat(user, span_notice("You tweak \the [src]'s piston valve to [fisto_setting]."))
+	return TRUE
+
+/obj/item/melee/powerfist/screwdriver_act(mob/living/user, obj/item/tool)
+	if(tank)
+		updateTank(tank, 1, user)
+		return TRUE
 
 /obj/item/melee/powerfist/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/tank/internals))
@@ -37,19 +53,6 @@
 				to_chat(user, span_warning("\The [IT] is too small for \the [src]."))
 				return
 			updateTank(W, 0, user)
-	else if(W.tool_behaviour == TOOL_WRENCH)
-		switch(fisto_setting)
-			if(1)
-				fisto_setting = 2
-			if(2)
-				fisto_setting = 3
-			if(3)
-				fisto_setting = 1
-		W.play_tool_sound(src)
-		to_chat(user, span_notice("You tweak \the [src]'s piston valve to [fisto_setting]."))
-	else if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(tank)
-			updateTank(tank, 1, user)
 
 /obj/item/melee/powerfist/proc/updateTank(obj/item/tank/internals/thetank, removing = 0, mob/living/carbon/human/user)
 	if(removing)

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -44,35 +44,38 @@
 	if(can_hack_open)
 		. += "The service panel is currently <b>[panel_open ? "unscrewed" : "screwed shut"]</b>."
 
-/obj/item/storage/secure/attackby(obj/item/weapon, mob/user, params)
+/obj/item/storage/secure/tool_act(mob/living/user, obj/item/tool)
 	if(can_hack_open && SEND_SIGNAL(src, COMSIG_IS_STORAGE_LOCKED))
-		if (weapon.tool_behaviour == TOOL_SCREWDRIVER)
-			if (weapon.use_tool(src, user, 20))
-				panel_open = !panel_open
-				to_chat(user, span_notice("You [panel_open ? "open" : "close"] the service panel."))
-			return
-		if (weapon.tool_behaviour == TOOL_WIRECUTTER)
-			to_chat(user, span_danger("[src] is protected from this sort of tampering, yet it appears the internal memory wires can still be <b>pulsed</b>."))
-			return
-		if (weapon.tool_behaviour == TOOL_MULTITOOL)
-			if(lock_hacking)
-				to_chat(user, span_danger("This safe is already being hacked."))
-				return
-			if(panel_open == TRUE)
-				to_chat(user, span_danger("Now attempting to reset internal memory, please hold."))
-				lock_hacking = TRUE
-				if (weapon.use_tool(src, user, 400))
-					to_chat(user, span_danger("Internal memory reset - lock has been disengaged."))
-					lock_set = FALSE
+		return ..()
+	else
+		return FALSE
 
-				lock_hacking = FALSE
-				return
+/obj/item/storage/secure/wirecutter_act(mob/living/user, obj/item/tool)
+	to_chat(user, span_danger("[src] is protected from this sort of tampering, yet it appears the internal memory wires can still be <b>pulsed</b>."))
+	return
 
-			to_chat(user, span_warning("You must <b>unscrew</b> the service panel before you can pulse the wiring!"))
-			return
+/obj/item/storage/secure/screwdriver_act(mob/living/user, obj/item/tool)
+	if(tool.use_tool(src, user, 20))
+		panel_open = !panel_open
+		to_chat(user, span_notice("You [panel_open ? "open" : "close"] the service panel."))
+		return TRUE
 
-	// -> storage/attackby() what with handle insertion, etc
-	return ..()
+/obj/item/storage/secure/multitool_act(mob/living/user, obj/item/tool)
+	. = TRUE
+	if(lock_hacking)
+		to_chat(user, span_danger("This safe is already being hacked."))
+		return
+	if(panel_open == TRUE)
+		to_chat(user, span_danger("Now attempting to reset internal memory, please hold."))
+		lock_hacking = TRUE
+		if (tool.use_tool(src, user, 400))
+			to_chat(user, span_danger("Internal memory reset - lock has been disengaged."))
+			lock_set = FALSE
+
+		lock_hacking = FALSE
+		return
+
+	to_chat(user, span_warning("You must <b>unscrew</b> the service panel before you can pulse the wiring!"))
 
 /obj/item/storage/secure/attack_self(mob/user)
 	var/locked = SEND_SIGNAL(src, COMSIG_IS_STORAGE_LOCKED)

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -296,8 +296,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 			to_chat(user, span_warning("Unable to locate a radio!"))
 	update_icons()
 
-	return TRUE
-
 /mob/living/silicon/robot/wrench_act(mob/living/user, obj/item/tool)
 	if(!(opened && !cell))	// Deconstruction. The flashes break from the fall, to prevent this from being a ghetto reset module.
 		return FALSE

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -5,23 +5,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	)))
 
 /mob/living/silicon/robot/attackby(obj/item/W, mob/living/user, params)
-	if(W.tool_behaviour == TOOL_WELDER && (!user.combat_mode || user == src))
-		user.changeNext_move(CLICK_CD_MELEE)
-		if (!getBruteLoss())
-			to_chat(user, span_warning("[src] is already in good condition!"))
-			return
-		if (!W.tool_start_check(user, amount=0)) //The welder has 1u of fuel consumed by it's afterattack, so we don't need to worry about taking any away.
-			return
-		if(src == user)
-			to_chat(user, span_notice("You start fixing yourself..."))
-			if(!W.use_tool(src, user, 50))
-				return
-
-		adjustBruteLoss(-30)
-		add_fingerprint(user)
-		visible_message(span_notice("[user] fixes some of the dents on [src]."))
-		return
-
 	if(istype(W, /obj/item/stack/cable_coil) && wiresexposed)
 		user.changeNext_move(CLICK_CD_MELEE)
 		var/obj/item/stack/cable_coil/coil = W
@@ -37,20 +20,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 				to_chat(user, span_warning("You need more cable to repair [src]!"))
 		else
 			to_chat(user, span_warning("The wires seem fine, there's no need to fix them."))
-		return
-
-	if(W.tool_behaviour == TOOL_CROWBAR) // crowbar means open or close the cover
-		if(opened)
-			to_chat(user, span_notice("You close the cover."))
-			opened = FALSE
-			update_icons()
-		else
-			if(locked)
-				to_chat(user, span_warning("The cover is locked and cannot be opened!"))
-			else
-				to_chat(user, span_notice("You open the cover."))
-				opened = TRUE
-				update_icons()
 		return
 
 	if(istype(W, /obj/item/stock_parts/cell) && opened) // trying to put a cell inside
@@ -74,31 +43,6 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 			to_chat(user, span_warning("You can't reach the wiring!"))
 		return
 
-	if(W.tool_behaviour == TOOL_SCREWDRIVER && opened) // wire hacking or radio management
-		if(!cell) //haxing
-			wiresexposed = !wiresexposed
-			to_chat(user, span_notice("The wires have been [wiresexposed ? "exposed" : "unexposed"]."))
-		else //radio
-			if(shell)
-				to_chat(user, span_warning("You cannot seem to open the radio compartment!")) //Prevent AI radio key theft
-			else if(radio)
-				radio.screwdriver_act(user, W)//Push it to the radio to let it handle everything
-			else
-				to_chat(user, span_warning("Unable to locate a radio!"))
-		update_icons()
-		return
-
-	if(W.tool_behaviour == TOOL_WRENCH && opened && !cell) //Deconstruction. The flashes break from the fall, to prevent this from being a ghetto reset module.
-		if(!lockcharge)
-			to_chat(user, span_warning("[src]'s bolts spark! Maybe you should lock them down first!"))
-			spark_system.start()
-			return
-		to_chat(user, span_notice("You start to unfasten [src]'s securing bolts..."))
-		if(W.use_tool(src, user, 50, volume=50) && !cell)
-			user.visible_message(span_notice("[user] deconstructs [src]!"), span_notice("You unfasten the securing bolts, and [src] falls to pieces!"))
-			deconstruct()
-		return
-
 	if(W.slot_flags & ITEM_SLOT_HEAD && hat_offset != INFINITY && !user.combat_mode && !is_type_in_typecache(W, GLOB.blacklisted_borg_hats))
 		if(user == src)
 			to_chat(user,  span_notice("You can't seem to manage to place [W] on your head by yourself!") )
@@ -112,6 +56,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 			if (user.temporarilyRemoveItemFromInventory(W, TRUE))
 				place_on_head(W)
 		return
+
 	if(istype(W, /obj/item/defibrillator) && !user.combat_mode)
 		if(!opened)
 			to_chat(user, span_warning("You must access the cyborg's internals!"))
@@ -183,7 +128,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 				to_chat(user, span_danger("Access denied."))
 		return
 
-	if(istype(W, /obj/item/borg/upgrade/))
+	if(istype(W, /obj/item/borg/upgrade))
 		var/obj/item/borg/upgrade/U = W
 		if(!opened)
 			to_chat(user, span_warning("You must access the cyborg's internals!"))
@@ -299,6 +244,73 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	spark_system.start()
 	step_away(src, user, 15)
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/_step_away, src, get_turf(user), 15), 3)
+
+/mob/living/silicon/robot/welder_act(mob/living/user, obj/item/tool)
+	if(user.combat_mode && usr != src)
+		return FALSE
+	. = TRUE
+	user.changeNext_move(CLICK_CD_MELEE)
+	if (!getBruteLoss())
+		to_chat(user, span_warning("[src] is already in good condition!"))
+		return
+	if (!tool.tool_start_check(user, amount=1)) //The welder has 1u of fuel consumed by it's afterattack, so we don't need to worry about taking any away.
+		return
+	if(src == user)
+		to_chat(user, span_notice("You start fixing yourself..."))
+		if(!tool.use_tool(src, user, 50))
+			return
+
+	adjustBruteLoss(-30)
+	add_fingerprint(user)
+	visible_message(span_notice("[user] fixes some of the dents on [src]."))
+
+/mob/living/silicon/robot/crowbar_act(mob/living/user, obj/item/tool)
+	. = TRUE
+	if(opened)
+		to_chat(user, span_notice("You close the cover."))
+		opened = FALSE
+		update_icons()
+	else
+		if(locked)
+			to_chat(user, span_warning("The cover is locked and cannot be opened!"))
+		else
+			to_chat(user, span_notice("You open the cover."))
+			opened = TRUE
+			update_icons()
+
+	return TRUE
+
+/mob/living/silicon/robot/screwdriver_act(mob/living/user, obj/item/tool)
+	if(!opened)
+		return FALSE
+	. = TRUE
+	if(!cell) // haxing
+		wiresexposed = !wiresexposed
+		to_chat(user, span_notice("The wires have been [wiresexposed ? "exposed" : "unexposed"]."))
+	else // radio
+		if(shell)
+			to_chat(user, span_warning("You cannot seem to open the radio compartment!")) //Prevent AI radio key theft
+		else if(radio)
+			radio.screwdriver_act(user, tool) // Push it to the radio to let it handle everything
+		else
+			to_chat(user, span_warning("Unable to locate a radio!"))
+	update_icons()
+
+	return TRUE
+
+/mob/living/silicon/robot/wrench_act(mob/living/user, obj/item/tool)
+	if(!(opened && !cell))	// Deconstruction. The flashes break from the fall, to prevent this from being a ghetto reset module.
+		return FALSE
+	. = TRUE
+	if(!lockcharge)
+		to_chat(user, span_warning("[src]'s bolts spark! Maybe you should lock them down first!"))
+		spark_system.start()
+		return
+	to_chat(user, span_notice("You start to unfasten [src]'s securing bolts..."))
+	if(tool.use_tool(src, user, 50, volume=50) && !cell)
+		user.visible_message(span_notice("[user] deconstructs [src]!"), span_notice("You unfasten the securing bolts, and [src] falls to pieces!"))
+		deconstruct()
+		return
 
 /mob/living/silicon/robot/fire_act()
 	if(!on_fire) //Silicons don't gain stacks from hotspots, but hotspots can ignite them


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces a bunch of tool behavior checks in attackby to instead use the respective procs. 
For instance, the behavior under a `if(I.tool_behaviour == TOOL_SCREWDRIVER)` check in `attackby()` will instead be found under that same object's `screwdriver_act()` proc. This is the first of a few PRs that I'd like to make to address this, since there's going to be a lot of code shuffled around.

This shouldn't have any impact on players, though some super observant folks might notice that they don't bash some items with tools when they meant to interact with them. I've tested all of these in game and they seem to still have the same behavior as before.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is kind of where this code should be, given that we have the whole melee attack chain with functionality for different tools. Looking down the road, this should make messing with existing behavior a lot easier, since it'll be separated by tool rather than all being lumped into a single elif chain.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Reworks some tool interactions to use specific tool procs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
