### PR TITLE
Tramstation's surgery rooms now require surgery access

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -31973,7 +31973,7 @@
 	},
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Freezer";
-	req_access_txt = "5"
+	req_access_txt = "45"
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -36315,7 +36315,7 @@
 "lFr" = (
 /obj/machinery/door/airlock/medical{
 	name = "Surgery";
-	req_access_txt = "5"
+	req_access_txt = "45"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -46620,7 +46620,7 @@
 	},
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Freezer";
-	req_access_txt = "5"
+	req_access_txt = "45"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
@@ -51791,7 +51791,7 @@
 "rsD" = (
 /obj/machinery/door/airlock/medical{
 	name = "Surgery B";
-	req_access_txt = "5"
+	req_access_txt = "45"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1


### PR DESCRIPTION
## About The Pull Request

Small fix, makes Tramstation's surgery room require surgery access.

## Why It's Good For The Game

Bug fix? Makes people who shouldn't have surgery access, unable to access surgery.

## Changelog

:cl:
fix: Tramstation's medical surgery area is now locked behind Surgery access rather than Medical.
/:cl: