### PR TITLE
Fixes pandemic bluescreen

### DIFF
--- a/tgui/packages/tgui/interfaces/Pandemic.tsx
+++ b/tgui/packages/tgui/interfaces/Pandemic.tsx
@@ -1,3 +1,4 @@
+import { BooleanLike } from '../../common/react';
 import { useBackend, useSharedState } from '../backend';
 import { Box, Button, Collapsible, Input, LabeledList, NoticeBox, ProgressBar, Section, Stack, Tabs, Tooltip } from '../components';
 import { Window } from '../layouts';
@@ -5,9 +6,9 @@ import { Window } from '../layouts';
 type PandemicContext = {
   beaker?: Beaker;
   blood?: Blood;
-  has_beaker: number;
-  has_blood: number;
-  is_ready: number;
+  has_beaker: BooleanLike;
+  has_blood: BooleanLike;
+  is_ready: BooleanLike;
   resistances?: Resistance[];
   viruses?: Virus[];
 };
@@ -29,9 +30,9 @@ type Resistance = {
 
 type Virus = {
   name: string;
-  can_rename: number;
-  is_adv: number;
-  symptoms: Symptom[];
+  can_rename: BooleanLike;
+  is_adv: BooleanLike;
+  symptoms?: Symptom[];
   resistance: number;
   stealth: number;
   stage_speed: number;
@@ -64,7 +65,7 @@ type Symptom = {
   stage_speed: number;
   transmission: number;
   level: number;
-  neutered: number;
+  neutered: BooleanLike;
   threshold_desc: Threshold[];
 };
 
@@ -242,13 +243,13 @@ const SpecimenDisplay = (_, context) => {
   const { act, data } = useBackend<PandemicContext>(context);
   const [tab, setTab] = useSharedState(context, 'tab', 0);
   const { is_ready, viruses = [] } = data;
-  if (!viruses?.length) {
-    return <NoticeBox>No viruses detected</NoticeBox>;
-  }
   const virus = viruses[tab];
   const setTabHandler = (index: number) => {
     setTab(index);
   };
+  if (!viruses?.length || !virus) {
+    return <NoticeBox>Nothing detected.</NoticeBox>;
+  }
 
   return (
     <Section
@@ -280,7 +281,7 @@ const SpecimenDisplay = (_, context) => {
           <VirusDisplay virus={virus} />
         </Stack.Item>
         <Stack.Item>
-          {virus.symptoms
+          {virus?.symptoms
           && <SymptomDisplay symptoms={virus.symptoms} />}
         </Stack.Item>
       </Stack>
@@ -295,9 +296,6 @@ const VirusTabs = (props: TabsProps, context) => {
   const { data } = useBackend<PandemicContext>(context);
   const { tab, tabHandler } = props;
   const { viruses = [] } = data;
-  if (!viruses) {
-    return <NoticeBox>No viruses detected</NoticeBox>;
-  }
 
   return (
     <Tabs>
@@ -350,7 +348,7 @@ const VirusTextInfo = (props: VirusInfoProps, context) => {
           <Input
             placeholder="Input a name"
             value={virus.name === 'Unknown' ? '' : virus.name}
-            onChange={(e, value) =>
+            onChange={(_, value) =>
               act('rename_disease', {
                 index: virus.index,
                 name: value,
@@ -418,7 +416,7 @@ const VirusTraitInfo = (props: VirusInfoProps) => {
  */
 const SymptomDisplay = (props: SymptomDisplayProps) => {
   const { symptoms = [] } = props;
-  if (!symptoms.length) {
+  if (!symptoms || !symptoms.length) {
     return <NoticeBox>No symptoms detected.</NoticeBox>;
   }
 

--- a/tgui/packages/tgui/interfaces/Pandemic.tsx
+++ b/tgui/packages/tgui/interfaces/Pandemic.tsx
@@ -1,5 +1,5 @@
 import { BooleanLike } from '../../common/react';
-import { useBackend, useSharedState } from '../backend';
+import { useBackend, useLocalState } from '../backend';
 import { Box, Button, Collapsible, Input, LabeledList, NoticeBox, ProgressBar, Section, Stack, Tabs, Tooltip } from '../components';
 import { Window } from '../layouts';
 
@@ -241,7 +241,7 @@ const AntibodyInfoDisplay = (_, context) => {
 /** Displays info for the loaded blood, if any */
 const SpecimenDisplay = (_, context) => {
   const { act, data } = useBackend<PandemicContext>(context);
-  const [tab, setTab] = useSharedState(context, 'tab', 0);
+  const [tab, setTab] = useLocalState(context, 'tab', 0);
   const { is_ready, viruses = [] } = data;
   const virus = viruses[tab];
   const setTabHandler = (index: number) => {


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
[GBP No Update please]
Adds more checks onto the Pandemic & removes the use of usesharedstate (literally just saved the tab)

In jlsnow301's great and infinite wisdom he did not predict a situation where a viro would actually cure a second virus then look back into the machine (the sharedstate would be null)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes
Fixes #65028
Fixes #65047
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes a blue screen in the Pandemic from loading multiple viruses.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
