### PR TITLE
fixes blast door exploits

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -27,6 +27,9 @@
 
 /obj/machinery/door/poddoor/multitool_act(mob/living/user, obj/item/tool)
 	. = ..()
+	if (density)
+		balloon_alert(user, "open the door first!")
+		return
 	if (!panel_open)
 		return
 	if (deconstruction != BLASTDOOR_FINISHED)
@@ -40,6 +43,9 @@
 
 /obj/machinery/door/poddoor/crowbar_act(mob/living/user, obj/item/tool)
 	. = ..()
+	if (density)
+		balloon_alert(user, "open the door first!")
+		return
 	if (!panel_open)
 		return
 	if (deconstruction != BLASTDOOR_FINISHED)
@@ -54,6 +60,9 @@
 
 /obj/machinery/door/poddoor/wirecutter_act(mob/living/user, obj/item/tool)
 	. = ..()
+	if (density)
+		balloon_alert(user, "open the door first!")
+		return
 	if (!panel_open)
 		return
 	if (deconstruction != BLASTDOOR_NEEDS_ELECTRONICS)
@@ -69,6 +78,9 @@
 
 /obj/machinery/door/poddoor/welder_act(mob/living/user, obj/item/tool)
 	. = ..()
+	if (density)
+		balloon_alert(user, "open the door first!")
+		return
 	if (!panel_open)
 		return
 	if (deconstruction != BLASTDOOR_NEEDS_WIRES)
@@ -162,6 +174,9 @@
 		return 0
 	else
 		return ..()
+
+/obj/machinery/door/poddoor/bumpopen()
+	return
 
 //"BLAST" doors are obviously stronger than regular doors when it comes to BLASTS.
 /obj/machinery/door/poddoor/ex_act(severity, target)

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -51,6 +51,3 @@
 /obj/machinery/door/poddoor/shutters/window/preopen
 	icon_state = "open"
 	density = FALSE
-
-/obj/machinery/door/poddoor/shutters/bumpopen()
-	return


### PR DESCRIPTION
## About The Pull Request

This PR makes blast doors unable to be opened through fireman carrying exploits or by any kind of bump opening

## Why It's Good For The Game

This could have been a disaster for any round in which blast doors become central to the gameplay of a round, say perhaps, security during revolution. The only reason this was not abused more was because admins shut it down and its a rather rare and unknown bug.

## Changelog
:cl:


fix: made blast doors unable to be opened via bumping of any kind
fix: made blastdoors unable to be interacted with via tools when closed
/:cl:

closes #55357
closes #58063
closes #61121