### PR TITLE
Gives me Dynamic codeowners*

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,7 @@
 
 # Mothblocks
 
+/code/game/gamemodes/ @Mothblocks
 /code/modules/autowiki/ @Mothblocks
 /code/modules/unit_tests/ @Mothblocks
 /code/modules/client/preferences/ @Mothblocks


### PR DESCRIPTION
Actually applies it to all of gamemodes, until the rest of the gamemode code is removed. Anything in there is just touching Dynamic but in a roundabout way.