### PR TITLE
Updates IceBoxStation Science to Accommodate Wall Decorations

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -16107,6 +16107,7 @@
 	c_tag = "Research Division West";
 	network = list("ss13","rd")
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},
@@ -24857,7 +24858,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white/side{
 	dir = 10
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR moves around the directional evacuation display in IceBoxStation's medbay to prevent overlap with the posters on the other side of the wall when seen from a top-down view. 

If you're confused, this is what it look like in-game (and in SDMM too):

![image](https://user-images.githubusercontent.com/34697715/151751273-cccc2004-965f-4a6b-abd7-d5baa949e4e5.png)

I moved the Evacuation Display off a little bit just so it won't do that again, like such:

![image](https://user-images.githubusercontent.com/34697715/151751800-fe4bf494-a6a6-4191-9790-cd59b4c62a35.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It doesn't look as weird/conflicting/ugly to AIs/Ghost Roles who can see the entire screen. Very nice!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Nanotrasen moved around some of the wall decorations in IceBoxStation's Science to appease the ghostly overlords (as well as the AI).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
