### PR TITLE
Logs changeling buying powers / respeccing powers in uplink log 

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -229,6 +229,10 @@ GLOBAL_LIST_INIT(testing_global_profiler, list("_PROFILE_NAME" = "Global"))
 	if (CONFIG_GET(flag/log_uplink))
 		WRITE_LOG(GLOB.world_uplink_log, "HERETIC RESEARCH: [text]")
 
+/proc/log_changeling_power(text)
+	if (CONFIG_GET(flag/log_uplink))
+		WRITE_LOG(GLOB.world_uplink_log, "CHANGELING: [text]")
+
 /proc/log_telecomms(text)
 	if (CONFIG_GET(flag/log_telecomms))
 		WRITE_LOG(GLOB.world_telecomms_log, "TCOMMS: [text]")

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -318,6 +318,7 @@
 	genetic_points -= new_action.dna_cost
 	purchased_powers[sting_path] = new_action
 	new_action.on_purchase(owner.current) // Grant() is ran in this proc, see changeling_powers.dm.
+	log_changeling_power("[key_name(owner)] adapted the [new_action] power")
 	return TRUE
 
 /*
@@ -326,20 +327,22 @@
 /datum/antagonist/changeling/proc/readapt()
 	if(!ishuman(owner.current) || ismonkey(owner.current))
 		to_chat(owner.current, span_warning("We can't remove our evolutions in this form!"))
-		return
+		return FALSE
+
 	if(HAS_TRAIT_FROM(owner.current, TRAIT_DEATHCOMA, CHANGELING_TRAIT))
 		to_chat(owner.current, span_warning("We are too busy reforming ourselves to readapt right now!"))
-		return
+		return FALSE
 
-	if(can_respec)
-		to_chat(owner.current, span_notice("We have removed our evolutions from this form, and are now ready to readapt."))
-		remove_changeling_powers()
-		can_respec = FALSE
-		SSblackbox.record_feedback("tally", "changeling_power_purchase", 1, "Readapt")
-		return TRUE
+	if(!can_respec)
+		to_chat(owner.current, span_warning("You lack the power to readapt your evolutions!"))
+		return FALSE
 
-	to_chat(owner.current, span_warning("You lack the power to readapt your evolutions!"))
-	return FALSE
+	to_chat(owner.current, span_notice("We have removed our evolutions from this form, and are now ready to readapt."))
+	remove_changeling_powers()
+	can_respec = FALSE
+	SSblackbox.record_feedback("tally", "changeling_power_purchase", 1, "Readapt")
+	log_changeling_power("[key_name(owner)] readapted their changeling powers")
+	return TRUE
 
 /*
  * Get the corresponding changeling profile for the passed name.


### PR DESCRIPTION
## About The Pull Request

- Puts changeling 'purchasing' of powers in uplink log
- Puts changeling power respeccing in uplink log

## Why It's Good For The Game

Some powers may be worth knowing if someone picked them up, like trans-sting or spiders. They're only logged in blackbox I think, and not entirely, so might as well put it in the uplink log (since traitor, wizard, and heretic stuff is there too). 

## Changelog

:cl: Melbert
admin: Changeling powers are now logged in uplink log.
/:cl:

