### PR TITLE
Add logging to cult rune inscribing (OFFICIAL) (SHE'S BACK)

### DIFF
--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -327,6 +327,7 @@
 	made_rune.add_mob_blood(cultist)
 
 	to_chat(cultist, span_cult("The [lowertext(made_rune.cultist_name)] rune [made_rune.cultist_desc]"))
+	cultist.log_message("scribed \a [lowertext(made_rune.cultist_name)] rune ([made_rune] ([made_rune.type])) at [AREACOORD(made_rune)] using [parent] ([parent.type])", LOG_GAME)
 	SSblackbox.record_feedback("tally", "cult_runes_scribed", 1, made_rune.cultist_name)
 
 	return TRUE

--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -327,7 +327,7 @@
 	made_rune.add_mob_blood(cultist)
 
 	to_chat(cultist, span_cult("The [lowertext(made_rune.cultist_name)] rune [made_rune.cultist_desc]"))
-	cultist.log_message("scribed \a [lowertext(made_rune.cultist_name)] rune ([made_rune] ([made_rune.type])) at [AREACOORD(made_rune)] using [parent] ([parent.type])", LOG_GAME)
+	cultist.log_message("scribed \a [lowertext(made_rune.cultist_name)] rune at [AREACOORD(made_rune)] using [parent] ([parent.type])", LOG_GAME)
 	SSblackbox.record_feedback("tally", "cult_runes_scribed", 1, made_rune.cultist_name)
 
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds logging to cult rune inscribing (scribing?) (when they are made)

## Why It's Good For The Game

Previously the game did not log and it was a challenge to prove what did or didn't happen with cult runes (see [this ban appeal thread](https://tgstation13.org/phpBB/viewtopic.php?f=7&t=30922)); they are now present in the game log.

``[2022-02-07 22:37:18.596] GAME: Bobbahbrown/(Kashindra Kalcronk) scribed an offer rune at Central Primary Hallway (107,144,2) using the ritual dagger (/obj/item/melee/cultblade/dagger) (Central Primary Hallway (107,144,2))``

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Frequently Asked Questions

**Why did you log the location effectively twice?**

This is *future-proofing*, maybe we'll have things that make runes on tiles that are not the tile that you're standing on at some point. I don't want to fall into a future-trap, do you? Didn't think so, pal.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: bobbahbrown
admin: Cult rune creation (inscribing?) is now logged on the player panel logs as well as the game log.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
