### PR TITLE
Adds some contextual screentips to botany related things

### DIFF
--- a/code/__DEFINES/botany.dm
+++ b/code/__DEFINES/botany.dm
@@ -32,6 +32,8 @@
 #define MAX_TRAY_WEEDS 10
 /// Minumum plant health required for gene shears.
 #define GENE_SHEAR_MIN_HEALTH 15
+/// Minumum plant endurance required to lock a mutation with a somatoray.
+#define FLORA_GUN_MIN_ENDURANCE 20
 
 /// -- Flags for genes --
 /// Plant genes that can be removed via gene shears.

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -38,6 +38,17 @@ GLOBAL_VAR_INIT(glowshrooms, 0)
 		/turf/open/floor/plating/beach/water,
 	))
 
+/obj/structure/glowshroom/Initialize(mapload, obj/item/seeds/newseed)
+	. = ..()
+	var/static/list/hovering_item_typechecks = list(
+		/obj/item/plant_analyzer = list(
+			SCREENTIP_CONTEXT_LMB = "Scan shroom stats",
+			SCREENTIP_CONTEXT_RMB = "Scan shroom chemicals"
+		),
+	)
+
+	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
+
 /obj/structure/glowshroom/glowcap
 	name = "glowcap"
 	desc = "Mycena Ruthenia, a species of mushroom that, while it does glow in the dark, is not actually bioluminescent."

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -38,17 +38,6 @@ GLOBAL_VAR_INIT(glowshrooms, 0)
 		/turf/open/floor/plating/beach/water,
 	))
 
-/obj/structure/glowshroom/Initialize(mapload, obj/item/seeds/newseed)
-	. = ..()
-	var/static/list/hovering_item_typechecks = list(
-		/obj/item/plant_analyzer = list(
-			SCREENTIP_CONTEXT_LMB = "Scan shroom stats",
-			SCREENTIP_CONTEXT_RMB = "Scan shroom chemicals"
-		),
-	)
-
-	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
-
 /obj/structure/glowshroom/glowcap
 	name = "glowcap"
 	desc = "Mycena Ruthenia, a species of mushroom that, while it does glow in the dark, is not actually bioluminescent."
@@ -115,6 +104,15 @@ GLOBAL_VAR_INIT(glowshrooms, 0)
 	COOLDOWN_START(src, spread_cooldown, rand(min_delay_spread, max_delay_spread))
 
 	START_PROCESSING(SSobj, src)
+
+	var/static/list/hovering_item_typechecks = list(
+		/obj/item/plant_analyzer = list(
+			SCREENTIP_CONTEXT_LMB = "Scan shroom stats",
+			SCREENTIP_CONTEXT_RMB = "Scan shroom chemicals"
+		),
+	)
+
+	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
 
 /obj/structure/glowshroom/Destroy()
 	if(isatom(myseed))

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -223,6 +223,21 @@
 	desc = "For the enterprising botanist on the go. Less efficient than the stationary model, it creates one seed per plant."
 	icon_state = "portaseeder"
 
+/obj/item/storage/bag/plants/portaseeder/Initialize(mapload)
+	. = ..()
+	register_context()
+
+/obj/item/storage/bag/plants/portaseeder/add_context(
+	atom/source,
+	list/context,
+	obj/item/held_item,
+	mob/living/user
+)
+
+	context[SCREENTIP_CONTEXT_CTRL_LMB] = "Make seeds"
+	return CONTEXTUAL_SCREENTIP_SET
+
+
 /obj/item/storage/bag/plants/portaseeder/examine(mob/user)
 	. = ..()
 	. += span_notice("Ctrl-click to activate seed extraction.")

--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -20,7 +20,6 @@
 	)
 
 	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
-	register_context()
 
 /obj/structure/loom/attackby(obj/item/I, mob/user)
 	if(weave(I, user))

--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -10,6 +10,18 @@
 	density = TRUE
 	anchored = TRUE
 
+/obj/structure/loom/Initialize(mapload)
+	. = ..()
+
+	var/static/list/hovering_item_typechecks = list(
+		/obj/item/stack/sheet/cotton = list(
+			SCREENTIP_CONTEXT_LMB = "Weave",
+		),
+	)
+
+	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
+	register_context()
+
 /obj/structure/loom/attackby(obj/item/I, mob/user)
 	if(weave(I, user))
 		return

--- a/code/modules/hydroponics/grafts.dm
+++ b/code/modules/hydroponics/grafts.dm
@@ -43,6 +43,14 @@
 		4 ; "graft_mushroom" , \
 		1 ; "graft_doom" )
 
+	var/static/list/hovering_item_typechecks = list(
+		/obj/item/plant_analyzer = list(
+			SCREENTIP_CONTEXT_LMB = "Scan graft",
+		),
+	)
+
+	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
+
 /obj/item/graft/Destroy()
 	QDEL_NULL(stored_trait)
 	return ..()

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -64,6 +64,9 @@
 	mob/living/user,
 )
 
+	if(isnull(held_item))
+		return NONE
+
 	if(held_item.get_sharpness())
 		// May be a little long, but I think "cut into planks" for steel caps may be confusing.
 		context[SCREENTIP_CONTEXT_LMB] = "Cut into [plank_name]"

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -53,6 +53,28 @@
 		/obj/item/food/grown/wheat,
 	))
 
+/obj/item/grown/log/Initialize(mapload, obj/item/seeds/new_seed)
+	. = ..()
+	register_context()
+
+/obj/item/grown/log/add_context(
+	atom/source,
+	list/context,
+	obj/item/held_item,
+	mob/living/user,
+)
+
+	if(held_item.get_sharpness())
+		// May be a little long, but I think "cut into planks" for steel caps may be confusing.
+		context[SCREENTIP_CONTEXT_LMB] = "Cut into [plank_name]"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(CheckAccepted(held_item))
+		context[SCREENTIP_CONTEXT_LMB] = "Make torch"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	return NONE
+
 /obj/item/grown/log/attackby(obj/item/W, mob/user, params)
 	if(W.get_sharpness())
 		user.show_message(span_notice("You make [plank_name] out of \the [src]!"), MSG_VISUAL)

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -10,11 +10,44 @@
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	slot_flags = ITEM_SLOT_BELT
-	custom_materials = list(/datum/material/iron=30, /datum/material/glass=20)
+	custom_materials = list(/datum/material/iron = 30, /datum/material/glass = 20)
+
+/obj/item/plant_analyzer/Initialize(mapload)
+	. = ..()
+	register_item_context()
 
 /obj/item/plant_analyzer/examine()
 	. = ..()
 	. += span_notice("Left click a plant to scan its growth stats, and right click to scan its chemical reagent stats.")
+
+/obj/item/plant_analyzer/add_item_context(
+	obj/item/source,
+	list/context,
+	atom/target,
+)
+
+	if(isliving(target))
+		// It's a health analyzer, but for podpeople.
+		var/mob/living/living_target = target
+		if(!(living_target.mob_biotypes & MOB_PLANT))
+			return NONE
+
+		context[SCREENTIP_CONTEXT_LMB] = "Scan health"
+		context[SCREENTIP_CONTEXT_RMB] = "Scan chemicals"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(isitem(target))
+		// Easier to handle this here, as grown items are split across two type-paths
+		var/obj/item/item_target = target
+		if(!item_target.get_plant_seed())
+			return NONE
+
+		context[SCREENTIP_CONTEXT_LMB] = "Scan plant stats"
+		context[SCREENTIP_CONTEXT_RMB] = "Scan plant chemicals"
+
+		return CONTEXTUAL_SCREENTIP_SET
+
+	return NONE
 
 /// When we attack something, first - try to scan something we hit with left click. Left-clicking uses scans for stats
 /obj/item/plant_analyzer/pre_attack(atom/target, mob/living/user)
@@ -557,7 +590,6 @@
 	attack_verb_continuous = list("slashes", "slices", "cuts")
 	attack_verb_simple = list("slash", "slice", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-
 
 // *************************************
 // Nutrient defines for hydroponics

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -44,7 +44,6 @@
 
 		context[SCREENTIP_CONTEXT_LMB] = "Scan plant stats"
 		context[SCREENTIP_CONTEXT_RMB] = "Scan plant chemicals"
-
 		return CONTEXTUAL_SCREENTIP_SET
 
 	return NONE

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -140,6 +140,11 @@
 		context[SCREENTIP_CONTEXT_LMB] = "Compost"
 		return CONTEXTUAL_SCREENTIP_SET
 
+	if(is_reagent_container(held_item) && length(held_item.reagents.reagent_list))
+		var/datum/reagent/most_common_reagent = held_item.reagents.get_master_reagent()
+		context[SCREENTIP_CONTEXT_LMB] = "[istype(most_common_reagent, /datum/reagent/water) ? "Water" : "Feed"] plant"
+		return CONTEXTUAL_SCREENTIP_SET
+
 	return NONE
 
 /obj/machinery/hydroponics/constructable

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -62,6 +62,86 @@
 	reagents.add_reagent(/datum/reagent/plantnutriment/eznutriment, 10) //Half filled nutrient trays for dirt trays to have more to grow with in prison/lavaland.
 	. = ..()
 
+	var/static/list/hovering_item_typechecks = list(
+		/obj/item/plant_analyzer = list(
+			SCREENTIP_CONTEXT_LMB = "Scan tray stats",
+			SCREENTIP_CONTEXT_RMB = "Scan tray chemicals"
+		),
+		/obj/item/cultivator = list(
+			SCREENTIP_CONTEXT_LMB = "Remove weeds",
+		),
+		/obj/item/shovel = list(
+			SCREENTIP_CONTEXT_LMB = "Clear tray",
+		),
+	)
+
+	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
+	register_context()
+
+/obj/machinery/hydroponics/add_context(
+	atom/source,
+	list/context,
+	obj/item/held_item,
+	mob/living/user,
+)
+
+	// If we don't have a seed, we can't do much.
+
+	// The only option is to plant a new seed.
+	if(!myseed)
+		if(istype(held_item, /obj/item/seeds))
+			context[SCREENTIP_CONTEXT_LMB] = "Plant seed"
+			return CONTEXTUAL_SCREENTIP_SET
+		return NONE
+
+	// If we DO have a seed, we can do a few things!
+
+	// With a hand we can harvest or remove dead plants
+	// If the plant's not in either state, we can't do much else, so early return.
+	if(isnull(held_item))
+		if(issilicon(user)) // Silicons can't interact with trays :frown:
+			return NONE
+
+		switch(plant_status)
+			if(HYDROTRAY_PLANT_DEAD)
+				context[SCREENTIP_CONTEXT_LMB] = "Remove dead plant"
+				return CONTEXTUAL_SCREENTIP_SET
+
+			if(HYDROTRAY_PLANT_HARVESTABLE)
+				context[SCREENTIP_CONTEXT_LMB] = "Harvest plant"
+				return CONTEXTUAL_SCREENTIP_SET
+
+		return NONE
+
+	// If the plant is harvestable, we can graft or harvest it with a plant bag
+	if(plant_status == HYDROTRAY_PLANT_HARVESTABLE)
+		if(istype(held_item, /obj/item/secateurs))
+			context[SCREENTIP_CONTEXT_LMB] = "Graft plant"
+			return CONTEXTUAL_SCREENTIP_SET
+
+		if(istype(held_item, /obj/item/storage/bag/plants))
+			context[SCREENTIP_CONTEXT_LMB] = "Harvest plant"
+			return CONTEXTUAL_SCREENTIP_SET
+
+	// If the plant's in good health, we can shear it
+	if(istype(held_item, /obj/item/geneshears) && plant_health > GENE_SHEAR_MIN_HEALTH)
+		context[SCREENTIP_CONTEXT_LMB] = "Remove plant gene"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	// If we've got a charged somatoray, we can mutation lock it
+	if(istype(held_item, /obj/item/gun/energy/floragun) && myseed.endurance > FLORA_GUN_MIN_ENDURANCE && LAZYLEN(myseed.mutatelist))
+		var/obj/item/gun/energy/floragun/flower_gun = held_item
+		if(flower_gun.cell.charge >= flower_gun.cell.maxcharge)
+			context[SCREENTIP_CONTEXT_LMB] = "Lock mutation"
+			return CONTEXTUAL_SCREENTIP_SET
+
+	// Edibles and pills can be composted
+	if(IS_EDIBLE(held_item) || istype(held_item, /obj/item/reagent_containers/pill))
+		context[SCREENTIP_CONTEXT_LMB] = "Compost"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	return NONE
+
 /obj/machinery/hydroponics/constructable
 	name = "hydroponics tray"
 	icon = 'icons/obj/hydroponics/equipment.dmi'
@@ -805,7 +885,7 @@
 		if(!myseed)
 			to_chat(user, span_warning("[src] is empty!"))
 			return
-		if(myseed.endurance <= 20)
+		if(myseed.endurance <= FLORA_GUN_MIN_ENDURANCE)
 			to_chat(user, span_warning("[myseed.plantname] isn't hardy enough to sequence it's mutation!"))
 			return
 		if(!LAZYLEN(myseed.mutatelist))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -177,6 +177,18 @@
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Tray efficiency at <b>[rating*100]%</b>.")
 
+/obj/machinery/hydroponics/constructable/add_context(
+	atom/source,
+	list/context,
+	obj/item/held_item,
+	mob/living/user,
+)
+
+	// Constructible trays will always show that you can activate auto-grow with ctrl+click
+	. = ..()
+	context[SCREENTIP_CONTEXT_CTRL_LMB] = "Activate auto-grow"
+	return CONTEXTUAL_SCREENTIP_SET
+
 /obj/machinery/hydroponics/Destroy()
 	if(myseed)
 		QDEL_NULL(myseed)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -99,7 +99,8 @@
 	// With a hand we can harvest or remove dead plants
 	// If the plant's not in either state, we can't do much else, so early return.
 	if(isnull(held_item))
-		if(issilicon(user)) // Silicons can't interact with trays :frown:
+		// Silicons can't interact with trays :frown:
+		if(issilicon(user))
 			return NONE
 
 		switch(plant_status)
@@ -113,7 +114,7 @@
 
 		return NONE
 
-	// If the plant is harvestable, we can graft or harvest it with a plant bag
+	// If the plant is harvestable, we can graft it with secateurs or harvest it with a plant bag.
 	if(plant_status == HYDROTRAY_PLANT_HARVESTABLE)
 		if(istype(held_item, /obj/item/secateurs))
 			context[SCREENTIP_CONTEXT_LMB] = "Graft plant"
@@ -123,23 +124,24 @@
 			context[SCREENTIP_CONTEXT_LMB] = "Harvest plant"
 			return CONTEXTUAL_SCREENTIP_SET
 
-	// If the plant's in good health, we can shear it
+	// If the plant's in good health, we can shear it.
 	if(istype(held_item, /obj/item/geneshears) && plant_health > GENE_SHEAR_MIN_HEALTH)
 		context[SCREENTIP_CONTEXT_LMB] = "Remove plant gene"
 		return CONTEXTUAL_SCREENTIP_SET
 
-	// If we've got a charged somatoray, we can mutation lock it
+	// If we've got a charged somatoray, we can mutation lock it.
 	if(istype(held_item, /obj/item/gun/energy/floragun) && myseed.endurance > FLORA_GUN_MIN_ENDURANCE && LAZYLEN(myseed.mutatelist))
 		var/obj/item/gun/energy/floragun/flower_gun = held_item
 		if(flower_gun.cell.charge >= flower_gun.cell.maxcharge)
 			context[SCREENTIP_CONTEXT_LMB] = "Lock mutation"
 			return CONTEXTUAL_SCREENTIP_SET
 
-	// Edibles and pills can be composted
+	// Edibles and pills can be composted.
 	if(IS_EDIBLE(held_item) || istype(held_item, /obj/item/reagent_containers/pill))
 		context[SCREENTIP_CONTEXT_LMB] = "Compost"
 		return CONTEXTUAL_SCREENTIP_SET
 
+	// Aand if a reagent container has water or plant fertilizer in it, we can use it on the plant.
 	if(is_reagent_container(held_item) && length(held_item.reagents.reagent_list))
 		var/datum/reagent/most_common_reagent = held_item.reagents.get_master_reagent()
 		context[SCREENTIP_CONTEXT_LMB] = "[istype(most_common_reagent, /datum/reagent/water) ? "Water" : "Feed"] plant"

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -525,7 +525,7 @@
 
 	var/static/list/hovering_item_typechecks = list(
 		/obj/item/stack/cable_coil = list(
-			SCREENTIP_CONTEXT_LMB = "Make plant battery",
+			SCREENTIP_CONTEXT_LMB = "Make [our_plant.name] battery", // I just think it'll be really funny to see "make potato battery" or "make cannabis leaf battery"
 		),
 	)
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -523,9 +523,10 @@
 
 	RegisterSignal(our_plant, COMSIG_PARENT_ATTACKBY, .proc/make_battery)
 
-	var/static/list/hovering_item_typechecks = list(
+	var/list/hovering_item_typechecks = list(
 		/obj/item/stack/cable_coil = list(
-			SCREENTIP_CONTEXT_LMB = "Make [our_plant.name] battery", // I just think it'll be really funny to see "make potato battery" or "make cannabis leaf battery"
+			// I just think it'll be really funny to see "make potato battery" or "make cannabis leaf battery"
+			SCREENTIP_CONTEXT_LMB = "Make [our_plant.name] battery",
 		),
 	)
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -531,7 +531,7 @@
  * Signal proc for [COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM] to add context to plant batteries.
  */
 /datum/plant_gene/trait/battery/proc/on_requesting_context_from_item(
-	datum/source,
+	obj/item/source,
 	list/context,
 	obj/item/held_item,
 	mob/living/user,
@@ -545,7 +545,7 @@
 	if(cabling.amount < cables_needed_per_battery)
 		return NONE
 
-	context[SCREENTIP_CONTEXT_LMB] = "Make [source] battery"
+	context[SCREENTIP_CONTEXT_LMB] = "Make [source.name] battery"
 	return CONTEXTUAL_SCREENTIP_SET
 
 /*

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -515,22 +515,38 @@
 /datum/plant_gene/trait/battery
 	name = "Capacitive Cell Production"
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
+	/// The number of cables needed to make a battery.
+	var/cables_needed_per_battery = 5
 
 /datum/plant_gene/trait/battery/on_new_plant(obj/item/our_plant, newloc)
 	. = ..()
 	if(!.)
 		return
 
+	our_plant.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
+	RegisterSignal(our_plant, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, .proc/on_requesting_context_from_item)
 	RegisterSignal(our_plant, COMSIG_PARENT_ATTACKBY, .proc/make_battery)
 
-	var/list/hovering_item_typechecks = list(
-		/obj/item/stack/cable_coil = list(
-			// I just think it'll be really funny to see "make potato battery" or "make cannabis leaf battery"
-			SCREENTIP_CONTEXT_LMB = "Make [our_plant.name] battery",
-		),
-	)
+/*
+ * Signal proc for [COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM] to add context to plant batteries.
+ */
+/datum/plant_gene/trait/battery/proc/on_requesting_context_from_item(
+	datum/source,
+	list/context,
+	obj/item/held_item,
+	mob/living/user,
+)
+	SIGNAL_HANDLER
 
-	our_plant.AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
+	if(!istype(held_item, /obj/item/stack/cable_coil))
+		return NONE
+
+	var/obj/item/stack/cable_coil/cabling = held_item
+	if(cabling.amount < cables_needed_per_battery)
+		return NONE
+
+	context[SCREENTIP_CONTEXT_LMB] = "Make [source] battery"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /*
  * When a plant with this gene is hit (attackby) with cables, we turn it into a battery.
@@ -547,7 +563,7 @@
 
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
 	var/obj/item/stack/cable_coil/cabling = hit_item
-	if(!cabling.use(5))
+	if(!cabling.use(cables_needed_per_battery))
 		to_chat(user, span_warning("You need five lengths of cable to make a [our_plant] battery!"))
 		return
 

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -523,6 +523,14 @@
 
 	RegisterSignal(our_plant, COMSIG_PARENT_ATTACKBY, .proc/make_battery)
 
+	var/static/list/hovering_item_typechecks = list(
+		/obj/item/stack/cable_coil = list(
+			SCREENTIP_CONTEXT_LMB = "Make plant battery",
+		),
+	)
+
+	our_plant.AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
+
 /*
  * When a plant with this gene is hit (attackby) with cables, we turn it into a battery.
  *

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -67,6 +67,31 @@
 	var/max_seeds = 1000
 	var/seed_multiplier = 1
 
+/obj/machinery/seed_extractor/Initialize(mapload, obj/item/seeds/new_seed)
+	. = ..()
+
+	var/static/list/hovering_item_typechecks = list(
+		/obj/item/storage/bag/plants = list(
+			SCREENTIP_CONTEXT_LMB = "Store seeds",
+		),
+	)
+
+	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
+	register_context()
+
+/obj/machinery/seed_extractor/add_context(
+	atom/source,
+	list/context,
+	obj/item/held_item,
+	mob/living/user,
+)
+
+	if(held_item?.get_plant_seed())
+		context[SCREENTIP_CONTEXT_LMB] = "Make seeds"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	return NONE
+
 /obj/machinery/seed_extractor/RefreshParts()
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		max_seeds = initial(max_seeds) * B.rating

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -69,14 +69,6 @@
 
 /obj/machinery/seed_extractor/Initialize(mapload, obj/item/seeds/new_seed)
 	. = ..()
-
-	var/static/list/hovering_item_typechecks = list(
-		/obj/item/storage/bag/plants = list(
-			SCREENTIP_CONTEXT_LMB = "Store seeds",
-		),
-	)
-
-	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
 	register_context()
 
 /obj/machinery/seed_extractor/add_context(
@@ -88,6 +80,10 @@
 
 	if(held_item?.get_plant_seed())
 		context[SCREENTIP_CONTEXT_LMB] = "Make seeds"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(istype(held_item, /obj/item/storage/bag/plants) && (locate(/obj/item/seeds) in held_item.contents))
+		context[SCREENTIP_CONTEXT_LMB] = "Store seeds"
 		return CONTEXTUAL_SCREENTIP_SET
 
 	return NONE

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -90,6 +90,15 @@
 			genes += new /datum/plant_gene/reagent(reag_id, reagents_add[reag_id])
 		reagents_from_genes() //quality coding
 
+	var/static/list/hovering_item_typechecks = list(
+		/obj/item/plant_analyzer = list(
+			SCREENTIP_CONTEXT_LMB = "Scan seed stats",
+			SCREENTIP_CONTEXT_RMB = "Scan seed chemicals"
+		),
+	)
+
+	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
+
 /obj/item/seeds/Destroy()
 	// No AS ANYTHING here, because the list/genes could have typepaths in it.
 	for(var/datum/plant_gene/gene in genes)


### PR DESCRIPTION
## About The Pull Request

- Glowshrooms
- The Portaseeder
- The Loom
- Grafts
- Logs 
- The Plant Analyzer
- The Hydroponics Tray
- Captive Cell plants
- and Seeds

All now have some contextual screentips. 
Also changed a flora-gun magic number to a define. 

## Why It's Good For The Game

Contextual screentips are kinda neat. Botany kind has some obtuse mechanics so explaining some of them in game helps. 

## Changelog

:cl:
qol: Many botany items now have contextual screentips. 
/:cl:

