### PR TITLE
Heavily nerfs hooch spawn chance

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -16197,7 +16197,7 @@
 	name = "Public Mining APC";
 	pixel_y = 25
 	},
-/obj/item/reagent_containers/food/drinks/bottle/hooch,
+/obj/effect/spawner/random/entertainment/drugs,
 /turf/open/floor/plating,
 /area/mine/storage)
 "ZC" = (

--- a/code/game/objects/effects/spawners/random/entertainment.dm
+++ b/code/game/objects/effects/spawners/random/entertainment.dm
@@ -109,11 +109,11 @@
 	name = "recreational drugs spawner"
 	icon_state = "pill"
 	loot = list(
-		/obj/item/reagent_containers/food/drinks/bottle/hooch = 50,
 		/obj/item/clothing/mask/cigarette/rollie/cannabis = 15,
 		/obj/item/reagent_containers/syringe = 15,
 		/obj/item/cigbutt/roach = 15,
 		/obj/item/clothing/mask/cigarette/rollie/mindbreaker = 5,
+		/obj/item/reagent_containers/food/drinks/bottle/hooch = 1,
 	)
 
 /obj/effect/spawner/random/entertainment/dice


### PR DESCRIPTION
## About The Pull Request
An alternative pr to #64693.

This PR brings the hooch bottle chance to spawn from a drugs loot spawner down from 50% to 1% to bring it in line with rare loot such as sunglasses, combat gloves etc

## Why It's Good For The Game

<details>
  <summary>TL; DR</summary>

  Make hooch harder to obtain for loot monkeys, while keeping it's value and use cases. Hooch IV, anyone?

</details>

____

The related PR's basis for completely removing hooch's healing is based off an assumption that hooch is a strong appeal to play assistant as it is an easily-obtainable healing item. It has also been discussed that assistant, the job with no job expectations, duties or requirements should not have any perks over other, more meaningful jobs.

However, as I see it, this point completely falls flat on it face seeing as:
1. Hooch's healing is not a unique trait and it exists in several other forms for other jobs, or even antagonists, some of them are even more powerful than others and Hooch. Some variants include Quad Sec, or even Quintuple Sec, mime and clown drinks etc. While those jobs are indeed expected to bring some sort of value to the crew and the shift as a whole, this can also very well be ignored by the player and the job's liver metabolism could be abused for powergaming purposes.
2. Hooch is the strongest job-specific drink, standing at 100 boozepwr, which heavily limits its safe consumption rate. Taking more than 20u of hooch in your system will lead to drunk debuffs as well as dealing heavy damage to the liver.
3. Hooch is, while a simple recipe, requires ethanol, welding fuel and universal enzyme, which require the player to:
   - find a source of those chems in any way
   - not fuck up the mixture, as otherwise you will have excess welder fuel in your drink, resulting in toxin and liver damage
The most accessible way of filtering out the excess would be a hooch/chemmaster, which require additional effort to find/build/steal etc
4. Hooch is by far not **the** perk of assistants. Assistants have access to maints, which is an area of the map that is widely inaccessible to the other crewmembers. Maints offer a variety of perks, such as maint loot (which, if the luck of the draw smiles upon you, can get a player a variety of powerful items), a way to traverse the map with no camera/bystanders' sight, and more protection against atmos shenanigans like plasma floods due to much less vent/scrubber coverage. Some other perks of the grey kind include little to no expectations from them and their contribution to the round, the assistant's horde mentality and complete lack of concern for their lives.
5. It is often much easier to obtain a medical kit with basic healing aids like sutures or NanoMed's medical sprays than go through obtaining hooch in other ways, while also providing a way to heal other people in case the situation calls for it.

A valid point from the aforementioned PR is that hooch is available as maint loot in 100u quantities, thus being the only job-specific drink outside of maybe Laughter (and that is a stretch) that may be available round-start. To even this out, I suggest reducing the spawn chance of hooch down to the rarer maint spawns such as sunglasses, combat/gorilla gloves, reactive table armor, swat belts and the like. This should help shift the hooch's accesibility in favor of anyone but assistants, while not completely nuking the value of the drink to the grey tide. With this, it will require either a lot of luck to get a bottle from maints, or extra time to get hooch by your own effort, which will inevitably require you to interact with the station much more than just scouring maint corridors, be it running a garden (hardmode) or via bartender/chemist/cook interactions (impossible)

## Changelog
:cl:
balance: Hooch is now a much, much rarer occurence in maints than before. The level of rarity is the same as a sunglasses spawn, being a 1/100 chance per a maint loot spawn instance.
/:cl: