### PR TITLE
Janitorial cart improvements

### DIFF
--- a/code/game/objects/items/broom.dm
+++ b/code/game/objects/items/broom.dm
@@ -93,21 +93,10 @@
 			to_chat(user, span_notice("You sweep the pile of garbage into [target_bin]."))
 		playsound(loc, 'sound/weapons/thudswoosh.ogg', 30, TRUE, -1)
 
-/**
- * Attempts to insert the push broom into a janicart
- *
- * Arguments:
- * * user - The user of the push broom
- * * J - The janicart to insert into
- */
-/obj/item/pushbroom/proc/janicart_insert(mob/user, obj/structure/janitorialcart/J) //bless you whoever fixes this copypasta
-	J.put_in_cart(src, user)
-	J.mybroom=src
-	J.update_appearance()
 
 /obj/item/pushbroom/cyborg
-	name = "robotic push broom"
+	name = "cyborg push broom"
 
-/obj/item/pushbroom/cyborg/janicart_insert(mob/user, obj/structure/janitorialcart/J)
-	to_chat(user, span_notice("You cannot place your [src] into the [J]"))
-	return FALSE
+/obj/item/pushbroom/cyborg/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, CYBORG_ITEM_TRAIT)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -254,13 +254,9 @@
 	if(!used)
 		to_chat(U, span_warning("\The [src]'s refill light blinks red."))
 
-/obj/item/lightreplacer/proc/janicart_insert(mob/user, obj/structure/janitorialcart/J)
-	J.put_in_cart(src, user)
-	J.myreplacer = src
-	J.update_appearance()
-
-/obj/item/lightreplacer/cyborg/janicart_insert(mob/user, obj/structure/janitorialcart/J)
-	return
+/obj/item/lightreplacer/cyborg/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, CYBORG_ITEM_TRAIT)
 
 #undef LIGHT_OK
 #undef LIGHT_EMPTY

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -66,17 +66,9 @@
 			to_chat(user, span_notice("You finish mopping."))
 			clean(T, user)
 
-/obj/item/mop/proc/janicart_insert(mob/user, obj/structure/janitorialcart/J)
-	if(insertable)
-		J.put_in_cart(src, user)
-		J.mymop=src
-		J.update_appearance()
-	else
-		to_chat(user, span_warning("You are unable to fit your [name] into the [J.name]."))
-		return
-
-/obj/item/mop/cyborg
-	insertable = FALSE
+/obj/item/mop/cyborg/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, CYBORG_ITEM_TRAIT)
 
 /obj/item/mop/advanced
 	desc = "The most advanced tool in a custodian's arsenal, complete with a condenser for self-wetting! Just think of all the viscera you will clean up with this!"

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -68,17 +68,9 @@
 			icon_state = "[initial(icon_state)]"
 	return ..()
 
-/obj/item/storage/bag/trash/cyborg
-	insertable = FALSE
-
-/obj/item/storage/bag/trash/proc/janicart_insert(mob/user, obj/structure/janitorialcart/J)
-	if(insertable)
-		J.put_in_cart(src, user)
-		J.mybag=src
-		J.update_appearance()
-	else
-		to_chat(user, span_warning("You are unable to fit your [name] into the [J.name]."))
-		return
+/obj/item/storage/bag/trash/cyborg/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, CYBORG_ITEM_TRAIT)
 
 /obj/item/storage/bag/trash/filled
 

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -111,7 +111,7 @@
 			to_chat(user, span_warning("[src]'s mop bucket is empty!"))
 			return
 		user.visible_message(span_notice("[user] begins to empty the contents of [src]."), span_notice("You begin to empty the contents of [src]..."))
-		if(I.use_tool(src, user, 30))
+		if(I.use_tool(src, user, 5 SECONDS))
 			to_chat(usr, span_notice("You empty the contents of [src]'s mop bucket onto the floor."))
 			reagents.expose(src.loc)
 			src.reagents.clear_reagents()
@@ -129,18 +129,25 @@
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	if(istype(I, /obj/item/reagent_containers) && I.is_open_container())
-		var/obj/item/reagent_containers/attacking_reagent_container = I
+		var/obj/item/reagent_containers/your_container = I
+		var/your_reagents = your_container.reagents.total_volume
+		var/your_capacity = your_container.reagents.maximum_volume
+		var/my_reagents = reagents.total_volume
 
-		if(attacking_reagent_container.reagents.total_volume >= attacking_reagent_container.reagents.maximum_volume)
-			to_chat(user, span_warning("[attacking_reagent_container] is full."))
+		if(your_reagents >= your_capacity)
+			to_chat(user, span_warning("[your_container] is full."))
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-		if(reagents.total_volume < 1)
+		if(my_reagents < 1)
 			to_chat(user, span_warning("[src]'s mop bucket is empty!"))
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-		reagents.trans_to(attacking_reagent_container, attacking_reagent_container.reagents.maximum_volume, transfered_by = user)
-		user.visible_message(span_warning("[user] fills [attacking_reagent_container] with [src]'s mop bucket."), span_notice("You fill [attacking_reagent_container] with [src]'s mop bucket."))
+		var/do_after_length = round((min(your_capacity-your_reagents, my_reagents) / 20),1) SECONDS //takes 5 seconds to steal whole thing
+		if(!do_after(user, do_after_length))
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+		reagents.trans_to(your_container, your_container.reagents.maximum_volume, transfered_by = user)
+		user.visible_message(span_warning("[user] fills [your_container] with [src]'s mop bucket."), span_notice("You fill [your_container] with [src]'s mop bucket."))
 		playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
 		update_appearance()
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -52,58 +52,58 @@
 
 /obj/structure/janitorialcart/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/mop))
-			if(mymop)
-				to_chat(user, span_warning("There is already a mop in [src]!"))
-				return
-			mymop = I
-			if(!put_in_cart(I, user))
-				mymop = null
+		if(mymop)
+			to_chat(user, span_warning("There is already a mop in [src]!"))
 			return
+		mymop = I
+		if(!put_in_cart(I, user))
+			mymop = null
+		return
 
 	else if(istype(I, /obj/item/pushbroom))
-			if(mybroom)
-				to_chat(user, span_warning("There is already a broom in [src]!"))
-				return
-			mybroom = I
-			if(!put_in_cart(I, user))
-				mybroom = null
+		if(mybroom)
+			to_chat(user, span_warning("There is already a broom in [src]!"))
 			return
+		mybroom = I
+		if(!put_in_cart(I, user))
+			mybroom = null
+		return
 
 	else if(istype(I, /obj/item/storage/bag/trash))
-			if(mybag)
-				to_chat(user, span_warning("There is already a trash bag in [src]!"))
-				return
-			mybag = I
-			if(!put_in_cart(I, user))
-				mybag = null
+		if(mybag)
+			to_chat(user, span_warning("There is already a trash bag in [src]!"))
 			return
+		mybag = I
+		if(!put_in_cart(I, user))
+			mybag = null
+		return
 
 	else if(istype(I, /obj/item/reagent_containers/spray/cleaner))
-			if(myspray)
-				to_chat(user, span_warning("There is already a spray bottle in [src]!"))
-				return
-			myspray = I
-			if(!put_in_cart(I, user))
-				myspray = null
+		if(myspray)
+			to_chat(user, span_warning("There is already a spray bottle in [src]!"))
 			return
+		myspray = I
+		if(!put_in_cart(I, user))
+			myspray = null
+		return
 
 	else if(istype(I, /obj/item/lightreplacer))
-			if(myreplacer)
-				to_chat(user, span_warning("There is already a light replacer in [src]!"))
-				return
-			myreplacer = I
-			if(!put_in_cart(I, user))
-				myreplacer = null
+		if(myreplacer)
+			to_chat(user, span_warning("There is already a light replacer in [src]!"))
 			return
+		myreplacer = I
+		if(!put_in_cart(I, user))
+			myreplacer = null
+		return
 
 	else if(istype(I, /obj/item/clothing/suit/caution))
-			if(signs >= max_signs)
-				to_chat(user, span_warning("[src] can't hold any more signs!"))
-				return
-			signs++
-			if(!put_in_cart(I, user))
-				signs--
+		if(signs >= max_signs)
+			to_chat(user, span_warning("[src] can't hold any more signs!"))
 			return
+		signs++
+		if(!put_in_cart(I, user))
+			signs--
+		return
 
 	else if(I.tool_behaviour == TOOL_CROWBAR)
 		if(reagents.total_volume < 1)

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -51,8 +51,7 @@
 
 
 /obj/structure/janitorialcart/attackby(obj/item/I, mob/user, params)
-	switch(I.type)
-		if(/obj/item/mop)
+	if(istype(I, /obj/item/mop))
 			if(mymop)
 				to_chat(user, span_warning("There is already a mop in [src]!"))
 				return
@@ -61,7 +60,7 @@
 				mymop = null
 			return
 
-		if(/obj/item/pushbroom)
+	else if(istype(I, /obj/item/pushbroom))
 			if(mybroom)
 				to_chat(user, span_warning("There is already a broom in [src]!"))
 				return
@@ -70,7 +69,7 @@
 				mybroom = null
 			return
 
-		if(/obj/item/storage/bag/trash)
+	else if(istype(I, /obj/item/storage/bag/trash))
 			if(mybag)
 				to_chat(user, span_warning("There is already a trash bag in [src]!"))
 				return
@@ -79,7 +78,7 @@
 				mybag = null
 			return
 
-		if(/obj/item/reagent_containers/spray/cleaner)
+	else if(istype(I, /obj/item/reagent_containers/spray/cleaner))
 			if(myspray)
 				to_chat(user, span_warning("There is already a spray bottle in [src]!"))
 				return
@@ -88,7 +87,7 @@
 				myspray = null
 			return
 
-		if(/obj/item/lightreplacer)
+	else if(istype(I, /obj/item/lightreplacer))
 			if(myreplacer)
 				to_chat(user, span_warning("There is already a light replacer in [src]!"))
 				return
@@ -97,7 +96,7 @@
 				myreplacer = null
 			return
 
-		if(/obj/item/clothing/suit/caution)
+	else if(istype(I, /obj/item/clothing/suit/caution))
 			if(signs >= max_signs)
 				to_chat(user, span_warning("[src] can't hold any more signs!"))
 				return
@@ -106,7 +105,7 @@
 				signs--
 			return
 
-	if(I.tool_behaviour == TOOL_CROWBAR)
+	else if(I.tool_behaviour == TOOL_CROWBAR)
 		if(reagents.total_volume < 1)
 			to_chat(user, span_warning("[src]'s mop bucket is empty!"))
 			return

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -20,78 +20,135 @@
 	. = ..()
 	create_reagents(100, OPENCONTAINER)
 
-/obj/structure/janitorialcart/proc/wet_mop(obj/item/mop, mob/user)
-	if(reagents.total_volume < 1)
-		to_chat(user, span_warning("[src] is out of water!"))
+/obj/structure/janitorialcart/examine(mob/user)
+	. = ..()
+	if(mymop)
+		. += span_info("<b>Right-click</b> to quickly remove [mymop].")
+	if(reagents.total_volume > 1)
+		. += span_info("<b>Right-click</b> with a mop to wet it.")
+		. += span_info("<b>Right-click</b> with an open container to fill from it.")
+		. += span_info("<b>Crowbar</b> it to empty it onto [get_turf(src)].")
+	if(mybag)
+		. += span_info("<b>Right-click</b> with an object to put it in [mybag].")
+
+/obj/structure/janitorialcart/proc/wet_mop(obj/item/mop/your_mop, mob/user)
+	if(your_mop.reagents.total_volume >= your_mop.reagents.maximum_volume)
+		to_chat(user, span_warning("[your_mop] is already soaked!"))
 		return FALSE
-	else
-		var/obj/item/mop/M = mop
-		reagents.trans_to(mop, M.max_reagent_volume, transfered_by = user)
-		to_chat(user, span_notice("You wet [mop] in [src]."))
-		playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
-		return TRUE
+	if(reagents.total_volume < 1)
+		to_chat(user, span_warning("[src]'s mop bucket is empty!"))
+		return FALSE
+	reagents.trans_to(your_mop, your_mop.reagents.maximum_volume, transfered_by = user)
+	to_chat(user, span_notice("You wet [your_mop] in [src]."))
+	playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
+	return TRUE
 
 /obj/structure/janitorialcart/proc/put_in_cart(obj/item/I, mob/user)
 	if(!user.transferItemToLoc(I, src))
-		return
+		return FALSE
 	to_chat(user, span_notice("You put [I] into [src]."))
-	return
+	update_appearance()
+	return TRUE
 
 
 /obj/structure/janitorialcart/attackby(obj/item/I, mob/user, params)
-	var/fail_msg = span_warning("There is already one of those in [src]!")
-
 	if(istype(I, /obj/item/mop))
-		var/obj/item/mop/m=I
-		if(m.reagents.total_volume < m.reagents.maximum_volume)
-			if (wet_mop(m, user))
-				return
-		if(!mymop)
-			m.janicart_insert(user, src)
-		else
-			to_chat(user, fail_msg)
+		if(mymop)
+			to_chat(user, span_warning("There is already a mop in [src]!"))
+			return
+		mymop = I
+		if(!put_in_cart(I, user))
+			mymop = null
+		return
+
 	else if(istype(I, /obj/item/pushbroom))
-		if(!mybroom)
-			var/obj/item/pushbroom/b=I
-			b.janicart_insert(user,src)
-		else
-			to_chat(user, fail_msg)
+		if(mybroom)
+			to_chat(user, span_warning("There is already a broom in [src]!"))
+			return
+		mybroom = I
+		if(!put_in_cart(I, user))
+			mybroom = null
+		return
+
 	else if(istype(I, /obj/item/storage/bag/trash))
-		if(!mybag)
-			var/obj/item/storage/bag/trash/t=I
-			t.janicart_insert(user, src)
-		else
-			to_chat(user,  fail_msg)
+		if(mybag)
+			to_chat(user, span_warning("There is already a trash bag in [src]!"))
+			return
+		mybag = I
+		if(!put_in_cart(I, user))
+			mybag = null
+		return
+
 	else if(istype(I, /obj/item/reagent_containers/spray/cleaner))
-		if(!myspray)
-			put_in_cart(I, user)
-			myspray=I
-			update_appearance()
-		else
-			to_chat(user, fail_msg)
+		if(myspray)
+			to_chat(user, span_warning("There is already a spray bottle in [src]!"))
+			return
+		myspray = I
+		if(!put_in_cart(I, user))
+			myspray = null
+		return
+
 	else if(istype(I, /obj/item/lightreplacer))
-		if(!myreplacer)
-			var/obj/item/lightreplacer/l=I
-			l.janicart_insert(user,src)
-		else
-			to_chat(user, fail_msg)
+		if(myreplacer)
+			to_chat(user, span_warning("There is already a light replacer in [src]!"))
+			return
+		myreplacer = I
+		if(!put_in_cart(I, user))
+			myreplacer = null
+		return
+
 	else if(istype(I, /obj/item/clothing/suit/caution))
-		if(signs < max_signs)
-			put_in_cart(I, user)
-			signs++
-			update_appearance()
-		else
+		if(signs >= max_signs)
 			to_chat(user, span_warning("[src] can't hold any more signs!"))
-	else if(mybag)
-		mybag.attackby(I, user)
+			return
+		signs++
+		if(!put_in_cart(I, user))
+			signs--
+		return
+
 	else if(I.tool_behaviour == TOOL_CROWBAR)
+		if(reagents.total_volume < 1)
+			to_chat(user, span_warning("[src]'s mop bucket is empty!"))
+			return
 		user.visible_message(span_notice("[user] begins to empty the contents of [src]."), span_notice("You begin to empty the contents of [src]..."))
 		if(I.use_tool(src, user, 30))
-			to_chat(usr, span_notice("You empty the contents of [src]'s bucket onto the floor."))
+			to_chat(usr, span_notice("You empty the contents of [src]'s mop bucket onto the floor."))
 			reagents.expose(src.loc)
 			src.reagents.clear_reagents()
-	else
-		return ..()
+			update_appearance()
+		return
+
+	..()
+	update_appearance()
+
+/obj/structure/janitorialcart/attackby_secondary(obj/item/I, mob/user, params)
+
+	if(istype(I, /obj/item/mop))
+		var/obj/item/mop/your_mop = I
+		wet_mop(your_mop, user)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	if(istype(I, /obj/item/reagent_containers) && I.is_open_container())
+		var/obj/item/reagent_containers/attacking_reagent_container = I
+
+		if(attacking_reagent_container.reagents.total_volume >= attacking_reagent_container.reagents.maximum_volume)
+			to_chat(user, span_warning("[attacking_reagent_container] is full."))
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+		if(reagents.total_volume < 1)
+			to_chat(user, span_warning("[src]'s mop bucket is empty!"))
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+		reagents.trans_to(attacking_reagent_container, attacking_reagent_container.reagents.maximum_volume, transfered_by = user)
+		user.visible_message(span_warning("[user] fills [attacking_reagent_container] with [src]'s mop bucket."), span_notice("You fill [attacking_reagent_container] with [src]'s mop bucket."))
+		playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
+		update_appearance()
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	if(mybag.attackby(I, user))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
 
 /obj/structure/janitorialcart/attack_hand(mob/user, list/modifiers)
 	. = ..()
@@ -115,8 +172,12 @@
 
 	if(!length(items))
 		return
-	items = sort_list(items)
-	var/pick = show_radial_menu(user, src, items, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 38, require_near = TRUE)
+
+	var/pick = items[1]
+	if(length(items) > 1)
+		items = sort_list(items)
+		pick = show_radial_menu(user, src, items, custom_check = CALLBACK(src, .proc/check_menu, user), radius = 38, require_near = TRUE)
+
 	if(!pick)
 		return
 	switch(pick)
@@ -160,6 +221,15 @@
 			return
 
 	update_appearance()
+
+/obj/structure/janitorialcart/attack_hand_secondary(mob/user, list/modifiers)
+	if(!mymop)
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
+	user.put_in_hands(mymop)
+	to_chat(user, span_notice("You take [mymop] from [src]."))
+	mymop = null
+	update_appearance()
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /**
  * check_menu: Checks if we are allowed to interact with a radial menu

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -82,6 +82,8 @@
 /obj/item/reagent_containers/pre_attack_secondary(atom/target, mob/living/user, params)
 	if(HAS_TRAIT(target, DO_NOT_SPLASH))
 		return ..()
+	if(!user.combat_mode)
+		return ..()
 	if (try_splash(user, target))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -80,6 +80,30 @@
 		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transfered_by = user)
 		to_chat(user, span_notice("You fill [src] with [trans] unit\s of the contents of [target]."))
 
+	target.update_appearance()
+
+/obj/item/reagent_containers/glass/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
+	if((!proximity_flag) || !check_allowed_items(target,target_self=1))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	if(!spillable)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+	if(target.is_drainable()) //A dispenser. Transfer FROM it TO us.
+		if(!target.reagents.total_volume)
+			to_chat(user, span_warning("[target] is empty!"))
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+		if(reagents.holder_full())
+			to_chat(user, span_warning("[src] is full."))
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transfered_by = user)
+		to_chat(user, span_notice("You fill [src] with [trans] unit\s of the contents of [target]."))
+
+	target.update_appearance()
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
+
 /obj/item/reagent_containers/glass/attackby(obj/item/I, mob/user, params)
 	var/hotness = I.get_temperature()
 	if(hotness && reagents)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- You now right-click to wet your mop and left-click to put it away to prevent having to double-click to get rid of it when it's not completely wet
- Can right-click with an empty hand to remove mop and skip radial menu
- You now right-click to put things in the trash bag (prevents trash bag unintentionally eating things, such as the crowbar you were trying to use to empty the cart)
- Left-clicking skips radial menu when there's only one item in the cart
- Can fill open reagent containers from drainables like the janitorial cart (useful to empty it)
- Adds examine hints for these changes
- Right-clicking to splash reagents now requires combat mode (this is because it interfered with using right-click to empty)
- Cyborg cleaning modules now use the NODROP trait to prevent them being put in the cart, instead of their own copypasted var and proc
- Fixes overlays not immediately updating when filling janitorial cart
- Fixes bludgeoning janitorial cart when filling it

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Should make it less clunky and more enjoyable to use.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Right-clicking to splash reagents requires combat mode
add: Remember the above
qol: You now right-click the janitorial cart to wet mops and left-click to put them away
qol: You can right-click the janitorial cart with an empty hand to quickly remove your mop
qol: You now right-click to put things in the trash bag
qol: Left-clicking the cart with an empty hand will skip the radial menu if there's only one item in the cart
add: Adds examine hints for these changes
fix: Fixes overlays not immediately updating when filling janitorial cart
fix: Fixes bludgeoning janitorial cart when filling it
add: You can right-click with "glass" reagent containers (e.g. buckets) to fill from drainable containers like janitorial carts
code: Improvements to janitorial cart code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
