### PR TITLE
Fixes holocall broadcasting caller's speech

### DIFF
--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -96,9 +96,7 @@
 	dialed_holopads.Cut()
 
 	if(calling_holopad)//if the call is answered, then calling_holopad wont be in dialed_holopads and thus wont have set_holocall(src, FALSE) called
-		calling_holopad.calling = FALSE
-		calling_holopad.outgoing_call = null
-		calling_holopad.SetLightsAndPower()
+		calling_holopad.callee_hung_up()
 		calling_holopad = null
 	if(connected_holopad)
 		connected_holopad.SetLightsAndPower()
@@ -163,7 +161,7 @@
 	if(!Check())
 		return
 
-	calling_holopad.calling = FALSE
+	calling_holopad.callee_picked_up()
 	hologram = answering_holopad.activate_holo(user)
 	hologram.HC = src
 

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -1,7 +1,8 @@
 #define CAN_HEAR_MASTERS (1<<0)
 #define CAN_HEAR_ACTIVE_HOLOCALLS (1<<1)
 #define CAN_HEAR_RECORD_MODE (1<<2)
-#define CAN_HEAR_ALL_FLAGS (CAN_HEAR_MASTERS|CAN_HEAR_ACTIVE_HOLOCALLS|CAN_HEAR_RECORD_MODE)
+#define CAN_HEAR_HOLOCALL_USER (1<<3)
+#define CAN_HEAR_ALL_FLAGS (CAN_HEAR_MASTERS|CAN_HEAR_ACTIVE_HOLOCALLS|CAN_HEAR_RECORD_MODE|CAN_HEAR_HOLOCALL_USER)
 
 /* Holograms!
  * Contains:
@@ -575,6 +576,21 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	qdel(masters[user]) // Get rid of user's hologram
 	unset_holo(user)
 	return TRUE
+
+/**
+ * Called by holocall to inform outgoing_call that the receiver picked up.
+ */
+/obj/machinery/holopad/proc/callee_picked_up()
+	calling = FALSE
+	set_can_hear_flags(CAN_HEAR_HOLOCALL_USER)
+
+/**
+ * Called by holocall to inform outgoing_call that the call is terminated.
+ */
+/obj/machinery/holopad/proc/callee_hung_up()
+	set_can_hear_flags(CAN_HEAR_HOLOCALL_USER, set_flag = FALSE)
+	calling = FALSE
+	outgoing_call = null
 
 /obj/machinery/holopad/proc/unset_holo(mob/living/user)
 	var/mob/living/silicon/ai/AI = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I decided to look into why holopads weren't broadcasting the speech of the person that started the call (as opposed to the person that received/accepted the call).
Turns out there was literally no code to enable the calling holopad to listen to anything. Guessing it got kicked into the stormdrain when the radio updates happened or something. Doesn't matter. Oddly the calling holopad isn't even notified in any way of a call starting, and since the CAN_HEAR flags are private to the holopad module, there's no way of setting it from `/datum/holocall` directly.

So I added functions to let the calling holopad handle the call starting and ending, refactoring the messy holocall code microscopically, adding the code to let the calling pad hear the caller person. The rest of the code in `holopad/Hear()` thankfully still worked fine.

That being said, I'm mainly relying on runechat revealing speaker sources since debugging this in a test server is confusing and difficult.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Holocalls are fun.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Calls via holopads now transmit the caller's speech again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
