### PR TITLE
Fixes runtimes with the mystery box

### DIFF
--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -76,7 +76,8 @@ GLOBAL_LIST_INIT(mystery_box_extended, list(
 	pixel_y = -4
 	anchored = TRUE
 	density = TRUE
-	uses_integrity = FALSE
+	max_integrity = 99999
+	damage_deflection = 100
 
 	var/crate_open_sound = 'sound/machines/crate_open.ogg'
 	var/crate_close_sound = 'sound/machines/crate_close.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I made an oopsie in #64061, where I thought uses_integrity was a var that let you enable/disable the atom using the integrity system. Turns out that it's actually a var stating whether it *should* be using the integrity system, and if it tries using integrity while the var is false, it just runtimes.

This PR changes the mystery box to be basically invincible through having a high integrity and damage_deflection value instead.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less runtimes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
