### PR TITLE
Mecha springclean P2: refactor mecha punch and fix bugs with it and improve logging

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -580,6 +580,10 @@
 	if(internal_damage & MECHA_INT_CONTROL_LOST)
 		target = pick(oview(1,src))
 
+	if(!has_charge(melee_energy_drain))
+		return
+	use_power(melee_energy_drain)
+
 	if(force)
 		target.mech_melee_attack(src, user)
 		TIMER_COOLDOWN_START(src, COOLDOWN_MECHA_MELEE_ATTACK, melee_cooldown)
@@ -724,7 +728,8 @@
 		return
 	if(bumpsmash) //Need a pilot to push the PUNCH button.
 		if(COOLDOWN_FINISHED(src, mecha_bump_smash))
-			obstacle.mech_melee_attack(src)
+			var/list/mob/mobster = return_drivers()
+			obstacle.mech_melee_attack(src, mobster[1])
 			COOLDOWN_START(src, mecha_bump_smash, smashcooldown)
 			if(!obstacle || obstacle.CanPass(src, get_dir(obstacle, src) || dir)) // The else is in case the obstacle is in the same turf.
 				step(src,dir)

--- a/code/modules/vehicles/mecha/mech_melee_attack.dm
+++ b/code/modules/vehicles/mecha/mech_melee_attack.dm
@@ -1,120 +1,101 @@
-///Called when a mech melee attacks an atom
-/atom/proc/mech_melee_attack(obj/vehicle/sealed/mecha/mecha_attacker)
-	return
-
-/turf/closed/wall/mech_melee_attack(obj/vehicle/sealed/mecha/mecha_attacker)
-	mecha_attacker.do_attack_animation(src)
-	switch(mecha_attacker.damtype)
-		if(BRUTE)
-			playsound(src, 'sound/weapons/punch4.ogg', 50, TRUE)
-			mecha_attacker.visible_message(span_danger("[mecha_attacker.name] hits [src]!"), \
-							span_danger("You hit [src]!"), null, COMBAT_MESSAGE_RANGE)
-			if(prob(hardness + mecha_attacker.force) && mecha_attacker.force > 20)
-				dismantle_wall(1)
-				playsound(src, 'sound/effects/meteorimpact.ogg', 100, TRUE)
-			else
-				add_dent(WALL_DENT_HIT)
-		if(BURN)
-			playsound(src, 'sound/items/welder.ogg', 100, TRUE)
-		if(TOX)
-			playsound(src, 'sound/effects/spray2.ogg', 100, TRUE)
-			return FALSE
-
-/obj/mech_melee_attack(obj/vehicle/sealed/mecha/mecha_attacker)
-	mecha_attacker.do_attack_animation(src)
-	var/play_soundeffect = 0
+/**
+ * ## Mech melee attack
+ * Called when a mech melees a target with fists
+ * Handles damaging the target & associated effects
+ * return value is number of damage dealt
+ * Arguments:
+ * * mecha_attacker: Mech attacking this target
+ * * user: mob that initiated the attack from inside the mech as a controller
+ */
+/atom/proc/mech_melee_attack(obj/vehicle/sealed/mecha/mecha_attacker, mob/living/user)
+	SHOULD_CALL_PARENT(TRUE)
 	var/mech_damtype = mecha_attacker.damtype
 	if(mecha_attacker.selected)
 		mech_damtype = mecha_attacker.selected.damtype
-		play_soundeffect = 1
-	else
-		switch(mecha_attacker.damtype)
-			if(BRUTE)
-				playsound(src, 'sound/weapons/punch4.ogg', 50, TRUE)
-			if(BURN)
-				playsound(src, 'sound/items/welder.ogg', 50, TRUE)
-			if(TOX)
-				playsound(src, 'sound/effects/spray2.ogg', 50, TRUE)
-				return 0
-			else
-				return 0
-	mecha_attacker.visible_message(span_danger("[mecha_attacker.name] hits [src]!"), span_danger("You hit [src]!"), null, COMBAT_MESSAGE_RANGE)
-	return take_damage(mecha_attacker.force * 3, mech_damtype, "melee", play_soundeffect, get_dir(src, mecha_attacker)) // multiplied by 3 so we can hit objs hard but not be overpowered against mobs.
+	log_combat(user, src, "attacked", mecha_attacker, "(COMBAT MODE: [uppertext(user.combat_mode)] (DAMTYPE: [uppertext(mech_damtype)])")
+	return 0
 
-/obj/structure/window/mech_melee_attack(obj/vehicle/sealed/mecha/mecha_attacker)
+/turf/closed/wall/mech_melee_attack(obj/vehicle/sealed/mecha/mecha_attacker, mob/living/user)
+	mecha_attacker.do_attack_animation(src)
+	var/mech_damtype = mecha_attacker.damtype
+	if(mecha_attacker.selected)
+		mech_damtype = mecha_attacker.selected.damtype
+	switch(mech_damtype)
+		if(BRUTE)
+			playsound(src, 'sound/weapons/punch4.ogg', 50, TRUE)
+		if(BURN)
+			playsound(src, 'sound/items/welder.ogg', 50, TRUE)
+		else
+			return 0
+	mecha_attacker.visible_message(span_danger("[mecha_attacker] hits [src]!"), span_danger("You hit [src]!"), null, COMBAT_MESSAGE_RANGE)
+	if(prob(hardness + mecha_attacker.force) && mecha_attacker.force > 20)
+		dismantle_wall(1)
+		playsound(src, 'sound/effects/meteorimpact.ogg', 100, TRUE)
+	else
+		add_dent(WALL_DENT_HIT)
+	..()
+	return 100 //this is an arbitrary "damage" number since the actual damage is rng dismantle
+
+/obj/mech_melee_attack(obj/vehicle/sealed/mecha/mecha_attacker, mob/living/user)
+	mecha_attacker.do_attack_animation(src)
+	var/mech_damtype = mecha_attacker.damtype
+	if(mecha_attacker.selected)
+		mech_damtype = mecha_attacker.selected.damtype
+	switch(mech_damtype)
+		if(BRUTE)
+			playsound(src, 'sound/weapons/punch4.ogg', 50, TRUE)
+		if(BURN)
+			playsound(src, 'sound/items/welder.ogg', 50, TRUE)
+		else
+			return 0
+	mecha_attacker.visible_message(span_danger("[mecha_attacker] hits [src]!"), span_danger("You hit [src]!"), null, COMBAT_MESSAGE_RANGE)
+	..()
+	return take_damage(mecha_attacker.force * 3, mech_damtype, "melee", mecha_attacker.selected, get_dir(src, mecha_attacker)) // multiplied by 3 so we can hit objs hard but not be overpowered against mobs.
+
+/obj/structure/window/mech_melee_attack(obj/vehicle/sealed/mecha/mecha_attacker, mob/living/user)
 	if(!can_be_reached())
-		return
+		return 0
 	return ..()
 
 /mob/living/mech_melee_attack(obj/vehicle/sealed/mecha/mecha_attacker, mob/living/user)
-	if(user.combat_mode)
-		if(HAS_TRAIT(user, TRAIT_PACIFISM))
-			to_chat(user, span_warning("You don't want to harm other living beings!"))
-			return
-		mecha_attacker.do_attack_animation(src)
-		if(mecha_attacker.damtype == "brute")
-			step_away(src, mecha_attacker, 15)
-		switch(mecha_attacker.damtype)
-			if(BRUTE)
-				Unconscious(20)
-				take_overall_damage(rand(mecha_attacker.force/2, mecha_attacker.force))
-				playsound(src, 'sound/weapons/punch4.ogg', 50, TRUE)
-			if(BURN)
-				take_overall_damage(0, rand(mecha_attacker.force * 0.5, mecha_attacker.force))
-				playsound(src, 'sound/items/welder.ogg', 50, TRUE)
-			if(TOX)
-				mecha_attacker.mech_toxin_damage(src)
-			else
-				return
-		updatehealth()
-		visible_message(span_danger("[mecha_attacker.name] hits [src]!"), \
-						span_userdanger("[mecha_attacker.name] hits you!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, mecha_attacker)
-		to_chat(mecha_attacker, span_danger("You hit [src]!"))
-		log_combat(user, src, "attacked", mecha_attacker, "(COMBAT MODE: [uppertext(user.combat_mode)]) (DAMTYPE: [uppertext(mecha_attacker.damtype)])")
-	else
+	if(!user.combat_mode)
 		step_away(src, mecha_attacker)
 		log_combat(user, src, "pushed", mecha_attacker)
 		visible_message(span_warning("[mecha_attacker] pushes [src] out of the way."), \
 						span_warning("[mecha_attacker] pushes you out of the way."), span_hear("You hear aggressive shuffling!"), 5, list(mecha_attacker))
 		to_chat(mecha_attacker, span_danger("You push [src] out of the way."))
+		return 0
 
-/mob/living/carbon/human/mech_melee_attack(obj/vehicle/sealed/mecha/mecha_attacker, mob/living/user)
-	if(!isliving(user))
-		return ..()
-	var/mob/living/attacker = user
-	if(attacker.combat_mode)
-		if(HAS_TRAIT(user, TRAIT_PACIFISM))
-			to_chat(user, span_warning("You don't want to harm other living beings!"))
-			return
-		mecha_attacker.do_attack_animation(src)
-		if(mecha_attacker.damtype == BRUTE)
-			step_away(src, mecha_attacker, 15)
-		var/obj/item/bodypart/temp = get_bodypart(pick(BODY_ZONE_CHEST, BODY_ZONE_CHEST, BODY_ZONE_CHEST, BODY_ZONE_HEAD))
-		if(temp)
-			var/update = 0
-			var/dmg = rand(mecha_attacker.force * 0.5, mecha_attacker.force)
-			switch(mecha_attacker.damtype)
-				if(BRUTE)
-					if(mecha_attacker.force > 35) // durand and other heavy mechas
-						Unconscious(20)
-					else if(mecha_attacker.force > 20 && !IsKnockdown()) // lightweight mechas like gygax
-						Knockdown(40)
-					update |= temp.receive_damage(dmg, 0)
-					playsound(src, 'sound/weapons/punch4.ogg', 50, TRUE)
-				if(FIRE)
-					update |= temp.receive_damage(0, dmg)
-					playsound(src, 'sound/items/welder.ogg', 50, TRUE)
-				if(TOX)
-					mecha_attacker.mech_toxin_damage(src)
-				else
-					return
-			if(update)
-				update_damage_overlays()
-			updatehealth()
-
-		visible_message(span_danger("[mecha_attacker.name] hits [src]!"), \
-						span_userdanger("[mecha_attacker.name] hits you!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, list(mecha_attacker))
-		to_chat(mecha_attacker, span_danger("You hit [src]!"))
-		log_combat(user, src, "attacked", mecha_attacker, "(COMBAT MODE: [uppertext(user.combat_mode)] (DAMTYPE: [uppertext(mecha_attacker.damtype)])")
-	else
-		return ..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, span_warning("You don't want to harm other living beings!"))
+		return 0
+	mecha_attacker.do_attack_animation(src)
+	if(mecha_attacker.damtype == BRUTE)
+		step_away(src, mecha_attacker, 15)
+	var/obj/item/bodypart/selected_zone = get_bodypart(pick(BODY_ZONE_CHEST, BODY_ZONE_CHEST, BODY_ZONE_CHEST, BODY_ZONE_HEAD))
+	if(selected_zone)
+		var/dmg = rand(mecha_attacker.force * 0.5, mecha_attacker.force)
+		switch(mecha_attacker.damtype)
+			if(BRUTE)
+				if(mecha_attacker.force > 35) // durand and other heavy mechas
+					Unconscious(20)
+				else if(mecha_attacker.force > 20 && !IsKnockdown()) // lightweight mechas like gygax
+					Knockdown(40)
+				selected_zone.receive_damage(dmg, 0, updating_health = TRUE)
+				playsound(src, 'sound/weapons/punch4.ogg', 50, TRUE)
+			if(FIRE)
+				selected_zone.receive_damage(0, dmg, updating_health = TRUE)
+				playsound(src, 'sound/items/welder.ogg', 50, TRUE)
+			if(TOX)
+				playsound(src, 'sound/effects/spray2.ogg', 50, TRUE)
+				if((reagents.get_reagent_amount(/datum/reagent/cryptobiolin) + mecha_attacker.force) < mecha_attacker.force*2)
+					reagents.add_reagent(/datum/reagent/cryptobiolin, mecha_attacker.force/2)
+				if((reagents.get_reagent_amount(/datum/reagent/toxin) + mecha_attacker.force) < mecha_attacker.force*2)
+					reagents.add_reagent(/datum/reagent/toxin, mecha_attacker.force/2.5)
+			else
+				return 0
+		. = dmg
+	visible_message(span_danger("[mecha_attacker.name] hits [src]!"), \
+		span_userdanger("[mecha_attacker.name] hits you!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, list(mecha_attacker))
+	to_chat(mecha_attacker, span_danger("You hit [src]!"))
+	..()

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -321,23 +321,6 @@
 		return
 	to_chat(user, span_warning("The [name] is at full integrity!"))
 
-/obj/vehicle/sealed/mecha/proc/mech_toxin_damage(mob/living/target)
-	playsound(src, 'sound/effects/spray2.ogg', 50, TRUE)
-	if(target.reagents)
-		if(target.reagents.get_reagent_amount(/datum/reagent/cryptobiolin) + force < force*2)
-			target.reagents.add_reagent(/datum/reagent/cryptobiolin, force/2)
-		if(target.reagents.get_reagent_amount(/datum/reagent/toxin) + force < force*2)
-			target.reagents.add_reagent(/datum/reagent/toxin, force/2.5)
-
-
-/obj/vehicle/sealed/mecha/mech_melee_attack(obj/vehicle/sealed/mecha/M, mob/living/user)
-	if(!has_charge(melee_energy_drain))
-		return NONE
-	use_power(melee_energy_drain)
-	if(M.damtype == BRUTE || M.damtype == BURN)
-		log_combat(user, src, "attacked", M, "(COMBAT MODE: [uppertext(user.combat_mode)] (DAMTYPE: [uppertext(M.damtype)])")
-		. = ..()
-
 /obj/vehicle/sealed/mecha/proc/full_repair(charge_cell)
 	atom_integrity = max_integrity
 	if(cell && charge_cell)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- see changelog
- also improved the autodoc
- made it always return the damage instead of only sometimes
- a couple early returns
- Instead of carbon punch being a copypasted living punch that ALSO called parent this is just now on living
- removed mech_toxin_damage it onlywas used to not copypaste toxins damage in the copypasted living procs
- removed some code that called health updates manually instead of just arg passing
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed gygax smash not logging the driver
fix: Fixed mechs being punched using power but punching as a mech not using power
fix: Fixed mechs not taking damage from mech punches if punched while having no power
fix: Fixed weapon damage types only being respected for mech punches sometimes
fix: Fixed toxins mech damage mode playing sounds on punches despite doing nothing
refactor: Mech punch code partly redone
admin: mech punches will now ALWAYS be logged, even against objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
