### PR TITLE
Fixes Hauntium runtiming to hell (get it) due to real fake weakrefs

### DIFF
--- a/code/datums/ai/_item_behaviors.dm
+++ b/code/datums/ai/_item_behaviors.dm
@@ -56,7 +56,5 @@
 
 /datum/ai_behavior/item_move_close_and_attack/ghostly/haunted/finish_action(datum/ai_controller/controller, succeeded, target_key, throw_count_key)
 	var/datum/weakref/target_ref = controller.blackboard[target_key]
-	var/atom/throw_target = target_ref?.resolve()
-	var/list/hauntee_list = controller.blackboard[BB_TO_HAUNT_LIST]
-	hauntee_list[throw_target]--
+	controller.blackboard[BB_TO_HAUNT_LIST][target_ref]--
 	return ..()

--- a/code/datums/ai/hauntium/haunted_controller.dm
+++ b/code/datums/ai/hauntium/haunted_controller.dm
@@ -23,6 +23,7 @@
 ///Signal response for when the item is picked up; stops listening for follow up equips, just waits for a drop.
 /datum/ai_controller/haunted/proc/on_equip(datum/source, mob/equipper, slot)
 	SIGNAL_HANDLER
+
 	UnregisterSignal(pawn, COMSIG_ITEM_EQUIPPED)
 	var/haunt_equipper = TRUE
 	if(isliving(equipper))
@@ -36,11 +37,11 @@
 		blackboard[BB_LIKES_EQUIPPER] = TRUE
 
 	RegisterSignal(pawn, COMSIG_ITEM_DROPPED, .proc/on_dropped)
-	SIGNAL_HANDLER
 
 ///Flip it so we listen for equip again but not for drop.
 /datum/ai_controller/haunted/proc/on_dropped(datum/source, mob/user)
 	SIGNAL_HANDLER
+
 	RegisterSignal(pawn, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 	blackboard[BB_LIKES_EQUIPPER] = FALSE
 	UnregisterSignal(pawn, COMSIG_ITEM_DROPPED)

--- a/code/datums/ai/hauntium/haunted_controller.dm
+++ b/code/datums/ai/hauntium/haunted_controller.dm
@@ -31,8 +31,8 @@
 		if(possibly_cool.mob_biotypes & MOB_UNDEAD)
 			haunt_equipper = FALSE
 	if(haunt_equipper)
-		var/list/hauntee_list = blackboard[BB_TO_HAUNT_LIST]
-		hauntee_list[WEAKREF(equipper)] += HAUNTED_ITEM_AGGRO_ADDITION //You have now become one of the victims of the HAAAAUNTTIIIINNGGG OOOOOO~~~
+		//You have now become one of the victims of the HAAAAUNTTIIIINNGGG OOOOOO~~~
+		blackboard[BB_TO_HAUNT_LIST][WEAKREF(equipper)] += HAUNTED_ITEM_AGGRO_ADDITION
 	else
 		blackboard[BB_LIKES_EQUIPPER] = TRUE
 

--- a/code/datums/ai/hauntium/haunted_controller.dm
+++ b/code/datums/ai/hauntium/haunted_controller.dm
@@ -29,11 +29,12 @@
 		var/mob/living/possibly_cool = equipper
 		if(possibly_cool.mob_biotypes & MOB_UNDEAD)
 			haunt_equipper = FALSE
-	if(!haunt_equipper)
-		blackboard[BB_LIKES_EQUIPPER] = TRUE
-	else
+	if(haunt_equipper)
 		var/list/hauntee_list = blackboard[BB_TO_HAUNT_LIST]
-		hauntee_list[equipper] = hauntee_list[equipper] + HAUNTED_ITEM_AGGRO_ADDITION //You have now become one of the victims of the HAAAAUNTTIIIINNGGG OOOOOO~~~
+		hauntee_list[WEAKREF(equipper)] += HAUNTED_ITEM_AGGRO_ADDITION //You have now become one of the victims of the HAAAAUNTTIIIINNGGG OOOOOO~~~
+	else
+		blackboard[BB_LIKES_EQUIPPER] = TRUE
+
 	RegisterSignal(pawn, COMSIG_ITEM_DROPPED, .proc/on_dropped)
 	SIGNAL_HANDLER
 

--- a/code/datums/ai/hauntium/hauntium_subtrees.dm
+++ b/code/datums/ai/hauntium/hauntium_subtrees.dm
@@ -14,12 +14,12 @@
 	var/list/to_haunt_list = controller.blackboard[BB_TO_HAUNT_LIST]
 
 	for(var/datum/weakref/target_ref as anything in to_haunt_list)
-		if(to_haunt_list[target_ref)] <= 0)
+		if(to_haunt_list[target_ref] <= 0)
 			to_haunt_list -= target_ref
 			continue
 
 		var/mob/living/real_target = target_ref?.resolve()
 		if(get_dist(real_target, item_pawn) <= 7)
-			controller.blackboard[BB_HAUNT_TARGET] = WEAKREF(potential_target)
+			controller.blackboard[BB_HAUNT_TARGET] = target_ref
 			controller.queue_behavior(/datum/ai_behavior/item_move_close_and_attack/ghostly/haunted, BB_HAUNT_TARGET, BB_HAUNTED_THROW_ATTEMPT_COUNT)
 			return SUBTREE_RETURN_FINISH_PLANNING

--- a/code/datums/ai/hauntium/hauntium_subtrees.dm
+++ b/code/datums/ai/hauntium/hauntium_subtrees.dm
@@ -18,7 +18,11 @@
 			to_haunt_list -= target_ref
 			continue
 
-		var/mob/living/real_target = target_ref?.resolve()
+		var/mob/living/real_target = target_ref.resolve()
+		if(QDELETED(real_target))
+			to_haunt_list -= target_ref
+			continue
+
 		if(get_dist(real_target, item_pawn) <= 7)
 			controller.blackboard[BB_HAUNT_TARGET] = target_ref
 			controller.queue_behavior(/datum/ai_behavior/item_move_close_and_attack/ghostly/haunted, BB_HAUNT_TARGET, BB_HAUNTED_THROW_ATTEMPT_COUNT)

--- a/code/datums/ai/hauntium/hauntium_subtrees.dm
+++ b/code/datums/ai/hauntium/hauntium_subtrees.dm
@@ -13,11 +13,13 @@
 
 	var/list/to_haunt_list = controller.blackboard[BB_TO_HAUNT_LIST]
 
-	for(var/mob/living/potential_target as anything in to_haunt_list)
-		if(to_haunt_list[potential_target] <= 0)
-			to_haunt_list -= potential_target
+	for(var/datum/weakref/target_ref as anything in to_haunt_list)
+		if(to_haunt_list[target_ref)] <= 0)
+			to_haunt_list -= target_ref
 			continue
-		if(get_dist(potential_target, item_pawn) <= 7)
-			controller.blackboard[BB_HAUNT_TARGET] = potential_target
+
+		var/mob/living/real_target = target_ref?.resolve()
+		if(get_dist(real_target, item_pawn) <= 7)
+			controller.blackboard[BB_HAUNT_TARGET] = WEAKREF(potential_target)
 			controller.queue_behavior(/datum/ai_behavior/item_move_close_and_attack/ghostly/haunted, BB_HAUNT_TARGET, BB_HAUNTED_THROW_ATTEMPT_COUNT)
 			return SUBTREE_RETURN_FINISH_PLANNING


### PR DESCRIPTION
## About The Pull Request

Hauntium AI was recently changed to use weakrefs to cut back on hard deletes
Unfortunately, not all cases of hauntium AI assigning references were swapped to weakrefs.
Meaning the haunting list ended up being some weird combination of hard references to mobs and weak references.

These hard references in the list caused a million runtimes a second because the ai was, of course, trying to `resolve()` hard references which doesn't work and it was doing it every second

Hauntium should now properly use weakrefs in the cases it's used in.

## Why It's Good For The Game

Spooky things actually haunt again

## Changelog

:cl: Melbert
fix: Fixes hauntium from runtiming a lot and not haunting people
/:cl:
