### PR TITLE
Fixes being able to engage in vore.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/deep_fryer.dm
@@ -8,7 +8,8 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	/obj/item/reagent_containers/food/condiment,
 	/obj/item/storage,
 	/obj/item/small_delivery,
-	/obj/item/his_grace)))
+	/obj/item/his_grace,
+	/obj/item/bodybag/bluespace)))
 
 /obj/machinery/deepfryer
 	name = "deep fryer"


### PR DESCRIPTION
## About The Pull Request

Fixes being able to engage in vore via using dwarfism to store someone in a bluespace bodybag, deep frying said body bag, and then eating it.

Actually, I think you were able to do this before dwarfism now that I think about it.

## Why It's Good For The Game

The title speaks for itself.

## Changelog

:cl:
fix: Fixes being able to engage in vore.
/:cl: