### PR TITLE
More items hurt you now if you walk on them barefoot

### DIFF
--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -151,6 +151,7 @@
 
 /obj/item/broken_bottle/Initialize(mapload)
 	. = ..()
+	AddComponent(/datum/component/caltrop, min_damage = force)
 	AddComponent(/datum/component/butchering, 200, 55)
 
 /obj/item/reagent_containers/food/drinks/bottle/beer

--- a/code/modules/food_and_drinks/plate.dm
+++ b/code/modules/food_and_drinks/plate.dm
@@ -107,3 +107,7 @@
 	force = 5
 	throwforce = 5
 	sharpness = SHARP_EDGED
+
+/obj/item/plate_shard/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/caltrop, min_damage = force)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -19,6 +19,7 @@
 
 /obj/item/reagent_containers/syringe/Initialize(mapload)
 	. = ..()
+	AddComponent(/datum/component/caltrop, min_damage = force)
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 /obj/item/reagent_containers/syringe/attackby(obj/item/I, mob/user, params)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -19,7 +19,6 @@
 
 /obj/item/reagent_containers/syringe/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/caltrop, min_damage = force)
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 /obj/item/reagent_containers/syringe/attackby(obj/item/I, mob/user, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**Edit: Syringe is removed from the list.**
Have you ever stepped on a sharp object as a kid before? I stepped on a broken tea cup when I was a kid, and I could tell you that it hurt like hell.

Light tube and glass shard already hurt you in-game if you step on them barefoot. The PR changes that **broken drinking/alcohol glass and broken plate shard** will also hurt you now if you step on them barefoot.
I was planning to add knives too but I thought that would be too much.

I hope this works.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having only light tube, glass shard, and D4 dice considered as sharp items that can hurt barefoot you is weird, and players suffer more consequences if they lose their shoes(HONK), or they decide not to wear ones.
It also makes Light Step quirk slightly more useful.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: broken drinking/alcohol glass and broken plate shard now hurt you if you step on them barefoot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
