### PR TITLE
Extrovert quick fix

### DIFF
--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -629,6 +629,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/commons/lounge
 	name = "\improper Bar Lounge"
 	icon_state = "lounge"
+	mood_bonus = 5
+    mood_message = "<span class='nicegreen'>I love being in the bar!</span>\n"
+    mood_trait = TRAIT_EXTROVERT
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
 
 /area/commons/fitness

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -630,8 +630,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Bar Lounge"
 	icon_state = "lounge"
 	mood_bonus = 5
-    mood_message = "<span class='nicegreen'>I love being in the bar!</span>\n"
-    mood_trait = TRAIT_EXTROVERT
+	mood_message = "<span class='nicegreen'>I love being in the bar!</span>\n"
+	mood_trait = TRAIT_EXTROVERT
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
 
 /area/commons/fitness


### PR DESCRIPTION

## About The Pull Request

There was an undersight from #64622 , mood boost is applied to the bar turf and not the lounge turf, this left it only applying to behind the bar counter.

## Why It's Good For The Game

This left the extrovert quirk not working, this will now let people once again hang out in the bar. I am very lonely, please come to my bar.

## Changelog

:cl:
fix: Being in the bar lounge makes extroverts happy once again!
/:cl:
