### PR TITLE
Fixes a potential "fail to setup jobs" state due to disappearing clients

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -426,7 +426,7 @@ SUBSYSTEM_DEF(job)
 					continue
 
 				// Filter any job that doesn't fit the current level.
-				var/player_job_level = player.client.prefs.job_preferences[job.title]
+				var/player_job_level = player.client?.prefs.job_preferences[job.title]
 				if(isnull(player_job_level))
 					JobDebug("FOC player job not enabled, Player: [player]")
 					continue


### PR DESCRIPTION
## About The Pull Request

- Fixes a runtime error that can occur during `DivideOccupations()` in the event that one of the players has their clients disappear during setup due to classic byond client volatility. 

If a new player's client vanishes during job setup, it will read as `null` instead of runtiming, which throws a `JobDebug` and moves onto the next player. 

## Why It's Good For The Game

So the game doesn't fail to start during job assignment, causing a revert back to lobby

## Changelog

:cl: Melbert
fix: Fixes a runtime which causes game start to fail and revert occasionally
/:cl:
