### PR TITLE
Fix status displays hard-del'ing

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -127,7 +127,9 @@
 	if(overlay)
 		qdel(overlay)
 
-	return new/obj/effect/overlay/status_display_text(src, line_y, message)
+	var/obj/effect/overlay/status_display_text/new_status_display_text = new/obj/effect/overlay/status_display_text(line_y, message)
+	vis_contents += new_status_display_text
+	return new_status_display_text
 
 /obj/machinery/status_display/update_appearance(updates=ALL)
 	. = ..()
@@ -239,12 +241,10 @@
 	vis_flags = VIS_INHERIT_LAYER | VIS_INHERIT_PLANE | VIS_INHERIT_ID
 
 	var/message
-	var/obj/sd_parent
 
-/obj/effect/overlay/status_display_text/New(obj/parent, yoffset, line)
+/obj/effect/overlay/status_display_text/New(yoffset, line)
 	maptext_y = yoffset
 	message = line
-	sd_parent = parent
 
 	var/line_length = length_char(line)
 
@@ -268,12 +268,6 @@
 		// Centered text
 		maptext = generate_text(line, center = TRUE)
 		maptext_x = 0
-
-	parent.vis_contents += src
-
-/obj/effect/overlay/status_display_text/Destroy()
-	sd_parent.vis_contents -= src
-	return ..()
 
 /obj/effect/overlay/status_display_text/proc/generate_text(text, center)
 	return {"<div style="font-size:[FONT_SIZE];color:[FONT_COLOR];font:'[FONT_STYLE]'[center ? ";text-align:center" : ""]" valign="top">[text]</div>"}

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -127,7 +127,7 @@
 	if(overlay)
 		qdel(overlay)
 
-	var/obj/effect/overlay/status_display_text/new_status_display_text = new/obj/effect/overlay/status_display_text(line_y, message)
+	var/obj/effect/overlay/status_display_text/new_status_display_text = new(src, line_y, message)
 	vis_contents += new_status_display_text
 	return new_status_display_text
 
@@ -233,6 +233,10 @@
 	else
 		return "The display says:<br>\t<tt>Shuttle missing!</tt>"
 
+/obj/machinery/status_display/Destroy()
+	remove_messages()
+	return ..()
+
 /**
  * Nice overlay to make text smoothly scroll with no client updates after setup.
  */
@@ -242,7 +246,9 @@
 
 	var/message
 
-/obj/effect/overlay/status_display_text/New(yoffset, line)
+/obj/effect/overlay/status_display_text/Initialize(mapload, yoffset, line)
+	. = ..()
+
 	maptext_y = yoffset
 	message = line
 
@@ -251,16 +257,16 @@
 	if(line_length > CHARS_PER_LINE)
 		// Marquee text
 		var/marquee_message = "[line] • [line] • [line]"
-		var/marqee_length = line_length * 3 + 6
+		var/marquee_length = line_length * 3 + 6
 		maptext = generate_text(marquee_message, center = FALSE)
-		maptext_width = 6 * marqee_length
+		maptext_width = 6 * marquee_length
 		maptext_x = 32
 
 		// Mask off to fit in screen.
 		add_filter("mask", 1, alpha_mask_filter(icon = icon(icon, "outline")))
 
 		// Scroll.
-		var/width = 4 * marqee_length
+		var/width = 4 * marquee_length
 		var/time = (width + 32) * SCROLL_RATE
 		animate(src, maptext_x = -width, time = time, loop = -1)
 		animate(maptext_x = 32, time = 0)


### PR DESCRIPTION
`sd_parent` had a reference holding onto it, which was not nulled.

The only reason this existed was to `sd_parent.vis_contents -= src`.

`Destroy()` already does this with `vis_locs = null`, so I removed the variable entirely.

Not tested, this is a web edit moment.