### PR TITLE
Gives lower Ice Box public mining an air alarm, vent and scrubber

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -16407,6 +16407,12 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"eWg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/commons/storage/mining)
 "eWw" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/secure/briefcase,
@@ -26796,6 +26802,15 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/medical/pharmacy)
 "kbh" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
+	color = "#0000ff";
+	name = "Supply multi deck pipe adapter"
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	color = "#ff0000";
+	name = "Scrubbers multi deck pipe adapter"
+	},
+/obj/effect/turf_decal/stripes/box,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/commons/storage/mining)
@@ -32564,6 +32579,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/commons/storage/mining)
 "nho" = (
@@ -83685,7 +83702,7 @@ bdg
 bed
 bfv
 kbh
-kbh
+eWg
 nhm
 elr
 hhJ

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -1557,6 +1557,8 @@
 /turf/closed/wall,
 /area/icemoon/underground/explored)
 "fw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/mine/storage)
 "fx" = (
@@ -2113,6 +2115,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/mine/eva)
+"hm" = (
+/obj/machinery/button/elevator{
+	id = "publicElevator";
+	pixel_y = -25
+	},
+/obj/machinery/door/window/southleft{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/mine/storage)
 "hn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2362,6 +2374,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"hV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/mine/storage)
 "hX" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -2386,6 +2404,8 @@
 /area/hallway/secondary/service)
 "ic" = (
 /obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/mine/storage)
 "id" = (
@@ -2725,6 +2745,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "iZ" = (
@@ -4256,6 +4278,12 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plating,
 /area/mine/eva)
+"om" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/mine/storage)
 "on" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -6409,6 +6437,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "uS" = (
@@ -6954,6 +6984,12 @@
 "wS" = (
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/unexplored)
+"wT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/mine/storage)
 "wU" = (
 /obj/structure/rack,
 /obj/item/pickaxe,
@@ -7377,6 +7413,12 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
+"yu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/mine/storage)
 "yv" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Service Hall Exit";
@@ -8386,6 +8428,8 @@
 /turf/open/floor/iron/freezer,
 /area/mine/laborcamp)
 "BJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "BL" = (
@@ -9485,6 +9529,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
 "Fj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/plating/elevatorshaft,
 /area/mine/storage)
 "Fk" = (
@@ -10205,6 +10252,15 @@
 /turf/closed/wall,
 /area/service/chapel/office)
 "Hy" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
+	color = "#0000ff";
+	name = "Supply multi deck pipe adapter"
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	color = "#ff0000";
+	name = "Scrubbers multi deck pipe adapter"
+	},
+/obj/effect/turf_decal/stripes/box,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/storage)
@@ -10696,6 +10752,9 @@
 "Ja" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/mine/storage)
@@ -14307,6 +14366,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/parquet,
 /area/service/bar/atrium)
+"Up" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/mine/storage)
 "Uq" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
 	dir = 8
@@ -44179,8 +44244,8 @@ NH
 NH
 qG
 Fj
-Fj
-Fj
+hV
+yu
 Hv
 TE
 NH
@@ -44435,9 +44500,9 @@ ak
 Hv
 Hv
 Hv
-Fj
-Fj
-Fj
+om
+wT
+Up
 Hv
 TE
 NH
@@ -44693,7 +44758,7 @@ Hv
 ZB
 AF
 AF
-AF
+hm
 AF
 Hv
 SR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Upper/lower
![](https://camo.githubusercontent.com/eac64b16f01af877de4eb6e641159ad5f49a02120e797b2d5705a7a92f82b8ad/68747470733a2f2f6d64622e616666656374656461726330372e636f2e756b2f46696c65732f333233343938372f343939343931323635372f302f6265666f72652e706e67) ![](https://camo.githubusercontent.com/9b7610347d789d8c740825b55b4d675dcbbe4d20c12865e01b49f0d672c1841a/68747470733a2f2f6d64622e616666656374656461726330372e636f2e756b2f46696c65732f333233343938372f343939343931323635372f312f6265666f72652e706e67) 

![](https://camo.githubusercontent.com/249f85560a2be6ddd9f3100b6eebb9935cefa65513845b7cbbd3d7da63e58275/68747470733a2f2f6d64622e616666656374656461726330372e636f2e756b2f46696c65732f333233343938372f343939343931323635372f302f61667465722e706e67) ![](https://camo.githubusercontent.com/df51ba5a9acad0dd55bfb612a007bb86b229094062a900a65a6ffa1fd9c5b6bd/68747470733a2f2f6d64622e616666656374656461726330372e636f2e756b2f46696c65732f333233343938372f343939343931323635372f312f61667465722e706e67)

Gives lower Ice Box public mining an air alarm, vent and scrubber. Opens up the elevator shaft to the vent and scrubber. Adds a windoor to the elevator shaft, warning lines around it and an elevator button.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bad air gets in through the airlocks. There's no vent, scrubber or air alarm in the area. Other lower areas such as the one beneath engineering have their own vent and scrubber.

It's not obvious that elevators immediately gib you, so adding a warning line around the bottom of the shaft hopefully indicates to unfamiliar players that this is an empty shaft and not a platform and hints that standing there is a bad idea.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: 
expansion: Gave lower Ice Box public mining an air alarm, vent and scrubber and made its elevator shaft more warning-like
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
