### PR TITLE
Fixes Thermite overlay not deleting properly + thermite component documentation

### DIFF
--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -1,23 +1,30 @@
 /datum/component/thermite
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+	///Amoumt of thermite on parent
 	var/amount
+	///Amount of thermite required to burn through parent
 	var/burn_require
+	///The thermite overlay
 	var/overlay
+	///The timer for burning parent
 	var/burn_timer
+	///The thermite fire overlay
+	var/obj/effect/overlay/thermite/fakefire
 
+	///Blacklist of turfs that cannot have thermite on it
 	var/static/list/blacklist = typecacheof(list(
 		/turf/open/lava,
 		/turf/open/space,
 		/turf/open/water,
 		/turf/open/chasm)
 		)
-
+	///List of turfs that are immune to thermite
 	var/static/list/immunelist = typecacheof(list(
 		/turf/closed/wall/mineral/diamond,
 		/turf/closed/indestructible,
 		/turf/open/indestructible)
 		)
-
+	///List of turfs that take extra thermite to burn through
 	var/static/list/resistlist = typecacheof(
 		/turf/closed/wall/r_wall
 		)
@@ -47,6 +54,7 @@
 	UnregisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT)
 	UnregisterSignal(parent, COMSIG_PARENT_ATTACKBY)
 	UnregisterSignal(parent, COMSIG_ATOM_FIRE_ACT)
+	UnregisterSignal(parent, COMSIG_PARENT_QDELETING)
 
 /datum/component/thermite/Destroy()
 	var/turf/master = parent
@@ -62,23 +70,32 @@
 		amount += _amount
 	if (burn_timer) // prevent people from skipping a longer timer
 		deltimer(burn_timer)
-		var/fakefire
-		for (var/obj/effect/overlay/thermite/fire in parent)
-			fakefire = fire
-		burn_timer = addtimer(CALLBACK(src, .proc/burn_parent, fakefire, usr), min(amount * 0.35 SECONDS, 20 SECONDS), TIMER_STOPPABLE)
+		burn_timer = addtimer(CALLBACK(src, .proc/burn_parent, usr), min(amount * 0.35 SECONDS, 20 SECONDS), TIMER_STOPPABLE)
 
+/**
+ * Used to begin the thermite burning process
+ *
+ * Arguments:
+ * * mob/user - The user igniting the thermite
+ */
 /datum/component/thermite/proc/thermite_melt(mob/user)
 	var/turf/master = parent
 	master.cut_overlay(overlay)
 	playsound(master, 'sound/items/welder.ogg', 100, TRUE)
-	var/obj/effect/overlay/thermite/fakefire = new(master)
-	burn_timer = addtimer(CALLBACK(src, .proc/burn_parent, fakefire, user), min(amount * 0.35 SECONDS, 20 SECONDS), TIMER_STOPPABLE)
+	fakefire = new(master)
+	burn_timer = addtimer(CALLBACK(src, .proc/burn_parent, user), min(amount * 0.35 SECONDS, 20 SECONDS), TIMER_STOPPABLE)
 	UnregisterFromParent()
+	RegisterSignal(parent, COMSIG_PARENT_QDELETING, .proc/delete_fire) //in case parent gets deleted, get ready to delete the fire
 
-/datum/component/thermite/proc/burn_parent(datum/fakefire, mob/user)
+/**
+ * Used to actually melt parent
+ *
+ * Arguments:
+ * * mob/user - The user that ignited the thermite
+ */
+/datum/component/thermite/proc/burn_parent(mob/user)
 	var/turf/master = parent
-	if(!QDELETED(fakefire))
-		qdel(fakefire)
+	delete_fire()
 	if(user)
 		master.add_hiddenprint(user)
 	if(amount >= burn_require)
@@ -86,6 +103,18 @@
 		master.burn_tile()
 	qdel(src)
 
+/**
+ * Used to delete the fake fire overlay
+ */
+/datum/component/thermite/proc/delete_fire()
+	SIGNAL_HANDLER
+
+	if(!QDELETED(fakefire))
+		qdel(fakefire)
+
+/**
+ * wash reaction, used to clean off thermite from parent
+ */
 /datum/component/thermite/proc/clean_react(datum/source, strength)
 	SIGNAL_HANDLER
 
@@ -93,11 +122,29 @@
 	qdel(src)
 	return COMPONENT_CLEANED
 
+/**
+ * fire_act reaction, has to be the correct temperature
+ *
+ * Arguments:
+ * * datum/source - The source of the flame
+ * * exposed_temperature - The temperature of the flame hitting the thermite
+ * * exposed_volume - The volume of the flame
+ */
 /datum/component/thermite/proc/flame_react(datum/source, exposed_temperature, exposed_volume)
 	SIGNAL_HANDLER
 
 	if(exposed_temperature > 1922) // This is roughly the real life requirement to ignite thermite
 		thermite_melt()
+
+/**
+ * attackby reaction, ignites the thermite if its a flame creating object
+ *
+ * Arguments:
+ * * datum/source - The source of the attack
+ * * obj/item/thing - Item being attacked by
+ * * mob/user - The user behind the attack
+ * * params - params
+ */
 
 /datum/component/thermite/proc/attackby_react(datum/source, obj/item/thing, mob/user, params)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request
Fixes the thermite burning overlay not deleting if parent was qdel'd (and prevents the permanent impassable tile).
Also, adds documentation to the thermite component
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes https://github.com/tgstation/tgstation/issues/64401
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Thermite will no longer leave an impassable fire tile if the turf beneath it is deleted/deconstructed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
