### PR TITLE
Adds Service Hallway to list of general (service) access list

### DIFF
--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -369,6 +369,7 @@
 	ACCESS_LIBRARY, \
 	ACCESS_THEATRE, \
 	ACCESS_LAWYER, \
+	ACCESS_SERVICE, \
 )
 /// Name for the Security region.
 #define REGION_SECURITY "Security"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does what the title says. This allows the Plexagon Access Manager (the HoP ID card access control program) to be aware that `ACCESS_SERVICE` exists, instead of just dropping it off the list when messing with/creating service staff ID cards.

I'm sure there are other systems that use the region system that might have been affected, but that was the main one.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's nice to be able to properly alter service staff ID cards without losing roundstart access.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
fix: Central Command has finally informed the Plexagon vendor that service hallway access exists, allowing HoP's to grant it to ID cards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
