### PR TITLE
Prevents instant summons from recalling anchored objects

### DIFF
--- a/code/modules/spells/spell_types/summonitem.dm
+++ b/code/modules/spells/spell_types/summonitem.dm
@@ -10,14 +10,13 @@
 	level_max = 0 //cannot be improved
 	cooldown_min = 100
 	include_user = TRUE
-
+	action_icon_state = "summons"
+	///The obj marked for recall
 	var/obj/marked_item
 
-	action_icon_state = "summons"
-
-/obj/effect/proc_holder/spell/targeted/summonitem/cast(list/targets,mob/user = usr)
+/obj/effect/proc_holder/spell/targeted/summonitem/cast(list/targets, mob/user = usr)
 	for(var/mob/living/L in targets)
-		var/list/hand_items = list(L.get_active_held_item(),L.get_inactive_held_item())
+		var/list/hand_items = list(L.get_active_held_item(), L.get_inactive_held_item())
 		var/message
 
 		if(!marked_item) //linking item to the spell
@@ -79,12 +78,15 @@
 						M.dropItemToGround(item_to_retrieve)
 
 					else
-						if(istype(item_to_retrieve.loc, /obj/machinery/portable_atmospherics/)) //Edge cases for moved machinery
-							var/obj/machinery/portable_atmospherics/P = item_to_retrieve.loc
+						var/obj/retrieved_item = item_to_retrieve.loc
+						if(retrieved_item.anchored)
+							break
+						if(istype(retrieved_item, /obj/machinery/portable_atmospherics)) //Edge cases for moved machinery
+							var/obj/machinery/portable_atmospherics/P = retrieved_item
 							P.disconnect()
 							P.update_appearance()
 
-						item_to_retrieve = item_to_retrieve.loc
+						item_to_retrieve = retrieved_item
 
 					infinite_recursion += 1
 

--- a/code/modules/spells/spell_types/summonitem.dm
+++ b/code/modules/spells/spell_types/summonitem.dm
@@ -80,7 +80,7 @@
 					else
 						var/obj/retrieved_item = item_to_retrieve.loc
 						if(retrieved_item.anchored)
-							break
+							return
 						if(istype(retrieved_item, /obj/machinery/portable_atmospherics)) //Edge cases for moved machinery
 							var/obj/machinery/portable_atmospherics/P = retrieved_item
 							P.disconnect()


### PR DESCRIPTION
## About The Pull Request

Small bug fix that prevents anchored objects from being taken, without sacrificing the rest of its intended features.

## Why It's Good For The Game

Closes an issue from 2017 - https://github.com/tgstation/tgstation/issues/22837

## Changelog

:cl:
fix: Instant recall spell no longer recalls anchored objects, such as microwaves, if the marked item is placed inside of one.
/:cl: