### PR TITLE
Always disable combo HUD on disassociate

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -727,9 +727,6 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	if(!holder)
 		return
 
-	if(combo_hud_enabled)
-		toggle_combo_hud()
-
 	holder.deactivate()
 
 	to_chat(src, span_interface("You are now a normal player."))

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -103,10 +103,13 @@ GLOBAL_PROTECT(href_token)
 	GLOB.deadmins[target] = src
 	GLOB.admin_datums -= target
 	deadmined = TRUE
-	var/client/C
-	if ((C = owner) || (C = GLOB.directory[target]))
+
+	var/client/client = owner || GLOB.directory[target]
+
+	if (!isnull(client))
 		disassociate()
-		add_verb(C, /client/proc/readmin)
+		add_verb(client, /client/proc/readmin)
+		client.disable_combo_hud()
 
 /datum/admins/proc/associate(client/client)
 	if(IsAdminAdvancedProcCall())

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -367,26 +367,51 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!check_rights(R_ADMIN))
 		return
 
-	combo_hud_enabled = !combo_hud_enabled
-
-	for(var/hudtype in list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_ADVANCED)) // add data huds
-		var/datum/atom_hud/H = GLOB.huds[hudtype]
-		(combo_hud_enabled) ? H.add_hud_to(usr) : H.remove_hud_from(usr)
-	for(var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/H in GLOB.active_alternate_appearances) // add antag huds
-		(combo_hud_enabled) ? H.add_hud_to(usr) : H.remove_hud_from(usr)
-
-	if(prefs.toggles & COMBOHUD_LIGHTING)
-		if(combo_hud_enabled)
-			mob.lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
-		else
-			mob.lighting_alpha = initial(mob.lighting_alpha)
-
-	mob.update_sight()
+	if (combo_hud_enabled)
+		disable_combo_hud()
+	else
+		enable_combo_hud()
 
 	to_chat(usr, "You toggled your admin combo HUD [combo_hud_enabled ? "ON" : "OFF"].", confidential = TRUE)
 	message_admins("[key_name_admin(usr)] toggled their admin combo HUD [combo_hud_enabled ? "ON" : "OFF"].")
 	log_admin("[key_name(usr)] toggled their admin combo HUD [combo_hud_enabled ? "ON" : "OFF"].")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Combo HUD", "[combo_hud_enabled ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/enable_combo_hud()
+	if (combo_hud_enabled)
+		return
+
+	combo_hud_enabled = TRUE
+
+	for (var/hudtype in list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_ADVANCED)) // add data huds
+		var/datum/atom_hud/atom_hud = GLOB.huds[hudtype]
+		atom_hud.add_hud_to(mob)
+
+	for (var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/antag_hud in GLOB.active_alternate_appearances) // add antag huds
+		antag_hud.add_hud_to(mob)
+
+	if (prefs.toggles & COMBOHUD_LIGHTING)
+		mob.lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
+
+	mob.update_sight()
+
+/client/proc/disable_combo_hud()
+	if (!combo_hud_enabled)
+		return
+
+	combo_hud_enabled = FALSE
+
+	for (var/hudtype in list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_ADVANCED)) // add data huds
+		var/datum/atom_hud/atom_hud = GLOB.huds[hudtype]
+		atom_hud.remove_hud_from(mob)
+
+	for (var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/antag_hud in GLOB.active_alternate_appearances) // add antag huds
+		antag_hud.remove_hud_from(mob)
+
+	if (prefs.toggles & COMBOHUD_LIGHTING)
+		mob.lighting_alpha = initial(mob.lighting_alpha)
+
+	mob.update_sight()
 
 /datum/admins/proc/show_traitor_panel(mob/target_mob in GLOB.mob_list)
 	set category = "Admin.Game"

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -383,11 +383,11 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	combo_hud_enabled = TRUE
 
-	for (var/hudtype in list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_ADVANCED)) // add data huds
+	for (var/hudtype in list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_ADVANCED))
 		var/datum/atom_hud/atom_hud = GLOB.huds[hudtype]
 		atom_hud.add_hud_to(mob)
 
-	for (var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/antag_hud in GLOB.active_alternate_appearances) // add antag huds
+	for (var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/antag_hud in GLOB.active_alternate_appearances)
 		antag_hud.add_hud_to(mob)
 
 	if (prefs.toggles & COMBOHUD_LIGHTING)
@@ -401,11 +401,11 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	combo_hud_enabled = FALSE
 
-	for (var/hudtype in list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_ADVANCED)) // add data huds
+	for (var/hudtype in list(DATA_HUD_SECURITY_ADVANCED, DATA_HUD_MEDICAL_ADVANCED, DATA_HUD_DIAGNOSTIC_ADVANCED))
 		var/datum/atom_hud/atom_hud = GLOB.huds[hudtype]
 		atom_hud.remove_hud_from(mob)
 
-	for (var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/antag_hud in GLOB.active_alternate_appearances) // add antag huds
+	for (var/datum/atom_hud/alternate_appearance/basic/antagonist_hud/antag_hud in GLOB.active_alternate_appearances)
 		antag_hud.remove_hud_from(mob)
 
 	if (prefs.toggles & COMBOHUD_LIGHTING)

--- a/code/modules/antagonists/_common/antag_hud.dm
+++ b/code/modules/antagonists/_common/antag_hud.dm
@@ -50,7 +50,7 @@ GLOBAL_LIST_EMPTY_TYPED(has_antagonist_huds, /datum/atom_hud/alternate_appearanc
 	return ..()
 
 /datum/atom_hud/alternate_appearance/basic/antagonist_hud/mobShouldSee(mob/mob)
-	return Master.current_runlevel >= RUNLEVEL_POSTGAME || mob.client?.combo_hud_enabled
+	return Master.current_runlevel >= RUNLEVEL_POSTGAME || (mob.client?.combo_hud_enabled && !isnull(mob.client?.holder))
 
 /datum/atom_hud/alternate_appearance/basic/antagonist_hud/process(delta_time)
 	index += 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Previously, combo HUD was only disabled on `deadmin`, which is only called by the verb. This does it on all `disassociate`.

Fixes #64598 