### PR TITLE
Tgui input hotfix

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -155,7 +155,7 @@
 		var/atom/current_parent = parent
 		var/obj/item/stack/item_stack = held_item
 		requested_amount = tgui_input_number(user, "How much do you want to insert?", "Inserting [item_stack.singular_name]s", item_stack.amount, item_stack.amount)
-		if(!requested_amount || QDELETED(held_item) || QDELETED(user) || QDELETED(src) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+		if(!requested_amount || QDELETED(held_item) || QDELETED(user) || QDELETED(src))
 			return
 		if(parent != current_parent || user.get_active_held_item() != active_held)
 			return

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -129,10 +129,12 @@
 	if(loc != user)
 		to_chat(user, span_warning("You must be holding the pen to continue!"))
 		return
+	var/whatever = tgui_alert(user, "Message", "Title", list("Rotate", "Nothing at all", "New pen description"))
 	var/deg = tgui_input_number(user, "What angle would you like to rotate the pen head to? (0-360)", "Rotate Pen Head", max_value = 360)
 	if(isnull(deg) || QDELETED(user) || QDELETED(src) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK) || loc != user)
 		return
-	to_chat(user, span_notice("You rotate the top of the pen to [degrees] degrees."))
+	degrees = deg
+	to_chat(user, span_notice("You rotate the top of the pen to [deg] degrees."))
 	SEND_SIGNAL(src, COMSIG_PEN_ROTATED, deg, user)
 
 /obj/item/pen/attack(mob/living/M, mob/user, params)

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -129,7 +129,6 @@
 	if(loc != user)
 		to_chat(user, span_warning("You must be holding the pen to continue!"))
 		return
-	var/whatever = tgui_alert(user, "Message", "Title", list("Rotate", "Nothing at all", "New pen description"))
 	var/deg = tgui_input_number(user, "What angle would you like to rotate the pen head to? (0-360)", "Rotate Pen Head", max_value = 360)
 	if(isnull(deg) || QDELETED(user) || QDELETED(src) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK) || loc != user)
 		return

--- a/code/modules/tgui/tgui_alert.dm
+++ b/code/modules/tgui/tgui_alert.dm
@@ -19,6 +19,12 @@
 			user = client.mob
 		else
 			return
+	// Client does NOT have tgui_input on: Returns regular input
+	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
+		if(length(buttons) == 2)
+			return alert(user, message, title, buttons[1], buttons[2])
+		if(length(buttons) == 3)
+			return alert(user, message, title, buttons[1], buttons[2], buttons[3])
 	var/datum/tgui_modal/alert = new(user, message, title, buttons, timeout, autofocus)
 	alert.ui_interact(user)
 	alert.wait()
@@ -48,6 +54,12 @@
 			user = client.mob
 		else
 			return
+	// Client does NOT have tgui_input on: Returns regular input
+	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
+		if(length(buttons) == 2)
+			return alert(user, message, title, buttons[1], buttons[2])
+		if(length(buttons) == 3)
+			return alert(user, message, title, buttons[1], buttons[2], buttons[3])
 	var/datum/tgui_modal/async/alert = new(user, message, title, buttons, callback, timeout, autofocus)
 	alert.ui_interact(user)
 
@@ -111,19 +123,15 @@
 /datum/tgui_modal/ui_state(mob/user)
 	return GLOB.always_state
 
-/datum/tgui_modal/ui_static_data(mob/user)
-	. = list(
-		"autofocus" = autofocus,
-		"buttons" = buttons,
-		"message" = message,
-		"preferences" = list(),
-		"title" = title
-	)
-	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
-	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
-
 /datum/tgui_modal/ui_data(mob/user)
 	. = list()
+	.["autofocus"] = autofocus
+	.["buttons"] = buttons
+	.["message"] = message
+	.["preferences"] = list()
+	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
+	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
+	.["title"] = title
 	if(timeout)
 		.["timeout"] = CLAMP01((timeout - (world.time - start_time) - 1 SECONDS) / (timeout - 1 SECONDS))
 

--- a/code/modules/tgui/tgui_input_list.dm
+++ b/code/modules/tgui/tgui_input_list.dm
@@ -141,10 +141,13 @@
 /datum/tgui_list_input/ui_state(mob/user)
 	return GLOB.always_state
 
+/datum/tgui_list_input/ui_static_data(mob/user)
+	. = list()
+	.["items"] = items
+
 /datum/tgui_list_input/ui_data(mob/user)
 	. = list()
 	.["init_value"] = default || items[1]
-	.["items"] = items
 	.["message"] = message
 	.["preferences"] = list()
 	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)

--- a/code/modules/tgui/tgui_input_list.dm
+++ b/code/modules/tgui/tgui_input_list.dm
@@ -132,7 +132,6 @@
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "ListInputModal")
-		ui.set_autoupdate(FALSE)
 		ui.open()
 
 /datum/tgui_list_input/ui_close(mob/user)
@@ -142,19 +141,15 @@
 /datum/tgui_list_input/ui_state(mob/user)
 	return GLOB.always_state
 
-/datum/tgui_list_input/ui_static_data(mob/user)
-	. = list(
-		"init_value" = default || items[1],
-		"items" = items,
-		"message" = message,
-		"preferences" = list(),
-		"title" = title
-	)
-	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
-	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
-
 /datum/tgui_list_input/ui_data(mob/user)
 	. = list()
+	.["init_value"] = default || items[1]
+	.["items"] = items
+	.["message"] = message
+	.["preferences"] = list()
+	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
+	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
+	.["title"] = title
 	if(timeout)
 		.["timeout"] = clamp((timeout - (world.time - start_time) - 1 SECONDS) / (timeout - 1 SECONDS), 0, 1)
 

--- a/code/modules/tgui/tgui_input_number.dm
+++ b/code/modules/tgui/tgui_input_number.dm
@@ -127,7 +127,6 @@
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "NumberInputModal")
-		ui.set_autoupdate(FALSE)
 		ui.open()
 
 /datum/tgui_input_number/ui_close(mob/user)
@@ -137,20 +136,16 @@
 /datum/tgui_input_number/ui_state(mob/user)
 	return GLOB.always_state
 
-/datum/tgui_input_number/ui_static_data(mob/user)
-	. = list(
-		"init_value" = default, // Default is a reserved keyword
-		"max_value" = max_value,
-		"message" = message,
-		"min_value" = min_value,
-		"preferences" = list(),
-		"title" = title
-	)
-	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
-	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
-
 /datum/tgui_input_number/ui_data(mob/user)
 	. = list()
+	.["init_value"] = default // Default is a reserved keyword
+	.["max_value"] = max_value
+	.["message"] = message
+	.["min_value"] = min_value
+	.["preferences"] = list()
+	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
+	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
+	.["title"] = title
 	if(timeout)
 		.["timeout"] = CLAMP01((timeout - (world.time - start_time) - 1 SECONDS) / (timeout - 1 SECONDS))
 

--- a/code/modules/tgui/tgui_input_text.dm
+++ b/code/modules/tgui/tgui_input_text.dm
@@ -138,7 +138,6 @@
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "TextInputModal")
-		ui.set_autoupdate(FALSE)
 		ui.open()
 
 /datum/tgui_input_text/ui_close(mob/user)
@@ -148,20 +147,16 @@
 /datum/tgui_input_text/ui_state(mob/user)
 	return GLOB.always_state
 
-/datum/tgui_input_text/ui_static_data(mob/user)
-	. = list(
-		"max_length" = max_length,
-		"message" = message,
-		"multiline" = multiline,
-		"placeholder" = default, // You cannot use default as a const
-		"preferences" = list(),
-		"title" = title
-	)
-	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
-	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
-
 /datum/tgui_input_text/ui_data(mob/user)
 	. = list()
+	.["max_length"] = max_length
+	.["message"] = message
+	.["multiline"] = multiline
+	.["placeholder"] = default // Default is a reserved keyword
+	.["preferences"] = list()
+	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
+	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
+	.["title"] = title
 	if(timeout)
 		.["timeout"] = CLAMP01((timeout - (world.time - start_time) - 1 SECONDS) / (timeout - 1 SECONDS))
 

--- a/tgui/packages/tgui/interfaces/AlertModal.tsx
+++ b/tgui/packages/tgui/interfaces/AlertModal.tsx
@@ -1,14 +1,7 @@
 import { Loader } from './common/Loader';
 import { Preferences } from './common/InputButtons';
 import { useBackend, useLocalState } from '../backend';
-import {
-  KEY_ESCAPE,
-  KEY_ENTER,
-  KEY_LEFT,
-  KEY_RIGHT,
-  KEY_SPACE,
-  KEY_TAB,
-} from '../../common/keycodes';
+import { KEY_ESCAPE, KEY_ENTER, KEY_LEFT, KEY_RIGHT, KEY_SPACE, KEY_TAB } from '../../common/keycodes';
 import { Autofocus, Box, Button, Flex, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
@@ -34,7 +27,7 @@ export const AlertModal = (_, context) => {
     = 100
     + Math.ceil(message.length / 3)
     + (message.length && large_buttons ? 5 : 0)
-    + (buttons.length > 2 ? buttons.length * 12 : 0);
+    + (buttons.length > 2 ? buttons.length * 25 : 0);
   const onKey = (direction: number) => {
     if (selected === 0 && direction === KEY_DECREMENT) {
       setSelected(buttons.length - 1);
@@ -74,7 +67,7 @@ export const AlertModal = (_, context) => {
               <Box color="label">{message}</Box>
             </Stack.Item>
             <Stack.Item>
-              {autofocus && <Autofocus />}
+              {!!autofocus && <Autofocus />}
               <ButtonDisplay selected={selected} />
             </Stack.Item>
           </Stack>
@@ -94,17 +87,15 @@ const ButtonDisplay = (props, context) => {
   const { buttons = [] } = data;
   const { selected } = props;
   const { large_buttons, swapped_buttons } = data.preferences;
+  const buttonDirection
+    = (buttons.length > 2 ? 'column' : 'row')
+    + (!swapped_buttons ? '-reverse' : '');
 
   return (
-    <Flex
-      align="center"
-      direction={!swapped_buttons ? 'row-reverse' : 'row'}
-      fill
-      justify="space-around"
-      wrap>
+    <Flex align="center" direction={buttonDirection} fill>
       {buttons?.map((button, index) =>
-        !large_buttons ? (
-          <Flex.Item key={index}>
+        !!large_buttons && buttons.length < 3 ? (
+          <Flex.Item grow key={index}>
             <AlertButton
               button={button}
               id={index.toString()}
@@ -112,7 +103,7 @@ const ButtonDisplay = (props, context) => {
             />
           </Flex.Item>
         ) : (
-          <Flex.Item grow key={index}>
+          <Flex.Item key={index}>
             <AlertButton
               button={button}
               id={index.toString()}

--- a/tgui/packages/tgui/interfaces/AlertModal.tsx
+++ b/tgui/packages/tgui/interfaces/AlertModal.tsx
@@ -2,7 +2,7 @@ import { Loader } from './common/Loader';
 import { Preferences } from './common/InputButtons';
 import { useBackend, useLocalState } from '../backend';
 import { KEY_ESCAPE, KEY_ENTER, KEY_LEFT, KEY_RIGHT, KEY_SPACE, KEY_TAB } from '../../common/keycodes';
-import { Autofocus, Box, Button, Flex, Section, Stack } from '../components';
+import { Autofocus, Box, Button, Flex, NoticeBox, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 type AlertModalData = {
@@ -19,15 +19,17 @@ const KEY_INCREMENT = 1;
 
 export const AlertModal = (_, context) => {
   const { act, data } = useBackend<AlertModalData>(context);
-  const { autofocus, buttons = [], message, timeout, title } = data;
-  const { large_buttons } = data.preferences;
+  const { autofocus, buttons = [], message, preferences, timeout, title } = data;
+  const { large_buttons } = preferences;
   const [selected, setSelected] = useLocalState<number>(context, 'selected', 0);
   // Dynamically sets window height
-  const windowHeight
-    = 100
+  let windowHeight = 100;
+  if (message && buttons) {
+    windowHeight = 100
     + Math.ceil(message.length / 3)
     + (message.length && large_buttons ? 5 : 0)
     + (buttons.length > 2 ? buttons.length * 25 : 0);
+  }
   const onKey = (direction: number) => {
     if (selected === 0 && direction === KEY_DECREMENT) {
       setSelected(buttons.length - 1);
@@ -64,7 +66,8 @@ export const AlertModal = (_, context) => {
         <Section fill>
           <Stack fill vertical>
             <Stack.Item grow m={1}>
-              <Box color="label">{message}</Box>
+              {message ? (
+                <Box color="label">{message}</Box>) : (<NoticeBox>Please reload to continue.</NoticeBox>)}
             </Stack.Item>
             <Stack.Item>
               {!!autofocus && <Autofocus />}
@@ -84,9 +87,9 @@ export const AlertModal = (_, context) => {
  */
 const ButtonDisplay = (props, context) => {
   const { data } = useBackend<AlertModalData>(context);
-  const { buttons = [] } = data;
+  const { buttons = [], preferences } = data;
   const { selected } = props;
-  const { large_buttons, swapped_buttons } = data.preferences;
+  const { large_buttons, swapped_buttons } = preferences;
   const buttonDirection
     = (buttons.length > 2 ? 'column' : 'row')
     + (!swapped_buttons ? '-reverse' : '');
@@ -121,8 +124,9 @@ const ButtonDisplay = (props, context) => {
  */
 const AlertButton = (props, context) => {
   const { act, data } = useBackend<AlertModalData>(context);
+  const { preferences } = data;
+  const { large_buttons } = preferences;
   const { button, selected } = props;
-  const { large_buttons } = data.preferences;
 
   return (
     <Button

--- a/tgui/packages/tgui/interfaces/AlertModal.tsx
+++ b/tgui/packages/tgui/interfaces/AlertModal.tsx
@@ -1,7 +1,7 @@
 import { Loader } from './common/Loader';
 import { Preferences } from './common/InputButtons';
 import { useBackend, useLocalState } from '../backend';
-import { KEY_ESCAPE, KEY_ENTER, KEY_LEFT, KEY_RIGHT, KEY_SPACE, KEY_TAB } from '../../common/keycodes';
+import { KEY_ENTER, KEY_ESCAPE, KEY_LEFT, KEY_RIGHT, KEY_SPACE, KEY_TAB } from '../../common/keycodes';
 import { Autofocus, Box, Button, Flex, NoticeBox, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
@@ -19,16 +19,24 @@ const KEY_INCREMENT = 1;
 
 export const AlertModal = (_, context) => {
   const { act, data } = useBackend<AlertModalData>(context);
-  const { autofocus, buttons = [], message, preferences, timeout, title } = data;
+  const {
+    autofocus,
+    buttons = [],
+    message,
+    preferences,
+    timeout,
+    title,
+  } = data;
   const { large_buttons } = preferences;
   const [selected, setSelected] = useLocalState<number>(context, 'selected', 0);
   // Dynamically sets window height
   let windowHeight = 100;
   if (message && buttons) {
-    windowHeight = 100
-    + Math.ceil(message.length / 3)
-    + (message.length && large_buttons ? 5 : 0)
-    + (buttons.length > 2 ? buttons.length * 25 : 0);
+    windowHeight
+      = 100
+      + Math.ceil(message.length / 3)
+      + (message.length && large_buttons ? 5 : 0)
+      + (buttons.length > 2 ? buttons.length * 25 : 0);
   }
   const onKey = (direction: number) => {
     if (selected === 0 && direction === KEY_DECREMENT) {
@@ -67,7 +75,10 @@ export const AlertModal = (_, context) => {
           <Stack fill vertical>
             <Stack.Item grow m={1}>
               {message ? (
-                <Box color="label">{message}</Box>) : (<NoticeBox>Please reload to continue.</NoticeBox>)}
+                <Box color="label">{message}</Box>
+              ) : (
+                <NoticeBox>Please reload to continue.</NoticeBox>
+              )}
             </Stack.Item>
             <Stack.Item>
               {!!autofocus && <Autofocus />}

--- a/tgui/packages/tgui/interfaces/AlertModal.tsx
+++ b/tgui/packages/tgui/interfaces/AlertModal.tsx
@@ -31,8 +31,8 @@ export const AlertModal = (_, context) => {
   const [selected, setSelected] = useLocalState<number>(context, 'selected', 0);
   // Dynamically sets window height
   const windowHeight
-  = 100
-  + Math.ceil(message.length / 3)
+  = 115
+  + (message.length > 30 ? message.length / 3 : 0)
   + (message.length && large_buttons ? 5 : 0)
   + (buttons.length > 2 ? buttons.length * 25 : 0);
   const onKey = (direction: number) => {
@@ -71,7 +71,7 @@ export const AlertModal = (_, context) => {
         <Section fill>
           <Stack fill vertical>
             <Stack.Item grow m={1}>
-              <Box color="label">{message}</Box>
+              <Box color="label" overflow="hidden">{message}</Box>
             </Stack.Item>
             <Stack.Item>
               {!!autofocus && <Autofocus />}

--- a/tgui/packages/tgui/interfaces/AlertModal.tsx
+++ b/tgui/packages/tgui/interfaces/AlertModal.tsx
@@ -2,7 +2,7 @@ import { Loader } from './common/Loader';
 import { Preferences } from './common/InputButtons';
 import { useBackend, useLocalState } from '../backend';
 import { KEY_ENTER, KEY_ESCAPE, KEY_LEFT, KEY_RIGHT, KEY_SPACE, KEY_TAB } from '../../common/keycodes';
-import { Autofocus, Box, Button, Flex, NoticeBox, Section, Stack } from '../components';
+import { Autofocus, Box, Button, Flex, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 type AlertModalData = {
@@ -30,14 +30,11 @@ export const AlertModal = (_, context) => {
   const { large_buttons } = preferences;
   const [selected, setSelected] = useLocalState<number>(context, 'selected', 0);
   // Dynamically sets window height
-  let windowHeight = 100;
-  if (message && buttons) {
-    windowHeight
-      = 100
-      + Math.ceil(message.length / 3)
-      + (message.length && large_buttons ? 5 : 0)
-      + (buttons.length > 2 ? buttons.length * 25 : 0);
-  }
+  const windowHeight
+  = 100
+  + Math.ceil(message.length / 3)
+  + (message.length && large_buttons ? 5 : 0)
+  + (buttons.length > 2 ? buttons.length * 25 : 0);
   const onKey = (direction: number) => {
     if (selected === 0 && direction === KEY_DECREMENT) {
       setSelected(buttons.length - 1);
@@ -74,11 +71,7 @@ export const AlertModal = (_, context) => {
         <Section fill>
           <Stack fill vertical>
             <Stack.Item grow m={1}>
-              {message ? (
-                <Box color="label">{message}</Box>
-              ) : (
-                <NoticeBox>Please reload to continue.</NoticeBox>
-              )}
+              <Box color="label">{message}</Box>
             </Stack.Item>
             <Stack.Item>
               {!!autofocus && <Autofocus />}
@@ -106,7 +99,11 @@ const ButtonDisplay = (props, context) => {
     + (!swapped_buttons ? '-reverse' : '');
 
   return (
-    <Flex align="center" direction={buttonDirection} fill>
+    <Flex
+      align="center"
+      direction={buttonDirection}
+      fill
+      justify="space-around">
       {buttons?.map((button, index) =>
         !!large_buttons && buttons.length < 3 ? (
           <Flex.Item grow key={index}>
@@ -149,8 +146,7 @@ const AlertButton = (props, context) => {
       pr={2}
       pt={large_buttons ? 0.33 : 0}
       selected={selected}
-      textAlign="center"
-      width={!large_buttons && button.length < 10 && 6}>
+      textAlign="center">
       {!large_buttons ? button : button.toUpperCase()}
     </Button>
   );

--- a/tgui/packages/tgui/interfaces/AlertModal.tsx
+++ b/tgui/packages/tgui/interfaces/AlertModal.tsx
@@ -32,7 +32,7 @@ export const AlertModal = (_, context) => {
   // Dynamically sets window height
   const windowHeight
   = 115
-  + (message.length > 30 ? message.length / 3 : 0)
+  + (message.length > 30 ? Math.ceil(message.length / 3) : 0)
   + (message.length && large_buttons ? 5 : 0)
   + (buttons.length > 2 ? buttons.length * 25 : 0);
   const onKey = (direction: number) => {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Missed a few things when making the new alert modals.
Cases where there are more than two buttons AND large buttons is set in UI. It resulted in a weird clipping issue with the text.
This solves the problem by making it a column if there's more than three buttons.

Also: fixes pens not fully adjusting their degrees when changed
Fixes precise material container insertion runtimes
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes UI issues that I caused
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Literally unplayable bugs fixed: Pens can now be rotated again.
fix: TGUI alerts now display buttons in a column when there's more than 2 options.
fix: TGUI alerts can now be disabled via turning TGUI inputs off in prefs.
fix: Fixed some bluescreens related to TGUI inputs.
fix: Fixes a runtime with material containers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
