### PR TITLE
Deltastation Medbay Deblobbening Differentiation

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -18454,7 +18454,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/medical/medbay/central)
+/area/medical/break_room)
 "cUS" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -18495,7 +18495,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "cUX" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -18510,6 +18510,15 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"cVn" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "cVr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -19249,15 +19258,17 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "cYb" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "cYc" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Medbay - Break Room";
@@ -19273,7 +19284,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "cYe" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -19281,7 +19292,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "cYi" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral{
@@ -19675,7 +19686,7 @@
 	},
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "cZN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
@@ -19691,7 +19702,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "cZQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -20023,7 +20034,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "dbC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron{
@@ -20509,7 +20520,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "ddj" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -20525,13 +20536,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "ddk" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "ddu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
@@ -20834,7 +20845,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/tank_holder/oxygen,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "deK" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -20843,7 +20854,7 @@
 /obj/item/mod/module/plasma_stabilizer,
 /obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "deM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
@@ -21058,7 +21069,7 @@
 "dfL" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "dfP" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -22739,14 +22750,14 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "dnw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "dnx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -22762,14 +22773,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "dny" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "dnB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -22995,6 +23006,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/department/science)
+"dou" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "dov" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/turf_decal/bot,
@@ -23150,8 +23177,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "dpy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -23756,8 +23786,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "dsD" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -23767,7 +23798,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "dsF" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -23777,7 +23808,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "dsG" = (
 /obj/structure/table/glass,
 /obj/machinery/camera/directional/south{
@@ -23798,8 +23829,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "dsI" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall,
@@ -32014,8 +32047,9 @@
 /area/hallway/secondary/exit/departure_lounge)
 "ehQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "ehZ" = (
 /obj/structure/sign/departments/psychology{
 	pixel_x = 32
@@ -32226,10 +32260,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006
 	},
@@ -34880,6 +34914,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"eWp" = (
+/turf/closed/wall,
+/area/medical/cryo)
 "eWx" = (
 /obj/structure/window/reinforced,
 /obj/machinery/light/small/directional/west,
@@ -35422,6 +35459,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"fcx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/cryo)
 "fcA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36201,7 +36242,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "fmE" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/briefcase,
@@ -38010,8 +38051,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "fND" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/light/small/directional/north,
@@ -41197,6 +41239,16 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/service/library)
+"gAJ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/medical/cryo)
 "gAR" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -41904,7 +41956,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "gJq" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/camera/directional/south{
@@ -42279,6 +42331,21 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central/aft)
+"gNk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/medical/break_room)
 "gNs" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -47127,7 +47194,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "hWE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47531,7 +47598,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "icz" = (
 /obj/item/circular_saw,
 /obj/item/scalpel{
@@ -53955,8 +54022,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "jNJ" = (
 /obj/machinery/icecream_vat,
 /obj/effect/turf_decal/bot/right,
@@ -54865,6 +54933,9 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"kaC" = (
+/turf/closed/wall,
+/area/medical/break_room)
 "kaF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
@@ -60479,6 +60550,20 @@
 	},
 /turf/open/floor/iron/checker,
 /area/service/hydroponics/garden/abandoned)
+"ltc" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "ltd" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "brigprison";
@@ -65837,6 +65922,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "mEY" = (
@@ -73009,7 +73095,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "ote" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -73433,6 +73519,17 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"oyW" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/medical/cryo)
 "ozb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
@@ -76512,7 +76609,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "prS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral{
@@ -77924,7 +78021,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "pJV" = (
 /obj/item/storage/pod{
 	pixel_x = 32
@@ -78941,7 +79038,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "pVL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -87624,6 +87721,19 @@
 /obj/machinery/bluespace_vendor/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central/fore)
+"smq" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "smv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -92967,6 +93077,15 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"tGi" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "tGC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -93998,6 +94117,17 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/iron/white,
 /area/hallway/primary/central/aft)
+"tUJ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/medical/cryo)
 "tUM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate,
@@ -97494,7 +97624,7 @@
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/suit_storage_unit/medical,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "uQf" = (
 /obj/machinery/door/window/brigdoor{
 	name = "Creature Pen";
@@ -99519,7 +99649,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "vpf" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -101423,8 +101553,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "vPt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -101480,6 +101611,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"vQt" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/medical/cryo)
 "vQv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -104363,7 +104505,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "wCU" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/warning/nosmoking{
@@ -106709,8 +106851,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "xjG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -107059,7 +107202,7 @@
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "xpm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -107472,7 +107615,7 @@
 	},
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "xuD" = (
 /obj/structure/bed,
 /obj/machinery/light/directional/south,
@@ -108076,8 +108219,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "xCH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -108145,7 +108289,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "xEm" = (
 /obj/item/chair/plastic,
 /obj/effect/decal/cleanable/dirt,
@@ -108687,7 +108831,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/medical/medbay/central)
+/area/medical/break_room)
 "xLR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -154776,11 +154920,11 @@ dfD
 dbr
 diE
 iVo
-cPy
-cNz
-dbr
-dbr
-cNz
+eWp
+fcx
+gAJ
+tUJ
+fcx
 vru
 xFF
 qDv
@@ -155033,9 +155177,9 @@ cUG
 cPv
 diJ
 bmh
-cNz
+fcx
 dnv
-dpv
+smq
 dpv
 dsC
 ivY
@@ -155290,7 +155434,7 @@ vzL
 lPy
 pPZ
 bmh
-cPy
+eWp
 dnw
 xEd
 xEd
@@ -155547,7 +155691,7 @@ cUG
 cPv
 diG
 lFN
-cNz
+fcx
 dnx
 xph
 ehQ
@@ -155804,7 +155948,7 @@ dfD
 dhm
 diM
 xkU
-cPy
+eWp
 dny
 icy
 icy
@@ -156061,10 +156205,10 @@ ovU
 abY
 diz
 xkU
-cNz
+fcx
 dnv
-dpv
-dpv
+dou
+ltc
 dsG
 ivY
 ekR
@@ -156318,11 +156462,11 @@ riX
 dho
 diM
 uFU
-cPy
-cNz
-dbr
-dbr
-cNz
+eWp
+fcx
+vQt
+oyW
+fcx
 vru
 xFF
 qDv
@@ -156578,7 +156722,7 @@ xkU
 rtI
 xkU
 xkU
-xkU
+cVn
 xkU
 oMA
 xkU
@@ -158621,13 +158765,13 @@ ghf
 cRl
 cHU
 cUP
-cPy
+kaC
 cYa
 cZL
 uQe
 ddh
 hWD
-cPy
+kaC
 dhq
 mWN
 bmh
@@ -158878,7 +159022,7 @@ gnq
 cIW
 cHU
 gJg
-cPy
+kaC
 cYb
 xCA
 dbw
@@ -159135,14 +159279,14 @@ heo
 cHW
 cHU
 wCS
-cPy
+kaC
 cYc
 xCA
 fNq
 jNF
 vPs
 xjz
-aGe
+tGi
 mEX
 bmh
 dmd
@@ -159394,7 +159538,7 @@ raB
 pVG
 osV
 fmC
-jNF
+gNk
 pJx
 ddj
 deJ
@@ -159649,13 +159793,13 @@ onF
 cRp
 cHU
 cUT
-cPy
+kaC
 cYe
 cZP
 xLA
 ddk
 deK
-cPy
+kaC
 iAW
 exG
 ehZ

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -65906,7 +65906,6 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "mEX" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -32047,7 +32047,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "ehQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/medical/cryo)
 "ehZ" = (
@@ -60090,7 +60089,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
 "loX" = (
@@ -79651,7 +79649,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/vending/wallmed/directional/south,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
 "qfA" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Let's take a look at DeltaStation's Medbay.

![image](https://user-images.githubusercontent.com/34697715/153700326-507feeec-de8b-44b6-98dc-f567f33ddf0a.png)

It's fucking massive. Why is it so massive? I have no clue, but let's deblobbify it with two very easy things.

Firstly, Cryo is "enough" in it's own area that we can give it it's own area.

![image](https://user-images.githubusercontent.com/34697715/153700329-17697738-c721-49fa-8be0-e5bc0ac491e3.png)

Ta-da.

For some reason, the area known colloquially as the Medbay break room is not actually set to the area for a breakroom. No clue why, but let's fix that:

![image](https://user-images.githubusercontent.com/34697715/153700335-fcba0bb3-9484-41fc-b6c3-afe1e510724d.png)

How splendid.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's not exactly a great thing to have large swaths of deparment be classified as one area, especially when some parts are obviously not meant to be part of that singular area.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: DeltaStation's Medbay Cryogenics Room gets it's own APC. I bet you were all waiting for this one.
fix: Nanotrasen realized that the area on DeltaStation colloquially known as the Medbay Break Room wasn't actually called the Medbay Break Room for some reason. This has been rectified.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
