### PR TITLE
Removes the fucking 20 second stunlock rng from tourettes because it's fucking stupid and I just had the most agonizing thirty fucking minutes of my goddamn life, holy shit

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -140,7 +140,6 @@
 
 /datum/mutation/human/tourettes/on_life(delta_time, times_fired)
 	if(DT_PROB(5 * GET_MUTATION_SYNCHRONIZER(src), delta_time) && owner.stat == CONSCIOUS && !owner.IsStun())
-		owner.Stun(200)
 		switch(rand(1, 3))
 			if(1)
 				owner.emote("twitch")


### PR DESCRIPTION
## About The Pull Request
Removes the fucking 20 second stunlock rng from tourettes because it's fucking stupid and I just had the most agonizing thirty fucking minutes of my goddamn life, holy shit, I hate this fucking mutation so goddamn much, who the fuck thought 20 second hard stun was a genius idea for a random mutation, especially the fact it gives absolutely zero indication that it's from the tourettes because the stun has no message attached

## Why It's Good For The Game

Oh my fucking god I hate this

Twenty fucking seconds of stunlocking

20 fucking whole seconds

This can end up being a solid fucking minute in laggy situations

This is fucking stupid

Fuck this symptom holy shit

## Changelog

:cl:
balance: Removes the fucking 20 second stunlock rng from tourettes because it's fucking stupid and I just had the most agonizing thirty fucking minutes of my goddamn life, holy shit, I hate this fucking mutation so goddamn much, who the fuck thought 20 second hard stun was a genius idea for a random mutation, especially the fact it gives absolutely zero indication that it's from the tourettes because the stun has no message attached
/:cl: