### PR TITLE
prevents finger guns from being used with something in your hand

### DIFF
--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -203,6 +203,9 @@
 	if(owner.incapacitated())
 		to_chat(owner, span_warning("You can't properly point your fingers while incapacitated."))
 		return
+	if(owner.get_active_held_item())
+		to_chat(owner, span_warning("You can't properly fire your finger guns with something in your hand."))
+		return
 	if(usr?.mind)
 		if(!usr.mind.miming)
 			to_chat(usr, span_warning("You must dedicate yourself to silence first!"))
@@ -213,6 +216,9 @@
 	..()
 
 /obj/effect/proc_holder/spell/aimed/finger_guns/InterceptClickOn(mob/living/caller, params, atom/target)
+	if(owner.get_active_held_item())
+		to_chat(owner, span_warning("You can't properly fire your finger guns with something in your hand."))
+		return
 	if(caller.incapacitated())
 		to_chat(caller, span_warning("You can't properly point your fingers while incapacitated."))
 		if(charge_type == "recharge")

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -176,7 +176,7 @@
 
 /obj/effect/proc_holder/spell/aimed/finger_guns
 	name = "Finger Guns"
-	desc = "Shoot up to three mimed bullets from your fingers that damage and mute their targets."
+	desc = "Shoot up to three mimed bullets from your fingers that damage and mute their targets. Can't be used if you have something in your hands."
 	school = SCHOOL_MIME
 	panel = "Mime"
 	charge_max = 300

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -216,8 +216,8 @@
 	..()
 
 /obj/effect/proc_holder/spell/aimed/finger_guns/InterceptClickOn(mob/living/caller, params, atom/target)
-	if(owner.get_active_held_item())
-		to_chat(owner, span_warning("You can't properly fire your finger guns with something in your hand."))
+	if(caller.get_active_held_item())
+		to_chat(caller, span_warning("You can't properly fire your finger guns with something in your hand."))
 		return
 	if(caller.incapacitated())
 		to_chat(caller, span_warning("You can't properly point your fingers while incapacitated."))


### PR DESCRIPTION
## About The Pull Request

Removes the ability to fire mime's finger guns if you have something in your hand, simple as. I find it to be an oversight and I assume an exploit.

## Why It's Good For The Game

It makes no sense you can shoot finger guns while holding something you're currently SUPPOSEDLY using to make finger guns with.
Also it is very unfair
https://user-images.githubusercontent.com/53777086/153124609-f18e5ceb-3777-42d3-bfa7-eebc71a4f350.mp4

## Changelog

:cl:
fix: Mime finger guns cannot be used while you have something in your hand.
/:cl: