### PR TITLE
Rework of how communication hotkeys are handled

### DIFF
--- a/code/datums/keybinding/communication.dm
+++ b/code/datums/keybinding/communication.dm
@@ -7,14 +7,35 @@
 	full_name = "IC Say"
 	keybind_signal = COMSIG_KB_CLIENT_SAY_DOWN
 
+/datum/keybinding/client/communication/say/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=say")
+	return TRUE
+
 /datum/keybinding/client/communication/ooc
 	hotkey_keys = list("O")
 	name = "OOC"
 	full_name = "Out Of Character Say (OOC)"
 	keybind_signal = COMSIG_KB_CLIENT_OOC_DOWN
 
+/datum/keybinding/client/communication/ooc/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=ooc")
+	return TRUE
+
 /datum/keybinding/client/communication/me
 	hotkey_keys = list("M")
 	name = "Me"
 	full_name = "Custom Emote (/Me)"
 	keybind_signal = COMSIG_KB_CLIENT_ME_DOWN
+
+/datum/keybinding/client/communication/me/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=me")
+	return TRUE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1017,12 +1017,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 					movement_keys[key] = WEST
 				if("South")
 					movement_keys[key] = SOUTH
-				if("Say")
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=say")
-				if("OOC")
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=ooc")
-				if("Me")
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=me")
 
 /client/proc/change_view(new_size)
 	if (isnull(new_size))


### PR DESCRIPTION
## About The Pull Request

This pull request reworks communication hotkeys a bit to make them more flexible and fix some bugs related to them

## Why It's Good For The Game

Now you don't need to relog into the game after rebinding the say, ooc or me hotkeys
This hotkeys now also works regardless of your keyboard layout (before you had to join the game with EN keyboard layout, otherwise your communication hotkeys won't work)
Future coder could change the behavior of this hotkeys without much digging into the nuances of the input system

(Not sure if I need to add a changelog for this)