### PR TITLE
return null in get_item_for_held_index, and not FALSE

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -28,7 +28,7 @@
 /mob/proc/get_item_for_held_index(i)
 	if(i > 0 && i <= held_items.len)
 		return held_items[i]
-	return FALSE
+	return null
 
 
 //Odd = left. Even = right


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
`isnull(held_item)` does not pass for ghosts, and that's idiotic.

I'm making this PR now as a reminder for myself, as I'm working on another feature right now. Will be looking over all cases of this and make sure this doesn't break anything.

Don't tell me to remove the line and return null implicitly please I like when it's clear and obvious