### PR TITLE
Fixes some light presets being brighter than intended

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_map.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_map.dm
@@ -70,7 +70,6 @@ GLOBAL_LIST_EMPTY(heretic_sacrifice_landmarks)
 	bulb_colour = "#d6b6a6ff"
 	brightness = 3
 	bulb_power = 0.5
-	fitting = "void" // If you set this to "tube" or "bulb" the brightness is reset in LateInitialize()
 
 /obj/machinery/light/very_dim/directional/north
 	dir = NORTH

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -91,11 +91,9 @@
 	. = ..()
 	switch(fitting)
 		if("tube")
-			brightness = 8
 			if(prob(2))
 				break_light_tube(TRUE)
 		if("bulb")
-			brightness = 4
 			if(prob(5))
 				break_light_tube(TRUE)
 	addtimer(CALLBACK(src, .proc/update, FALSE), 0.1 SECONDS)

--- a/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/code/modules/power/lighting/light_mapping_helpers.dm
@@ -31,13 +31,13 @@
 	bulb_colour = "#FF3232"
 	nightshift_allowed = FALSE
 	no_emergency = TRUE
-	brightness = 2
+	brightness = 4
 	bulb_power = 0.7
 
 /obj/machinery/light/blacklight
 	bulb_colour = "#A700FF"
 	nightshift_allowed = FALSE
-	brightness = 2
+	brightness = 4
 	bulb_power = 0.8
 
 /obj/machinery/light/dim
@@ -74,13 +74,13 @@
 	bulb_colour = "#FF3232"
 	no_emergency = TRUE
 	nightshift_allowed = FALSE
-	brightness = 1
+	brightness = 2
 	bulb_power = 0.8
 
 /obj/machinery/light/small/blacklight
 	bulb_colour = "#A700FF"
 	nightshift_allowed = FALSE
-	brightness = 1
+	brightness = 2
 	bulb_power = 0.9
 
 // -------- Directional presets


### PR DESCRIPTION
I do not know why but the brightness of light fixtures was being overwritten in LateInitialize(), from my testing this made no difference except making light presets not work properly

Fixing this made some non standard lights look much dimmer than was intended so I upped their brightness a bit, these are mostly used for ambience in ruins so the impact should be minimal

:cl:
fix: Fixed blacklight and red lights being brighter than intended
/:cl: