### PR TITLE
Makes non-dense mobs not knock monkeys over

### DIFF
--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -173,7 +173,7 @@ have ways of interacting with a specific mob and control it.
 /datum/ai_controller/monkey/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 	var/mob/living/living_pawn = pawn
-	if(!IS_DEAD_OR_INCAP(living_pawn) && isliving(arrived))
+	if(!IS_DEAD_OR_INCAP(living_pawn) && isliving(arrived) && arrived.density)
 		var/mob/living/in_the_way_mob = arrived
 		in_the_way_mob.knockOver(living_pawn)
 		return


### PR DESCRIPTION
## About The Pull Request

Monkeys only get knocked over when you walk over them (not even when you swap places with them, which I thought was supposed to be the case), this makes non-dense mobs not knock them over. Which means Revenants, bots, small animals (lizards/butterflies), larvas, ect. will not knock monkeys over.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/64071
Makes monkeys more consistent with what should/shouldnt knock them over.

## Changelog

:cl:
fix: Non-dense mobs will no longer knock monkeys over (Ex: Revenants, Bots, Lizards, Alien larvas).
/:cl: