### PR TITLE
Secure closets now have a damage deflection of 21 instead of 20.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -6,4 +6,4 @@
 	max_integrity = 250
 	armor = list(MELEE = 30, BULLET = 50, LASER = 50, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 80, ACID = 80)
 	secure = TRUE
-	damage_deflection = 20
+	damage_deflection = 21


### PR DESCRIPTION
## About The Pull Request

Secure closets now have a damage deflection of 21 instead of 20.

## Why It's Good For The Game

Greytiding secure lockers is bad, actually. @Rohesie said they don't like it so I'm removing it.

## Changelog
:cl:
balance: Secure closets now have a damage deflection of 21 instead of 20.
/:cl:
