### PR TITLE
Fixes species uplinks

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -200,7 +200,7 @@
 			"restricted_roles" = item.restricted_roles,
 			"restricted_species" = item.restricted_species,
 			"progression_minimum" = item.progression_minimum,
-			"ref" = REF(item)
+			"ref" = REF(item),
 		))
 
 	var/list/remaining_stock = list()
@@ -218,6 +218,7 @@
 	data["has_objectives"] = uplink_handler.has_objectives
 	data["lockable"] = lockable
 	data["assigned_role"] = uplink_handler.assigned_role
+	data["assigned_species"] = uplink_handler.assigned_species
 	data["debug"] = uplink_handler.debug_mode
 	return data
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -55,14 +55,16 @@
 
 		if(uplink_handler.progression_points < SStraitor.current_global_progression)
 			uplink_handler.progression_points = SStraitor.current_global_progression * SStraitor.newjoin_progression_coeff
+
 		var/list/uplink_items = list()
 		for(var/datum/uplink_item/item as anything in SStraitor.uplink_items)
-			if(item.item && (!length(item.restricted_roles) || (uplink_handler.assigned_role in item.restricted_roles)) \
-				&& !item.cant_discount && (item.purchasable_from & uplink_handler.uplink_flag) && item.cost > 1)
-				uplink_items += item
-			if(item.item && (!length(item.restricted_species) || (uplink_handler.assigned_species in item.restricted_species)) \
-				&& !item.cant_discount && (item.purchasable_from & uplink_handler.uplink_flag) && item.cost > 1)
-				uplink_items += item
+			if(item.item && !item.cant_discount && (item.purchasable_from & uplink_handler.uplink_flag) && item.cost > 1)
+				if(!length(item.restricted_roles) && !length(item.restricted_species))
+					uplink_items += item
+					continue
+				if((uplink_handler.assigned_role in item.restricted_roles) || (uplink_handler.assigned_species in item.restricted_species))
+					uplink_items += item
+					continue
 		uplink_handler.extra_purchasable += create_uplink_sales(uplink_sale_count, /datum/uplink_category/discounts, -1, uplink_items)
 
 	if(give_objectives)

--- a/code/modules/asset_cache/assets/uplink.dm
+++ b/code/modules/asset_cache/assets/uplink.dm
@@ -23,7 +23,7 @@
 				"name" = item.name,
 				"cost" = item.cost,
 				"desc" = item.desc,
-				"category" = item.category? initial(item.category.name) : null,
+				"category" = item.category ? initial(item.category.name) : null,
 				"purchasable_from" = item.purchasable_from,
 				"restricted" = item.restricted,
 				"limited_stock" = item.limited_stock,

--- a/code/modules/uplink/uplink_items/species.dm
+++ b/code/modules/uplink/uplink_items/species.dm
@@ -5,6 +5,7 @@
 /datum/uplink_item/species_restricted
 	category = /datum/uplink_category/species
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
+	surplus = 0
 
 /datum/uplink_item/species_restricted/moth_lantern
 	name = "Extra-Bright Lantern"


### PR DESCRIPTION
## About The Pull Request

I was fucking deranged when I originally made this. I not only didn't actually include the assigned species to the uplink's ui data, but I made the code add each objective item to the uplink list twice. This fixes both of those problems, and makes it more readable.

## Why It's Good For The Game

Fixes a mistake I caused.
Closes https://github.com/tgstation/tgstation/issues/64806

## Changelog

:cl:
fix: Role-restricted and species restricted items can be purchased again.
fix: Species-restricted items no longer appear in surplus.
/:cl:
