### PR TITLE
Makes The Tramstation Aux Base Use The Correct Aux Base Construction Console

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -4326,9 +4326,11 @@
 /turf/open/floor/vault,
 /area/hallway/primary/tram/right)
 "aAP" = (
-/obj/machinery/computer/camera_advanced/base_construction,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
+	},
+/obj/machinery/computer/camera_advanced/base_construction/aux{
+	structures = list("fans" = 4, "turrets" = 4)
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently Tramstation uses a generic aux base construction console which lets you move the camera around/through walls and spy on the station advanced camera console style. This PR replaces it with the proper aux base construction console. For like the 2 people that ever use the aux base. I swear that place is more often used as a cult base than it is for its intended purpose.

fixes #62778

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I fucking hate that little dickhead probe. Cunt cannon rushes me every goddamn time I fight Protoss. No stalkers, no zealots, no adepts just CANNON CANNON CANNON. Doesn't even build a single production structure build order is just pylon -> forge -> CANNON x infinity.

Also exploiting oversights is bad I guess. Yeah.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Tramstation aux base console now uses the correct type, and is no longer a ghetto advanced camera console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
