### PR TITLE
The mc now detects if its priority budget gets out of sync with reality and soft resets.

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -511,7 +511,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 			else
 				//error state
 				if (. == 0)
-					log_world("MC: tick_budget sync error. [json_encode(list(current_tick_budget, queue_priority_count, queue_priority_count_bg, bg_calc, SS, queue_node_priority))]")
+					log_world("MC: tick_budget sync error. [json_encode(list(current_tick_budget, queue_priority_count, queue_priority_count_bg, bg_calc, queue_node, queue_node_priority))]")
 				. = -1
 				tick_precentage = tick_remaining //just because we lost track of priority calculations doesn't mean we can't try to finish off the run, if the error state persists, we don't want to stop ticks from happening
 

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -505,7 +505,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 					bg_calc = TRUE
 				else
 					//error state, do sane fallback behavior
-					if (. = 0)
+					if (. == 0)
 						log_world("MC: Queue logic failure, non-background subsystem queued to run after a background subsystem: [queue_node] queue_prev:[queue_node.queue_prev]")
 					. = -1
 					current_tick_budget = queue_priority_count //this won't even be right, but is the closet we have.

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -499,9 +499,18 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 				queue_node = queue_node.queue_next
 				continue
 
-			if (!bg_calc && (queue_node_flags & SS_BACKGROUND))
-				current_tick_budget = queue_priority_count_bg
-				bg_calc = TRUE
+			if ((queue_node_flags & SS_BACKGROUND))
+				if (!bg_calc)
+					current_tick_budget = queue_priority_count_bg
+					bg_calc = TRUE
+				else
+					//error state, do sane fallback behavior
+					if (. = 0)
+						log_world("MC: Queue logic failure, non-background subsystem queued to run after a background subsystem: [queue_node] queue_prev:[queue_node.queue_prev]")
+					. = -1
+					current_tick_budget = queue_priority_count //this won't even be right, but is the closet we have.
+					bg_calc = FALSE
+					
 
 			tick_remaining = TICK_LIMIT_RUNNING - TICK_USAGE
 

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -588,7 +588,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 // called if any mc's queue procs runtime or exit improperly.
 /datum/controller/master/proc/SoftReset(list/ticker_SS, list/runlevel_SS)
 	. = 0
-	log_world("MC: SoftReset called, resetting MC queue state.")
+	stack_trace("MC: SoftReset called, resetting MC queue state.")
+
 	if (!istype(subsystems) || !istype(ticker_SS) || !istype(runlevel_SS))
 		log_world("MC: SoftReset: Bad list contents: '[subsystems]' '[ticker_SS]' '[runlevel_SS]'")
 		return

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -513,19 +513,19 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 				if (!bg_calc)
 					current_tick_budget = queue_priority_count_bg
 					bg_calc = TRUE
-				else
-					//error state, do sane fallback behavior
-					if (. == 0)
-						log_world("MC: Queue logic failure, non-background subsystem queued to run after a background subsystem: [queue_node] queue_prev:[queue_node.queue_prev]")
-					. = -1
-					current_tick_budget = queue_priority_count //this won't even be right, but is the closet we have.
-					bg_calc = FALSE
-					
+			else if (bg_calc)
+				//error state, do sane fallback behavior
+				if (. == 0)
+					log_world("MC: Queue logic failure, non-background subsystem queued to run after a background subsystem: [queue_node] queue_prev:[queue_node.queue_prev]")
+				. = -1
+				current_tick_budget = queue_priority_count //this won't even be right, but is the best we have.
+				bg_calc = FALSE
+
 
 			tick_remaining = TICK_LIMIT_RUNNING - TICK_USAGE
 
-			if (current_tick_budget > 0 && queue_node_priority > 0)
-				//Give the subsystem a precentage of the remaining tick based on the remaning priority
+			if (queue_node_priority >= 0 && current_tick_budget > 0 && current_tick_budget >= queue_node_priority)
+				//Give the subsystem a precentage of the remaining tick based on the remaining priority
 				tick_precentage = tick_remaining * (queue_node_priority / current_tick_budget)
 			else
 				//error state

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -401,7 +401,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 				iteration++
 			error_level++
 			current_ticklimit = TICK_LIMIT_RUNNING
-			sleep((1 SECOND) * error_level)
+			sleep((1 SECONDS) * error_level)
 			continue
 
 		if (queue_head)
@@ -413,9 +413,10 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 					iteration++
 				error_level++
 				current_ticklimit = TICK_LIMIT_RUNNING
-				sleep((1 SECOND) * error_level)
+				sleep((1 SECONDS) * error_level)
 				continue
-		error_level--
+		if (error_level > 0)
+			error_level--
 		if (!queue_head) //reset the counts if the queue is empty, in the off chance they get out of sync
 			queue_priority_count = 0
 			queue_priority_count_bg = 0


### PR DESCRIPTION
This should fix background subsystems getting allocated the entirety of the tick, while making the error state more loud.


I have a feeling thou, that this will lead to the mc resetting every tick the moment its tested, as this is a core logic error in the tracking of what subsystems are queued or not, so i don't think its intermittent. after i download the zip and test we'll know.