### PR TITLE
Fixes blast doors showing a balloon alert when you crowbar them open while unpowered

### DIFF
--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -46,7 +46,7 @@
 	if(machine_stat & NOPOWER)
 		open(TRUE)
 		return
-	if (density && hasPower())
+	if (density)
 		balloon_alert(user, "open the door first!")
 		return
 	if (!panel_open)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -43,7 +43,7 @@
 
 /obj/machinery/door/poddoor/crowbar_act(mob/living/user, obj/item/tool)
 	. = ..()
-	if (density & hasPower())
+	if (density && hasPower())
 		balloon_alert(user, "open the door first!")
 		return
 	if (!panel_open)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -43,6 +43,9 @@
 
 /obj/machinery/door/poddoor/crowbar_act(mob/living/user, obj/item/tool)
 	. = ..()
+	if(machine_stat & NOPOWER)
+		open(TRUE)
+		return
 	if (density && hasPower())
 		balloon_alert(user, "open the door first!")
 		return
@@ -199,10 +202,6 @@
 
 /obj/machinery/door/poddoor/try_to_activate_door(mob/user)
 	return
-
-/obj/machinery/door/poddoor/try_to_crowbar(obj/item/I, mob/user)
-	if(machine_stat & NOPOWER)
-		open(TRUE)
 
 /obj/machinery/door/poddoor/attack_alien(mob/living/carbon/alien/humanoid/user, list/modifiers)
 	if(density & !(resistance_flags & INDESTRUCTIBLE))

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -43,7 +43,7 @@
 
 /obj/machinery/door/poddoor/crowbar_act(mob/living/user, obj/item/tool)
 	. = ..()
-	if (density)
+	if (density & hasPower())
 		balloon_alert(user, "open the door first!")
 		return
 	if (!panel_open)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Now it will only give a balloon alert if you crowbar it while powered!
Also moves the crowbar opening from `try_to_crowbar` to `crowbar_act`.
## Why It's Good For The Game
Closes #64805 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: blast doors no longer give you a balloon alert about opening it first when you crowbar them open while unpowered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
