### PR TITLE
Adds USB port to Fire Alarms

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -71,7 +71,8 @@
 #define COMSIG_LIGHT_SWITCH_SET "light_switch_set"
 
 /// from /obj/machinery/fire_alarm/reset(), /obj/machinery/fire_alarm/alarm(): (status)
-#define COMSIG_FIREALARM_USED "light_switch_set"
+#define COMSIG_FIREALARM_ON_TRIGGER "firealarm_trigger"
+#define COMSIG_FIREALARM_ON_RESET "firealarm_reset"
 
 // /obj access signals
 

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -70,6 +70,9 @@
 /// from /obj/machinery/light_switch/set_lights(), sent to every switch in the area: (status)
 #define COMSIG_LIGHT_SWITCH_SET "light_switch_set"
 
+/// from /obj/machinery/fire_alarm/reset(), /obj/machinery/fire_alarm/alarm(): (status)
+#define COMSIG_FIREALARM_USED "light_switch_set"
+
 // /obj access signals
 
 #define COMSIG_OBJ_ALLOWED "door_try_to_activate"

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -180,7 +180,7 @@
 	if(user)
 		log_game("[user] triggered a fire alarm at [COORD(src)]")
 	soundloop.start() //Manually pulled fire alarms will make the sound, rather than the doors.
-	SEND_SIGNAL(src, COMSIG_FIREALARM_USED)
+	SEND_SIGNAL(src, COMSIG_FIREALARM_ON_TRIGGER)
 
 /**
  * Resets all firelocks in the area. Also tells the area to disable alarm lighting, if it was enabled.
@@ -198,7 +198,7 @@
 	if(user)
 		log_game("[user] reset a fire alarm at [COORD(src)]")
 	soundloop.stop()
-	SEND_SIGNAL(src, COMSIG_FIREALARM_USED)
+	SEND_SIGNAL(src, COMSIG_FIREALARM_ON_RESET)
 
 /obj/machinery/firealarm/attack_hand(mob/user, list/modifiers)
 	if(buildstage != 2)
@@ -429,33 +429,54 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/firealarm, 26)
 /obj/item/circuit_component/firealarm
 	display_name = "Fire Alarm"
 	desc = "Allows you to interface with the Fire Alarm."
-	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL
 
-	/////When the firealarm is used
+	var/datum/port/input/alarm_trigger
+	var/datum/port/input/reset_trigger
+
+	/// Returns a boolean value of 0 or 1 if the fire alarm is on or not.
 	var/datum/port/output/is_on
+	/// Returns when the alarm is turned on
+	var/datum/port/output/triggered
+	/// Returns when the alarm is turned off
+	var/datum/port/output/reset
 
 	var/obj/machinery/firealarm/attached_alarm
 
 /obj/item/circuit_component/firealarm/populate_ports()
-	is_on = add_output_port("Active", PORT_TYPE_NUMBER)
+	alarm_trigger = add_input_port("Set", PORT_TYPE_SIGNAL)
+	reset_trigger = add_input_port("Reset", PORT_TYPE_SIGNAL)
+
+	is_on = add_output_port("Is On", PORT_TYPE_NUMBER)
+	triggered = add_output_port("Triggered", PORT_TYPE_SIGNAL)
+	reset = add_output_port("Reset", PORT_TYPE_SIGNAL)
 
 /obj/item/circuit_component/firealarm/register_usb_parent(atom/movable/parent)
 	. = ..()
 	if(istype(parent, /obj/machinery/firealarm))
 		attached_alarm = parent
-		RegisterSignal(parent, COMSIG_FIREALARM_USED, .proc/on_firealarm_used)
+		RegisterSignal(parent, COMSIG_FIREALARM_ON_TRIGGER, .proc/on_firealarm_triggered)
+		RegisterSignal(parent, COMSIG_FIREALARM_ON_RESET, .proc/on_firealarm_reset)
 
 /obj/item/circuit_component/firealarm/unregister_usb_parent(atom/movable/parent)
 	attached_alarm = null
-	UnregisterSignal(parent, COMSIG_FIREALARM_USED)
+	UnregisterSignal(parent, COMSIG_FIREALARM_ON_TRIGGER)
+	UnregisterSignal(parent, COMSIG_FIREALARM_ON_RESET)
 	return ..()
 
-/obj/item/circuit_component/firealarm/proc/on_firealarm_used(datum/source)
+/obj/item/circuit_component/firealarm/proc/on_firealarm_triggered(datum/source)
 	SIGNAL_HANDLER
-	is_on.set_output(attached_alarm.my_area.fire)
+	is_on.set_output(1)
+	triggered.set_output(COMPONENT_SIGNAL)
+
+/obj/item/circuit_component/firealarm/proc/on_firealarm_reset(datum/source)
+	SIGNAL_HANDLER
+	is_on.set_output(0)
+	reset.set_output(COMPONENT_SIGNAL)
+
 
 /obj/item/circuit_component/firealarm/input_received(datum/port/input/port)
-	if(attached_alarm.my_area.fire)
-		attached_alarm?.reset()
-	else
+	if(COMPONENT_TRIGGERED_BY(alarm_trigger, port))
 		attached_alarm?.alarm()
+
+	if(COMPONENT_TRIGGERED_BY(reset_trigger, port))
+		attached_alarm?.reset()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives fire alarms a usb port that lets you toggle it on and off and check its state

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Buffs circuits to interact with the world more, while also not making them better at killing people

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a usb port to fire alarms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
