### PR TITLE
Fixes air mixer on delta station atmos

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -40690,10 +40690,6 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "gtY" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix{
-	node1_concentration = 0.21;
-	node2_concentration = 0.79
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -40705,6 +40701,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "guh" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -40690,7 +40690,10 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "gtY" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix,
+/obj/machinery/atmospherics/components/trinary/mixer/airmix{
+	node1_concentration = 0.21;
+	node2_concentration = 0.79
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Air mixer on deltastation's reworked atmospherics was set wrong and was pumping in 79% oxygen 21% nitrogen air, this pr changes the mixer to be 21% oxygen and 79% nitrogen like it is supposed to be.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a mapping mistake
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: Fixes air mixer on delta station atmos

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
