### PR TITLE
Adds new food tag and felinid taste preference modification.

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -15,6 +15,7 @@
 #define CLOTH (1<<14)
 #define NUTS (1<<15)
 #define SEAFOOD (1<<16)
+#define ORANGES (1<<17)
 
 /// A list of food type names, in order of their flags
 #define FOOD_FLAGS list( \
@@ -32,10 +33,10 @@
 	"TOXIC", \
 	"PINEAPPLE", \
 	"BREAKFAST", \
-	"ORANGES", \
 	"CLOTH", \
 	"NUTS", \
 	"SEAFOOD", \
+	"ORANGES", \
 )
 
 #define DRINK_NICE 1

--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -32,6 +32,7 @@
 	"TOXIC", \
 	"PINEAPPLE", \
 	"BREAKFAST", \
+	"ORANGES", \
 	"CLOTH", \
 	"NUTS", \
 	"SEAFOOD", \

--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -104,7 +104,7 @@
 	icon_state = "orangecake"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 20, /datum/reagent/consumable/nutriment/vitamin = 10)
 	tastes = list("cake" = 5, "sweetness" = 2, "oranges" = 2)
-	foodtypes = GRAIN | DAIRY | FRUIT | SUGAR
+	foodtypes = GRAIN | DAIRY | FRUIT | SUGAR | ORANGES
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/cake/orange/MakeProcessable()
@@ -115,7 +115,7 @@
 	desc = "Just a slice of cake, it is enough for everyone."
 	icon_state = "orangecake_slice"
 	tastes = list("cake" = 5, "sweetness" = 2, "oranges" = 2)
-	foodtypes = GRAIN | DAIRY | FRUIT | SUGAR
+	foodtypes = GRAIN | DAIRY | FRUIT | SUGAR | ORANGES
 
 /obj/item/food/cake/lime
 	name = "lime cake"

--- a/code/game/objects/items/food/frozen.dm
+++ b/code/game/objects/items/food/frozen.dm
@@ -117,7 +117,7 @@
 	icon_state = "orange_sc"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/orangejuice = 5, /datum/reagent/water = 11)
 	tastes = list("ice" = 1, "water" = 1, "orange" = 5)
-	foodtypes = FRUIT
+	foodtypes = FRUIT | ORANGES
 
 /obj/item/food/snowcones/blue
 	name = "bluecherry snowcone"
@@ -149,7 +149,7 @@
 	icon_state = "fruitsalad_sc"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/lemonjuice = 5, /datum/reagent/consumable/limejuice = 5, /datum/reagent/consumable/orangejuice = 5, /datum/reagent/water = 11)
 	tastes = list("ice" = 1, "water" = 1, "oranges" = 5, "limes" = 5, "lemons" = 5, "citrus" = 5, "salad" = 5)
-	foodtypes = FRUIT
+	foodtypes = FRUIT | ORANGES
 
 /obj/item/food/snowcones/pineapple
 	name = "pineapple snowcone"
@@ -277,7 +277,7 @@
 	name = "orange creamsicle"
 	desc = "A classic orange creamsicle. A sunny frozen treat."
 	food_reagents = list(/datum/reagent/consumable/orangejuice = 4, /datum/reagent/consumable/cream = 2, /datum/reagent/consumable/vanilla = 2, /datum/reagent/consumable/sugar = 4)
-	foodtypes = FRUIT | DAIRY | SUGAR
+	foodtypes = FRUIT | DAIRY | SUGAR | ORANGES
 
 /obj/item/food/popsicle/creamsicle_berry
 	name = "berry creamsicle"

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -314,7 +314,7 @@
 	icon_state = "chocoorange"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/sugar = 1)
 	tastes = list("chocolate" = 3, "oranges" = 1)
-	foodtypes = JUNKFOOD | SUGAR
+	foodtypes = JUNKFOOD | SUGAR | ORANGES
 	food_flags = FOOD_FINGER_FOOD
 	w_class = WEIGHT_CLASS_SMALL
 

--- a/code/game/objects/items/food/salad.dm
+++ b/code/game/objects/items/food/salad.dm
@@ -57,7 +57,7 @@
 	icon_state = "citrusdelight"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 11, /datum/reagent/consumable/nutriment/vitamin = 7)
 	tastes = list("sourness" = 1, "leaves" = 1)
-	foodtypes = FRUIT
+	foodtypes = FRUIT | ORANGES
 
 /obj/item/food/salad/ricebowl
 	name = "ricebowl"

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -55,6 +55,7 @@
 	name = "orange"
 	desc = "It's a tangy fruit."
 	icon_state = "orange"
+	foodtypes = ORANGES
 	juice_results = list(/datum/reagent/consumable/orangejuice = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/triple_sec
 
@@ -133,6 +134,7 @@
 	name = "extradimensional orange"
 	desc = "You can hardly wrap your head around this thing."
 	icon_state = "orang"
+	foodtypes = ORANGES
 	alt_icon = "orange"
 	bite_consumption_mod = 2
 	juice_results = list(/datum/reagent/consumable/orangejuice = 0)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -12,7 +12,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/felinid
 	disliked_food = GROSS | CLOTH | RAW
-	liked_food = SEAFOOD
+	liked_food = SEAFOOD | ORANGES
 	var/original_felinid = TRUE //set to false for felinids created by mass-purrbation
 	payday_modifier = 0.75
 	ass_image = 'icons/ass/asscat.png'


### PR DESCRIPTION

## About The Pull Request

I have chosen to give one of the fruits we have in-game to have its own unique food tag while still maintaining its current fruit tag, we can modify this later for things involving scurvy and such.

![image](https://user-images.githubusercontent.com/16896032/153392270-5badaf27-9e7b-47cd-9edc-cf3535b9be22.png)


## Why It's Good For The Game

Felinids can't survive off fish alone, this provides more variety in their diet and prevents SCURVY

![image](https://user-images.githubusercontent.com/16896032/153392400-7a6d134a-6536-4a17-ba3a-6ff23dbbcc77.png)


## Changelog

:cl:
qol: Felinids love oranges as much as he loves them!
/:cl:
