### PR TITLE
Actually inserts the implant when using an autosurgeon on someone else

### DIFF
--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -82,6 +82,7 @@
 	user.visible_message(span_notice("[user] presses a button on [src], and you hear a short mechanical noise."), span_notice("You press a button on [src] as it plunges into [target]'s body."))
 	to_chat(target, span_notice("You feel a sharp sting as something plunges into your body!"))
 	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, vary = TRUE)
+	storedorgan.Insert(user)//insert stored organ into the user
 	use_autosurgeon()
 
 /obj/item/autosurgeon/organ/screwdriver_act(mob/living/user, obj/item/screwtool)

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -82,7 +82,7 @@
 	user.visible_message(span_notice("[user] presses a button on [src], and you hear a short mechanical noise."), span_notice("You press a button on [src] as it plunges into [target]'s body."))
 	to_chat(target, span_notice("You feel a sharp sting as something plunges into your body!"))
 	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, vary = TRUE)
-	storedorgan.Insert(user)//insert stored organ into the user
+	storedorgan.Insert(target) //let's actually get the organ into the target, yeah?
 	use_autosurgeon()
 
 /obj/item/autosurgeon/organ/screwdriver_act(mob/living/user, obj/item/screwtool)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I forgot to add the code that actually lets the stored organ/implant get implanted on `attack()` when using an autosurgeon on someone, hooray.

## Why It's Good For The Game

Bugs are bad, no gbp
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Using an autosurgeon on someone else now properly gives them the implant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
