### PR TITLE
Adds the semi-recent headcoder ruling that issue managers cannot edit PR labels

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -83,10 +83,10 @@ This should help you understand what you can and can't do with your newfound git
 Things you **CAN** do:
 * Label issues appropriately
 * Close issues when appropriate
-* Label PRs when appropriate
 
 Things you **CAN'T** do:
 * [Close PRs](https://imgur.com/w2RqpX8.png): Only maintainers are allowed to close PRs. Do not hit that button.
+* Label PRs, leave that for maintainers to handle.
 
 </details>
 


### PR DESCRIPTION
## About The Pull Request

I found this out while reading through the contributing file today and thought I should change it before goof uses it as an excuse to label a ton of PRs again.
For those unaware: https://github.com/orgs/tgstation/teams/issue-managers/discussions/10

## Why It's Good For The Game

github thing, not a game one.

## Changelog

Not needed.