### PR TITLE
Fixes paper bluescreening. Truly the digital future we all imagined.

### DIFF
--- a/tgui/packages/tgui/interfaces/PaperSheet.js
+++ b/tgui/packages/tgui/interfaces/PaperSheet.js
@@ -5,6 +5,7 @@
  * @author Changes stylemistake
  * @author Changes ThePotato97
  * @author Changes Ghommie
+ * @author Changes Timberpoes
  * @license MIT
  */
 

--- a/tgui/packages/tgui/interfaces/PaperSheet.js
+++ b/tgui/packages/tgui/interfaces/PaperSheet.js
@@ -10,7 +10,7 @@
 
 import { classes } from 'common/react';
 import { Component } from 'inferno';
-import marked from 'marked';
+import { marked } from 'marked';
 import { useBackend } from '../backend';
 import { Box, Flex, Tabs, TextArea } from '../components';
 import { Window } from '../layouts';
@@ -359,7 +359,7 @@ class PaperSheetStamper extends Component {
 
 // This creates the html from marked text as well as the form fields
 const createPreview = (
-  value, 
+  value,
   text,
   do_fields = false,
   field_counter,
@@ -420,7 +420,7 @@ class PaperSheetEdit extends Component {
 
   createPreviewFromData(value, do_fields = false) {
     const { data } = useBackend(this.context);
-    return createPreview(value, 
+    return createPreview(value,
       this.state.old_text,
       do_fields,
       this.state.counter,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When attempting to enter text in the input field for paper on live (tested on Manuel and Sybil) the following error pops up.

![image](https://user-images.githubusercontent.com/24975989/151426133-e04ce1d5-17b9-43e5-b1f4-ba4d3a60f276.png)

With the benefit of dev tools, this parses much better to non-bundle files as

```
  store FatalError: TypeError: Object expected
  at run_marked_default (./tgui-workspace/packages/tgui/interfaces/PaperSheet.js:103)
  at createPreview (./tgui-workspace/packages/tgui/interfaces/PaperSheet.js:386)
  at createPreviewFromData (./tgui-workspace/packages/tgui/interfaces/PaperSheet.js:423)
  at Anonymous function (./tgui-workspace/packages/tgui/interfaces/PaperSheet.js:451)
  at queueStateChanges (inferno/dist/index.esm.js:2038)
  at setState (inferno/dist/index.esm.js:2146)
  at onInputHandler (./tgui-workspace/packages/tgui/interfaces/PaperSheet.js:451)
  at _this.handleOnInput (./tgui-workspace/packages/tgui/components/TextArea.js:32)
```

Checking out line 103 of PaperSheet.js I noticed nothing out of the ordinary that would trigger this error.

I checked the import and noticed the marked import wasn't wrapped in { braces }. I wrapped it in { braces } since I was wondering if the error was that it expected `marked` itself to be an object, hot updated tgui and I was able to successfully write on paper on the live game servers again, including previewing and saving what I'd written, without it bluescreening.

Not sure WHAT caused this, since this import has been in place without the braces since papercode was converted to tgui.

As a result, I'm gonna CC @stylemistake for their views. The fix works, but I'm not sure why it went from working to broken seemingly out of nowhere.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Roleplay is good. Paper facilitates roleplay. Also paper shouldn't bluescreen. Probably.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Attempting to write to paper no longer comically bluescreens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
