### PR TITLE
adjust minimum cold on space helmets and add (some) doc

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -90,8 +90,12 @@
 
 //CLOTHES
 
+// Welcome to Tsu's explanation on: what is this shit? Basically, the minimum temp protection values dictates the absolute lowest of a temperature someone can handle before they
+// start taking temperature damage. The way it is setup makes it kind of seem like its "bounds" for what the temperature protection possibly "could" be, but nope!
+// Its what it is. Weird. Don't set space helmet temperature protections to 2.0, because then you can go naked into space and not be cold. This is bad.
+
 /// what min_cold_protection_temperature is set to for space-helmet quality headwear. MUST NOT BE 0.
-#define SPACE_HELM_MIN_TEMP_PROTECT 2.0
+#define SPACE_HELM_MIN_TEMP_PROTECT 72
 /// Thermal insulation works both ways /Malkevin
 #define SPACE_HELM_MAX_TEMP_PROTECT 1500
 /// what min_cold_protection_temperature is set to for space-suit quality jumpsuits or suits. MUST NOT BE 0.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

before, you were able to wear a space helmet out into space completely naked, and not be cold at all. this adjusts the SPACE_HELM_MIN_TEMP_PROTECT from 2.0 (space temperatures) to 72 (same as suit). when the thermal regulator on a suit is enabled, you return to have full cold protection.

fixes #64398

## Why It's Good For The Game

refer to branch name

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed space helmet temperature bounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
