### PR TITLE
Fixes the void Ritual of Knowledge + unit tests main path lengths 

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -154,7 +154,7 @@
 		/datum/heretic_knowledge/knowledge_ritual/rust,
 		/datum/heretic_knowledge/knowledge_ritual/flesh,
 	)
-	route = PATH_RUST
+	route = PATH_VOID
 
 /datum/heretic_knowledge/spell/void_phase
 	name = "Void Phase"

--- a/code/modules/unit_tests/heretic_knowledge.dm
+++ b/code/modules/unit_tests/heretic_knowledge.dm
@@ -45,3 +45,41 @@
 		var/list/unreachables = all_possible_knowledge - list_to_check
 		for(var/datum/heretic_knowledge/lost_knowledge as anything in unreachables)
 			Fail("Heretic Knowlege: [lost_knowledge] is unreachable by players! Add it to another knowledge's 'next_knowledge' list. If it is purposeful, set its route to 'null'.")
+
+
+/*
+ * This test checks that all main heretic paths are of the same length.
+ *
+ * If any two main paths are not equal length, the test will fail and quit, reporting
+ * which two paths did not match. Then, whichever is erroneous can be determined manually.
+ */
+/datum/unit_test/heretic_main_paths
+
+/datum/unit_test/heretic_main_paths/Run()
+
+	// Our starting knowledge node, we use this to deduce what main paths we have.
+	var/datum/heretic_knowledge/spell/basic/starter_node = allocate(/datum/heretic_knowledge/spell/basic)
+	// An assoc list of [path string] to [number of nodes we found of that path].
+	var/list/paths = list()
+
+	// Go through and determine what paths exist from our base node.
+	for(var/datum/heretic_knowledge/possible_path as anything in starter_node.next_knowledge)
+		paths[initial(possible_path.route)] = 0
+
+	// Now go through all the knowledges and record how many of each  main path exist.
+	for(var/datum/heretic_knowledge/knowledge as anything in subtypesof(/datum/heretic_knowledge))
+		var/knowledge_route = initial(knowledge.route)
+		// null (abstract), side paths, and start paths we can skip
+		if(isnull(knowledge_route) || knowledge_route == PATH_SIDE || knowledge_route == PATH_START)
+			continue
+
+		paths[knowledge_route]++
+
+	// Now all entries in the paths list should have an equal value.
+	// If any two entries do not match, then one of them is incorrect, and the test fails.
+	for(var/main_path in paths)
+		for(var/other_main_path in (paths - main_path))
+			TEST_ASSERT(paths[main_path] == paths[other_main_path], \
+				"Heretic Knowledge: [main_path] had [paths[main_path]] knowledges, \
+				which was not equal to [other_main_path]'s [paths[other_main_path]] knowledges. \
+				All main paths should have the same number of knowledges!")

--- a/code/modules/unit_tests/heretic_knowledge.dm
+++ b/code/modules/unit_tests/heretic_knowledge.dm
@@ -56,21 +56,28 @@
 /datum/unit_test/heretic_main_paths
 
 /datum/unit_test/heretic_main_paths/Run()
-
-	// Our starting knowledge node, we use this to deduce what main paths we have.
-	var/datum/heretic_knowledge/spell/basic/starter_node = allocate(/datum/heretic_knowledge/spell/basic)
+	// A list of path strings we don't need to check.
+	var/list/paths_we_dont_check = list(PATH_SIDE, PATH_START)
 	// An assoc list of [path string] to [number of nodes we found of that path].
 	var/list/paths = list()
+	// The starting knowledge node, we use this to deduce what main paths we have.
+	var/datum/heretic_knowledge/spell/basic/starter_node = new()
 
 	// Go through and determine what paths exist from our base node.
 	for(var/datum/heretic_knowledge/possible_path as anything in starter_node.next_knowledge)
 		paths[initial(possible_path.route)] = 0
 
+	qdel(starter_node) // Get rid of that starter node, we don't need it anymore.
+
 	// Now go through all the knowledges and record how many of each  main path exist.
 	for(var/datum/heretic_knowledge/knowledge as anything in subtypesof(/datum/heretic_knowledge))
 		var/knowledge_route = initial(knowledge.route)
 		// null (abstract), side paths, and start paths we can skip
-		if(isnull(knowledge_route) || knowledge_route == PATH_SIDE || knowledge_route == PATH_START)
+		if(isnull(knowledge_route) || knowledge_route in paths_we_dont_check)
+			continue
+
+		if(isnull(paths[knowledge_route]))
+			Fail("Heretic Knowledge: An invalid knowledge route ([knowledge_route]) was found on [knowledge].")
 			continue
 
 		paths[knowledge_route]++

--- a/code/modules/unit_tests/heretic_knowledge.dm
+++ b/code/modules/unit_tests/heretic_knowledge.dm
@@ -73,7 +73,7 @@
 	for(var/datum/heretic_knowledge/knowledge as anything in subtypesof(/datum/heretic_knowledge))
 		var/knowledge_route = initial(knowledge.route)
 		// null (abstract), side paths, and start paths we can skip
-		if(isnull(knowledge_route) || knowledge_route in paths_we_dont_check)
+		if(isnull(knowledge_route) || (knowledge_route in paths_we_dont_check))
 			continue
 
 		if(isnull(paths[knowledge_route]))


### PR DESCRIPTION
## About The Pull Request

Void ritual of knowledge should be of the void path. This fixes that. 

Also adds a unit test to ensure all main paths are of the same length.

Funnily I think this was causing the main route calculations to be off, so the knowledge objective should be easier by one. 

## Why It's Good For The Game

Path should follow the path

## Changelog

:cl: Melbert
fix: Void's ritual of knowledge is void path correctly
/:cl:
