### PR TITLE
Fixes Area Turf Definition of The Courtroom on IceBoxStation

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -18155,7 +18155,7 @@
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
-/area/security/courtroom)
+/area/hallway/primary/fore)
 "gjg" = (
 /obj/structure/chair{
 	dir = 4
@@ -26221,7 +26221,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/iron,
-/area/security/courtroom)
+/area/hallway/primary/fore)
 "kdK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -86576,7 +86576,7 @@ iIk
 dZz
 aiX
 kdH
-ajn
+anz
 gjb
 eMl
 wCm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hello there,

I saw this thing:

![image](https://user-images.githubusercontent.com/34697715/154782108-f6b370a0-7ecb-4168-a73c-f65222d2a549.png)

So I had to fix it, like this:

![image](https://user-images.githubusercontent.com/34697715/154782112-23ffdb8a-3f0a-4965-9e0a-c6638e2dfe05.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Discrete areas should be kept discrete.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: On IceBoxStation, the courtroom no longer owns a bit of the hall.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
