### PR TITLE
Make status displays scroll long messages smoothly.

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -5,7 +5,9 @@
 #define FONT_SIZE "5pt"
 #define FONT_COLOR "#09f"
 #define FONT_STYLE "Small Fonts"
-#define SCROLL_SPEED 2
+#define SCROLL_RATE (0.04 SECONDS) // time per pixel
+#define LINE1_Y -8
+#define LINE2_Y -15
 
 #define SD_BLANK 0  // 0 = Blank
 #define SD_EMERGENCY 1  // 1 = Emergency Shuttle timer
@@ -27,14 +29,8 @@
 	idle_power_usage = 10
 	layer = ABOVE_WINDOW_LAYER
 
-	maptext_height = 26
-	maptext_width = 32
-	maptext_y = -1
-
-	var/message1 = "" // message line 1
-	var/message2 = "" // message line 2
-	var/index1 // display index for scrolling messages or 0 if non-scrolling
-	var/index2
+	var/obj/effect/overlay/status_display_text/message1_overlay
+	var/obj/effect/overlay/status_display_text/message2_overlay
 
 /obj/item/wallframe/status_display
 	name = "status display frame"
@@ -83,8 +79,11 @@
 /// Immediately blank the display.
 /obj/machinery/status_display/proc/remove_display()
 	cut_overlays()
-	if(maptext)
-		maptext = ""
+	vis_contents.Cut()
+	if(message1_overlay)
+		QDEL_NULL(message1_overlay)
+	if(message2_overlay)
+		QDEL_NULL(message2_overlay)
 
 /// Immediately change the display to the given picture.
 /obj/machinery/status_display/proc/set_picture(state)
@@ -93,57 +92,29 @@
 
 /// Immediately change the display to the given two lines.
 /obj/machinery/status_display/proc/update_display(line1, line2)
+	if( \
+		(message1_overlay && message1_overlay.message == line1) && \
+		(message2_overlay && message2_overlay.message == line2))
+		return
+
+	remove_display()
+
 	line1 = uppertext(line1)
 	line2 = uppertext(line2)
-	var/new_text = {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]';text-align:center;" valign="top">[line1]<br>[line2]</div>"}
-	if(maptext != new_text)
-		maptext = new_text
 
-/// Prepare the display to marquee the given two lines.
-///
-/// Call with no arguments to disable.
-/obj/machinery/status_display/proc/set_message(m1, m2)
-	if(m1)
-		index1 = (length_char(m1) > CHARS_PER_LINE)
-		message1 = m1
-	else
-		message1 = ""
-		index1 = 0
+	message1_overlay = new(LINE1_Y, line1)
+	vis_contents += message1_overlay
 
-	if(m2)
-		index2 = (length_char(m2) > CHARS_PER_LINE)
-		message2 = m2
-	else
-		message2 = ""
-		index2 = 0
+	message2_overlay = new(LINE2_Y, line2)
+	vis_contents += message2_overlay
 
-// Timed process - performs default marquee action if so needed.
+// Timed process - performs nothing in the base class
 /obj/machinery/status_display/process()
 	if(machine_stat & NOPOWER)
 		// No power, no processing.
 		remove_display()
-		return PROCESS_KILL
 
-	var/line1 = message1
-	if(index1)
-		line1 = copytext_char("[message1]|[message1]", index1, index1 + CHARS_PER_LINE)
-		var/message1_len = length_char(message1)
-		index1 += SCROLL_SPEED
-		if(index1 > message1_len + 1)
-			index1 -= (message1_len + 1)
-
-	var/line2 = message2
-	if(index2)
-		line2 = copytext_char("[message2]|[message2]", index2, index2 + CHARS_PER_LINE)
-		var/message2_len = length_char(message2)
-		index2 += SCROLL_SPEED
-		if(index2 > message2_len + 1)
-			index2 -= (message2_len + 1)
-
-	update_display(line1, line2)
-	if (!index1 && !index2)
-		// No marquee, no processing.
-		return PROCESS_KILL
+	return PROCESS_KILL
 
 /// Update the display and, if necessary, re-enable processing.
 /obj/machinery/status_display/proc/update()
@@ -162,12 +133,12 @@
 
 /obj/machinery/status_display/examine(mob/user)
 	. = ..()
-	if (message1 || message2)
+	if (message1_overlay || message2_overlay)
 		. += "The display says:"
-		if (message1)
-			. += "<br>\t<tt>[html_encode(message1)]</tt>"
-		if (message2)
-			. += "<br>\t<tt>[html_encode(message2)]</tt>"
+		if (message1_overlay.message)
+			. += "<br>\t<tt>[html_encode(message1_overlay.message)]</tt>"
+		if (message2_overlay.message)
+			. += "<br>\t<tt>[html_encode(message2_overlay.message)]</tt>"
 
 // Helper procs for child display types.
 /obj/machinery/status_display/proc/display_shuttle_status(obj/docking_port/mobile/shuttle)
@@ -198,6 +169,44 @@
 	else
 		return "The display says:<br>\t<tt>Shuttle missing!</tt>"
 
+/**
+ * Nice overlay to make text smoothly scroll with no client updates after setup.
+ */
+/obj/effect/overlay/status_display_text
+	icon = 'icons/obj/status_display.dmi'
+	vis_flags = VIS_INHERIT_LAYER | VIS_INHERIT_PLANE | VIS_INHERIT_ID
+
+	var/message = ""
+
+/obj/effect/overlay/status_display_text/New(yoffset, line)
+	maptext_y = yoffset
+	message = line
+
+	var/line_length = length_char(line)
+
+	if(line_length > CHARS_PER_LINE)
+		// Marquee text
+		var/marquee_message = "[line] • [line] • [line]"
+		var/marqee_length = line_length * 3 + 6
+		maptext = generate_text(marquee_message, FALSE)
+		maptext_width = 6 * marqee_length
+		maptext_x = 32
+
+		// Mask off to fit in screen.
+		filters = filter(type = "alpha", icon = icon(icon, "outline"))
+
+		// Scroll.
+		var/width = 4 * marqee_length
+		var/time = (width + 32) * SCROLL_RATE
+		animate(src, maptext_x = -width, time = time, loop = -1)
+		animate(maptext_x = 32, time = 0)
+	else
+		// Centered text
+		maptext = generate_text(line, TRUE)
+		maptext_x = 0
+
+/obj/effect/overlay/status_display_text/proc/generate_text(text, center)
+	return {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]'[center ? ";text-align:center" : ""]" valign="top">[text]</div>"}
 
 /// Evac display which shows shuttle timer or message set by Command.
 /obj/machinery/status_display/evac
@@ -241,7 +250,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 			return display_shuttle_status(SSshuttle.emergency)
 
 		if(SD_MESSAGE)
-			return ..()
+			return PROCESS_KILL
 
 		if(SD_PICTURE)
 			set_picture(last_picture)
@@ -251,20 +260,20 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 	. = ..()
 	if(mode == SD_EMERGENCY)
 		. += examine_shuttle(user, SSshuttle.emergency)
-	else if(!message1 && !message2)
+	else if(!message1_overlay && !message2_overlay)
 		. += "The display is blank."
 
 /obj/machinery/status_display/evac/receive_signal(datum/signal/signal)
 	switch(signal.data["command"])
 		if("blank")
 			mode = SD_BLANK
-			set_message(null, null)
+			remove_display()
 		if("shuttle")
 			mode = SD_EMERGENCY
-			set_message(null, null)
+			remove_display()
 		if("message")
 			mode = SD_MESSAGE
-			set_message(signal.data["msg1"], signal.data["msg2"])
+			update_display(signal.data["msg1"], signal.data["msg2"])
 		if("alert")
 			mode = SD_PICTURE
 			last_picture = signal.data["picture_state"]
@@ -416,4 +425,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/ai, 32)
 #undef FONT_SIZE
 #undef FONT_COLOR
 #undef FONT_STYLE
-#undef SCROLL_SPEED
+#undef SCROLL_RATE
+#undef LINE1_Y
+#undef LINE2_Y

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -92,15 +92,16 @@
 
 /// Immediately change the display to the given two lines.
 /obj/machinery/status_display/proc/update_display(line1, line2)
+	line1 = uppertext(line1)
+	line2 = uppertext(line2)
+
 	if( \
 		(message1_overlay && message1_overlay.message == line1) && \
-		(message2_overlay && message2_overlay.message == line2))
+		(message2_overlay && message2_overlay.message == line2) \
+	)
 		return
 
 	remove_display()
-
-	line1 = uppertext(line1)
-	line2 = uppertext(line2)
 
 	message1_overlay = new(LINE1_Y, line1)
 	vis_contents += message1_overlay
@@ -188,12 +189,12 @@
 		// Marquee text
 		var/marquee_message = "[line] • [line] • [line]"
 		var/marqee_length = line_length * 3 + 6
-		maptext = generate_text(marquee_message, FALSE)
+		maptext = generate_text(marquee_message, center = FALSE)
 		maptext_width = 6 * marqee_length
 		maptext_x = 32
 
 		// Mask off to fit in screen.
-		filters = filter(type = "alpha", icon = icon(icon, "outline"))
+		add_filter("mask", 1, alpha_mask_filter(icon = icon(icon, "outline")))
 
 		// Scroll.
 		var/width = 4 * marqee_length
@@ -202,7 +203,7 @@
 		animate(maptext_x = 32, time = 0)
 	else
 		// Centered text
-		maptext = generate_text(line, TRUE)
+		maptext = generate_text(line, center = TRUE)
 		maptext_x = 0
 
 /obj/effect/overlay/status_display_text/proc/generate_text(text, center)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes status displays with long messages not be unreadable garbage. When the machine was created, we didn't have fancy filters and vis_contents and whatnot, but now we do. This costs no net traffic after the message is initially updated.

Note that lines with 5 or less characters still statically display centered, particularly for the sake of the countdowns.

[Video demo (sorry for video compression)](https://i.imgur.com/SlZoUOh.mp4)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The message feature of the status display was in theory nice but has never been pleasant to decipher if the lines were more than 5 characters.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
qol: Status displays now scroll text smoothly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
