### PR TITLE
Makes extinguisher sprays look nicer

### DIFF
--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -37,17 +37,21 @@
 /obj/effect/decal/chempuff/blob_act(obj/structure/blob/B)
 	return
 
-/obj/effect/decal/chempuff/proc/loop_ended(datum/source)
+/obj/effect/decal/chempuff/proc/end_life(datum/move_loop/engine)
+	QDEL_IN(src, engine.delay) //Gotta let it stop drifting
+	animate(src, alpha = 0, time = engine.delay)
+
+/obj/effect/decal/chempuff/proc/loop_ended(datum/move_loop/source)
 	SIGNAL_HANDLER
 	if(QDELETED(src))
 		return
-	qdel(src)
+	end_life(source)
 
 /obj/effect/decal/chempuff/proc/check_move(datum/move_loop/source, succeeded)
 	if(QDELETED(src)) //Reasons PLEASE WORK I SWEAR TO GOD
 		return
 	if(!succeeded) //If we hit something
-		qdel(src)
+		end_life(source)
 		return
 
 	var/puff_reagents_string = reagents.log_list()
@@ -92,7 +96,7 @@
 
 	// Did we use up all the puff early?
 	if(lifetime < 0)
-		qdel(src)
+		end_life(source)
 
 /obj/effect/decal/fakelattice
 	name = "lattice"

--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -36,6 +36,27 @@
 	for(var/atom/thing as anything in get_turf(src))
 		reagents.expose(thing)
 
+/// Starts the effect moving at a target with a delay in deciseconds, and a lifetime in moves
+/// Returns the created loop
+/obj/effect/particle_effect/water/extinguisher/proc/move_at(atom/target, delay, lifetime)
+	var/datum/move_loop/loop = SSmove_manager.move_towards_legacy(src, target, delay, timeout = delay * lifetime, flags = MOVEMENT_LOOP_START_FAST, priority = MOVEMENT_ABOVE_SPACE_PRIORITY)
+	RegisterSignal(loop, COMSIG_MOVELOOP_POSTPROCESS, .proc/post_forcemove)
+	RegisterSignal(loop, COMSIG_PARENT_QDELETING, .proc/movement_stopped)
+	return loop
+
+/obj/effect/particle_effect/water/extinguisher/proc/post_forcemove(datum/move_loop/source, success)
+	SIGNAL_HANDLER
+	if(!success)
+		end_life(source)
+
+/obj/effect/particle_effect/water/extinguisher/proc/movement_stopped(datum/move_loop/source)
+	SIGNAL_HANDLER
+	if(!QDELETED(src))
+		end_life(source)
+
+/obj/effect/particle_effect/water/extinguisher/proc/end_life(datum/move_loop/engine)
+	QDEL_IN(src, engine.delay) //Gotta let it stop drifting
+	animate(src, alpha = 0, time = engine.delay)
 
 /////////////////////////////////////////////
 // GENERIC STEAM SPREAD SYSTEM

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -218,7 +218,7 @@
 	var/delay = 2
 	// Second loop: Get all the water particles and make them move to their target
 	for(var/obj/effect/particle_effect/water/extinguisher/water as anything in particles)
-		SSmove_manager.move_towards_legacy(water, particles[water], delay, timeout = delay * power, flags = MOVEMENT_LOOP_START_FAST, priority = MOVEMENT_ABOVE_SPACE_PRIORITY)
+		water.move_at(particles[water], delay, power)
 
 //Chair movement loop
 /obj/item/extinguisher/proc/move_chair(obj/buckled_object, movementdirection)

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -202,7 +202,7 @@
 	reagents.trans_to(water, 1)
 
 	var/delay = 2
-	var/datum/move_loop/our_loop = SSmove_manager.move_towards_legacy(water, pick(targets), delay, timeout = delay * 4, priority = MOVEMENT_ABOVE_SPACE_PRIORITY)
+	var/datum/move_loop/our_loop = water.move_at(pick(targets), delay, 4)
 	RegisterSignal(our_loop, COMSIG_PARENT_QDELETING, .proc/water_finished_moving)
 
 /obj/item/mecha_parts/mecha_equipment/extinguisher/proc/water_finished_moving(datum/move_loop/has_target/source)


### PR DESCRIPTION




<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Rather then sticking around till their 7 second delay, they dissipate once they finish their movement. 
This dissipation comes with a fading and such to make things look nicer.

I've applied the fading behavior to sprays too, since they could also use the help.


## Why It's Good For The Game

I really hate how things look currently, makes me break out in hives

https://user-images.githubusercontent.com/58055496/154176345-9628ccc1-9593-494d-acfe-9a4948642885.mp4

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The sprays that come off extinguishers will no longer stick around after they've hit the ground, and they'll also fade out before disappearing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
