### PR TITLE
Adds a trigger version of the variable setter circuit component

### DIFF
--- a/code/modules/research/designs/wiremod_designs.dm
+++ b/code/modules/research/designs/wiremod_designs.dm
@@ -381,6 +381,11 @@
 	id = "comp_id_access_reader"
 	build_path = /obj/item/circuit_component/id_access_reader
 
+/datum/design/component/setter_trigger
+	name = "Set Variable Trigger"
+	id = "comp_set_variable_trigger"
+	build_path = /obj/item/circuit_component/variable/setter/trigger
+
 /datum/design/component/access_checker
 	name = "Access Checker Component"
 	id = "comp_access_checker"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -269,6 +269,7 @@
 		"comp_router",
 		"comp_select_query",
 		"comp_self",
+		"comp_set_variable_trigger",
 		"comp_soundemitter",
 		"comp_species",
 		"comp_speech",

--- a/code/modules/wiremod/components/variables/setter.dm
+++ b/code/modules/wiremod/components/variables/setter.dm
@@ -12,6 +12,11 @@
 
 	circuit_size = 0
 
+/obj/item/circuit_component/variable/setter/trigger
+	display_name = "Trigger Variable Setter"
+	desc = "A component that sets a variable globally on the circuit. This one requires input signals and also provides an output signal"
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
+
 /obj/item/circuit_component/variable/setter/get_variable_list(obj/item/integrated_circuit/integrated_circuit)
 	return integrated_circuit.modifiable_circuit_variables
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
See title. Lets you use input and output signals to set variables instead of automatically setting them.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Gives more control, additionally there may be cases where you don't want this, and the normal component still exists.
They're two separate components so that the first one can be a lot more compact

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Adds a trigger version of the current variable setter circuit component.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
