### PR TITLE
Fixes the "skeletal guardian" away mission role not being a skeleton.

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/away_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/away_roles.dm
@@ -9,6 +9,7 @@
 	icon_state = "remains"
 	mob_name = "skeleton"
 	prompt_name = "a skeletal guardian"
+	mob_species = /datum/species/skeleton
 	you_are_text = "By unknown powers, your skeletal remains have been reanimated!"
 	flavour_text = "Walk this mortal plane and terrorize all living adventurers who dare cross your path."
 	spawner_job_path = /datum/job/skeleton


### PR DESCRIPTION
## About The Pull Request
See the title. RATTLE ME BONES!

## Why It's Good For The Game
This will fix #64489.

## Changelog

:cl:
fix: Fixed the "skeletal guardian" away mission role not being a skeleton.
/:cl:
