### PR TITLE
gravitum fixes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2629,6 +2629,7 @@
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM //20 times as long, so it's actually viable to use
 	var/time_multiplier = 1 MINUTES //1 minute per unit of gravitum on objects. Seems overpowered, but the whole thing is very niche
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	self_consuming = TRUE //this works on objects, so it should work on skeletons and robots too
 
 /datum/reagent/gravitum/expose_obj(obj/exposed_obj, volume)
 	. = ..()
@@ -2639,7 +2640,7 @@
 	L.AddElement(/datum/element/forced_gravity, 0) //0 is the gravity, and in this case weightless
 	return ..()
 
-/datum/reagent/gravitum/on_mob_end_metabolize(mob/living/L)
+/datum/reagent/gravitum/on_mob_delete(mob/living/L)
 	L.RemoveElement(/datum/element/forced_gravity, 0)
 
 /datum/reagent/cellulose

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2636,11 +2636,11 @@
 	exposed_obj.AddElement(/datum/element/forced_gravity, 0)
 	addtimer(CALLBACK(exposed_obj, .proc/_RemoveElement, list(/datum/element/forced_gravity, 0)), volume * time_multiplier)
 
-/datum/reagent/gravitum/on_mob_add(mob/living/L)
+/datum/reagent/gravitum/on_mob_metabolize(mob/living/L)
 	L.AddElement(/datum/element/forced_gravity, 0) //0 is the gravity, and in this case weightless
 	return ..()
 
-/datum/reagent/gravitum/on_mob_delete(mob/living/L)
+/datum/reagent/gravitum/on_mob_end_metabolize(mob/living/L)
 	L.RemoveElement(/datum/element/forced_gravity, 0)
 
 /datum/reagent/cellulose


### PR DESCRIPTION
## About The Pull Request

Gravitum's on_mob_add() effect is now an on_mob_metabolize() effect.

Gravitum can now be metabolized by liverless creatures.

## Why It's Good For The Game

The antigravity effect of gravitum is currently applied via on_mob_add(), but removed by on_mob_end_metabolize(). This means that if you're under the effects of gravitum, then strap yourself to a stasis bed, then unbuckle yourself from that stasis bed, you'll stop floating and will not be able to be put under the effects of gravitum again until the previous sample of gravitum completely leaves your system AND you receive a new dose of it. It also means that golems, androids, etc. can retain the effects of gravitum indefinitely, because they never started metabolizing it to begin with.

This PR fixes that mess.

Because gravitum can affect objects, I concluding that liverless creatures being affected by it was probably intentional and kept that in.

Side rant: I wanted to make gravititum also continue to affect and decay in corpses, but from what I can tell from the code, self_consuming chems that process just fine in robots, golems, and other unliving creatures stop processing if their host dies. We have a REAGENT_DEAD_PROCESS flag that allows reagents to continue to process in dead people, but it only works on dead hosts **WITH LIVERS**. AHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH-

## Changelog

:cl: ATHATH
fix: Buckling yourself to and then unbuckling yourself from a stasis bed will no longer permanently halt the effects of any gravitum in your system.
fix: Liverless creatures can no longer retain the effects of gravitum indefinitely, as it will now decay in their bodies (just as it does in the bodies of livered creatures).
/:cl: