### PR TITLE
Adjust balloon alerts for the rotate component

### DIFF
--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -110,7 +110,6 @@
 
 	var/obj/rotated_obj = parent
 	rotated_obj.setDir(turn(rotated_obj.dir, degrees))
-	rotated_obj.balloon_alert(user, "you [degrees == ROTATION_FLIP ? "flip" : "rotate"] [rotated_obj]")
 	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
 		playsound(rotated_obj, 'sound/items/ratchet.ogg', 50, TRUE)
 		
@@ -131,13 +130,13 @@
 			return FALSE
 		var/obj/item/tool = user.get_active_held_item()
 		if(!tool || tool.tool_behaviour != TOOL_WRENCH)
-			rotated_obj.balloon_alert(user, "need a wrench")
+			rotated_obj.balloon_alert(user, "need a wrench!")
 			return FALSE
 	if(!(rotation_flags & ROTATION_IGNORE_ANCHORED) && rotated_obj.anchored)
 		if(istype(rotated_obj, /obj/structure/window))
-			rotated_obj.balloon_alert(user, "need to unscrew")
+			rotated_obj.balloon_alert(user, "need to unscrew!")
 		else
-			rotated_obj.balloon_alert(user, "need to unwrench")
+			rotated_obj.balloon_alert(user, "need to unwrench!")
 		return FALSE
 
 	if(rotation_flags & ROTATION_NEEDS_ROOM)
@@ -145,7 +144,7 @@
 		var/obj/structure/window/rotated_window = rotated_obj
 		var/fulltile = istype(rotated_window) ? rotated_window.fulltile : FALSE
 		if(!valid_window_location(rotated_obj.loc, target_dir, is_fulltile = fulltile))
-			rotated_obj.balloon_alert(user, "cannot rotate in that direction")
+			rotated_obj.balloon_alert(user, "cannot rotate in that direction!")
 			return FALSE
 	return TRUE
 

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -144,7 +144,7 @@
 		var/obj/structure/window/rotated_window = rotated_obj
 		var/fulltile = istype(rotated_window) ? rotated_window.fulltile : FALSE
 		if(!valid_window_location(rotated_obj.loc, target_dir, is_fulltile = fulltile))
-			rotated_obj.balloon_alert(user, "cannot rotate in that direction!")
+			rotated_obj.balloon_alert(user, "can't rotate in that direction!")
 			return FALSE
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1. Adjusts the failure balloon alerts to have a `!`, which is standard.
2. Remove the balloon alert for rotating/flipping things, as the visual feedback is already there: it's the thing getting rotated/flipped. Plus it's too long.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Made the balloon alerts for rotating stuff more consistent and less intrusive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
