### PR TITLE
Fixes IceBoxStation's Wall Placement for Secure Tech Storage

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -13715,10 +13715,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/greater)
 "dYL" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Secure Tech Storage"
-	},
 /obj/structure/cable,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "dZu" = (
@@ -16098,8 +16096,8 @@
 /area/service/bar/atrium)
 "fmv" = (
 /obj/structure/rack,
-/obj/machinery/light/small/directional/west,
 /obj/effect/spawner/random/techstorage/command_all,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "fmJ" = (
@@ -33833,6 +33831,9 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/fore)
+"ocP" = (
+/turf/closed/wall/r_wall,
+/area/engineering/storage/tech)
 "ocR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/directional/west{
@@ -80208,7 +80209,7 @@ aJw
 gKh
 dzF
 dzF
-dzF
+ocP
 dzF
 dzF
 gKh


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hello there. This PR fixes this weird visual oddity with IceBoxStation. Please refer to this photograph placed below:

![image](https://user-images.githubusercontent.com/34697715/154585180-59f93ace-e66d-472d-80d6-250f9e28a62c.png)

Why are both the camera and the light on a window? That's not correct. Let's fix that.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/154585219-1bd37bb9-3f1f-41c5-9f75-f8fe09858f45.png)

The reinforced wall doesn't actually do much but be a good anchor for that light, and the camera was moved off to the side. The visibility from the camera would literally only lead into empty snow/maintenance anyways, so I don't think anything of value was lost.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: As far as the Secure Tech Storage on IceBoxStation, Nanotrasen has finally realized that they should stop installing lights and cameras on their windows.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
