### PR TITLE
Fixes a default warning in reference sanity.

### DIFF
--- a/code/modules/unit_tests/find_reference_sanity.dm
+++ b/code/modules/unit_tests/find_reference_sanity.dm
@@ -115,6 +115,7 @@
 /datum/unit_test/find_reference_static_investigation/Run()
 	var/atom/movable/ref_test/victim = allocate(/atom/movable/ref_test)
 	var/atom/movable/ref_holder/testbed = allocate(/atom/movable/ref_holder)
+	pass(testbed)
 	SSgarbage.should_save_refs = TRUE
 
 	//Lets check static vars now, since those can be a real headache


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
Life is pain

## Why It's Good For The Game
Life is pain

## Changelog

Life is pain
