### PR TITLE
Fixes unwise else case in Spellbook UI, causing runtimes

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -795,6 +795,7 @@
 						entry.limit--
 					uses -= entry.cost
 			update_static_data(wizard) //update statics!
+			return
 		if("refund")
 			var/datum/spellbook_entry/entry = locate(params["spellref"]) in entries
 			if(entry?.refundable)
@@ -804,6 +805,7 @@
 						entry.limit += result
 					uses += result
 			update_static_data(wizard) //update statics!
+			return
 	//actions that are only available if you have full spell points
 	if(uses < initial(uses))
 		to_chat(wizard, span_warning("You need to have all your spell points to do this!"))
@@ -815,8 +817,8 @@
 		if("randomize")
 			randomize(wizard, full_random_bonus)
 			update_static_data(wizard) //update statics!
-		else //some loadout
-			wizard_loadout(wizard, action)
+		if("purchase_loadout")
+			wizard_loadout(wizard, locate(params["id"]))
 
 /obj/item/spellbook/proc/wizard_loadout(mob/living/carbon/human/wizard, loadout)
 	var/list/wanted_spell_names

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -794,8 +794,7 @@
 					if(entry.limit)
 						entry.limit--
 					uses -= entry.cost
-			update_static_data(wizard) //update statics!
-			return
+			return TRUE
 		if("refund")
 			var/datum/spellbook_entry/entry = locate(params["spellref"]) in entries
 			if(entry?.refundable)
@@ -804,8 +803,7 @@
 					if(!isnull(entry.limit))
 						entry.limit += result
 					uses += result
-			update_static_data(wizard) //update statics!
-			return
+			return TRUE
 	//actions that are only available if you have full spell points
 	if(uses < initial(uses))
 		to_chat(wizard, span_warning("You need to have all your spell points to do this!"))

--- a/tgui/packages/tgui/interfaces/Spellbook.js
+++ b/tgui/packages/tgui/interfaces/Spellbook.js
@@ -225,7 +225,9 @@ const SingleLoadout = (props, context) => {
           fluid
           icon={icon}
           content="Purchase Loadout"
-          onClick={() => act(loadoutId)} />
+          onClick={() => act('purchase_loadout', {
+            id: loadoutId,
+          })} />
         <Divider />
         <Box color={loadoutColor}>
           Added by {author}.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

With specific dextrous use of the spellbook you can both trigger "purchase" and the wizard loadout proc at the same time. Why? Because I am not smart and my backend has more holes in it than swiss cheese

## Why It's Good For The Game

Bugfix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes a weird bug with spellbooks that may have been locking some spell options when you did some specific actions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
