### PR TITLE
[Icebox] Fixes GAMEBREAKING problem with Law office (replaces one tile)

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -16280,7 +16280,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/service/lawoffice)
 "eZJ" = (
 /obj/structure/sign/warning/electricshock,


### PR DESCRIPTION
## About The Pull Request

Some delusional schizo MANIAC put PLATING under the Law office door, this has the DISASTROUS side effect of the DETECTIVE Office (a SECURITY area) looking BETTER than the Law office (a SERVICE area). This is GAME-RUINING.
![image](https://user-images.githubusercontent.com/53777086/152388245-3ea38d28-fcfb-46ca-a3b6-1215025c1db1.png)

## Why It's Good For The Game

I assume this was accidental, and it has bugged me since forever. It's a small edit that makes the law office door consistent with other entrances.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes Icebox's Law office door having plating instead of a Wood floor like all other entrances.
/:cl: