### PR TITLE
Fixes projectiles logging/displaying messages twice

### DIFF
--- a/code/game/atom_defense.dm
+++ b/code/game/atom_defense.dm
@@ -130,3 +130,7 @@
 		atom_break(damage_type)
 		return TRUE
 	return FALSE
+
+/// A cut-out proc for [/atom/proc/bullet_act] so living mobs can have their own armor behavior checks without causing issues with needing their own on_hit call
+/atom/proc/check_projectile_armor(def_zone, obj/projectile/impacting_projectile)
+	return 0

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -572,7 +572,8 @@
  */
 /atom/proc/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit = FALSE)
 	SEND_SIGNAL(src, COMSIG_ATOM_BULLET_ACT, hitting_projectile, def_zone)
-	. = hitting_projectile.on_hit(src, 0, def_zone, piercing_hit)
+	var/armor = check_projectile_armor(def_zone, hitting_projectile)
+	. = hitting_projectile.on_hit(src, armor, def_zone, piercing_hit)
 
 ///Return true if we're inside the passed in atom
 /atom/proc/in_contents_of(container)//can take class or object instance as argument

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -51,15 +51,16 @@
 
 /mob/living/bullet_act(obj/projectile/P, def_zone, piercing_hit = FALSE)
 	. = ..()
-	var/armor = run_armor_check(def_zone, P.flag, "","",P.armour_penetration, "", FALSE, P.weak_against_armour)
-	var/on_hit_state = P.on_hit(src, armor, piercing_hit)
-	if(!P.nodamage && on_hit_state != BULLET_ACT_BLOCK)
+	if(!P.nodamage && (. != BULLET_ACT_BLOCK))
 		var/attack_direction = get_dir(P.starting, src)
 		apply_damage(P.damage, P.damage_type, def_zone, armor, wound_bonus=P.wound_bonus, bare_wound_bonus=P.bare_wound_bonus, sharpness = P.sharpness, attack_direction = attack_direction)
 		apply_effects(P.stun, P.knockdown, P.unconscious, P.slur, P.stutter, P.eyeblur, P.drowsy, armor, P.stamina, P.jitter, P.paralyze, P.immobilize)
 		if(P.dismemberment)
 			check_projectile_dismemberment(P, def_zone)
-	return on_hit_state ? BULLET_ACT_HIT : BULLET_ACT_BLOCK
+	return . ? BULLET_ACT_HIT : BULLET_ACT_BLOCK
+
+/mob/living/check_projectile_armor(def_zone, obj/projectile/impacting_projectile)
+	return run_armor_check(def_zone, impacting_projectile.flag, "","",impacting_projectile.armour_penetration, "", FALSE, impacting_projectile.weak_against_armour)
 
 /mob/living/proc/check_projectile_dismemberment(obj/projectile/P, def_zone)
 	return 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #64659

#64659 introduced a bug where, now that mob/living/bullet_act() was now calling parent, which called projectile.on_hit() while also calling on_hit() itself with its own armor arguments, would cause duplicated logging entries, impact effects, and messages among other things. This was an annoying bug to figure out a fix for as on_hit was something that all atoms need to call in bullet_act, but it had to be run at the top of the proc since it had to be run alongside the COMSIG_ATOM_BULLET_ACT signal.

The solution I settled on was simply introducing a cut-out proc for getting the armor type that's supposed to be used for on_hit. Note that on_hit doesn't appear to have any mechanical effects like dealing damage or stuns, so there were no effects on actual balance.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more duplicated logs and messages.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ryll/Shaps
fix: Shooting living mobs with projectiles will no longer cause duplicated logs/messages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
