### PR TITLE
Fixes BEPIS giving tech for free anymore and fixes unreachable message

### DIFF
--- a/code/modules/research/bepis.dm
+++ b/code/modules/research/bepis.dm
@@ -7,6 +7,7 @@
 #define MAJOR_THRESHOLD 6*CARGO_CRATE_VALUE
 #define MINOR_THRESHOLD 4*CARGO_CRATE_VALUE
 #define STANDARD_DEVIATION 2*CARGO_CRATE_VALUE
+#define PART_CASH_OFFSET_AMOUNT 0.5*CARGO_CRATE_VALUE
 
 /obj/machinery/rnd/bepis
 	name = "\improper B.E.P.I.S. Chamber"
@@ -91,10 +92,10 @@
 		C += ((Cap.rating - 1) * 0.1)
 	power_saver = 1 - C
 	for(var/obj/item/stock_parts/manipulator/Manip in component_parts)
-		M += ((Manip.rating - 1) * 250)
+		M += ((Manip.rating - 1) * PART_CASH_OFFSET_AMOUNT)
 	positive_cash_offset = M
 	for(var/obj/item/stock_parts/micro_laser/Laser in component_parts)
-		L += ((Laser.rating - 1) * 250)
+		L += ((Laser.rating - 1) * PART_CASH_OFFSET_AMOUNT)
 	negative_cash_offset = L
 	for(var/obj/item/stock_parts/scanning_module/Scan in component_parts)
 		S += ((Scan.rating - 1) * 0.25)
@@ -258,12 +259,12 @@
 	flick("chamber_flash",src)
 	update_appearance()
 	banked_cash = 0
-	if((gauss_real >= gauss_major) && (SSresearch.techweb_nodes_experimental.len > 0)) //Major Success.
-		say("Experiment concluded with major success. New technology node discovered on technology disc.")
-		new /obj/item/disk/tech_disk/major(dropturf,1)
-		if(SSresearch.techweb_nodes_experimental.len == 0)
-			say("Expended all available experimental technology nodes. Resorting to minor rewards.")
-		return
+	if((gauss_real >= gauss_major)) //Major Success.
+		if(SSresearch.techweb_nodes_experimental.len > 0)
+			say("Experiment concluded with major success. New technology node discovered on technology disc.")
+			new /obj/item/disk/tech_disk/major(dropturf,1)
+			return
+		say("Expended all available experimental technology nodes. Resorting to minor rewards.")
 	if(gauss_real >= gauss_minor) //Minor Success.
 		var/reward = pick(minor_rewards)
 		new reward(dropturf)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The major and minor thresholds were based on CARGO_CRATE_VALUE from #55617, but how much parts affect it weren't, so upgraded BEPISes could reach the threshold incredibly easily. This scales the part benefits based on CARGO_CRATE_VALUE as well (using the original 500 for a cargo crate). Now, you need 200 credits to have a 50% chance for a minor tech and 600 to have a 50% chance for a major tech with T4 parts.

Also makes the "Expended all available experimental technology nodes. Resorting to minor rewards." message display properly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #63396 (although this has been an issue long before that its just that nobody made an issue report of it and saw it as intentional)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Upgraded BEPISes now longer give tech for free. For a fully upgraded machine, you now need 200 credits for a 50% chance of a minor reward, and 600 credits for a 50% chance of a major reward.
fix: The BEPIS message telling you that you've gotten all the tech disks and therefore are getting a minor reward instead now properly displays.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
