### PR TITLE
Stops 'bad touch' from triggering on dead people

### DIFF
--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -844,6 +844,9 @@
 /datum/quirk/bad_touch/proc/uncomfortable_touch()
 	SIGNAL_HANDLER
 
+	if(quirk_holder.stat == DEAD)
+		return
+
 	new /obj/effect/temp_visual/annoyed(quirk_holder.loc)
 	var/datum/component/mood/mood = quirk_holder.GetComponent(/datum/component/mood)
 	if(mood.sanity <= SANITY_NEUTRAL)


### PR DESCRIPTION
## About The Pull Request

- Prevents the 'Bad Touch' quirk from triggering on people who are dead.

## Why It's Good For The Game

Doesn't really make sense that you get a negative moodlet about hating being touched if you're dead when it happened. 

Namely cause it's just weird to see the annoyed popup float up grabbing a dead body

## Changelog

:cl: Melbert
qol: Bad Touch doesn't trigger if the person's dead
/:cl:
