### PR TITLE
Fixes a bunch map log runtimes, adds CI to catch some more potential map issues

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -519,7 +519,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 1;
 	name = "Cargo Bay APC";
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/structure/closet/emcloset/anchored,
 /obj/effect/decal/cleanable/dirt,
@@ -931,7 +931,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 1;
 	name = "Virology APC";
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -2565,7 +2565,7 @@
 	},
 /obj/machinery/power/apc/syndicate{
 	name = "Dormitories APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
@@ -3294,7 +3294,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 1;
 	name = "Engineering APC";
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4{
 	dir = 9
@@ -4072,7 +4072,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/machinery/power/apc/syndicate{
 	name = "Bar APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -4378,7 +4378,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 1;
 	name = "Arrival Hallway APC";
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4680,7 +4680,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 4;
 	name = "Medbay APC";
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/commswilding_1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/commswilding_1.dmm
@@ -106,7 +106,7 @@
 	},
 /obj/machinery/power/apc/syndicate{
 	name = "Telecommunications APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/commswilding_2.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/commswilding_2.dmm
@@ -33,7 +33,7 @@
 	},
 /obj/machinery/power/apc/syndicate{
 	name = "Telecommunications APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /turf/open/floor/wood,
 /area/ruin/syndicate_lava_base/telecomms)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/commswilding_3.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/commswilding_3.dmm
@@ -57,7 +57,7 @@
 	},
 /obj/machinery/power/apc/syndicate{
 	name = "Telecommunications APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_feasible.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_feasible.dmm
@@ -411,7 +411,7 @@
 "X" = (
 /obj/machinery/power/apc/syndicate{
 	name = "Experimentation Lab APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_inevitable.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_inevitable.dmm
@@ -10,7 +10,7 @@
 "be" = (
 /obj/machinery/power/apc/syndicate{
 	name = "Experimentation Lab APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -65,7 +65,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Cargo Bay APC";
-	pixel_x = 24;
+	pixel_x = 25;
 	start_charge = 0
 	},
 /obj/structure/cable,
@@ -658,8 +658,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Power Storage APC";
-	pixel_x = 24;
-	pixel_y = 2;
+	pixel_x = 25;
 	start_charge = 0
 	},
 /obj/structure/cable,
@@ -741,7 +740,7 @@
 "ck" = (
 /obj/machinery/power/apc{
 	name = "Tradepost APC";
-	pixel_y = -23;
+	pixel_y = -25;
 	start_charge = 0
 	},
 /obj/structure/cable,
@@ -1456,7 +1455,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Cargo Storage APC";
-	pixel_x = 24;
+	pixel_x = 25;
 	start_charge = 0
 	},
 /obj/structure/cable,

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -405,7 +405,7 @@
 /obj/machinery/power/apc/unlocked{
 	dir = 1;
 	environ = 0;
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -746,7 +746,7 @@
 /obj/machinery/power/apc/unlocked{
 	dir = 1;
 	environ = 0;
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -904,7 +904,7 @@
 "dN" = (
 /obj/machinery/power/apc/unlocked{
 	dir = 1;
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -128,7 +128,7 @@
 "aE" = (
 /obj/machinery/power/apc/away{
 	name = "Recycling APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -633,7 +633,7 @@
 "bN" = (
 /obj/machinery/power/apc/away{
 	name = "Kitchen APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
@@ -781,7 +781,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Hydroponics APC";
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -790,7 +790,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/away{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -1105,7 +1105,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Storage APC";
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -1507,7 +1507,7 @@
 	},
 /obj/machinery/power/apc/away{
 	name = "Main Area APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -1564,7 +1564,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Armory APC";
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -1795,7 +1795,7 @@
 /obj/machinery/power/apc/away{
 	dir = 1;
 	name = "Airlock Control APC";
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -2062,8 +2062,7 @@
 /obj/machinery/power/apc/away{
 	dir = 8;
 	name = "Power and Atmospherics APC";
-	pixel_x = -25;
-	pixel_y = 1
+	pixel_x = -25
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -2115,7 +2114,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Dormitory APC";
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -327,7 +327,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 1;
 	name = "Syndicate Cargo Pod APC";
-	pixel_y = 32;
+	pixel_y = 25;
 	start_charge = 0
 	},
 /obj/structure/cable,
@@ -444,7 +444,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 1;
 	name = "Syndicate Forgotten Ship APC";
-	pixel_y = 32;
+	pixel_y = 25;
 	start_charge = 0
 	},
 /obj/structure/cable,

--- a/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hellfactory.dmm
@@ -689,7 +689,8 @@
 "cm" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/ten_k{
-	dir = 1
+	dir = 1;
+	pixel_y = 25
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hellfactory)
@@ -969,7 +970,8 @@
 /area/ruin/space/has_grav/hellfactory)
 "wv" = (
 /obj/machinery/power/apc/highcap/ten_k{
-	dir = 1
+	dir = 1;
+	pixel_y = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -858,7 +858,7 @@
 /obj/machinery/power/apc/syndicate{
 	dir = 4;
 	name = "Syndicate Listening Post APC";
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -747,7 +747,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Beta Station Main Corridor APC";
-	pixel_y = 23;
+	pixel_y = 25;
 	start_charge = 0
 	},
 /turf/open/floor/iron,
@@ -1435,7 +1435,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Charlie Station Bridge APC";
-	pixel_y = 23;
+	pixel_y = 25;
 	start_charge = 0
 	},
 /obj/effect/decal/cleanable/cobweb,
@@ -1473,7 +1473,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Delta Station RnD APC";
-	pixel_y = 23;
+	pixel_y = 25;
 	start_charge = 0
 	},
 /turf/open/floor/iron/white,
@@ -2215,7 +2215,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Delta Station Artifical Program Core APC";
-	pixel_x = 24;
+	pixel_x = 25;
 	start_charge = 0
 	},
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -2441,7 +2441,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	name = "Charlie Station Garden APC ";
-	pixel_y = -23;
+	pixel_y = -25;
 	start_charge = 0
 	},
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
@@ -3272,7 +3272,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Charlie Engineering APC";
-	pixel_x = 24;
+	pixel_x = 25;
 	start_charge = 0
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -3920,7 +3920,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Charlie Main Corridor APC";
-	pixel_x = 24;
+	pixel_x = 25;
 	start_charge = 0
 	},
 /obj/structure/cable,
@@ -3995,7 +3995,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Beta Atmospherics APC";
-	pixel_x = 24;
+	pixel_x = 25;
 	start_charge = 0
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4066,7 +4066,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Delta Prototype Lab APC";
-	pixel_y = 23;
+	pixel_y = 25;
 	start_charge = 0
 	},
 /obj/structure/cable,
@@ -4543,7 +4543,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Delta Station Corridor APC";
-	pixel_x = 24;
+	pixel_x = 25;
 	start_charge = 0
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4559,7 +4559,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Charlie Station Kitchen APC";
-	pixel_y = 23;
+	pixel_y = 25;
 	start_charge = 0
 	},
 /obj/structure/cable,
@@ -4922,7 +4922,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Beta Station Medbay APC";
-	pixel_y = 23;
+	pixel_y = 25;
 	start_charge = 0
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -5091,7 +5091,7 @@
 "mQ" = (
 /obj/machinery/power/apc{
 	name = "Beta Station Mining Equipment APC ";
-	pixel_y = -23;
+	pixel_y = -25;
 	start_charge = 0
 	},
 /obj/effect/turf_decal/tile/brown{

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -3,7 +3,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
 	name = "Guest Room APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /turf/open/floor/carpet/purple,
 /area/ruin/space/has_grav/hotel/guestroom/room_5)
@@ -118,7 +118,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Guest Room APC";
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
@@ -204,7 +204,7 @@
 	},
 /obj/machinery/power/apc/highcap/five_k{
 	name = "Dock APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /obj/structure/chair{
@@ -802,7 +802,7 @@
 "hT" = (
 /obj/machinery/power/apc/highcap/five_k{
 	name = "Kitchen APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
@@ -1437,7 +1437,7 @@
 "mh" = (
 /obj/machinery/power/apc/highcap/five_k{
 	name = "Guest Room APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
@@ -1899,7 +1899,7 @@
 "qG" = (
 /obj/machinery/power/apc/highcap/five_k{
 	name = "Custodial APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /obj/structure/sink{
@@ -2987,7 +2987,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Guest Room APC";
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/structure/cable,
 /obj/item/pen,
@@ -3133,7 +3133,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Power Storage APC";
-	pixel_y = 23
+	pixel_y = 25
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/power)
@@ -3606,7 +3606,7 @@
 "MQ" = (
 /obj/machinery/power/apc/highcap/five_k{
 	name = "Pool APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
@@ -3779,7 +3779,7 @@
 /obj/structure/table/wood/fancy/orange,
 /obj/machinery/power/apc/highcap/five_k{
 	name = "Guest Room APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblue,
@@ -4361,7 +4361,7 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/power/apc/highcap/five_k{
 	name = "Staff Room APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /obj/item/gps/spaceruin{
@@ -4675,7 +4675,7 @@
 /obj/item/paper_bin,
 /obj/machinery/power/apc/highcap/five_k{
 	name = "Guest Room APC";
-	pixel_y = -23
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /obj/item/pen,

--- a/_maps/RandomZLevels/Academy.dmm
+++ b/_maps/RandomZLevels/Academy.dmm
@@ -43,7 +43,7 @@
 "aj" = (
 /obj/machinery/power/apc/unlocked{
 	dir = 1;
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -868,7 +868,7 @@
 "ek" = (
 /obj/machinery/power/apc/unlocked{
 	dir = 1;
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
@@ -1652,7 +1652,7 @@
 "hl" = (
 /obj/machinery/power/apc/unlocked{
 	dir = 1;
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -2281,7 +2281,7 @@
 "kh" = (
 /obj/machinery/power/apc/unlocked{
 	dir = 1;
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -2495,7 +2495,7 @@
 "lp" = (
 /obj/machinery/power/apc{
 	dir = 1;
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/vault,

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -1209,7 +1209,7 @@
 "cK" = (
 /obj/machinery/power/apc/highcap/fifteen_k{
 	name = "Worn-out APC";
-	pixel_y = -23;
+	pixel_y = -25;
 	req_access_txt = "150";
 	start_charge = 0
 	},
@@ -2971,7 +2971,7 @@
 	dir = 4;
 	locked = 0;
 	name = "Worn-out APC";
-	pixel_x = 24;
+	pixel_x = 25;
 	start_charge = 100
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -4385,7 +4385,7 @@
 	dir = 1;
 	locked = 0;
 	name = "Worn-out APC";
-	pixel_y = 23;
+	pixel_y = 25;
 	start_charge = 100
 	},
 /obj/structure/cable,

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -390,8 +390,7 @@
 	auto_name = 1;
 	dir = 4;
 	name = "Engineering APC";
-	pixel_x = 24;
-	pixel_y = 2
+	pixel_x = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -780,7 +779,7 @@
 /obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 4;
 	name = "Gateway APC";
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -1077,7 +1076,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Genetics APC";
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -1811,20 +1810,6 @@
 	dir = 8
 	},
 /area/awaymission/research/interior)
-"eo" = (
-/obj/structure/chair/stool/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/awaymission/research/interior/security)
 "ep" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/automatic/pistol/m1911,
@@ -2132,7 +2117,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Cryostatis APC";
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -2314,7 +2299,7 @@
 /obj/machinery/power/apc/highcap/fifteen_k{
 	dir = 4;
 	name = "Vault APC";
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -4525,7 +4510,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 4;
 	name = "Dorms APC";
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -4701,10 +4686,6 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
-/turf/open/floor/iron,
-/area/awaymission/research/interior/dorm)
-"kU" = (
-/obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
 /area/awaymission/research/interior/dorm)
 "kV" = (
@@ -5613,10 +5594,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
-"qo" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/awaymission/research/interior/dorm)
 "qS" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -2460,7 +2460,7 @@
 /obj/machinery/power/apc/highcap/fifteen_k{
 	locked = 0;
 	name = "Hydroponics APC";
-	pixel_y = -23;
+	pixel_y = -25;
 	start_charge = 100
 	},
 /obj/effect/turf_decal/tile/green,
@@ -4676,7 +4676,7 @@
 	dir = 1;
 	locked = 0;
 	name = "UO45 Bar APC";
-	pixel_y = 23;
+	pixel_y = 25;
 	start_charge = 100
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -5687,7 +5687,7 @@
 /obj/machinery/power/apc/highcap/fifteen_k{
 	locked = 0;
 	name = "UO45 Research Division APC";
-	pixel_y = -23;
+	pixel_y = -25;
 	start_charge = 100
 	},
 /obj/structure/disposalpipe/segment{
@@ -6204,7 +6204,7 @@
 /obj/machinery/power/apc/highcap/fifteen_k{
 	locked = 0;
 	name = "UO45 Gateway APC";
-	pixel_y = -23;
+	pixel_y = -25;
 	start_charge = 100
 	},
 /obj/structure/rack,
@@ -9372,7 +9372,7 @@
 /obj/machinery/power/apc/highcap/fifteen_k{
 	locked = 0;
 	name = "UO45 Mining APC";
-	pixel_y = -23;
+	pixel_y = -25;
 	start_charge = 100
 	},
 /obj/machinery/light/small/directional/south,

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -15940,7 +15940,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Public Mining APC";
-	pixel_y = 23
+	pixel_y = 25
 	},
 /obj/item/reagent_containers/food/drinks/bottle/hooch,
 /turf/open/floor/plating,

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -4327,14 +4327,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/mine/laborcamp)
-"UB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/mine/laborcamp)
 "UC" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Mining Station Mech Bay";
@@ -10501,7 +10493,7 @@ ar
 aB
 vj
 vj
-UB
+GY
 GY
 GY
 GY

--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -190,7 +190,7 @@
 	aidisabled = 1;
 	area = "/area/shuttle/syndicate/bridge";
 	name = "Infiltrator E.V.A APC";
-	pixel_y = -26
+	pixel_y = -25
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium/red,
@@ -338,7 +338,7 @@
 	area = "/area/shuttle/syndicate/airlock";
 	dir = 4;
 	name = "Infiltrator Airlock APC";
-	pixel_x = 28
+	pixel_x = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
@@ -409,11 +409,11 @@
 	area = "/area/shuttle/syndicate/hallway";
 	dir = 1;
 	name = "Infiltrator APC";
-	pixel_y = 26
+	pixel_y = 25
 	},
 /obj/machinery/airalarm/syndicate{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
@@ -876,7 +876,7 @@
 	area = "/area/shuttle/syndicate/eva";
 	dir = 1;
 	name = "Infiltrator E.V.A APC";
-	pixel_y = 26
+	pixel_y = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/pod/dark,
@@ -1742,7 +1742,7 @@
 	area = "/area/shuttle/syndicate/medical";
 	dir = 8;
 	name = "Infiltrator Medical APC";
-	pixel_x = -28
+	pixel_x = -25
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -1806,7 +1806,7 @@
 	area = "/area/shuttle/syndicate/armory";
 	dir = 4;
 	name = "Infiltrator Armory APC";
-	pixel_x = 28
+	pixel_x = 25
 	},
 /obj/structure/cable,
 /turf/open/floor/pod/dark,

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -345,11 +345,7 @@
 /obj/item/food/muffin/berry,
 /obj/item/food/tofu,
 /obj/item/food/burrito,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Hospital Ship Crew Quarters APC";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -538,12 +538,14 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	if(note_path && !istype(note_path, /obj/item/paper)) //don't put non-paper in the paper slot thank you
 		log_mapping("[src] at [x],[y] had an improper note_path path, could not place paper note.")
 		qdel(src)
+		return
 	if(locate(/obj/machinery/door/airlock) in turf)
 		var/obj/machinery/door/airlock/found_airlock = locate(/obj/machinery/door/airlock) in turf
 		if(note_path)
 			found_airlock.note = note_path
 			found_airlock.update_appearance()
 			qdel(src)
+			return
 		if(note_info)
 			var/obj/item/paper/paper = new /obj/item/paper(src)
 			if(note_name)
@@ -553,8 +555,10 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 			paper.forceMove(found_airlock)
 			found_airlock.update_appearance()
 			qdel(src)
+			return
 		log_mapping("[src] at [x],[y] had no note_path or note_info, cannot place paper note.")
 		qdel(src)
+		return
 	log_mapping("[src] at [x],[y] could not find an airlock on current turf, cannot place paper note.")
 	qdel(src)
 

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -50,6 +50,13 @@ if grep -Pzo '"\w+" = \(\n[^)]*?/obj/machinery/atmospherics/pipe/(?<type>[/\w]*)
     echo "ERROR: found multiple identical pipes on the same tile, please remove them."
     st=1
 fi;
+if grep -Pzo '/obj/machinery/power/apc[/\w]*?\{\n[^}]*?pixel_[xy] = -?[013-9]\d*?[^\d]*?\s*?\},?\n' _maps/**/*.dmm ||
+	grep -Pzo '/obj/machinery/power/apc[/\w]*?\{\n[^}]*?pixel_[xy] = -?\d+?[0-46-9][^\d]*?\s*?\},?\n' _maps/**/*.dmm ||
+	grep -Pzo '/obj/machinery/power/apc[/\w]*?\{\n[^}]*?pixel_[xy] = -?\d{3,1000}[^\d]*?\s*?\},?\n' _maps/**/*.dmm ;	then
+	echo
+    echo "ERROR: found an APC with a manually set pixel_x or pixel_y that is not +-25."
+    st=1
+fi;
 if grep -P '^/area/.+[\{]' _maps/**/*.dmm;	then
     echo "ERROR: Vareditted /area path use detected in maps, please replace with proper paths."
     st=1

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -6,6 +6,7 @@ shopt -s globstar
 
 st=0
 
+echo "Checking for map issues"
 if grep -El '^\".+\" = \(.+\)' _maps/**/*.dmm;	then
     echo "ERROR: Non-TGM formatted map detected. Please convert it using Map Merger!"
     st=1
@@ -26,7 +27,6 @@ if grep -P 'pixel_[^xy]' _maps/**/*.dmm;	then
     echo "ERROR: incorrect pixel offset variables detected in maps, please remove them."
     st=1
 fi;
-echo "Checking for cable varedits"
 if grep -P '/obj/structure/cable(/\w+)+\{' _maps/**/*.dmm;	then
     echo "ERROR: vareditted cables detected, please remove them."
     st=1
@@ -35,9 +35,19 @@ if grep -P '\td[1-2] =' _maps/**/*.dmm;	then
     echo "ERROR: d1/d2 cable variables detected in maps, please remove them."
     st=1
 fi;
-echo "Checking for stacked cables"
-if grep -P '"\w+" = \(\n([^)]+\n)*/obj/structure/cable,\n([^)]+\n)*/obj/structure/cable,\n([^)]+\n)*/area/.+\)' _maps/**/*.dmm;	then
-    echo "found multiple cables on the same tile, please remove them."
+if grep -Pzo '"\w+" = \(\n[^)]*?/obj/structure/cable,\n[^)]*?/obj/structure/cable,\n[^)]*?/area/.+?\)' _maps/**/*.dmm;	then
+	echo
+    echo "ERROR: found multiple cables on the same tile, please remove them."
+    st=1
+fi;
+if grep -Pzo '"\w+" = \(\n[^)]*?/obj/structure/lattice[/\w]*?,\n[^)]*?/obj/structure/lattice[/\w]*?,\n[^)]*?/area/.+?\)' _maps/**/*.dmm;	then
+	echo
+    echo "ERROR: found multiple lattices on the same tile, please remove them."
+    st=1
+fi;
+if grep -Pzo '"\w+" = \(\n[^)]*?/obj/machinery/atmospherics/pipe/(?<type>[/\w]*),\n[^)]*?/obj/machinery/atmospherics/pipe/\g{type},\n[^)]*?/area/.+\)' _maps/**/*.dmm;	then
+	echo
+    echo "ERROR: found multiple identical pipes on the same tile, please remove them."
     st=1
 fi;
 if grep -P '^/area/.+[\{]' _maps/**/*.dmm;	then
@@ -52,12 +62,11 @@ if grep -P '^/*var/' code/**/*.dm; then
     echo "ERROR: Unmanaged global var use detected in code, please use the helpers."
     st=1
 fi;
-echo "Checking for space indentation"
+echo "Checking for whitespace issues"
 if grep -P '(^ {2})|(^ [^ * ])|(^    +)' code/**/*.dm; then
     echo "space indentation detected"
     st=1
 fi;
-echo "Checking for mixed indentation"
 if grep -P '^\t+ [^ *]' code/**/*.dm; then
     echo "mixed <tab><space> indentation detected"
     st=1
@@ -72,6 +81,7 @@ while read f; do
         st=1
     fi;
 done < <(find . -type f -name '*.dm')
+echo "Checking for common mistakes"
 if grep -P '^/[\w/]\S+\(.*(var/|, ?var/.*).*\)' code/**/*.dm; then
     echo "changed files contains proc argument starting with 'var'"
     st=1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

* Fixes the CI test to detect doubled up cables, and adds one for lattices, another for identical pipes by path, and checks if any APC's have manually set their pixel_x/y to something other than +-25.
* Fixes loads of RandomZ maps that have bad APC pixel offsets. There may be ones I missed that aren't auto directional but also don't set the pixel offset either, as I didn't create a check for that.
* I also removed a doubled up cable on Lavaland Mining. Probably something else somewhere.
* Fixes the airlock note placer map helper, as it was running through multiple code paths and showing errors on success like a madman.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Cleans up loads of runtimes, realistically probably saves like 1 second a startup, but prevents the spamming of mapping runtimes so we can see all the other runtimes in their glory.

This was the entire `map_errors.log` after I fully started a game locally after doing all this (first try):
```log
[2022-02-01 08:05:40.267] There are 3 active turfs at roundstart caused by a difference of the air between the adjacent turfs. You can see its coordinates using "Mapping -> Show roundstart AT list" verb (debug verbs required).
```

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
server: Added some more CI linter checks for maps, that are otherwise caught at runtime. This will likely fail downstream maps if they're double stacking objects which aren't allowed to stack, or misplacing APC's.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
