### PR TITLE
Refactors anomanly neutralizer to use the effect remover component

### DIFF
--- a/code/datums/components/effect_remover.dm
+++ b/code/datums/components/effect_remover.dm
@@ -64,4 +64,6 @@
 		real_feedback = replacetext(real_feedback, "%THEWEAPON", "\the [item_parent]")
 		to_chat(user, span_notice(real_feedback))
 	on_clear_callback?.Invoke(target, user)
-	qdel(target)
+
+	if(!QDELETED(target))
+		qdel(target)

--- a/code/datums/components/effect_remover.dm
+++ b/code/datums/components/effect_remover.dm
@@ -3,6 +3,7 @@
  * certain effects (such as cult runes) in one attack.
  */
 /datum/component/effect_remover
+	dupe_mode = COMPONENT_DUPE_ALLOWED
 	/// Line sent to the user on successful removal.
 	var/success_feedback
 	/// Line forcesaid by the user on successful removal.
@@ -59,8 +60,8 @@
 	if(success_forcesay)
 		user.say(success_forcesay, forced = item_parent.name)
 	if(success_feedback)
-		var/real_feedback = replacetext(success_feedback, "%THEEFFECT", "[target]")
-		real_feedback = replacetext(real_feedback, "%THEWEAPON", "[item_parent]")
+		var/real_feedback = replacetext(success_feedback, "%THEEFFECT", "\the [target]")
+		real_feedback = replacetext(real_feedback, "%THEWEAPON", "\the [item_parent]")
 		to_chat(user, span_notice(real_feedback))
 	on_clear_callback?.Invoke(target, user)
 	qdel(target)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -89,9 +89,12 @@
 	qdel(src)
 
 
-/obj/effect/anomaly/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_ANALYZER)
+/obj/effect/anomaly/attackby(obj/item/weapon, mob/user, params)
+	if(weapon.tool_behaviour == TOOL_ANALYZER)
 		to_chat(user, span_notice("Analyzing... [src]'s unstable field is fluctuating along frequency [format_frequency(aSignal.frequency)], code [aSignal.code]."))
+		return TRUE
+
+	return ..()
 
 ///////////////////////
 

--- a/code/game/objects/items/devices/anomaly_neutralizer.dm
+++ b/code/game/objects/items/devices/anomaly_neutralizer.dm
@@ -14,24 +14,27 @@
 /obj/item/anomaly_neutralizer/Initialize(mapload)
 	. = ..()
 
-	// Can be used to delete drained heretic influences
+	// Primarily used to delete and neutralize anomalies.
+	AddComponent(/datum/component/effect_remover, \
+		success_feedback = "You neutralize %THEEFFECT with %THEWEAPON, frying its circuitry in the process.", \
+		on_clear_callback = CALLBACK(src, .proc/on_anomaly_neutralized), \
+		effects_we_clear = list(/obj/effect/anomaly))
+
+	// Can also be used to delete drained heretic influences, to stop fools from losing arms.
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You close %THEEFFECT with %THEWEAPON, frying its circuitry in the process.", \
 		on_clear_callback = CALLBACK(src, .proc/on_use), \
 		effects_we_clear = list(/obj/effect/visible_heretic_influence))
 
-/obj/item/anomaly_neutralizer/afterattack(atom/target, mob/user, proximity)
-	..()
-	if(!proximity || !target)
-		return
-	if(istype(target, /obj/effect/anomaly))
-		var/obj/effect/anomaly/A = target
-		to_chat(user, span_notice("The circuitry of [src] fries from the strain of neutralizing [A]!"))
-		A.anomalyNeutralize()
-		qdel(src)
+/**
+ * Callback for the effect remover component to handle neutralizing anomalies.
+ */
+/obj/item/anomaly_neutralizer/proc/on_anomaly_neutralized(obj/effect/anomaly/target, mob/living/user)
+	target.anomalyNeutralize()
+	on_use(target, user)
 
-/*
- * Callback for the effect remover component to delete after use.
+/**
+ * Use up the anomaly neutralizer. Cause some sparks and delete it.
  */
 /obj/item/anomaly_neutralizer/proc/on_use(obj/effect/target, mob/living/user)
 	do_sparks(3, FALSE, user)


### PR DESCRIPTION
## About The Pull Request

Changes the anomaly neutralizer from an attackby override to the effect remover component to handle removing anomalies.

## Why It's Good For The Game

Anomalies are effects, effect remover is made to remove effects, might as well make use of it?

Also makes some cool sparks around it now so that's neat

## Changelog

:cl: Melbert
refactor: The Anomaly Neutralizer uses the effect remover component now
/:cl:
