### PR TITLE
ethereals can now loop charging from lights

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -456,7 +456,8 @@
 				return
 			to_chat(electrician, span_notice("You start channeling some power through the [fitting] into your body."))
 			stomach.drain_time = world.time + LIGHT_DRAIN_TIME
-			if(do_after(user, LIGHT_DRAIN_TIME, target = src))
+			while(do_after(user, LIGHT_DRAIN_TIME, target = src))
+				stomach.drain_time = world.time + LIGHT_DRAIN_TIME
 				if(istype(stomach))
 					to_chat(electrician, span_notice("You receive some charge from the [fitting]."))
 					stomach.adjust_charge(LIGHT_POWER_GAIN)


### PR DESCRIPTION

## About The Pull Request

This PR allows ethereals to stand still next to lights, and keep charging from them without having to click a significant amount of times.

## Why It's Good For The Game

Quality of Life is important and we want to reduce unnecessary click spam.

## Changelog

:cl:

qol: made ethereals charging from lights repeat until they move.

/:cl: