### PR TITLE
Revenants can no longer use abilities or Harvest while standing on a wall.

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -28,6 +28,9 @@
 
 //Harvest; activated by clicking the target, will try to drain their essence.
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
+	if(istype(get_turf(src), /turf/closed))
+		to_chat(src, span_revenwarning("You can't quite materialize in this space! Try a more open space.")
+		return
 	if(!castcheck(0))
 		return
 	if(draining)
@@ -152,6 +155,8 @@
 		name = "[initial(name)] ([cast_amount]E)"
 
 /obj/effect/proc_holder/spell/aoe_turf/revenant/can_cast(mob/living/simple_animal/revenant/user = usr)
+	if(istype(get_turf(src), /turf/closed))
+		return FALSE
 	if(charge_counter < charge_max)
 		return FALSE
 	if(!istype(user)) //Badmins, no. Badmins, don't do it.


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game

I love being in medbay and being ready to defib a patient on the operating table, defibbing the patient, and then the revenant proceeds to suck the patient to death right after I defib them from the wall or the wall corner where I can't hit them while they get to drain off of the guy I just revived until he dies again. Then he chain lightnings me if I try to do a revival surgery instead. Also from a wall where we can't hit them.

Melbert is working on a revenant rework, but this should make revenants manageable and allow you to actually have a swing at them if they choose to do extremely ballsy public drains.

If you're playing revenant normally and isolating targets and haunting them to kill them, you'll have a much better chance of succeeding.

## Changelog

:cl:
balance: Revenants can no longer use abilities or Harvest while standing on a wall.
/:cl:
