### PR TITLE
Fixes grenades being unable to be reset

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -105,7 +105,7 @@
 		balloon_alert(user, span_notice("resetting trigger..."))
 		if (do_after(user, 2 SECONDS, src))
 			balloon_alert(user, span_notice("trigger reset"))
-			dud_flags &= GRENADE_USED
+			dud_flags &= ~GRENADE_USED
 		return
 
 	if(stage == GRENADE_WIRED)


### PR DESCRIPTION
<details>
<summary>~</summary>

I forgot to add a `~` when I made used grenades duds so you can't reset them.
This fixes #64728 

No gbp please.

🆑 
fix: You can actually reset used grenades now.
/🆑 
</details>
