### PR TITLE
Nerfs field gen repel stun

### DIFF
--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -135,7 +135,7 @@
 	var/shock_damage = min(rand(30,40),rand(30,40))
 
 	if(iscarbon(user))
-		user.Paralyze(300)
+		user.Paralyze(10 SECONDS)
 		user.electrocute_act(shock_damage, src, 1)
 
 	else if(issilicon(user))
@@ -158,5 +158,8 @@
 	has_shocked = TRUE
 	do_sparks(5, TRUE, considered_atom.loc)
 	var/atom/target = get_edge_target_turf(considered_atom, get_dir(src, get_step_away(considered_atom, src)))
-	considered_atom.throw_at(target, 200, 4)
+	if(isliving(considered_atom))
+		to_chat(considered_atom, span_userdanger("The field repels you with tremendous force!"))
+	playsound(src, 'sound/effects/gravhit.ogg', 75, TRUE)
+	considered_atom.throw_at(target, rand(6, 12), 4)
 	addtimer(CALLBACK(src, .proc/clear_shock), 5)

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -161,5 +161,5 @@
 	if(isliving(considered_atom))
 		to_chat(considered_atom, span_userdanger("The field repels you with tremendous force!"))
 	playsound(src, 'sound/effects/gravhit.ogg', 50, TRUE)
-	considered_atom.throw_at(target, rand(6, 12), 4)
+	considered_atom.throw_at(target, 200, 4)
 	addtimer(CALLBACK(src, .proc/clear_shock), 5)

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -160,6 +160,6 @@
 	var/atom/target = get_edge_target_turf(considered_atom, get_dir(src, get_step_away(considered_atom, src)))
 	if(isliving(considered_atom))
 		to_chat(considered_atom, span_userdanger("The field repels you with tremendous force!"))
-	playsound(src, 'sound/effects/gravhit.ogg', 75, TRUE)
+	playsound(src, 'sound/effects/gravhit.ogg', 50, TRUE)
 	considered_atom.throw_at(target, rand(6, 12), 4)
 	addtimer(CALLBACK(src, .proc/clear_shock), 5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

By popular demand I've removed the reduction in throw range (Which really wasn't the biggest issue)

Field gens had a 200 tile throw and a 30 second stun.

30 => 10

Now accidentally touching a field gen won't catapult you into a free break from the game. This adds a sound and chat message when a user bumps into the field, too.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I for one do not like to stare at my helpless pixels for 30 entire seconds because I touched the wobbly blue line

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Nerfs the stun on touching a field gen from 30 seconds(!) down to 10. Adds sound and chat message feedback.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
