### PR TITLE
Adds a GPS to The Lizards Gas

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/thelizardsgas.dmm
+++ b/_maps/RandomRuins/SpaceRuins/thelizardsgas.dmm
@@ -516,6 +516,7 @@
 /area/ruin/space/has_grav/thelizardsgas)
 "VP" = (
 /obj/structure/table/reinforced,
+/obj/item/gps/spaceruin,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Someone brought up to my attention that this space ruin (that I made) was missing one, so I decided to go back and add one so it can be a bit more locatable. How does this affect the lore? Let's just assume that when those hemp ropes loosened themselves and the station cast off from wherever it came from, the proprietor simply forgot that it had a GPS. I'll run with that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Apparently, it was a lot harder to find this ruin (as opposed to the others) due to the lack of a GPS. I added one to be more locatable. I double-checked on local and it still shows up as "Distant Signal", so we should be good on that front.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The Space Ruin "The Lizard's Gas" now has a GPS on it, so you can seek it out a little bit easier now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
