### PR TITLE
Fix stickyban SS runtiming on initialize

### DIFF
--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -44,6 +44,12 @@ SUBSYSTEM_DEF(stickyban)
 		if (ckey != bannedkey)
 			world.SetConfig("ban", bannedkey, null)
 
+		//get_stickyban_from_ckey returned null, aka something broke. Notify admins about it
+		if (!ban)
+			message_admins("Failed to apply stickyban for [bannedkey]. Check the DB for corrupt stickyban entries.")
+			log_admin_private ("Failed to apply stickyban for [bannedkey]. Check the DB for corrupt stickyban entries.")
+			continue
+
 		if (!ban["ckey"])
 			ban["ckey"] = ckey
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Currently the stickyban subsystem is runtiming on every round start:
![image](https://user-images.githubusercontent.com/33846895/151846156-e6a11809-75a4-4849-86c9-34497acf7813.png)
Most likely some broken entry in the DB.
This PR makes it so it no longer runtimes if get_stickyban_from_ckey doesn't return an entry and instead sends the problematic key to admins logs and chat.

I wasn't really able to test this since I longer have a local DB setup + no idea how the broken entry would even look in the DB.
So maybe testmerge?
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stickyban subsystem crashing on initialize is probably a bad thing and most likely results in some bans not getting applied
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Gamer025
fix: Stickyban subsystem no longer runtimes on invalid entries
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
