### PR TITLE
Eating deep fried inedible items moves them to stomach

### DIFF
--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -324,20 +324,23 @@
 	return ..()
 
 /obj/item/food/deepfryholder/proc/On_Consume(eater, feeder)
-	if(contents)
-		if(isliving(eater))
-			var/mob/living/guy_fieri = eater
-			var/obj/item/organ/stomach/stomach = guy_fieri.getorganslot(ORGAN_SLOT_STOMACH)
-			if(stomach)
-				var/inedible = FALSE
-				for(var/atom/movable/thing in contents)
-					if(!IsEdible(thing))
-						inedible = TRUE
-						thing.forceMove(stomach)
-
-				if(inedible)
-					to_chat(guy_fieri, span_notice("That didn't taste very good...")) //this isn't flavortown
+	if(!contents)
+		return
+	if(!isliving(eater))
 		QDEL_LIST(contents)
+
+	var/mob/living/guy = eater
+	var/obj/item/organ/stomach/stomach = guy.getorganslot(ORGAN_SLOT_STOMACH)
+	if(!stomach)
+		return
+	var/inedible = FALSE
+	for(var/atom/movable/thing in contents)
+		if(!IsEdible(thing))
+			inedible = TRUE
+			thing.forceMove(stomach)
+
+	if(inedible)
+		to_chat(guy, span_notice("That didn't taste very good...")) //this isn't flavortown
 
 
 /obj/item/food/deepfryholder/proc/fry(cook_time = 30)

--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -325,6 +325,18 @@
 
 /obj/item/food/deepfryholder/proc/On_Consume(eater, feeder)
 	if(contents)
+		if(isliving(eater))
+			var/mob/living/guy_fieri = eater
+			var/obj/item/organ/stomach/stomach = guy_fieri.getorganslot(ORGAN_SLOT_STOMACH)
+			if(stomach)
+				var/inedible = FALSE
+				for(var/atom/movable/thing in contents)
+					if(!IsEdible(thing))
+						inedible = TRUE
+						thing.forceMove(stomach)
+
+				if(inedible)
+					to_chat(guy_fieri, span_notice("That didn't taste very good...")) //this isn't flavortown
 		QDEL_LIST(contents)
 
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -287,7 +287,7 @@
 	if(!user)
 		return
 
-	if(mystomach.get_contents_size() > 10) // if he's (un)bright enough to have a round and full belly...
+	if(mystomach.get_contents_size() >= mystomach.max_combined_w_class - 5) // if he's (un)bright enough to have a round and full belly...
 		user.visible_message(span_suicide("And pretty much, [user] was beyond full, and died from having [user.p_their()] insides completely damaged!"))
 		sleep(2 SECONDS) //let them read the message
 		user.vomit(100, TRUE, distance = 0)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -287,13 +287,13 @@
 	if(!user)
 		return
 
-	if(mystomach.contents.len > 1) // if he's (un)bright enough to have a round and full belly...
-		user.visible_message(span_suicide("And pretty much, [user] was beyond full, and died from having his insides completely damaged!"))
-		sleep(20)
+	if(mystomach.get_contents_size() > 10) // if he's (un)bright enough to have a round and full belly...
 		user.vomit(100, TRUE, distance = 0)
 		for(var/obj/item/organ/current_organ in user.internal_organs)
 			if(current_organ.zone == BODY_ZONE_CHEST)
 				current_organ.damage = current_organ.maxHealth
+		sleep(3 SECONDS) //let them feel it first
+		user.visible_message(span_suicide("And pretty much, [user] was beyond full, and died from having his insides completely damaged!"))
 		user.death(FALSE)
 		user.suicide_log()
 		user.set_suicide(TRUE)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -288,12 +288,12 @@
 		return
 
 	if(mystomach.get_contents_size() > 10) // if he's (un)bright enough to have a round and full belly...
+		user.visible_message(span_suicide("And pretty much, [user] was beyond full, and died from having [user.p_their()] insides completely damaged!"))
+		sleep(2 SECONDS) //let them read the message
 		user.vomit(100, TRUE, distance = 0)
 		for(var/obj/item/organ/current_organ in user.internal_organs)
 			if(current_organ.zone == BODY_ZONE_CHEST)
 				current_organ.damage = current_organ.maxHealth
-		sleep(3 SECONDS) //let them feel it first
-		user.visible_message(span_suicide("And pretty much, [user] was beyond full, and died from having his insides completely damaged!"))
 		user.death(FALSE)
 		user.suicide_log()
 		user.set_suicide(TRUE)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -438,6 +438,12 @@
 	if(stun)
 		Paralyze(80)
 
+	var/obj/item/organ/stomach/stomach = src.getorganslot(ORGAN_SLOT_STOMACH)
+	if(stomach)
+		for(var/atom/movable/thing in stomach.contents)
+			src.visible_message(span_warning("[src] vomits up [thing]!"), span_userdanger("You suddenly vomit up [thing]!"))
+			thing.forceMove(src.drop_location())
+
 	playsound(get_turf(src), 'sound/effects/splat.ogg', 50, TRUE)
 	var/turf/T = get_turf(src)
 	if(!blood)

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -42,9 +42,9 @@
 /obj/item/organ/stomach/attack_self(mob/user, modifiers)
 	. = ..()
 
-	if(contents.len)
+	if(length(contents))
 		to_chat(user, span_notice("You begin squeezing out the contents of [src]..."))
-		if(do_after(user, contents.len SECONDS / 2))
+		if(do_after(user, length(contents) SECONDS / 2))
 			to_chat(user, span_notice("You squeeze out the contents of [src]."))
 			for(var/atom/movable/thing in contents)
 				thing.forceMove(user.drop_location())
@@ -93,7 +93,7 @@
 	//Handle disgust
 	if(body)
 		handle_disgust(body, delta_time, times_fired)
-		if(contents.len)
+		if(length(contents))
 			handle_contents(body, delta_time)
 
 	//If the stomach is not damage exit out

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -44,12 +44,14 @@
 /obj/item/organ/stomach/attack_self(mob/user, modifiers)
 	. = ..()
 
-	if(length(contents))
-		to_chat(user, span_notice("You begin squeezing out the contents of [src]..."))
-		if(do_after(user, length(contents) SECONDS / 2))
-			to_chat(user, span_notice("You squeeze out the contents of [src]."))
-			for(var/atom/movable/thing in contents)
-				thing.forceMove(user.drop_location())
+	if(!length(contents))
+		return
+	to_chat(user, span_notice("You begin squeezing out the contents of [src]..."))
+	if(!do_after(user, length(contents) SECONDS / 2))
+		return
+	to_chat(user, span_notice("You squeeze out the contents of [src]."))
+	for(var/atom/movable/thing in contents)
+		thing.forceMove(user.drop_location())
 
 /obj/item/organ/stomach/on_life(delta_time, times_fired)
 	. = ..()
@@ -222,15 +224,17 @@
 /obj/item/organ/stomach/proc/handle_contents(mob/living/carbon/human/mule, delta_time)
 	var/indigestibles_size = 0
 	for(var/atom/movable/thing in contents)
-		if(!IsEdible(thing) && isitem(thing))
-			var/obj/item/indigestible_item = thing
-			indigestibles_size += 1 * indigestible_item.w_class
+		if(IsEdible(thing) || !isitem(thing))
+			continue
+		var/obj/item/indigestible_item = thing
+		indigestibles_size += 1 * indigestible_item.w_class
 
 	if(get_contents_size() > max_combined_w_class)
 		to_chat(mule, span_danger("Your stomach feels uncomfortably full!"))
 		var/spew_blood = indigestibles_size ? TRUE : FALSE
 		mule.vomit(100, spew_blood, distance = 0)
 		damage += indigestibles_size
+		return
 
 	if(!indigestibles_size)
 		return

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -30,6 +30,7 @@
 	///The rate that the stomach will transfer reagents to the body
 	var/metabolism_efficiency = 0.05 // the lowest we should go is 0.05
 
+	var/max_combined_w_class = 14
 
 /obj/item/organ/stomach/Initialize(mapload)
 	. = ..()
@@ -221,10 +222,17 @@
 	var/inedibles = 0
 	for(var/atom/movable/thing in contents)
 		if(!IsEdible(thing))
-			inedibles += 1
+			var/size = 1
+			if(isitem(thing))
+				var/obj/item/inedible_item = thing
+				size = inedible_item.w_class
+			inedibles += 1 * size
 
 	if(!inedibles)
 		return
+
+	if(inedibles > max_combined_w_class)
+		mule.adjust_disgust(5)
 
 	if(DT_PROB(5, delta_time))
 		mule.adjust_disgust(5*inedibles)

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -45,6 +45,7 @@
 	. = ..()
 
 	if(!length(contents))
+		to_chat(user, span_notice("[src] is empty."))
 		return
 	to_chat(user, span_notice("You begin squeezing out the contents of [src]..."))
 	if(!do_after(user, length(contents) SECONDS / 2))
@@ -52,6 +53,12 @@
 	to_chat(user, span_notice("You squeeze out the contents of [src]."))
 	for(var/atom/movable/thing in contents)
 		thing.forceMove(user.drop_location())
+
+/obj/item/organ/stomach/examine(mob/user)
+	. = ..()
+
+	if(length(contents))
+		. += span_info("Use in-hand to empty it.")
 
 /obj/item/organ/stomach/on_life(delta_time, times_fired)
 	. = ..()

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -30,6 +30,7 @@
 	///The rate that the stomach will transfer reagents to the body
 	var/metabolism_efficiency = 0.05 // the lowest we should go is 0.05
 
+	///The max combined weight class of inedible objects held before we vomit.
 	var/max_combined_w_class = 14
 
 /obj/item/organ/stomach/Initialize(mapload)
@@ -232,7 +233,12 @@
 		return
 
 	if(inedibles > max_combined_w_class)
-		mule.adjust_disgust(5)
+		to_chat(mule, span_danger("Your stomach is much too full!"))
+		mule.vomit(100, TRUE, distance = 0)
+
+	if(DT_PROB(2.5, delta_time))
+		to_chat(mule, span_warning("Your stomach hurts!"))
+		damage += inedibles
 
 	if(DT_PROB(5, delta_time))
 		mule.adjust_disgust(5*inedibles)

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -1,5 +1,7 @@
 //The contant in the rate of reagent transfer on life ticks
 #define STOMACH_METABOLISM_CONSTANT 0.25
+//How much inedible garbage it can hold before you immediately chuck
+#define STANDARD_STOMACH_MAX_COMBINED_W_CLASS 12
 
 /obj/item/organ/stomach
 	name = "stomach"
@@ -31,7 +33,7 @@
 	var/metabolism_efficiency = 0.05 // the lowest we should go is 0.05
 
 	///The max combined weight class of objects held before we vomit.
-	var/max_combined_w_class = 15
+	var/max_combined_w_class = STANDARD_STOMACH_MAX_COMBINED_W_CLASS //so 4 normal-sized objects
 
 /obj/item/organ/stomach/Initialize(mapload)
 	. = ..()
@@ -340,6 +342,7 @@
 	desc = "A basic device designed to mimic the functions of a human stomach"
 	organ_flags = ORGAN_SYNTHETIC
 	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.5
+	max_combined_w_class = STANDARD_STOMACH_MAX_COMBINED_W_CLASS * 0.5
 	var/emp_vulnerability = 80 //Chance of permanent effects if emp-ed.
 	metabolism_efficiency = 0.35 // not as good at digestion
 
@@ -348,6 +351,7 @@
 	icon_state = "stomach-c-u"
 	desc = "An electronic device designed to mimic the functions of a human stomach. Handles disgusting food a bit better."
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD
+	max_combined_w_class = 1.5 * STANDARD_STOMACH_MAX_COMBINED_W_CLASS
 	disgust_metabolism = 2
 	emp_vulnerability = 40
 	metabolism_efficiency = 0.07
@@ -357,6 +361,7 @@
 	icon_state = "stomach-c-u2"
 	desc = "An upgraded version of the cybernetic stomach, designed to improve further upon organic stomachs. Handles disgusting food very well."
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
+	max_combined_w_class = 2 * STANDARD_STOMACH_MAX_COMBINED_W_CLASS
 	disgust_metabolism = 3
 	emp_vulnerability = 20
 	metabolism_efficiency = 0.1
@@ -373,3 +378,4 @@
 
 
 #undef STOMACH_METABOLISM_CONSTANT
+#undef STANDARD_STOMACH_MAX_COMBINED_W_CLASS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Having inedibles in stomach increases disgust at random intervals based on the amount
- Vomiting empties stomach contents
- Can squeeze out contents of stomachs in hand
- Stomachs only hold a combined weight class of 15 (so 5 normal sized objects)
- Updates toy singulo suicide to use stomach instead of cavity implants

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Stops people using the publicly available deep fryers to brick or delete items by instead moving the item to the eater's stomach which is a semi-difficult place to retrieve them from and leads to all sorts of wacky hijinks trying to do it. Randomly vomiting up a slew of items is funny too.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Deep fried inedible items move to stomach when eaten instead of being deleted 
add: Having inedibles in stomach increases disgust and/or damages stomach at random intervals based on the amount
add: Vomiting empties stomach contents
add: Can squeeze out contents of stomachs in hand
expansion: Toy singulo suicide uses stomach instead of cavity implants
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
