### PR TITLE
Fixes a wizard rod form hard-del + cleans up code

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -56,7 +56,6 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	anchored = TRUE
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 	movement_type = PHASING | FLYING
-	var/mob/living/wizard
 	var/z_original = 0
 	var/destination
 	var/notify = TRUE

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -270,24 +270,28 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		return
 
 	playsound(src, 'sound/effects/meteorimpact.ogg', 100, TRUE)
-	for(var/mob/M in urange(8, src))
-		if(M.stat != CONSCIOUS)
+	for(var/mob/nearby_mob in urange(8, src))
+		if(nearby_mob.stat != CONSCIOUS)
 			continue
-		shake_camera(M, 2, 3)
+		shake_camera(nearby_mob, 2, 3)
 
-	if(wizard)
-		user.visible_message(span_boldwarning("[src] transforms into [wizard] as [user] suplexes them!"), span_warning("As you grab [src], it suddenly turns into [wizard] as you suplex them!"))
-		to_chat(wizard, span_boldwarning("You're suddenly jolted out of rod-form as [user] somehow manages to grab you, slamming you into the ground!"))
-		wizard.Stun(60)
-		wizard.apply_damage(25, BRUTE)
-		qdel(src)
-	else
-		user.client.give_award(/datum/award/achievement/misc/feat_of_strength, user) //rod-form wizards would probably make this a lot easier to get so keep it to regular rods only
-		user.visible_message(span_boldwarning("[user] suplexes [src] into the ground!"), span_warning("You suplex [src] into the ground!"))
-		new /obj/structure/festivus/anchored(drop_location())
-		new /obj/effect/anomaly/flux(drop_location())
-		qdel(src)
+	return suplex_rod(user)
 
+/**
+ * Called when someone manages to suplex the rod.
+ *
+ * Arguments
+ * * strongman - the suplexer of the rod.
+ */
+/obj/effect/immovablerod/proc/suplex_rod(mob/living/strongman)
+	strongman.client?.give_award(/datum/award/achievement/misc/feat_of_strength, strongman)
+	strongman.visible_message(
+		span_boldwarning("[strongman] suplexes [src] into the ground!"),
+		span_warning("You suplex [src] into the ground!")
+		)
+	new /obj/structure/festivus/anchored(drop_location())
+	new /obj/effect/anomaly/flux(drop_location())
+	qdel(src)
 	return TRUE
 
 /* Below are a couple of admin helper procs when dealing with immovable rod memes. */

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -35,12 +35,13 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	priority_announce("What the fuck was that?!", "General Alert")
 
 /datum/round_event/immovable_rod/start()
-	var/datum/round_event_control/immovable_rod/C = control
+	var/datum/round_event_control/immovable_rod/our_controller = control
 	var/startside = pick(GLOB.cardinals)
-	var/turf/endT = get_edge_target_turf(get_random_station_turf(), turn(startside, 180))
-	var/turf/startT = spaceDebrisStartLoc(startside, endT.z)
-	var/atom/rod = new /obj/effect/immovablerod(startT, endT, C.special_target, C.force_looping)
-	C.special_target = null //Cleanup for future event rolls.
+	var/turf/end_turf = get_edge_target_turf(get_random_station_turf(), turn(startside, 180))
+	var/turf/start_turf = spaceDebrisStartLoc(startside, end_turf.z)
+	var/atom/rod = new /obj/effect/immovablerod(start_turf, end_turf, our_controller.special_target, our_controller.force_looping)
+	our_controller.special_target = null //Cleanup for future event rolls.
+	our_controller.force_looping = FALSE
 	announce_to_ghosts(rod)
 
 /obj/effect/immovablerod
@@ -73,13 +74,13 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	/// Whether the rod can loop across other z-levels. The rod will still loop when the z-level is self-looping even if this is FALSE.
 	var/loopy_rod = FALSE
 
-/obj/effect/immovablerod/New(atom/start, atom/end, aimed_at, force_looping)
+/obj/effect/immovablerod/Initialize(mapload, atom/target_atom, atom/specific_target, force_looping = FALSE)
 	. = ..()
 	SSaugury.register_doom(src, 2000)
 
-	var/turf/real_destination = get_turf(end)
+	var/turf/real_destination = get_turf(target_atom)
 	destination_turf = real_destination
-	special_target = aimed_at
+	special_target = specific_target
 	loopy_rod = force_looping
 
 	SSpoints_of_interest.make_point_of_interest(src)
@@ -95,6 +96,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	UnregisterSignal(src, COMSIG_ATOM_ENTERING)
 	SSaugury.unregister_doom(src)
 	destination_turf = null
+	special_target = null
 	return ..()
 
 /obj/effect/immovablerod/examine(mob/user)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -77,7 +77,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	. = ..()
 	SSaugury.register_doom(src, 2000)
 
-	var/turf/real_destination = isturf(end) ? end : get_turf(end)
+	var/turf/real_destination = get_turf(end)
 	destination_turf = real_destination
 	special_target = aimed_at
 	loopy_rod = force_looping
@@ -271,7 +271,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		return
 
 	playsound(src, 'sound/effects/meteorimpact.ogg', 100, TRUE)
-	for(var/mob/nearby_mob in urange(8, src))
+	for(var/mob/living/nearby_mob in urange(8, src))
 		if(nearby_mob.stat != CONSCIOUS)
 			continue
 		shake_camera(nearby_mob, 2, 3)

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -12,47 +12,64 @@
 	invocation_type = INVOCATION_SHOUT
 	action_icon_state = "immrod"
 
-/obj/effect/proc_holder/spell/targeted/rod_form/cast(list/targets,mob/user = usr)
-	var/area/A = get_area(user)
-	if(istype(A, /area/wizard_station))
+/obj/effect/proc_holder/spell/targeted/rod_form/cast(list/targets, mob/user = usr)
+	var/area/our_area = get_area(user)
+	if(istype(our_area, /area/wizard_station))
 		to_chat(user, span_warning("You know better than to trash Wizard Federation property. Best wait until you leave to use [src]."))
 		return
-	for(var/mob/living/M in targets)
-		var/turf/start = get_turf(M)
-		var/obj/effect/immovablerod/wizard/W = new(start, get_ranged_target_turf(start, M.dir, (15 + spell_level * 3)))
-		W.wizard = M
-		W.max_distance += spell_level * 3 //You travel farther when you upgrade the spell
-		W.damage_bonus += spell_level * 20 //You do more damage when you upgrade the spell
-		W.start_turf = start
-		M.forceMove(W)
-		M.notransform = TRUE
-		M.status_flags |= GODMODE
+	for(var/mob/living/caster in targets)
+		var/turf/start = get_turf(caster)
+		var/obj/effect/immovablerod/wizard/wiz_rod = new(start, get_ranged_target_turf(start, caster.dir, (15 + spell_level * 3)))
+		wiz_rod.wizard = WEAKREF(caster)
+		wiz_rod.max_distance += spell_level * 3 //You travel farther when you upgrade the spell
+		wiz_rod.damage_bonus += spell_level * 20 //You do more damage when you upgrade the spell
+		wiz_rod.start_turf = start
 
-//Wizard Version of the Immovable Rod
+		caster.forceMove(wiz_rod)
+		caster.notransform = TRUE
+		caster.status_flags |= GODMODE
 
+/// Wizard Version of the Immovable Rod.
 /obj/effect/immovablerod/wizard
-	var/max_distance = 13
-	var/damage_bonus = 0
-	var/turf/start_turf
 	notify = FALSE
 	dnd_style_level_up = FALSE
+	/// The wizard who's piloting our rod.
+	var/datum/weakref/our_wizard
+	/// The distance the rod will go.
+	var/max_distance = 13
+	/// The damage bonus of the rod when it smacks people.
+	var/damage_bonus = 0
+	/// The turf the rod started from, to calcuate distance.
+	var/turf/start_turf
 
 /obj/effect/immovablerod/wizard/Moved()
 	. = ..()
 	if(get_dist(start_turf, get_turf(src)) >= max_distance)
-		qdel(src)
+		stop_travel()
 
-/obj/effect/immovablerod/wizard/Destroy()
+/obj/effect/immovablerod/wizard/penetrate(mob/living/penetrated)
+	if(penetrated.anti_magic_check())
+		penetrated.visible_message(
+			span_danger("[src] hits [penetrated], but it bounces back, then vanishes!"),
+			span_userdanger("[src] hits you... but it bounces back, then vanishes!"),
+			span_danger("You hear a weak, sad, CLANG.")
+			)
+		stop_travel()
+		return
+
+	penetrated.visible_message(
+		span_danger("[penetrated] is penetrated by an immovable rod!"),
+		span_userdanger("The [src] penetrates you!"),
+		span_danger("You hear a CLANG!"),
+		)
+	penetrated.adjustBruteLoss(70 + damage_bonus)
+
+/obj/effect/immovablerod/wizard/proc/stop_travel()
+	var/mob/living/wizard = our_wizard?.resolve()
 	if(wizard)
 		wizard.status_flags &= ~GODMODE
 		wizard.notransform = FALSE
 		wizard.forceMove(get_turf(src))
-	return ..()
-
-/obj/effect/immovablerod/wizard/penetrate(mob/living/L)
-	if(L.anti_magic_check())
-		L.visible_message(span_danger("[src] hits [L], but it bounces back, then vanishes!") , span_userdanger("[src] hits you... but it bounces back, then vanishes!") , span_danger("You hear a weak, sad, CLANG."))
-		qdel(src)
-		return
-	L.visible_message(span_danger("[L] is penetrated by an immovable rod!") , span_userdanger("The rod penetrates you!") , span_danger("You hear a CLANG!"))
-	L.adjustBruteLoss(70 + damage_bonus)
+		wizard = null
+	start_turf = null
+	qdel(src)

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -93,5 +93,5 @@
 		wizard.status_flags &= ~GODMODE
 		wizard.notransform = FALSE
 		wizard.forceMove(get_turf(src))
-		wizard = null
+		our_wizard = null
 	qdel(src)

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -20,7 +20,7 @@
 	for(var/mob/living/caster in targets)
 		var/turf/start = get_turf(caster)
 		var/obj/effect/immovablerod/wizard/wiz_rod = new(start, get_ranged_target_turf(start, caster.dir, (15 + spell_level * 3)))
-		wiz_rod.wizard = WEAKREF(caster)
+		wiz_rod.our_wizard = WEAKREF(caster)
 		wiz_rod.max_distance += spell_level * 3 //You travel farther when you upgrade the spell
 		wiz_rod.damage_bonus += spell_level * 20 //You do more damage when you upgrade the spell
 		wiz_rod.start_turf = start
@@ -64,9 +64,28 @@
 		)
 	penetrated.adjustBruteLoss(70 + damage_bonus)
 
+/obj/effect/immovablerod/wizard/suplex_rod(mob/living/strongman)
+	var/mob/living/wizard = our_wizard?.resolve()
+	if(QDELETED(wizard))
+		return ..() // There's no wizard in this rod? It's pretty much a normal rod at this point
+
+	strongman.visible_message(
+		span_boldwarning("[src] transforms into [wizard] as [strongman] suplexes them!"),
+		span_warning("As you grab [src], it suddenly turns into [wizard] as you suplex them!")
+		)
+	to_chat(wizard, span_boldwarning("You're suddenly jolted out of rod-form as [strongman] somehow manages to grab you, slamming you into the ground!"))
+	stop_travel()
+	wizard.Stun(60)
+	wizard.apply_damage(25, BRUTE)
+	return TRUE
+
+/**
+ * Called when the wizard rod reaches it's maximum distance.
+ * Dumps out the wizard and deletes.
+ */
 /obj/effect/immovablerod/wizard/proc/stop_travel()
 	var/mob/living/wizard = our_wizard?.resolve()
-	if(wizard)
+	if(!QDELETED(wizard))
 		wizard.status_flags &= ~GODMODE
 		wizard.notransform = FALSE
 		wizard.forceMove(get_turf(src))

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -42,6 +42,10 @@
 	/// The turf the rod started from, to calcuate distance.
 	var/turf/start_turf
 
+/obj/effect/immovablerod/wizard/Destroy(force)
+	start_turf = null
+	return ..()
+
 /obj/effect/immovablerod/wizard/Moved()
 	. = ..()
 	if(get_dist(start_turf, get_turf(src)) >= max_distance)
@@ -90,5 +94,4 @@
 		wizard.notransform = FALSE
 		wizard.forceMove(get_turf(src))
 		wizard = null
-	start_turf = null
 	qdel(src)

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -56,8 +56,9 @@
 
 /obj/effect/immovablerod/wizard/New(atom/start, atom/end, aimed_at, force_looping, mob/living/wizard, max_distance, damage_bonus)
 	. = ..()
-	set_wizard(wizard)
-	start_turf = start
+	if(wizard)
+		set_wizard(wizard)
+	start_turf = get_turf(start)
 	src.max_distance = max_distance
 	src.damage_bonus = damage_bonus
 

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -136,3 +136,5 @@
 	wizard.notransform = FALSE
 	wizard.forceMove(get_turf(src))
 	our_wizard = null
+
+#undef BASE_WIZ_ROD_RANGE

--- a/code/modules/spells/spell_types/rod_form.dm
+++ b/code/modules/spells/spell_types/rod_form.dm
@@ -31,14 +31,14 @@
 	var/rod_damage_bonus = (spell_level * damage_per_spell_rank)
 
 	for(var/mob/living/caster in targets)
-		var/turf/start_turf = get_turf(caster)
 		new /obj/effect/immovablerod/wizard(
-			start_turf,
-			start = start_turf,
-			end = get_ranged_target_turf(start_turf, caster.dir, (rod_max_distance + 2)), // Just a bit over the distance we got
-			wizard = caster,
-			max_distance = rod_max_distance,
-			damage_bonus = rod_damage_bonus,
+			get_turf(caster),
+			get_ranged_target_turf(get_turf(caster), caster.dir, (rod_max_distance + 2)), // Just a bit over the distance we got
+			null,
+			FALSE,
+			caster,
+			rod_max_distance,
+			rod_damage_bonus,
 		)
 
 /// Wizard Version of the Immovable Rod.
@@ -54,11 +54,11 @@
 	/// The turf the rod started from, to calcuate distance.
 	var/turf/start_turf
 
-/obj/effect/immovablerod/wizard/New(atom/start, atom/end, aimed_at, force_looping, mob/living/wizard, max_distance, damage_bonus)
+/obj/effect/immovablerod/wizard/Initialize(mapload, atom/target_atom, atom/specific_target, force_looping = FALSE, mob/living/wizard, max_distance = BASE_WIZ_ROD_RANGE, damage_bonus = 0)
 	. = ..()
 	if(wizard)
 		set_wizard(wizard)
-	start_turf = get_turf(start)
+	start_turf = get_turf(src)
 	src.max_distance = max_distance
 	src.damage_bonus = damage_bonus
 


### PR DESCRIPTION
## About The Pull Request

- Fixes a hard delete with wizard rod form
- Moves the wizard var from the base immovable rod to the wizard subtype
- Cleans up the code a bit. Better var names / more modern. 
- Splits the suplex action into a separate proc for the wizard form of rods. 

## Why It's Good For The Game

hard dels go brrrr

## Changelog

:cl: Melbert
fix: Fixes a hard delete with rod form. Also cleans up some rod code. 
fix: Admin sending a looping rod will no longer make all following rods loop
/:cl:
