### PR TITLE
Secbots call out real names

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -307,7 +307,7 @@
 		current_target.Paralyze(100)
 		var/mob/living/carbon/human/human_target = current_target
 		threat = human_target.assess_threat(judgement_criteria, weaponcheck = CALLBACK(src, .proc/check_for_weapons))
-		target_name = human_target.get_id_name()
+		target_name = human_target.get_face_name(get_id_name())
 	else
 		current_target.Paralyze(100)
 		current_target.stuttering = 5

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -298,6 +298,7 @@
 	icon_state = "[initial(icon_state)]-c"
 	addtimer(CALLBACK(src, /atom.proc/update_appearance), 0.2 SECONDS)
 	var/threat = 5
+	var/target_name = current_target
 
 	if(harm)
 		weapon.attack(current_target, src)
@@ -306,6 +307,7 @@
 		current_target.Paralyze(100)
 		var/mob/living/carbon/human/human_target = current_target
 		threat = human_target.assess_threat(judgement_criteria, weaponcheck = CALLBACK(src, .proc/check_for_weapons))
+		target_name = human_target.get_id_name()
 	else
 		current_target.Paralyze(100)
 		current_target.stuttering = 5
@@ -314,7 +316,7 @@
 	log_combat(src, target, "stunned")
 	if(security_mode_flags & SECBOT_DECLARE_ARRESTS)
 		var/area/location = get_area(src)
-		speak("[security_mode_flags & SECBOT_HANDCUFF_TARGET ? "Arresting" : "Detaining"] level [threat] scumbag <b>[current_target]</b> in [location].", radio_channel)
+		speak("[security_mode_flags & SECBOT_HANDCUFF_TARGET ? "Arresting" : "Detaining"] level [threat] scumbag <b>[target_name]</b> in [location].", radio_channel)
 	current_target.visible_message(span_danger("[src] stuns [current_target]!"),\
 							span_userdanger("[src] stuns you!"))
 

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -307,7 +307,7 @@
 		current_target.Paralyze(100)
 		var/mob/living/carbon/human/human_target = current_target
 		threat = human_target.assess_threat(judgement_criteria, weaponcheck = CALLBACK(src, .proc/check_for_weapons))
-		target_name = human_target.get_face_name(get_id_name())
+		target_name = human_target.get_face_name(human_target.get_id_name())
 	else
 		current_target.Paralyze(100)
 		current_target.stuttering = 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
"Detaining level 10 scumbag **Chadley (as Hentai Enjoyer)** in the Bar."
This pr simply removes "(as id name)" when secbots are calling out arrests. Something quick I remembered I wanted to do but never got to it

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's weird to have them call out whos ID they're holding when the code for assessing a human's wanted threat relies on the face.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Secbots no longer call out differing voice and ID names, i.e. "Arresting level 10 scumbag Nutty (as Verbs-The-Noun)"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
