### PR TITLE
Rotation component refactor and improvements

### DIFF
--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -110,7 +110,7 @@
 			rot_degree = 90
 		if(ROTATION_FLIP)
 			rot_degree = 180
-	rotated_obj.setDir(turn(AM.dir, rot_degree))
+	rotated_obj.setDir(turn(rotated_obj.dir, rot_degree))
 	after_rotation.Invoke(user, rotation_type)
 
 /datum/component/simple_rotation/proc/default_can_user_rotate(mob/living/user, rotation_type)

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -139,8 +139,7 @@
 
 /datum/component/simple_rotation/proc/default_after_rotation(mob/user, rotation_type)
 	var/obj/rotated_obj = parent
-	to_chat(user, span_notice("You [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [rotated_obj]."))
-	rotated_obj.add_fingerprint(user)
+	rotated_obj.balloon_alert(user, "you [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [rotated_obj]")
 
 /atom/movable/proc/simple_rotate_clockwise()
 	set name = "Rotate Clockwise"

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -1,10 +1,18 @@
+/// If an object can be rotated by alt clicking
 #define ROTATION_ALTCLICK (1<<0)
+/// If an object can be rotated with a wrench
 #define ROTATION_WRENCH (1<<1)
+/// If an object will have rotation options presented as verbs to a mob
 #define ROTATION_VERBS (1<<2)
+/// If an object can be rotated counterclockwise
 #define ROTATION_COUNTERCLOCKWISE (1<<3)
+/// If an object can be rotated clockwise
 #define ROTATION_CLOCKWISE (1<<4)
+/// If an object can be rotated 180 degrees
 #define ROTATION_FLIP (1<<5)
+/// If ghosts can rotate an object (if the ghost config is enabled)
 #define ROTATION_GHOSTS_ALLOWED (1<6)
+/// If an object can be rotated if it's anchored (used for chairs)
 #define ROTATION_ANCHORED_ALLOWED (1<7)
 
 /datum/component/simple_rotation

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -1,7 +1,7 @@
 /// If an object can be rotated by alt clicking
 #define ROTATION_ALTCLICK (1<<0)
 /// If an object can be rotated with a wrench
-#define ROTATION_WRENCH (1<<1)
+#define ROTATION_REQUIRE_WRENCH (1<<1)
 /// If an object will have rotation options presented as verbs to a mob
 #define ROTATION_VERBS (1<<2)
 /// If an object can be rotated counterclockwise
@@ -111,7 +111,7 @@
 	SIGNAL_HANDLER
 
 	examine_list += span_notice("Alt-click + LMB to rotate it clockwise. Alt-click + RMB to rotate it counterclockwise.")
-	if(rotation_flags & ROTATION_WRENCH)
+	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
 		examine_list += span_notice("This requires a wrench to be rotated.")
 
 /datum/component/simple_rotation/proc/RotateLeft(datum/source, mob/user, rotation = default_rotation_direction)
@@ -155,18 +155,19 @@
 	return FALSE
 
 /datum/component/simple_rotation/proc/default_can_be_rotated(mob/living/user, rotation_type)
-	if(src.rotation_flags & ROTATION_WRENCH)
+	var/atom/movable/AM = parent
+
+	if(src.rotation_flags & ROTATION_REQUIRE_WRENCH)
 		if(!istype(user))
 			return FALSE
 		var/obj/item/tool = user.get_active_held_item()
 		if(!tool || tool.tool_behaviour != TOOL_WRENCH)
-			balloon_alert(user, "You need a wrench to rotate [parent]!")
+			AM.balloon_alert(user, "You need a wrench to rotate [AM]!")
 			return FALSE
 			//return COMPONENT_BLOCK_TOOL_ATTACK do we need this?  I don't think we do...
 	if(src.rotation_flags & ROTATION_ANCHORED_ALLOWED) // used to ignore chairs being anchored
 		return TRUE
 
-	var/atom/movable/AM = parent
 	//to_chat(user, span_warning("It is fastened to the floor!"))
 	return !AM.anchored
 

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -23,7 +23,7 @@
 	var/rotation_flags = NONE
 	var/default_rotation_direction = ROTATION_CLOCKWISE
 
-/datum/component/simple_rotation/Initialize(rotation_flags = NONE ,can_user_rotate,can_be_rotated,after_rotation)
+/datum/component/simple_rotation/Initialize(rotation_flags = NONE, can_user_rotate, can_be_rotated, after_rotation)
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -172,6 +172,7 @@
 
 /datum/component/simple_rotation/proc/default_after_rotation(mob/user, rotation_type)
 	to_chat(user,span_notice("You [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [parent]."))
+	add_fingerprint(user)
 
 /atom/movable/proc/simple_rotate_clockwise()
 	set name = "Rotate Clockwise"

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -1,6 +1,4 @@
-/// If an object can be rotated by alt clicking
-#define ROTATION_ALTCLICK (1<<0)
-/// If an object can be rotated with a wrench
+/// If an object needs to be rotated with a wrench
 #define ROTATION_REQUIRE_WRENCH (1<<1)
 /// If an object will have rotation options presented as verbs to a mob
 #define ROTATION_VERBS (1<<2)
@@ -55,10 +53,9 @@
 		default_rotation_direction = ROTATION_CLOCKWISE
 
 /datum/component/simple_rotation/proc/add_signals()
-	if(rotation_flags & ROTATION_ALTCLICK)
-		RegisterSignal(parent, COMSIG_CLICK_ALT, .proc/RotateLeft)
-		RegisterSignal(parent, COMSIG_CLICK_ALT_SECONDARY, .proc/RotateRight)
-		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/ExamineMessage)
+	RegisterSignal(parent, COMSIG_CLICK_ALT, .proc/RotateLeft)
+	RegisterSignal(parent, COMSIG_CLICK_ALT_SECONDARY, .proc/RotateRight)
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/ExamineMessage)
 
 /datum/component/simple_rotation/proc/add_verbs()
 	if(rotation_flags & ROTATION_VERBS)

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -61,6 +61,8 @@
 		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/ExamineMessage)
 	if(rotation_flags & ROTATION_WRENCH)
 		RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_WRENCH), .proc/WrenchRot)
+		RegisterSignal(parent, COMSIG_ATOM_SECONDARY_TOOL_ACT(TOOL_WRENCH), .proc/WrenchRot)
+
 
 /datum/component/simple_rotation/proc/add_verbs()
 	if(rotation_flags & ROTATION_VERBS)
@@ -129,10 +131,11 @@
 		rotation = ROTATION_COUNTERCLOCKWISE
 		Rotate(user, rotation)
 
-/datum/component/simple_rotation/proc/WrenchRot(datum/source, obj/item/I, mob/living/user)
+/datum/component/simple_rotation/proc/WrenchRot(datum/source, obj/item/I, mob/living/user) // mob/living/user, obj/item/I)
 	SIGNAL_HANDLER
 
 	if(!can_be_rotated.Invoke(user,default_rotation_direction) || !can_user_rotate.Invoke(user,default_rotation_direction))
+		//balloon_alert(user, "you need a wrench!")
 		return
 	Rotate(user,default_rotation_direction)
 	return COMPONENT_BLOCK_TOOL_ATTACK
@@ -168,11 +171,13 @@
 		return TRUE
 	else
 		var/atom/movable/AM = parent
+		//to_chat(user, span_warning("It is fastened to the floor!"))
 		return !AM.anchored
 
 /datum/component/simple_rotation/proc/default_after_rotation(mob/user, rotation_type)
-	to_chat(user,span_notice("You [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [parent]."))
-	add_fingerprint(user)
+	var/atom/rotated_atom = parent
+	to_chat(user,span_notice("You [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [rotated_atom]."))
+	rotated_atom.add_fingerprint(user)
 
 /atom/movable/proc/simple_rotate_clockwise()
 	set name = "Rotate Clockwise"

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -5,6 +5,7 @@
 #define ROTATION_CLOCKWISE (1<<4)
 #define ROTATION_FLIP (1<<5)
 #define ROTATION_GHOSTS_ALLOWED (1<6)
+#define ROTATION_ANCHORED_ALLOWED (1<7)
 
 /datum/component/simple_rotation
 	var/datum/callback/can_user_rotate //Checks if user can rotate
@@ -155,8 +156,11 @@
 	return FALSE
 
 /datum/component/simple_rotation/proc/default_can_be_rotated(mob/user, rotation_type)
-	var/atom/movable/AM = parent
-	return !AM.anchored
+	if(src.rotation_flags & ROTATION_ANCHORED_ALLOWED)
+		return TRUE
+	else
+		var/atom/movable/AM = parent
+		return !AM.anchored
 
 /datum/component/simple_rotation/proc/default_after_rotation(mob/user, rotation_type)
 	to_chat(user,span_notice("You [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [parent]."))

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -1,9 +1,9 @@
 /// If an object needs to be rotated with a wrench
 #define ROTATION_REQUIRE_WRENCH (1<<0)
 /// If ghosts can rotate an object (if the ghost config is enabled)
-#define ROTATION_GHOSTS_ALLOWED (1<1)
+#define ROTATION_GHOSTS_ALLOWED (1<<1)
 /// If an object will ignore anchored for rotation (used for chairs)
-#define ROTATION_IGNORE_ANCHORED (1<2)
+#define ROTATION_IGNORE_ANCHORED (1<<2)
 
 /// Rotate an object clockwise
 #define ROTATION_CLOCKWISE 1
@@ -82,7 +82,7 @@
 /datum/component/simple_rotation/proc/ExamineMessage(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	examine_list += span_notice("Alt-click + LMB to rotate it clockwise. Alt-click + RMB to rotate it counterclockwise.")
+	examine_list += span_notice("Alt-click + RMB to rotate it clockwise. Alt-click + LMB to rotate it counterclockwise.")
 	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
 		examine_list += span_notice("This requires a wrench to be rotated.")
 

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -117,7 +117,7 @@
 /datum/component/simple_rotation/proc/CanUserRotate(mob/user, degrees)
 	if(isliving(user) && user.canUseTopic(parent, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
 		return TRUE
-	if((rotation_flags & ROTATION_GHOSTS_ALLOWED) && (isobserver(user) && CONFIG_GET(flag/ghost_interaction)))
+	if((rotation_flags & ROTATION_GHOSTS_ALLOWED) && isobserver(user) && CONFIG_GET(flag/ghost_interaction))
 		return TRUE	
 	return FALSE
 

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -7,7 +7,7 @@
 /// If an object will omit flipping from rotation (used for pipes since they use custom handling)
 #define ROTATION_NO_FLIPPING (1<<3)
 /// If an object needs to have an empty spot available in target direction (used for windoors and railings)
-#define ROTATION_NEEDS_ROOM
+#define ROTATION_NEEDS_ROOM (1<<4)
 
 /// Rotate an object clockwise
 #define ROTATION_CLOCKWISE -90

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -6,6 +6,8 @@
 #define ROTATION_IGNORE_ANCHORED (1<<2)
 /// If an object will omit flipping from rotation (used for pipes since they use custom handling)
 #define ROTATION_NO_FLIPPING (1<<3)
+/// 
+#define ROTATION_
 
 /// Rotate an object clockwise
 #define ROTATION_CLOCKWISE 1

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -126,7 +126,11 @@
 			rotated_obj.balloon_alert(user, "need a wrench")
 			return FALSE
 	if(!(rotation_flags & ROTATION_IGNORE_ANCHORED) && rotated_obj.anchored)
-		rotated_obj.balloon_alert(user, "need to unwrench")
+		var/obj/structure/window/rotated_window = rotated_obj
+		if(istype(rotated_obj, /obj/structure/window)
+			rotated_obj.balloon_alert(user, "need to unscrew")
+		else
+			rotated_obj.balloon_alert(user, "need to unwrench")
 		return FALSE
 
 	if(rotation_flags & ROTATION_NEEDS_ROOM)

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -16,11 +16,11 @@
 
 /datum/component/simple_rotation
 	/// Checks if user can rotate
-	var/datum/callback/can_user_rotate
+	var/datum/callback/CanUserRotate
 	/// Check if object can be rotated at all
-	var/datum/callback/can_be_rotated
+	var/datum/callback/CanBeRotated
 	/// Additional stuff to do after rotation
-	var/datum/callback/after_rotation
+	var/datum/callback/AfterRotation
 	/// Rotation flags for special behavior 
 	var/rotation_flags = NONE
 

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -38,9 +38,9 @@
 		return COMPONENT_INCOMPATIBLE
 
 	src.rotation_flags = rotation_flags
-	src.can_user_rotate = can_user_rotate || CALLBACK(src,.proc/default_can_user_rotate)
-	src.can_be_rotated = can_be_rotated || CALLBACK(src,.proc/default_can_be_rotated)
-	src.after_rotation = after_rotation || CALLBACK(src,.proc/default_after_rotation)
+	src.can_user_rotate = can_user_rotate || CALLBACK(src,. proc/default_can_user_rotate)
+	src.can_be_rotated = can_be_rotated || CALLBACK(src,. proc/default_can_be_rotated)
+	src.after_rotation = after_rotation || CALLBACK(src, .proc/default_after_rotation)
 
 /datum/component/simple_rotation/proc/add_signals()
 	RegisterSignal(parent, COMSIG_CLICK_ALT, .proc/RotateLeft)

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -127,7 +127,7 @@
 			return FALSE
 	if(!(rotation_flags & ROTATION_IGNORE_ANCHORED) && rotated_obj.anchored)
 		var/obj/structure/window/rotated_window = rotated_obj
-		if(istype(rotated_obj, /obj/structure/window)
+		if(istype(rotated_obj, /obj/structure/window))
 			rotated_obj.balloon_alert(user, "need to unscrew")
 		else
 			rotated_obj.balloon_alert(user, "need to unwrench")

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -53,7 +53,7 @@
 		rotated_obj.verbs -= /atom/movable/proc/simple_rotate_counterclockwise
 
 /datum/component/simple_rotation/proc/remove_signals()
-	UnregisterSignal(parent, list(COMSIG_CLICK_ALT, COMSIG_PARENT_EXAMINE, COMSIG_PARENT_ATTACKBY))
+	UnregisterSignal(parent, list(COMSIG_CLICK_ALT, COMSIG_CLICK_ALT_SECONDARY, COMSIG_PARENT_EXAMINE))
 
 /datum/component/simple_rotation/RegisterWithParent()
 	add_verbs()

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -98,8 +98,10 @@
 	Rotate(user, ROTATION_COUNTERCLOCKWISE)
 
 /datum/component/simple_rotation/proc/Rotate(mob/user, degrees)
+	if(QDELETED(user))
+		stack_trace("[src] is being rotated [user ? "with a qdeleting" : "without a"] user")
 	if(!istype(user))
-		stack_trace("[src] is being rotated without a user")
+		stack_trace("[src] is being rotated without a user of the wrong type: [user.type]")
 		
 	if(!CanBeRotated(user, degrees) || !CanUserRotate(user, degrees))
 		return

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -38,8 +38,8 @@
 		return COMPONENT_INCOMPATIBLE
 
 	src.rotation_flags = rotation_flags
-	src.can_user_rotate = can_user_rotate || CALLBACK(src,. proc/default_can_user_rotate)
-	src.can_be_rotated = can_be_rotated || CALLBACK(src,. proc/default_can_be_rotated)
+	src.can_user_rotate = can_user_rotate || CALLBACK(src, .proc/default_can_user_rotate)
+	src.can_be_rotated = can_be_rotated || CALLBACK(src, .proc/default_can_be_rotated)
 	src.after_rotation = after_rotation || CALLBACK(src, .proc/default_after_rotation)
 
 /datum/component/simple_rotation/proc/add_signals()
@@ -125,21 +125,21 @@
 /datum/component/simple_rotation/proc/default_can_user_rotate(mob/living/user, rotation_type)
 	if(istype(user) && user.canUseTopic(parent, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
 		return TRUE
-	if(isobserver(user) && CONFIG_GET(flag/ghost_interaction) && (src.rotation_flags & ROTATION_GHOSTS_ALLOWED))
+	if(isobserver(user) && CONFIG_GET(flag/ghost_interaction) && (rotation_flags & ROTATION_GHOSTS_ALLOWED))
 		return TRUE	
 	return FALSE
 
 /datum/component/simple_rotation/proc/default_can_be_rotated(mob/living/user, rotation_type)
 	var/obj/rotated_obj = parent
 
-	if(src.rotation_flags & ROTATION_REQUIRE_WRENCH)
+	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
 		if(!istype(user))
 			return FALSE
 		var/obj/item/tool = user.get_active_held_item()
 		if(!tool || tool.tool_behaviour != TOOL_WRENCH)
 			rotated_obj.balloon_alert(user, "need a wrench")
 			return FALSE
-	if(src.rotation_flags & ROTATION_IGNORE_ANCHORED) // used to ignore chairs being anchored
+	if(rotation_flags & ROTATION_IGNORE_ANCHORED) // used to ignore chairs being anchored
 		return TRUE
 	if(rotated_obj.anchored)
 		rotated_obj.balloon_alert(user, "need to unwrench")
@@ -149,7 +149,7 @@
 /datum/component/simple_rotation/proc/default_after_rotation(mob/user, rotation_type)
 	var/obj/rotated_obj = parent
 	rotated_obj.balloon_alert(user, "you [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [rotated_obj]")
-	if(src.rotation_flags & ROTATION_REQUIRE_WRENCH)
+	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
 		playsound(rotated_obj, 'sound/items/ratchet.ogg', 50, TRUE)
 
 /atom/movable/proc/simple_rotate_clockwise()

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -24,6 +24,15 @@
 	/// Rotation flags for special behavior 
 	var/rotation_flags = NONE
 
+/**
+ * Adds the ability to rotate an object by Alt-click or using Right-click verbs.
+ * 
+ * args:
+ * * rotation_flags (optional) Bitflags that determine behavior for rotation (defined at the top of this file)
+ * * can_user_rotate (optional) Callback proc that determines if a user can rotate the object (is user human? nearby? etc.)
+ * * can_be_rotated (optional) Callback proc that determines if the object can be rotated (is obj anchored, etc.)
+ * * after_rotation (optional) Callback proc that is used after the object is rotated (sound effects, balloon alerts, etc.)
+**/
 /datum/component/simple_rotation/Initialize(rotation_flags = NONE, can_user_rotate, can_be_rotated, after_rotation)
 	if(!ismovable(parent))
 		return COMPONENT_INCOMPATIBLE

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -131,9 +131,10 @@
 
 	if(rotation_flags & ROTATION_NEEDS_ROOM)
 		var/target_dir = turn(rotated_obj.dir, degrees)
-		var/fulltile = rotated_obj.fulltile ? TRUE : FALSE
+		var/obj/structure/window/rotated_window = rotated_obj
+		var/fulltile = istype(rotated_window) ? rotated_window.fulltile : FALSE
 		if(!valid_window_location(rotated_obj.loc, target_dir, is_fulltile = fulltile))
-			balloon_alert(user, "cannot rotate in that direction")
+			rotated_obj.balloon_alert(user, "cannot rotate in that direction")
 			return FALSE
 	return TRUE
 

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -130,7 +130,6 @@
 			rotated_obj.balloon_alert(user, "need a wrench")
 			return FALSE
 	if(!(rotation_flags & ROTATION_IGNORE_ANCHORED) && rotated_obj.anchored)
-		var/obj/structure/window/rotated_window = rotated_obj
 		if(istype(rotated_obj, /obj/structure/window))
 			rotated_obj.balloon_alert(user, "need to unscrew")
 		else

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -106,6 +106,10 @@
 
 	var/obj/rotated_obj = parent
 	rotated_obj.setDir(turn(rotated_obj.dir, degrees))
+	rotated_obj.balloon_alert(user, "you [degrees == ROTATION_FLIP ? "flip" : "rotate"] [rotated_obj]")
+	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
+		playsound(rotated_obj, 'sound/items/ratchet.ogg', 50, TRUE)
+		
 	AfterRotation.Invoke(user, degrees)
 
 /datum/component/simple_rotation/proc/CanUserRotate(mob/user, degrees)
@@ -143,10 +147,7 @@
 	return TRUE
 
 /datum/component/simple_rotation/proc/DefaultAfterRotation(mob/user, degrees)
-	var/obj/rotated_obj = parent
-	rotated_obj.balloon_alert(user, "you [degrees == ROTATION_FLIP ? "flip" : "rotate"] [rotated_obj]")
-	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
-		playsound(rotated_obj, 'sound/items/ratchet.ogg', 50, TRUE)
+	return 
 
 /atom/movable/proc/SimpleRotateClockwise()
 	set name = "Rotate Clockwise"

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -145,6 +145,8 @@
 /datum/component/simple_rotation/proc/default_after_rotation(mob/user, rotation_type)
 	var/obj/rotated_obj = parent
 	rotated_obj.balloon_alert(user, "you [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [rotated_obj]")
+	if(src.rotation_flags & ROTATION_REQUIRE_WRENCH)
+		playsound(rotated_obj, 'sound/items/ratchet.ogg', 50, TRUE)
 
 /atom/movable/proc/simple_rotate_clockwise()
 	set name = "Rotate Clockwise"

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -93,20 +93,26 @@
 
 /datum/component/simple_rotation/proc/ExamineMessage(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
-
 	examine_list += span_notice("Alt + Right-click to rotate it clockwise. Alt + Left-click to rotate it counterclockwise.")
 	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
 		examine_list += span_notice("This requires a wrench to be rotated.")
 
 /datum/component/simple_rotation/proc/RotateRight(datum/source, mob/user)
 	SIGNAL_HANDLER
+	if(!istype(user))
+		return FALSE
 	Rotate(user, ROTATION_CLOCKWISE)
 
 /datum/component/simple_rotation/proc/RotateLeft(datum/source, mob/user)
 	SIGNAL_HANDLER
+	if(!istype(user))
+		return FALSE
 	Rotate(user, ROTATION_COUNTERCLOCKWISE)
 
 /datum/component/simple_rotation/proc/Rotate(mob/user, rotation_type)
+	if(!istype(user))
+		return FALSE
+		
 	if(!can_be_rotated.Invoke(user, rotation_type) || !can_user_rotate.Invoke(user, rotation_type))
 		return
 
@@ -122,18 +128,18 @@
 	rotated_obj.setDir(turn(rotated_obj.dir, rot_degree))
 	after_rotation.Invoke(user, rotation_type)
 
-/datum/component/simple_rotation/proc/default_can_user_rotate(mob/living/user, rotation_type)
-	if(istype(user) && user.canUseTopic(parent, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
+/datum/component/simple_rotation/proc/default_can_user_rotate(mob/user, rotation_type)
+	if(isliving(user) && user.canUseTopic(parent, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
 		return TRUE
-	if(isobserver(user) && CONFIG_GET(flag/ghost_interaction) && (rotation_flags & ROTATION_GHOSTS_ALLOWED))
+	if((rotation_flags & ROTATION_GHOSTS_ALLOWED) && (isobserver(user) && CONFIG_GET(flag/ghost_interaction)))
 		return TRUE	
 	return FALSE
 
-/datum/component/simple_rotation/proc/default_can_be_rotated(mob/living/user, rotation_type)
+/datum/component/simple_rotation/proc/default_can_be_rotated(mob/user, rotation_type)
 	var/obj/rotated_obj = parent
 
 	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
-		if(!istype(user))
+		if(!isliving(user))
 			return FALSE
 		var/obj/item/tool = user.get_active_held_item()
 		if(!tool || tool.tool_behaviour != TOOL_WRENCH)

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -99,10 +99,12 @@
 
 /datum/component/simple_rotation/proc/Rotate(mob/user, degrees)
 	if(QDELETED(user))
-		stack_trace("[src] is being rotated [user ? "with a qdeleting" : "without a"] user")
+		CRASH("[src] is being rotated [user ? "with a qdeleting" : "without a"] user")
 	if(!istype(user))
-		stack_trace("[src] is being rotated without a user of the wrong type: [user.type]")
-		
+		CRASH("[src] is being rotated without a user of the wrong type: [user.type]")
+	if(!isnum(degrees))
+		CRASH("[src] is being rotated without providing the amount of degrees needed") 
+
 	if(!CanBeRotated(user, degrees) || !CanUserRotate(user, degrees))
 		return
 

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -4,6 +4,8 @@
 #define ROTATION_GHOSTS_ALLOWED (1<<1)
 /// If an object will ignore anchored for rotation (used for chairs)
 #define ROTATION_IGNORE_ANCHORED (1<<2)
+/// If an object will omit flipping from rotation (used for pipes since they use custom handling)
+#define ROTATION_NO_FLIPPING (1<<3)
 
 /// Rotate an object clockwise
 #define ROTATION_CLOCKWISE 1
@@ -38,9 +40,10 @@
 
 /datum/component/simple_rotation/proc/add_verbs()
 	var/obj/rotated_obj = parent
-	rotated_obj.verbs += /atom/movable/proc/simple_rotate_flip
 	rotated_obj.verbs += /atom/movable/proc/simple_rotate_clockwise
 	rotated_obj.verbs += /atom/movable/proc/simple_rotate_counterclockwise
+	if(!(rotation_flags & ROTATION_NO_FLIPPING))
+		rotated_obj.verbs += /atom/movable/proc/simple_rotate_flip
 
 /datum/component/simple_rotation/proc/remove_verbs()
 	if(parent)

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -145,9 +145,7 @@
 		if(!tool || tool.tool_behaviour != TOOL_WRENCH)
 			rotated_obj.balloon_alert(user, "need a wrench")
 			return FALSE
-	if(rotation_flags & ROTATION_IGNORE_ANCHORED) // used to ignore chairs being anchored
-		return TRUE
-	if(rotated_obj.anchored)
+	if(!(rotation_flags & ROTATION_IGNORE_ANCHORED) && rotated_obj.anchored)
 		rotated_obj.balloon_alert(user, "need to unwrench")
 		return FALSE
 	return TRUE

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -6,8 +6,6 @@
 #define ROTATION_IGNORE_ANCHORED (1<<2)
 /// If an object will omit flipping from rotation (used for pipes since they use custom handling)
 #define ROTATION_NO_FLIPPING (1<<3)
-/// 
-#define ROTATION_
 
 /// Rotate an object clockwise
 #define ROTATION_CLOCKWISE 1

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -99,19 +99,15 @@
 
 /datum/component/simple_rotation/proc/RotateRight(datum/source, mob/user)
 	SIGNAL_HANDLER
-	if(!istype(user))
-		return FALSE
 	Rotate(user, ROTATION_CLOCKWISE)
 
 /datum/component/simple_rotation/proc/RotateLeft(datum/source, mob/user)
 	SIGNAL_HANDLER
-	if(!istype(user))
-		return FALSE
 	Rotate(user, ROTATION_COUNTERCLOCKWISE)
 
 /datum/component/simple_rotation/proc/Rotate(mob/user, rotation_type)
 	if(!istype(user))
-		return FALSE
+		stack_trace("[src] is being rotated without a user")
 		
 	if(!CanBeRotated.Invoke(user, rotation_type) || !CanUserRotate.Invoke(user, rotation_type))
 		return

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -87,7 +87,7 @@
 /datum/component/simple_rotation/proc/ExamineMessage(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	examine_list += span_notice("Alt-click + RMB to rotate it clockwise. Alt-click + LMB to rotate it counterclockwise.")
+	examine_list += span_notice("Alt + Right-click to rotate it clockwise. Alt + Left-click to rotate it counterclockwise.")
 	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
 		examine_list += span_notice("This requires a wrench to be rotated.")
 
@@ -101,9 +101,6 @@
 
 /datum/component/simple_rotation/proc/Rotate(mob/user, rotation_type)
 	if(!can_be_rotated.Invoke(user, rotation_type) || !can_user_rotate.Invoke(user, rotation_type))
-		// delete this message_admins logging
-		// reminder!  DO NOT FORGET before PR is merged... 
-		message_admins("[src] would not rotate properly and is being early returned")
 		return
 
 	var/obj/rotated_obj = parent

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -3,6 +3,10 @@
 	icon_state = "0"
 	state = 0
 
+/obj/structure/frame/computer/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/simple_rotation)
+
 /obj/structure/frame/computer/attackby(obj/item/P, mob/living/user, params)
 	add_fingerprint(user)
 	switch(state)
@@ -169,14 +173,3 @@
 		if(state >= 3)
 			new /obj/item/stack/cable_coil(drop_location(), 5)
 	..()
-
-/obj/structure/frame/computer/AltClick(mob/user)
-	..()
-	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
-		return
-
-	if(anchored)
-		to_chat(usr, span_warning("You must unwrench [src] before rotating it!"))
-		return
-
-	setDir(turn(dir, -90))

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -23,9 +23,6 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION, .proc/sense_explosion)
 	RegisterSignal(src, COMSIG_MOVABLE_SET_ANCHORED, .proc/power_change)
 	printer_ready = world.time + PRINTER_TIMEOUT
-
-/obj/machinery/doppler_array/ComponentInitialize()
-	. = ..()
 	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src,.proc/rot_message))
 
 /datum/data/tachyon_record

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -26,7 +26,7 @@
 
 /obj/machinery/doppler_array/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE,null,null,CALLBACK(src,.proc/rot_message))
+	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src,.proc/rot_message))
 
 /datum/data/tachyon_record
 	name = "Log Recording"

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -26,7 +26,7 @@
 
 /obj/machinery/doppler_array/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE,null,null,CALLBACK(src,.proc/rot_message))
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE,null,null,CALLBACK(src,.proc/rot_message))
 
 /datum/data/tachyon_record
 	name = "Log Recording"

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -23,7 +23,9 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_EXPLOSION, .proc/sense_explosion)
 	RegisterSignal(src, COMSIG_MOVABLE_SET_ANCHORED, .proc/power_change)
 	printer_ready = world.time + PRINTER_TIMEOUT
-	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src,.proc/rot_message))
+	// Alt clicking when unwrenched does not rotate. (likely from UI not returning the mouse click)
+	// Also there is no sprite change for rotation dir, this shouldn't even have a rotate component tbh
+	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src, .proc/rot_message))
 
 /datum/data/tachyon_record
 	name = "Log Recording"

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -25,7 +25,7 @@
 	printer_ready = world.time + PRINTER_TIMEOUT
 	// Alt clicking when unwrenched does not rotate. (likely from UI not returning the mouse click)
 	// Also there is no sprite change for rotation dir, this shouldn't even have a rotate component tbh
-	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src, .proc/rot_message))
+	AddComponent(/datum/component/simple_rotation, AfterRotation = CALLBACK(src, .proc/RotationMessage))
 
 /datum/data/tachyon_record
 	name = "Log Recording"
@@ -125,7 +125,7 @@
 		return
 	return ..()
 
-/obj/machinery/doppler_array/proc/rot_message(mob/user)
+/obj/machinery/doppler_array/proc/RotationMessage(mob/user)
 	to_chat(user, span_notice("You adjust [src]'s dish to face to the [dir2text(dir)]."))
 	playsound(src, 'sound/items/screwdriver2.ogg', 50, TRUE)
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -344,13 +344,7 @@
 
 /obj/machinery/iv_drip/plumbing/Initialize(mapload)
 	. = ..()
-
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
 	AddComponent(/datum/component/plumbing/iv_drip, anchored)
-
-///Check if we can be rotated for the rotation component
-/obj/machinery/iv_drip/plumbing/proc/can_be_rotated(mob/user,rotation_type)
-	return !anchored
 
 /obj/machinery/iv_drip/plumbing/wrench_act(mob/living/user, obj/item/I)
 	..()

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -45,7 +45,7 @@ Buildable meters
 
 /obj/item/pipe/ComponentInitialize()
 	//Flipping handled manually due to custom handling for trinary pipes
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE)
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE)
 
 /obj/item/pipe/Initialize(mapload, _pipe_type, _dir, obj/machinery/atmospherics/make_from, device_color, device_init_dir = SOUTH)
 	if(make_from)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -45,7 +45,7 @@ Buildable meters
 
 /obj/item/pipe/ComponentInitialize()
 	//Flipping handled manually due to custom handling for trinary pipes
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE)
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/item/pipe/Initialize(mapload, _pipe_type, _dir, obj/machinery/atmospherics/make_from, device_color, device_init_dir = SOUTH)
 	if(make_from)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -43,10 +43,6 @@ Buildable meters
 /obj/item/pipe/quaternary
 	RPD_type = PIPE_ONEDIR
 
-/obj/item/pipe/ComponentInitialize()
-	//Flipping handled manually due to custom handling for trinary pipes
-	AddComponent(/datum/component/simple_rotation)
-
 /obj/item/pipe/Initialize(mapload, _pipe_type, _dir, obj/machinery/atmospherics/make_from, device_color, device_init_dir = SOUTH)
 	if(make_from)
 		make_from_existing(make_from)
@@ -59,6 +55,9 @@ Buildable meters
 	update()
 	pixel_x += rand(-5, 5)
 	pixel_y += rand(-5, 5)
+	
+	//Flipping handled manually due to custom handling for trinary pipes
+	AddComponent(/datum/component/simple_rotation)
 	return ..()
 
 /obj/item/pipe/proc/make_from_existing(obj/machinery/atmospherics/make_from)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -301,23 +301,28 @@ Buildable meters
 /obj/item/pipe/examine(mob/user)
 	. = ..()
 	. += span_notice("The pipe layer is set to [piping_layer].")
-	. += span_notice("You can change the pipe layer by Alt-Right-Clicking the device.")
-	. += span_notice("You can rotate it by using it in hand or by Alt-Left-Clicking the device.")
+	. += span_notice("You can change the pipe layer by Right-Clicking the device.")
 
-/obj/item/pipe/alt_click_secondary(mob/user)
+/obj/item/pipe/attack_hand_secondary(mob/user, params)
 	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
 	var/layer_to_set = (piping_layer >= PIPING_LAYER_MAX) ? PIPING_LAYER_MIN : (piping_layer + 1)
 	set_piping_layer(layer_to_set)
-	visible_message("You set the pipe layer to [piping_layer].")
+	balloon_alert(user, "pipe layer set to [piping_layer]")
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/pipe/trinary/flippable/examine(mob/user)
 	. = ..()
-	. += span_notice("You can flip the device by Ctrl-Clicking it.")
+	. += span_notice("You can flip the device by Right-Clicking it.")
 
-/obj/item/pipe/trinary/flippable/CtrlClick(mob/user)
+/obj/item/pipe/trinary/flippable/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
 	do_a_flip()
-	visible_message("You flip the device.")
+	balloon_alert(user, "pipe was flipped")
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/pipe_meter
 	name = "meter"

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -303,7 +303,7 @@ Buildable meters
 	. += span_notice("The pipe layer is set to [piping_layer].")
 	. += span_notice("You can change the pipe layer by Right-Clicking the device.")
 
-/obj/item/pipe/attack_hand_secondary(mob/user, params)
+/obj/item/pipe/attack_hand_secondary(mob/user, list/modifiers)
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 		return

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -57,7 +57,7 @@ Buildable meters
 	pixel_y += rand(-5, 5)
 	
 	//Flipping handled manually due to custom handling for trinary pipes
-	AddComponent(/datum/component/simple_rotation)
+	AddComponent(/datum/component/simple_rotation, ROTATION_NO_FLIPPING)
 	return ..()
 
 /obj/item/pipe/proc/make_from_existing(obj/machinery/atmospherics/make_from)

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -98,7 +98,7 @@ Buildable meters
 
 /obj/item/pipe/verb/flip()
 	set category = "Object"
-	set name = "Flip Pipe"
+	set name = "Invert Pipe"
 	set src in view(1)
 
 	if ( usr.incapacitated() )

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -622,7 +622,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 						if(queued_p_flipped)
 							tube.setDir(turn(queued_p_dir, 45))
-							tube.simple_rotate_flip()
+							tube.SimpleRotateFlip()
 
 						tube.add_fingerprint(usr)
 						if(mode & WRENCH_MODE)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -32,7 +32,7 @@
 
 ///This proc adds the rotate component, overwrite this if you for some reason want to change some specific args.
 /obj/structure/chair/proc/MakeRotate()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_ANCHORED_ALLOWED | ROTATION_GHOSTS_ALLOWED)
+	AddComponent(/datum/component/simple_rotation, ROTATION_ANCHORED_ALLOWED|ROTATION_GHOSTS_ALLOWED)
 
 /obj/structure/chair/Destroy()
 	RemoveFromLatejoin()

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -32,7 +32,7 @@
 
 ///This proc adds the rotate component, overwrite this if you for some reason want to change some specific args.
 /obj/structure/chair/proc/MakeRotate()
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_ANCHORED_ALLOWED | ROTATION_GHOSTS_ALLOWED)
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_ANCHORED_ALLOWED | ROTATION_GHOSTS_ALLOWED)
 
 /obj/structure/chair/Destroy()
 	RemoveFromLatejoin()

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -28,8 +28,10 @@
 		addtimer(CALLBACK(src, .proc/RemoveFromLatejoin), 0)
 	if(prob(0.2))
 		name = "tactical [name]"
+	MakeRotate()
 
-/obj/structure/chair/ComponentInitialize()
+///This proc adds the rotate component, overwrite this if you for some reason want to change some specific args.
+/obj/structure/chair/proc/MakeRotate()
 	. = ..()
 	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_ANCHORED_ALLOWED | ROTATION_GHOSTS_ALLOWED)
 

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -31,22 +31,7 @@
 
 /obj/structure/chair/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE, CALLBACK(src, .proc/can_user_rotate),CALLBACK(src, .proc/can_be_rotated),null)
-
-/obj/structure/chair/proc/can_be_rotated(mob/user)
-	return TRUE
-
-/obj/structure/chair/proc/can_user_rotate(mob/user)
-	var/mob/living/L = user
-
-	if(istype(L))
-		if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
-			return FALSE
-		else
-			return TRUE
-	else if(isobserver(user) && CONFIG_GET(flag/ghost_interaction))
-		return TRUE
-	return FALSE
+	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_ANCHORED_ALLOWED | ROTATION_GHOSTS_ALLOWED)
 
 /obj/structure/chair/Destroy()
 	RemoveFromLatejoin()

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -32,7 +32,7 @@
 
 ///This proc adds the rotate component, overwrite this if you for some reason want to change some specific args.
 /obj/structure/chair/proc/MakeRotate()
-	AddComponent(/datum/component/simple_rotation, ROTATION_ANCHORED_ALLOWED|ROTATION_GHOSTS_ALLOWED)
+	AddComponent(/datum/component/simple_rotation, ROTATION_IGNORE_ANCHORED|ROTATION_GHOSTS_ALLOWED)
 
 /obj/structure/chair/Destroy()
 	RemoveFromLatejoin()

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -32,7 +32,6 @@
 
 ///This proc adds the rotate component, overwrite this if you for some reason want to change some specific args.
 /obj/structure/chair/proc/MakeRotate()
-	. = ..()
 	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_ANCHORED_ALLOWED | ROTATION_GHOSTS_ALLOWED)
 
 /obj/structure/chair/Destroy()

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -9,6 +9,11 @@
 	buildstackamount = 3
 	item_chair = null
 
+///This proc adds the rotate component, overwrite this if you for some reason want to change some specific args.
+/obj/structure/chair/pew/MakeRotate()
+	. = ..()
+	AddComponent(/datum/component/simple_rotation, ROTATION_WRENCH | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_ANCHORED_ALLOWED)
+
 /obj/structure/chair/pew/left
 	name = "left wooden pew end"
 	icon_state = "pewend_left"
@@ -70,16 +75,3 @@
 /obj/structure/chair/pew/right/post_unbuckle_mob()
 	. = ..()
 	update_rightpewarmrest()
-
-/obj/structure/chair/pew/can_user_rotate(mob/user)
-	. = ..()
-	if(!.)
-		return
-
-	var/mob/living/living_user = user
-	if(!istype(living_user))
-		return
-	var/obj/item/tool = living_user.get_active_held_item()
-	if(!tool || tool.tool_behaviour != TOOL_WRENCH)
-		balloon_alert(user, "you need a wrench!")
-		return FALSE

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -11,7 +11,7 @@
 
 ///This proc adds the rotate component, overwrite this if you for some reason want to change some specific args.
 /obj/structure/chair/pew/MakeRotate()
-	AddComponent(/datum/component/simple_rotation, ROTATION_REQUIRE_WRENCH|ROTATION_ANCHORED_ALLOWED)
+	AddComponent(/datum/component/simple_rotation, ROTATION_REQUIRE_WRENCH|ROTATION_IGNORE_ANCHORED)
 
 /obj/structure/chair/pew/left
 	name = "left wooden pew end"

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -11,7 +11,7 @@
 
 ///This proc adds the rotate component, overwrite this if you for some reason want to change some specific args.
 /obj/structure/chair/pew/MakeRotate()
-	AddComponent(/datum/component/simple_rotation, ROTATION_REQUIRE_WRENCH | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_ANCHORED_ALLOWED)
+	AddComponent(/datum/component/simple_rotation, ROTATION_REQUIRE_WRENCH|ROTATION_ANCHORED_ALLOWED)
 
 /obj/structure/chair/pew/left
 	name = "left wooden pew end"

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -11,7 +11,6 @@
 
 ///This proc adds the rotate component, overwrite this if you for some reason want to change some specific args.
 /obj/structure/chair/pew/MakeRotate()
-	. = ..()
 	AddComponent(/datum/component/simple_rotation, ROTATION_WRENCH | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_ANCHORED_ALLOWED)
 
 /obj/structure/chair/pew/left

--- a/code/game/objects/structures/beds_chairs/pew.dm
+++ b/code/game/objects/structures/beds_chairs/pew.dm
@@ -11,7 +11,7 @@
 
 ///This proc adds the rotate component, overwrite this if you for some reason want to change some specific args.
 /obj/structure/chair/pew/MakeRotate()
-	AddComponent(/datum/component/simple_rotation, ROTATION_WRENCH | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_ANCHORED_ALLOWED)
+	AddComponent(/datum/component/simple_rotation, ROTATION_REQUIRE_WRENCH | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_ANCHORED_ALLOWED)
 
 /obj/structure/chair/pew/left
 	name = "left wooden pew end"

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -32,7 +32,7 @@
 		)
 		AddElement(/datum/element/connect_loc, loc_connections)
 
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated),CALLBACK(src,.proc/after_rotation))
+	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS , can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 
 /obj/structure/railing/attackby(obj/item/I, mob/living/user, params)
 	..()
@@ -126,6 +126,3 @@
 /obj/structure/railing/proc/check_anchored(checked_anchored)
 	if(anchored == checked_anchored)
 		return TRUE
-
-/obj/structure/railing/proc/after_rotation(mob/user,rotation_type)
-	add_fingerprint(user)

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -32,7 +32,7 @@
 		)
 		AddElement(/datum/element/connect_loc, loc_connections)
 
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS , can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS , can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 
 /obj/structure/railing/attackby(obj/item/I, mob/living/user, params)
 	..()

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -32,7 +32,7 @@
 		)
 		AddElement(/datum/element/connect_loc, loc_connections)
 
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS , can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 
 /obj/structure/railing/attackby(obj/item/I, mob/living/user, params)
 	..()

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -111,15 +111,15 @@
 	leaving.Bump(src)
 	return COMPONENT_ATOM_BLOCK_EXIT
 
-/obj/structure/railing/proc/can_be_rotated(mob/user,rotation_type)
+/obj/structure/railing/proc/can_be_rotated(mob/user, rotation_type)
 	if(anchored)
-		to_chat(user, span_warning("[src] cannot be rotated while it is fastened to the floor!"))
+		balloon_alert(user, "need to unwrench")
 		return FALSE
 
 	var/target_dir = turn(dir, rotation_type == ROTATION_CLOCKWISE ? -90 : 90)
 
 	if(!valid_window_location(loc, target_dir, is_fulltile = FALSE)) //Expanded to include rails, as well!
-		to_chat(user, span_warning("[src] cannot be rotated in that direction!"))
+		balloon_alert(user, "cannot rotate in that direction")
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -32,7 +32,7 @@
 		)
 		AddElement(/datum/element/connect_loc, loc_connections)
 
-	AddComponent(/datum/component/simple_rotation, CanBeRotated = CALLBACK(src, .proc/CanBeRotated))
+	AddComponent(/datum/component/simple_rotation, ROTATION_NEEDS_ROOM)
 
 /obj/structure/railing/attackby(obj/item/I, mob/living/user, params)
 	..()
@@ -110,18 +110,6 @@
 
 	leaving.Bump(src)
 	return COMPONENT_ATOM_BLOCK_EXIT
-
-/obj/structure/railing/proc/CanBeRotated(mob/user, rotation_type)
-	if(anchored)
-		balloon_alert(user, "need to unwrench")
-		return FALSE
-
-	var/target_dir = turn(dir, rotation_type == ROTATION_CLOCKWISE ? -90 : 90)
-
-	if(!valid_window_location(loc, target_dir, is_fulltile = FALSE)) //Expanded to include rails, as well!
-		balloon_alert(user, "cannot rotate in that direction")
-		return FALSE
-	return TRUE
 
 /obj/structure/railing/proc/check_anchored(checked_anchored)
 	if(anchored == checked_anchored)

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -32,7 +32,7 @@
 		)
 		AddElement(/datum/element/connect_loc, loc_connections)
 
-	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, CanBeRotated = CALLBACK(src, .proc/CanBeRotated))
 
 /obj/structure/railing/attackby(obj/item/I, mob/living/user, params)
 	..()
@@ -111,7 +111,7 @@
 	leaving.Bump(src)
 	return COMPONENT_ATOM_BLOCK_EXIT
 
-/obj/structure/railing/proc/can_be_rotated(mob/user, rotation_type)
+/obj/structure/railing/proc/CanBeRotated(mob/user, rotation_type)
 	if(anchored)
 		balloon_alert(user, "need to unwrench")
 		return FALSE

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -204,7 +204,7 @@
 
 /obj/structure/showerframe/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 
 /obj/structure/showerframe/proc/can_be_rotated(mob/user, rotation_type)
 	if(anchored)

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -204,7 +204,7 @@
 
 /obj/structure/showerframe/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
 
 /obj/structure/showerframe/proc/can_be_rotated(mob/user, rotation_type)
 	if(anchored)

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -204,12 +204,7 @@
 
 /obj/structure/showerframe/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
-
-/obj/structure/showerframe/proc/can_be_rotated(mob/user, rotation_type)
-	if(anchored)
-		to_chat(user, span_warning("It is fastened to the floor!"))
-	return !anchored
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/effect/mist
 	name = "mist"

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -14,6 +14,10 @@
 	var/flipped_build_type
 	var/base_icon
 
+/obj/structure/c_transit_tube/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src,.proc/after_rot))
+
 /obj/structure/c_transit_tube/proc/can_wrench_in_loc(mob/user)
 	var/turf/source_turf = get_turf(loc)
 	var/existing_tubes = 0
@@ -23,10 +27,6 @@
 			to_chat(user, "[span_warning("You cannot wrench any more transit tubes!")] ")
 			return FALSE
 	return TRUE
-
-/obj/structure/c_transit_tube/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src,.proc/after_rot))
 
 /obj/structure/c_transit_tube/proc/after_rot(mob/user,rotation_type)
 	if(flipped_build_type && rotation_type == ROTATION_FLIP)

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -26,7 +26,10 @@
 
 /obj/structure/c_transit_tube/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_FLIP | ROTATION_VERBS,null,null,CALLBACK(src,.proc/after_rot))
+	AddComponent(/datum/component/simple_rotation, \
+		rotation_flags = ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_FLIP | ROTATION_VERBS, \
+		after_rotation = CALLBACK(src,.proc/after_rot) \
+	)
 
 /obj/structure/c_transit_tube/proc/after_rot(mob/user,rotation_type)
 	if(flipped_build_type && rotation_type == ROTATION_FLIP)

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -27,7 +27,7 @@
 /obj/structure/c_transit_tube/ComponentInitialize()
 	. = ..()
 	AddComponent(/datum/component/simple_rotation, \
-		rotation_flags = ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_FLIP | ROTATION_VERBS, \
+		rotation_flags = ROTATION_CLOCKWISE | ROTATION_FLIP | ROTATION_VERBS, \
 		after_rotation = CALLBACK(src,.proc/after_rot) \
 	)
 

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -26,10 +26,7 @@
 
 /obj/structure/c_transit_tube/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, \
-		rotation_flags = ROTATION_CLOCKWISE | ROTATION_FLIP | ROTATION_VERBS, \
-		after_rotation = CALLBACK(src,.proc/after_rot) \
-	)
+	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src,.proc/after_rot))
 
 /obj/structure/c_transit_tube/proc/after_rot(mob/user,rotation_type)
 	if(flipped_build_type && rotation_type == ROTATION_FLIP)

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -16,7 +16,7 @@
 
 /obj/structure/c_transit_tube/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src, .proc/after_rot))
+	AddComponent(/datum/component/simple_rotation, AfterRotation = CALLBACK(src, .proc/AfterRotation))
 
 /obj/structure/c_transit_tube/proc/can_wrench_in_loc(mob/user)
 	var/turf/source_turf = get_turf(loc)
@@ -28,7 +28,7 @@
 			return FALSE
 	return TRUE
 
-/obj/structure/c_transit_tube/proc/after_rot(mob/user,rotation_type)
+/obj/structure/c_transit_tube/proc/AfterRotation(mob/user,rotation_type)
 	if(flipped_build_type && rotation_type == ROTATION_FLIP)
 		setDir(turn(dir,-180)) //Turn back we don't actually flip
 		flipped = !flipped

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -28,9 +28,9 @@
 			return FALSE
 	return TRUE
 
-/obj/structure/c_transit_tube/proc/AfterRotation(mob/user,rotation_type)
-	if(flipped_build_type && rotation_type == ROTATION_FLIP)
-		setDir(turn(dir,-180)) //Turn back we don't actually flip
+/obj/structure/c_transit_tube/proc/AfterRotation(mob/user, degrees)
+	if(flipped_build_type && degrees == ROTATION_FLIP)
+		setDir(turn(dir, degrees)) //Turn back we don't actually flip
 		flipped = !flipped
 		var/cur_flip = initial(flipped) ? !flipped : flipped
 		if(cur_flip)

--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -16,7 +16,7 @@
 
 /obj/structure/c_transit_tube/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src,.proc/after_rot))
+	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src, .proc/after_rot))
 
 /obj/structure/c_transit_tube/proc/can_wrench_in_loc(mob/user)
 	var/turf/source_turf = get_turf(loc)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -458,7 +458,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 
 /obj/structure/sinkframe/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 
 /obj/structure/sinkframe/proc/can_be_rotated(mob/user, rotation_type)
 	if(anchored)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -456,7 +456,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 	anchored = FALSE
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS
 
-/obj/structure/sinkframe/ComponentInitialize()
+/obj/structure/sinkframe/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -458,7 +458,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 
 /obj/structure/sinkframe/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
 
 /obj/structure/sinkframe/proc/can_be_rotated(mob/user, rotation_type)
 	if(anchored)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -458,12 +458,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 
 /obj/structure/sinkframe/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
-
-/obj/structure/sinkframe/proc/can_be_rotated(mob/user, rotation_type)
-	if(anchored)
-		to_chat(user, span_warning("It is fastened to the floor!"))
-	return !anchored
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/structure/sinkframe/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/stock_parts/water_recycler))

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -325,7 +325,7 @@
 
 /obj/structure/windoor_assembly/ComponentInitialize()
 	. = ..()
-	var/static/rotation_flags = ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS
+	var/static/rotation_flags = ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS
 	AddComponent(/datum/component/simple_rotation, rotation_flags, can_be_rotated=CALLBACK(src, .proc/can_be_rotated), after_rotation=CALLBACK(src,.proc/after_rotation))
 
 /obj/structure/windoor_assembly/proc/can_be_rotated(mob/user,rotation_type)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -40,6 +40,7 @@
 	)
 
 	AddElement(/datum/element/connect_loc, loc_connections)
+	AddComponent(/datum/component/simple_rotation, can_be_rotated=CALLBACK(src, .proc/can_be_rotated), after_rotation=CALLBACK(src,.proc/after_rotation))
 
 /obj/structure/windoor_assembly/Destroy()
 	set_density(FALSE)
@@ -320,12 +321,6 @@
 
 	//Update to reflect changes(if applicable)
 	update_appearance()
-
-
-
-/obj/structure/windoor_assembly/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/simple_rotation, can_be_rotated=CALLBACK(src, .proc/can_be_rotated), after_rotation=CALLBACK(src,.proc/after_rotation))
 
 /obj/structure/windoor_assembly/proc/can_be_rotated(mob/user,rotation_type)
 	if(anchored)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -325,8 +325,7 @@
 
 /obj/structure/windoor_assembly/ComponentInitialize()
 	. = ..()
-	var/static/rotation_flags = ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS
-	AddComponent(/datum/component/simple_rotation, rotation_flags, can_be_rotated=CALLBACK(src, .proc/can_be_rotated), after_rotation=CALLBACK(src,.proc/after_rotation))
+	AddComponent(/datum/component/simple_rotation, can_be_rotated=CALLBACK(src, .proc/can_be_rotated), after_rotation=CALLBACK(src,.proc/after_rotation))
 
 /obj/structure/windoor_assembly/proc/can_be_rotated(mob/user,rotation_type)
 	if(anchored)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -40,7 +40,7 @@
 	)
 
 	AddElement(/datum/element/connect_loc, loc_connections)
-	AddComponent(/datum/component/simple_rotation, can_be_rotated=CALLBACK(src, .proc/can_be_rotated), after_rotation=CALLBACK(src,.proc/after_rotation))
+	AddComponent(/datum/component/simple_rotation, can_be_rotated=CALLBACK(src, .proc/can_be_rotated))
 
 /obj/structure/windoor_assembly/Destroy()
 	set_density(FALSE)
@@ -324,17 +324,15 @@
 
 /obj/structure/windoor_assembly/proc/can_be_rotated(mob/user,rotation_type)
 	if(anchored)
-		to_chat(user, span_warning("[src] cannot be rotated while it is fastened to the floor!"))
+		balloon_alert(user, "need to unwrench")
 		return FALSE
+
 	var/target_dir = turn(dir, rotation_type == ROTATION_CLOCKWISE ? -90 : 90)
 
 	if(!valid_window_location(loc, target_dir, is_fulltile = FALSE))
-		to_chat(user, span_warning("[src] cannot be rotated in that direction!"))
+		balloon_alert(user, "cannot rotate in that direction")
 		return FALSE
 	return TRUE
-
-/obj/structure/windoor_assembly/proc/after_rotation(mob/user)
-	update_appearance()
 
 //Flips the windoor assembly, determines whather the door opens to the left or the right
 /obj/structure/windoor_assembly/verb/flip()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -40,7 +40,7 @@
 	)
 
 	AddElement(/datum/element/connect_loc, loc_connections)
-	AddComponent(/datum/component/simple_rotation, CanBeRotated=CALLBACK(src, .proc/CanBeRotated))
+	AddComponent(/datum/component/simple_rotation, ROTATION_NEEDS_ROOM)
 
 /obj/structure/windoor_assembly/Destroy()
 	set_density(FALSE)
@@ -321,18 +321,6 @@
 
 	//Update to reflect changes(if applicable)
 	update_appearance()
-
-/obj/structure/windoor_assembly/proc/CanBeRotated(mob/user,rotation_type)
-	if(anchored)
-		balloon_alert(user, "need to unwrench")
-		return FALSE
-
-	var/target_dir = turn(dir, rotation_type == ROTATION_CLOCKWISE ? -90 : 90)
-
-	if(!valid_window_location(loc, target_dir, is_fulltile = FALSE))
-		balloon_alert(user, "cannot rotate in that direction")
-		return FALSE
-	return TRUE
 
 //Flips the windoor assembly, determines whather the door opens to the left or the right
 /obj/structure/windoor_assembly/verb/flip()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -40,7 +40,7 @@
 	)
 
 	AddElement(/datum/element/connect_loc, loc_connections)
-	AddComponent(/datum/component/simple_rotation, can_be_rotated=CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, CanBeRotated=CALLBACK(src, .proc/CanBeRotated))
 
 /obj/structure/windoor_assembly/Destroy()
 	set_density(FALSE)
@@ -322,7 +322,7 @@
 	//Update to reflect changes(if applicable)
 	update_appearance()
 
-/obj/structure/windoor_assembly/proc/can_be_rotated(mob/user,rotation_type)
+/obj/structure/windoor_assembly/proc/CanBeRotated(mob/user,rotation_type)
 	if(anchored)
 		balloon_alert(user, "need to unwrench")
 		return FALSE

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -80,7 +80,7 @@
 
 /obj/structure/window/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated),CALLBACK(src,.proc/after_rotation))
+	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated), after_rotation = CALLBACK(src,.proc/after_rotation))
 
 /obj/structure/window/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -80,7 +80,7 @@
 
 /obj/structure/window/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated),CALLBACK(src,.proc/after_rotation))
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated),CALLBACK(src,.proc/after_rotation))
 
 /obj/structure/window/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -70,7 +70,7 @@
 	flags_1 |= ALLOW_DARK_PAINTS_1
 	RegisterSignal(src, COMSIG_OBJ_PAINTED, .proc/on_painted)
 	AddElement(/datum/element/atmos_sensitive, mapload)
-	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated), after_rotation = CALLBACK(src,.proc/after_rotation))
+	AddComponent(/datum/component/simple_rotation, CanBeRotated = CALLBACK(src, .proc/CanBeRotated), AfterRotation = CALLBACK(src,.proc/AfterRotation))
 
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_EXIT = .proc/on_exit,
@@ -292,7 +292,7 @@
 	if (fulltile)
 		. += new /obj/item/shard(location)
 
-/obj/structure/window/proc/can_be_rotated(mob/user, rotation_type)
+/obj/structure/window/proc/CanBeRotated(mob/user, rotation_type)
 	if(anchored)
 		balloon_alert(user, "need to unscrew")
 		return FALSE
@@ -304,7 +304,7 @@
 		return FALSE
 	return TRUE
 
-/obj/structure/window/proc/after_rotation(mob/user, rotation_type)
+/obj/structure/window/proc/AfterRotation(mob/user, rotation_type)
 	air_update_turf(TRUE, FALSE)
 	add_fingerprint(user)
 	balloon_alert(user, "you [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [src]")

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -295,21 +295,22 @@
 	if (fulltile)
 		. += new /obj/item/shard(location)
 
-/obj/structure/window/proc/can_be_rotated(mob/user,rotation_type)
+/obj/structure/window/proc/can_be_rotated(mob/user, rotation_type)
 	if(anchored)
-		to_chat(user, span_warning("[src] cannot be rotated while it is fastened to the floor!"))
+		balloon_alert(user, "need to unscrew")
 		return FALSE
 
 	var/target_dir = turn(dir, rotation_type == ROTATION_CLOCKWISE ? -90 : 90)
 
 	if(!valid_window_location(loc, target_dir, is_fulltile = fulltile))
-		to_chat(user, span_warning("[src] cannot be rotated in that direction!"))
+		balloon_alert(user, "cannot rotate in that direction")
 		return FALSE
 	return TRUE
 
-/obj/structure/window/proc/after_rotation(mob/user,rotation_type)
+/obj/structure/window/proc/after_rotation(mob/user, rotation_type)
 	air_update_turf(TRUE, FALSE)
 	add_fingerprint(user)
+	balloon_alert(user, "you [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [src]")
 
 /obj/structure/window/proc/on_painted(obj/structure/window/source, is_dark_color)
 	SIGNAL_HANDLER

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -294,7 +294,6 @@
 
 /obj/structure/window/proc/AfterRotation(mob/user, degrees)
 	air_update_turf(TRUE, FALSE)
-	balloon_alert(user, "you [degrees == ROTATION_FLIP ? "flip" : "rotate"] [src]")
 
 /obj/structure/window/proc/on_painted(obj/structure/window/source, is_dark_color)
 	SIGNAL_HANDLER

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -70,6 +70,7 @@
 	flags_1 |= ALLOW_DARK_PAINTS_1
 	RegisterSignal(src, COMSIG_OBJ_PAINTED, .proc/on_painted)
 	AddElement(/datum/element/atmos_sensitive, mapload)
+	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated), after_rotation = CALLBACK(src,.proc/after_rotation))
 
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_EXIT = .proc/on_exit,
@@ -77,10 +78,6 @@
 
 	if (flags_1 & ON_BORDER_1)
 		AddElement(/datum/element/connect_loc, loc_connections)
-
-/obj/structure/window/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated), after_rotation = CALLBACK(src,.proc/after_rotation))
 
 /obj/structure/window/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -292,10 +292,10 @@
 	if (fulltile)
 		. += new /obj/item/shard(location)
 
-/obj/structure/window/proc/AfterRotation(mob/user, rotation_type)
+/obj/structure/window/proc/AfterRotation(mob/user, degrees)
 	air_update_turf(TRUE, FALSE)
 	add_fingerprint(user)
-	balloon_alert(user, "you [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [src]")
+	balloon_alert(user, "you [degrees == ROTATION_FLIP ? "flip" : "rotate"] [src]")
 
 /obj/structure/window/proc/on_painted(obj/structure/window/source, is_dark_color)
 	SIGNAL_HANDLER

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -70,7 +70,7 @@
 	flags_1 |= ALLOW_DARK_PAINTS_1
 	RegisterSignal(src, COMSIG_OBJ_PAINTED, .proc/on_painted)
 	AddElement(/datum/element/atmos_sensitive, mapload)
-	AddComponent(/datum/component/simple_rotation, CanBeRotated = CALLBACK(src, .proc/CanBeRotated), AfterRotation = CALLBACK(src,.proc/AfterRotation))
+	AddComponent(/datum/component/simple_rotation, ROTATION_NEEDS_ROOM, AfterRotation = CALLBACK(src,.proc/AfterRotation))
 
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_EXIT = .proc/on_exit,
@@ -291,18 +291,6 @@
 		. += new /obj/item/stack/rods(location, (fulltile ? 2 : 1))
 	if (fulltile)
 		. += new /obj/item/shard(location)
-
-/obj/structure/window/proc/CanBeRotated(mob/user, rotation_type)
-	if(anchored)
-		balloon_alert(user, "need to unscrew")
-		return FALSE
-
-	var/target_dir = turn(dir, rotation_type == ROTATION_CLOCKWISE ? -90 : 90)
-
-	if(!valid_window_location(loc, target_dir, is_fulltile = fulltile))
-		balloon_alert(user, "cannot rotate in that direction")
-		return FALSE
-	return TRUE
 
 /obj/structure/window/proc/AfterRotation(mob/user, rotation_type)
 	air_update_turf(TRUE, FALSE)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -294,7 +294,6 @@
 
 /obj/structure/window/proc/AfterRotation(mob/user, degrees)
 	air_update_turf(TRUE, FALSE)
-	add_fingerprint(user)
 	balloon_alert(user, "you [degrees == ROTATION_FLIP ? "flip" : "rotate"] [src]")
 
 /obj/structure/window/proc/on_painted(obj/structure/window/source, is_dark_color)

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -21,7 +21,10 @@
 	. = ..()
 	AddElement(art_type, impressiveness)
 	AddElement(/datum/element/beauty, impressiveness * 75)
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE, CALLBACK(src, .proc/can_user_rotate), CALLBACK(src, .proc/can_be_rotated), null)
+	AddComponent(/datum/component/simple_rotation, \
+		can_user_rotate = CALLBACK(src, .proc/can_user_rotate), \ 
+		can_be_rotated = CALLBACK(src, .proc/can_be_rotated) \
+	)
 
 /obj/structure/statue/proc/can_be_rotated(mob/user)
 	if(!anchored)

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -21,7 +21,7 @@
 	. = ..()
 	AddElement(art_type, impressiveness)
 	AddElement(/datum/element/beauty, impressiveness * 75)
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE, CALLBACK(src, .proc/can_user_rotate), CALLBACK(src, .proc/can_be_rotated), null)
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE, CALLBACK(src, .proc/can_user_rotate), CALLBACK(src, .proc/can_be_rotated), null)
 
 /obj/structure/statue/proc/can_be_rotated(mob/user)
 	if(!anchored)

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -21,10 +21,7 @@
 	. = ..()
 	AddElement(art_type, impressiveness)
 	AddElement(/datum/element/beauty, impressiveness * 75)
-	AddComponent(/datum/component/simple_rotation, \
-		can_user_rotate = CALLBACK(src, .proc/can_user_rotate), \ 
-		can_be_rotated = CALLBACK(src, .proc/can_be_rotated) \
-	)
+	AddComponent(/datum/component/simple_rotation, can_user_rotate = CALLBACK(src, .proc/can_user_rotate), can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 
 /obj/structure/statue/proc/can_be_rotated(mob/user)
 	if(!anchored)

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -21,15 +21,7 @@
 	. = ..()
 	AddElement(art_type, impressiveness)
 	AddElement(/datum/element/beauty, impressiveness * 75)
-	AddComponent(/datum/component/simple_rotation, can_user_rotate = CALLBACK(src, .proc/can_user_rotate), can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
-
-/obj/structure/statue/proc/can_be_rotated(mob/user)
-	if(!anchored)
-		return TRUE
-	to_chat(user, span_warning("It's bolted to the floor, you'll need to unwrench it first."))
-
-/obj/structure/statue/proc/can_user_rotate(mob/user)
-	return user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user))
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/structure/statue/attackby(obj/item/W, mob/living/user, params)
 	add_fingerprint(user)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -14,7 +14,7 @@
 	var/obj/item/assembly/a_left = null
 	var/obj/item/assembly/a_right = null
 
-/obj/item/assembly_holder/ComponentInitialize()
+/obj/item/assembly_holder/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/simple_rotation)
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -16,7 +16,7 @@
 
 /obj/item/assembly_holder/ComponentInitialize()
 	. = ..()
-	var/static/rotation_flags = ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_FLIP | ROTATION_VERBS
+	var/static/rotation_flags = ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_FLIP | ROTATION_VERBS
 	AddComponent(/datum/component/simple_rotation, rotation_flags)
 
 /obj/item/assembly_holder/Destroy()

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -16,8 +16,7 @@
 
 /obj/item/assembly_holder/ComponentInitialize()
 	. = ..()
-	var/static/rotation_flags = ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_FLIP | ROTATION_VERBS
-	AddComponent(/datum/component/simple_rotation, rotation_flags)
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/item/assembly_holder/Destroy()
 	QDEL_NULL(a_left)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -21,7 +21,7 @@
 
 /obj/item/assembly/infra/ComponentInitialize()
 	. = ..()
-	var/static/rotation_flags = ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_FLIP | ROTATION_VERBS
+	var/static/rotation_flags = ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_FLIP | ROTATION_VERBS
 	AddComponent(/datum/component/simple_rotation, rotation_flags, after_rotation=CALLBACK(src,.proc/after_rotation))
 
 /obj/item/assembly/infra/proc/after_rotation()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -21,8 +21,7 @@
 
 /obj/item/assembly/infra/ComponentInitialize()
 	. = ..()
-	var/static/rotation_flags = ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_FLIP | ROTATION_VERBS
-	AddComponent(/datum/component/simple_rotation, rotation_flags, after_rotation=CALLBACK(src,.proc/after_rotation))
+	AddComponent(/datum/component/simple_rotation, after_rotation=CALLBACK(src,.proc/after_rotation))
 
 /obj/item/assembly/infra/proc/after_rotation()
 	refreshBeam()

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -21,10 +21,11 @@
 
 /obj/item/assembly/infra/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, after_rotation=CALLBACK(src,.proc/after_rotation))
+	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src, .proc/after_rotation))
 
-/obj/item/assembly/infra/proc/after_rotation()
+/obj/item/assembly/infra/proc/after_rotation(mob/user, rotation_type)
 	refreshBeam()
+	balloon_alert(user, "you [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [src]")
 
 /obj/item/assembly/infra/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -20,9 +20,9 @@
 	START_PROCESSING(SSobj, src)
 	AddComponent(/datum/component/simple_rotation, AfterRotation = CALLBACK(src, .proc/AfterRotation))
 
-/obj/item/assembly/infra/proc/AfterRotation(mob/user, rotation_type)
+/obj/item/assembly/infra/proc/AfterRotation(mob/user, degrees)
 	refreshBeam()
-	balloon_alert(user, "you [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [src]")
+	balloon_alert(user, "you [degrees == ROTATION_FLIP ? "flip" : "rotate"] [src]")
 
 /obj/item/assembly/infra/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -22,7 +22,6 @@
 
 /obj/item/assembly/infra/proc/AfterRotation(mob/user, degrees)
 	refreshBeam()
-	balloon_alert(user, "you [degrees == ROTATION_FLIP ? "flip" : "rotate"] [src]")
 
 /obj/item/assembly/infra/Destroy()
 	STOP_PROCESSING(SSobj, src)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -18,9 +18,6 @@
 	. = ..()
 	beams = list()
 	START_PROCESSING(SSobj, src)
-
-/obj/item/assembly/infra/ComponentInitialize()
-	. = ..()
 	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src, .proc/after_rotation))
 
 /obj/item/assembly/infra/proc/after_rotation(mob/user, rotation_type)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -18,9 +18,9 @@
 	. = ..()
 	beams = list()
 	START_PROCESSING(SSobj, src)
-	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src, .proc/after_rotation))
+	AddComponent(/datum/component/simple_rotation, AfterRotation = CALLBACK(src, .proc/AfterRotation))
 
-/obj/item/assembly/infra/proc/after_rotation(mob/user, rotation_type)
+/obj/item/assembly/infra/proc/AfterRotation(mob/user, rotation_type)
 	refreshBeam()
 	balloon_alert(user, "you [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [src]")
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -27,7 +27,7 @@
 
 /obj/machinery/atmospherics/components/binary/circulator/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS )
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS )
 
 /obj/machinery/atmospherics/components/binary/circulator/Destroy()
 	if(generator)

--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -27,7 +27,7 @@
 
 /obj/machinery/atmospherics/components/binary/circulator/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS )
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/machinery/atmospherics/components/binary/circulator/Destroy()
 	if(generator)

--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -21,13 +21,13 @@
 	var/mode = CIRCULATOR_HOT
 	var/obj/machinery/power/generator/generator
 
+/obj/machinery/atmospherics/components/binary/circulator/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/simple_rotation)
+
 //default cold circ for mappers
 /obj/machinery/atmospherics/components/binary/circulator/cold
 	mode = CIRCULATOR_COLD
-
-/obj/machinery/atmospherics/components/binary/circulator/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/simple_rotation)
 
 /obj/machinery/atmospherics/components/binary/circulator/Destroy()
 	if(generator)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -69,7 +69,7 @@
 
 /obj/machinery/hydroponics/constructable/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
 	AddComponent(/datum/component/plumbing/simple_demand)
 	AddComponent(/datum/component/usb_port, list(/obj/item/circuit_component/hydroponics))
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -69,7 +69,7 @@
 
 /obj/machinery/hydroponics/constructable/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 	AddComponent(/datum/component/plumbing/simple_demand)
 	AddComponent(/datum/component/usb_port, list(/obj/item/circuit_component/hydroponics))
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -69,12 +69,9 @@
 
 /obj/machinery/hydroponics/constructable/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation)
 	AddComponent(/datum/component/plumbing/simple_demand)
 	AddComponent(/datum/component/usb_port, list(/obj/item/circuit_component/hydroponics))
-
-/obj/machinery/hydroponics/constructable/proc/can_be_rotated(mob/user, rotation_type)
-	return !anchored
 
 /obj/machinery/hydroponics/constructable/RefreshParts()
 	var/tmp_capacity = 0

--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -21,10 +21,7 @@
 	. = ..()
 	set_anchored(bolt)
 	create_reagents(buffer, reagent_flags)
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
-
-/obj/machinery/plumbing/proc/can_be_rotated(mob/user,rotation_type)
-	return !anchored
+	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS)
 
 /obj/machinery/plumbing/examine(mob/user)
 	. = ..()

--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -21,7 +21,7 @@
 	. = ..()
 	set_anchored(bolt)
 	create_reagents(buffer, reagent_flags)
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS)
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS)
 
 /obj/machinery/plumbing/examine(mob/user)
 	. = ..()

--- a/code/modules/plumbing/plumbers/_plumb_machinery.dm
+++ b/code/modules/plumbing/plumbers/_plumb_machinery.dm
@@ -21,7 +21,7 @@
 	. = ..()
 	set_anchored(bolt)
 	create_reagents(buffer, reagent_flags)
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS)
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/machinery/plumbing/examine(mob/user)
 	. = ..()

--- a/code/modules/plumbing/plumbers/bottler.dm
+++ b/code/modules/plumbing/plumbers/bottler.dm
@@ -29,12 +29,6 @@
 	if(!valid_output_configuration)
 		. += span_warning("A flashing notification on the screen reads: \"Output location error!\"")
 
-/obj/machinery/plumbing/bottler/can_be_rotated(mob/user, rotation_type)
-	if(anchored)
-		to_chat(user, span_warning("It is fastened to the floor!"))
-		return FALSE
-	return TRUE
-
 ///changes the tile array
 /obj/machinery/plumbing/bottler/setDir(newdir)
 	. = ..()

--- a/code/modules/plumbing/plumbers/fermenter.dm
+++ b/code/modules/plumbing/plumbers/fermenter.dm
@@ -18,12 +18,6 @@
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
-/obj/machinery/plumbing/grinder_chemical/can_be_rotated(mob/user, rotation_type)
-	if(anchored)
-		to_chat(user, span_warning("It is fastened to the floor!"))
-		return FALSE
-	return TRUE
-
 /obj/machinery/plumbing/fermenter/setDir(newdir)
 	. = ..()
 	eat_dir = newdir

--- a/code/modules/plumbing/plumbers/grinder_chemical.dm
+++ b/code/modules/plumbing/plumbers/grinder_chemical.dm
@@ -17,12 +17,6 @@
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
-/obj/machinery/plumbing/grinder_chemical/can_be_rotated(mob/user, rotation_type)
-	if(anchored)
-		to_chat(user, span_warning("It is fastened to the floor!"))
-		return FALSE
-	return TRUE
-
 /obj/machinery/plumbing/grinder_chemical/setDir(newdir)
 	. = ..()
 	eat_dir = newdir

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -24,7 +24,7 @@
 
 /obj/machinery/power/generator/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS )
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS )
 
 /obj/machinery/power/generator/Destroy()
 	kill_circs()

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -17,14 +17,11 @@
 
 /obj/machinery/power/generator/Initialize(mapload)
 	. = ..()
+	AddComponent(/datum/component/simple_rotation)
 	find_circs()
 	connect_to_network()
 	SSair.start_processing_machine(src)
 	update_appearance()
-
-/obj/machinery/power/generator/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/simple_rotation)
 
 /obj/machinery/power/generator/Destroy()
 	kill_circs()

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -24,7 +24,7 @@
 
 /obj/machinery/power/generator/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS )
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/machinery/power/generator/Destroy()
 	kill_circs()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -134,7 +134,7 @@
 
 /obj/machinery/power/emitter/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
 
 /obj/machinery/power/emitter/proc/can_be_rotated(mob/user, rotation_type)
 	if(!anchored)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -59,21 +59,6 @@
 	///stores the direction and orientation of the last projectile
 	var/last_projectile_params
 
-
-/obj/machinery/power/emitter/welded/Initialize(mapload)
-	welded = TRUE
-	. = ..()
-
-/obj/machinery/power/emitter/ctf
-	name = "Energy Cannon"
-	active = TRUE
-	active_power_usage = 0
-	idle_power_usage = 0
-	locked = TRUE
-	req_access_txt = "100"
-	welded = TRUE
-	use_power = NO_POWER_USE
-
 /obj/machinery/power/emitter/Initialize(mapload)
 	. = ..()
 	RefreshParts()
@@ -86,10 +71,12 @@
 	sparks = new
 	sparks.attach(src)
 	sparks.set_up(5, TRUE, src)
-
-/obj/machinery/power/emitter/ComponentInitialize()
-	. = ..()
+	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF | EMP_PROTECT_WIRES)
+
+/obj/machinery/power/emitter/welded/Initialize(mapload)
+	welded = TRUE
+	. = ..()
 
 /obj/machinery/power/emitter/set_anchored(anchorvalue)
 	. = ..()
@@ -131,10 +118,6 @@
 	else
 		. += span_notice("Its status display reads: Emitting one beam every <b>[DisplayTimeText(fire_delay)]</b>.")
 		. += span_notice("Power consumption at <b>[display_power(active_power_usage)]</b>.")
-
-/obj/machinery/power/emitter/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 
 /obj/machinery/power/emitter/proc/can_be_rotated(mob/user, rotation_type)
 	if(!anchored)
@@ -559,3 +542,12 @@
 	else if (emitter.charge < 10)
 		playsound(src,'sound/machines/buzz-sigh.ogg', 50, TRUE)
 
+/obj/machinery/power/emitter/ctf
+	name = "Energy Cannon"
+	active = TRUE
+	active_power_usage = 0
+	idle_power_usage = 0
+	locked = TRUE
+	req_access_txt = "100"
+	welded = TRUE
+	use_power = NO_POWER_USE

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -134,7 +134,7 @@
 
 /obj/machinery/power/emitter/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 
 /obj/machinery/power/emitter/proc/can_be_rotated(mob/user, rotation_type)
 	if(!anchored)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -71,7 +71,7 @@
 	sparks = new
 	sparks.attach(src)
 	sparks.set_up(5, TRUE, src)
-	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation)
 	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF | EMP_PROTECT_WIRES)
 
 /obj/machinery/power/emitter/welded/Initialize(mapload)
@@ -118,12 +118,6 @@
 	else
 		. += span_notice("Its status display reads: Emitting one beam every <b>[DisplayTimeText(fire_delay)]</b>.")
 		. += span_notice("Power consumption at <b>[display_power(active_power_usage)]</b>.")
-
-/obj/machinery/power/emitter/proc/can_be_rotated(mob/user, rotation_type)
-	if(!anchored)
-		return TRUE
-	to_chat(user, span_warning("It is fastened to the floor!"))
-	return FALSE
 
 /obj/machinery/power/emitter/should_have_node()
 	return welded

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -439,7 +439,7 @@
 
 /obj/machinery/chem_dispenser/drinks/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE)
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE)
 
 /obj/machinery/chem_dispenser/drinks/setDir()
 	var/old = dir

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -439,7 +439,7 @@
 
 /obj/machinery/chem_dispenser/drinks/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE)
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/machinery/chem_dispenser/drinks/setDir()
 	var/old = dir

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -247,7 +247,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/virusfood, 30
 
 /obj/structure/reagent_dispensers/plumbed/storage/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 
 /obj/structure/reagent_dispensers/plumbed/storage/update_overlays()
 	. = ..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -232,20 +232,21 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/virusfood, 30
 	desc = "A stationary, plumbed, water tank."
 	can_be_tanked = FALSE
 
+/obj/structure/reagent_dispensers/plumbed/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/plumbing/simple_supply)
+
 /obj/structure/reagent_dispensers/plumbed/wrench_act(mob/living/user, obj/item/I)
 	..()
 	default_unfasten_wrench(user, I)
 	return TRUE
-
-/obj/structure/reagent_dispensers/plumbed/ComponentInitialize()
-	AddComponent(/datum/component/plumbing/simple_supply)
 
 /obj/structure/reagent_dispensers/plumbed/storage
 	name = "stationary storage tank"
 	icon_state = "tank_stationary"
 	reagent_id = null //start empty
 
-/obj/structure/reagent_dispensers/plumbed/storage/ComponentInitialize()
+/obj/structure/reagent_dispensers/plumbed/storage/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -247,7 +247,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/virusfood, 30
 
 /obj/structure/reagent_dispensers/plumbed/storage/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, .proc/can_be_rotated))
 
 /obj/structure/reagent_dispensers/plumbed/storage/update_overlays()
 	. = ..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -248,7 +248,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/virusfood, 30
 
 /obj/structure/reagent_dispensers/plumbed/storage/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated))
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/structure/reagent_dispensers/plumbed/storage/update_overlays()
 	. = ..()
@@ -261,11 +261,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/reagent_dispensers/wall/virusfood, 30
 	var/mutable_appearance/tank_color = mutable_appearance('icons/obj/chemical_tanks.dmi', "tank_chem_overlay")
 	tank_color.color = mix_color_from_reagents(reagents.reagent_list)
 	. += tank_color
-
-/obj/structure/reagent_dispensers/plumbed/storage/proc/can_be_rotated(mob/user, rotation_type)
-	if(anchored)
-		to_chat(user, span_warning("It is fastened to the floor!"))
-	return !anchored
 
 /obj/structure/reagent_dispensers/plumbed/fuel
 	name = "stationary fuel tank"

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -87,7 +87,7 @@
 
 /obj/structure/disposalconstruct/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_FLIP | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated), CALLBACK(src, .proc/after_rot))
+	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated), after_rotation = CALLBACK(src, .proc/after_rot))
 
 /obj/structure/disposalconstruct/proc/after_rot(mob/user,rotation_type)
 	if(rotation_type == ROTATION_FLIP)

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -35,7 +35,7 @@
 
 	if(flip)
 		var/datum/component/simple_rotation/rotcomp = GetComponent(/datum/component/simple_rotation)
-		rotcomp.BaseRot(null,ROTATION_FLIP)
+		rotcomp.Rotate(null,ROTATION_FLIP)
 
 	update_appearance()
 

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -87,7 +87,7 @@
 
 /obj/structure/disposalconstruct/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_FLIP | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated), CALLBACK(src, .proc/after_rot))
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_FLIP | ROTATION_VERBS ,null,CALLBACK(src, .proc/can_be_rotated), CALLBACK(src, .proc/after_rot))
 
 /obj/structure/disposalconstruct/proc/after_rot(mob/user,rotation_type)
 	if(rotation_type == ROTATION_FLIP)

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -33,6 +33,7 @@
 
 	pipename = initial(pipe_type.name)
 
+	//might need to insert the AddComponent for rotation above the if(flip)
 	if(flip)
 		var/datum/component/simple_rotation/rotcomp = GetComponent(/datum/component/simple_rotation)
 		rotcomp.Rotate(null,ROTATION_FLIP)
@@ -40,6 +41,8 @@
 	update_appearance()
 
 	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
+	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated), after_rotation = CALLBACK(src, .proc/after_rot))
+
 
 /obj/structure/disposalconstruct/Move()
 	var/old_dir = dir
@@ -84,10 +87,6 @@
 		if(initialize_dirs & DISP_DIR_FLIP)
 			dpdir |= turn(dir, 180)
 	return dpdir
-
-/obj/structure/disposalconstruct/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated), after_rotation = CALLBACK(src, .proc/after_rot))
 
 /obj/structure/disposalconstruct/proc/after_rot(mob/user,rotation_type)
 	if(rotation_type == ROTATION_FLIP)

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -93,7 +93,6 @@
 			if(ISDIAGONALDIR(dir)) // Fix RPD-induced diagonal turning
 				setDir(turn(dir, 45))
 			pipe_type = initial(temp.flip_type)
-	balloon_alert(user, "you [degrees == ROTATION_FLIP ? "flip" : "rotate"] [src]")	
 	update_appearance()
 
 // construction/deconstruction

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -33,16 +33,14 @@
 
 	pipename = initial(pipe_type.name)
 
-	//might need to insert the AddComponent for rotation above the if(flip)
+	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src, .proc/after_rot))
+	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
+
 	if(flip)
 		var/datum/component/simple_rotation/rotcomp = GetComponent(/datum/component/simple_rotation)
-		rotcomp.Rotate(null, ROTATION_FLIP)
+		rotcomp.Rotate(usr, ROTATION_FLIP) // this only gets used by pipes created by RPDs or pipe dispensers
 
 	update_appearance()
-
-	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
-	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src, .proc/after_rot))
-
 
 /obj/structure/disposalconstruct/Move()
 	var/old_dir = dir

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -33,7 +33,7 @@
 
 	pipename = initial(pipe_type.name)
 
-	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src, .proc/after_rot))
+	AddComponent(/datum/component/simple_rotation, AfterRotation = CALLBACK(src, .proc/AfterRotation))
 	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
 
 	if(flip)
@@ -86,7 +86,7 @@
 			dpdir |= turn(dir, 180)
 	return dpdir
 
-/obj/structure/disposalconstruct/proc/after_rot(mob/user, rotation_type)
+/obj/structure/disposalconstruct/proc/AfterRotation(mob/user, rotation_type)
 	if(rotation_type == ROTATION_FLIP)
 		var/obj/structure/disposalpipe/temp = pipe_type
 		if(initial(temp.flip_type))

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -86,14 +86,14 @@
 			dpdir |= turn(dir, 180)
 	return dpdir
 
-/obj/structure/disposalconstruct/proc/AfterRotation(mob/user, rotation_type)
-	if(rotation_type == ROTATION_FLIP)
+/obj/structure/disposalconstruct/proc/AfterRotation(mob/user, degrees)
+	if(degrees == ROTATION_FLIP)
 		var/obj/structure/disposalpipe/temp = pipe_type
 		if(initial(temp.flip_type))
 			if(ISDIAGONALDIR(dir)) // Fix RPD-induced diagonal turning
 				setDir(turn(dir, 45))
 			pipe_type = initial(temp.flip_type)
-	balloon_alert(user, "you [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [src]")	
+	balloon_alert(user, "you [degrees == ROTATION_FLIP ? "flip" : "rotate"] [src]")	
 	update_appearance()
 
 // construction/deconstruction

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -36,12 +36,12 @@
 	//might need to insert the AddComponent for rotation above the if(flip)
 	if(flip)
 		var/datum/component/simple_rotation/rotcomp = GetComponent(/datum/component/simple_rotation)
-		rotcomp.Rotate(null,ROTATION_FLIP)
+		rotcomp.Rotate(null, ROTATION_FLIP)
 
 	update_appearance()
 
 	AddElement(/datum/element/undertile, TRAIT_T_RAY_VISIBLE)
-	AddComponent(/datum/component/simple_rotation, can_be_rotated = CALLBACK(src, .proc/can_be_rotated), after_rotation = CALLBACK(src, .proc/after_rot))
+	AddComponent(/datum/component/simple_rotation, after_rotation = CALLBACK(src, .proc/after_rot))
 
 
 /obj/structure/disposalconstruct/Move()
@@ -88,20 +88,15 @@
 			dpdir |= turn(dir, 180)
 	return dpdir
 
-/obj/structure/disposalconstruct/proc/after_rot(mob/user,rotation_type)
+/obj/structure/disposalconstruct/proc/after_rot(mob/user, rotation_type)
 	if(rotation_type == ROTATION_FLIP)
 		var/obj/structure/disposalpipe/temp = pipe_type
 		if(initial(temp.flip_type))
 			if(ISDIAGONALDIR(dir)) // Fix RPD-induced diagonal turning
 				setDir(turn(dir, 45))
 			pipe_type = initial(temp.flip_type)
+	balloon_alert(user, "you [rotation_type == ROTATION_FLIP ? "flip" : "rotate"] [src]")	
 	update_appearance()
-
-/obj/structure/disposalconstruct/proc/can_be_rotated(mob/user,rotation_type)
-	if(anchored)
-		to_chat(user, span_warning("You must unfasten the pipe before rotating it!"))
-		return FALSE
-	return TRUE
 
 // construction/deconstruction
 // wrench: (un)anchor

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -20,10 +20,7 @@
 	make_ridable()
 	wheels_overlay = image(icon, overlay_icon, FLY_LAYER)
 	ADD_TRAIT(src, TRAIT_NO_IMMOBILIZE, INNATE_TRAIT)
-
-/obj/vehicle/ridden/wheelchair/ComponentInitialize() //Since it's technically a chair I want it to have chair properties
-	. = ..()
-	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE)
+	AddComponent(/datum/component/simple_rotation) //Since it's technically a chair I want it to have chair properties
 
 /obj/vehicle/ridden/wheelchair/atom_destruction(damage_flag)
 	new /obj/item/stack/rods(drop_location(), 1)

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -23,7 +23,7 @@
 
 /obj/vehicle/ridden/wheelchair/ComponentInitialize() //Since it's technically a chair I want it to have chair properties
 	. = ..()
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE, CALLBACK(src, .proc/can_user_rotate),CALLBACK(src, .proc/can_be_rotated),null)
+	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE)
 
 /obj/vehicle/ridden/wheelchair/atom_destruction(damage_flag)
 	new /obj/item/stack/rods(drop_location(), 1)
@@ -57,21 +57,6 @@
 	. = ..()
 	if(has_buckled_mobs())
 		. += wheels_overlay
-
-
-///used for simple rotation component checks
-/obj/vehicle/ridden/wheelchair/proc/can_be_rotated(mob/living/user)
-	return TRUE
-
-///used in simple rotation component checks as to whether a user can rotate this chair
-/obj/vehicle/ridden/wheelchair/proc/can_user_rotate(mob/living/user)
-	var/mob/living/L = user
-	if(istype(L))
-		if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, !iscyborg(user)))
-			return FALSE
-	if(isobserver(user) && CONFIG_GET(flag/ghost_interaction))
-		return TRUE
-	return FALSE
 
 /// I assign the ridable element in this so i don't have to fuss with hand wheelchairs and motor wheelchairs having different subtypes
 /obj/vehicle/ridden/wheelchair/proc/make_ridable()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -23,7 +23,7 @@
 
 /obj/vehicle/ridden/wheelchair/ComponentInitialize() //Since it's technically a chair I want it to have chair properties
 	. = ..()
-	AddComponent(/datum/component/simple_rotation,ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE)
+	AddComponent(/datum/component/simple_rotation, ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE)
 
 /obj/vehicle/ridden/wheelchair/atom_destruction(damage_flag)
 	new /obj/item/stack/rods(drop_location(), 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This adds some new defines and flags for the rotation component that lets us remove lots of c/p code chunks. I also added documentation to all the rotation defines that currently exist and in other spots that had weird behavior.

New rotation flags:

`ROTATION_GHOSTS_ALLOWED` - checks if ghosts are able to manipulate objects in config and lets them rotate the object
`ROTATION_IGNORE_ANCHORED` - this skips checking if an object is anchored (which normally prevents us from rotating) Used mainly for chairs.
`ROTATION_NO_FLIPPING` - this removes the flip verb from possible right click rotation options. Used for pipes that have custom flipping verbs instead
`ROTATION_NEEDS_ROOM` - this checks if an object needs to have an empty spot available in target direction. Used for windows and railings.

Objects can now be rotated in the direction based on which LMB or RMB you click with when you ALT click it.  LMB is counter clockwise.  RMB is clockwise.  Before some objects could only be rotated clockwise.  Now any object that inherits the rotation component can be rotated in either direction.

There was also a bug with wheelchairs that existed from when they were ported over from another codebase.  The rotation logic was broken and never allowed anyone to rotate them.  This has been fixed.

Rotation for IV_drips was enabled however Alt Click was being used for another proc and rotation was ignored because of this.  I removed the rotation component due to this since I didn't want to change the hotkeys for IV drips since those have an actual effect on gameplay interactions while rotation does not.

Fingerprints are no longer added when something gets rotated.  Only a few objects had this enabled but I believe this interaction was very spammy and unnecessary.  I can readd this as a flag if needed but for now it's removed.

Alert balloons have replaced a lot of rotation `to_chat()` messages for the same reason as fingerprints. Rotating objects has almost no effect on gameplay and will only clutter a player's  message log.

The hotkeys for pipe interactions had to be redone since Alt clicking was already being used in some situations.  For regular pipes: Right clicking now changes the pipe layer. Alt clicking rotates the pipe.  For Trinary pipes:  Right clicking now flips the pipe device.  Alt clicking rotates the device.

`ComponentInitialize()` is a deprecated function and the `AddComponent` proc was moved to `Initialize` for several objects.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Better code quality.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Remove rotation from IV drips.
del: Rotating objects will no longer leave fingerprints.
qol: Add right-clicking and left-clicking to rotate objects in different directions for alt click. Left is counterclockwise and right is clockwise.
qol: Replace to_chat rotation messages with balloon alerts to stop redundant chat spamming.
qol: Hotkeys for some pipe interactions had to be changed. Right clicking on an unwrenched pipe now changes the pipe layer.  Right clicking on a unwrenched trinary pipe device now flips it.  Alt clicking handles rotation.
qol: Computer frames now have rotation component 
fix: Fix rotation on wheelchairs to work properly.
refactor: Refactored the entire rotation component and all objects that use it.  Remove a lot of deprecated code to make things cleaner. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
