### PR TITLE
Fixes the Illegal tech node being unobtainable

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1994,6 +1994,12 @@
 
 /datum/techweb_node/syndicate_basic/New() //Crappy way of making syndicate gear decon supported until there's another way.
 	. = ..()
+	if(!SStraitor.initialized)
+		RegisterSignal(SStraitor, COMSIG_SUBSYSTEM_POST_INITIALIZE, .proc/register_uplink_items)
+	else
+		register_uplink_items()
+
+/datum/techweb_node/syndicate_basic/proc/register_uplink_items()
 	boost_item_paths = list()
 	for(var/datum/uplink_item/item_path as anything in SStraitor.uplink_items_by_type)
 		var/datum/uplink_item/item = SStraitor.uplink_items_by_type[item_path]

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -2000,6 +2000,7 @@
 		register_uplink_items()
 
 /datum/techweb_node/syndicate_basic/proc/register_uplink_items()
+	UnregisterSignal(SStraitor, COMSIG_SUBSYSTEM_POST_INITIALIZE)
 	boost_item_paths = list()
 	for(var/datum/uplink_item/item_path as anything in SStraitor.uplink_items_by_type)
 		var/datum/uplink_item/item = SStraitor.uplink_items_by_type[item_path]

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -2000,6 +2000,7 @@
 		register_uplink_items()
 
 /datum/techweb_node/syndicate_basic/proc/register_uplink_items()
+	SIGNAL_HANDLER
 	UnregisterSignal(SStraitor, COMSIG_SUBSYSTEM_POST_INITIALIZE)
 	boost_item_paths = list()
 	for(var/datum/uplink_item/item_path as anything in SStraitor.uplink_items_by_type)


### PR DESCRIPTION
## About The Pull Request
The loop responsible for storing uplink item paths in the `boost_item_paths` list of that node has been moved to its own proc which is called once the SStraitor subsystem has finished initializing.

## Why It's Good For The Game
This will fix #64284

## Changelog

:cl:
fix: Fixed the Illegal tech node being unobtainable.
/:cl:
