### PR TITLE
Fixes Intercom Placement in MetaStation Security Engineering Outpost

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2410,6 +2410,7 @@
 	},
 /obj/machinery/newscaster/security_unit/directional/south,
 /obj/effect/landmark/start/depsec/engineering,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "atF" = (
@@ -38022,9 +38023,6 @@
 	pixel_y = 4
 	},
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/obj/item/radio/intercom/directional/north{
-	pixel_x = 32
-	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "lrr" = (
@@ -71247,9 +71245,6 @@
 /obj/item/paper{
 	pixel_x = -4;
 	pixel_y = 6
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR seeks out to fix a weird placement of the intercom in MetaStation's Engineering Security Outpost. I had to kill a poster to do it, but I think Engineering already has plenty of posters elsewhere.

![image](https://user-images.githubusercontent.com/34697715/152698610-4414b332-223f-495b-8b44-47707872f499.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes #64714.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Security Outpost in MetaStation's Engineering no longer has an intercom installed between the walls. It is now actually accessible to those who can not phase into walls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
