### PR TITLE
Autosurgeons can now be used on other people

### DIFF
--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -77,7 +77,7 @@
 	if(do_after(user, (8 SECONDS * surgery_speed), target))
 		user.visible_message(span_notice("[user] presses a button on [src], and you hear a short mechanical noise."), span_notice("You press a button on [src] as it plunges into [target]'s body."))
 		to_chat(target, span_notice("You feel a sharp sting as something plunges into your body!"))
-		playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, TRUE)
+		playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, vary = TRUE)
 		storedorgan = null
 		name = initial(name)
 		if(uses != INFINITE)

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -22,10 +22,12 @@
 	var/organ_type = /obj/item/organ
 	var/starting_organ
 	var/obj/item/organ/storedorgan
+	var/surgery_speed = 1
 
 /obj/item/autosurgeon/organ/syndicate
 	name = "suspicious implant autosurgeon"
 	icon_state = "syndicate_autoimplanter"
+	surgery_speed = 0.75
 
 /obj/item/autosurgeon/organ/Initialize(mapload)
 	. = ..()
@@ -68,6 +70,20 @@
 		to_chat(user, span_notice("You insert the [weapon] into [src]."))
 	else
 		return ..()
+
+/obj/item/autosurgeon/organ/attack(mob/living/target, mob/living/user, params)
+	add_fingerprint(user)
+	to_chat(user, span_notice("You begin to prepare to use [src] on [target]."))
+	if(do_after(user, (8 SECONDS * surgery_speed), target))
+		user.visible_message(span_notice("[user] presses a button on [src], and you hear a short mechanical noise."), span_notice("You press a button on [src] as it plunges into [target]'s body."))
+		to_chat(target, span_notice("You feel a sharp sting as something plunges into your body!"))
+		playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, TRUE)
+		storedorgan = null
+		name = initial(name)
+		if(uses != INFINITE)
+			uses--
+		if(!uses)
+			desc = "[initial(desc)] Looks like it's been used up."
 
 /obj/item/autosurgeon/organ/screwdriver_act(mob/living/user, obj/item/screwtool)
 	if(..())

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -39,6 +39,14 @@
 	item.forceMove(src)
 	name = "[initial(name)] ([storedorgan.name])"
 
+/obj/item/autosurgeon/organ/proc/use_autosurgeon()
+	storedorgan = null
+	name = initial(name)
+	if(uses != INFINITE)
+		uses--
+	if(!uses)
+		desc = "[initial(desc)] Looks like it's been used up."
+
 /obj/item/autosurgeon/organ/attack_self(mob/user)//when the object it used...
 	if(!uses)
 		to_chat(user, span_alert("[src] has already been used. The tools are dull and won't reactivate."))
@@ -49,12 +57,7 @@
 	storedorgan.Insert(user)//insert stored organ into the user
 	user.visible_message(span_notice("[user] presses a button on [src], and you hear a short mechanical noise."), span_notice("You feel a sharp sting as [src] plunges into your body."))
 	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, TRUE)
-	storedorgan = null
-	name = initial(name)
-	if(uses != INFINITE)
-		uses--
-	if(!uses)
-		desc = "[initial(desc)] Looks like it's been used up."
+	use_autosurgeon()
 
 /obj/item/autosurgeon/organ/attackby(obj/item/weapon, mob/user, params)
 	if(istype(weapon, organ_type))
@@ -73,17 +76,13 @@
 
 /obj/item/autosurgeon/organ/attack(mob/living/target, mob/living/user, params)
 	add_fingerprint(user)
-	to_chat(user, span_notice("You begin to prepare to use [src] on [target]."))
-	if(do_after(user, (8 SECONDS * surgery_speed), target))
-		user.visible_message(span_notice("[user] presses a button on [src], and you hear a short mechanical noise."), span_notice("You press a button on [src] as it plunges into [target]'s body."))
-		to_chat(target, span_notice("You feel a sharp sting as something plunges into your body!"))
-		playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, vary = TRUE)
-		storedorgan = null
-		name = initial(name)
-		if(uses != INFINITE)
-			uses--
-		if(!uses)
-			desc = "[initial(desc)] Looks like it's been used up."
+	user.balloon_alert_to_viewers("Prepares to use [src] on [target].", "You begin to prepare to use [src] on [target].")
+	if(!do_after(user, (8 SECONDS * surgery_speed), target))
+		return
+	user.visible_message(span_notice("[user] presses a button on [src], and you hear a short mechanical noise."), span_notice("You press a button on [src] as it plunges into [target]'s body."))
+	to_chat(target, span_notice("You feel a sharp sting as something plunges into your body!"))
+	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, vary = TRUE)
+	use_autosurgeon()
 
 /obj/item/autosurgeon/organ/screwdriver_act(mob/living/user, obj/item/screwtool)
 	if(..())
@@ -97,11 +96,7 @@
 
 		to_chat(user, span_notice("You remove the [storedorgan] from [src]."))
 		screwtool.play_tool_sound(src)
-		storedorgan = null
-		if(uses != INFINITE)
-			uses--
-		if(!uses)
-			desc = "[initial(desc)] Looks like it's been used up."
+		use_autosurgeon()
 	return TRUE
 
 /obj/item/autosurgeon/organ/cmo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Autosurgeons can now be used on people other than yourself, after an 8 second actionbar (multiplied by 3/4ths for syndicate ones).

## Why It's Good For The Game
Felt like it might be interesting for the game, seemed a bit odd that it couldn't be done.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can now use autosurgeons on other people after a delay.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
