### PR TITLE
fire breath can be done without the ability to speak + SPELL code improvement

### DIFF
--- a/code/__DEFINES/magic.dm
+++ b/code/__DEFINES/magic.dm
@@ -21,6 +21,8 @@
 
 //invocation types - what does the wizard need to do to invoke (cast) the spell?
 
+///Allows being able to cast the spell without saying anything.
+#define INVOCATION_NONE "none"
 ///Forces the wizard to shout (and be able to) to cast the spell.
 #define INVOCATION_SHOUT "shout"
 ///Forces the wizard to emote (and be able to) to cast the spell.

--- a/code/datums/mutations/actions.dm
+++ b/code/datums/mutations/actions.dm
@@ -121,6 +121,7 @@
 	desc = "You breathe a cone of fire directly in front of you."
 	school = SCHOOL_EVOCATION
 	invocation = ""
+	invocation_type = INVOCATION_NONE
 	charge_max = 400
 	clothes_req = FALSE
 	range = 20

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -167,7 +167,7 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 	nonabstract_req = TRUE
 	phase_allowed = TRUE
 	antimagic_allowed = TRUE
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 
 /obj/effect/proc_holder/spell/self/special_equipment_fallback/cast(list/targets, mob/user)
 	var/datum/mind/mind = user.mind

--- a/code/modules/admin/verbs/SDQL2/SDQL_spells/spell_edit_menu.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_spells/spell_edit_menu.dm
@@ -90,7 +90,7 @@ GLOBAL_LIST_INIT_TYPED(sdql_spells, /obj/effect/proc_holder/spell, list())
 	)
 
 	var/static/list/enum_vars = list(
-		"invocation_type" = list("none", "whisper", "shout", "emote"),
+		"invocation_type" = list(INVOCATION_NONE, INVOCATION_WHISPER, INVOCATION_SHOUT, INVOCATION_EMOTE),
 		"selection_type" = list("view", "range"),
 		"smoke_spread" = list(0, 1, 2, 3),
 		"random_target_priority" = list(0, 1),
@@ -216,6 +216,7 @@ GLOBAL_LIST_INIT_TYPED(sdql_spells, /obj/effect/proc_holder/spell, list())
 			"phase_allowed" = "Whether the spell can be cast while the user is jaunting or bloodcrawling.",
 			"antimagic_allowed" = "Whether the spell can be cast while the user is affected by anti-magic effects.",
 			"invocation_type" = "How the spell is invoked.\n\
+				When set to \"none\", the user will not state anything when invocating.\n\
 				When set to \"whisper\", the user whispers the invocation, as if with the whisper verb.\n\
 				When set to \"shout\", the user says the invocation, as if with the say verb.\n\
 				When set to \"emote\", a visible message is produced.",

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -305,7 +305,7 @@
 	school = SCHOOL_FORBIDDEN
 	charge_max = 150
 	clothes_req = FALSE
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	range = 2
 	action_icon = 'icons/mob/actions/actions_ecult.dmi'
 	action_icon_state = "mad_touch"
@@ -504,7 +504,7 @@
 /obj/effect/proc_holder/spell/targeted/worm_contract
 	name = "Force Contract"
 	desc = "Forces your body to contract onto a single tile."
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	school = SCHOOL_FORBIDDEN
 	clothes_req = FALSE
 	action_background_icon_state = "bg_ecult"
@@ -572,7 +572,7 @@
 	charge_max = 300
 	clothes_req = FALSE
 	invocation = "PI'RC' TH' M'ND"
-	invocation_type = "whisper"
+	invocation_type = INVOCATION_WHISPER
 	range = 10
 	action_icon = 'icons/mob/actions/actions_ecult.dmi'
 	action_icon_state = "mansus_link"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -599,7 +599,7 @@
 	desc = "Exits the body you are possessing."
 	charge_max = 60
 	clothes_req = 0
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	max_targets = 1
 	range = -1
 	include_user = TRUE

--- a/code/modules/research/xenobiology/crossbreeding/_mobs.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_mobs.dm
@@ -11,7 +11,7 @@ Slimecrossing Mobs
 	action_icon_state = "transformslime"
 	cooldown_min = 0
 	charge_max = 0
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	shapeshift_type = /mob/living/simple_animal/slime/transformedslime
 	convert_damage = TRUE
 	convert_damage_type = CLONE

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	var/antimagic_allowed = FALSE // If false, the spell cannot be cast while under the effect of antimagic
 	var/invocation = "HURP DURP" //what is uttered when the wizard casts the spell
 	var/invocation_emote_self = null
-	var/invocation_type = "none" //can be none, whisper, emote and shout
+	var/invocation_type = INVOCATION_NONE //can be none, whisper, emote and shout
 	var/range = 7 //the range of the spell; outer radius for aoe spells
 	var/message = "" //whatever it says to the guy affected by it
 	var/selection_type = "view" //can be "range" or "view"

--- a/code/modules/spells/spell_types/cone_spells.dm
+++ b/code/modules/spells/spell_types/cone_spells.dm
@@ -5,7 +5,7 @@
 	charge_max = 100
 	clothes_req = FALSE
 	invocation = "FUKAN NOTHAN"
-	invocation_type = "shout"
+	invocation_type = INVOCATION_SHOUT
 	sound = 'sound/magic/forcewall.ogg'
 	action_icon_state = "shield"
 	range = -1

--- a/code/modules/spells/spell_types/conjure.dm
+++ b/code/modules/spells/spell_types/conjure.dm
@@ -79,7 +79,7 @@
 /obj/effect/proc_holder/spell/targeted/conjure_item
 	name = "Summon weapon"
 	desc = "A generic spell that should not exist.  This summons an instance of a specific type of item, or if one already exists, un-summons it.  Summons into hand if possible."
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	include_user = TRUE
 	range = -1
 	clothes_req = FALSE

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -16,7 +16,7 @@
 	charge_max = 5 SECONDS
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	range = 2
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
 	action_icon_state = "areaconvert"
@@ -36,7 +36,7 @@
 	charge_max = 2 SECONDS
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	range = 0
 	summon_type = list(/turf/open/floor/engine/cult)
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
@@ -52,7 +52,7 @@
 	charge_max = 10 SECONDS
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	range = 0
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
 	action_icon_state = "lesserconstruct"
@@ -69,7 +69,7 @@
 	charge_max = 30 SECONDS
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	range = 0
 
 	summon_type = list(/turf/closed/wall/r_wall)
@@ -82,7 +82,7 @@
 	charge_max = 4 MINUTES
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	range = 0
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
 	action_icon_state = "summonsoulstone"
@@ -110,7 +110,7 @@
 	charge_max = 40 SECONDS
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	wall_type = /obj/effect/forcefield/cult
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
 	action_icon_state = "cultforcewall"
@@ -126,7 +126,7 @@
 	charge_max = 25 SECONDS
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	jaunt_duration = 5 SECONDS
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
 	action_icon_state = "phaseshift"
@@ -155,7 +155,7 @@
 	charge_max = 40 SECONDS
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	max_targets = 6
 	action_icon_state = "magicm"
 	action_background_icon_state = "bg_demon"
@@ -173,7 +173,7 @@
 	charge_max = 20 SECONDS
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	range = -1
 	include_user = TRUE
 	cooldown_min = 20 //25 deciseconds reduction per rank
@@ -192,7 +192,7 @@
 	school = SCHOOL_EVOCATION
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	ranged_mousepointer = 'icons/effects/mouse_pointers/cult_target.dmi'
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
 	action_background_icon_state = "bg_demon"
@@ -252,7 +252,7 @@
 	school = SCHOOL_EVOCATION
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	ranged_mousepointer = 'icons/effects/mouse_pointers/cult_target.dmi'
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
 	action_background_icon_state = "bg_demon"

--- a/code/modules/spells/spell_types/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/ethereal_jaunt.dm
@@ -6,7 +6,7 @@
 	charge_max = 30 SECONDS
 	clothes_req = TRUE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	range = -1
 	cooldown_min = 10 SECONDS
 	include_user = TRUE

--- a/code/modules/spells/spell_types/infinite_guns.dm
+++ b/code/modules/spells/spell_types/infinite_guns.dm
@@ -1,7 +1,7 @@
 /obj/effect/proc_holder/spell/targeted/infinite_guns
 	name = "Lesser Summon Guns"
 	desc = "Why reload when you have infinite guns? Summons an unending stream of bolt action rifles that deal little damage, but will knock targets down. Requires both hands free to use. Learning this spell makes you unable to learn Arcane Barrage."
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	include_user = TRUE
 	range = -1
 

--- a/code/modules/spells/spell_types/touch_attacks.dm
+++ b/code/modules/spells/spell_types/touch_attacks.dm
@@ -3,7 +3,7 @@
 	var/obj/item/melee/touch_attack/attached_hand = null
 	var/drawmessage = "You channel the power of the spell to your hand."
 	var/dropmessage = "You draw the power out of your hand."
-	invocation_type = "none" //you scream on connecting, not summoning
+	invocation_type = INVOCATION_NONE //you scream on connecting, not summoning
 	include_user = TRUE
 	range = -1
 

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -65,7 +65,7 @@
 	charge_max = 120
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	range = -1
 	include_user = TRUE
 	cooldown_min = 20 //25 deciseconds reduction per rank
@@ -84,7 +84,7 @@
 	charge_max = 360
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	range = -1
 	include_user = TRUE
 
@@ -116,7 +116,7 @@
 	charge_max = 20
 	clothes_req = TRUE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	range = -1
 	include_user = TRUE
 	cooldown_min = 5 //4 deciseconds reduction per rank
@@ -202,7 +202,7 @@
 	charge_max = 600
 	clothes_req = FALSE
 	invocation = "none"
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	range = 0
 	summon_type = list(/obj/structure/constructshell)
 	action_icon = 'icons/mob/actions/actions_cult.dmi'
@@ -306,7 +306,7 @@
 	antimagic_allowed = TRUE
 	range = 2
 	cooldown_min = 150
-	invocation_type = "none"
+	invocation_type = INVOCATION_NONE
 	sparkle_path = /obj/effect/temp_visual/dir_setting/tailsweep
 	action_icon = 'icons/mob/actions/actions_xeno.dmi'
 	action_icon_state = "tailsweep"


### PR DESCRIPTION
## About The Pull Request

Spell code 😦 
Fire breath currently requires you can speak, which doesn't make sense, it was actually a one-line change, but I didn't like doing just the one line change because it wasn't defined, so I defined it, and swapped all the others that didn't use defines.
## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/62697
Makes the code neater and defines one thing that previously wasn't, while the 3 others were.

## Changelog

:cl:
fix: Fire breath can be used even if you can't speak (you're welcome tongue tied mains).
/:cl: