### PR TITLE
The Engineering Break Room Division

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4268,6 +4268,10 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"aTm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/hallway)
 "aTn" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -15419,7 +15423,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "cwL" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -16848,7 +16852,7 @@
 "cOc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "cOf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -22523,7 +22527,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "dmR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -36953,7 +36957,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "fxw" = (
 /obj/structure/closet/wardrobe/black,
 /obj/effect/turf_decal/tile/neutral{
@@ -37060,7 +37064,7 @@
 /obj/structure/tank_holder/oxygen/yellow,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "fzh" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/bot,
@@ -37354,7 +37358,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "fDA" = (
 /obj/machinery/washing_machine,
 /obj/effect/decal/cleanable/cobweb,
@@ -38484,7 +38488,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "fTP" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light/directional/east,
@@ -40260,7 +40264,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "goM" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -41113,7 +41117,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "gzx" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -47493,7 +47497,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "ici" = (
 /obj/structure/bed/roller,
 /obj/structure/sign/departments/chemistry{
@@ -48016,7 +48020,7 @@
 /obj/item/kirbyplants/random,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "ijr" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/table/wood,
@@ -50530,7 +50534,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "iSa" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/blue{
@@ -63880,7 +63884,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "mfP" = (
 /obj/machinery/vending/autodrobe,
 /obj/machinery/light/small/directional/north,
@@ -64539,8 +64543,10 @@
 /area/engineering/break_room)
 "mnu" = (
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "mnP" = (
 /obj/structure/table/wood,
 /obj/item/camera,
@@ -71370,7 +71376,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "nZh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
@@ -72380,7 +72386,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "omJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72650,7 +72656,7 @@
 	name = "engineering camera"
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "oph" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77519,7 +77525,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "pEX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -79803,7 +79809,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "qij" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
@@ -81346,6 +81352,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"qEs" = (
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron,
+/area/engineering/hallway)
 "qEu" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -81479,7 +81489,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "qHk" = (
 /obj/machinery/space_heater/improvised_chem_heater,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -86660,7 +86670,7 @@
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "rZH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -87609,7 +87619,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "smp" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -89507,7 +89517,7 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "sKN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
@@ -90548,6 +90558,9 @@
 /obj/machinery/bounty_board/directional/south,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"sZC" = (
+/turf/closed/wall/r_wall,
+/area/engineering/hallway)
 "sZD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -96923,7 +96936,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "uIx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -99875,6 +99888,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/hfr_room)
+"vtJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/hallway)
 "vtP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -104223,7 +104242,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "wBx" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -107280,7 +107299,7 @@
 	req_one_access_txt = "13;19;32"
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "xsB" = (
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
@@ -129007,11 +129026,11 @@ qYo
 aaa
 nUT
 qYo
-pFk
-pFk
+sZC
+sZC
 wBr
-pFk
-pFk
+sZC
+sZC
 vVc
 eBF
 vVc
@@ -129264,11 +129283,11 @@ uHd
 qYo
 nUT
 qYo
-pFk
+sZC
 gox
 cwJ
 qig
-pFk
+sZC
 bCL
 bCL
 bCL
@@ -129520,12 +129539,12 @@ aaa
 xNe
 aaa
 uUT
-pFk
-pFk
-pFk
+sZC
+sZC
+sZC
 xsv
-pFk
-pFk
+sZC
+sZC
 fQp
 aEt
 vJV
@@ -129777,7 +129796,7 @@ xTK
 xTK
 qYo
 nUT
-pFk
+sZC
 sKI
 rZC
 smc
@@ -130034,7 +130053,7 @@ qYo
 aaa
 aaa
 nUT
-mPn
+aTm
 iRW
 ibZ
 nYY
@@ -130291,7 +130310,7 @@ xTK
 xTK
 qYo
 nUT
-mPn
+aTm
 iRW
 dmQ
 cOc
@@ -130548,7 +130567,7 @@ gnH
 gnH
 gnH
 uch
-mPn
+aTm
 uHS
 smc
 qHj
@@ -130805,7 +130824,7 @@ eYl
 vFd
 vFd
 qYo
-mPn
+aTm
 iRW
 smc
 fxv
@@ -131062,7 +131081,7 @@ wEb
 tDV
 vFd
 vVc
-pFk
+sZC
 opd
 smc
 mfK
@@ -131319,10 +131338,10 @@ tDV
 wNz
 vFd
 qYo
-mPn
+aTm
 iRW
 nYY
-msU
+vtJ
 lqH
 gNJ
 lJW
@@ -131576,7 +131595,7 @@ rwr
 pfb
 vFd
 vVc
-mPn
+aTm
 fDi
 nYY
 mnu
@@ -131833,10 +131852,10 @@ jEV
 osb
 vFd
 qYo
-mPn
+aTm
 iRW
 omA
-mnu
+qEs
 xOA
 hbo
 wlQ
@@ -132090,7 +132109,7 @@ qYo
 tXi
 qYo
 qYo
-mPn
+aTm
 iRW
 gzu
 pEU
@@ -132347,7 +132366,7 @@ xXs
 hOT
 kPH
 qYo
-pFk
+sZC
 iiS
 gzu
 fyU

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -25514,7 +25514,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "cUt" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -26267,7 +26267,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "djK" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "IsolationCell";
@@ -26464,7 +26464,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "doj" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/delivery,
@@ -29085,7 +29085,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "enZ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "gravity";
@@ -29929,7 +29929,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "eDq" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -30172,7 +30172,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "eIR" = (
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/wood{
@@ -32168,7 +32168,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "fsk" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
 /obj/effect/turf_decal/bot,
@@ -32268,7 +32268,7 @@
 "fuC" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "fuK" = (
 /turf/closed/wall,
 /area/commons/toilet/restrooms)
@@ -33387,7 +33387,7 @@
 /obj/effect/turf_decal/box,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "fRx" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -37520,13 +37520,14 @@
 "hva" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
-/obj/machinery/status_display/evac/directional/north,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "hwo" = (
@@ -37994,7 +37995,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "hGD" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/item/radio/intercom/prison/directional/south,
@@ -40014,7 +40015,7 @@
 	icon_state = "plant-05"
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "ist" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Surgery Maintenance";
@@ -40737,6 +40738,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "iFI" = (
@@ -48136,7 +48138,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "liP" = (
 /obj/machinery/door/airlock/mining{
 	name = "Auxiliary Base";
@@ -48436,7 +48438,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "lmP" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue{
@@ -49082,7 +49084,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "lxB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -49438,7 +49440,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "lGn" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -50088,7 +50090,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "lSH" = (
 /turf/closed/wall/rust,
 /area/commons/toilet/restrooms)
@@ -50901,7 +50903,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "mfD" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -51690,7 +51692,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "msx" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -52022,7 +52024,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "myb" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -53027,7 +53029,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "mPI" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -55036,7 +55038,7 @@
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "nFQ" = (
 /obj/item/canvas/nineteen_nineteen,
 /obj/structure/easel,
@@ -58702,7 +58704,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "oZM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -60670,7 +60672,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "pFC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/holosign/barrier/atmos,
@@ -63179,7 +63181,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "qGh" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/neutral{
@@ -63349,7 +63351,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "qJc" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -72317,7 +72319,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "tSE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72772,7 +72774,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "uaJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -76715,7 +76717,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "vDc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77486,6 +77488,9 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "vSg" = (
@@ -77921,7 +77926,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "wct" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -80161,7 +80166,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "wPR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -81159,7 +81164,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "xju" = (
-/obj/structure/sign/warning/securearea,
 /turf/closed/wall,
 /area/engineering/break_room)
 "xjT" = (
@@ -81470,7 +81474,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "xpL" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -82074,7 +82078,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "xwT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -83848,7 +83852,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/break_room)
+/area/engineering/hallway)
 "ygB" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -119378,7 +119382,7 @@ bEg
 bEg
 hJi
 bEg
-efC
+uHl
 hva
 fPw
 lUO

--- a/code/game/area/space_station_13_areas.dm
+++ b/code/game/area/space_station_13_areas.dm
@@ -869,6 +869,10 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Engineering"
 	icon_state = "engine"
 
+/area/engineering/hallway
+	name = "Engineering Hallway"
+	icon_state = "engine_hallway"
+
 /area/engineering/atmos
 	name = "Atmospherics"
 	icon_state = "atmos"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR splits up the vastness of what we currently call the "break room" for Engineers. Let's take a look at Deltastation:

![image](https://user-images.githubusercontent.com/34697715/153106882-9c6df799-5133-4ab5-a238-677a772da6e5.png)

Why is this all just the breakroom? What? Let's fix that using a sprite I found just sitting in areas.dmi, all unused (no merge conflicts? yippie!):

![image](https://user-images.githubusercontent.com/34697715/153106890-76381e3e-c144-439d-9641-664ae1774cdc.png)

Much better to my eyes. I also applied this level of change to Kilostation.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Helps fix absolute fucking vast blobs of room definitions, especially when it doesn't make a great deal of sense.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Engineering Unions are planning strikes after their break rooms have been slashed in half by Nanotrasen on DeltaStation and KiloStation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
