### PR TITLE
Fixes disposal self deletion

### DIFF
--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -89,6 +89,7 @@
 	SIGNAL_HANDLER
 	current_pipe = null
 	last_pipe = null
+	active = FALSE
 
 //failsafe in the case the holder is somehow forcemoved somewhere that's not a disposal pipe. Otherwise the above loop breaks.
 /obj/structure/disposalholder/Moved(atom/oldLoc, dir)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disposal holders are meant to stack up in the pipe if they're not moving
The check for this is typically done using the active variable when two holders collide.
Unfortunately when I converted holders over to move loops, I forgot to set active to false properly.

This means the part of deconstruct code that handled ejecting the contents of the pipe couldn't really function, since there was more then one holder stored in the pipe. so all but one of the holders just got qdel'd. Not good, makes people upset for some reason

This resolves that issue

## Why It's Good For The Game

Fixes #64515

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Welding up a disposal segment will not longer delete most of the people/things/dogs inside it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
