### PR TITLE
Adjusts Sleeper's Directional Variants in Medbay Mapping (and more)

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -33204,7 +33204,9 @@
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "ene" = (
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -34334,7 +34336,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "eDj" = (
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -16263,7 +16263,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "eRR" = (
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/large,
 /area/medical/treatment_center)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -30112,6 +30112,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
+"isu" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/stasis{
+	dir = 4
+	},
+/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "isE" = (
 /obj/structure/dresser,
 /obj/machinery/newscaster/directional/north,
@@ -94850,7 +94868,7 @@ uWR
 dux
 mVW
 dux
-jqO
+isu
 nCO
 gIf
 vjp

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -269,7 +269,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "aX" = (
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "aY" = (

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -1333,6 +1333,18 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/escape)
+"Rk" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/stasis{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/escape)
 "TK" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -1757,7 +1769,7 @@ ay
 aE
 aE
 aL
-aQ
+Rk
 af
 aY
 ba

--- a/_maps/shuttles/emergency_donut.dmm
+++ b/_maps/shuttles/emergency_donut.dmm
@@ -470,6 +470,12 @@
 /obj/structure/table/optable,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"im" = (
+/obj/machinery/stasis{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -752,7 +758,7 @@ aW
 aX
 aZ
 ac
-bf
+im
 bg
 bp
 ab

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -1617,6 +1617,13 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"XD" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/stasis{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aa
@@ -1772,7 +1779,7 @@ bD
 bK
 cg
 cm
-cu
+XD
 cE
 cN
 cW

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -610,15 +610,6 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/carpet/green,
 /area/shuttle/escape/luxury)
-"ca" = (
-/obj/machinery/iv_drip,
-/mob/living/simple_animal/bot/medbot{
-	name = "\improper emergency medibot";
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/turf/open/floor/carpet/cyan,
-/area/shuttle/escape/luxury)
 "cb" = (
 /obj/machinery/stasis,
 /turf/open/floor/carpet/cyan,
@@ -633,12 +624,6 @@
 "cd" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Emergency Shuttle Infirmary"
-	},
-/turf/open/floor/carpet/cyan,
-/area/shuttle/escape/luxury)
-"ce" = (
-/obj/machinery/vending/wallmed/directional/east{
-	use_power = 0
 	},
 /turf/open/floor/carpet/cyan,
 /area/shuttle/escape/luxury)
@@ -693,8 +678,11 @@
 /turf/open/floor/iron,
 /area/shuttle/escape/luxury)
 "cl" = (
-/obj/structure/table/optable,
-/obj/item/surgical_drapes,
+/mob/living/simple_animal/bot/medbot{
+	name = "\improper emergency medibot";
+	pixel_x = -3;
+	pixel_y = 2
+	},
 /turf/open/floor/carpet/cyan,
 /area/shuttle/escape/luxury)
 "cm" = (
@@ -825,11 +813,6 @@
 /turf/open/floor/carpet/green,
 /area/shuttle/escape/luxury)
 "cG" = (
-/obj/machinery/stasis,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/cyan,
-/area/shuttle/escape/luxury)
-"cH" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/advanced,
 /obj/item/storage/firstaid/regular,
@@ -860,7 +843,13 @@
 	pixel_x = 3;
 	pixel_y = -2
 	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/cyan,
+/area/shuttle/escape/luxury)
+"cH" = (
 /obj/machinery/light/directional/south,
+/obj/structure/table/optable,
+/obj/item/surgical_drapes,
 /turf/open/floor/carpet/cyan,
 /area/shuttle/escape/luxury)
 "cI" = (
@@ -905,6 +894,14 @@
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape/luxury)
+"zh" = (
+/turf/open/floor/mineral/diamond,
+/area/shuttle/escape/luxury)
+"Eg" = (
+/obj/machinery/vending/wallmed/directional/north,
+/obj/machinery/iv_drip,
+/turf/open/floor/carpet/cyan,
 /area/shuttle/escape/luxury)
 "Lt" = (
 /obj/machinery/door/airlock/security/glass{
@@ -1258,9 +1255,9 @@ aw
 aw
 bP
 ag
-ca
-aB
 cj
+aB
+cm
 ag
 ag
 ag
@@ -1288,9 +1285,9 @@ ag
 aM
 aM
 aM
-aM
+zh
 ag
-cb
+Eg
 aB
 cl
 ag
@@ -1307,8 +1304,8 @@ bl
 bv
 ag
 cb
-ce
-cm
+cb
+cb
 ag
 qa
 bb

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -413,7 +413,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "aY" = (

--- a/_maps/shuttles/emergency_russiafightpit.dmm
+++ b/_maps/shuttles/emergency_russiafightpit.dmm
@@ -528,6 +528,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"gn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/stasis{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/shuttle/escape)
 "iJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -765,7 +772,7 @@ ax
 ax
 ad
 bA
-bD
+gn
 bA
 bK
 bL

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -239,7 +239,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aK" = (
-/obj/machinery/stasis,
+/obj/machinery/stasis{
+	dir = 4
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "aL" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So basically, this PR changes the sleepers in this configuration (ugly):

![image](https://user-images.githubusercontent.com/34697715/151640809-1e99cd1d-2600-4690-8139-c54190d8c4b8.png)

To the sleepers in this configuration (cute and swag):

![image](https://user-images.githubusercontent.com/34697715/151640821-0a69a449-2e64-4745-a70d-b53a44901414.png)

Also, in the Emergency Luxury Shuttle, the sleepers looked like this:

![image](https://user-images.githubusercontent.com/34697715/151641541-55706684-563f-4b7a-aa62-8e0cbf80e2a7.png)

What? That's not worthy for such honorable 500 credit guests! I just rearranged the whole room like such (nothing added):

![image](https://user-images.githubusercontent.com/34697715/151641842-0948b15e-73e0-4082-8ce8-f892f163f9df.png)

And so on, and so forth.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We have such nice directional sprites for stasis beds, and it's pretty weird that some maps use them (Tram and Kilo) but other maps (IceBox, Delta, and Meta) just never really bothered with them. I think it looks a lot nicer to have the white slopey pillow bit against the wall, and have the patient's toes face outwards (like it does on the westernly variant).

I also fixed it in some of the emergency shuttles as well.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: If you're looking through the Medbay on some stations (and shuttles too), take a moment to appreciate that the stasis beds have been re-arranged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
