### PR TITLE
improves meatspike code, makes it use default buckle

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -28,16 +28,15 @@
 
 /obj/structure/kitchenspike_frame/attackby(obj/item/attacking_item, mob/user, params)
 	add_fingerprint(user)
-	if(istype(attacking_item, /obj/item/stack/rods))
-		var/obj/item/stack/rods/used_rods = attacking_item
-		if(used_rods.get_amount() >= MEATSPIKE_IRONROD_REQUIREMENT)
-			used_rods.use(MEATSPIKE_IRONROD_REQUIREMENT)
-			to_chat(user, span_notice("You add spikes to the frame."))
-			var/obj/structure/new_meatspike = new /obj/structure/kitchenspike(loc)
-			transfer_fingerprints_to(new_meatspike)
-			qdel(src)
-			return
-	return ..()
+	if(!istype(attacking_item, /obj/item/stack/rods))
+		return ..()
+	var/obj/item/stack/rods/used_rods = attacking_item
+	if(used_rods.get_amount() >= MEATSPIKE_IRONROD_REQUIREMENT)
+		used_rods.use(MEATSPIKE_IRONROD_REQUIREMENT)
+		to_chat(user, span_notice("You add spikes to the frame."))
+		var/obj/structure/new_meatspike = new /obj/structure/kitchenspike(loc)
+		transfer_fingerprints_to(new_meatspike)
+		qdel(src)
 
 /obj/structure/kitchenspike
 	name = "meat spike"

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -64,7 +64,7 @@
 	return FALSE
 
 /obj/structure/kitchenspike/user_buckle_mob(mob/living/target, mob/user, check_loc = TRUE)
-	if(!iscarbon(target))
+	if(!iscarbon(target) && !isanimal_or_basicmob(target))
 		return
 	if(!do_mob(user, target, 10 SECONDS))
 		return

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -1,5 +1,4 @@
-//////Kitchen Spike
-#define VIABLE_MOB_CHECK(X) (isliving(X) && !issilicon(X) && !isbot(X))
+#define MEATSPIKE_IRONROD_REQUIREMENT 4
 
 /obj/structure/kitchenspike_frame
 	name = "meatspike frame"
@@ -10,31 +9,35 @@
 	anchored = FALSE
 	max_integrity = 200
 
-/obj/structure/kitchenspike_frame/attackby(obj/item/I, mob/user, params)
+/obj/structure/kitchenspike_frame/welder_act(mob/living/user, obj/item/tool)
+	if(!tool.tool_start_check(user, amount = 0))
+		return FALSE
+	to_chat(user, span_notice("You begin cutting \the [src] apart..."))
+	if(!tool.use_tool(src, user, 5 SECONDS, volume = 50))
+		return TRUE
+	visible_message(span_notice("[user] slices apart \the [src]."),
+		span_notice("You cut \the [src] apart with \the [tool]."),
+		span_hear("You hear welding."))
+	new /obj/item/stack/sheet/iron(loc, MEATSPIKE_IRONROD_REQUIREMENT)
+	qdel(src)
+	return TRUE
+
+/obj/structure/kitchenspike_frame/wrench_act(mob/living/user, obj/item/tool)
+	default_unfasten_wrench(user, tool)
+	return TRUE
+
+/obj/structure/kitchenspike_frame/attackby(obj/item/attacking_item, mob/user, params)
 	add_fingerprint(user)
-	if(default_unfasten_wrench(user, I))
-		return
-	else if(istype(I, /obj/item/stack/rods))
-		var/obj/item/stack/rods/R = I
-		if(R.get_amount() >= 4)
-			R.use(4)
+	if(istype(attacking_item, /obj/item/stack/rods))
+		var/obj/item/stack/rods/used_rods = attacking_item
+		if(used_rods.get_amount() >= MEATSPIKE_IRONROD_REQUIREMENT)
+			used_rods.use(MEATSPIKE_IRONROD_REQUIREMENT)
 			to_chat(user, span_notice("You add spikes to the frame."))
-			var/obj/F = new /obj/structure/kitchenspike(src.loc)
-			transfer_fingerprints_to(F)
+			var/obj/structure/new_meatspike = new /obj/structure/kitchenspike(loc)
+			transfer_fingerprints_to(new_meatspike)
 			qdel(src)
-	else if(I.tool_behaviour == TOOL_WELDER)
-		if(!I.tool_start_check(user, amount=0))
 			return
-		to_chat(user, span_notice("You begin cutting \the [src] apart..."))
-		if(I.use_tool(src, user, 50, volume=50))
-			visible_message(span_notice("[user] slices apart \the [src]."),
-				span_notice("You cut \the [src] apart with \the [I]."),
-				span_hear("You hear welding."))
-			new /obj/item/stack/sheet/iron(src.loc, 4)
-			qdel(src)
-		return
-	else
-		return ..()
+	return ..()
 
 /obj/structure/kitchenspike
 	name = "meat spike"
@@ -43,107 +46,80 @@
 	desc = "A spike for collecting meat from animals."
 	density = TRUE
 	anchored = TRUE
-	buckle_lying = 0
-	can_buckle = 1
+	buckle_lying = FALSE
+	can_buckle = TRUE
 	max_integrity = 250
 
 /obj/structure/kitchenspike/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)
 
-/obj/structure/kitchenspike/crowbar_act(mob/living/user, obj/item/I)
+/obj/structure/kitchenspike/crowbar_act(mob/living/user, obj/item/tool)
 	if(has_buckled_mobs())
 		to_chat(user, span_warning("You can't do that while something's on the spike!"))
 		return TRUE
 
-	if(I.use_tool(src, user, 20, volume=100))
+	if(tool.use_tool(src, user, 2 SECONDS, volume = 100))
 		to_chat(user, span_notice("You pry the spikes out of the frame."))
 		deconstruct(TRUE)
-	return TRUE
+		return TRUE
+	return FALSE
 
-//ATTACK HAND IGNORING PARENT RETURN VALUE
-/obj/structure/kitchenspike/attack_hand(mob/living/user, list/modifiers)
-	if(VIABLE_MOB_CHECK(user.pulling) && user.combat_mode && !has_buckled_mobs())
-		var/mob/living/L = user.pulling
-		if(do_mob(user, src, 120))
-			if(has_buckled_mobs()) //to prevent spam/queing up attacks
-				return
-			if(L.buckled)
-				return
-			if(user.pulling != L)
-				return
-			playsound(src.loc, 'sound/effects/splat.ogg', 25, TRUE)
-			L.visible_message(span_danger("[user] slams [L] onto the meat spike!"), span_userdanger("[user] slams you onto the meat spike!"), span_hear("You hear a squishy wet noise."))
-			L.forceMove(drop_location())
-			L.emote("scream")
-			L.add_splatter_floor()
-			L.adjustBruteLoss(30)
-			L.setDir(2)
-			buckle_mob(L, force=1)
-			var/matrix/m180 = matrix(L.transform)
-			m180.Turn(180)
-			animate(L, transform = m180, time = 3)
-			L.pixel_y = L.base_pixel_y + PIXEL_Y_OFFSET_LYING
-	else if (has_buckled_mobs())
-		for(var/mob/living/L in buckled_mobs)
-			user_unbuckle_mob(L, user)
-	else
-		..()
-
-
-
-/obj/structure/kitchenspike/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE) //Don't want them getting put on the rack other than by spiking
-	return
-
-/obj/structure/kitchenspike/user_unbuckle_mob(mob/living/buckled_mob, mob/living/carbon/human/user)
-	if(buckled_mob)
-		var/mob/living/M = buckled_mob
-		if(M != user)
-			M.visible_message(span_notice("[user] tries to pull [M] free of [src]!"),\
-				span_notice("[user] is trying to pull you off [src], opening up fresh wounds!"),\
-				span_hear("You hear a squishy wet noise."))
-			if(!do_after(user, 300, target = src))
-				if(M?.buckled)
-					M.visible_message(span_notice("[user] fails to free [M]!"),\
-					span_notice("[user] fails to pull you off of [src]."))
-				return
-
-		else
-			M.visible_message(span_warning("[M] struggles to break free from [src]!"),\
-			span_notice("You struggle to break free from [src], exacerbating your wounds! (Stay still for two minutes.)"),\
-			span_hear("You hear a wet squishing noise.."))
-			M.adjustBruteLoss(30)
-			if(!do_after(M, 1200, target = src))
-				if(M?.buckled)
-					to_chat(M, span_warning("You fail to free yourself!"))
-				return
-		if(!M.buckled)
-			return
-		release_mob(M)
-
-/obj/structure/kitchenspike/proc/release_mob(mob/living/M)
-	var/matrix/m180 = matrix(M.transform)
-	m180.Turn(180)
-	animate(M, transform = m180, time = 3)
-	M.pixel_y = M.base_pixel_y + PIXEL_Y_OFFSET_LYING
-	M.adjustBruteLoss(30)
-	src.visible_message(span_danger("[M] falls free of [src]!"))
-	unbuckle_mob(M,force=1)
-	INVOKE_ASYNC(M, /mob/proc/emote, "scream")
-	M.AdjustParalyzed(20)
-
-/obj/structure/kitchenspike/Destroy()
-	if(has_buckled_mobs())
-		for(var/mob/living/spiked_lad as anything in buckled_mobs)
-			release_mob(spiked_lad)
+/obj/structure/kitchenspike/user_buckle_mob(mob/living/target, mob/user, check_loc = TRUE)
+	if(!iscarbon(target))
+		return
+	if(!do_mob(user, target, 10 SECONDS))
+		return
 	return ..()
+
+/obj/structure/kitchenspike/post_buckle_mob(mob/living/target)
+	playsound(src.loc, 'sound/effects/splat.ogg', 25, TRUE)
+	target.emote("scream")
+	target.add_splatter_floor()
+	target.adjustBruteLoss(30)
+	target.setDir(2)
+	var/matrix/m180 = matrix(target.transform)
+	m180.Turn(180)
+	animate(target, transform = m180, time = 3)
+	target.pixel_y = target.base_pixel_y + PIXEL_Y_OFFSET_LYING
+
+/obj/structure/kitchenspike/user_unbuckle_mob(mob/living/buckled_mob, mob/user)
+	if(buckled_mob != user)
+		buckled_mob.visible_message(span_notice("[user] tries to pull [buckled_mob] free of [src]!"),\
+			span_notice("[user] is trying to pull you off [src], opening up fresh wounds!"),\
+			span_hear("You hear a squishy wet noise."))
+		if(!do_after(user, 30 SECONDS, target = src))
+			if(buckled_mob?.buckled)
+				buckled_mob.visible_message(span_notice("[user] fails to free [buckled_mob]!"),\
+					span_notice("[user] fails to pull you off of [src]."))
+			return
+
+	else
+		buckled_mob.visible_message(span_warning("[buckled_mob] struggles to break free from [src]!"),\
+		span_notice("You struggle to break free from [src], exacerbating your wounds! (Stay still for two minutes.)"),\
+		span_hear("You hear a wet squishing noise.."))
+		buckled_mob.adjustBruteLoss(30)
+		if(!do_after(buckled_mob, 2 MINUTES, target = src))
+			if(buckled_mob?.buckled)
+				to_chat(buckled_mob, span_warning("You fail to free yourself!"))
+			return
+	return ..()
+
+/obj/structure/kitchenspike/post_unbuckle_mob(mob/living/buckled_mob)
+	buckled_mob.adjustBruteLoss(30)
+	INVOKE_ASYNC(buckled_mob, /mob/proc/emote, "scream")
+	buckled_mob.AdjustParalyzed(20)
+	var/matrix/m180 = matrix(buckled_mob.transform)
+	m180.Turn(180)
+	animate(buckled_mob, transform = m180, time = 3)
+	buckled_mob.pixel_y = buckled_mob.base_pixel_y + PIXEL_Y_OFFSET_LYING
 
 /obj/structure/kitchenspike/deconstruct(disassembled = TRUE)
 	if(disassembled)
-		var/obj/F = new /obj/structure/kitchenspike_frame(src.loc)
-		transfer_fingerprints_to(F)
+		var/obj/structure/meatspike_frame = new /obj/structure/kitchenspike_frame(src.loc)
+		transfer_fingerprints_to(meatspike_frame)
 	else
 		new /obj/item/stack/sheet/iron(src.loc, 4)
-	new /obj/item/stack/rods(loc, 4)
+	new /obj/item/stack/rods(loc, MEATSPIKE_IRONROD_REQUIREMENT)
 	qdel(src)
 
-#undef VIABLE_MOB_CHECK
+#undef MEATSPIKE_IRONROD_REQUIREMENT


### PR DESCRIPTION
## About The Pull Request

- You now buckle people onto meatspikes by click + dragging people onto the meatspike, rather than clicking on it with an empty hand.
- Removes the dumb "is not silicon" check with a regular "carbon/simplemob/basicmob" one.
- Also general code improvement because I didn't like how it was previously.

## Why It's Good For The Game

short answer: better consistency
longer answer: Meatspikes are way too confusing to use because they just use snowflake code compared to every other structure that you can buckle mobs onto, I don't see why this should be any different than say, a guillotine. No reason for this to be any special other than to just confuse chefs on how the hell they are supposed to get people on it.

For those unaware, to buckle someone onto a meatspike you need:
1. Have someone (A living mob that isn't a bot or Silicon) aggro grabbed
2. be on combat mode (???)
3. Click on the spike with an empty hand, then wait 12 seconds

## Changelog

:cl:
qol: You can now buckle people onto meatspikes the same way you buckle people onto anything else.
/:cl: