### PR TITLE
Deletes a Clock Cult changelog mistakenly left in the strings folder for four years. 

### DIFF
--- a/strings/clockwork_cult_changelog.txt
+++ b/strings/clockwork_cult_changelog.txt
@@ -1,1 +1,0 @@
-Stargazers have been removed. Integration cogs are now the primary way of creating power.


### PR DESCRIPTION
## About The Pull Request

Removes `strings/clockwork_cult_changelog.txt`

## Why It's Good For The Game

Saves us a few bytes

## Changelog

Not needed
