### PR TITLE
Fixes heretic target assignment, also adds a debug verb to help debug objectives and similar

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -827,6 +827,14 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 //)
 
+/**
+ * Debug verb that spawns human crewmembers
+ * of each job type, gives them a mind and assigns the role,
+ * and injects them into the manifest, as if they were a "player".
+ *
+ * This spawns humans with minds and jobs, but does NOT make them 'players'.
+ * They're all clientles mobs with minds / jobs.
+ */
 /client/proc/spawn_debug_full_crew()
 	set name = "Spawn Debug Full Crew"
 	set desc = "Creates a full crew for the station, filling the datacore and assigning them all minds / jobs. Don't do this on live"
@@ -848,41 +856,46 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	if(tgui_alert(admin, "I sure hope you aren't doing this on live. Are you sure?", "Spawn Crew (Be certain)", list("Yes", "Cancel")) != "Yes")
 		return
 
-	// Go through all nameable occupations.
-	// Pick out all jobs that have JOB_CREW_MEMBER set.
-	// (As we're technically forcing them all to 'latejoin').
-	// Then, make the mob, give it a mind, and send them to the station.
-	var/number_made = 0
-
+	// Find the observer spawn, so we have a place to dump the dummies.
 	var/obj/effect/landmark/observer_start/observer_point = locate(/obj/effect/landmark/observer_start) in GLOB.landmarks_list
 	var/turf/destination = get_turf(observer_point)
 	if(!destination)
 		to_chat(admin, "Failed to find the observer spawn to send the dummies.")
 		return
 
+	// Okay, now go through all nameable occupations.
+	// Pick out all jobs that have JOB_CREW_MEMBER set.
+	// Then, spawn a human and slap a person into it.
+	var/number_made = 0
 	for(var/rank in SSjob.name_occupations)
 		var/datum/job/job = SSjob.GetJob(rank)
 
+		// JOB_CREW_MEMBER is all jobs that pretty much aren't silicon
 		if(!(job.job_flags & JOB_CREW_MEMBER))
 			continue
 
+		// Create our new_player for this job and set up its mind.
 		var/mob/dead/new_player/new_guy = new()
 		new_guy.mind_initialize()
 		new_guy.mind.name = "[rank] Dummy"
 
+		// Assign the rank to the new player dummy.
 		if(!SSjob.AssignRole(new_guy, job))
 			qdel(new_guy)
 			to_chat(admin, "[rank] wasn't able to be spawned.")
 			continue
 
+		// It's got a job, spawn in a human and shove it in the human.
 		var/mob/living/carbon/human/character = new(destination)
 		character.name = new_guy.mind.name
 		new_guy.mind.transfer_to(character)
 		qdel(new_guy)
 
+		// Then equip up the human with job gear.
 		SSjob.EquipRank(character, job)
 		job.after_latejoin_spawn(character)
 
+		// Finally, ensure the minds are tracked and in the manifest.
 		SSticker.minds += character.mind
 		if(ishuman(character))
 			GLOB.data_core.manifest_inject(character)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -194,6 +194,7 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/load_circuit,
 	/client/proc/cmd_admin_toggle_fov,
 	/client/proc/cmd_admin_debug_traitor_objectives,
+	/client/proc/spawn_debug_full_crew,
 	)
 GLOBAL_LIST_INIT(admin_verbs_possess, list(/proc/possess, /proc/release))
 GLOBAL_PROTECT(admin_verbs_possess)
@@ -823,3 +824,70 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	set category = "Debug"
 
 	src << link("?debug=profile&type=sendmaps&window=test")
+
+//)
+
+/client/proc/spawn_debug_full_crew()
+	set name = "Spawn Debug Full Crew"
+	set desc = "Creates a full crew for the station, filling the datacore and assigning them all minds / jobs. Don't do this on live"
+	set category = "Debug"
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	var/mob/admin = usr
+
+	if(SSticker.current_state != GAME_STATE_PLAYING)
+		to_chat(admin, "You should only be using this after a round has setup and started.")
+		return
+
+	// Two input checks here to make sure people are certain when they're using this.
+	if(tgui_alert(admin, "This command will create a bunch of dummy crewmembers with minds, job, and datacore entries, which will take a while and fill the manifest.", "Spawn Crew", list("Yes", "Cancel")) != "Yes")
+		return
+
+	if(tgui_alert(admin, "I sure hope you aren't doing this on live. Are you sure?", "Spawn Crew (Be certain)", list("Yes", "Cancel")) != "Yes")
+		return
+
+	// Go through all nameable occupations.
+	// Pick out all jobs that have JOB_CREW_MEMBER set.
+	// (As we're technically forcing them all to 'latejoin').
+	// Then, make the mob, give it a mind, and send them to the station.
+	var/number_made = 0
+
+	var/obj/effect/landmark/observer_start/observer_point = locate(/obj/effect/landmark/observer_start) in GLOB.landmarks_list
+	var/turf/destination = get_turf(observer_point)
+	if(!destination)
+		to_chat(admin, "Failed to find the observer spawn to send the dummies.")
+		return
+
+	for(var/rank in SSjob.name_occupations)
+		var/datum/job/job = SSjob.GetJob(rank)
+
+		if(!(job.job_flags & JOB_CREW_MEMBER))
+			continue
+
+		var/mob/dead/new_player/new_guy = new()
+		new_guy.mind_initialize()
+		new_guy.mind.name = "[rank] Dummy"
+
+		if(!SSjob.AssignRole(new_guy, job))
+			qdel(new_guy)
+			to_chat(admin, "[rank] wasn't able to be spawned.")
+			continue
+
+		var/mob/living/carbon/human/character = new(destination)
+		character.name = new_guy.mind.name
+		new_guy.mind.transfer_to(character)
+		qdel(new_guy)
+
+		SSjob.EquipRank(character, job)
+		job.after_latejoin_spawn(character)
+
+		SSticker.minds += character.mind
+		if(ishuman(character))
+			GLOB.data_core.manifest_inject(character)
+
+		number_made++
+		CHECK_TICK
+
+	to_chat(admin, "[number_made] crewmembers have been created.")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -825,8 +825,6 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 	src << link("?debug=profile&type=sendmaps&window=test")
 
-//)
-
 /**
  * Debug verb that spawns human crewmembers
  * of each job type, gives them a mind and assigns the role,

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -119,24 +119,21 @@
 	var/list/datum/mind/final_targets = list()
 
 	// First target, any command.
-	shuffle_inplace(valid_targets)
-	for(var/datum/mind/head_mind as anything in valid_targets)
+	for(var/datum/mind/head_mind as anything in shuffle(valid_targets))
 		if(head_mind.assigned_role?.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
 			final_targets += head_mind
 			valid_targets -= head_mind
 			break
 
 	// Second target, any security
-	shuffle_inplace(valid_targets)
-	for(var/datum/mind/sec_mind as anything in valid_targets)
+	for(var/datum/mind/sec_mind as anything in shuffle(valid_targets))
 		if(sec_mind.assigned_role?.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
 			final_targets += sec_mind
 			valid_targets -= sec_mind
 			break
 
 	// Third target, someone in their department.
-	shuffle_inplace(valid_targets)
-	for(var/datum/mind/department_mind as anything in valid_targets)
+	for(var/datum/mind/department_mind as anything in shuffle(valid_targets))
 		if(department_mind.assigned_role?.departments_bitflags & user.mind.assigned_role?.departments_bitflags)
 			final_targets += department_mind
 			valid_targets -= department_mind

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -119,21 +119,24 @@
 	var/list/datum/mind/final_targets = list()
 
 	// First target, any command.
-	for(var/datum/mind/head_mind as anything in shuffle_inplace(valid_targets))
+	shuffle_inplace(valid_targets)
+	for(var/datum/mind/head_mind as anything in valid_targets)
 		if(head_mind.assigned_role?.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
 			final_targets += head_mind
 			valid_targets -= head_mind
 			break
 
 	// Second target, any security
-	for(var/datum/mind/sec_mind as anything in shuffle_inplace(valid_targets))
+	shuffle_inplace(valid_targets)
+	for(var/datum/mind/sec_mind as anything in valid_targets)
 		if(sec_mind.assigned_role?.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
 			final_targets += sec_mind
 			valid_targets -= sec_mind
 			break
 
 	// Third target, someone in their department.
-	for(var/datum/mind/department_mind as anything in shuffle_inplace(valid_targets))
+	shuffle_inplace(valid_targets)
+	for(var/datum/mind/department_mind as anything in valid_targets)
 		if(department_mind.assigned_role?.departments_bitflags & user.mind.assigned_role?.departments_bitflags)
 			final_targets += department_mind
 			valid_targets -= department_mind


### PR DESCRIPTION
## About The Pull Request

Closes #64897 

This PR adds a new debug button to spawn in a bunch of human dummies, assign them to one of each station job, and add them to the manifest to simulate a "full crew" on a live server. 

This PR also fixes heretic target assignment. `shuffle_inplace()` doesn't return the list it shuffled, so the loops never functioned, and all targets were randomly picked instead of picked with the logic. 

## Why It's Good For The Game

Debug command helpful for testing bugs. 

Heretics getting targets they should be expecting is also nice.

## Changelog

:cl: Melbert
fix: Fixes heretic target assignment. They should actually be getting Heads of Staff and such as intended as sacrifice targets. 
/:cl:
