### PR TITLE
Adds logic to hopefully prevent/yell about init breaking

### DIFF
--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(atoms)
 	set_tracked_initalized(INITIALIZATION_INNEW_MAPLOAD)
 
 	// This may look a bit odd, but if the actual atom creation runtimes for some reason, we absolutely need to set initialized BACK
-	CreateAtoms()
+	CreateAtoms(atoms, atoms_to_return)
 	clear_tracked_initalize()
 
 	if(late_loaders.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Initialize code is honestly a bit hacky, I really think we should be doing some of these things differently.

That aside, currently if you call initalize_atoms once, then before the other one finishes call it again, you will cause the atoms subsystem to be permenently stuck in mapload mode. 
This breaks a few things, and effectively perma delays late init.

Not good, leads to sparks that just sit on the ground forever.

Of course the real trouble is how initialize tracks maploading, but we're not going to worry about that here.

All I'm doing here is preventing old_initialized from being overriden by two nested calls. 
This should hopefully fix the class of errors discussed above.

There's some other headaches here, like 
A: We should really have a system to detect say, a failure for init to finish, but that's hard.
B: We really really need a better way to designate something as "mapload" rather then just setting a var on the whole subsystem, and then allowing sleeps. S dumb. (This is easy to do for initialize_atoms, less easy for the other uses

## Why It's Good For The Game

I'm feeling kinda ill at the moment though, so this'll have to do for now.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Hopefully fixes sparks just, sitting in the air sometimes. At the very least it'll cause more visible complaints
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
