### PR TITLE
Fixes heartless species being unable to be heretics

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -36,7 +36,7 @@
 	/// Assoc list of [typepath] = [knowledge instance]. A list of all knowledge this heretic's reserached.
 	var/list/researched_knowledge = list()
 	/// The organ slot we place our Living Heart in.
-	var/heart_organ_slot = ORGAN_SLOT_HEART
+	var/living_heart_organ_slot = ORGAN_SLOT_HEART
 	/// A list of TOTAL how many sacrifices completed. (Includes high value sacrifices)
 	var/total_sacrifices = 0
 	/// A list of TOTAL how many high value sacrifices completed.
@@ -412,7 +412,7 @@
 /datum/antagonist/heretic/get_admin_commands()
 	. = ..()
 
-	var/obj/item/organ/our_living_heart = owner.current?.getorganslot(heart_organ_slot)
+	var/obj/item/organ/our_living_heart = owner.current?.getorganslot(living_heart_organ_slot)
 	if(our_living_heart)
 		if(HAS_TRAIT(our_living_heart, TRAIT_LIVING_HEART))
 			.["Add Heart Target (Marked Mob)"] = CALLBACK(src, .proc/add_marked_as_target)

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -35,6 +35,8 @@
 	var/passive_gain_timer = 20 MINUTES
 	/// Assoc list of [typepath] = [knowledge instance]. A list of all knowledge this heretic's reserached.
 	var/list/researched_knowledge = list()
+	/// The organ slot we place our Living Heart in.
+	var/heart_organ_slot = ORGAN_SLOT_HEART
 	/// A list of TOTAL how many sacrifices completed. (Includes high value sacrifices)
 	var/total_sacrifices = 0
 	/// A list of TOTAL how many high value sacrifices completed.
@@ -410,9 +412,9 @@
 /datum/antagonist/heretic/get_admin_commands()
 	. = ..()
 
-	var/obj/item/organ/heart/our_heart = owner.current?.getorganslot(ORGAN_SLOT_HEART)
-	if(our_heart)
-		if(HAS_TRAIT(our_heart, TRAIT_LIVING_HEART))
+	var/obj/item/organ/our_living_heart = owner.current?.getorganslot(heart_organ_slot)
+	if(our_living_heart)
+		if(HAS_TRAIT(our_living_heart, TRAIT_LIVING_HEART))
 			.["Add Heart Target (Marked Mob)"] = CALLBACK(src, .proc/add_marked_as_target)
 			.["Remove Heart Target"] = CALLBACK(src, .proc/remove_target)
 		else

--- a/code/modules/antagonists/heretic/knowledge/general_side.dm
+++ b/code/modules/antagonists/heretic/knowledge/general_side.dm
@@ -17,7 +17,7 @@
 /datum/heretic_knowledge/reroll_targets/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
 
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
-	var/obj/item/organ/our_living_heart = user.getorganslot(heretic_datum.heart_organ_slot)
+	var/obj/item/organ/our_living_heart = user.getorganslot(heretic_datum.living_heart_organ_slot)
 	if(!our_living_heart || !HAS_TRAIT(our_living_heart, TRAIT_LIVING_HEART))
 		return FALSE
 

--- a/code/modules/antagonists/heretic/knowledge/general_side.dm
+++ b/code/modules/antagonists/heretic/knowledge/general_side.dm
@@ -15,11 +15,12 @@
 	route = PATH_SIDE
 
 /datum/heretic_knowledge/reroll_targets/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
-	var/obj/item/organ/heart/our_heart = user.getorganslot(ORGAN_SLOT_HEART)
-	if(!our_heart || !HAS_TRAIT(our_heart, TRAIT_LIVING_HEART))
-		return FALSE
 
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
+	var/obj/item/organ/our_living_heart = user.getorganslot(heretic_datum.heart_organ_slot)
+	if(!our_living_heart || !HAS_TRAIT(our_living_heart, TRAIT_LIVING_HEART))
+		return FALSE
+
 	if(!LAZYLEN(heretic_datum.sac_targets))
 		return FALSE
 

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -52,7 +52,7 @@
 	// then returns TRUE if skip_this_ritual is FALSE and the user's on top of the rune.
 	// If skip_this_ritual is TRUE, returns FALSE to fail the check and move onto the next ritual.
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
-	var/obj/item/organ/our_living_heart = user.getorganslot(heretic_datum.heart_organ_slot)
+	var/obj/item/organ/our_living_heart = user.getorganslot(heretic_datum.living_heart_organ_slot)
 	if(!our_living_heart || !HAS_TRAIT(our_living_heart, TRAIT_LIVING_HEART))
 		return FALSE
 

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -48,14 +48,14 @@
 		CRASH("Failed to initialize heretic sacrifice z-level!")
 
 /datum/heretic_knowledge/hunt_and_sacrifice/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
-	var/obj/item/organ/heart/our_heart = user.getorganslot(ORGAN_SLOT_HEART)
-	if(!our_heart || !HAS_TRAIT(our_heart, TRAIT_LIVING_HEART))
-		return FALSE
-
 	// We've got no targets set, let's try to set some. Adds the user to the list of atoms,
 	// then returns TRUE if skip_this_ritual is FALSE and the user's on top of the rune.
 	// If skip_this_ritual is TRUE, returns FALSE to fail the check and move onto the next ritual.
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
+	var/obj/item/organ/our_living_heart = user.getorganslot(heretic_datum.heart_organ_slot)
+	if(!our_living_heart || !HAS_TRAIT(our_living_heart, TRAIT_LIVING_HEART))
+		return FALSE
+
 	if(!LAZYLEN(heretic_datum.sac_targets))
 		if(skip_this_ritual)
 			return FALSE

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -56,14 +56,13 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	. = ..()
 
 	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
-	var/obj/item/organ/where_to_put_our_heart = user.getorganslot(our_heretic.heart_organ_slot)
+	var/obj/item/organ/where_to_put_our_heart = user.getorganslot(our_heretic.living_heart_organ_slot)
 
 	// If a heretic is made from a species without a heart, we need to find a backup.
 	if(!where_to_put_our_heart)
-
 		var/static/list/backup_organs = list(
 			ORGAN_SLOT_LUNGS = /obj/item/organ/lungs,
-			ORGAN_SLOT_LIVER = /obj/item/organ/lungs,
+			ORGAN_SLOT_LIVER = /obj/item/organ/liver,
 			ORGAN_SLOT_STOMACH = /obj/item/organ/stomach,
 		)
 
@@ -71,7 +70,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 			var/obj/item/organ/look_for_backup = user.getorganslot(backup_slot)
 			if(look_for_backup)
 				where_to_put_our_heart = look_for_backup
-				our_heretic.heart_organ_slot = backup_slot
+				our_heretic.living_heart_organ_slot = backup_slot
 				required_organ_type = backup_organs[backup_slot]
 				to_chat(user, span_boldnotice("As your species does not have a heart, your Living Heart is located in your [look_for_backup.name]."))
 				break
@@ -90,13 +89,13 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 
 /datum/heretic_knowledge/living_heart/on_lose(mob/user)
 	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
-	var/obj/item/organ/our_living_heart = user.getorganslot(our_heretic.heart_organ_slot)
+	var/obj/item/organ/our_living_heart = user.getorganslot(our_heretic.living_heart_organ_slot)
 	if(our_living_heart)
 		qdel(our_living_heart.GetComponent(/datum/component/living_heart))
 
 /datum/heretic_knowledge/living_heart/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
 	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
-	var/obj/item/organ/our_living_heart = user.getorganslot(our_heretic.heart_organ_slot)
+	var/obj/item/organ/our_living_heart = user.getorganslot(our_heretic.living_heart_organ_slot)
 	if(!our_living_heart || HAS_TRAIT(our_living_heart, TRAIT_LIVING_HEART))
 		return FALSE
 
@@ -117,7 +116,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 
 /datum/heretic_knowledge/living_heart/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
-	var/obj/item/organ/our_new_heart = user.getorganslot(our_heretic.heart_organ_slot)
+	var/obj/item/organ/our_new_heart = user.getorganslot(our_heretic.living_heart_organ_slot)
 
 	if(our_new_heart.status != ORGAN_ORGANIC)
 		var/obj/item/organ/our_replacement_heart = locate(required_organ_type) in selected_atoms

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -126,7 +126,7 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 			INVOKE_ASYNC(user, /mob/proc/emote, "scream")
 			user.apply_damage(20, BRUTE, BODY_ZONE_CHEST)
 
-			our_replacement_heart.Insert(user, special = TRUE, drop_if_replaced = TRUE)
+			our_replacement_heart.Insert(user, TRUE, TRUE)
 			our_new_heart.throw_at(get_edge_target_turf(user, pick(GLOB.alldirs)), 2, 2)
 			our_new_heart = our_replacement_heart
 

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -78,9 +78,11 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 
 	if(where_to_put_our_heart)
 		where_to_put_our_heart.AddComponent(/datum/component/living_heart)
-		desc = "Grants you a Living Heart, tied to your [where_to_put_our_heart.name], allowing you to track sacrifice targets. \
+		desc = "Grants you a Living Heart, tied to your [where_to_put_our_heart.name], \
+			allowing you to track sacrifice targets. \
 			Should you lose your [where_to_put_our_heart.name], you can transmute a poppy and a pool of blood \
-			to awaken your [where_to_put_our_heart.name] into a Living Heart. If your heart is cybernetic, \
+			to awaken your replacement [where_to_put_our_heart.name] into a Living Heart. \
+			If your [where_to_put_our_heart.name] is cybernetic, \
 			you will additionally require a usable organic [where_to_put_our_heart.name] in the transmutation."
 
 	else

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -49,58 +49,93 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	)
 	cost = 0
 	route = PATH_START
+	/// The typepath of the organ type required for our heart.
+	var/required_organ_type = /obj/item/organ/heart
 
 /datum/heretic_knowledge/living_heart/on_research(mob/user)
 	. = ..()
 
-	var/obj/item/organ/heart/our_heart = user.getorganslot(ORGAN_SLOT_HEART)
-	if(our_heart)
-		our_heart.AddComponent(/datum/component/living_heart)
+	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
+	var/obj/item/organ/where_to_put_our_heart = user.getorganslot(our_heretic.heart_organ_slot)
+
+	// If a heretic is made from a species without a heart, we need to find a backup.
+	if(!where_to_put_our_heart)
+
+		var/static/list/backup_organs = list(
+			ORGAN_SLOT_LUNGS = /obj/item/organ/lungs,
+			ORGAN_SLOT_LIVER = /obj/item/organ/lungs,
+			ORGAN_SLOT_STOMACH = /obj/item/organ/stomach,
+		)
+
+		for(var/backup_slot in backup_organs)
+			var/obj/item/organ/look_for_backup = user.getorganslot(backup_slot)
+			if(look_for_backup)
+				where_to_put_our_heart = look_for_backup
+				our_heretic.heart_organ_slot = backup_slot
+				required_organ_type = backup_organs[backup_slot]
+				to_chat(user, span_boldnotice("As your species does not have a heart, your Living Heart is located in your [look_for_backup.name]."))
+				break
+
+	if(where_to_put_our_heart)
+		where_to_put_our_heart.AddComponent(/datum/component/living_heart)
+		desc = "Grants you a Living Heart, tied to your [where_to_put_our_heart.name], allowing you to track sacrifice targets. \
+			Should you lose your [where_to_put_our_heart.name], you can transmute a poppy and a pool of blood \
+			to awaken your [where_to_put_our_heart.name] into a Living Heart. If your heart is cybernetic, \
+			you will additionally require a usable organic [where_to_put_our_heart.name] in the transmutation."
+
+	else
+		to_chat(user, span_boldnotice("You don't have a heart, or any chest organs for that matter. You didn't get a Living Heart because of it."))
 
 /datum/heretic_knowledge/living_heart/on_lose(mob/user)
-	var/obj/item/organ/heart/our_heart = user.getorganslot(ORGAN_SLOT_HEART)
-	if(our_heart)
-		qdel(our_heart.GetComponent(/datum/component/living_heart))
+	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
+	var/obj/item/organ/our_living_heart = user.getorganslot(our_heretic.heart_organ_slot)
+	if(our_living_heart)
+		qdel(our_living_heart.GetComponent(/datum/component/living_heart))
 
 /datum/heretic_knowledge/living_heart/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
-	var/obj/item/organ/heart/our_heart = user.getorganslot(ORGAN_SLOT_HEART)
-	if(!our_heart || HAS_TRAIT(our_heart, TRAIT_LIVING_HEART))
+	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
+	var/obj/item/organ/our_living_heart = user.getorganslot(our_heretic.heart_organ_slot)
+	if(!our_living_heart || HAS_TRAIT(our_living_heart, TRAIT_LIVING_HEART))
 		return FALSE
 
-	if(our_heart.status == ORGAN_ORGANIC)
+	if(our_living_heart.status == ORGAN_ORGANIC)
 		return TRUE
 
 	else
-		for(var/obj/item/organ/heart/nearby_heart in atoms)
-			if(nearby_heart.status == ORGAN_ORGANIC && nearby_heart.useable)
-				selected_atoms += nearby_heart
+		for(var/obj/item/organ/nearby_organ in atoms)
+			if(!istype(nearby_organ, required_organ_type))
+				continue
+
+			if(nearby_organ.status == ORGAN_ORGANIC && nearby_organ.useable)
+				selected_atoms += nearby_organ
 				return TRUE
 
 		return FALSE
 
 
 /datum/heretic_knowledge/living_heart/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
+	var/datum/antagonist/heretic/our_heretic = IS_HERETIC(user)
+	var/obj/item/organ/our_new_heart = user.getorganslot(our_heretic.heart_organ_slot)
 
-	var/obj/item/organ/heart/our_heart = user.getorganslot(ORGAN_SLOT_HEART)
-
-	if(our_heart.status != ORGAN_ORGANIC)
-		var/obj/item/organ/heart/our_replacement_heart = locate() in selected_atoms
+	if(our_new_heart.status != ORGAN_ORGANIC)
+		var/obj/item/organ/our_replacement_heart = locate(required_organ_type) in selected_atoms
 		if(our_replacement_heart)
 			user.visible_message("[user]'s [our_replacement_heart.name] bursts suddenly out of [user.p_their()] chest!")
 			INVOKE_ASYNC(user, /mob/proc/emote, "scream")
 			user.apply_damage(20, BRUTE, BODY_ZONE_CHEST)
 
 			our_replacement_heart.Insert(user, special = TRUE, drop_if_replaced = TRUE)
-			our_heart.throw_at(get_edge_target_turf(user, pick(GLOB.alldirs)), 2, 2)
-			our_heart = our_replacement_heart
+			our_new_heart.throw_at(get_edge_target_turf(user, pick(GLOB.alldirs)), 2, 2)
+			our_new_heart = our_replacement_heart
 
-	if(!our_heart)
+	if(!our_new_heart)
 		CRASH("[type] somehow made it to on_finished_recipe without a heart. What?")
 
-	if(our_heart in selected_atoms)
-		selected_atoms -= our_heart
-	our_heart.AddComponent(/datum/component/living_heart)
-	to_chat(user, span_warning("You feel your [our_heart.name] begin pulse faster and faster as it awakens!"))
+	if(our_new_heart in selected_atoms)
+		selected_atoms -= our_new_heart
+
+	our_new_heart.AddComponent(/datum/component/living_heart)
+	to_chat(user, span_warning("You feel your [our_new_heart.name] begin pulse faster and faster as it awakens!"))
 	playsound(user, 'sound/magic/demon_consume.ogg', 50, TRUE)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

I thought that Plasmamen had hearts, but there a mutant heart. 
I was incorrect!

Species without a heart will not pick from a list of backup organs to bestow them a Living Heart.
It'll be more like a Living Liver but it's close enough I suppose

## Why It's Good For The Game

Lets Plasmamen heretic

## Changelog

:cl: Melbert
fix: Species without hearts can get Living Hearts now. 
/:cl:

