### PR TITLE
Renamed areas rename fire alarm panels too

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -227,17 +227,19 @@
 	return TRUE
 
 
-/proc/set_area_machinery_title(area/A, title, oldtitle)
+/proc/set_area_machinery_title(area/area, title, oldtitle)
 	if(!oldtitle) // or replacetext goes to infinite loop
 		return
-	for(var/obj/machinery/airalarm/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	for(var/obj/machinery/power/apc/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	for(var/obj/machinery/atmospherics/components/unary/vent_pump/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
-	for(var/obj/machinery/door/M in A)
-		M.name = replacetext(M.name,oldtitle,title)
+	for(var/obj/machinery/airalarm/airpanel in area)
+		airpanel.name = replacetext(airpanel.name,oldtitle,title)
+	for(var/obj/machinery/power/apc/apcpanel in area)
+		apcpanel.name = replacetext(apcpanel.name,oldtitle,title)
+	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/scrubber in area)
+		scrubber.name = replacetext(scrubber.name,oldtitle,title)
+	for(var/obj/machinery/atmospherics/components/unary/vent_pump/vent in area)
+		vent.name = replacetext(vent.name,oldtitle,title)
+	for(var/obj/machinery/door/door in area)
+		door.name = replacetext(door.name,oldtitle,title)
+	for(var/obj/machinery/firealarm/firepanel in area)
+		firepanel.name = replacetext(firepanel.name,oldtitle,title)
 	//TODO: much much more. Unnamed airlocks, cameras, etc.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Renaming an area renames machinery in that area. This includes things like APCs and air alarms, but not fire alarms. This fixes that.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes troubleshooting fire alarms easier. They don't display in Canary as being in "The Adminbus" and when you get to the bar you have a "Bar fire alarm" which doesn't clear it and an "Atrium fire alarm" which does but should've been renamed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: cacogen
fix: Fire alarms will be renamed with areas like air alarms, e.g. Bar fire alarm --> The Adminbus fire alarm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
