### PR TITLE
Control Points now generate 1 point rather than 0.5

### DIFF
--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -588,7 +588,7 @@
 	resistance_flags = INDESTRUCTIBLE
 	var/obj/machinery/capture_the_flag/controlling
 	var/team = "none"
-	var/point_rate = 0.5
+	var/point_rate = 1
 	var/game_area = /area/ctf
 
 /obj/machinery/control_point/process(delta_time)

--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -588,6 +588,7 @@
 	resistance_flags = INDESTRUCTIBLE
 	var/obj/machinery/capture_the_flag/controlling
 	var/team = "none"
+	///This var controls how many points are added each tick while being captured, one tick in this case is aproximately one second
 	var/point_rate = 1
 	var/game_area = /area/ctf
 

--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -588,7 +588,7 @@
 	resistance_flags = INDESTRUCTIBLE
 	var/obj/machinery/capture_the_flag/controlling
 	var/team = "none"
-	///This var controls how many points are added each tick while being captured, one tick in this case is aproximately one second
+	///This is how many points are gained a second while controlling this point
 	var/point_rate = 1
 	var/game_area = /area/ctf
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Raising CTF control points to generate 1 point at a time rather than half a point. Initially limbo was intended to have a 3 minute control point timer but that was because I assumed that the timer was correctly set up that point generation would be 1:1 minutes to points. This turned out not to be the case , this PR makes it the case, fixing unintendedly long CTF rounds and just makes things make more sense.

Requesting GBP no update

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

CTF Limbo had an unintentionally long control point timer since point generation was set to 0.5 a second, this was not intended, point generation is now 1 per second

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: CTF Limbo's control point timer is now correctly set to 3 minutes rather than 6
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
