### PR TITLE
Change NodeJS on Windows to 64-bit, downgrade to v14.16.1

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,8 +11,8 @@ export BYOND_MINOR=1560
 export RUST_G_VERSION=0.5.0
 
 #node version
-export NODE_VERSION=16
-export NODE_VERSION_PRECISE=16.13.1
+export NODE_VERSION=14
+export NODE_VERSION_PRECISE=14.16.1
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.7.1

--- a/tools/bootstrap/node.bat
+++ b/tools/bootstrap/node.bat
@@ -1,4 +1,5 @@
 @echo off
+set NODE_SKIP_PLATFORM_CHECK=1
 call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Download-Node
 for /f "tokens=* USEBACKQ" %%s in (`
 	call powershell -NoLogo -ExecutionPolicy Bypass -File "%~dp0\node_.ps1" Get-Path

--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -30,8 +30,8 @@ if ($Env:TG_BOOTSTRAP_CACHE) {
 	$Cache = $Env:TG_BOOTSTRAP_CACHE
 }
 $NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_PRECISE"
-$NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x86/node.exe"
-$NodeTargetDir = "$Cache\node-v$NodeVersion"
+$NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x64/node.exe"
+$NodeTargetDir = "$Cache\node-v$NodeVersion-x64"
 $NodeTarget = "$NodeTargetDir\node.exe"
 
 ## Just print the path and exit


### PR DESCRIPTION
## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/64511.

This does not dramatically increase the physical memory usage of the build scripts, it seems likely that lots of NodeJS stuff involving WASM uses a bunch of virtual memory for some reason.

Let's see if it works...

