### PR TITLE
Fixes the inputs for the linear and exponential sustain settings of the song editor.

### DIFF
--- a/code/modules/instruments/songs/_song.dm
+++ b/code/modules/instruments/songs/_song.dm
@@ -370,7 +370,7 @@
  * Setter for setting linear falloff duration.
  */
 /datum/song/proc/set_linear_falloff_duration(duration)
-	sustain_linear_duration = clamp(round(duration * 10, world.tick_lag), 0.1, INSTRUMENT_MAX_TOTAL_SUSTAIN)
+	sustain_linear_duration = clamp(round(duration * 10, world.tick_lag), world.tick_lag, INSTRUMENT_MAX_TOTAL_SUSTAIN)
 	update_sustain()
 	updateDialog()
 

--- a/code/modules/instruments/songs/editor.dm
+++ b/code/modules/instruments/songs/editor.dm
@@ -185,12 +185,12 @@
 		stop_playing()
 
 	else if(href_list["setlinearfalloff"])
-		var/amount = tgui_input_number(usr, "Set linear sustain duration in seconds", "Linear Sustain Duration", 0.1, INSTRUMENT_MAX_TOTAL_SUSTAIN, 0.1)
+		var/amount = tgui_input_number(usr, "Set linear sustain duration in seconds", "Linear Sustain Duration", 0.1, INSTRUMENT_MAX_TOTAL_SUSTAIN, 0.1, round_value = FALSE)
 		if(!isnull(amount))
 			set_linear_falloff_duration(amount)
 
 	else if(href_list["setexpfalloff"])
-		var/amount = tgui_input_number(usr, "Set exponential sustain factor", "Exponential sustain factor", INSTRUMENT_EXP_FALLOFF_MIN, INSTRUMENT_EXP_FALLOFF_MAX,  INSTRUMENT_EXP_FALLOFF_MIN)
+		var/amount = tgui_input_number(usr, "Set exponential sustain factor", "Exponential sustain factor", INSTRUMENT_EXP_FALLOFF_MIN, INSTRUMENT_EXP_FALLOFF_MAX,  INSTRUMENT_EXP_FALLOFF_MIN, round_value = FALSE)
 		if(!isnull(amount))
 			set_exponential_drop_rate(amount)
 

--- a/code/modules/tgui/tgui_input_number.dm
+++ b/code/modules/tgui/tgui_input_number.dm
@@ -13,8 +13,9 @@
  * * max_value - Specifies a maximum value. If none is set, any number can be entered. Pressing "max" defaults to 1000.
  * * min_value - Specifies a minimum value. Often 0.
  * * timeout - The timeout of the number input, after which the modal will close and qdel itself. Set to zero for no timeout.
+ * * round_value - whether the inputted number is rounded down into an integer.
  */
-/proc/tgui_input_number(mob/user, message, title = "Number Input", default = 0, max_value = 10000, min_value = 0, timeout = 0)
+/proc/tgui_input_number(mob/user, message, title = "Number Input", default = 0, max_value = 10000, min_value = 0, timeout = 0, round_value = TRUE)
 	if (!user)
 		user = usr
 	if (!istype(user))
@@ -25,8 +26,9 @@
 			return
 	// Client does NOT have tgui_input on: Returns regular input
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
-		return clamp(round(input(user, message, title, default) as null|num), min_value, max_value)
-	var/datum/tgui_input_number/number_input = new(user, message, title, default, max_value, min_value, timeout)
+		var/input_number = input(user, message, title, default) as null|num
+		return clamp(round_value ? round(input_number) : input_number, min_value, max_value)
+	var/datum/tgui_input_number/number_input = new(user, message, title, default, max_value, min_value, timeout, round_value)
 	number_input.ui_interact(user)
 	number_input.wait()
 	if (number_input)
@@ -47,8 +49,9 @@
  * * min_value - Specifies a minimum value. Often 0.
  * * callback - The callback to be invoked when a choice is made.
  * * timeout - The timeout of the number input, after which the modal will close and qdel itself. Set to zero for no timeout.
+ * * round_value - whether the inputted number is rounded down into an integer.
  */
-/proc/tgui_input_number_async(mob/user, message, title = "Number Input", default = 0, max_value = 10000, min_value = 0, datum/callback/callback, timeout = 60 SECONDS)
+/proc/tgui_input_number_async(mob/user, message, title = "Number Input", default = 0, max_value = 10000, min_value = 0, datum/callback/callback, timeout = 60 SECONDS, round_value = TRUE)
 	if (!user)
 		user = usr
 	if (!istype(user))
@@ -59,8 +62,9 @@
 			return
 	// Client does NOT have tgui_input on: Returns regular input
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
-		return clamp(round(input(user, message, title, default) as null|num), min_value, max_value)
-	var/datum/tgui_input_number/async/number_input = new(user, message, title, default, max_value, min_value, callback, timeout)
+		var/input_number = input(user, message, title, default) as null|num
+		return clamp(round_value ? round(input_number) : input_number, min_value, max_value)
+	var/datum/tgui_input_number/async/number_input = new(user, message, title, default, max_value, min_value, callback, timeout, round_value)
 	number_input.ui_interact(user)
 
 /**
@@ -88,14 +92,17 @@
 	var/timeout
 	/// The title of the TGUI window
 	var/title
+	/// Whether the submitted number is rounded down into an integer.
+	var/round_value
 
 
-/datum/tgui_input_number/New(mob/user, message, title, default, max_value, min_value, timeout)
+/datum/tgui_input_number/New(mob/user, message, title, default, max_value, min_value, timeout, round_value)
 	src.default = default
 	src.max_value = max_value
 	src.message = message
 	src.min_value = min_value
 	src.title = title
+	src.round_value = round_value
 	if (timeout)
 		src.timeout = timeout
 		start_time = world.time
@@ -159,7 +166,7 @@
 		if("submit")
 			if(!isnum(params["entry"]))
 				CRASH("A non number was input into tgui input number by [usr]")
-			var/choice = round(params["entry"])
+			var/choice = round_value ? round(params["entry"]) : params["entry"]
 			if(choice > max_value)
 				CRASH("A number greater than the max value was input into tgui input number by [usr]")
 			if(choice < min_value)


### PR DESCRIPTION
## About The Pull Request
Fixes an issue that arose when the inputs for several settings of the song editor (instruments, basically) menu were changed to use TGUI.
Basically, the tgui numerical input always rounds down the submitted value to an integer in the current situation, and this messes up with the linear and exponential sustain settings of songs. To solve this problem I moved the round() call responsible of it behind a conditional operator tied to a new argument and variable called `round_value`.
Pretty straightforward stuff, the input will only be rounded down only if the arg is true now (which is by default, except for those two settings I talked about). This should fix the problem best.

## Why It's Good For The Game
This will fix #64992

## Changelog

:cl:
fix: Fixed the inputs for the linear and exponential sustain settings of the song editor (instruments UI).
/:cl:
