### PR TITLE
Vaccines must now be injected, and require 5 units to cure.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -121,7 +121,7 @@
 
 /datum/reagent/vaccine/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message=TRUE, touch_protection=0)
 	. = ..()
-	if(!islist(data) || !(methods & (INGEST|INJECT)))
+	if(!islist(data) || !(methods & INJECT) || reac_volume < 5)
 		return
 
 	for(var/thing in exposed_mob.diseases)


### PR DESCRIPTION
## About The Pull Request

Vaccines must now be injected, and require 5 units to cure.

## Why It's Good For The Game

Currently, the process of curing a virus for the entire crew is:
1. Grab a cured person after giving them their sugar or ethanol or whatever
2. Get a blood sample
3. Go back to the Pandemic
4. Generate a bunch of vaccine culture bottles
5. Make approximately 500~ Vaccine (0.1u) pills and drop them on the floor in front of medbay
6. Go back to virology for the rest of the round, or leave medbay or whatever

This is boring as shit, involves nobody but the virologist and whoever the person who's blood you took is, and leads to massive stacks of objects on the floor.

By making vaccines require injection and a minimum of 5 units, it encourages the virologist to dose out vaccine shots and employ the other medical staff in getting shots in arms. 

This gives viruses more of an opportunity to impact someone rather than them beelining medbay and eating the first pill they see off the ground the second they sniff or see a face pop up on their health HUD. It also means virologists have reasons to keep getting samples from cured patients, as they'll now need to produce far more vaccine culture to cure patients.

Also, I hate seeing 50000 pill stacks of Vaccine (0.1u) on the floor in medbay.

## Changelog

:cl:
balance: Vaccines must now be injected, and require 5 units to cure.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
