### PR TITLE
The CRAB-17 is now indestructible, but it's waaaaaay easier to swipe your ID card

### DIFF
--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -47,10 +47,6 @@
 	var/mob/living/bogdanoff
 	var/canwalk = FALSE
 
-/obj/structure/checkoutmachine/examine(mob/living/user)
-	. = ..()
-	. += span_info("It's integrated integrity meter reads: <b>HEALTH: [atom_integrity]</b>.")
-
 /obj/structure/checkoutmachine/proc/check_if_finished()
 	for(var/i in accounts_to_rob)
 		var/datum/bank_account/B = i

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -65,7 +65,7 @@
 
 	var/obj/item/card/id/card = attacking_item.GetID()
 	if(!card)
-		balloon_alert(user, "your [attacking_item.name] gets repelled by the id card reader")
+		balloon_alert(user, "your [attacking_item.name] gets repelled by the id card reader!")
 
 		var/throwtarget = get_step(user, get_dir(src, user))
 		user.safe_throw_at(throwtarget, 1, 1, force = MOVE_FORCE_EXTREMELY_STRONG)

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -39,7 +39,7 @@
 	icon_state = "bogdanoff"
 	layer = ABOVE_ALL_MOB_LAYER
 	plane = ABOVE_GAME_PLANE
-	armor = list(MELEE = 80, BULLET = 30, LASER = 30, ENERGY = 60, BOMB = 90, BIO = 0, FIRE = 100, ACID = 80)
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	density = TRUE
 	pixel_z = -8
 	max_integrity = 5000
@@ -58,28 +58,38 @@
 			return FALSE
 	return TRUE
 
-/obj/structure/checkoutmachine/attackby(obj/item/W, mob/user, params)
+/obj/structure/checkoutmachine/attackby(obj/item/attacking_item, mob/user, params)
 	if(check_if_finished())
 		qdel(src)
 		return
-	if(istype(W, /obj/item/card/id))
-		var/obj/item/card/id/card = W
-		if(!card.registered_account)
-			to_chat(user, span_warning("This card does not have a registered account!"))
-			return
-		if(!card.registered_account.being_dumped)
-			to_chat(user, span_warning("It appears that your funds are safe from draining!"))
-			return
-		if(do_after(user, 40, target = src))
-			if(!card.registered_account.being_dumped)
-				return
-			to_chat(user, span_warning("You quickly cash out your funds to a more secure banking location. Funds are safu.")) // This is a reference and not a typo
-			card.registered_account.being_dumped = FALSE
-			if(check_if_finished())
-				qdel(src)
-				return
-	else
-		return ..()
+
+	var/obj/item/card/id/card = attacking_item.GetID()
+	if(!card)
+		balloon_alert(user, "your [attacking_item.name] gets repelled by the id card reader")
+
+		var/throwtarget = get_step(user, get_dir(src, user))
+		user.safe_throw_at(throwtarget, 1, 1, force = MOVE_FORCE_EXTREMELY_STRONG)
+		playsound(get_turf(src),'sound/magic/repulse.ogg', 100, TRUE)
+
+		return
+
+	if(!card.registered_account)
+		to_chat(user, span_warning("This card does not have a registered account!"))
+		return
+
+	if(!card.registered_account.being_dumped)
+		to_chat(user, span_warning("It appears that your funds are safe from draining!"))
+		return
+
+	if(!card.registered_account.being_dumped)
+		return
+
+	to_chat(user, span_warning("You quickly cash out your funds to a more secure banking location. Funds are safu.")) // This is a reference and not a typo
+	card.registered_account.being_dumped = FALSE
+
+	if(check_if_finished())
+		qdel(src)
+		return
 
 /obj/structure/checkoutmachine/Initialize(mapload, mob/living/user)
 	. = ..()

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -47,6 +47,10 @@
 	var/mob/living/bogdanoff
 	var/canwalk = FALSE
 
+/obj/structure/checkoutmachine/examine(mob/living/user)
+	. = ..()
+	. += span_info("It has a flashing <b>ID card reader</b> for convenient cashing out.")
+
 /obj/structure/checkoutmachine/proc/check_if_finished()
 	for(var/i in accounts_to_rob)
 		var/datum/bank_account/B = i
@@ -61,7 +65,7 @@
 
 	var/obj/item/card/id/card = attacking_item.GetID()
 	if(!card)
-		balloon_alert(user, "your [attacking_item.name] gets repelled by the id card reader!")
+		balloon_alert(user, "your [attacking_item.name] gets repelled by the id card reader")
 
 		var/throwtarget = get_step(user, get_dir(src, user))
 		user.safe_throw_at(throwtarget, 1, 1, force = MOVE_FORCE_EXTREMELY_STRONG)

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -81,9 +81,6 @@
 		to_chat(user, span_warning("It appears that your funds are safe from draining!"))
 		return
 
-	if(!card.registered_account.being_dumped)
-		return
-
 	to_chat(user, span_warning("You quickly cash out your funds to a more secure banking location. Funds are safu.")) // This is a reference and not a typo
 	card.registered_account.being_dumped = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the CRAB-17 practically indestructible.
Removes the do_after for swiping your ID card. It now uses a wireless card reader that is instant.
Adds the ability to swipe any object that overrides `GetID()` to return a contained ID card, meaning you can swipe your PDA, laptop, tablet or wallet without having to remove you ID first.
Makes attacking the crab with anything that isn't an ID card display a bubble popup hinting at what you're supposed to do - swipe your ID card. It also repulses them back one turf via a safe throw proc.

Big gif showcasing this behaviour:
https://cdn.discordapp.com/attachments/585862469508005888/943695959337087026/R960OFxfTW.gif

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The goal of the CRAB-17 is to provide a very large station-wide distraction that temporarily draws crew away from their areas and moves them elsewhere. It's not supposed to sit there for 8 minutes while the players ineffectually smash their faces against it until it explodes then complain it sucks and is boring.

Why players keep doing this when swiping their ID and walking off is a better solution, is a question only their tiny lizard brains can answer.

This change encourages players to go to the crab, swipe their ID card and then go back on with their shift. This is the CRAB's purpose and expected design space. It discourages players beating the damn thing for 3 minutes getting pissed off and raging that all their money is draining away. And players can no longer just ignore the CRAB and wait for other crew to destroy it unless they want their credits drained over 8 minutes.

If all crew swipe their IDs then it explodes early. Otherwise it taunts players over the 8 minutes, trying to draw them away from their departments to go find it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The CRAB-17/Nanotrasen Space-Coin Market is now indestructible. Attacking it repulses you back one tile instead. ID cards now instantly swipe on it instead of requiring a progress bar, and ID card holders like PDAs and wallets can also be directly used on it without having to remove IDs. It still blows up when all ID cards with bank accounts have been swiped on it or after 8 minutes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
