### PR TITLE
Slight improvements to manual mining

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -74,15 +74,15 @@
 		if (!isturf(T))
 			return
 
-		if(TIMER_COOLDOWN_CHECK(src, user)) //prevents mining turfs in progress
+		if(TIMER_COOLDOWN_CHECK(src, REF(user))) //prevents mining turfs in progress
 			return
 
-		TIMER_COOLDOWN_START(src, user, tool_mine_speed)
+		TIMER_COOLDOWN_START(src, REF(user), tool_mine_speed)
 
 		to_chat(user, span_notice("You start picking..."))
 
 		if(!I.use_tool(src, user, tool_mine_speed, volume=50))
-			TIMER_COOLDOWN_END(src, user) //if we fail we can start again immediately
+			TIMER_COOLDOWN_END(src, REF(user)) //if we fail we can start again immediately
 			return
 		if(ismineralturf(src))
 			to_chat(user, span_notice("You finish cutting into the rock."))
@@ -97,14 +97,14 @@
 	var/turf/user_turf = user.loc
 	if (!isturf(user_turf))
 		return
-	if(TIMER_COOLDOWN_CHECK(src, user)) //prevents mining turfs in progress
+	if(TIMER_COOLDOWN_CHECK(src, REF(user))) //prevents mining turfs in progress
 		return
-	TIMER_COOLDOWN_START(src, user, hand_mine_speed)
+	TIMER_COOLDOWN_START(src, REF(user), hand_mine_speed)
 	var/skill_modifier = 1
 	skill_modifier = user?.mind.get_skill_modifier(/datum/skill/mining, SKILL_SPEED_MODIFIER)
 	to_chat(user, span_notice("You start pulling out pieces of [src] with your hands..."))
 	if(!do_after(user, hand_mine_speed * skill_modifier, target = src))
-		TIMER_COOLDOWN_END(src, user) //if we fail we can start again immediately
+		TIMER_COOLDOWN_END(src, REF(user)) //if we fail we can start again immediately
 		return
 	if(ismineralturf(src))
 		to_chat(user, span_notice("You finish pulling apart [src]."))

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -101,8 +101,7 @@
 		return
 	TIMER_COOLDOWN_START(src, user, hand_mine_speed)
 	var/skill_modifier = 1
-	if(ishuman(user) && user.mind)
-		skill_modifier = user.mind.get_skill_modifier(/datum/skill/mining, SKILL_SPEED_MODIFIER)
+	skill_modifier = user?.mind.get_skill_modifier(/datum/skill/mining, SKILL_SPEED_MODIFIER)
 	to_chat(user, span_notice("You start pulling out pieces of [src] with your hands..."))
 	if(!do_after(user, hand_mine_speed * skill_modifier, target = src))
 		TIMER_COOLDOWN_END(src, user) //if we fail we can start again immediately

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -21,11 +21,14 @@
 	var/turf/open/floor/plating/turf_type = /turf/open/floor/plating/asteroid/airless
 	var/obj/item/stack/ore/mineralType = null
 	var/mineralAmt = 3
-	var/last_act = 0
 	var/scan_state = "" //Holder for the image we display when we're pinged by a mining scanner
 	var/defer_change = 0
 	// If true you can mine the mineral turf with your hands
 	var/weak_turf = FALSE
+	///How long it takes to mine this turf with tools, before the tool's speed and the user's skill modifier are factored in.
+	var/tool_mine_speed = 4 SECONDS
+	///How long it takes to mine this turf with hands, if it's weak.
+	var/hand_mine_speed = 15 SECONDS
 
 /turf/closed/mineral/Initialize(mapload)
 	. = ..()
@@ -71,16 +74,20 @@
 		if (!isturf(T))
 			return
 
-		if(last_act + (40 * I.toolspeed) > world.time)//prevents message spam
+		if(TIMER_COOLDOWN_CHECK(src, user)) //prevents mining turfs in progress
 			return
-		last_act = world.time
+
+		TIMER_COOLDOWN_START(src, user, tool_mine_speed)
+
 		to_chat(user, span_notice("You start picking..."))
 
-		if(I.use_tool(src, user, 40, volume=50))
-			if(ismineralturf(src))
-				to_chat(user, span_notice("You finish cutting into the rock."))
-				gets_drilled(user, TRUE)
-				SSblackbox.record_feedback("tally", "pick_used_mining", 1, I.type)
+		if(!I.use_tool(src, user, tool_mine_speed, volume=50))
+			TIMER_COOLDOWN_END(src, user) //if we fail we can start again immediately
+			return
+		if(ismineralturf(src))
+			to_chat(user, span_notice("You finish cutting into the rock."))
+			gets_drilled(user, TRUE)
+			SSblackbox.record_feedback("tally", "pick_used_mining", 1, I.type)
 	else
 		return attack_hand(user)
 
@@ -90,11 +97,15 @@
 	var/turf/user_turf = user.loc
 	if (!isturf(user_turf))
 		return
-	if(last_act + MINING_MESSAGE_COOLDOWN > world.time)//prevents message spam
+	if(TIMER_COOLDOWN_CHECK(src, user)) //prevents mining turfs in progress
 		return
-	last_act = world.time
+	TIMER_COOLDOWN_START(src, user, hand_mine_speed)
+	var/skill_modifier = 1
+	if(ishuman(user) && user.mind)
+		skill_modifier = user.mind.get_skill_modifier(/datum/skill/mining, SKILL_SPEED_MODIFIER)
 	to_chat(user, span_notice("You start pulling out pieces of [src] with your hands..."))
-	if(!do_after(user, 15 SECONDS, target = src))
+	if(!do_after(user, hand_mine_speed * skill_modifier, target = src))
+		TIMER_COOLDOWN_END(src, user) //if we fail we can start again immediately
 		return
 	if(ismineralturf(src))
 		to_chat(user, span_notice("You finish pulling apart [src]."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Uses cooldown system instead of last_act var
- Ends cooldown on failure to mine a turf
- Increases cooldown on hand mining to the maximum time it could take
- Incorporates mining skill speed modifier into hand mining weak turfs (so legendary would take 7.5 seconds instead of 15)
- Uses variables for mining speeds instead of magic numbers, making use of SECONDS define

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Using the cooldown system allows multiple people to try to mine the same turf simultaneously. Previously there was one cooldown var for mining each turf that applied to everyone and didn't reset when someone failed.

Ending the cooldown on failure means there aren't situations where you have to wait a couple of seconds to try to mine the same turf again because you failed two seconds into a four second cooldown.

Increasing the cooldown on hand mining to the maximum time it could take prevents trying to mine a turf you're already mining. If you fail, the cooldown ends so you can try again immediately.

Making mining skill affect hand mining makes sense and is a small mercy in case someone ever has to use it (and also happens to have a good enough mining skill for it to make a difference). I've personally never used it before.

Magic numbers and using deciseconds instead of the time defines are not good I'm told.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Hand mining weak turfs (i.e. snow) is now affected by mining level (so legendary would take 7.5 seconds instead of 15)
qol: Multiple people can now attempt to manually mine the same mineral turf
qol: If you fail to manually mine a turf you can try again immediately instead of having to wait for the cooldown to end
fix: You can no longer mine a snow turf by hand if you're already doing it
code: Uses variables and time defines for mining speeds instead of deciseconds and magic numbers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
