### PR TITLE
Fix BYOND-related runtime in SDQL2 _new wrapper.

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -85,7 +85,13 @@
 	return min(arglist(args))
 
 /proc/_new(type, arguments)
-	var/datum/result = new type(arglist(arguments))
+	var/datum/result
+
+	if(!length(arguments))
+		result = new type()
+	else
+		result = new type(arglist(arguments))
+
 	if(istype(result))
 		result.datum_flags |= DF_VAR_EDITED
 	return result


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/24975989/153741787-15f1c364-8476-492a-a7ae-f76f247a1910.png)

When trying to create a new `/datum` using SDQL2 wrappers, `arglist()` will runtime if the `/datum` doesn't have a `New()` defined. This is due to an old BYOND issue that has never been fixed/addressed.

http://www.byond.com/forum/post/2524183

You can't argslist with an empty list either, as THAT runtimes too (due to list length errors).

A lot of our datums don't have a `New()` defined. In this scenario, it makes sense to be able to create the datum without args.

As a result, I've added a logic branch to allow for a new datum to be created without args if either none are provided or the argslist is empty. This catches BOTH potential runtimes that would have resulted from the old argslist call.

This is sort of a workaround for a BYOND issue, but seems the most simple way to approach the problem.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Feex.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: SDQL2 commands that attempted to _new some very simple datums will no longer runtime.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
