### PR TITLE
Gives Omega soap 800 uses instead of 301

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -53,7 +53,7 @@
 
 /obj/item/soap/homemade
 	desc = "A homemade bar of soap. Smells of... well...."
-	grind_results = list(/datum/reagent/liquidgibs = 8, /datum/reagent/lye) = 8 //diminishing returns
+	grind_results = list(/datum/reagent/liquidgibs = 9, /datum/reagent/lye = 9)
 	icon_state = "soapgibs"
 	cleanspeed = 3 SECONDS // faster than base soap to reward chemists for going to the effort
 
@@ -66,17 +66,20 @@
 
 /obj/item/soap/deluxe
 	desc = "A deluxe Waffle Co. brand bar of soap. Smells of high-class luxury."
+	grind_results = list(/datum/reagent/consumable/aloejuice = 10, /datum/reagent/lye = 10)
 	icon_state = "soapdeluxe"
 	cleanspeed = 2 SECONDS //captain gets one of these
 
 /obj/item/soap/syndie
 	desc = "An untrustworthy bar of soap made of strong chemical agents that dissolve blood faster."
+	grind_results = list(/datum/reagent/toxin/acid = 10, /datum/reagent/lye = 10)
 	icon_state = "soapsyndie"
 	cleanspeed = 0.5 SECONDS //faster than mops so it's useful for traitors who want to clean crime scenes
 
 /obj/item/soap/omega
 	name = "\improper Omega soap"
 	desc = "The most advanced soap known to mankind. The beginning of the end for germs."
+	grind_results = list(/datum/reagent/consumable/potato_juice = 9, /datum/reagent/consumable/ethanol/lizardwine = 9, /datum/reagent/monkey_powder = 9, /datum/reagent/drug/krokodil = 9, /datum/reagent/toxin/acid/nitracid = 9, /datum/reagent/baldium = 9, /datum/reagent/consumable/ethanol/hooch = 9, /datum/reagent/bluespace = 9, /datum/reagent/drug/pumpup = 9, /datum/reagent/consumable/space_cola = 9)
 	icon_state = "soapomega"
 	cleanspeed = 0.3 SECONDS //Only the truest of mind soul and body get one of these
 	uses = 800 //In the Greek numeric system, Omega has a value of 800

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -24,7 +24,7 @@
 	throw_speed = 3
 	throw_range = 7
 	grind_results = list(/datum/reagent/lye = 10)
-	var/cleanspeed = 35 //slower than mop
+	var/cleanspeed = 3.5 SECONDS //slower than mop
 	force_string = "robust... against germs"
 	var/uses = 100
 
@@ -51,34 +51,35 @@
 				msg = "It's seen some light use, but it's still pretty fresh."
 	. += span_notice("[msg]")
 
+/obj/item/soap/homemade
+	desc = "A homemade bar of soap. Smells of... well...."
+	grind_results = list(/datum/reagent/liquidgibs = 8, /datum/reagent/lye) = 8 //diminishing returns
+	icon_state = "soapgibs"
+	cleanspeed = 3 SECONDS // faster than base soap to reward chemists for going to the effort
+
 /obj/item/soap/nanotrasen
 	desc = "A heavy duty bar of Nanotrasen brand soap. Smells of plasma."
 	grind_results = list(/datum/reagent/toxin/plasma = 10, /datum/reagent/lye = 10)
 	icon_state = "soapnt"
-	cleanspeed = 28 //janitor gets this
+	cleanspeed = 2.8 SECONDS //janitor gets this
 	uses = 300
-
-/obj/item/soap/homemade
-	desc = "A homemade bar of soap. Smells of... well...."
-	icon_state = "soapgibs"
-	cleanspeed = 30 // faster to reward chemists for going to the effort
 
 /obj/item/soap/deluxe
 	desc = "A deluxe Waffle Co. brand bar of soap. Smells of high-class luxury."
 	icon_state = "soapdeluxe"
-	cleanspeed = 20 //captain gets one of these
+	cleanspeed = 2 SECONDS //captain gets one of these
 
 /obj/item/soap/syndie
 	desc = "An untrustworthy bar of soap made of strong chemical agents that dissolve blood faster."
 	icon_state = "soapsyndie"
-	cleanspeed = 5 //faster than mop so it is useful for traitors who want to clean crime scenes
+	cleanspeed = 0.5 SECONDS //faster than mops so it's useful for traitors who want to clean crime scenes
 
 /obj/item/soap/omega
-	name = "omega soap"
-	desc = "The most advanced soap known to mankind."
+	name = "\improper Omega soap"
+	desc = "The most advanced soap known to mankind. The beginning of the end for germs."
 	icon_state = "soapomega"
-	cleanspeed = 3 //Only the truest of mind soul and body get one of these
-	uses = 301
+	cleanspeed = 0.3 SECONDS //Only the truest of mind soul and body get one of these
+	uses = 800 //In the Greek numeric system, Omega has a value of 800
 
 /obj/item/soap/omega/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is using [src] to scrub themselves from the timeline! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -14,14 +14,15 @@
 	attack_verb_simple = list("mop", "bash", "bludgeon", "whack")
 	resistance_flags = FLAMMABLE
 	var/mopcount = 0
-	var/mopcap = 15
-	var/mopspeed = 15
+	///Maximum volume of reagents it can hold.
+	var/max_reagent_volume = 15
+	var/mopspeed = 1.5 SECONDS
 	force_string = "robust... against germs"
 	var/insertable = TRUE
 
 /obj/item/mop/Initialize(mapload)
 	. = ..()
-	create_reagents(mopcap)
+	create_reagents(max_reagent_volume)
 
 
 /obj/item/mop/proc/clean(turf/A, mob/living/cleaner)
@@ -80,7 +81,7 @@
 /obj/item/mop/advanced
 	desc = "The most advanced tool in a custodian's arsenal, complete with a condenser for self-wetting! Just think of all the viscera you will clean up with this!"
 	name = "advanced mop"
-	mopcap = 10
+	max_reagent_volume = 10
 	icon_state = "advmop"
 	inhand_icon_state = "mop"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
@@ -88,7 +89,7 @@
 	force = 12
 	throwforce = 14
 	throw_range = 4
-	mopspeed = 8
+	mopspeed = 0.8 SECONDS
 	var/refill_enabled = TRUE //Self-refill toggle for when a janitor decides to mop with something other than water.
 	/// Amount of reagent to refill per second
 	var/refill_rate = 0.5
@@ -108,7 +109,7 @@
 	playsound(user, 'sound/machines/click.ogg', 30, TRUE)
 
 /obj/item/mop/advanced/process(delta_time)
-	var/amadd = min(mopcap - reagents.total_volume, refill_rate * delta_time)
+	var/amadd = min(max_reagent_volume - reagents.total_volume, refill_rate * delta_time)
 	if(amadd > 0)
 		reagents.add_reagent(refill_reagent, amadd)
 

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -26,7 +26,7 @@
 		return FALSE
 	else
 		var/obj/item/mop/M = mop
-		reagents.trans_to(mop, M.mopcap, transfered_by = user)
+		reagents.trans_to(mop, M.max_reagent_volume, transfered_by = user)
 		to_chat(user, span_notice("You wet [mop] in [src]."))
 		playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
 		return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives Omega soap 800 uses instead of 301. Also does some other misc stuff (described in detail in commit messages).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It takes a great deal of time, effort and departmental cooperation to only have 1 more use than the base soap. Giving it 800 uses makes it more worthwhile to make.

Right now it just feels like a scam for newer players when it's much easier to just make space cleaner or use the floor buffer upgrade or advanced mop when they become available.

The amount also ties into the whole Omega thing and helps justify why it's called that. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: cacogen
balance: Omega soap now has 800 uses instead of 301
expansion: Gave all soaps custom grind results, mainly for consistency
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
