### PR TITLE
Always use vendored NodeJS on Windows

### DIFF
--- a/tools/bootstrap/node.bat
+++ b/tools/bootstrap/node.bat
@@ -1,11 +1,4 @@
 @echo off
-where node.exe >nul 2>nul
-if %errorlevel% == 0 (
-	echo | set /p printed_str="Using system-wide Node "
-	call node.exe --version
-	call node.exe %*
-	goto exit_with_last_error_level
-)
 call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Download-Node
 for /f "tokens=* USEBACKQ" %%s in (`
 	call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Get-Path


### PR DESCRIPTION
As @SpaceManiac said:

> A big part of the point of the bootstrap scripts is to provide a reproducible environment

Here I am, web-removing the bit of code that allows using a system-wide version of NodeJS. Now we're vendored only.