### PR TITLE
Fix the mc getting completely fucked in the brain due to background ticker subsystems

### DIFF
--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -168,7 +168,7 @@
 		queue_node_priority = queue_node.queued_priority
 		queue_node_flags = queue_node.flags
 
-		if (queue_node_flags & SS_TICKER)
+		if (queue_node_flags & (SS_TICKER|SS_BACKGROUND)) == SS_TICKER)
 			if ((SS_flags & (SS_TICKER|SS_BACKGROUND)) != SS_TICKER)
 				continue
 			if (queue_node_priority < SS_priority)

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -168,7 +168,7 @@
 		queue_node_priority = queue_node.queued_priority
 		queue_node_flags = queue_node.flags
 
-		if (queue_node_flags & (SS_TICKER|SS_BACKGROUND)) == SS_TICKER)
+		if (queue_node_flags & (SS_TICKER|SS_BACKGROUND) == SS_TICKER)
 			if ((SS_flags & (SS_TICKER|SS_BACKGROUND)) != SS_TICKER)
 				continue
 			if (queue_node_priority < SS_priority)


### PR DESCRIPTION
When the first bug with background + ticker subsystems was reported, like 4 years ago, I should have just stated that the behavior was undefined and an error condition and updated the comments on the flags.

I pay every day for that mistake.

Heavy amount of credit to @LemonInTheDark who helped log and debug the mc's state tick by tick, subsystem fire by subsystem fire.