### PR TITLE
Fixes balloon alerts sourced on turfs (heavy rain edition) 

### DIFF
--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -107,8 +107,8 @@ Turf and target are separate in case you want to teleport some distance from a t
  * * stop_type - optional - stops looking if stop_type is found in the turf, returning that type (if found).
  **/
 /proc/get_atom_on_turf(atom/movable/something_in_turf, stop_type)
-	if(!istype(atom_on_turf))
-		CRASH("get_atom_on_turf was not passed an /atom/movable! Got [isnull(atom_on_turf) ? "null":"type: [atom_on_turf.type]"]")
+	if(!istype(something_in_turf))
+		CRASH("get_atom_on_turf was not passed an /atom/movable! Got [isnull(something_in_turf) ? "null":"type: [something_in_turf.type]"]")
 
 	var/atom/movable/topmost_thing = something_in_turf
 

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -103,21 +103,21 @@ Turf and target are separate in case you want to teleport some distance from a t
  * will return the mob because it's on the turf.
  *
  * Arguments
- * * atom_on_turf - a movable within the turf.
+ * * something_in_turf - a movable within the turf, somewhere.
  * * stop_type - optional - stops looking if stop_type is found in the turf, returning that type (if found).
  **/
-/proc/get_atom_on_turf(atom/movable/atom_on_turf, stop_type)
+/proc/get_atom_on_turf(atom/movable/something_in_turf, stop_type)
 	if(!istype(atom_on_turf))
 		CRASH("get_atom_on_turf was not passed an /atom/movable! Got [isnull(atom_on_turf) ? "null":"type: [atom_on_turf.type]"]")
 
-	var/atom/thing_in_turf = atom_on_turf
+	var/atom/movable/topmost_thing = something_in_turf
 
-	while(thing_in_turf?.loc && !isturf(thing_on_turf.loc))
-		thing_in_turf = thing_in_turf.loc
-		if(stop_type && istype(thing_in_turf, stop_type))
+	while(topmost_thing?.loc && !isturf(topmost_thing.loc))
+		topmost_thing = topmost_thing.loc
+		if(stop_type && istype(topmost_thing, stop_type))
 			break
 
-	return thing_in_turf
+	return topmost_thing
 
 ///Returns the turf located at the map edge in the specified direction relative to target_atom used for mass driver
 /proc/get_edge_target_turf(atom/target_atom, direction)

--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -98,17 +98,26 @@ Turf and target are separate in case you want to teleport some distance from a t
 	return destination
 
 /**
- * Returns the atom sitting on the turf.
- * For example, using this on a disk, which is in a bag, on a mob, will return the mob because it's on the turf.
- * Optional arg 'type' to stop once it reaches a specific type instead of a turf.
-**/
+ * Returns the top-most atom sitting on the turf.
+ * For example, using this on a disk, which is in a bag, on a mob,
+ * will return the mob because it's on the turf.
+ *
+ * Arguments
+ * * atom_on_turf - a movable within the turf.
+ * * stop_type - optional - stops looking if stop_type is found in the turf, returning that type (if found).
+ **/
 /proc/get_atom_on_turf(atom/movable/atom_on_turf, stop_type)
-	var/atom/turf_to_check = atom_on_turf
-	while(turf_to_check?.loc && !isturf(turf_to_check.loc))
-		turf_to_check = turf_to_check.loc
-		if(stop_type && istype(turf_to_check, stop_type))
+	if(!istype(atom_on_turf))
+		CRASH("get_atom_on_turf was not passed an /atom/movable! Got [isnull(atom_on_turf) ? "null":"type: [atom_on_turf.type]"]")
+
+	var/atom/thing_in_turf = atom_on_turf
+
+	while(thing_in_turf?.loc && !isturf(thing_on_turf.loc))
+		thing_in_turf = thing_in_turf.loc
+		if(stop_type && istype(thing_in_turf, stop_type))
 			break
-	return turf_to_check
+
+	return thing_in_turf
 
 ///Returns the turf located at the map edge in the specified direction relative to target_atom used for mass driver
 /proc/get_edge_target_turf(atom/target_atom, direction)

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -170,7 +170,7 @@
 	approx_lines = max(1, mheight / CHAT_MESSAGE_APPROX_LHEIGHT)
 
 	// Translate any existing messages upwards, apply exponential decay factors to timers
-	message_loc = get_atom_on_turf(target)
+	message_loc = isturf(target) ? target : get_atom_on_turf(target)
 	if (owned_by.seen_messages)
 		var/idx = 1
 		var/combined_height = approx_lines

--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -42,7 +42,7 @@
 		var/atom/movable/movable_source = src
 		bound_width = movable_source.bound_width
 
-	var/image/balloon_alert = image(loc = get_atom_on_turf(src), layer = ABOVE_MOB_LAYER)
+	var/image/balloon_alert = image(loc = isturf(src) ? src : get_atom_on_turf(src), layer = ABOVE_MOB_LAYER)
 	balloon_alert.plane = BALLOON_CHAT_PLANE
 	balloon_alert.alpha = 0
 	balloon_alert.appearance_flags = RESET_ALPHA|RESET_COLOR|RESET_TRANSFORM


### PR DESCRIPTION
## About The Pull Request

- Balloon alerts sourced from turfs will now properly only show on one turf.
- `get_atom_on_turf()` will now `CRASH()` if passed a turf instead of an `atom/movable`. I look through all uses and made sure any place that may send a turf won't, but it SHOULD be fine. 

## Why It's Good For The Game

https://user-images.githubusercontent.com/51863163/151310759-b5055cd5-f924-45de-bbc3-74da77cab941.mp4

## Changelog

:cl: Melbert
fix: Balloon alerts sourced on turfs work properly.
/:cl:
