### PR TITLE
Fixes obsessed hug objective

### DIFF
--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -80,10 +80,13 @@
 			to_chat(owner, span_warning("Being near [obsession] makes you nervous and you begin to stutter..."))
 		owner.stuttering = max(3, owner.stuttering)
 
-/datum/brain_trauma/special/obsessed/proc/on_hug(mob/living/hugger, mob/living/hugged)
+/datum/brain_trauma/special/obsessed/proc/on_hug(datum/source, mob/living/hugger, mob/living/hugged)
 	SIGNAL_HANDLER
-	if(hugged == obsession)
-		obsession_hug_count++
+
+	if(hugged != obsession)
+		return
+
+	obsession_hug_count++
 
 /datum/brain_trauma/special/obsessed/proc/on_failed_social_interaction()
 	if(QDELETED(owner) || owner.stat >= UNCONSCIOUS)


### PR DESCRIPTION
## About The Pull Request

The passed arguments of the signal were incorrectly received, `hugged` was actually `hugger` because it was missing the source argument

## Why It's Good For The Game

Makes objectives work 

## Changelog

:cl: Melbert
fix: Obsessed hug objective functions again
/:cl:
