### PR TITLE
Fixes active turfs in the DJ space ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_2.dmm
@@ -14,14 +14,14 @@
 	},
 /area/ruin/space/djstation)
 "k" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
 /area/ruin/space/djstation)
 "o" = (
 /obj/structure/table_frame,
 /obj/machinery/light/broken/directional/east,
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "panelscorched"
 	},
 /area/ruin/space/djstation)
@@ -69,7 +69,7 @@
 /turf/template_noop,
 /area/template_noop)
 "S" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
 /area/ruin/space/djstation)
@@ -78,7 +78,7 @@
 /turf/template_noop,
 /area/space/nearstation)
 "W" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
 /area/ruin/space/djstation)

--- a/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_3.dmm
@@ -27,7 +27,7 @@
 /obj/structure/disposaloutlet{
 	dir = 1
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
 /area/ruin/space/djstation)

--- a/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_4.dmm
@@ -76,7 +76,7 @@
 /obj/structure/disposaloutlet{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/djstation)
 "J" = (
 /obj/machinery/griddle,

--- a/_maps/RandomRuins/SpaceRuins/DJstation/solars_1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/solars_1.dmm
@@ -23,12 +23,12 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
 /area/ruin/space/djstation/solars)
 "n" = (
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
 /area/ruin/space/djstation/solars)
@@ -64,7 +64,7 @@
 	pixel_x = -8;
 	pixel_y = -3
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
 /area/ruin/space/djstation/solars)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes some incorrect turfs from the DJ space ruin.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less active turfs are always nice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: DJ Space ruin no longer uses incorrect turfs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
