### PR TITLE
Gives wardens their sechud icon back

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -550,6 +550,7 @@
 /datum/id_trim/job/warden
 	assignment = "Warden"
 	trim_state = "trim_warden"
+	sechud_icon_state = SECHUD_WARDEN
 	extra_access = list(ACCESS_FORENSICS_LOCKERS, ACCESS_MAINT_TUNNELS, ACCESS_MORGUE)
 	minimal_access = list(ACCESS_ARMORY, ACCESS_BRIG, ACCESS_COURT, ACCESS_MECH_SECURITY, ACCESS_MINERAL_STOREROOM,
 					ACCESS_SECURITY, ACCESS_SEC_DOORS, ACCESS_WEAPONS) // See /datum/job/warden/get_access()


### PR DESCRIPTION
## About The Pull Request

THE GOVERNMENT IS OUT FOR YOUR SECURITY HUD ICON STATE DON'T LET THEM IN
![image](https://user-images.githubusercontent.com/53777086/153113019-cd731e07-63c5-4feb-ba79-39edebddcb2e.png)

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/64777

## Changelog

:cl:
fix: Wardens have a SecHUD icon again
/:cl: