### PR TITLE
Tweak CIMS to ignore Syndicate Owned crystal.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -52,7 +52,7 @@
 		return
 	for(var/obj/machinery/power/supermatter_crystal/crystal in GLOB.machines)
 		//Exclude Syndicate owned, Delaminating, not within coverage, not on a tile.
-		if (crystal.radio_key == /obj/item/encryptionkey/syndicate || !isturf(crystal.loc) || !(is_station_level(crystal.z) || is_mining_level(crystal.z) || crystal.z == user_turf.z))
+		if (!crystal.include_in_cims || !isturf(crystal.loc) || !(is_station_level(crystal.z) || is_mining_level(crystal.z) || crystal.z == user_turf.z))
 			continue
 		supermatters.Add(crystal)
 		RegisterSignal(crystal, COMSIG_PARENT_QDELETING, .proc/react_to_del)

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -47,15 +47,15 @@
 	for(var/supermatter in supermatters)
 		clear_supermatter(supermatter)
 	supermatters = list()
-	var/turf/T = get_turf(ui_host())
-	if(!T)
+	var/turf/user_turf = get_turf(ui_host())
+	if(!user_turf)
 		return
-	for(var/obj/machinery/power/supermatter_crystal/S in GLOB.machines)
+	for(var/obj/machinery/power/supermatter_crystal/crystal in GLOB.machines)
 		//Exclude Syndicate owned, Delaminating, not within coverage, not on a tile.
-		if (S.radio_key == /obj/item/encryptionkey/syndicate || !isturf(S.loc) || !(is_station_level(S.z) || is_mining_level(S.z) || S.z == T.z))
+		if (crystal.radio_key == /obj/item/encryptionkey/syndicate || !isturf(crystal.loc) || !(is_station_level(crystal.z) || is_mining_level(crystal.z) || crystal.z == user_turf.z))
 			continue
-		supermatters.Add(S)
-		RegisterSignal(S, COMSIG_PARENT_QDELETING, .proc/react_to_del)
+		supermatters.Add(crystal)
+		RegisterSignal(crystal, COMSIG_PARENT_QDELETING, .proc/react_to_del)
 
 /datum/computer_file/program/supermatter_monitor/proc/get_status()
 	. = SUPERMATTER_INACTIVE

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -51,8 +51,8 @@
 	if(!T)
 		return
 	for(var/obj/machinery/power/supermatter_crystal/S in GLOB.machines)
-		// Delaminating, not within coverage, not on a tile.
-		if (!isturf(S.loc) || !(is_station_level(S.z) || is_mining_level(S.z) || S.z == T.z))
+		//Exclude Syndicate owned, Delaminating, not within coverage, not on a tile.
+		if (S.radio_key == /obj/item/encryptionkey/syndicate || !isturf(S.loc) || !(is_station_level(S.z) || is_mining_level(S.z) || S.z == T.z))
 			continue
 		supermatters.Add(S)
 		RegisterSignal(S, COMSIG_PARENT_QDELETING, .proc/react_to_del)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -244,6 +244,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/processes = TRUE
 	///Stores the time of when the last zap occurred
 	var/last_power_zap = 0
+	///Do we show this crystal in the CIMS modular program
+	var/include_in_cims = TRUE
 
 
 /obj/machinery/power/supermatter_crystal/Initialize(mapload)

--- a/code/modules/ruins/lavalandruin_code/syndicate_base.dm
+++ b/code/modules/ruins/lavalandruin_code/syndicate_base.dm
@@ -53,6 +53,7 @@
 	radio_key = /obj/item/encryptionkey/syndicate
 	engineering_channel = "Syndicate"
 	common_channel = "Syndicate"
+	include_in_cims = FALSE
 
 /obj/machinery/power/supermatter_crystal/shard/syndicate/attackby(obj/item/item, mob/living/user, params)
 	if(istype(item, /obj/item/scalpel/supermatter)) //You can already yoink the docs as a free objective win, another would be just gross


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

One of the modular chunks the Syndicate comms base contains a stolen SM shard to experiment with. When reviewing this I saw the var edits preventing the crystal from talking on the station radio and believed that visibility of the shard from the station was taken care of. I did not check NT CIMS.

Unfortunately it's visible in NT CIMS. I should have caught this.

Closes #64527

Instead of removing the map I have tweaked CIMS to check who owns the crystal. I have added a var on the base SM crystal based on Mothblock's feedback for this purpose. 

## Why It's Good For The Game

Giving the station roundstart knowledge of a ghost role spawning ruin is not acceptable. Particularly since it's a stealthy ghost role.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: NT CIMS no longer detects Supermatter crystals and shards that are not owned by Nanotrasen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
