### PR TITLE
Fixes freezer/heater and thermomachine inconsistency

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -58,8 +58,8 @@
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/board/thermomachine
-	name = "Machine Design (Freezer/Heater Board)"
-	desc = "The circuit board for a freezer/heater."
+	name = "Machine Design (Thermomachine Board)"
+	desc = "The circuit board for a thermomachine."
 	id = "thermomachine"
 	build_path = /obj/item/circuitboard/machine/thermomachine
 	category = list ("Engineering Machinery")
@@ -687,7 +687,7 @@
 
 /datum/design/board/HFR_fuel_input
 	name = "Machine Design (HFR fuel input)"
-	desc = "The circuit board for a freezer/heater."
+	desc = "The circuit board for an HFR fuel input."
 	id = "HFR_fuel_input"
 	build_path = /obj/item/circuitboard/machine/HFR_fuel_input
 	category = list ("Engineering Machinery")
@@ -695,7 +695,7 @@
 
 /datum/design/board/HFR_waste_output
 	name = "Machine Design (HFR waste output)"
-	desc = "The circuit board for a freezer/heater."
+	desc = "The circuit board for an HFR waste output."
 	id = "HFR_waste_output"
 	build_path = /obj/item/circuitboard/machine/HFR_waste_output
 	category = list ("Engineering Machinery")
@@ -703,7 +703,7 @@
 
 /datum/design/board/HFR_moderator_input
 	name = "Machine Design (HFR moderator input)"
-	desc = "The circuit board for a freezer/heater."
+	desc = "The circuit board for an HFR moderator input."
 	id = "HFR_moderator_input"
 	build_path = /obj/item/circuitboard/machine/HFR_moderator_input
 	category = list ("Engineering Machinery")
@@ -711,7 +711,7 @@
 
 /datum/design/board/HFR_corner
 	name = "Machine Design (HFR corner)"
-	desc = "The circuit board for a freezer/heater."
+	desc = "The circuit board for an HFR corner."
 	id = "HFR_corner"
 	build_path = /obj/item/circuitboard/machine/HFR_corner
 	category = list ("Engineering Machinery")
@@ -719,7 +719,7 @@
 
 /datum/design/board/HFR_interface
 	name = "Machine Design (HFR interface)"
-	desc = "The circuit board for a freezer/heater."
+	desc = "The circuit board for an HFR interface."
 	id = "HFR_interface"
 	build_path = /obj/item/circuitboard/machine/HFR_interface
 	category = list ("Engineering Machinery")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes the thermomachine board being listed as a freezer/heater board in the circuit imprinter. There was also HFR boards that had the same description as the freezer/heater, but to my knowledge the descriptions aren't showed anywhere so it shouldn't matter too much.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Consistency is good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed the thermomachine board being listed as a freezer/heater board in the circuit imprinter.
code: Changes the descriptions of the HFR boards to not be the same as the freezer/heater.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
