### PR TITLE
Metalfoam structures can now be used as girders to finish building walls.

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -276,7 +276,7 @@
 	gender = PLURAL
 	max_integrity = 20
 	can_atmos_pass = ATMOS_PASS_DENSITY
-	///Prevents spamming of the construction sound
+	///Var used to prevent spamming of the construction sound
 	var/next_beep = 0
 
 /obj/structure/foamedmetal/Initialize(mapload)
@@ -327,7 +327,7 @@
 			return
 		to_chat(user, span_notice("You start adding plating to the foam structure..."))
 		if (do_after(user, 40*platingmodifier, target = src))
-			if(sheet_for_plating.get_amount() < 2)
+			if(!sheet_for_plating.use(2))
 				return
 			sheet_for_plating.use(2)
 			to_chat(user, span_notice("You add the plating."))
@@ -337,12 +337,12 @@
 			qdel(src)
 		return
 	if(!sheet_for_plating.has_unique_girder)
-		if(sheet_for_plating.get_amount() < 2)
+		if(!sheet_for_plating.use(2))
 			to_chat(user, span_warning("You need at least two sheets to add plating!"))
 			return
 		to_chat(user, span_notice("You start adding plating to the foam structure..."))
 		if (do_after(user, 40, target = src))
-			if(sheet_for_plating.get_amount() < 2)
+			if(!sheet_for_plating.use(2))
 				return
 			sheet_for_plating.use(2)
 			to_chat(user, span_notice("You add the plating."))

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -329,34 +329,9 @@
 		if (do_after(user, 40*platingmodifier, target = src))
 			if(!sheet_for_plating.use(2))
 				return
-			sheet_for_plating.use(2)
 			to_chat(user, span_notice("You add the plating."))
 			var/turf/T = get_turf(src)
 			T.PlaceOnTop(/turf/closed/wall)
-			transfer_fingerprints_to(T)
-			qdel(src)
-		return
-	if(!sheet_for_plating.has_unique_girder)
-		if(!sheet_for_plating.use(2))
-			to_chat(user, span_warning("You need at least two sheets to add plating!"))
-			return
-		to_chat(user, span_notice("You start adding plating to the foam structure..."))
-		if (do_after(user, 40, target = src))
-			if(!sheet_for_plating.use(2))
-				return
-			sheet_for_plating.use(2)
-			to_chat(user, span_notice("You add the plating."))
-			var/turf/T = get_turf(src)
-			if(sheet_for_plating.walltype)
-				T.PlaceOnTop(sheet_for_plating.walltype)
-			else
-				var/turf/newturf = T.PlaceOnTop(/turf/closed/wall/material)
-				var/list/material_list = list()
-				if(sheet_for_plating.material_type)
-					material_list[GET_MATERIAL_REF(sheet_for_plating.material_type)] = MINERAL_MATERIAL_AMOUNT * 2
-				if(material_list)
-					newturf.set_custom_materials(material_list)
-
 			transfer_fingerprints_to(T)
 			qdel(src)
 		return

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -272,10 +272,12 @@
 	layer = EDGED_TURF_LAYER
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	name = "foamed metal"
-	desc = "A lightweight foamed metal wall."
+	desc = "A lightweight foamed metal wall that can be used as base to construct a wall."
 	gender = PLURAL
 	max_integrity = 20
 	can_atmos_pass = ATMOS_PASS_DENSITY
+	///Prevents spamming of the construction sound
+	var/next_beep = 0
 
 /obj/structure/foamedmetal/Initialize(mapload)
 	. = ..()
@@ -305,6 +307,62 @@
 	to_chat(user, span_warning("You hit [src] but bounce off it!"))
 	playsound(src.loc, 'sound/weapons/tap.ogg', 100, TRUE)
 
+/obj/structure/foamedmetal/attackby(obj/item/W, mob/user, params)
+	///A speed modifier for how fast the wall is build
+	var/platingmodifier = 1
+	if(HAS_TRAIT(user, TRAIT_QUICK_BUILD))
+		platingmodifier = 0.7
+		if(next_beep <= world.time)
+			next_beep = world.time + 10
+			playsound(src, 'sound/machines/clockcult/integration_cog_install.ogg', 50, TRUE)
+	add_fingerprint(user)
+
+	if(!istype(W, /obj/item/stack/sheet))
+		return ..()
+
+	var/obj/item/stack/sheet/sheet_for_plating = W
+	if(istype(sheet_for_plating, /obj/item/stack/sheet/iron))
+		if(sheet_for_plating.get_amount() < 2)
+			to_chat(user, span_warning("You need two sheets of iron to finish a wall!"))
+			return
+		to_chat(user, span_notice("You start adding plating to the foam structure..."))
+		if (do_after(user, 40*platingmodifier, target = src))
+			if(sheet_for_plating.get_amount() < 2)
+				return
+			sheet_for_plating.use(2)
+			to_chat(user, span_notice("You add the plating."))
+			var/turf/T = get_turf(src)
+			T.PlaceOnTop(/turf/closed/wall)
+			transfer_fingerprints_to(T)
+			qdel(src)
+		return
+	if(!sheet_for_plating.has_unique_girder)
+		if(sheet_for_plating.get_amount() < 2)
+			to_chat(user, span_warning("You need at least two sheets to add plating!"))
+			return
+		to_chat(user, span_notice("You start adding plating to the foam structure..."))
+		if (do_after(user, 40, target = src))
+			if(sheet_for_plating.get_amount() < 2)
+				return
+			sheet_for_plating.use(2)
+			to_chat(user, span_notice("You add the plating."))
+			var/turf/T = get_turf(src)
+			if(sheet_for_plating.walltype)
+				T.PlaceOnTop(sheet_for_plating.walltype)
+			else
+				var/turf/newturf = T.PlaceOnTop(/turf/closed/wall/material)
+				var/list/material_list = list()
+				if(sheet_for_plating.material_type)
+					material_list[GET_MATERIAL_REF(sheet_for_plating.material_type)] = MINERAL_MATERIAL_AMOUNT * 2
+				if(material_list)
+					newturf.set_custom_materials(material_list)
+
+			transfer_fingerprints_to(T)
+			qdel(src)
+		return
+
+	add_hiddenprint(user)
+
 /obj/structure/foamedmetal/iron
 	max_integrity = 50
 	icon_state = "ironfoam"
@@ -312,7 +370,7 @@
 //Atmos Backpack Resin, transparent, prevents atmos and filters the air
 /obj/structure/foamedmetal/resin
 	name = "\improper ATMOS Resin"
-	desc = "A lightweight, transparent resin used to suffocate fires, scrub the air of toxins, and restore the air to a safe temperature."
+	desc = "A lightweight, transparent resin used to suffocate fires, scrub the air of toxins, and restore the air to a safe temperature. It can be used as base to construct a wall."
 	opacity = FALSE
 	icon_state = "atmos_resin"
 	alpha = 120


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Let Metal foam structures work as a "girder" if you use metal sheets on them, finishing into a normal wall.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rebuilding an area after an explosion without an RCD is slow, metal foam helps a lot if you don't have an RCD but you lose time on the clean up.
This cuts one step down at least, you can finish a wall on top of foam instead of breaking the foam barrier down and building a girder/wall from scratch in its place, possibly letting more of the atmos get spaced while doing it...
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
qol: Metalfoam structures can now be used as a girder to finish building walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
