### PR TITLE
People with dwarfism fit into backpack (when folded inside bluespace body bag)

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -142,6 +142,11 @@
 		content.forceMove(B)
 		if(isliving(content))
 			to_chat(content, span_userdanger("You're suddenly forced into a tiny, compressed space!"))
+		if(iscarbon(content))
+			var/mob/living/carbon/mob = content
+			if (mob.dna.get_mutation(DWARFISM))
+				max_weight_of_contents = max(WEIGHT_CLASS_NORMAL, max_weight_of_contents)
+				continue
 		if(!isitem(content))
 			max_weight_of_contents = max(WEIGHT_CLASS_BULKY, max_weight_of_contents)
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

People with dwarfism count as normal weight class inside of bluespace bodybag.

## Why it is good for the game

If you take dwarfism mutation, expect to be kidnapped more easily. Also it makes sense that small people fit into backpack.

:cl:
balance: Folded bluespace bodybag with dwarves fit into backpack
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
