### PR TITLE
Fixing ghost bobbing (for real this time)

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -767,6 +767,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define DRONE_SHY_TRAIT "drone_shy"
 /// Pacifism trait given by stabilized light pink extracts.
 #define STABILIZED_LIGHT_PINK_TRAIT "stabilized_light_pink"
+/// Trait given to a ghost when they orbit something.
+#define GHOST_ORBITING_TRAIT "ghost_orbiting"
 
 /**
 * Trait granted by [/mob/living/carbon/Initialize] and

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -493,13 +493,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/orbit()
 	setDir(2)//reset dir so the right directional sprites show up
+	ADD_TRAIT(src, TRAIT_NO_FLOATING_ANIM, GHOST_ORBITING_TRAIT)
 	return ..()
 
 /mob/dead/observer/stop_orbit(datum/component/orbiter/orbits)
 	. = ..()
 	//restart our floating animation after orbit is done.
 	pixel_y = base_pixel_y
-	animate(src, pixel_y = base_pixel_y + 2, time = 1 SECONDS, loop = -1)
+	REMOVE_TRAIT(src, TRAIT_NO_FLOATING_ANIM, GHOST_ORBITING_TRAIT)
 
 /mob/dead/observer/verb/jumptomob() //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"


### PR DESCRIPTION
## About The Pull Request
Ghost weren't bobbing anymore as soon as you'd orbit someone, for the rest of your time as an observer. That's lame.
So I used a trait that was clearly meant for this and it worked perfectly.

## Why It's Good For The Game
I like it when ghosts bob up and down like they're meant to be.

## Changelog

:cl: GoldenAlpharex
fix: Ghosts will now get back to bobbing up and down after they're done orbiting something, as intended.
/:cl: