### PR TITLE
Fixes mod control unit silhouette in SSU

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -228,7 +228,7 @@
 			"suit" = create_silhouette_of(/obj/item/clothing/suit/space/eva),
 			"helmet" = create_silhouette_of(/obj/item/clothing/head/helmet/space/eva),
 			"mask" = create_silhouette_of(/obj/item/clothing/mask/breath),
-			"mod" = create_silhouette_of(/obj/item/mod),
+			"mod" = create_silhouette_of(/obj/item/mod/control),
 			"storage" = create_silhouette_of(/obj/item/tank/internals/oxygen),
 		)
 


### PR DESCRIPTION
## About The Pull Request
Fixes #64769  where SSUs without a mod control unit displayed an error instead of the proper silhouette. 

![mod_silhouette](https://user-images.githubusercontent.com/60521518/153636211-983e5244-1c2a-461b-a492-ff752665c4f4.png)
## Why It's Good For The Game
Big red ERROR sprite gone, that's good probably.

## Changelog
:cl:
fix: changes one line of code, fixes mod control unit's silhouette in the SSU.
:cl:
