### PR TITLE
Malf AIs and Combat-Upgraded AIs can now use the borg console to detonate borgs (again).

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -40,8 +40,8 @@
 
 	data["can_detonate"] = FALSE
 	if(isAI(user))
-		var/mob/living/silicon/ai/AI = user
-		data["can_detonate"] = !isnull(AI.malf_picker)
+		var/mob/living/silicon/ai/ai = user
+		data["can_detonate"] = !isnull(ai.malf_picker)
 
 	data["cyborgs"] = list()
 	for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
@@ -105,13 +105,13 @@
 		if("killbot") //Malf AIs, and AIs with a combat upgrade, can detonate their cyborgs remotely.
 			if(!isAI(usr))
 				return
-			var/mob/living/silicon/ai/AI = usr
-			if(!AI.malf_picker)
+			var/mob/living/silicon/ai/ai = usr
+			if(!ai.malf_picker)
 				return
 			var/mob/living/silicon/robot/target = locate(params["ref"]) in GLOB.silicon_mobs
 			if(!istype(target))
 				return
-			if(target.connected_ai != AI)
+			if(target.connected_ai != ai)
 				return
 			target.self_destruct(usr)
 

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -38,11 +38,10 @@
 	else if(isAdminGhostAI(user))
 		data["can_hack"] = TRUE
 
-	data["can_deto"] = FALSE
+	data["can_detonate"] = FALSE
 	if(isAI(user))
-		var/mob/living/silicon/ai/arty = user
-		if(arty.malf_picker)
-			data["can_deto"] = TRUE
+		var/mob/living/silicon/ai/AI = user
+		data["can_detonate"] = !isnull(AI.malf_picker)
 
 	data["cyborgs"] = list()
 	for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
@@ -106,13 +105,15 @@
 		if("killbot") //Malf AIs, and AIs with a combat upgrade, can detonate their cyborgs remotely.
 			if(!isAI(usr))
 				return
-			var/mob/living/silicon/ai/arty = usr
-			if(!arty.malf_picker)
+			var/mob/living/silicon/ai/AI = usr
+			if(!AI.malf_picker)
 				return
-			var/mob/living/silicon/robot/rob = locate(params["ref"]) in GLOB.silicon_mobs
-			if(rob.connected_ai != arty)
+			var/mob/living/silicon/robot/target = locate(params["ref"]) in GLOB.silicon_mobs
+			if(!istype(target))
 				return
-			rob.self_destruct(usr)
+			if(target.connected_ai != AI)
+				return
+			target.self_destruct(usr)
 
 		if("magbot")
 			var/mob/living/silicon/S = usr

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -38,6 +38,12 @@
 	else if(isAdminGhostAI(user))
 		data["can_hack"] = TRUE
 
+	data["can_deto"] = FALSE
+	if(isAI(user))
+		var/mob/living/silicon/ai/arty = user
+		if(arty.malf_picker)
+			data["can_deto"] = TRUE
+
 	data["cyborgs"] = list()
 	for(var/mob/living/silicon/robot/R in GLOB.silicon_mobs)
 		if(!can_control(user, R))
@@ -96,6 +102,18 @@
 						to_chat(usr, span_danger("Cyborg locked by an user with superior permissions."))
 			else
 				to_chat(usr, span_danger("Access Denied."))
+
+		if("killbot") //Malf AIs, and AIs with a combat upgrade, can detonate their cyborgs remotely.
+			if(!isAI(usr))
+				return
+			var/mob/living/silicon/ai/arty = usr
+			if(!arty.malf_picker)
+				return
+			var/mob/living/silicon/robot/rob = locate(params["ref"]) in GLOB.silicon_mobs
+			if(rob.connected_ai != arty)
+				return
+			rob.self_destruct(usr)
+
 		if("magbot")
 			var/mob/living/silicon/S = usr
 			if((istype(S) && S.hack_software) || isAdminGhostAI(usr))
@@ -105,6 +123,7 @@
 					message_admins("[ADMIN_LOOKUPFLW(usr)] emagged cyborg [key_name_admin(R)] using robotic console!")
 					R.SetEmagged(TRUE)
 					R.logevent("WARN: root privleges granted to PID [num2hex(rand(1,65535), -1)][num2hex(rand(1,65535), -1)].") //random eight digit hex value. Two are used because rand(1,4294967295) throws an error
+
 		if("killdrone")
 			if(allowed(usr))
 				var/mob/living/simple_animal/drone/D = locate(params["ref"]) in GLOB.mob_list

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -36,7 +36,7 @@ export const RoboticsControlConsole = (props, context) => {
           <Cyborgs
             cyborgs={cyborgs}
             can_hack={can_hack}
-            can_detonate={can_detonate}/>
+            can_detonate={can_detonate} />
         )}
         {tab === 2 && (
           <Drones drones={drones} />

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -7,7 +7,7 @@ export const RoboticsControlConsole = (props, context) => {
   const [tab, setTab] = useSharedState(context, 'tab', 1);
   const {
     can_hack,
-    can_deto,
+    can_detonate,
     cyborgs = [],
     drones = [],
   } = data;
@@ -33,7 +33,7 @@ export const RoboticsControlConsole = (props, context) => {
           </Tabs.Tab>
         </Tabs>
         {tab === 1 && (
-          <Cyborgs cyborgs={cyborgs} can_hack={can_hack} can_deto={can_deto} />
+          <Cyborgs cyborgs={cyborgs} can_hack={can_hack} can_detonate={can_detonate} />
         )}
         {tab === 2 && (
           <Drones drones={drones} />
@@ -44,7 +44,7 @@ export const RoboticsControlConsole = (props, context) => {
 };
 
 const Cyborgs = (props, context) => {
-  const { cyborgs, can_hack, can_deto } = props;
+  const { cyborgs, can_hack, can_detonate } = props;
   const { act, data } = useBackend(context);
   if (!cyborgs.length) {
     return (
@@ -76,7 +76,7 @@ const Cyborgs = (props, context) => {
               onClick={() => act('stopbot', {
                 ref: cyborg.ref,
               })} />
-            {!!can_deto && (
+            {!!can_detonate && (
               <Button.Confirm
                 icon="bomb"
                 content="Detonate"

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -33,7 +33,10 @@ export const RoboticsControlConsole = (props, context) => {
           </Tabs.Tab>
         </Tabs>
         {tab === 1 && (
-          <Cyborgs cyborgs={cyborgs} can_hack={can_hack} can_detonate={can_detonate} />
+          <Cyborgs
+            cyborgs={cyborgs}
+            can_hack={can_hack}
+            can_detonate={can_detonate}/>
         )}
         {tab === 2 && (
           <Drones drones={drones} />

--- a/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
+++ b/tgui/packages/tgui/interfaces/RoboticsControlConsole.js
@@ -7,6 +7,7 @@ export const RoboticsControlConsole = (props, context) => {
   const [tab, setTab] = useSharedState(context, 'tab', 1);
   const {
     can_hack,
+    can_deto,
     cyborgs = [],
     drones = [],
   } = data;
@@ -32,7 +33,7 @@ export const RoboticsControlConsole = (props, context) => {
           </Tabs.Tab>
         </Tabs>
         {tab === 1 && (
-          <Cyborgs cyborgs={cyborgs} can_hack={can_hack} />
+          <Cyborgs cyborgs={cyborgs} can_hack={can_hack} can_deto={can_deto} />
         )}
         {tab === 2 && (
           <Drones drones={drones} />
@@ -43,7 +44,7 @@ export const RoboticsControlConsole = (props, context) => {
 };
 
 const Cyborgs = (props, context) => {
-  const { cyborgs, can_hack } = props;
+  const { cyborgs, can_hack, can_deto } = props;
   const { act, data } = useBackend(context);
   if (!cyborgs.length) {
     return (
@@ -75,6 +76,15 @@ const Cyborgs = (props, context) => {
               onClick={() => act('stopbot', {
                 ref: cyborg.ref,
               })} />
+            {!!can_deto && (
+              <Button.Confirm
+                icon="bomb"
+                content="Detonate"
+                color="bad"
+                onClick={() => act('killbot', {
+                  ref: cyborg.ref,
+                })} />
+            )}
           </>
         )}>
         <LabeledList>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows Malf/Combat AIs to detonate borgs, to fulfill their various goals. Non-emagged borgs will leave a possibly angry and vengeful brain behind.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was removed when the robotics console was reworked a bit ago, with the assumption that Malf AIs could use Machine Overload to accomplish the same task. This is incorrect (and also, having to use 20 malfbux to get rid of a borg that's braindead or sloppy enough to reveal you is lame). So we re-add this one thing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Malf AIs can detonate their borgs at the robotics console once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
