### PR TITLE
Icebox surgery room requires surgery access

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -45291,7 +45291,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/medical{
 	name = "Surgery B";
-	req_access_txt = "5"
+	req_access_txt = "45"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{


### PR DESCRIPTION
## About The Pull Request

Same as https://github.com/tgstation/tgstation/pull/64972 - Makes surgery access limited to people who have surgery access.

## Why It's Good For The Game

Same as https://github.com/tgstation/tgstation/pull/64972

## Changelog

:cl:
fix: Icebox's medical surgery area is now locked behind Surgery access rather than Medical.
/:cl: