### PR TITLE
Add's food processor function to spider eggs and carp filet. Yaki imo recipe change

### DIFF
--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -482,7 +482,7 @@
 
 /obj/item/food/sashimi
 	name = "carp sashimi"
-	desc = "Celebrate surviving attack from hostile alien lifeforms by hospitalising yourself. You sure hope whoever made this is skilled"
+	desc = "Celebrate surviving attack from hostile alien lifeforms by hospitalising yourself. You sure hope whoever made this is skilled."
 	icon_state = "sashimi"
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 10, /datum/reagent/consumable/capsaicin = 9, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("fish" = 1, "hot peppers" = 1)

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -482,11 +482,11 @@
 
 /obj/item/food/sashimi
 	name = "carp sashimi"
-	desc = "Celebrate surviving attack from hostile alien lifeforms by hospitalising yourself."
+	desc = "Celebrate surviving attack from hostile alien lifeforms by hospitalising yourself. You sure hope whoever made this is skilled"
 	icon_state = "sashimi"
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 10, /datum/reagent/consumable/capsaicin = 9, /datum/reagent/consumable/nutriment/vitamin = 4)
 	tastes = list("fish" = 1, "hot peppers" = 1)
-	foodtypes = SEAFOOD | TOXIC
+	foodtypes = SEAFOOD 
 	w_class = WEIGHT_CLASS_TINY
 	//total price of this dish is 20 and a small amount more for soy sauce, all of which are available at the orders console
 	venue_value = FOOD_PRICE_CHEAP

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -263,6 +263,15 @@
 	foodtypes = MEAT | TOXIC
 	w_class = WEIGHT_CLASS_TINY
 
+/obj/item/food/spidereggs/processed
+	name = "spider eggs"
+	desc = "A cluster of juicy spider eggs. Pops in your mouth without making you sick."
+	icon_state = "spidereggs"
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4)
+	tastes = list("cobwebs" = 1)
+	foodtypes = MEAT 
+	w_class = WEIGHT_CLASS_TINY
+
 /obj/item/food/spiderling
 	name = "spiderling"
 	desc = "It's slightly twitching in your hand. Ew..."
@@ -338,6 +347,7 @@
 	tastes = list("sweet potato" = 1)
 	foodtypes = VEGETABLES | SUGAR
 	w_class = WEIGHT_CLASS_SMALL
+	burns_in_oven = TRUE
 
 /obj/item/food/roastparsnip
 	name = "roast parsnip"

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -73,6 +73,10 @@
 	multiplier = 3
 	blacklist = null
 
+/datum/food_processor_process/cutlet/chicken
+	input = /obj/item/food/meat/cutlet/chicken
+	output = /obj/item/food/raw_meatball/chicken
+
 /datum/food_processor_process/fishmeat
 	input = /obj/item/food/fishmeat/carp
 	output = /obj/item/food/fishmeat

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -73,14 +73,18 @@
 	multiplier = 3
 	blacklist = null
 
-/datum/food_processor_process/cutlet/chicken
-	input = /obj/item/food/meat/cutlet/chicken
-	output = /obj/item/food/raw_meatball/chicken
+/datum/food_processor_process/fishmeat
+	input = /obj/item/food/fishmeat/carp
+	output = /obj/item/food/fishmeat
 	blacklist = null
 
 /datum/food_processor_process/bacon
 	input = /obj/item/food/meat/rawcutlet
 	output = /obj/item/food/meat/rawbacon
+
+/datum/food_processor_process/spidereggs
+	input = /obj/item/food/spidereggs
+	output = /obj/item/food/spidereggs/processed
 
 /datum/food_processor_process/potatowedges
 	input = /obj/item/food/grown/potato/wedges
@@ -89,6 +93,10 @@
 /datum/food_processor_process/sweetpotato
 	input = /obj/item/food/grown/potato/sweet
 	output = /obj/item/food/yakiimo
+
+/datum/food_processor_process/spidereggs
+	input = /obj/item/food/spidereggs
+	output = /obj/item/food/spidereggs/processed
 
 /datum/food_processor_process/potato
 	input = /obj/item/food/grown/potato

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -90,10 +90,6 @@
 	input = /obj/item/food/grown/potato/wedges
 	output = /obj/item/food/fries
 
-/datum/food_processor_process/sweetpotato
-	input = /obj/item/food/grown/potato/sweet
-	output = /obj/item/food/yakiimo
-
 /datum/food_processor_process/spidereggs
 	input = /obj/item/food/spidereggs
 	output = /obj/item/food/spidereggs/processed

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -86,10 +86,6 @@
 	input = /obj/item/food/meat/rawcutlet
 	output = /obj/item/food/meat/rawbacon
 
-/datum/food_processor_process/spidereggs
-	input = /obj/item/food/spidereggs
-	output = /obj/item/food/spidereggs/processed
-
 /datum/food_processor_process/potatowedges
 	input = /obj/item/food/grown/potato/wedges
 	output = /obj/item/food/fries

--- a/code/modules/hydroponics/grown/potato.dm
+++ b/code/modules/hydroponics/grown/potato.dm
@@ -62,3 +62,6 @@
 	desc = "It's sweet."
 	icon_state = "sweetpotato"
 	distill_reagent = /datum/reagent/consumable/ethanol/sbiten
+
+/obj/item/food/grown/potato/sweet/MakeBakeable()
+	AddComponent(/datum/component/bakeable, /obj/item/food/yakiimo, rand(15 SECONDS, 35 SECONDS), TRUE, TRUE)


### PR DESCRIPTION
## About The Pull Request

At the moment carp meat kind of has no use at all for the chef, the meat is poisonous which is just kind of a drag. The only practical use for carp at the moment is rezadone. 

Also uh, we have ovens now so yaki imo should be made in the oven.

## Why It's Good For The Game

Allows choice for whether carp corpses are dragged to the kitchen or chemistry instead of the easy choice of just making chems with the carp corpses. This allows us to cook 6 carp recipes for the crew while still leaving the option to keep it poisoned, this also allows chefs to stealthily poison their food by just not processing the feesh.

Also, fish and chips will no longer be toxic so we can yell fush and chups at oranges, very based/10 and TOTALLY not the sole reason I made this PR, please trust me.

## Changelog


:cl:
expansion: Gives food processor function to make spider eggs and carp meat non-toxic.
/:cl: