### PR TITLE
fixed ethereals being unable to charge from APCs

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -798,54 +798,51 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, APC_PIXEL_OFFSET
 /obj/machinery/power/apc/proc/ethereal_interact(mob/living/user,list/modifiers)
 	if(!ishuman(user))
 		return
-	else
-		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/stomach/maybe_stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+	var/mob/living/carbon/human/H = user
+	var/obj/item/organ/stomach/maybe_stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 
-		if(!istype(maybe_stomach, /obj/item/organ/stomach/ethereal))
+	if(!istype(maybe_stomach, /obj/item/organ/stomach/ethereal))
+		return
+	var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - APC_POWER_GAIN
+	var/obj/item/organ/stomach/ethereal/stomach = maybe_stomach
+	if(!((stomach?.drain_time < world.time) && LAZYACCESS(modifiers, RIGHT_CLICK)))
+		return
+	if(H.combat_mode)
+		if(cell.charge <= (cell.maxcharge / 2)) // ethereals can't drain APCs under half charge, this is so that they are forced to look to alternative power sources if the station is running low
+			to_chat(H, span_warning("The APC's syphon safeties prevent you from draining power!"))
 			return
-		else
-			var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - APC_POWER_GAIN
-			var/obj/item/organ/stomach/ethereal/stomach = maybe_stomach
-			if(!((stomach?.drain_time < world.time) && LAZYACCESS(modifiers, RIGHT_CLICK)))
+		if(stomach.crystal_charge > charge_limit)
+			to_chat(H, span_warning("Your charge is full!"))
+			return
+		stomach.drain_time = world.time + APC_DRAIN_TIME
+		to_chat(H, span_notice("You start channeling some power through the APC into your body."))
+		if(do_after(user, APC_DRAIN_TIME, target = src))
+			if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > charge_limit))
 				return
+			to_chat(H, span_notice("You receive some charge from the APC."))
+			stomach.adjust_charge(APC_POWER_GAIN)
+			cell.charge -= APC_POWER_GAIN
+		return
+	else
+		if(cell.charge >= cell.maxcharge - APC_POWER_GAIN)
+			to_chat(H, span_warning("The APC can't receive anymore power!"))
+			return
+		if(stomach.crystal_charge < APC_POWER_GAIN)
+			to_chat(H, span_warning("Your charge is too low!"))
+			return
+		stomach.drain_time = world.time + APC_DRAIN_TIME
+		to_chat(H, span_notice("You start channeling power through your body into the APC."))
+		if(do_after(user, APC_DRAIN_TIME, target = src))
+			if((cell.charge >= (cell.maxcharge - APC_POWER_GAIN)) || (stomach.crystal_charge < APC_POWER_GAIN))
+				to_chat(H, span_warning("You can't transfer power to the APC!"))
+				return
+			if(istype(stomach))
+				to_chat(H, span_notice("You transfer some power to the APC."))
+				stomach.adjust_charge(-APC_POWER_GAIN)
+				cell.charge += APC_POWER_GAIN
 			else
-				if(H.combat_mode)
-					if(cell.charge <= (cell.maxcharge / 2)) // ethereals can't drain APCs under half charge, this is so that they are forced to look to alternative power sources if the station is running low
-						to_chat(H, span_warning("The APC's syphon safeties prevent you from draining power!"))
-						return
-					if(stomach.crystal_charge > charge_limit)
-						to_chat(H, span_warning("Your charge is full!"))
-						return
-					stomach.drain_time = world.time + APC_DRAIN_TIME
-					to_chat(H, span_notice("You start channeling some power through the APC into your body."))
-					if(do_after(user, APC_DRAIN_TIME, target = src))
-						if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > charge_limit))
-							return
-						to_chat(H, span_notice("You receive some charge from the APC."))
-						stomach.adjust_charge(APC_POWER_GAIN)
-						cell.charge -= APC_POWER_GAIN
-					return
-				else
-					if(cell.charge >= cell.maxcharge - APC_POWER_GAIN)
-						to_chat(H, span_warning("The APC can't receive anymore power!"))
-						return
-					if(stomach.crystal_charge < APC_POWER_GAIN)
-						to_chat(H, span_warning("Your charge is too low!"))
-						return
-					stomach.drain_time = world.time + APC_DRAIN_TIME
-					to_chat(H, span_notice("You start channeling power through your body into the APC."))
-					if(do_after(user, APC_DRAIN_TIME, target = src))
-						if((cell.charge >= (cell.maxcharge - APC_POWER_GAIN)) || (stomach.crystal_charge < APC_POWER_GAIN))
-							to_chat(H, span_warning("You can't transfer power to the APC!"))
-							return
-						if(istype(stomach))
-							to_chat(H, span_notice("You transfer some power to the APC."))
-							stomach.adjust_charge(-APC_POWER_GAIN)
-							cell.charge += APC_POWER_GAIN
-						else
-							to_chat(H, span_warning("You can't transfer power to the APC!"))
-					return
+				to_chat(H, span_warning("You can't transfer power to the APC!"))
+		return
 
 /obj/machinery/power/apc/proc/togglelock(mob/living/user)
 	if(obj_flags & EMAGGED)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -781,8 +781,63 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, APC_PIXEL_OFFSET
 		return
 	if(!user.canUseTopic(src, !issilicon(user)) || !isturf(loc))
 		return
-	togglelock(user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/obj/item/organ/stomach/maybe_stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+		if(istype(maybe_stomach, /obj/item/organ/stomach/ethereal))
+			var/obj/item/organ/stomach/ethereal/stomach = maybe_stomach
+			if(stomach.crystal_charge >= ETHEREAL_CHARGE_NORMAL)
+				togglelock(user)
+			ethereal_interact(user,modifiers)
+		else
+			togglelock(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/machinery/power/apc/proc/ethereal_interact(mob/living/user,list/modifiers)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/obj/item/organ/stomach/maybe_stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
+
+		if(istype(maybe_stomach, /obj/item/organ/stomach/ethereal))
+			var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - APC_POWER_GAIN
+			var/obj/item/organ/stomach/ethereal/stomach = maybe_stomach
+			if((stomach?.drain_time < world.time) && LAZYACCESS(modifiers, RIGHT_CLICK))
+				if(H.combat_mode)
+					if(cell.charge <= (cell.maxcharge / 2)) // ethereals can't drain APCs under half charge, this is so that they are forced to look to alternative power sources if the station is running low
+						to_chat(H, span_warning("The APC's syphon safeties prevent you from draining power!"))
+						return
+					if(stomach.crystal_charge > charge_limit)
+						to_chat(H, span_warning("Your charge is full!"))
+						return
+					stomach.drain_time = world.time + APC_DRAIN_TIME
+					to_chat(H, span_notice("You start channeling some power through the APC into your body."))
+					if(do_after(user, APC_DRAIN_TIME, target = src))
+						if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > charge_limit))
+							return
+						to_chat(H, span_notice("You receive some charge from the APC."))
+						stomach.adjust_charge(APC_POWER_GAIN)
+						cell.charge -= APC_POWER_GAIN
+					return
+				else
+					if(cell.charge >= cell.maxcharge - APC_POWER_GAIN)
+						to_chat(H, span_warning("The APC can't receive anymore power!"))
+						return
+					if(stomach.crystal_charge < APC_POWER_GAIN)
+						to_chat(H, span_warning("Your charge is too low!"))
+						return
+					stomach.drain_time = world.time + APC_DRAIN_TIME
+					to_chat(H, span_notice("You start channeling power through your body into the APC."))
+					if(do_after(user, APC_DRAIN_TIME, target = src))
+						if((cell.charge >= (cell.maxcharge - APC_POWER_GAIN)) || (stomach.crystal_charge < APC_POWER_GAIN))
+							to_chat(H, span_warning("You can't transfer power to the APC!"))
+							return
+						if(istype(stomach))
+							to_chat(H, span_notice("You transfer some power to the APC."))
+							stomach.adjust_charge(-APC_POWER_GAIN)
+							cell.charge += APC_POWER_GAIN
+						else
+							to_chat(H, span_warning("You can't transfer power to the APC!"))
+					return
 
 /obj/machinery/power/apc/proc/togglelock(mob/living/user)
 	if(obj_flags & EMAGGED)
@@ -852,51 +907,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, APC_PIXEL_OFFSET
 	. = ..()
 	if(.)
 		return
-
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/stomach/maybe_stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
-
-		if(istype(maybe_stomach, /obj/item/organ/stomach/ethereal))
-			var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - APC_POWER_GAIN
-			var/obj/item/organ/stomach/ethereal/stomach = maybe_stomach
-			if((stomach?.drain_time < world.time) && LAZYACCESS(modifiers, RIGHT_CLICK))
-				if(H.combat_mode)
-					if(cell.charge <= (cell.maxcharge / 2)) // ethereals can't drain APCs under half charge, this is so that they are forced to look to alternative power sources if the station is running low
-						to_chat(H, span_warning("The APC's syphon safeties prevent you from draining power!"))
-						return
-					if(stomach.crystal_charge > charge_limit)
-						to_chat(H, span_warning("Your charge is full!"))
-						return
-					stomach.drain_time = world.time + APC_DRAIN_TIME
-					to_chat(H, span_notice("You start channeling some power through the APC into your body."))
-					if(do_after(user, APC_DRAIN_TIME, target = src))
-						if(cell.charge <= (cell.maxcharge / 2) || (stomach.crystal_charge > charge_limit))
-							return
-						to_chat(H, span_notice("You receive some charge from the APC."))
-						stomach.adjust_charge(APC_POWER_GAIN)
-						cell.charge -= APC_POWER_GAIN
-					return
-				else
-					if(cell.charge >= cell.maxcharge - APC_POWER_GAIN)
-						to_chat(H, span_warning("The APC can't receive anymore power!"))
-						return
-					if(stomach.crystal_charge < APC_POWER_GAIN)
-						to_chat(H, span_warning("Your charge is too low!"))
-						return
-					stomach.drain_time = world.time + APC_DRAIN_TIME
-					to_chat(H, span_notice("You start channeling power through your body into the APC."))
-					if(do_after(user, APC_DRAIN_TIME, target = src))
-						if((cell.charge >= (cell.maxcharge - APC_POWER_GAIN)) || (stomach.crystal_charge < APC_POWER_GAIN))
-							to_chat(H, span_warning("You can't transfer power to the APC!"))
-							return
-						if(istype(stomach))
-							to_chat(H, span_notice("You transfer some power to the APC."))
-							stomach.adjust_charge(-APC_POWER_GAIN)
-							cell.charge += APC_POWER_GAIN
-						else
-							to_chat(H, span_warning("You can't transfer power to the APC!"))
-					return
 
 	if(opened && (!issilicon(user)))
 		if(cell)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -781,27 +781,35 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/power/apc/auto_name, APC_PIXEL_OFFSET
 		return
 	if(!user.canUseTopic(src, !issilicon(user)) || !isturf(loc))
 		return
-	if(ishuman(user))
+	if(!ishuman(user))
+		return
+	else
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/stomach/maybe_stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
-		if(istype(maybe_stomach, /obj/item/organ/stomach/ethereal))
+		if(!istype(maybe_stomach, /obj/item/organ/stomach/ethereal))
+			togglelock(user)
+		else
 			var/obj/item/organ/stomach/ethereal/stomach = maybe_stomach
 			if(stomach.crystal_charge >= ETHEREAL_CHARGE_NORMAL)
 				togglelock(user)
 			ethereal_interact(user,modifiers)
-		else
-			togglelock(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/power/apc/proc/ethereal_interact(mob/living/user,list/modifiers)
-	if(ishuman(user))
+	if(!ishuman(user))
+		return
+	else
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/stomach/maybe_stomach = H.getorganslot(ORGAN_SLOT_STOMACH)
 
-		if(istype(maybe_stomach, /obj/item/organ/stomach/ethereal))
+		if(!istype(maybe_stomach, /obj/item/organ/stomach/ethereal))
+			return
+		else
 			var/charge_limit = ETHEREAL_CHARGE_DANGEROUS - APC_POWER_GAIN
 			var/obj/item/organ/stomach/ethereal/stomach = maybe_stomach
-			if((stomach?.drain_time < world.time) && LAZYACCESS(modifiers, RIGHT_CLICK))
+			if(!((stomach?.drain_time < world.time) && LAZYACCESS(modifiers, RIGHT_CLICK)))
+				return
+			else
 				if(H.combat_mode)
 					if(cell.charge <= (cell.maxcharge / 2)) // ethereals can't drain APCs under half charge, this is so that they are forced to look to alternative power sources if the station is running low
 						to_chat(H, span_warning("The APC's syphon safeties prevent you from draining power!"))


### PR DESCRIPTION
## About The Pull Request

This PR allows ethereals to receive and give charge to APCs again. I had to make some design choices due to the fact there is no clear solution with ethereals having an action with two possible outcomes. I moved ethereal APC charging to its own function called from the right click attack hand function.

## Why It's Good For The Game

APC charging is the main way ethereals gain nutrition and a previous PR made them unable to gain charge from nutrition.
This fixes that as best as possible by making them able to unlock and lock APCs above normal charge(No orange warning battery) with right click.

closes #64517
closes #64485

## Changelog
:cl:
fix: ethereals can now charge themselves using right click, but they will also lock/unlock the APC above normal charge
/:cl: