### PR TITLE
Adds an extra signaler check to compare frequencies with the incoming signal

### DIFF
--- a/code/game/objects/items/devices/pressureplates.dm
+++ b/code/game/objects/items/devices/pressureplates.dm
@@ -29,7 +29,7 @@
 	if(roundstart_signaller)
 		sigdev = new
 		sigdev.code = roundstart_signaller_code
-		sigdev.frequency = roundstart_signaller_freq
+		sigdev.set_frequency(roundstart_signaller_freq)
 
 	if(undertile_pressureplate)
 		AddElement(/datum/element/undertile, tile_overlay = tile_overlay, use_anchor = TRUE)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -98,8 +98,7 @@
 			INVOKE_ASYNC(src, .proc/signal)
 			. = TRUE
 		if("freq")
-			new_frequency = unformat_frequency(params["freq"])
-			new_frequency = sanitize_frequency(new_frequency, TRUE)
+			var/new_frequency = sanitize_frequency(unformat_frequency(params["freq"]), TRUE)
 			set_frequency(new_frequency)
 			. = TRUE
 		if("code")

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -84,7 +84,7 @@
 	data["maxFrequency"] = MAX_FREE_FREQ
 	return data
 
-/obj/item/assembly/signaler/ui_act(action, params, new_frequency)
+/obj/item/assembly/signaler/ui_act(action, params)
 	. = ..()
 	if(.)
 		return

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -84,7 +84,7 @@
 	data["maxFrequency"] = MAX_FREE_FREQ
 	return data
 
-/obj/item/assembly/signaler/ui_act(action, params)
+/obj/item/assembly/signaler/ui_act(action, params, new_frequency)
 	. = ..()
 	if(.)
 		return
@@ -98,9 +98,9 @@
 			INVOKE_ASYNC(src, .proc/signal)
 			. = TRUE
 		if("freq")
-			frequency = unformat_frequency(params["freq"])
-			frequency = sanitize_frequency(frequency, TRUE)
-			set_frequency(frequency)
+			new_frequency = unformat_frequency(params["freq"])
+			new_frequency = sanitize_frequency(new_frequency, TRUE)
+			set_frequency(new_frequency)
 			. = TRUE
 		if("code")
 			code = text2num(params["code"])
@@ -136,14 +136,12 @@
 		logging_data = "[time] <B>:</B> [usr.key] used [src] @ location ([T.x],[T.y],[T.z]) <B>:</B> [format_frequency(frequency)]/[code]"
 		GLOB.lastsignalers.Add(logging_data)
 
-	var/datum/signal/signal = new(list("code" = code, "freq" = frequency), logging_data = logging_data)
+	var/datum/signal/signal = new(list("code" = code), logging_data = logging_data)
 	radio_connection.post_signal(src, signal)
 
 /obj/item/assembly/signaler/receive_signal(datum/signal/signal)
 	. = FALSE
 	if(!signal)
-		return
-	if(signal.data["freq"] != frequency)
 		return
 	if(signal.data["code"] != code)
 		return

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -136,12 +136,14 @@
 		logging_data = "[time] <B>:</B> [usr.key] used [src] @ location ([T.x],[T.y],[T.z]) <B>:</B> [format_frequency(frequency)]/[code]"
 		GLOB.lastsignalers.Add(logging_data)
 
-	var/datum/signal/signal = new(list("code" = code), logging_data = logging_data)
+	var/datum/signal/signal = new(list("code" = code, "freq" = frequency), logging_data = logging_data)
 	radio_connection.post_signal(src, signal)
 
 /obj/item/assembly/signaler/receive_signal(datum/signal/signal)
 	. = FALSE
 	if(!signal)
+		return
+	if(signal.data["freq"] != frequency)
 		return
 	if(signal.data["code"] != code)
 		return

--- a/code/modules/modular_computers/file_system/programs/signaler.dm
+++ b/code/modules/modular_computers/file_system/programs/signaler.dm
@@ -46,9 +46,8 @@
 			INVOKE_ASYNC(src, .proc/signal)
 			. = TRUE
 		if("freq")
-			signal_frequency = unformat_frequency(params["freq"])
-			signal_frequency = sanitize_frequency(signal_frequency, TRUE)
-			set_frequency(signal_frequency)
+			var/new_signal_frequency = sanitize_frequency(unformat_frequency(params["freq"]), TRUE)
+			set_frequency(new_signal_frequency)
 			. = TRUE
 		if("code")
 			signal_code = text2num(params["code"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So, signalers are meant to pulse when they receive a signal that matches their EXACT code and frequency. However, for some reason 145.7 or FREQ_SIGNALER bypasses this and pings everything with the same code regardless of the receiving signaler's frequency. I do not know why this happens, it just does. This PR adds an extra check to compare the incoming signal's frequency with the receiver's frequency to prevent this bug.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One out of one people I surveyed didn't enjoy having their lab blown up randomly.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The 145.7 frequency is no longer received by all signalers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
