### PR TITLE
The Starfury Battle Cruiser is no longer available as a final objective.

### DIFF
--- a/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
@@ -1,8 +1,7 @@
 /datum/traitor_objective_category/final_objective
 	name = "Final Objective"
 	objectives = list(
-		/datum/traitor_objective/final/romerol = 1,
-		/datum/traitor_objective/final/battlecruiser = 1,
+		/datum/traitor_objective/final/romerol = 1
 	)
 	weight = 100
 


### PR DESCRIPTION
## About The Pull Request

The Starfury Battle Cruiser is no longer available as a final objective.

## Why It's Good For The Game

If the round needs Nuke Ops, Dynamic or the Admins should be the ones calling nuke ops, not literally any traitor.

## Changelog

:cl:
del: The Starfury Battle Cruiser is no longer available as a final objective.
/:cl: