### PR TITLE
Fix chainlink fence doors having incorrect icon/density

### DIFF
--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -110,7 +110,6 @@
 	desc = "Not very useful without a real lock."
 	icon_state = "door_closed"
 	cuttable = FALSE
-	var/open = FALSE
 
 /obj/structure/fence/door/Initialize(mapload)
 	. = ..()
@@ -119,8 +118,7 @@
 
 /obj/structure/fence/door/opened
 	icon_state = "door_opened"
-	open = TRUE
-	density = TRUE
+	density = FALSE
 
 /obj/structure/fence/door/attack_hand(mob/user, list/modifiers)
 	if(can_open(user))
@@ -129,13 +127,12 @@
 	return TRUE
 
 /obj/structure/fence/door/proc/toggle(mob/user)
-	open = !open
-	visible_message(span_notice("\The [user] [open ? "opens" : "closes"] \the [src]."))
+	visible_message(span_notice("\The [user] [density ? "opens" : "closes"] \the [src]."))
+	set_density(!density)
 	update_door_status()
 	playsound(src, 'sound/machines/click.ogg', 100, TRUE)
 
 /obj/structure/fence/door/proc/update_door_status()
-	set_density(!density)
 	icon_state = density ? "door_closed" : "door_opened"
 
 /obj/structure/fence/door/proc/can_open(mob/user)

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -134,6 +134,7 @@
 
 /obj/structure/fence/door/update_icon_state()
 	icon_state = density ? "door_closed" : "door_opened"
+	return ..()
 
 /obj/structure/fence/door/proc/can_open(mob/user)
 	return TRUE

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -114,7 +114,7 @@
 /obj/structure/fence/door/Initialize(mapload)
 	. = ..()
 
-	update_door_status()
+	update_icon_state()
 
 /obj/structure/fence/door/opened
 	icon_state = "door_opened"
@@ -129,10 +129,10 @@
 /obj/structure/fence/door/proc/toggle(mob/user)
 	visible_message(span_notice("\The [user] [density ? "opens" : "closes"] \the [src]."))
 	set_density(!density)
-	update_door_status()
+	update_icon_state()
 	playsound(src, 'sound/machines/click.ogg', 100, TRUE)
 
-/obj/structure/fence/door/proc/update_door_status()
+/obj/structure/fence/door/update_icon_state()
 	icon_state = density ? "door_closed" : "door_opened"
 
 /obj/structure/fence/door/proc/can_open(mob/user)


### PR DESCRIPTION
## About The Pull Request

Fence doors used a var to track if they were opened or not, but it doesn't sync consistently with the density var. Density was getting set when updating icon state instead of when toggling the door. This removes the unneeded open var and flips density only during toggle.

## Why It's Good For The Game

Fences are cute for mapping but their doors weren't behaving as expected. They should now make as much sense as other doors.