### PR TITLE
Fixes runtime errors that occur when mindless mobs examine heirlooms, + code improvements

### DIFF
--- a/code/datums/components/heirloom.dm
+++ b/code/datums/components/heirloom.dm
@@ -26,16 +26,15 @@
 /datum/component/heirloom/proc/on_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	if(!user.mind || isobserver(user))
-		examine_list += span_notice("It is the [family_name] family heirloom, belonging to [owner].")
-		return
+	var/datum/mind/examiner_mind = user.mind
 
-	if(user.mind == owner)
+	if(examiner_mind == owner)
 		examine_list += span_notice("It is your precious [family_name] family heirloom. Keep it safe!")
 		return
 
-	var/datum/antagonist/obsessed/our_creeper = user.mind.has_antag_datum(/datum/antagonist/obsessed)
+	var/datum/antagonist/obsessed/our_creeper = examiner_mind?.has_antag_datum(/datum/antagonist/obsessed)
 	if(our_creeper?.trauma.obsession == owner)
 		examine_list += span_nicegreen("This must be [owner]'s family heirloom! It smells just like them...")
-	else
-		examine_list += span_notice("It is the [family_name] family heirloom, belonging to [owner].")
+		return
+
+	examine_list += span_notice("It is the [family_name] family heirloom, belonging to [owner].")

--- a/code/datums/components/heirloom.dm
+++ b/code/datums/components/heirloom.dm
@@ -35,7 +35,7 @@
 		return
 
 	var/datum/antagonist/obsessed/our_creeper = user.mind.has_antag_datum(/datum/antagonist/obsessed)
-	 if(our_creeper?.trauma.obsession == owner)
+	if(our_creeper?.trauma.obsession == owner)
 		examine_list += span_nicegreen("This must be [owner]'s family heirloom! It smells just like them...")
 	else
 		examine_list += span_notice("It is the [family_name] family heirloom, belonging to [owner].")

--- a/code/datums/components/heirloom.dm
+++ b/code/datums/components/heirloom.dm
@@ -1,5 +1,8 @@
+/// Heirloom component. For use with the family heirloom quirk, tracks that an item is someone's family heirloom.
 /datum/component/heirloom
+	/// The mind that actually owns our heirloom.
 	var/datum/mind/owner
+	/// Flavor. The family name of the owner of the heirloom.
 	var/family_name
 
 /datum/component/heirloom/Initialize(new_owner, new_family_name)
@@ -9,16 +12,30 @@
 	owner = new_owner
 	family_name = new_family_name
 
-	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/examine)
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)
 
-/datum/component/heirloom/proc/examine(datum/source, mob/user, list/examine_list)
+/datum/component/heirloom/Destroy(force, silent)
+	owner = null
+	return ..()
+
+/**
+ * Signal proc for [COMSIG_PARENT_EXAMINE].
+ *
+ * Shows who owns the heirloom on examine.
+ */
+/datum/component/heirloom/proc/on_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	var/datum/antagonist/obsessed/creeper = user.mind.has_antag_datum(/datum/antagonist/obsessed)
+	if(!user.mind || isobserver(user))
+		examine_list += span_notice("It is the [family_name] family heirloom, belonging to [owner].")
+		return
 
 	if(user.mind == owner)
 		examine_list += span_notice("It is your precious [family_name] family heirloom. Keep it safe!")
-	else if(creeper && creeper.trauma.obsession == owner)
+		return
+
+	var/datum/antagonist/obsessed/our_creeper = user.mind.has_antag_datum(/datum/antagonist/obsessed)
+	 if(our_creeper?.trauma.obsession == owner)
 		examine_list += span_nicegreen("This must be [owner]'s family heirloom! It smells just like them...")
 	else
 		examine_list += span_notice("It is the [family_name] family heirloom, belonging to [owner].")


### PR DESCRIPTION
## About The Pull Request

Mindless mobs (such as observers without an initialized mind) examining family heirlooms would cause runtime errors due to the `user.mind.has_antag_datum(...)` line. 

- Rearranges the examine proc to prevent runtimes from occurring due to mindless mobs examining heirlooms. Adds an observer check at the beginning, just for sanity sake, even though it doesn't matter functionally. 
- Renamed the proc to `on_examine` for clarity
- Auto doc'd the proc + comments
- Handled a reference on Destroy

## Why It's Good For The Game

Runtimes that stop examine bad

## Changelog


:cl: Melbert
fix: Fixes uncommon runtimes that could occur when observers examine heirlooms
/:cl:
