### PR TITLE
Makes locker staff decaying closets dump contents before qdel

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -311,7 +311,7 @@
 
 ///Fade away into nothing
 /obj/structure/closet/decay/proc/decay()
-	animate(src, alpha = 0, time = 30)
+	animate(src, alpha = 0, time = 3 SECONDS)
 	addtimer(CALLBACK(src, .proc/decay_finished), 30)
 
 /obj/structure/closet/decay/proc/decay_finished()

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -297,11 +297,6 @@
 	if(weld_state)
 		unmagify()
 
-///Fade away into nothing
-/obj/structure/closet/decay/proc/decay()
-	animate(src, alpha = 0, time = 30)
-	addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, src), 30)
-
 /obj/structure/closet/decay/open(mob/living/user, force = FALSE)
 	. = ..()
 	if(.)
@@ -313,6 +308,15 @@
 	update_appearance()
 
 	addtimer(CALLBACK(src, .proc/decay), 15 SECONDS)
+
+///Fade away into nothing
+/obj/structure/closet/decay/proc/decay()
+	animate(src, alpha = 0, time = 30)
+	addtimer(CALLBACK(src, .proc/decay_finished), 30)
+
+/obj/structure/closet/decay/proc/decay_finished()
+	dump_contents()
+	qdel(src)
 
 /obj/projectile/magic/flying
 	name = "bolt of flying"

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -312,7 +312,7 @@
 ///Fade away into nothing
 /obj/structure/closet/decay/proc/decay()
 	animate(src, alpha = 0, time = 3 SECONDS)
-	addtimer(CALLBACK(src, .proc/decay_finished), 30)
+	addtimer(CALLBACK(src, .proc/decay_finished), 3 SECONDS)
 
 /obj/structure/closet/decay/proc/decay_finished()
 	dump_contents()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #64692 
Decaying lockers from the locker staff now dump contents before deleting themselves.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Funny locker probably shouldn't permanently remove anything that gets shut in it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Decaying lockers from the locker staff no longer delete their contents when vanishing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
