### PR TITLE
Makes wired rods bulky, and fixes an exploit allowing players to bypass crafting times on spears and cattleprods.

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -290,7 +290,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	if(istype(I, /obj/item/shard))
 		user.balloon_alert(user, "crafting spear")
 		if(do_after(user, 4 SECONDS, src))
-			var/obj/item/spear/S = new /obj/item/spear
+			var/obj/item/spear/crafted_spear = new /obj/item/spear
 
 			remove_item_from_storage(user)
 			if (!user.transferItemToLoc(I, S))

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -317,8 +317,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 			user.put_in_hands(prod)
 			user.balloon_alert(user, "crafted")
-	else
-		return ..()
+			return
+	return ..()
 
 
 /obj/item/throwing_star

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -281,35 +281,41 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	flags_1 = CONDUCT_1
 	force = 9
 	throwforce = 10
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	custom_materials = list(/datum/material/iron=1150, /datum/material/glass=75)
 	attack_verb_continuous = list("hits", "bludgeons", "whacks", "bonks")
 	attack_verb_simple = list("hit", "bludgeon", "whack", "bonk")
 
 /obj/item/wirerod/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/shard))
-		var/obj/item/spear/S = new /obj/item/spear
+		user.balloon_alert(user, "crafting spear")
+		if(do_after(user, 4 SECONDS, src))
+			var/obj/item/spear/S = new /obj/item/spear
 
-		remove_item_from_storage(user)
-		if (!user.transferItemToLoc(I, S))
-			return
-		S.CheckParts(list(I))
-		qdel(src)
+			remove_item_from_storage(user)
+			if (!user.transferItemToLoc(I, S))
+				return
+			S.CheckParts(list(I))
+			qdel(src)
 
-		user.put_in_hands(S)
-		to_chat(user, span_notice("You fasten the glass shard to the top of the rod with the cable."))
+			user.put_in_hands(S)
+			to_chat(user, span_notice("You fasten the glass shard to the top of the rod with the cable."))
+			user.balloon_alert(user, "crafted")
 
 	else if(istype(I, /obj/item/assembly/igniter) && !(HAS_TRAIT(I, TRAIT_NODROP)))
-		var/obj/item/melee/baton/security/cattleprod/prod = new
+		user.balloon_alert(user, "crafting cattleprod")
+		if(do_after(user, 4 SECONDS, src))
+			var/obj/item/melee/baton/security/cattleprod/prod = new
 
-		remove_item_from_storage(user)
+			remove_item_from_storage(user)
 
-		to_chat(user, span_notice("You fasten [I] to the top of the rod with the cable."))
+			to_chat(user, span_notice("You fasten [I] to the top of the rod with the cable."))
 
-		qdel(I)
-		qdel(src)
+			qdel(I)
+			qdel(src)
 
-		user.put_in_hands(prod)
+			user.put_in_hands(prod)
+			user.balloon_alert(user, "crafted")
 	else
 		return ..()
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -288,8 +288,9 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 /obj/item/wirerod/attackby(obj/item/attacking_item, mob/user, params)
 	if(istype(attacking_item, /obj/item/shard))
+		var/datum/crafting_recipe/recipe_to_use = /datum/crafting_recipe/spear
 		user.balloon_alert(user, "crafting spear")
-		if(do_after(user, 4 SECONDS, src))
+		if(do_after(user, initial(recipe_to_use.time), src)) // we do initial work here to get the correct timer
 			var/obj/item/spear/crafted_spear = new /obj/item/spear()
 
 			remove_item_from_storage(user)
@@ -304,8 +305,9 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		return
 
 	if(istype(attacking_item, /obj/item/assembly/igniter) && !(HAS_TRAIT(attacking_item, TRAIT_NODROP)))
+		var/datum/crafting_recipe/recipe_to_use = /datum/crafting_recipe/stunprod
 		user.balloon_alert(user, "crafting cattleprod")
-		if(do_after(user, 4 SECONDS, src))
+		if(do_after(user, initial(recipe_to_use.time), src))
 			var/obj/item/melee/baton/security/cattleprod/prod = new
 
 			remove_item_from_storage(user)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -289,7 +289,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/wirerod/attackby(obj/item/attacking_item, mob/user, params)
 	if(istype(attacking_item, /obj/item/shard))
 		var/datum/crafting_recipe/recipe_to_use = /datum/crafting_recipe/spear
-		user.balloon_alert(user, "crafting spear")
+		user.balloon_alert(user, "crafting spear...")
 		if(do_after(user, initial(recipe_to_use.time), src)) // we do initial work here to get the correct timer
 			var/obj/item/spear/crafted_spear = new /obj/item/spear()
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -305,7 +305,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 	if(istype(attacking_item, /obj/item/assembly/igniter) && !(HAS_TRAIT(attacking_item, TRAIT_NODROP)))
 		var/datum/crafting_recipe/recipe_to_use = /datum/crafting_recipe/stunprod
-		user.balloon_alert(user, "crafting cattleprod")
+		user.balloon_alert(user, "crafting cattleprod...")
 		if(do_after(user, initial(recipe_to_use.time), src))
 			var/obj/item/melee/baton/security/cattleprod/prod = new
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -311,8 +311,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 			remove_item_from_storage(user)
 
-			to_chat(user, span_notice("You fasten [attacking_item] to the top of the rod with the cable."))
-
 			qdel(attacking_item)
 			qdel(src)
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -315,7 +315,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			qdel(src)
 
 			user.put_in_hands(prod)
-			user.balloon_alert(user, "crafted")
+			user.balloon_alert(user, "crafted cattleprod")
 		return
 	return ..()
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -300,8 +300,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			qdel(src)
 
 			user.put_in_hands(crafted_spear)
-			to_chat(user, span_notice("You fasten the glass shard to the top of the rod with the cable."))
-			user.balloon_alert(user, "crafted")
+			user.balloon_alert(user, "crafted spear")
 		return
 
 	if(istype(attacking_item, /obj/item/assembly/igniter) && !(HAS_TRAIT(attacking_item, TRAIT_NODROP)))

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -301,6 +301,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			user.put_in_hands(crafted_spear)
 			to_chat(user, span_notice("You fasten the glass shard to the top of the rod with the cable."))
 			user.balloon_alert(user, "crafted")
+			return
 
 	else if(istype(attacking_item, /obj/item/assembly/igniter) && !(HAS_TRAIT(attacking_item, TRAIT_NODROP)))
 		user.balloon_alert(user, "crafting cattleprod")

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -317,7 +317,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 			user.put_in_hands(prod)
 			user.balloon_alert(user, "crafted")
-			return
+		return
 	return ..()
 
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -303,7 +303,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			user.balloon_alert(user, "crafted")
 			return
 
-	else if(istype(attacking_item, /obj/item/assembly/igniter) && !(HAS_TRAIT(attacking_item, TRAIT_NODROP)))
+	if(istype(attacking_item, /obj/item/assembly/igniter) && !(HAS_TRAIT(attacking_item, TRAIT_NODROP)))
 		user.balloon_alert(user, "crafting cattleprod")
 		if(do_after(user, 4 SECONDS, src))
 			var/obj/item/melee/baton/security/cattleprod/prod = new

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -286,32 +286,32 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	attack_verb_continuous = list("hits", "bludgeons", "whacks", "bonks")
 	attack_verb_simple = list("hit", "bludgeon", "whack", "bonk")
 
-/obj/item/wirerod/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/shard))
+/obj/item/wirerod/attackby(obj/item/attacking_item, mob/user, params)
+	if(istype(attacking_item, /obj/item/shard))
 		user.balloon_alert(user, "crafting spear")
 		if(do_after(user, 4 SECONDS, src))
-			var/obj/item/spear/crafted_spear = new /obj/item/spear
+			var/obj/item/spear/crafted_spear = new /obj/item/spear()
 
 			remove_item_from_storage(user)
-			if (!user.transferItemToLoc(I, S))
+			if (!user.transferItemToLoc(attacking_item, crafted_spear))
 				return
-			S.CheckParts(list(I))
+			crafted_spear.CheckParts(list(attacking_item))
 			qdel(src)
 
 			user.put_in_hands(crafted_spear)
 			to_chat(user, span_notice("You fasten the glass shard to the top of the rod with the cable."))
 			user.balloon_alert(user, "crafted")
 
-	else if(istype(I, /obj/item/assembly/igniter) && !(HAS_TRAIT(I, TRAIT_NODROP)))
+	else if(istype(attacking_item, /obj/item/assembly/igniter) && !(HAS_TRAIT(attacking_item, TRAIT_NODROP)))
 		user.balloon_alert(user, "crafting cattleprod")
 		if(do_after(user, 4 SECONDS, src))
 			var/obj/item/melee/baton/security/cattleprod/prod = new
 
 			remove_item_from_storage(user)
 
-			to_chat(user, span_notice("You fasten [I] to the top of the rod with the cable."))
+			to_chat(user, span_notice("You fasten [attacking_item] to the top of the rod with the cable."))
 
-			qdel(I)
+			qdel(attacking_item)
 			qdel(src)
 
 			user.put_in_hands(prod)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -301,7 +301,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			user.put_in_hands(crafted_spear)
 			to_chat(user, span_notice("You fasten the glass shard to the top of the rod with the cable."))
 			user.balloon_alert(user, "crafted")
-			return
+		return
 
 	if(istype(attacking_item, /obj/item/assembly/igniter) && !(HAS_TRAIT(attacking_item, TRAIT_NODROP)))
 		user.balloon_alert(user, "crafting cattleprod")

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -298,7 +298,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			S.CheckParts(list(I))
 			qdel(src)
 
-			user.put_in_hands(S)
+			user.put_in_hands(crafted_spear)
 			to_chat(user, span_notice("You fasten the glass shard to the top of the rod with the cable."))
 			user.balloon_alert(user, "crafted")
 


### PR DESCRIPTION
## About The Pull Request

Fixes an exploit allowing players to bypass crafting times on spears and cattleprods.
Wired Rods are now bulky.

## Why It's Good For The Game

Exploits are bad, actually.
Wired Rods should be bulky so you can't keep 5 spears in your backpack disassembled.

## Changelog
:cl:
fix: Fixes an exploit allowing players to bypass crafting times on spears and cattleprods.
balance: Wired Rods are now bulky.
/:cl: