### PR TITLE
Lets you flash your luscious hair by undeploying active MODsuit helmets

### DIFF
--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -17,7 +17,7 @@
 	var/obj/item/part = locate(part_reference) in mod_parts
 	if(!istype(part) || user.incapacitated())
 		return
-	if(active || activating)
+	if((active && part != helmet) || activating)
 		balloon_alert(user, "deactivate the suit first!")
 		playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 		return


### PR DESCRIPTION
## About The Pull Request
Basically, just does what hardsuits allowed you to do in the past, and allows you to retract the helmet of your MODsuit at any time, except when the MODsuit's activating or powering down.

No, there's no balance implications here, it's mostly used for roleplay, it makes you no longer pressure-proof, and doesn't invalidate the eating apparatus because that one can still be used in the vacuum of space.

## Why It's Good For The Game
You know you want it.
![image](https://user-images.githubusercontent.com/58045821/151647468-b4fcb123-3d0e-4193-8645-466ad3fa59cb.png)


## Changelog

:cl: GoldenAlpharex
balance: You can now undeploy your MODsuit's helmet, even if your suit is fully activated.
/:cl: