### PR TITLE
Fixes Orion Trail reloading static data

### DIFF
--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -177,14 +177,16 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 
 	data["reason"] = reason
 
+	data["settlers"] = settlers
+	data["settlermoods"] = settlermoods
+
 	return data
 
 /obj/machinery/computer/arcade/orion_trail/ui_static_data(mob/user)
 	var/list/static_data = list()
 	static_data["gamename"] = name
 	static_data["emagged"] = obj_flags & EMAGGED
-	static_data["settlers"] = settlers
-	static_data["settlermoods"] = settlermoods
+
 	return static_data
 
 /obj/machinery/computer/arcade/orion_trail/ui_act(action, list/params)
@@ -219,7 +221,6 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 			set_game_over(gamer)
 			return
 		new_settler_mood() //events shake people up a bit and can also change food
-		update_static_data(usr)
 		return TRUE
 	switch(action)
 		if("start_game")
@@ -348,7 +349,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 
 /obj/machinery/computer/arcade/orion_trail/proc/set_game_over(user, given_reason)
 	usr.lost_game()
-	
+
 	gameStatus = ORION_STATUS_GAMEOVER
 	event = null
 	reason = given_reason || death_reason(user)
@@ -396,7 +397,6 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 		alive++
 	if(update)
 		new_settler_mood()//new faces!
-		update_static_data(usr)
 	return newcrew
 
 
@@ -417,7 +417,6 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 		alive--
 	if(update)
 		new_settler_mood()//bro, i...
-		update_static_data(usr)
 	return removed
 
 /**
@@ -476,7 +475,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 
 /obj/machinery/computer/arcade/orion_trail/proc/win(mob/user)
 	usr.won_game()
-	
+
 	gameStatus = ORION_STATUS_START
 	say("Congratulations, you made it to Orion!")
 	if(obj_flags & EMAGGED)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Orion trail was using static data for its settlers when it really shouldn't

This was triggering the throttle on send_full_update and just generally being annoying
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more loading screens while playing video games inside a video game inside a video game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Following numerous reports, CentCom has downloaded more RAM into the Orion Trail arcade machines, thus drastically reducing the occurrence of loading screens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
