### PR TITLE
Puts the kinetic crusher's projectile firing on rmb

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -130,9 +130,10 @@
 
 /obj/item/kinetic_crusher/afterattack_secondary(atom/target, mob/living/user, clickparams)
 	if(!wielded)
+		balloon_alert(user, "wield it first!")
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	if(target == user)
-		to_chat(user, span_warning("You can't aim [src] at yourself!"))
+		balloon_alert(user, "can't aim at yourself!")
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	fire_kinetic_blast(target, user, clickparams)
 	user.changeNext_move(CLICK_CD_MELEE)
@@ -145,15 +146,14 @@
 	var/turf/proj_turf = user.loc
 	if(!isturf(proj_turf))
 		return
-	var/obj/projectile/destabilizer/D = new /obj/projectile/destabilizer(proj_turf)
-	for(var/t in trophies)
-		var/obj/item/crusher_trophy/T = t
-		T.on_projectile_fire(D, user)
-	D.preparePixelProjectile(target, user, modifiers)
-	D.firer = user
-	D.hammer_synced = src
+	var/obj/projectile/destabilizer/destabilizer = new(proj_turf)
+	for(var/obj/item/crusher_trophy/attached_trophy as anything in trophies)
+		attached_trophy.on_projectile_fire(destabilizer, user)
+	destabilizer.preparePixelProjectile(target, user, modifiers)
+	destabilizer.firer = user
+	destabilizer.hammer_synced = src
 	playsound(user, 'sound/weapons/plasma_cutter.ogg', 100, TRUE)
-	D.fire()
+	destabilizer.fire()
 	charged = FALSE
 	update_appearance()
 	addtimer(CALLBACK(src, .proc/Recharge), charge_time)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -138,6 +138,7 @@
 /obj/item/kinetic_crusher/afterattack_secondary(atom/target, mob/living/user, clickparams)
 	if(wielded)
 		fire_kinetic_blast(target, user, clickparams)
+		user.changeNext_move(CLICK_CD_MELEE)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/kinetic_crusher/proc/fire_kinetic_blast(atom/target, mob/living/user, clickparams)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -57,7 +57,7 @@
 
 /obj/item/kinetic_crusher/examine(mob/living/user)
 	. = ..()
-	. += span_notice("Mark a large creature with the destabilizing force with right click, then hit them in melee to do <b>[force + detonation_damage]</b> damage.")
+	. += span_notice("Mark a large creature with a destabilizing force with right-click, then hit them in melee to do <b>[force + detonation_damage]</b> damage.")
 	. += span_notice("Does <b>[force + detonation_damage + backstab_bonus]</b> damage if the target is backstabbed, instead of <b>[force + detonation_damage]</b>.")
 	for(var/t in trophies)
 		var/obj/item/crusher_trophy/T = t
@@ -125,40 +125,38 @@
 					C.total_damage += detonation_damage
 				L.apply_damage(detonation_damage, BRUTE, blocked = def_check)
 
-/obj/item/kinetic_crusher/attack_secondary(atom/target, mob/living/user) //This is for aiming at yourself/adjacent mobs
-	if(target != user && wielded)
-		fire_kinetic_blast(target, user)
-	if(target == user)
-		to_chat(user, span_warning("You can't aim [src] at yourself!"))
-	if(!wielded)
-		to_chat(user, span_warning("[src] is too heavy to use with one hand! You fumble and drop everything."))
-		user.drop_all_held_items()
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+/obj/item/kinetic_crusher/attack_secondary(atom/target, mob/living/user, clickparams)
+	return SECONDARY_ATTACK_CONTINUE_CHAIN
 
 /obj/item/kinetic_crusher/afterattack_secondary(atom/target, mob/living/user, clickparams)
-	if(wielded)
-		fire_kinetic_blast(target, user, clickparams)
-		user.changeNext_move(CLICK_CD_MELEE)
+	if(!wielded)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	if(target == user)
+		to_chat(user, span_warning("You can't aim [src] at yourself!"))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	fire_kinetic_blast(target, user, clickparams)
+	user.changeNext_move(CLICK_CD_MELEE)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/kinetic_crusher/proc/fire_kinetic_blast(atom/target, mob/living/user, clickparams)
+	if(!charged)
+		return
 	var/modifiers = params2list(clickparams)
-	if(charged)
-		var/turf/proj_turf = user.loc
-		if(!isturf(proj_turf))
-			return
-		var/obj/projectile/destabilizer/D = new /obj/projectile/destabilizer(proj_turf)
-		for(var/t in trophies)
-			var/obj/item/crusher_trophy/T = t
-			T.on_projectile_fire(D, user)
-		D.preparePixelProjectile(target, user, modifiers)
-		D.firer = user
-		D.hammer_synced = src
-		playsound(user, 'sound/weapons/plasma_cutter.ogg', 100, TRUE)
-		D.fire()
-		charged = FALSE
-		update_appearance()
-		addtimer(CALLBACK(src, .proc/Recharge), charge_time)
+	var/turf/proj_turf = user.loc
+	if(!isturf(proj_turf))
+		return
+	var/obj/projectile/destabilizer/D = new /obj/projectile/destabilizer(proj_turf)
+	for(var/t in trophies)
+		var/obj/item/crusher_trophy/T = t
+		T.on_projectile_fire(D, user)
+	D.preparePixelProjectile(target, user, modifiers)
+	D.firer = user
+	D.hammer_synced = src
+	playsound(user, 'sound/weapons/plasma_cutter.ogg', 100, TRUE)
+	D.fire()
+	charged = FALSE
+	update_appearance()
+	addtimer(CALLBACK(src, .proc/Recharge), charge_time)
 
 /obj/item/kinetic_crusher/proc/Recharge()
 	if(!charged)


### PR DESCRIPTION
## About The Pull Request
Splits the crusher's afterattack so that left click is the melee hit/detonation effect and right click is to fire the projectile that marks/mines while retaining the previous behavior

## Why It's Good For The Game
It's counterintuitive that in order to hit something adjacent to you with the crusher's projectile you are required to move your mouse beyond your target.
Putting the projectile on rmb allows you to stand next to a mob or tile you want to mine and just right click on it to shoot it.

You still have to do two clicks to mark and then detonate, and this does not allow you to trigger them more rapidly.

## Changelog
:cl:
qol: Kinetic crushers now fire their projectile with the right mouse button, allowing you to fire at targets that are adjacent to you without moving your mouse away from your target.
/:cl:
