### PR TITLE
fix for airlocks being unhackable

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -793,7 +793,52 @@
 			return
 	add_fingerprint(user)
 
-	if(panel_open)
+	if(is_wire_tool(C) && panel_open)
+		attempt_wire_interaction(user)
+		return
+	else if(istype(C, /obj/item/pai_cable))
+		var/obj/item/pai_cable/cable = C
+		cable.plugin(src, user)
+	else if(istype(C, /obj/item/airlock_painter))
+		change_paintjob(C, user)
+	else if(istype(C, /obj/item/door_seal)) //adding the seal
+		var/obj/item/door_seal/airlockseal = C
+		if(!density)
+			to_chat(user, span_warning("[src] must be closed before you can seal it!"))
+			return
+		if(seal)
+			to_chat(user, span_warning("[src] has already been sealed!"))
+			return
+		user.visible_message(span_notice("[user] begins sealing [src]."), span_notice("You begin sealing [src]."))
+		playsound(src, 'sound/items/jaws_pry.ogg', 30, TRUE)
+		if(!do_after(user, airlockseal.seal_time, target = src))
+			return
+		if(!density)
+			to_chat(user, span_warning("[src] must be closed before you can seal it!"))
+			return
+		if(seal)
+			to_chat(user, span_warning("[src] has already been sealed!"))
+			return
+		if(!user.transferItemToLoc(airlockseal, src))
+			to_chat(user, span_warning("For some reason, you can't attach [airlockseal]!"))
+			return
+		playsound(src, 'sound/machines/airlockforced.ogg', 30, TRUE)
+		user.visible_message(span_notice("[user] finishes sealing [src]."), span_notice("You finish sealing [src]."))
+		seal = airlockseal
+		modify_max_integrity(max_integrity * AIRLOCK_SEAL_MULTIPLIER)
+		update_appearance()
+
+	else if(istype(C, /obj/item/paper) || istype(C, /obj/item/photo))
+		if(note)
+			to_chat(user, span_warning("There's already something pinned to this airlock! Use wirecutters to remove it."))
+			return
+		if(!user.transferItemToLoc(C, src))
+			to_chat(user, span_warning("For some reason, you can't attach [C]!"))
+			return
+		user.visible_message(span_notice("[user] pins [C] to [src]."), span_notice("You pin [C] to [src]."))
+		note = C
+		update_appearance()
+	else if(panel_open)
 		switch(security_level)
 			if(AIRLOCK_SECURITY_NONE)
 				if(istype(C, /obj/item/stack/sheet/iron))
@@ -909,51 +954,6 @@
 											span_notice("You cut through \the [src]'s outer grille."))
 						security_level = AIRLOCK_SECURITY_PLASTEEL_O
 					return
-	else if(is_wire_tool(C) && panel_open)
-		attempt_wire_interaction(user)
-		return
-	else if(istype(C, /obj/item/pai_cable))
-		var/obj/item/pai_cable/cable = C
-		cable.plugin(src, user)
-	else if(istype(C, /obj/item/airlock_painter))
-		change_paintjob(C, user)
-	else if(istype(C, /obj/item/door_seal)) //adding the seal
-		var/obj/item/door_seal/airlockseal = C
-		if(!density)
-			to_chat(user, span_warning("[src] must be closed before you can seal it!"))
-			return
-		if(seal)
-			to_chat(user, span_warning("[src] has already been sealed!"))
-			return
-		user.visible_message(span_notice("[user] begins sealing [src]."), span_notice("You begin sealing [src]."))
-		playsound(src, 'sound/items/jaws_pry.ogg', 30, TRUE)
-		if(!do_after(user, airlockseal.seal_time, target = src))
-			return
-		if(!density)
-			to_chat(user, span_warning("[src] must be closed before you can seal it!"))
-			return
-		if(seal)
-			to_chat(user, span_warning("[src] has already been sealed!"))
-			return
-		if(!user.transferItemToLoc(airlockseal, src))
-			to_chat(user, span_warning("For some reason, you can't attach [airlockseal]!"))
-			return
-		playsound(src, 'sound/machines/airlockforced.ogg', 30, TRUE)
-		user.visible_message(span_notice("[user] finishes sealing [src]."), span_notice("You finish sealing [src]."))
-		seal = airlockseal
-		modify_max_integrity(max_integrity * AIRLOCK_SEAL_MULTIPLIER)
-		update_appearance()
-
-	else if(istype(C, /obj/item/paper) || istype(C, /obj/item/photo))
-		if(note)
-			to_chat(user, span_warning("There's already something pinned to this airlock! Use wirecutters to remove it."))
-			return
-		if(!user.transferItemToLoc(C, src))
-			to_chat(user, span_warning("For some reason, you can't attach [C]!"))
-			return
-		user.visible_message(span_notice("[user] pins [C] to [src]."), span_notice("You pin [C] to [src]."))
-		note = C
-		update_appearance()
 	else
 		return ..()
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -793,52 +793,7 @@
 			return
 	add_fingerprint(user)
 
-	if(is_wire_tool(C) && panel_open)
-		attempt_wire_interaction(user)
-		return
-	else if(istype(C, /obj/item/pai_cable))
-		var/obj/item/pai_cable/cable = C
-		cable.plugin(src, user)
-	else if(istype(C, /obj/item/airlock_painter))
-		change_paintjob(C, user)
-	else if(istype(C, /obj/item/door_seal)) //adding the seal
-		var/obj/item/door_seal/airlockseal = C
-		if(!density)
-			to_chat(user, span_warning("[src] must be closed before you can seal it!"))
-			return
-		if(seal)
-			to_chat(user, span_warning("[src] has already been sealed!"))
-			return
-		user.visible_message(span_notice("[user] begins sealing [src]."), span_notice("You begin sealing [src]."))
-		playsound(src, 'sound/items/jaws_pry.ogg', 30, TRUE)
-		if(!do_after(user, airlockseal.seal_time, target = src))
-			return
-		if(!density)
-			to_chat(user, span_warning("[src] must be closed before you can seal it!"))
-			return
-		if(seal)
-			to_chat(user, span_warning("[src] has already been sealed!"))
-			return
-		if(!user.transferItemToLoc(airlockseal, src))
-			to_chat(user, span_warning("For some reason, you can't attach [airlockseal]!"))
-			return
-		playsound(src, 'sound/machines/airlockforced.ogg', 30, TRUE)
-		user.visible_message(span_notice("[user] finishes sealing [src]."), span_notice("You finish sealing [src]."))
-		seal = airlockseal
-		modify_max_integrity(max_integrity * AIRLOCK_SEAL_MULTIPLIER)
-		update_appearance()
-
-	else if(istype(C, /obj/item/paper) || istype(C, /obj/item/photo))
-		if(note)
-			to_chat(user, span_warning("There's already something pinned to this airlock! Use wirecutters to remove it."))
-			return
-		if(!user.transferItemToLoc(C, src))
-			to_chat(user, span_warning("For some reason, you can't attach [C]!"))
-			return
-		user.visible_message(span_notice("[user] pins [C] to [src]."), span_notice("You pin [C] to [src]."))
-		note = C
-		update_appearance()
-	else if(panel_open)
+	if(panel_open || !is_wire_tool(C))
 		switch(security_level)
 			if(AIRLOCK_SECURITY_NONE)
 				if(istype(C, /obj/item/stack/sheet/iron))
@@ -954,6 +909,52 @@
 											span_notice("You cut through \the [src]'s outer grille."))
 						security_level = AIRLOCK_SECURITY_PLASTEEL_O
 					return
+
+	if(is_wire_tool(C) && panel_open)
+		attempt_wire_interaction(user)
+		return
+	else if(istype(C, /obj/item/pai_cable))
+		var/obj/item/pai_cable/cable = C
+		cable.plugin(src, user)
+	else if(istype(C, /obj/item/airlock_painter))
+		change_paintjob(C, user)
+	else if(istype(C, /obj/item/door_seal)) //adding the seal
+		var/obj/item/door_seal/airlockseal = C
+		if(!density)
+			to_chat(user, span_warning("[src] must be closed before you can seal it!"))
+			return
+		if(seal)
+			to_chat(user, span_warning("[src] has already been sealed!"))
+			return
+		user.visible_message(span_notice("[user] begins sealing [src]."), span_notice("You begin sealing [src]."))
+		playsound(src, 'sound/items/jaws_pry.ogg', 30, TRUE)
+		if(!do_after(user, airlockseal.seal_time, target = src))
+			return
+		if(!density)
+			to_chat(user, span_warning("[src] must be closed before you can seal it!"))
+			return
+		if(seal)
+			to_chat(user, span_warning("[src] has already been sealed!"))
+			return
+		if(!user.transferItemToLoc(airlockseal, src))
+			to_chat(user, span_warning("For some reason, you can't attach [airlockseal]!"))
+			return
+		playsound(src, 'sound/machines/airlockforced.ogg', 30, TRUE)
+		user.visible_message(span_notice("[user] finishes sealing [src]."), span_notice("You finish sealing [src]."))
+		seal = airlockseal
+		modify_max_integrity(max_integrity * AIRLOCK_SEAL_MULTIPLIER)
+		update_appearance()
+
+	else if(istype(C, /obj/item/paper) || istype(C, /obj/item/photo))
+		if(note)
+			to_chat(user, span_warning("There's already something pinned to this airlock! Use wirecutters to remove it."))
+			return
+		if(!user.transferItemToLoc(C, src))
+			to_chat(user, span_warning("For some reason, you can't attach [C]!"))
+			return
+		user.visible_message(span_notice("[user] pins [C] to [src]."), span_notice("You pin [C] to [src]."))
+		note = C
+		update_appearance()
 	else
 		return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

i believe this is a fix to make the unhackable airlock some servers are having (most notably bagil) working again. this is the only thing that may be causing issues as far as i can see. when you call attempt_wire_interaction as an atom proccall, you get the wire ui popping up and everything is working fine. panel_open checks out, as well as all others procs and variables that are checked to ensure you can hack the door. this rearranges the if statement to check if the tools are hacking tools/other usable tools BEFORE checking if you're adding reinforcements or not.

fixes #64432

## Why It's Good For The Game

dae bash windows to get past unhackable doors

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: restructures some code to make airlocks hackable again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
