### PR TITLE
toy talking is an audible message instead of a visible message (i blind pr)

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -657,7 +657,7 @@
 		sleep(10)
 
 /obj/item/toy/talking/proc/toy_talk(mob/user, message)
-	user.loc.visible_message("<span class='[span]'>[icon2html(src, viewers(user.loc))] [message]</span>")
+	user.loc.audible_message("<span class='[span]'>[icon2html(src, viewers(user.loc))] [message]</span>")
 	if(chattering)
 		chatter(message, phomeme, user)
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -657,7 +657,7 @@
 		sleep(10)
 
 /obj/item/toy/talking/proc/toy_talk(mob/user, message)
-	user.loc.audible_message("<span class='[span]'>[icon2html(src, viewers(user.loc))] [message]</span>")
+	say(message, spans = list(span))
 	if(chattering)
 		chatter(message, phomeme, user)
 


### PR DESCRIPTION
## About The Pull Request

- Talking toys display their icon and speech audibly, not visibly

## Why It's Good For The Game

it's literally TALKING why is it a VISIBLE MESSAGE oh my god

## Changelog

:cl: Melbert
qol: blind people can hear talking toys
/:cl:
