### PR TITLE
Fixes being able to vote for maps which are outside their configured population range

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -388,6 +388,11 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		message_admins("Failed to set new map with next_map.json for [VM.map_name]! Using default as backup!")
 		return
 
+	if (VM.config_min_users > 0 && GLOB.clients.len < VM.config_min_users)
+		message_admins("[VM.map_name] was chosen for the next map despite there being less players than its set min population range!")
+	if (VM.config_max_users > 0 && GLOB.clients.len > VM.config_max_users)
+		message_admins("[VM.map_name] was chosen for the next map, despite there being more players than its set max population range!")
+
 	next_map_config = VM
 	return TRUE
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -389,9 +389,11 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		return
 
 	if (VM.config_min_users > 0 && GLOB.clients.len < VM.config_min_users)
-		message_admins("[VM.map_name] was chosen for the next map despite there being less players than its set min population range!")
+		message_admins("[VM.map_name] was chosen for the next map, despite there being less current players than its set minimum population range!")
+		log_game("[VM.map_name] was chosen for the next map, despite there being less current players than its set minimum population range!")
 	if (VM.config_max_users > 0 && GLOB.clients.len > VM.config_max_users)
-		message_admins("[VM.map_name] was chosen for the next map, despite there being more players than its set max population range!")
+		message_admins("[VM.map_name] was chosen for the next map, despite there being more current players than its set maximum population range!")
+		log_game("[VM.map_name] was chosen for the next map, despite there being more current players than its set maximum population range!")
 
 	next_map_config = VM
 	return TRUE

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -183,6 +183,10 @@ SUBSYSTEM_DEF(vote)
 					var/datum/map_config/VM = config.maplist[map]
 					if(!VM.votable || (VM.map_name in SSpersistence.blocked_maps))
 						continue
+					if (VM.config_min_users > 0 && GLOB.clients.len < VM.config_min_users)
+						continue
+					if (VM.config_max_users > 0 && GLOB.clients.len > VM.config_max_users)
+						continue
 					maps += VM.map_name
 					shuffle_inplace(maps)
 				for(var/valid_map in maps)


### PR DESCRIPTION
## About The Pull Request

Fixes #64618 
Adds an alert for if a map with a set when it's population range is unsuitable for the current player count

Config pop range (From maps.txt.) was only ever checked for automated map rotation.
For map votes, it NEVER checked the supplied config's population range vs current population. 

## Why It's Good For The Game

Makes a config work as anticipated?

## Changelog

:cl: Melbert
fix: Fixes being able to vote for maps which are outside their configured population range (Such as Kilostation).
/:cl:

