### PR TITLE
Disease and blob camera mobs can move vertically while a location or host hasn't been chosen yet. Revenants can also freely move vertically.

### DIFF
--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -114,6 +114,8 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 		return
 	var/turf/target_turf = .
 	if(!is_valid_turf(target_turf)) // Allows unplaced blobs to travel through station z-levels
+		if(z_move_flags & ZMOVE_FEEDBACK)
+			to_chat(src, "Your destination is invalid. Move somewhere else and try again.")
 		return null
 
 /mob/camera/blob/proc/is_valid_turf(turf/T)

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -107,7 +107,14 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 				to_chat(src, "The <b><font color=\"[blobstrain.color]\">[blobstrain.name]</b></font> strain [blobstrain.effectdesc]")
 
 /mob/camera/blob/can_z_move(direction, turf/start, turf/destination, z_move_flags = NONE, mob/living/rider)
-	return FALSE
+	if(placed) // The blob can't expand vertically (yet)
+		return FALSE
+	. = ..()
+	if(!.)
+		return
+	var/turf/target_turf = .
+	if(!is_valid_turf(target_turf)) // Allows unplaced blobs to travel through station z-levels
+		return null
 
 /mob/camera/blob/proc/is_valid_turf(turf/T)
 	var/area/A = get_area(T)

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -28,8 +28,7 @@
 		if(T.density)
 			to_chat(src, span_warning("This spot is too dense to place a blob core on!"))
 			return FALSE
-		var/area/A = get_area(T)
-		if(isspaceturf(T) || A && !(A.area_flags & BLOBS_ALLOWED))
+		if(!is_valid_turf(T))
 			to_chat(src, span_warning("You cannot place your core here!"))
 			return FALSE
 		for(var/obj/O in T)

--- a/code/modules/antagonists/disease/disease_mob.dm
+++ b/code/modules/antagonists/disease/disease_mob.dm
@@ -135,6 +135,8 @@ the new instance inside the host to be updated to the template's stats.
 			last_move_tick = world.time
 
 /mob/camera/disease/can_z_move(direction, turf/start, turf/destination, z_move_flags = NONE, mob/living/rider)
+	if(freemove)
+		return ..()
 	return FALSE
 
 /mob/camera/disease/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods = list())

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -21,6 +21,20 @@
 /mob/camera/canUseStorage()
 	return FALSE
 
+/mob/camera/up()
+	set name = "Move Upwards"
+	set category = "IC"
+
+	if(zMove(UP, z_move_flags = ZMOVE_FEEDBACK))
+		to_chat(src, span_notice("You move upwards."))
+
+/mob/camera/down()
+	set name = "Move Down"
+	set category = "IC"
+
+	if(zMove(DOWN, z_move_flags = ZMOVE_FEEDBACK))
+		to_chat(src, span_notice("You move down."))
+
 /mob/camera/can_z_move(direction, turf/start, turf/destination, z_move_flags = NONE, mob/living/rider)
 	z_move_flags |= ZMOVE_IGNORE_OBSTACLES  //cameras do not respect these FLOORS you speak so much of
 	return ..()

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -21,5 +21,9 @@
 /mob/camera/canUseStorage()
 	return FALSE
 
+/mob/camera/can_z_move(direction, turf/start, turf/destination, z_move_flags = NONE, mob/living/rider)
+	z_move_flags |= ZMOVE_IGNORE_OBSTACLES  //cameras do not respect these FLOORS you speak so much of
+	return ..()
+
 /mob/camera/emote(act, m_type=1, message = null, intentional = FALSE, force_silence = FALSE)
 	return FALSE

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -78,6 +78,11 @@
 			to_chat(rider || src, span_warning("[rider ? src : "You"] can't do that right now!"))
 		return FALSE
 	if(!buckled || !(z_move_flags & ZMOVE_ALLOW_BUCKLED))
+		if(!(z_move_flags & ZMOVE_FALL_CHECKS) && incorporeal_move && (!rider || rider.incorporeal_move))
+			//An incorporeal mob will ignore obstacles unless it's a potential fall (it'd suck hard) or is carrying corporeal mobs.
+			//Coupled with flying/floating, this allows the mob to move up and down freely.
+			//By itself, it only allows the mob to move down.
+			z_move_flags |= ZMOVE_IGNORE_OBSTACLES
 		return ..()
 	switch(SEND_SIGNAL(buckled, COMSIG_BUCKLED_CAN_Z_MOVE, direction, start, destination, z_move_flags, src))
 		if(COMPONENT_RIDDEN_ALLOW_Z_MOVE) // Can be ridden.

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -106,10 +106,6 @@
 	if(.)
 		setLoc(loc, force_update = TRUE)
 
-/mob/camera/ai_eye/can_z_move(direction, turf/start, turf/destination, z_move_flags = NONE, mob/living/rider)
-	z_move_flags |= ZMOVE_IGNORE_OBSTACLES  //cameras do not respect these FLOORS you speak so much of
-	return ..()
-
 /mob/camera/ai_eye/Move()
 	return
 


### PR DESCRIPTION
## About The Pull Request
I found out on the icebox map, roughly a week or two ago, that the camera mob couldn't be moved to the other station leveleven **before the core was placed**. I believe this to be an oversight, which is why this PR has been made.
Sentient diseases also suffer from a similar issue while on the host selection stage, so I'm fixing that too.

EDIT: Someone pointed out that revenants (and other mobs with incorporeal movement) don't ignore turfs and obstacles when moving vertically, so I have added a few lines to `living/can_z_move` to hopefully fix that.

## Why It's Good For The Game
This PR aims to fix both issues explained in the above section.

## Changelog

:cl:
fix: blob overminds can now move vertically through station z-levels while its core hasn't been placed yet.
fix: disease mobs can too move vertically while a host hasn't been selected yet.
fix: (unrevealed) revenants can now move up and down more freely, without having to be standing on or below open space. This also applies to other living mobs with generic incorporeal movement (not to be confused with the nightmare or wizard's jaunt) as long as they can fly or there's no gravity.
/:cl:
