### PR TITLE
Fixes a bug with the eldritch medallion

### DIFF
--- a/code/modules/antagonists/heretic/items/heretic_necks.dm
+++ b/code/modules/antagonists/heretic/items/heretic_necks.dm
@@ -23,9 +23,9 @@
 
 /obj/item/clothing/neck/eldritch_amulet/equipped(mob/user, slot)
 	. = ..()
-	if(!ishuman(user) || !user.mind)
+	if(slot != ITEM_SLOT_NECK)
 		return
-	if(!IS_HERETIC_OR_MONSTER(user))
+	if(!ishuman(user) || !IS_HERETIC_OR_MONSTER(user))
 		return
 
 	ADD_TRAIT(user, heretic_only_trait, "[CLOTHING_TRAIT] [REF(src)]")


### PR DESCRIPTION
## About The Pull Request

The Eldritch Amulet only gives you thermal vision when it's equipped in the neck.
Also re-arranges some of the checks for redundancy purposes. (mindless mobs wouldn't pass anyways)
I didn't check for the correct slot in equipped. Stupid mistake.


## Why It's Good For The Game

Free thermals guh

## Changelog

:cl: Melbert
fix: Eldritch Amulet no longer gives thermal vision when it shouldn't
/:cl:

