### PR TITLE
Fixes Active Turfs on The Lizard's Gas

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/thelizardsgas.dmm
+++ b/_maps/RandomRuins/SpaceRuins/thelizardsgas.dmm
@@ -542,7 +542,9 @@
 /area/ruin/space/has_grav/thelizardsgas)
 "WY" = (
 /obj/machinery/air_sensor/atmos/plasma_tank,
-/turf/open/floor/engine/plasma,
+/turf/open/floor/engine/plasma{
+	initial_gas_mix = "plasma=35000;TEMP=293.15"
+	},
 /area/ruin/space/has_grav/thelizardsgas)
 "XB" = (
 /obj/machinery/power/terminal,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fikou brought the following to my attention:

![image](https://user-images.githubusercontent.com/34697715/153796481-329700fb-2c79-496c-84c4-b71ad3c3bd3b.png)

I believe this PR should fix that since I think one of the plasma floors wasn't var-edited correctly. Please feel free to let me know if I'm wrong.

![image](https://user-images.githubusercontent.com/34697715/153796509-724f24c8-41f2-481a-b1ff-f8152ffefb0a.png)

Note: My game booted it to Ice Box and I didn't want to have to reload so the list is very long, but The Lizard's Gas and markers don't show up any more (I wonder why that is, though...). Splendid.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Active turfs bad, me fixing my own shit is good.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Lizard's Gas will no longer start out with Active Turfs at the start of a round. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
