### PR TITLE
Actually fixes illegal tech.

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1997,14 +1997,18 @@
 
 /datum/techweb_node/syndicate_basic/New() //Crappy way of making syndicate gear decon supported until there's another way.
 	. = ..()
-	if(!SStraitor.initialized)
-		RegisterSignal(SStraitor, COMSIG_SUBSYSTEM_POST_INITIALIZE, .proc/register_uplink_items)
+	if(!SSassets.initialized)
+		RegisterSignal(SSassets, COMSIG_SUBSYSTEM_POST_INITIALIZE, .proc/register_uplink_items)
 	else
 		register_uplink_items()
 
+/**
+ * This needs some clarification: The uplink_items_by_type list is populated on datum/asset/json/uplink/generate.
+ * SStraitor doesn't actually initialize. I'm bamboozled.
+ */
 /datum/techweb_node/syndicate_basic/proc/register_uplink_items()
 	SIGNAL_HANDLER
-	UnregisterSignal(SStraitor, COMSIG_SUBSYSTEM_POST_INITIALIZE)
+	UnregisterSignal(SSassets, COMSIG_SUBSYSTEM_POST_INITIALIZE)
 	boost_item_paths = list()
 	for(var/datum/uplink_item/item_path as anything in SStraitor.uplink_items_by_type)
 		var/datum/uplink_item/item = SStraitor.uplink_items_by_type[item_path]


### PR DESCRIPTION
## About The Pull Request
I had been pinged on the chat a few days ago about the Illegal tech node being still unobtainable, so I checked the code again and found out, to my surprise, that the SStraitors doesn't actually initialize and the list is actually populated on `/datum/assets/json/uplink` during the initialization of SSassets.
Thankfully enough, it doesn't seem assets registration is asynced, so simply changing the accessed object from SStraitors to SSassets in a few lines should be enough.

## Why It's Good For The Game
This will actually fix #64284. No GBP update.

## Changelog

:cl:
fix: ACTUALLY fixes the Illegal Technology node being unobtainable.
/:cl:
