### PR TITLE
Fixes heretic's ash mark

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -448,14 +448,14 @@
 
 /datum/status_effect/eldritch/ash/on_creation(mob/living/new_owner, _repetition = 5)
 	. = ..()
-	repetitions = min(1,_repetition)
+	repetitions = max(1,_repetition)
 
 /datum/status_effect/eldritch/ash/on_effect()
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
 		carbon_owner.adjustStaminaLoss(10 * repetitions)
 		carbon_owner.adjustFireLoss(5 * repetitions)
-		for(var/mob/living/carbon/victim in range(1,carbon_owner))
+		for(var/mob/living/carbon/victim in shuffle(range(1,carbon_owner)))
 			if(IS_HERETIC(victim) || victim == carbon_owner)
 				continue
 			victim.apply_status_effect(type,repetitions-1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #63605, meaning ash mark now does 50 stam and 25 burn damage on the first hit, decreasing by 10 stam and 5 burn with each hit, down to a minimum of 10 stam and 5 burn from the 5th hit onwards.

Also makes the bounce target of the mark random, preventing it from getting stuck bouncing between the same two players forever.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ash mark shouldn't be healing people you're trying to attack with it, and the bouncing should be random.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ash mark now deals the correct amount of damage and no longer gets stuck bouncing between the same two targets.
balance: Ash mark is significantly stronger due to this fix.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
