### PR TITLE
Logs tool usage

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -122,6 +122,10 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
 /proc/log_silicon(text)
 	if (CONFIG_GET(flag/log_silicon))
 		WRITE_LOG(GLOB.world_silicon_log, "SILICON: [text]")
+	
+/proc/log_tool(text, mob/initiator)
+	if(CONFIG_GET(flag/log_tools))
+		WRITE_LOG(GLOB.world_tool_log, "TOOL: [text]")
 
 /**
  * Writes to a special log file if the log_suspicious_login config flag is set,

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -4,6 +4,8 @@ GLOBAL_VAR(world_game_log)
 GLOBAL_PROTECT(world_game_log)
 GLOBAL_VAR(world_silicon_log)
 GLOBAL_PROTECT(world_silicon_log)
+GLOBAL_VAR(world_tool_log)
+GLOBAL_PROTECT(world_tool_log)
 /// Log associated with [/proc/log_suspicious_login()] - Intended to hold all logins that failed due to suspicious circumstances such as ban detection, CID randomisation etc.
 GLOBAL_VAR(world_suspicious_login_log)
 GLOBAL_PROTECT(world_suspicious_login_log)

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -2,7 +2,7 @@
 /datum/config_entry/flag/autoadmin
 	protection = CONFIG_ENTRY_LOCKED
 
-// the rank given to autoadmins
+/// the rank given to autoadmins
 /datum/config_entry/string/autoadmin_rank
 	default = "Game Master"
 	protection = CONFIG_ENTRY_LOCKED

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -70,6 +70,8 @@
 /datum/config_entry/flag/log_law/DeprecationUpdate(value)
 	return value
 
+/datum/config_entry/flag/log_tools // log using tools on machines
+
 /datum/config_entry/flag/log_game // log game events
 
 /datum/config_entry/flag/log_mecha // log mech data

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -1,7 +1,9 @@
-/datum/config_entry/flag/autoadmin  // if autoadmin is enabled
+/// if autoadmin is enabled
+/datum/config_entry/flag/autoadmin
 	protection = CONFIG_ENTRY_LOCKED
 
-/datum/config_entry/string/autoadmin_rank // the rank for autoadmins
+// the rank given to autoadmins
+/datum/config_entry/string/autoadmin_rank
 	default = "Game Master"
 	protection = CONFIG_ENTRY_LOCKED
 
@@ -25,44 +27,57 @@
 	protection = CONFIG_ENTRY_LOCKED
 
 
-/datum/config_entry/string/servername // server name (the name of the game window)
+/// server name (the name of the game window)
+/datum/config_entry/string/servername
 
-/datum/config_entry/string/serversqlname // short form server name used for the DB
+/// short form server name used for the DB
+/datum/config_entry/string/serversqlname
 
-/datum/config_entry/string/stationname // station name (the name of the station in-game)
+/// station name (the name of the station in-game)
+/datum/config_entry/string/stationname
 
-/datum/config_entry/number/lobby_countdown // In between round countdown.
+/// Countdown between lobby and the round starting.
+/datum/config_entry/number/lobby_countdown
 	default = 120
 	integer = FALSE
 	min_val = 0
 
-/datum/config_entry/number/round_end_countdown // Post round murder death kill countdown
+/// Post round murder death kill countdown.
+/datum/config_entry/number/round_end_countdown
 	default = 25
 	integer = FALSE
 	min_val = 0
 
-/datum/config_entry/flag/hub // if the game appears on the hub or not
+/// if the game appears on the hub or not
+/datum/config_entry/flag/hub
 
-/datum/config_entry/number/max_hub_pop //At what pop to take hub off the server
+/// Pop requirement for the server to be removed from the hub
+/datum/config_entry/number/max_hub_pop
 	default = 0 //0 means disabled
 	integer = TRUE
 	min_val = 0
 
-/datum/config_entry/flag/log_ooc // log OOC channel
+/// log messages sent in OOC
+/datum/config_entry/flag/log_ooc
 
-/datum/config_entry/flag/log_access // log login/logout
+/// log login/logout
+/datum/config_entry/flag/log_access
 
 /// Config entry which special logging of failed logins under suspicious circumstances.
 /datum/config_entry/flag/log_suspicious_login
 
-/datum/config_entry/flag/log_say // log client say
+/// log client say
+/datum/config_entry/flag/log_say
 
-/datum/config_entry/flag/log_admin // log admin actions
+/// log admin actions
+/datum/config_entry/flag/log_admin
 	protection = CONFIG_ENTRY_LOCKED
 
-/datum/config_entry/flag/log_prayer // log prayers
+/// log prayers
+/datum/config_entry/flag/log_prayer
 
-/datum/config_entry/flag/log_silicon // log silicons
+/// log silicons
+/datum/config_entry/flag/log_silicon
 
 /datum/config_entry/flag/log_law
 	deprecated_by = /datum/config_entry/flag/log_silicon
@@ -70,70 +85,99 @@
 /datum/config_entry/flag/log_law/DeprecationUpdate(value)
 	return value
 
-/datum/config_entry/flag/log_tools // log using tools on machines
+/// log usage of tools
+/datum/config_entry/flag/log_tools
 
-/datum/config_entry/flag/log_game // log game events
+/// log game events
+/datum/config_entry/flag/log_game
 
-/datum/config_entry/flag/log_mecha // log mech data
+/// log mech data
+/datum/config_entry/flag/log_mecha
 
-/datum/config_entry/flag/log_virus // log virology data
+/// log virology data
+/datum/config_entry/flag/log_virus
 
-/datum/config_entry/flag/log_cloning // log cloning actions.
+/// log cloning actions.
+/datum/config_entry/flag/log_cloning
 
-/datum/config_entry/flag/log_asset //asset logging
+/// log assets
+/datum/config_entry/flag/log_asset
 
-/datum/config_entry/flag/log_vote // log voting
+/// log voting
+/datum/config_entry/flag/log_vote
 
-/datum/config_entry/flag/log_whisper // log client whisper
+/// log client whisper
+/datum/config_entry/flag/log_whisper
 
-/datum/config_entry/flag/log_attack // log attack messages
+/// log attack messages
+/datum/config_entry/flag/log_attack
 
-/datum/config_entry/flag/log_emote // log emotes
+/// log emotes
+/datum/config_entry/flag/log_emote
 
-/datum/config_entry/flag/log_econ // log economy actions
+/// log economy actions
+/datum/config_entry/flag/log_econ
 
-/datum/config_entry/flag/log_adminchat // log admin chat messages
+/// log admin chat messages
+/datum/config_entry/flag/log_adminchat
 	protection = CONFIG_ENTRY_LOCKED
 
-/datum/config_entry/flag/log_pda // log pda messages
+/// log pda messages
+/datum/config_entry/flag/log_pda
 
-/datum/config_entry/flag/log_uplink // log uplink/spellbook/codex ciatrix purchases and refunds
+/// log uplink/spellbook/codex ciatrix purchases and refunds
+/datum/config_entry/flag/log_uplink
 
-/datum/config_entry/flag/log_telecomms // log telecomms messages
+/// log telecomms messages
+/datum/config_entry/flag/log_telecomms
 
-/datum/config_entry/flag/log_twitter // log certain expliotable parrots and other such fun things in a JSON file of twitter valid phrases.
+/// log certain expliotable parrots and other such fun things in a JSON file of twitter valid phrases.
+/datum/config_entry/flag/log_twitter
 
-/datum/config_entry/flag/log_world_topic // log all world.Topic() calls
+/// log all world.Topic() calls
+/datum/config_entry/flag/log_world_topic
 
-/datum/config_entry/flag/log_manifest // log crew manifest to separate file
+/// log crew manifest to separate file
+/datum/config_entry/flag/log_manifest
 
-/datum/config_entry/flag/log_job_debug // log roundstart divide occupations debug information to a file
+/// log roundstart divide occupations debug information to a file
+/datum/config_entry/flag/log_job_debug
 
-/datum/config_entry/flag/log_shuttle // log shuttle related actions, ie shuttle computers, shuttle manipulator, emergency console
+/// log shuttle related actions, ie shuttle computers, shuttle manipulator, emergency console
+/datum/config_entry/flag/log_shuttle
 
-/datum/config_entry/flag/log_timers_on_bucket_reset // logs all timers in buckets on automatic bucket reset (Useful for timer debugging)
+/// logs all timers in buckets on automatic bucket reset (Useful for timer debugging)
+/datum/config_entry/flag/log_timers_on_bucket_reset
 
-/datum/config_entry/flag/allow_admin_ooccolor // Allows admins with relevant permissions to have their own ooc colour
+/// allows admins with relevant permissions to have their own ooc colour
+/datum/config_entry/flag/allow_admin_ooccolor
 
-/datum/config_entry/flag/allow_admin_asaycolor //Allows admins with relevant permissions to have a personalized asay color
+/// allows admins with relevant permissions to have a personalized asay color
+/datum/config_entry/flag/allow_admin_asaycolor
 
-/datum/config_entry/flag/allow_vote_restart // allow votes to restart
+/// allow votes to restart
+/datum/config_entry/flag/allow_vote_restart
 
-/datum/config_entry/flag/allow_vote_map // allow votes to change map
+/// allow votes to change map
+/datum/config_entry/flag/allow_vote_map
 
-/datum/config_entry/number/vote_delay // minimum time between voting sessions (deciseconds, 10 minute default)
+/// minimum time between voting sessions (deciseconds, 10 minute default)
+/datum/config_entry/number/vote_delay
 	default = 6000
 	integer = FALSE
 	min_val = 0
 
-/datum/config_entry/number/vote_period  // length of voting period (deciseconds, default 1 minute)
+/// length of voting period (deciseconds, default 1 minute)
+/datum/config_entry/number/vote_period
 	default = 600
 	integer = FALSE
 	min_val = 0
 
-/datum/config_entry/flag/default_no_vote // vote does not default to nochange/norestart
+/// vote does not default to nochange/norestart.
+/datum/config_entry/flag/default_no_vote
 
-/datum/config_entry/flag/no_dead_vote // dead people can't vote
+/// Prevents dead people from voting.
+/datum/config_entry/flag/no_dead_vote
 
 /// Gives the ability to send players a maptext popup.
 /datum/config_entry/flag/popup_admin_pm
@@ -142,7 +186,7 @@
 	default = 20
 	integer = FALSE
 	min_val = 1
-	max_val = 100   //byond will start crapping out at 50, so this is just ridic
+	max_val = 100 //byond will start crapping out at 50, so this is just ridic
 	var/sync_validate = FALSE
 
 /datum/config_entry/number/fps/ValidateAndSet(str_val)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1414,6 +1414,7 @@
 			if(TOOL_ANALYZER)
 				act_result = analyzer_act_secondary(user, tool)
 	if(act_result) // A tooltype_act has completed successfully
+		log_tool("[key_name(user)] used [tool] on [src][is_right_clicking ? "(right click)" : ""]")
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1414,7 +1414,7 @@
 			if(TOOL_ANALYZER)
 				act_result = analyzer_act_secondary(user, tool)
 	if(act_result) // A tooltype_act has completed successfully
-		log_tool("[key_name(user)] used [tool] on [src][is_right_clicking ? "(right click)" : ""]")
+		log_tool("[key_name(user)] used [tool] on [src][is_right_clicking ? "(right click)" : ""] at [AREACOORD(src)]")
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -127,7 +127,7 @@ GLOBAL_VAR(restart_counter)
 
 	GLOB.world_game_log = "[GLOB.log_directory]/game.log"
 	GLOB.world_silicon_log = "[GLOB.log_directory]/silicon.log"
-	GLOB.world_silicon_log = "[GLOB.log_directory]/tools.log"
+	GLOB.world_tool_log = "[GLOB.log_directory]/tools.log"
 	GLOB.world_suspicious_login_log = "[GLOB.log_directory]/suspicious_logins.log"
 	GLOB.world_mecha_log = "[GLOB.log_directory]/mecha.log"
 	GLOB.world_virus_log = "[GLOB.log_directory]/virus.log"

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -127,6 +127,7 @@ GLOBAL_VAR(restart_counter)
 
 	GLOB.world_game_log = "[GLOB.log_directory]/game.log"
 	GLOB.world_silicon_log = "[GLOB.log_directory]/silicon.log"
+	GLOB.world_silicon_log = "[GLOB.log_directory]/tools.log"
 	GLOB.world_suspicious_login_log = "[GLOB.log_directory]/suspicious_logins.log"
 	GLOB.world_mecha_log = "[GLOB.log_directory]/mecha.log"
 	GLOB.world_virus_log = "[GLOB.log_directory]/virus.log"

--- a/config/config.txt
+++ b/config/config.txt
@@ -160,6 +160,9 @@ LOG_CLONING
 ## log shuttle actions
 LOG_SHUTTLE
 
+## log tool interactions [/atom/proc/tool_act]
+LOG_TOOLS
+
 ## Log all timers on timer auto reset
 # LOG_TIMERS_ON_BUCKET_RESET
 


### PR DESCRIPTION
## About The Pull Request

Thanks to https://github.com/tgstation/tgstation/pull/64375 and https://github.com/tgstation/tgstation/pull/64428 - Tool logging seems like it can be added as a reliable thing.

## Why It's Good For The Game

I find it potentially useful for staff, there's certain scenarios you would want to figure out who did what to a certain machine
Examples are:
- Welding doors shut
- Who deconstructed an ORM
- Who wrenched vendors to block doors
- Who deconstructed all the techfabs
- Ect

I would mention welding walls but that's logged in game (which could probably be removed now)

![image](https://user-images.githubusercontent.com/53777086/151093783-384d0d6d-f859-431d-b254-585cd193de6f.png)

## Changelog

:cl:
admin: Tool usage is now (config-locked) logged!
/:cl: