### PR TITLE
Fixes longstanding oversight of thrown spears being able to break lockers

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -8,7 +8,7 @@
 	force = 10
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
-	throwforce = 20
+	throwforce = 19
 	throw_speed = 4
 	embedding = list("impact_pain_mult" = 2, "remove_pain_mult" = 4, "jostle_chance" = 2.5)
 	armour_penetration = 10


### PR DESCRIPTION
:cl: Spear Balance Committee
balance: Throwing spears no longer breaks open lockers
/:cl:

This was always a weird and unintuitive gamey thing that's just been a holdover from the past. If you need to bust open a locker as a greyshirt, you can use more creative means such as: exploding a fuel tank, using an emitter, throwing firebombs, stealing basically anything that can be used for it, such as guns, etc.
Plasma-shard tip spears and bone spears still work, so you'll still have the chance to crack em open if you go out of your way to get ahold of those.
