### PR TITLE
Tgui loading screens no longer resize the window

### DIFF
--- a/tgui/packages/tgui/routes.js
+++ b/tgui/packages/tgui/routes.js
@@ -5,7 +5,7 @@
  */
 
 import { selectBackend } from './backend';
-import { Icon, Stack } from './components';
+import { Icon, Section, Stack } from './components';
 import { selectDebug } from './debug/selectors';
 import { Window } from './layouts';
 
@@ -35,17 +35,20 @@ const SuspendedWindow = () => {
 };
 
 const RefreshingWindow = () => {
+
   return (
-    <Window height={130} title="Loading" width={150}>
+    <Window title="Loading">
       <Window.Content>
-        <Stack align="center" fill justify="center" vertical>
-          <Stack.Item>
-            <Icon color="blue" name="toolbox" spin size={4} />
-          </Stack.Item>
-          <Stack.Item>
-            Please wait...
-          </Stack.Item>
-        </Stack>
+        <Section fill>
+          <Stack align="center" fill justify="center" vertical>
+            <Stack.Item>
+              <Icon color="blue" name="toolbox" spin size={4} />
+            </Stack.Item>
+            <Stack.Item>
+              Please wait...
+            </Stack.Item>
+          </Stack>
+        </Section>
       </Window.Content>
     </Window>
   );


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
"Thanks I hate it"

I was a little too busy being thrilled that it worked to care about user experience, apparently.

The window now inherits the window sizing of the current:
![dreamseeker_pyc1miRzKW](https://user-images.githubusercontent.com/42397676/153733228-23886094-58f2-48f2-a0ec-36070e095e75.gif)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better UX to not move their UI all over the place
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: TGUI static data loading screens no longer resize the window temporarily. Note: If you are using a UI that gets a lot of these, please make an issue report.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
