### PR TITLE
Removes ghost control from Venus Human Traps.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -180,32 +180,6 @@
 	. = ..()
 	to_chat(src, span_boldwarning("You are a venus human trap!  Protect the kudzu at all costs, and feast on those who oppose you!"))
 
-/mob/living/simple_animal/hostile/venus_human_trap/attack_ghost(mob/user)
-	. = ..()
-	if(. || !(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER))
-		return
-	humanize_plant(user)
-
-/**
- * Sets a ghost to control the plant if the plant is eligible
- *
- * Asks the interacting ghost if they would like to control the plant.
- * If they answer yes, and another ghost hasn't taken control, sets the ghost to control the plant.
- * Arguments:
- * * mob/user - The ghost to possibly control the plant
- */
-/mob/living/simple_animal/hostile/venus_human_trap/proc/humanize_plant(mob/user)
-	if(key || !playable_plant || stat)
-		return
-	var/plant_ask = tgui_alert(usr,"Become a venus human trap?", "Are you reverse vegan?", list("Yes", "No"))
-	if(plant_ask == "No" || QDELETED(src))
-		return
-	if(key)
-		to_chat(user, span_warning("Someone else already took this plant!"))
-		return
-	key = user.key
-	log_game("[key_name(src)] took control of [name].")
-
 /**
  * Manages how the vines should affect the things they're attached to.
  *


### PR DESCRIPTION
## About The Pull Request

Removes ghost control from Venus Human Traps

## Why It's Good For The Game

Who in their right mind thinks that ranged insta-baton no damage slowdown powergamer plants are fun and enjoyable? They're literally only reasonably fightable by a deathsquad due to the fact they're player-controlled and capable of just corpse rushing the crew, destroying and running off with vital infrastructure, and just all around fucking awful to deal with. 

They turn vines from a threat that needs dealt with into "thats it, the round is over, you will never destroy the vines because they'll kill Pete and then murder anyone who tries to reliably cull the vines, pray that they don't rush the comms consoles and circuit printers to prevent a shuttle call" if you don't catch them literally instantly.

No other vine mutation is this strong. It's absurd. Especially since they infinitely respawn and the ghosts can 100% just corpserush the crew down using the free constant respawns.

I've been meaning to make this PR for awhile, but these are just the most unfun player enemies to fight. They're enjoyable to deal with when AI controlled, but the fact they're players means they can do the most bullshit maneuvers and make the combat arena unenjoyable for anyone that isn't literally a death-squad or armed with death-squad gear.

Really tired of having to spend all this GBP on making the game playable. Someone else should really help.
## Changelog

:cl:
del: Removes ghost control from Venus Human Traps.
/:cl:
