### PR TITLE
Changes how robotics control console works

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -81,10 +81,10 @@
 			if(allowed(usr))
 				var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
 				if(can_control(usr, R) && !..())
-					if(isAI(usr)&&R.ailockdown&&R.lockcharge||isAI(usr)&&!R.lockcharge||!isAI(usr))
-						R.ailockdown = FALSE
+					if(isAI(usr) && (R.ai_lockdown && R.lockcharge || !R.lockcharge) || !isAI(usr))
+						R.ai_lockdown = FALSE
 						if(isAI(usr)&&!R.lockcharge)
-							R.ailockdown = TRUE
+							R.ai_lockdown = TRUE
 						message_admins(span_notice("[ADMIN_LOOKUPFLW(usr)] [!R.lockcharge ? "locked down" : "released"] [ADMIN_LOOKUPFLW(R)]!"))
 						log_silicon("[key_name(usr)] [!R.lockcharge ? "locked down" : "released"] [key_name(R)]!")
 						log_combat(usr, R, "[!R.lockcharge ? "locked down" : "released"] cyborg")

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -77,13 +77,6 @@
 		return
 
 	switch(action)
-		if("killbot")
-			if(isAI(usr)&&IS_MALF_AI(usr))
-				var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
-				if(can_control(usr, R) && !..())
-					R.self_destruct(usr)
-			else
-				to_chat(usr, span_danger("Access Denied."))
 		if("stopbot")
 			if(allowed(usr))
 				var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
@@ -100,7 +93,7 @@
 						if(R.connected_ai)
 							to_chat(R.connected_ai, "[!R.lockcharge ? span_notice("NOTICE - Cyborg lockdown lifted") : span_alert("ALERT - Cyborg lockdown detected")]: <a href='?src=[REF(R.connected_ai)];track=[html_encode(R.name)]'>[R.name]</a><br>")
 					else
-					to_chat(usr, span_danger("Cyborg locked by an user with superior permissions."))
+						to_chat(usr, span_danger("Cyborg locked by an user with superior permissions."))
 			else
 				to_chat(usr, span_danger("Access Denied."))
 		if("magbot")

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -3,7 +3,7 @@
 	desc = "Used to remotely lockdown or detonate linked Cyborgs and Drones."
 	icon_screen = "robot"
 	icon_keyboard = "rd_key"
-	req_access = list(ACCESS_ROBOTICS)
+	req_access = list(ACCESS_AI_UPLOAD)
 	circuit = /obj/item/circuitboard/computer/robotics
 	light_color = LIGHT_COLOR_PINK
 
@@ -78,7 +78,7 @@
 
 	switch(action)
 		if("killbot")
-			if(allowed(usr))
+			if(isAI(usr)&&IS_MALF_AI(usr))
 				var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
 				if(can_control(usr, R) && !..())
 					R.self_destruct(usr)
@@ -88,13 +88,19 @@
 			if(allowed(usr))
 				var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
 				if(can_control(usr, R) && !..())
-					message_admins(span_notice("[ADMIN_LOOKUPFLW(usr)] [!R.lockcharge ? "locked down" : "released"] [ADMIN_LOOKUPFLW(R)]!"))
-					log_silicon("[key_name(usr)] [!R.lockcharge ? "locked down" : "released"] [key_name(R)]!")
-					log_combat(usr, R, "[!R.lockcharge ? "locked down" : "released"] cyborg")
-					R.SetLockdown(!R.lockcharge)
-					to_chat(R, !R.lockcharge ? span_notice("Your lockdown has been lifted!") : span_alert("You have been locked down!"))
-					if(R.connected_ai)
-						to_chat(R.connected_ai, "[!R.lockcharge ? span_notice("NOTICE - Cyborg lockdown lifted") : span_alert("ALERT - Cyborg lockdown detected")]: <a href='?src=[REF(R.connected_ai)];track=[html_encode(R.name)]'>[R.name]</a><br>")
+					if(isAI(usr)&&R.ailockdown&&R.lockcharge||isAI(usr)&&!R.lockcharge||!isAI(usr))
+						R.ailockdown = FALSE
+						if(isAI(usr)&&!R.lockcharge)
+							R.ailockdown = TRUE
+						message_admins(span_notice("[ADMIN_LOOKUPFLW(usr)] [!R.lockcharge ? "locked down" : "released"] [ADMIN_LOOKUPFLW(R)]!"))
+						log_silicon("[key_name(usr)] [!R.lockcharge ? "locked down" : "released"] [key_name(R)]!")
+						log_combat(usr, R, "[!R.lockcharge ? "locked down" : "released"] cyborg")
+						R.SetLockdown(!R.lockcharge)
+						to_chat(R, !R.lockcharge ? span_notice("Your lockdown has been lifted!") : span_alert("You have been locked down!"))
+						if(R.connected_ai)
+							to_chat(R.connected_ai, "[!R.lockcharge ? span_notice("NOTICE - Cyborg lockdown lifted") : span_alert("ALERT - Cyborg lockdown detected")]: <a href='?src=[REF(R.connected_ai)];track=[html_encode(R.name)]'>[R.name]</a><br>")
+					else
+					to_chat(usr, span_danger("Cyborg locked by an user with superior permissions."))
 			else
 				to_chat(usr, span_danger("Access Denied."))
 		if("magbot")

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -1,6 +1,6 @@
 /obj/machinery/computer/robotics
 	name = "robotics control console"
-	desc = "Used to remotely lockdown or detonate linked Cyborgs and Drones."
+	desc = "Used to remotely lockdown linked Cyborgs and Drones."
 	icon_screen = "robot"
 	icon_keyboard = "rd_key"
 	req_access = list(ACCESS_AI_UPLOAD)

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -3,7 +3,7 @@
 	desc = "Used to remotely lockdown linked Cyborgs and Drones."
 	icon_screen = "robot"
 	icon_keyboard = "rd_key"
-	req_access = list(ACCESS_AI_UPLOAD)
+	req_access = list(ACCESS_ROBOTICS)
 	circuit = /obj/item/circuitboard/computer/robotics
 	light_color = LIGHT_COLOR_PINK
 

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -94,8 +94,8 @@
 	var/scrambledcodes = FALSE
 	///Boolean of whether the borg is locked down or not
 	var/lockcharge = FALSE
-	//Boolean of whether the borg was locked by its AI or nothing
-	var/ailockdown = FALSE
+	///Boolean of whether the borg was locked by its AI or nothing
+	var/ai_lockdown = FALSE
 	///Random serial number generated for each cyborg upon its initialization
 	var/ident = 0
 	var/locked = TRUE

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -94,7 +94,8 @@
 	var/scrambledcodes = FALSE
 	///Boolean of whether the borg is locked down or not
 	var/lockcharge = FALSE
-
+	//Boolean of whether the borg was locked by its AI or nothing
+	var/ailockdown = FALSE
 	///Random serial number generated for each cyborg upon its initialization
 	var/ident = 0
 	var/locked = TRUE

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -141,6 +141,7 @@
 	name = "Computer Design (Robotics Control Console)"
 	desc = "Allows for the construction of circuit boards used to build a Robotics Control console."
 	id = "robocontrol"
+	materials = list(/datum/material/glass = 1000, /datum/material/gold = 1000, /datum/material/silver = 1000, /datum/material/bluespace = 2000)
 	build_path = /obj/item/circuitboard/computer/robotics
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -75,15 +75,6 @@ const Cyborgs = (props, context) => {
               onClick={() => act('stopbot', {
                 ref: cyborg.ref,
               })} />
-            {!!can_hack && (
-              <Button.Confirm
-                icon="bomb"
-                content="Detonate"
-                color="bad"
-                onClick={() => act('killbot', {
-                  ref: cyborg.ref,
-                })} />
-            )}
           </>
         )}>
         <LabeledList>

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -75,13 +75,15 @@ const Cyborgs = (props, context) => {
               onClick={() => act('stopbot', {
                 ref: cyborg.ref,
               })} />
-            <Button.Confirm
-              icon="bomb"
-              content="Detonate"
-              color="bad"
-              onClick={() => act('killbot', {
-                ref: cyborg.ref,
-              })} />
+            {!!can_hack && (
+              <Button.Confirm
+                icon="bomb"
+                content="Detonate"
+                color="bad"
+                onClick={() => act('killbot', {
+                  ref: cyborg.ref,
+                })} />
+            )}
           </>
         )}>
         <LabeledList>


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes remote detonation a feature only for malfuncioning ais, restricts lockdown to IDs with upload access, makes borgs not unlockable by AI if human locks them. Also makes robotics console cost more to print. Kyler said yes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Removes an easy way to round remove few players without gameplay,
- Requires slightly more effort to curb malfunctioning silicons.
- Makes cyborg factories more viable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Nanotrasen finally realized that installing a powerful explosive in their most popular cyborg model was stupid, so they replaced it with more robust locking system
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
