### PR TITLE
Silicon airlock hotkey screen tips 

### DIFF
--- a/code/__DEFINES/screentips.dm
+++ b/code/__DEFINES/screentips.dm
@@ -13,7 +13,7 @@
 /// Context applied to Alt-LMB actions
 #define SCREENTIP_CONTEXT_ALT_LMB "Alt-LMB"
 
-/// Context applied to Ctrl-LMB actions
+/// Context applied to Ctrl-Shift-LMB actions
 #define SCREENTIP_CONTEXT_CTRL_SHIFT_LMB "Ctrl-Shift-LMB"
 
 /// Screentips are always disabled

--- a/code/__DEFINES/screentips.dm
+++ b/code/__DEFINES/screentips.dm
@@ -4,11 +4,17 @@
 /// Context applied to RMB actions
 #define SCREENTIP_CONTEXT_RMB "RMB"
 
+/// Context applied to Shift-LMB actions
+#define SCREENTIP_CONTEXT_SHIFT_LMB "Shift-LMB"
+
 /// Context applied to Ctrl-LMB actions
 #define SCREENTIP_CONTEXT_CTRL_LMB "Ctrl-LMB"
 
 /// Context applied to Alt-LMB actions
 #define SCREENTIP_CONTEXT_ALT_LMB "Alt-LMB"
+
+/// Context applied to Ctrl-LMB actions
+#define SCREENTIP_CONTEXT_CTRL_SHIFT_LMB "Ctrl-Shift-LMB"
 
 /// Screentips are always disabled
 #define SCREENTIP_PREFERENCE_DISABLED "Disabled"

--- a/code/_onclick/hud/screentip.dm
+++ b/code/_onclick/hud/screentip.dm
@@ -2,7 +2,7 @@
 	icon = null
 	icon_state = null
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	screen_loc = "TOP,LEFT"
+	screen_loc = "TOP-1,LEFT"
 	maptext_height = 480
 	maptext_width = 480
 	maptext = ""

--- a/code/_onclick/hud/screentip.dm
+++ b/code/_onclick/hud/screentip.dm
@@ -2,7 +2,7 @@
 	icon = null
 	icon_state = null
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	screen_loc = "TOP-1,LEFT"
+	screen_loc = "TOP,LEFT"
 	maptext_height = 480
 	maptext_width = 480
 	maptext = ""

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -2167,8 +2167,8 @@
 
 						if(extra_lines)
 							extra_context = "<br><span style='font-size: 7px'>[lmb_rmb_line][ctrl_lmb_alt_lmb_line][shift_lmb_ctrl_shift_lmb_line]</span>"
-							active_hud.screentip_text.maptext_y = -10 + (extra_lines - 1) * -9 //first extra line pushes atom name line up 10px, subsequent lines push it up 9px, \
-																								this offsets that and keeps the first line in the same place
+							//first extra line pushes atom name line up 10px, subsequent lines push it up 9px, this offsets that and keeps the first line in the same place
+							active_hud.screentip_text.maptext_y = -10 + (extra_lines - 1) * -9
 
 			if (screentips_enabled == SCREENTIP_PREFERENCE_CONTEXT_ONLY && extra_context == "")
 				active_hud.screentip_text.maptext = ""

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -2111,9 +2111,11 @@
 		if(screentips_enabled == SCREENTIP_PREFERENCE_DISABLED || (flags_1 & NO_SCREENTIPS_1))
 			active_hud.screentip_text.maptext = ""
 		else
+			active_hud.screentip_text.maptext_y = 0
 			var/lmb_rmb_line = ""
 			var/ctrl_lmb_alt_lmb_line = ""
 			var/shift_lmb_ctrl_shift_lmb_line = ""
+			var/extra_lines = 0
 			var/extra_context = ""
 
 			if (isliving(user) || isovermind(user) || isaicamera(user))
@@ -2141,6 +2143,7 @@
 						// Ctrl-LMB, Alt-LMB on one line...
 						if (lmb_rmb_line != "")
 							lmb_rmb_line += "<br>"
+							extra_lines++
 						if (SCREENTIP_CONTEXT_CTRL_LMB in context)
 							ctrl_lmb_alt_lmb_line += "[SCREENTIP_CONTEXT_CTRL_LMB]: [context[SCREENTIP_CONTEXT_CTRL_LMB]]"
 						if (SCREENTIP_CONTEXT_ALT_LMB in context)
@@ -2151,6 +2154,7 @@
 						// Shift-LMB, Ctrl-Shift-LMB on one line...
 						if (ctrl_lmb_alt_lmb_line != "")
 							ctrl_lmb_alt_lmb_line += "<br>"
+							extra_lines++
 						if (SCREENTIP_CONTEXT_SHIFT_LMB in context)
 							shift_lmb_ctrl_shift_lmb_line += "[SCREENTIP_CONTEXT_SHIFT_LMB]: [context[SCREENTIP_CONTEXT_SHIFT_LMB]]"
 						if (SCREENTIP_CONTEXT_CTRL_SHIFT_LMB in context)
@@ -2158,8 +2162,13 @@
 								shift_lmb_ctrl_shift_lmb_line += " | "
 							shift_lmb_ctrl_shift_lmb_line += "[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB]: [context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB]]"
 
-						if(lmb_rmb_line != "" || ctrl_lmb_alt_lmb_line != "" || shift_lmb_ctrl_shift_lmb_line != "")
+						if (shift_lmb_ctrl_shift_lmb_line != "")
+							extra_lines++
+
+						if(extra_lines)
 							extra_context = "<br><span style='font-size: 7px'>[lmb_rmb_line][ctrl_lmb_alt_lmb_line][shift_lmb_ctrl_shift_lmb_line]</span>"
+							active_hud.screentip_text.maptext_y = -10 + (extra_lines - 1) * -9 //first extra line pushes atom name line up 10px, subsequent lines push it up 9px, \
+																								this offsets that and keeps the first line in the same place
 
 			if (screentips_enabled == SCREENTIP_PREFERENCE_CONTEXT_ONLY && extra_context == "")
 				active_hud.screentip_text.maptext = ""

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -2116,7 +2116,7 @@
 			var/shift_lmb_ctrl_shift_lmb_line = ""
 			var/extra_context = ""
 
-			if (isliving(user) || isovermind(user))
+			if (isliving(user) || isovermind(user) || isaicamera(user))
 				var/obj/item/held_item = user.get_active_held_item()
 
 				if ((flags_1 & HAS_CONTEXTUAL_SCREENTIPS_1) || (held_item?.item_flags & ITEM_HAS_CONTEXTUAL_SCREENTIPS))
@@ -2158,7 +2158,8 @@
 								shift_lmb_ctrl_shift_lmb_line += " | "
 							shift_lmb_ctrl_shift_lmb_line += "[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB]: [context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB]]"
 
-						extra_context = "<br><span style='font-size: 7px'>[lmb_rmb_line][ctrl_lmb_alt_lmb_line][shift_lmb_ctrl_shift_lmb_line]</span>"
+						if(lmb_rmb_line != "" || ctrl_lmb_alt_lmb_line != "" || shift_lmb_ctrl_shift_lmb_line != "")
+							extra_context = "<br><span style='font-size: 7px'>[lmb_rmb_line][ctrl_lmb_alt_lmb_line][shift_lmb_ctrl_shift_lmb_line]</span>"
 
 			if (screentips_enabled == SCREENTIP_PREFERENCE_CONTEXT_ONLY && extra_context == "")
 				active_hud.screentip_text.maptext = ""

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -2113,6 +2113,7 @@
 		else
 			var/lmb_rmb_line = ""
 			var/ctrl_lmb_alt_lmb_line = ""
+			var/shift_lmb_ctrl_shift_lmb_line = ""
 			var/extra_context = ""
 
 			if (isliving(user) || isovermind(user))
@@ -2147,7 +2148,17 @@
 								ctrl_lmb_alt_lmb_line += " | "
 							ctrl_lmb_alt_lmb_line += "[SCREENTIP_CONTEXT_ALT_LMB]: [context[SCREENTIP_CONTEXT_ALT_LMB]]"
 
-						extra_context = "<br><span style='font-size: 7px'>[lmb_rmb_line][ctrl_lmb_alt_lmb_line]</span>"
+						// Shift-LMB, Ctrl-Shift-LMB on one line...
+						if (ctrl_lmb_alt_lmb_line != "")
+							ctrl_lmb_alt_lmb_line += "<br>"
+						if (SCREENTIP_CONTEXT_SHIFT_LMB in context)
+							shift_lmb_ctrl_shift_lmb_line += "[SCREENTIP_CONTEXT_SHIFT_LMB]: [context[SCREENTIP_CONTEXT_SHIFT_LMB]]"
+						if (SCREENTIP_CONTEXT_CTRL_SHIFT_LMB in context)
+							if (shift_lmb_ctrl_shift_lmb_line != "")
+								shift_lmb_ctrl_shift_lmb_line += " | "
+							shift_lmb_ctrl_shift_lmb_line += "[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB]: [context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB]]"
+
+						extra_context = "<br><span style='font-size: 7px'>[lmb_rmb_line][ctrl_lmb_alt_lmb_line][shift_lmb_ctrl_shift_lmb_line]</span>"
 
 			if (screentips_enabled == SCREENTIP_PREFERENCE_CONTEXT_ONLY && extra_context == "")
 				active_hud.screentip_text.maptext = ""

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -630,7 +630,7 @@
 /obj/machinery/door/airlock/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 
-	if(isaicamera(user) || iscyborg(user))
+	if(isAI(user) || iscyborg(user))
 		if(!(machine_stat & BROKEN))
 			var/ui = SStgui.try_update_ui(user, src)
 			if(!ui && !held_item)
@@ -642,6 +642,9 @@
 			. = CONTEXTUAL_SCREENTIP_SET
 
 	if(!isliving(user))
+		return .
+
+	if(!Adjacent(user))
 		return .
 
 	switch (held_item?.tool_behaviour)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -630,6 +630,17 @@
 /obj/machinery/door/airlock/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 
+	if(isaicamera(user) || issilicon(user))
+		var/ui = SStgui.try_update_ui(user, src)
+		if(!ui)
+			context[SCREENTIP_CONTEXT_LMB] = "Open UI"
+		if(!(machine_stat & BROKEN))
+			context[SCREENTIP_CONTEXT_SHIFT_LMB] = density ? "Open" : "Close"
+			context[SCREENTIP_CONTEXT_CTRL_LMB] = locked ? "Unbolt" : "Bolt"
+			context[SCREENTIP_CONTEXT_ALT_LMB] = isElectrified() ? "Unelectrify" : "Electrify"
+			context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = emergency ? "Unset EA" : "Set EA"
+		return CONTEXTUAL_SCREENTIP_SET
+
 	if(!isliving(user))
 		return .
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -630,21 +630,24 @@
 /obj/machinery/door/airlock/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 
-	if(isaicamera(user) || issilicon(user))
-		var/ui = SStgui.try_update_ui(user, src)
-		if(!ui)
-			context[SCREENTIP_CONTEXT_LMB] = "Open UI"
+	if(isaicamera(user) || iscyborg(user))
 		if(!(machine_stat & BROKEN))
+			var/ui = SStgui.try_update_ui(user, src)
+			if(!ui)
+				context[SCREENTIP_CONTEXT_LMB] = "Open UI"
 			context[SCREENTIP_CONTEXT_SHIFT_LMB] = density ? "Open" : "Close"
 			context[SCREENTIP_CONTEXT_CTRL_LMB] = locked ? "Unbolt" : "Bolt"
 			context[SCREENTIP_CONTEXT_ALT_LMB] = isElectrified() ? "Unelectrify" : "Electrify"
 			context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = emergency ? "Unset emergency access" : "Set emergency access"
-		return CONTEXTUAL_SCREENTIP_SET
+			. = CONTEXTUAL_SCREENTIP_SET
 
 	if(!isliving(user))
 		return .
 
 	switch (held_item?.tool_behaviour)
+		if (TOOL_SCREWDRIVER)
+			context[SCREENTIP_CONTEXT_LMB] = panel_open ? "Close panel" : "Open panel"
+			return CONTEXTUAL_SCREENTIP_SET
 		if (TOOL_CROWBAR)
 			if (panel_open)
 				if (security_level == AIRLOCK_SECURITY_PLASTEEL_O_S || security_level == AIRLOCK_SECURITY_PLASTEEL_I_S)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -638,7 +638,7 @@
 			context[SCREENTIP_CONTEXT_SHIFT_LMB] = density ? "Open" : "Close"
 			context[SCREENTIP_CONTEXT_CTRL_LMB] = locked ? "Unbolt" : "Bolt"
 			context[SCREENTIP_CONTEXT_ALT_LMB] = isElectrified() ? "Unelectrify" : "Electrify"
-			context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = emergency ? "Unset EA" : "Set EA"
+			context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = emergency ? "Unset emergency access" : "Set emergency access"
 		return CONTEXTUAL_SCREENTIP_SET
 
 	if(!isliving(user))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -633,7 +633,7 @@
 	if(isaicamera(user) || iscyborg(user))
 		if(!(machine_stat & BROKEN))
 			var/ui = SStgui.try_update_ui(user, src)
-			if(!ui)
+			if(!ui && !held_item)
 				context[SCREENTIP_CONTEXT_LMB] = "Open UI"
 			context[SCREENTIP_CONTEXT_SHIFT_LMB] = density ? "Open" : "Close"
 			context[SCREENTIP_CONTEXT_CTRL_LMB] = locked ? "Unbolt" : "Bolt"

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -55,10 +55,10 @@
 /obj/machinery/door/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 
-	if(!isliving(user))
+	if(isaicamera(user) || issilicon(user))
 		return .
 
-	if (isnull(held_item))
+	if (isnull(held_item) && Adjacent(user))
 		context[SCREENTIP_CONTEXT_LMB] = "Open"
 		return CONTEXTUAL_SCREENTIP_SET
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Adds support for screen tips for cyborgs and AIs
- Adds support for screen tips for shift-click, alt-click and ctrl-shift-click interactions
- Adds screen tips for cyborgs and AI airlock interactions
- ⚠️Moves screen tips down a tile ⚠️ so they don't get cut off when you have more than two lines' worth
- Makes the "LMB: Open" door screen tip for living mobs only show when they're adjacent to them (I don't think I'm going to be the one to make it check for edge cases like TK)

https://user-images.githubusercontent.com/25089914/154612360-44242e99-b8c2-4993-a51f-50734cdee857.png
https://user-images.githubusercontent.com/25089914/154612366-aedeb88c-e919-441d-97bf-ae4b3fbbe470.png
https://user-images.githubusercontent.com/25089914/154614182-dff65c1e-5736-4546-83fb-c9c715ca932e.png
https://user-images.githubusercontent.com/25089914/154614187-7282ef45-4d14-4091-ab8e-c0cc3b2b1489.png

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Demystifies airlock hotkeys for newer silicon players (I know you can just examine but they don't know that)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Screen tips for cyborg and AI airlock hotkeys
qol: The "LMB: Open" screentip for doors will only show when adjacent (no, it doesn't factor in things like TK)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
