### PR TITLE
fixes not being able to resist out of aggro grabs

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -939,7 +939,7 @@
 	..(pressure_difference, direction, pressure_resistance_prob_delta)
 
 /mob/living/can_resist()
-	if(!(next_move > world.time))
+	if(next_move > world.time)
 		return FALSE
 	if(incapacitated(IGNORE_RESTRAINTS|IGNORE_STASIS))
 		return FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -438,28 +438,26 @@
 	death()
 
 /**
- * Checks if a mob is incapacitated 
+ * Checks if a mob is incapacitated
  *
  * Normally being restrained, agressively grabbed, or in stasis counts as incapacitated
  * unless there is a flag being used to check if it's ignored
- * 
+ *
  * args:
  * * flags (optional) bitflags that determine if special situations are exempt from being considered incapacitated
- * 
+ *
  * bitflags: (see code/__DEFINES/status_effects.dm)
  * * IGNORE_RESTRAINTS - mob in a restraint (handcuffs) is not considered incapacitated
  * * IGNORE_STASIS - mob in stasis (stasis bed, etc.) is not considered incapacitated
- * * IGNORE_GRAB - mob that is agressively grabbed is not considered incapacitated 
+ * * IGNORE_GRAB - mob that is agressively grabbed is not considered incapacitated
 **/
 /mob/living/incapacitated(flags)
 	if(HAS_TRAIT(src, TRAIT_INCAPACITATED))
 		return TRUE
 
-	if(HAS_TRAIT(src, TRAIT_RESTRAINED) && !(flags & IGNORE_RESTRAINTS))
+	if(!(flags & IGNORE_RESTRAINTS) && (HAS_TRAIT(src, TRAIT_RESTRAINED) || (!(flags & IGNORE_GRAB) && pulledby && pulledby.grab_state >= GRAB_AGGRESSIVE)))
 		return TRUE
-	if(IS_IN_STASIS(src) && !(flags & IGNORE_STASIS))
-		return TRUE
-	if((pulledby && pulledby.grab_state >= GRAB_AGGRESSIVE) && !(flags & IGNORE_GRAB)) 
+	if(!(flags & IGNORE_STASIS) && IS_IN_STASIS(src))
 		return TRUE
 	return FALSE
 
@@ -941,7 +939,11 @@
 	..(pressure_difference, direction, pressure_resistance_prob_delta)
 
 /mob/living/can_resist()
-	return !((next_move > world.time) || incapacitated(IGNORE_RESTRAINTS|IGNORE_STASIS))
+	if(!(next_move > world.time))
+		return FALSE
+	if(incapacitated(IGNORE_RESTRAINTS|IGNORE_STASIS))
+		return FALSE
+	return TRUE
 
 /mob/living/verb/resist()
 	set name = "Resist"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -455,7 +455,9 @@
 	if(HAS_TRAIT(src, TRAIT_INCAPACITATED))
 		return TRUE
 
-	if(!(flags & IGNORE_RESTRAINTS) && (HAS_TRAIT(src, TRAIT_RESTRAINED) || (!(flags & IGNORE_GRAB) && pulledby && pulledby.grab_state >= GRAB_AGGRESSIVE)))
+	if(!(flags & IGNORE_RESTRAINTS) && HAS_TRAIT(src, TRAIT_RESTRAINED))
+		return TRUE
+	if(!(flags & IGNORE_GRAB) && pulledby && pulledby.grab_state >= GRAB_AGGRESSIVE)
 		return TRUE
 	if(!(flags & IGNORE_STASIS) && IS_IN_STASIS(src))
 		return TRUE
@@ -941,7 +943,7 @@
 /mob/living/can_resist()
 	if(next_move > world.time)
 		return FALSE
-	if(incapacitated(IGNORE_RESTRAINTS|IGNORE_STASIS))
+	if(incapacitated(IGNORE_RESTRAINTS|IGNORE_STASIS|IGNORE_GRAB))
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -943,7 +943,7 @@
 /mob/living/can_resist()
 	if(next_move > world.time)
 		return FALSE
-	if(incapacitated(IGNORE_RESTRAINTS|IGNORE_STASIS|IGNORE_GRAB))
+	if(HAS_TRAIT(src, TRAIT_INCAPACITATED))
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -177,7 +177,7 @@
 		return FALSE
 	if(mob.pulledby == mob.pulling && mob.pulledby.grab_state == GRAB_PASSIVE) //Don't autoresist passive grabs if we're grabbing them too.
 		return FALSE
-	if(mob.incapacitated(IGNORE_RESTRAINTS))
+	if(mob.incapacitated(IGNORE_RESTRAINTS|IGNORE_STASIS|IGNORE_GRAB))
 		COOLDOWN_START(src, move_delay, 1 SECONDS)
 		return TRUE
 	else if(HAS_TRAIT(mob, TRAIT_RESTRAINED))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -177,7 +177,7 @@
 		return FALSE
 	if(mob.pulledby == mob.pulling && mob.pulledby.grab_state == GRAB_PASSIVE) //Don't autoresist passive grabs if we're grabbing them too.
 		return FALSE
-	if(mob.incapacitated(IGNORE_RESTRAINTS|IGNORE_STASIS|IGNORE_GRAB))
+	if(HAS_TRAIT(mob, TRAIT_INCAPACITATED))
 		COOLDOWN_START(src, move_delay, 1 SECONDS)
 		return TRUE
 	else if(HAS_TRAIT(mob, TRAIT_RESTRAINED))


### PR DESCRIPTION
## About The Pull Request

Caused by https://github.com/tgstation/tgstation/pull/63771 - Mostly a revert of what broke it.
They separated the same check into 2 separate ones, apaprently ignore_grab is only checked if you also meet ignore_restraints 
I don't like it.

Proof of testing:
![image](https://user-images.githubusercontent.com/53777086/152292945-ec7fb45c-17c5-4da8-9271-449804b5fd30.png)

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/64597
Makes people actually able to move after being aggro grabbed.

## Changelog

:cl:
fix: You can now once again resist out of aggressive grabs.
/:cl:
