### PR TITLE
Changes how tgui handles static data

### DIFF
--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -310,8 +310,9 @@
 		if("ready")
 			// Send a full update when the user manually refreshes the UI
 			if (initialized)
-				if(!COOLDOWN_FINISHED(src, refresh_cooldown) && !refreshing)
-					addtimer(CALLBACK(src, .proc/send_full_update), TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
+				if(!COOLDOWN_FINISHED(src, refresh_cooldown))
+					if(!refreshing)
+						addtimer(CALLBACK(src, .proc/send_full_update), TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
 					refreshing = TRUE
 				else
 					send_full_update()

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -310,7 +310,7 @@
 	switch(type)
 		if("ready")
 			// Send a full update when the user manually refreshes the UI
-			if (!initialized)
+			if(!initialized)
 				initialized = TRUE
 				return
 			if(!COOLDOWN_FINISHED(src, refresh_cooldown))

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -310,9 +310,8 @@
 		if("ready")
 			// Send a full update when the user manually refreshes the UI
 			if (initialized)
-				if(!COOLDOWN_FINISHED(src, refresh_cooldown))
-					if(!refreshing)
-						addtimer(CALLBACK(src, .proc/send_full_update), TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
+				if(!COOLDOWN_FINISHED(src, refresh_cooldown) && !refreshing)
+					addtimer(CALLBACK(src, .proc/send_full_update), TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
 					refreshing = TRUE
 				else
 					send_full_update()

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -184,6 +184,10 @@
 /datum/tgui/proc/send_full_update(custom_data, force)
 	if(!user.client || !initialized || closing)
 		return
+	if(!COOLDOWN_FINISHED(src, refresh_cooldown))
+		refreshing = TRUE
+		addtimer(CALLBACK(src, .proc/send_full_update), TGUI_REFRESH_FULL_UPDATE_COOLDOWN, TIMER_UNIQUE)
+		return
 	refreshing = FALSE
 	var/should_update_data = force || status >= UI_UPDATE
 	window.send_message("update", get_payload(
@@ -310,14 +314,9 @@
 	switch(type)
 		if("ready")
 			// Send a full update when the user manually refreshes the UI
-			if(!initialized)
-				initialized = TRUE
-				return
-			if(!COOLDOWN_FINISHED(src, refresh_cooldown))
-				refreshing = TRUE
-				addtimer(CALLBACK(src, .proc/send_full_update), TGUI_REFRESH_FULL_UPDATE_COOLDOWN, TIMER_UNIQUE)
-			else
+			if(initialized)
 				send_full_update()
+			initialized = TRUE
 		if("pingReply")
 			initialized = TRUE
 		if("suspend")

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -190,6 +190,7 @@
 		custom_data,
 		with_data = should_update_data,
 		with_static_data = TRUE))
+	COOLDOWN_START(src, refresh_cooldown, TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
 
 /**
  * public
@@ -309,15 +310,14 @@
 	switch(type)
 		if("ready")
 			// Send a full update when the user manually refreshes the UI
-			if (initialized)
-				if(!COOLDOWN_FINISHED(src, refresh_cooldown))
-					if(!refreshing)
-						addtimer(CALLBACK(src, .proc/send_full_update), TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
-					refreshing = TRUE
-				else
-					send_full_update()
-				COOLDOWN_START(src, refresh_cooldown, TGUI_REFRESH_FULL_UPDATE_COOLDOWN)
-			initialized = TRUE
+			if (!initialized)
+				initialized = TRUE
+				return
+			if(!COOLDOWN_FINISHED(src, refresh_cooldown))
+				refreshing = TRUE
+				addtimer(CALLBACK(src, .proc/send_full_update), TGUI_REFRESH_FULL_UPDATE_COOLDOWN, TIMER_UNIQUE)
+			else
+				send_full_update()
 		if("pingReply")
 			initialized = TRUE
 		if("suspend")

--- a/code/modules/tgui/tgui_alert.dm
+++ b/code/modules/tgui/tgui_alert.dm
@@ -123,15 +123,17 @@
 /datum/tgui_modal/ui_state(mob/user)
 	return GLOB.always_state
 
-/datum/tgui_modal/ui_data(mob/user)
+/datum/tgui_modal/ui_static_data(mob/user)
 	. = list()
 	.["autofocus"] = autofocus
 	.["buttons"] = buttons
 	.["message"] = message
-	.["preferences"] = list()
-	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
-	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
+	.["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
+	.["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
 	.["title"] = title
+
+/datum/tgui_modal/ui_data(mob/user)
+	. = list()
 	if(timeout)
 		.["timeout"] = CLAMP01((timeout - (world.time - start_time) - 1 SECONDS) / (timeout - 1 SECONDS))
 

--- a/code/modules/tgui/tgui_input_list.dm
+++ b/code/modules/tgui/tgui_input_list.dm
@@ -143,16 +143,15 @@
 
 /datum/tgui_list_input/ui_static_data(mob/user)
 	. = list()
+	.["init_value"] = default || items[1]
 	.["items"] = items
+	.["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
+	.["message"] = message
+	.["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
+	.["title"] = title
 
 /datum/tgui_list_input/ui_data(mob/user)
 	. = list()
-	.["init_value"] = default || items[1]
-	.["message"] = message
-	.["preferences"] = list()
-	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
-	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
-	.["title"] = title
 	if(timeout)
 		.["timeout"] = clamp((timeout - (world.time - start_time) - 1 SECONDS) / (timeout - 1 SECONDS), 0, 1)
 

--- a/code/modules/tgui/tgui_input_number.dm
+++ b/code/modules/tgui/tgui_input_number.dm
@@ -136,16 +136,18 @@
 /datum/tgui_input_number/ui_state(mob/user)
 	return GLOB.always_state
 
-/datum/tgui_input_number/ui_data(mob/user)
+/datum/tgui_input_number/ui_static_data(mob/user)
 	. = list()
 	.["init_value"] = default // Default is a reserved keyword
+	.["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
 	.["max_value"] = max_value
 	.["message"] = message
 	.["min_value"] = min_value
-	.["preferences"] = list()
-	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
-	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
+	.["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
 	.["title"] = title
+
+/datum/tgui_input_number/ui_data(mob/user)
+	. = list()
 	if(timeout)
 		.["timeout"] = CLAMP01((timeout - (world.time - start_time) - 1 SECONDS) / (timeout - 1 SECONDS))
 

--- a/code/modules/tgui/tgui_input_text.dm
+++ b/code/modules/tgui/tgui_input_text.dm
@@ -147,16 +147,18 @@
 /datum/tgui_input_text/ui_state(mob/user)
 	return GLOB.always_state
 
-/datum/tgui_input_text/ui_data(mob/user)
+/datum/tgui_input_text/ui_static_data(mob/user)
 	. = list()
+	.["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
 	.["max_length"] = max_length
 	.["message"] = message
 	.["multiline"] = multiline
 	.["placeholder"] = default // Default is a reserved keyword
-	.["preferences"] = list()
-	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
-	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
+	.["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
 	.["title"] = title
+
+/datum/tgui_input_text/ui_data(mob/user)
+	. = list()
 	if(timeout)
 		.["timeout"] = CLAMP01((timeout - (world.time - start_time) - 1 SECONDS) / (timeout - 1 SECONDS))
 

--- a/tgui/packages/tgui/backend.ts
+++ b/tgui/packages/tgui/backend.ts
@@ -253,6 +253,7 @@ type BackendState<TData> = {
     title: string,
     status: number,
     interface: string,
+    refreshing: boolean,
     window: {
       key: string,
       size: [number, number],

--- a/tgui/packages/tgui/interfaces/AlertModal.tsx
+++ b/tgui/packages/tgui/interfaces/AlertModal.tsx
@@ -1,15 +1,6 @@
 import { Loader } from './common/Loader';
 import { useBackend, useLocalState } from '../backend';
-import {
-  KEY_DOWN,
-  KEY_ENTER,
-  KEY_ESCAPE,
-  KEY_LEFT,
-  KEY_RIGHT,
-  KEY_SPACE,
-  KEY_TAB,
-  KEY_UP,
-} from '../../common/keycodes';
+import { KEY_ENTER, KEY_ESCAPE, KEY_LEFT, KEY_RIGHT, KEY_SPACE, KEY_TAB } from '../../common/keycodes';
 import { Autofocus, Box, Button, Flex, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
@@ -37,15 +28,12 @@ export const AlertModal = (_, context) => {
     title,
   } = data;
   const [selected, setSelected] = useLocalState<number>(context, 'selected', 0);
-  const isVertical = buttons.length > 2;
   // Dynamically sets window dimensions
   const windowHeight
     = 115
     + (message.length > 30 ? Math.ceil(message.length / 4) : 0)
     + (message.length && large_buttons ? 5 : 0);
-  const windowWidth
-    = 325
-    + (buttons.length > 2 ? 55 : 0);
+  const windowWidth = 325 + (buttons.length > 2 ? 55 : 0);
   const onKey = (direction: number) => {
     if (selected === 0 && direction === KEY_DECREMENT) {
       setSelected(buttons.length - 1);
@@ -70,17 +58,10 @@ export const AlertModal = (_, context) => {
             act('choose', { choice: buttons[selected] });
           } else if (keyCode === KEY_ESCAPE) {
             act('cancel');
-          } else if (
-            (!isVertical && keyCode === KEY_LEFT)
-            || (isVertical && keyCode === KEY_UP)
-          ) {
+          } else if (keyCode === KEY_LEFT) {
             e.preventDefault();
             onKey(KEY_DECREMENT);
-          } else if (
-            keyCode === KEY_TAB
-            || (!isVertical && keyCode === KEY_RIGHT)
-            || (isVertical && keyCode === KEY_DOWN)
-          ) {
+          } else if (keyCode === KEY_TAB || keyCode === KEY_RIGHT) {
             e.preventDefault();
             onKey(KEY_INCREMENT);
           }
@@ -116,7 +97,7 @@ const ButtonDisplay = (props, context) => {
   return (
     <Flex
       align="center"
-      direction={!swapped_buttons ? "row-reverse" : "row"}
+      direction={!swapped_buttons ? 'row-reverse' : 'row'}
       fill
       justify="space-around"
       wrap>

--- a/tgui/packages/tgui/interfaces/AlertModal.tsx
+++ b/tgui/packages/tgui/interfaces/AlertModal.tsx
@@ -1,5 +1,4 @@
 import { Loader } from './common/Loader';
-import { Preferences } from './common/InputButtons';
 import { useBackend, useLocalState } from '../backend';
 import { KEY_ENTER, KEY_ESCAPE, KEY_LEFT, KEY_RIGHT, KEY_SPACE, KEY_TAB } from '../../common/keycodes';
 import { Autofocus, Box, Button, Flex, Section, Stack } from '../components';
@@ -8,8 +7,9 @@ import { Window } from '../layouts';
 type AlertModalData = {
   autofocus: boolean;
   buttons: string[];
+  large_buttons: boolean;
   message: string;
-  preferences: Preferences;
+  swapped_buttons: boolean;
   timeout: number;
   title: string;
 };
@@ -22,19 +22,18 @@ export const AlertModal = (_, context) => {
   const {
     autofocus,
     buttons = [],
+    large_buttons,
     message,
-    preferences,
     timeout,
     title,
   } = data;
-  const { large_buttons } = preferences;
   const [selected, setSelected] = useLocalState<number>(context, 'selected', 0);
   // Dynamically sets window height
-  const windowHeight
-  = 115
-  + (message.length > 30 ? Math.ceil(message.length / 3) : 0)
-  + (message.length && large_buttons ? 5 : 0)
-  + (buttons.length > 2 ? buttons.length * 25 : 0);
+  let windowHeight
+    = 115
+    + (message.length > 30 ? Math.ceil(message.length / 3) : 0)
+    + (message.length && large_buttons ? 5 : 0)
+    + (buttons.length > 2 ? buttons.length * 25 : 0);
   const onKey = (direction: number) => {
     if (selected === 0 && direction === KEY_DECREMENT) {
       setSelected(buttons.length - 1);
@@ -47,7 +46,7 @@ export const AlertModal = (_, context) => {
 
   return (
     <Window height={windowHeight} title={title} width={325}>
-      {timeout && <Loader value={timeout} />}
+      {!!timeout && <Loader value={timeout} />}
       <Window.Content
         onKeyDown={(e) => {
           const keyCode = window.event ? e.which : e.keyCode;
@@ -71,7 +70,9 @@ export const AlertModal = (_, context) => {
         <Section fill>
           <Stack fill vertical>
             <Stack.Item grow m={1}>
-              <Box color="label" overflow="hidden">{message}</Box>
+              <Box color="label" overflow="hidden">
+                {message}
+              </Box>
             </Stack.Item>
             <Stack.Item>
               {!!autofocus && <Autofocus />}
@@ -91,9 +92,8 @@ export const AlertModal = (_, context) => {
  */
 const ButtonDisplay = (props, context) => {
   const { data } = useBackend<AlertModalData>(context);
-  const { buttons = [], preferences } = data;
+  const { buttons = [], large_buttons, swapped_buttons } = data;
   const { selected } = props;
-  const { large_buttons, swapped_buttons } = preferences;
   const buttonDirection
     = (buttons.length > 2 ? 'column' : 'row')
     + (!swapped_buttons ? '-reverse' : '');
@@ -132,8 +132,7 @@ const ButtonDisplay = (props, context) => {
  */
 const AlertButton = (props, context) => {
   const { act, data } = useBackend<AlertModalData>(context);
-  const { preferences } = data;
-  const { large_buttons } = preferences;
+  const { large_buttons } = data;
   const { button, selected } = props;
 
   return (

--- a/tgui/packages/tgui/interfaces/AlertModal.tsx
+++ b/tgui/packages/tgui/interfaces/AlertModal.tsx
@@ -23,7 +23,7 @@ export const AlertModal = (_, context) => {
     autofocus,
     buttons = [],
     large_buttons,
-    message,
+    message = "",
     timeout,
     title,
   } = data;

--- a/tgui/packages/tgui/interfaces/AlertModal.tsx
+++ b/tgui/packages/tgui/interfaces/AlertModal.tsx
@@ -29,9 +29,9 @@ export const AlertModal = (_, context) => {
   } = data;
   const [selected, setSelected] = useLocalState<number>(context, 'selected', 0);
   // Dynamically sets window height
-  let windowHeight
+  const windowHeight
     = 115
-    + (message.length > 30 ? Math.ceil(message.length / 3) : 0)
+    + (message.length > 30 ? Math.ceil(message.length / 4) : 0)
     + (message.length && large_buttons ? 5 : 0)
     + (buttons.length > 2 ? buttons.length * 25 : 0);
   const onKey = (direction: number) => {

--- a/tgui/packages/tgui/interfaces/ListInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/ListInputModal.tsx
@@ -1,23 +1,29 @@
 import { Loader } from './common/Loader';
-import { InputButtons, Preferences } from './common/InputButtons';
+import { InputButtons } from './common/InputButtons';
 import { Button, Input, Section, Stack } from '../components';
+import { useBackend, useLocalState } from '../backend';
 import { KEY_A, KEY_DOWN, KEY_ESCAPE, KEY_ENTER, KEY_UP, KEY_Z } from '../../common/keycodes';
 import { Window } from '../layouts';
-import { useBackend, useLocalState } from '../backend';
 
 type ListInputData = {
-  items: string[];
-  message: string;
   init_value: string;
-  preferences: Preferences;
+  items: string[];
+  large_buttons: boolean;
+  message: string;
   timeout: number;
   title: string;
 };
 
 export const ListInputModal = (_, context) => {
   const { act, data } = useBackend<ListInputData>(context);
-  const { items = [], message, init_value, preferences, timeout, title } = data;
-  const { large_buttons } = preferences;
+  const {
+    items = [],
+    message,
+    init_value,
+    large_buttons,
+    timeout,
+    title,
+  } = data;
   const [selected, setSelected] = useLocalState<number>(
     context,
     'selected',
@@ -98,7 +104,7 @@ export const ListInputModal = (_, context) => {
   );
   // Dynamically changes the window height based on the message.
   const windowHeight
-    = 325 + Math.ceil(message?.length / 3) + (large_buttons ? 5 : 0);
+    = 325 + Math.ceil(message.length / 3) + (large_buttons ? 5 : 0);
   // Grabs the cursor when no search bar is visible.
   if (!searchBarVisible) {
     setTimeout(() => document!.getElementById(selected.toString())?.focus(), 1);
@@ -131,15 +137,16 @@ export const ListInputModal = (_, context) => {
           buttons={
             <Button
               compact
-              icon={searchBarVisible ? "search" : "font"}
+              icon={searchBarVisible ? 'search' : 'font'}
               selected
-              tooltip={searchBarVisible
-                ? "Search Mode. Type to search or use arrow keys to select manually."
-                : "Hotkey Mode. Type a letter to jump to the first match. Enter to select."}
+              tooltip={
+                searchBarVisible
+                  ? 'Search Mode. Type to search or use arrow keys to select manually.'
+                  : 'Hotkey Mode. Type a letter to jump to the first match. Enter to select.'
+              }
               tooltipPosition="left"
               onClick={() => onSearchBarToggle()}
             />
-
           }
           className="ListInput__Section"
           fill

--- a/tgui/packages/tgui/interfaces/ListInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/ListInputModal.tsx
@@ -18,7 +18,7 @@ export const ListInputModal = (_, context) => {
   const { act, data } = useBackend<ListInputData>(context);
   const {
     items = [],
-    message,
+    message = "",
     init_value,
     large_buttons,
     timeout,

--- a/tgui/packages/tgui/interfaces/NumberInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/NumberInputModal.tsx
@@ -1,24 +1,24 @@
 import { Loader } from './common/Loader';
-import { InputButtons, Preferences } from './common/InputButtons';
+import { InputButtons } from './common/InputButtons';
 import { KEY_ENTER, KEY_ESCAPE } from '../../common/keycodes';
 import { useBackend, useLocalState } from '../backend';
 import { Box, Button, RestrictedInput, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
 type NumberInputData = {
+  init_value: number;
+  large_buttons: boolean;
   max_value: number | null;
   message: string;
   min_value: number | null;
-  init_value: number;
-  preferences: Preferences;
   timeout: number;
   title: string;
 };
 
 export const NumberInputModal = (_, context) => {
   const { act, data } = useBackend<NumberInputData>(context);
-  const { message, init_value, preferences, timeout, title } = data;
-  const { large_buttons } = preferences;
+  const { message, init_value, large_buttons, timeout, title }
+    = data;
   const [input, setInput] = useLocalState(context, 'input', init_value);
   const onChange = (value: number) => {
     if (value === input) {

--- a/tgui/packages/tgui/interfaces/NumberInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/NumberInputModal.tsx
@@ -17,7 +17,7 @@ type NumberInputData = {
 
 export const NumberInputModal = (_, context) => {
   const { act, data } = useBackend<NumberInputData>(context);
-  const { message, init_value, large_buttons, timeout, title }
+  const { init_value, large_buttons, message, timeout, title }
     = data;
   const [input, setInput] = useLocalState(context, 'input', init_value);
   const onChange = (value: number) => {
@@ -34,8 +34,8 @@ export const NumberInputModal = (_, context) => {
   };
   // Dynamically changes the window height based on the message.
   const windowHeight
-    = 130
-    + Math.ceil(message.length / 3)
+    = 140
+    + (message.length > 30 ? Math.ceil(message.length / 3) : 0)
     + (message.length && large_buttons ? 5 : 0);
 
   return (

--- a/tgui/packages/tgui/interfaces/NumberInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/NumberInputModal.tsx
@@ -17,7 +17,7 @@ type NumberInputData = {
 
 export const NumberInputModal = (_, context) => {
   const { act, data } = useBackend<NumberInputData>(context);
-  const { init_value, large_buttons, message, timeout, title }
+  const { init_value, large_buttons, message = "", timeout, title }
     = data;
   const [input, setInput] = useLocalState(context, 'input', init_value);
   const onChange = (value: number) => {

--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -1,16 +1,16 @@
 import { Loader } from './common/Loader';
-import { InputButtons, Preferences } from './common/InputButtons';
+import { InputButtons } from './common/InputButtons';
 import { useBackend, useLocalState } from '../backend';
 import { KEY_ENTER, KEY_ESCAPE } from '../../common/keycodes';
 import { Box, Section, Stack, TextArea } from '../components';
 import { Window } from '../layouts';
 
 type TextInputData = {
+  large_buttons: boolean;
   max_length: number;
   message: string;
   multiline: boolean;
   placeholder: string;
-  preferences: Preferences;
   timeout: number;
   title: string;
 };
@@ -18,15 +18,14 @@ type TextInputData = {
 export const TextInputModal = (_, context) => {
   const { act, data } = useBackend<TextInputData>(context);
   const {
+    large_buttons,
     max_length,
     message,
     multiline,
     placeholder,
-    preferences,
     timeout,
     title,
   } = data;
-  const { large_buttons } = preferences;
   const [input, setInput] = useLocalState<string>(
     context,
     'input',

--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -20,7 +20,7 @@ export const TextInputModal = (_, context) => {
   const {
     large_buttons,
     max_length,
-    message,
+    message = "",
     multiline,
     placeholder,
     timeout,

--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -39,8 +39,8 @@ export const TextInputModal = (_, context) => {
   };
   // Dynamically changes the window height based on the message.
   const windowHeight
-    = 125
-    + Math.ceil(message.length / 3)
+    = 135
+    + (message.length > 30 ? Math.ceil(message.length / 4) : 0)
     + (multiline || input.length >= 30 ? 75 : 0)
     + (message.length && large_buttons ? 5 : 0);
 
@@ -94,6 +94,7 @@ const InputArea = (props, context) => {
         const keyCode = window.event ? event.which : event.keyCode;
         if (keyCode === KEY_ENTER) {
           act('submit', { entry: input });
+          event.preventDefault();
         }
         if (keyCode === KEY_ESCAPE) {
           act('cancel');

--- a/tgui/packages/tgui/interfaces/common/InputButtons.tsx
+++ b/tgui/packages/tgui/interfaces/common/InputButtons.tsx
@@ -2,7 +2,8 @@ import { useBackend } from '../../backend';
 import { Box, Button, Flex } from '../../components';
 
 type InputButtonsData = {
-  preferences: Preferences;
+  large_buttons: boolean;
+  swapped_buttons: boolean;
 };
 
 type InputButtonsProps = {
@@ -10,14 +11,9 @@ type InputButtonsProps = {
   message?: string;
 };
 
-export type Preferences = {
-  large_buttons: boolean;
-  swapped_buttons: boolean;
-};
-
 export const InputButtons = (props: InputButtonsProps, context) => {
   const { act, data } = useBackend<InputButtonsData>(context);
-  const { large_buttons, swapped_buttons } = data.preferences;
+  const { large_buttons, swapped_buttons } = data;
   const { input, message } = props;
   const submitButton = (
     <Button

--- a/tgui/packages/tgui/routes.js
+++ b/tgui/packages/tgui/routes.js
@@ -5,6 +5,7 @@
  */
 
 import { selectBackend } from './backend';
+import { Icon, Stack } from './components';
 import { selectDebug } from './debug/selectors';
 import { Window } from './layouts';
 
@@ -33,11 +34,31 @@ const SuspendedWindow = () => {
   );
 };
 
+const RefreshingWindow = () => {
+  return (
+    <Window height={130} title="Loading" width={150}>
+      <Window.Content>
+        <Stack align="center" fill justify="center" vertical>
+          <Stack.Item>
+            <Icon color="blue" name="toolbox" spin size={4} />
+          </Stack.Item>
+          <Stack.Item>
+            Please wait...
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};
+
 export const getRoutedComponent = store => {
   const state = store.getState();
   const { suspended, config } = selectBackend(state);
   if (suspended) {
     return SuspendedWindow;
+  }
+  if (config.refreshing) {
+    return RefreshingWindow;
   }
   if (process.env.NODE_ENV !== 'production') {
     const debug = selectDebug(state);


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So tgui sends two types of data- standard and static. For optimization purposes you can send data as static data - but there's a problem if the user updates the screen. Refreshing the screen does not always send static data as it's on a cooldown.

Good UIs will have the error case handled where there is no static data retrieved.
Most will just not render anything, like vending machines, so forth.
Almost all UIs will try to cover for this case by casting objects as arrays so they can execute .map on them.

Here's an example of a UI which uses static data. If I tap F5 it will eventually hit the refresh cooldown and not send anything at all. This isn't a "bug in code" per se, it's just how it works and I disagree with that design. You can see that it has the error case handled for no static data already:
<details>
<summary><b>VIEW</b></summary>

![dreamseeker_yHg0ouLX4S](https://user-images.githubusercontent.com/42397676/152899979-62fe77d9-4738-4e3f-9b80-540daf4e177e.gif)
</details>


I've changed it to where DM will wait for the cooldown to send new static data over. I've also added a canary of sorts to the internals of TGUI that detects when it's waiting on this data refresh. This should outright prevent any bluescreens that occur if/when someone tries to act on data that isn't sent over due to a refresh. No more .length of undefined, .includes of undefined etc. And it gives a visual cue while doing so:
<details>
<summary><b>VIEW</b></summary>

![dreamseeker_AUQt34qDPQ](https://user-images.githubusercontent.com/42397676/152900427-89fa5bc8-7c24-48d2-a006-b58689789c1d.gif)
</details>

oh and of course i messed with some window sizing and stuff elsewhere
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Uis can safely rely on static data
Since the timer is built into ```send_full_update``` now, other cases where UIs use it no longer bypass the refresh cooldown
The user will understand the ui isn't "broken" if it's just waiting
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: TGUI now alerts the user when it is waiting on a refresh cooldown. In many cases, this will prevent screens from breaking that rely on static data.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
