### PR TITLE
fixes the chaplain's sparring soulstone description

### DIFF
--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -114,7 +114,7 @@
 	icon_state = "purified_soulstone"
 	theme = THEME_HOLY
 
-/obj/item/soulstone/anybody/sparring/Initialize(mapload)
+/obj/item/soulstone/anybody/chaplain/sparring/Initialize(mapload)
 	. = ..()
 	name = "[GLOB.deity]'s punishment"
 	desc = "A prison for those who lost [GLOB.deity]'s game."


### PR DESCRIPTION
## About The Pull Request

Small change, the Initialize was using the wrong path.

## Why It's Good For The Game

small fix

## Changelog

:cl:
fix: Chaplain Sparring sect's soulstone now has their intended unique name and description.
/:cl:
