### PR TITLE
Makes people unable to hear in space

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -20,7 +20,6 @@
 	. = ..()
 	if(HAS_TRAIT(src, TRAIT_DEAF))
 		return INFINITY //For all my homies that can not hear in the world
-
 	var/obj/item/organ/ears/E = getorganslot(ORGAN_SLOT_EARS)
 	if(!E)
 		return INFINITY

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -20,6 +20,13 @@
 	. = ..()
 	if(HAS_TRAIT(src, TRAIT_DEAF))
 		return INFINITY //For all my homies that can not hear in the world
+
+	var/turf/current_turf = get_turf(src)
+	var/datum/gas_mixture/environment = current_turf.return_air()
+	var/pressure = environment ? environment.return_pressure() : 0
+	if(pressure < SOUND_MINIMUM_PRESSURE) //space is empty
+		return INFINITY
+
 	var/obj/item/organ/ears/E = getorganslot(ORGAN_SLOT_EARS)
 	if(!E)
 		return INFINITY

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -21,12 +21,6 @@
 	if(HAS_TRAIT(src, TRAIT_DEAF))
 		return INFINITY //For all my homies that can not hear in the world
 
-	var/turf/current_turf = get_turf(src)
-	var/datum/gas_mixture/environment = current_turf.return_air()
-	var/pressure = environment ? environment.return_pressure() : 0
-	if(pressure < SOUND_MINIMUM_PRESSURE) //space is empty
-		return INFINITY
-
 	var/obj/item/organ/ears/E = getorganslot(ORGAN_SLOT_EARS)
 	if(!E)
 		return INFINITY

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -37,6 +37,11 @@
 
 //this returns the mob's protection against ear damage (0:no protection; 1: some ear protection; 2: has no ears)
 /mob/living/proc/get_ear_protection()
+	var/turf/current_turf = get_turf(src)
+	var/datum/gas_mixture/environment = current_turf.return_air()
+	var/pressure = environment ? environment.return_pressure() : 0
+	if(pressure < SOUND_MINIMUM_PRESSURE) //space is empty
+		return 1
 	return 0
 
 /mob/living/proc/is_mouth_covered(head_only = 0, mask_only = 0)


### PR DESCRIPTION
## About The Pull Request

This is used solely for flashbangs (including hypnoflashbang) and Peackeeper's harm alarm as far as I can see, in case you were already wondering.
![image](https://user-images.githubusercontent.com/53777086/153115165-bfa3cdc9-912e-4332-916c-3d4c07be014e.png)


## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/63893
Fixes a consistency issue of being able to hear shit in space, just like you can't hear people talking.

## Changelog

:cl:
fix: You can no longer hear things in space (like flashbangs).
/:cl: