### PR TITLE
Fix bottlers runtiming every second if input turf is empty

### DIFF
--- a/code/modules/plumbing/plumbers/bottler.dm
+++ b/code/modules/plumbing/plumbers/bottler.dm
@@ -75,8 +75,8 @@
 		valid_output_configuration = FALSE
 		return PROCESS_KILL
 
-	///see if machine has enough to fill
-	if(reagents.total_volume >= wanted_amount && anchored)
+	///see if machine has enough to fill, is anchored down and has any inputspot objects to pick from
+	if(reagents.total_volume >= wanted_amount && anchored && inputspot.contents.len)
 		var/obj/AM = pick(inputspot.contents)///pick a reagent_container that could be used
 		if((istype(AM, /obj/item/reagent_containers) && !istype(AM, /obj/item/reagent_containers/hypospray/medipen)) || istype(AM, /obj/item/ammo_casing/shotgun/dart))
 			var/obj/item/reagent_containers/B = AM

--- a/code/modules/plumbing/plumbers/bottler.dm
+++ b/code/modules/plumbing/plumbers/bottler.dm
@@ -76,7 +76,7 @@
 		return PROCESS_KILL
 
 	///see if machine has enough to fill, is anchored down and has any inputspot objects to pick from
-	if(reagents.total_volume >= wanted_amount && anchored && inputspot.contents.len)
+	if(reagents.total_volume >= wanted_amount && anchored && length(inputspot.contents))
 		var/obj/AM = pick(inputspot.contents)///pick a reagent_container that could be used
 		if((istype(AM, /obj/item/reagent_containers) && !istype(AM, /obj/item/reagent_containers/hypospray/medipen)) || istype(AM, /obj/item/ammo_casing/shotgun/dart))
 			var/obj/item/reagent_containers/B = AM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes bottlers runtiming if the input turf doesn't contain any objects/content is empty:
![image](https://user-images.githubusercontent.com/33846895/152689238-f2ee3ce7-a320-4bfd-b916-449cd240b33d.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bottler should no longer cause a runtime every second if it runs out of beakers to fill
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Gamer025
fix: Bottlers no longer runtime if they run out of beakers/containers to fill
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
