### PR TITLE
Adds proper external airlocks to Public Mining Storage on Ice Box

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -174,7 +174,7 @@
 /area/mine/laborcamp/security)
 "aE" = (
 /obj/structure/sign/warning/coldtemp{
-	pixel_x = -30
+	pixel_x = -29
 	},
 /obj/structure/sign/warning/gasmask{
 	desc = "A sign that warns of dangerous gasses in the air, instructing you to wear internals.";
@@ -3772,12 +3772,6 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"my" = (
-/obj/structure/sign/warning/xeno_mining{
-	pixel_x = -30
-	},
-/turf/open/floor/plating/elevatorshaft,
-/area/mine/storage)
 "mA" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -6135,6 +6129,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/structure/sign/warning/xeno_mining{
+	pixel_y = -32
 	},
 /turf/open/floor/iron/dark,
 /area/mine/storage)
@@ -13158,6 +13155,9 @@
 	opacity = 0
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/sign/warning/xeno_mining{
+	pixel_x = 29
+	},
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "QX" = (
@@ -15025,12 +15025,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"WK" = (
-/obj/structure/sign/warning/xeno_mining{
-	pixel_x = -30
-	},
-/turf/open/floor/iron/dark,
-/area/mine/storage)
 "WM" = (
 /obj/machinery/shower{
 	pixel_y = 22
@@ -15965,10 +15959,6 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
-"ZN" = (
-/obj/structure/sign/warning/xeno_mining,
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/mine/storage)
 "ZP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -44187,7 +44177,7 @@ ak
 NH
 NH
 qG
-my
+Fj
 Fj
 Fj
 Hv
@@ -44959,7 +44949,7 @@ Hv
 Hy
 fw
 ic
-WK
+BJ
 QW
 aE
 YZ
@@ -47019,7 +47009,7 @@ ak
 ak
 ak
 NH
-ZN
+NH
 NH
 NH
 ak

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -172,6 +172,16 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
+"aE" = (
+/obj/structure/sign/warning/coldtemp{
+	pixel_x = -30
+	},
+/obj/structure/sign/warning/gasmask{
+	desc = "A sign that warns of dangerous gasses in the air, instructing you to wear internals.";
+	pixel_x = 30
+	},
+/turf/open/floor/iron/dark,
+/area/mine/storage)
 "aF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "labor";
@@ -3123,6 +3133,16 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/medical)
+"kx" = (
+/obj/structure/sign/warning/gasmask{
+	desc = "A sign that warns of dangerous gasses in the air, instructing you to wear internals.";
+	pixel_y = -32
+	},
+/obj/structure/sign/warning/coldtemp{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark,
+/area/mine/storage)
 "ky" = (
 /turf/open/floor/plating,
 /area/medical/virology)
@@ -3752,6 +3772,12 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"my" = (
+/obj/structure/sign/warning/xeno_mining{
+	pixel_x = -30
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/mine/storage)
 "mA" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -4992,7 +5018,7 @@
 /area/service/chapel)
 "qG" = (
 /obj/structure/sign/poster/contraband/random,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/mine/storage)
 "qI" = (
 /obj/effect/turf_decal/bot,
@@ -6102,8 +6128,13 @@
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
 "tV" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Public Mining Storage"
+/obj/machinery/door/airlock/external{
+	glass = 1;
+	name = "Public Mining Storage";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/mine/storage)
@@ -8184,6 +8215,17 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/medical)
+"Bh" = (
+/obj/machinery/door/airlock/external{
+	glass = 1;
+	name = "Public Mining Storage";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/mine/storage)
 "Bi" = (
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/wood,
@@ -10154,8 +10196,7 @@
 /turf/open/floor/plating,
 /area/mine/mechbay)
 "Hv" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/closed/wall/r_wall,
 /area/mine/storage)
 "Hw" = (
 /turf/open/floor/iron/dark/side{
@@ -10862,6 +10903,10 @@
 	dir = 1
 	},
 /area/service/hydroponics)
+"JK" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/mine/storage)
 "JL" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -13106,6 +13151,15 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plating,
 /area/mine/production)
+"QW" = (
+/obj/machinery/door/airlock/external{
+	glass = 1;
+	name = "Public Mining Storage";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron/dark,
+/area/mine/storage)
 "QX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -13751,8 +13805,8 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "SR" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall,
 /area/mine/storage)
 "SS" = (
 /obj/structure/table/wood,
@@ -14971,6 +15025,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"WK" = (
+/obj/structure/sign/warning/xeno_mining{
+	pixel_x = -30
+	},
+/turf/open/floor/iron/dark,
+/area/mine/storage)
 "WM" = (
 /obj/machinery/shower{
 	pixel_y = 22
@@ -15294,8 +15354,8 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "XV" = (
-/obj/structure/sign/warning,
-/turf/closed/wall,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/asteroid/snow/icemoon,
 /area/mine/storage)
 "XW" = (
 /obj/machinery/door/window/northleft{
@@ -15640,6 +15700,17 @@
 /obj/item/stack/rods/ten,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"YZ" = (
+/obj/machinery/door/airlock/external{
+	glass = 1;
+	name = "Public Mining Storage";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/mine/storage)
 "Za" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -15894,6 +15965,10 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/medical/virology)
+"ZN" = (
+/obj/structure/sign/warning/xeno_mining,
+/turf/open/floor/plating/asteroid/snow/icemoon,
+/area/mine/storage)
 "ZP" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -43084,9 +43159,9 @@ ak
 ak
 ak
 NH
+XV
 NH
-NH
-NH
+XV
 NH
 NH
 NH
@@ -43341,9 +43416,9 @@ ak
 ak
 NH
 NH
-NH
-NH
-NH
+SR
+Bh
+SR
 NH
 NH
 NH
@@ -43599,7 +43674,7 @@ NH
 NH
 NH
 Hv
-NH
+kx
 Hv
 NH
 NH
@@ -43854,11 +43929,11 @@ ak
 ak
 NH
 NH
-AF
-XV
+Hv
+Hv
 tV
-XV
-AF
+Hv
+Hv
 TE
 NH
 ak
@@ -44112,10 +44187,10 @@ ak
 NH
 NH
 qG
+my
 Fj
 Fj
-Fj
-AF
+Hv
 TE
 NH
 ak
@@ -44366,13 +44441,13 @@ ak
 ak
 ak
 ak
-AF
-AF
-AF
+Hv
+Hv
+Hv
 Fj
 Fj
 Fj
-AF
+Hv
 TE
 NH
 ak
@@ -44623,15 +44698,15 @@ ak
 ak
 ak
 ak
-AF
+Hv
 ZB
 AF
 AF
 AF
 AF
-XV
+Hv
 SR
-NH
+JK
 ak
 ak
 ak
@@ -44880,14 +44955,14 @@ ak
 ak
 ak
 ak
-AF
+Hv
 Hy
 fw
 ic
-BJ
-BJ
-tV
-NH
+WK
+QW
+aE
+YZ
 NH
 ak
 ak
@@ -45137,15 +45212,15 @@ ak
 ak
 ak
 ak
-AF
+Hv
 iw
 AF
 AF
 BJ
 AF
-XV
+Hv
 SR
-NH
+JK
 ak
 ak
 ak
@@ -45394,13 +45469,13 @@ ak
 ak
 ak
 ak
-AF
-AF
-AF
+Hv
+Hv
+Hv
 iX
 uP
 Ja
-AF
+Hv
 sT
 NH
 ak
@@ -45653,11 +45728,11 @@ ak
 ak
 NH
 sT
-AF
+Hv
 Sk
 KT
 LW
-AF
+Hv
 NH
 NH
 ak
@@ -45910,11 +45985,11 @@ ak
 NH
 NH
 NH
-AF
-AF
-AF
-AF
-AF
+Hv
+Hv
+Hv
+Hv
+Hv
 NH
 NH
 ak
@@ -46944,7 +47019,7 @@ ak
 ak
 ak
 NH
-NH
+ZN
 NH
 NH
 ak


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Downstairs Public Mining Storage on Ice Box uses normal airlocks to the outside instead of pairs of external airlocks. 

![](https://camo.githubusercontent.com/f739ff0a228a2b0ae1fd846c410709e9bb9caa9cd6cafdae7a56c79acd8eb193/68747470733a2f2f6d64622e616666656374656461726330372e636f2e756b2f46696c65732f333233343938372f343936313633363834332f302f6265666f72652e706e67)

When somebody uses them, the lower part becomes cold, depressurised and airless and the top part is constantly triggering fire alarms. The cold seeps out into Central Primary and eventually it becomes firelocked too.

This replaces them with two sets of normal external airlocks, which are used everywhere else on Ice Box. 

![](https://camo.githubusercontent.com/fd3f5886325b9df8a54ea9368bd4312b0b2b7891253fd41bfb3d3a78a01e6b48/68747470733a2f2f6d64622e616666656374656461726330372e636f2e756b2f46696c65732f333233343938372f343936313633363834332f302f61667465722e706e67)

Also replaced the external regular walls with reinforced ones as hostile wildlife can't destroy these in one hit. The normal walls get cut through like butter by fauna chasing players, which also causes atmos issues.

Also added some posters describing the hazards out there (instead of just the "external airlock" poster with a picture of someone being thrown into space some of the external airlocks on Ice Box have).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Less atmosphere alarms on Ice Box due to questionable choices in external airlocks and fauna breaking walls.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ice Box Public Mining downstairs now uses proper external airlocks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
