### PR TITLE
Fixes ghosts not reliably bobbing when they should be bobbing

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -771,8 +771,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STABILIZED_LIGHT_PINK_TRAIT "stabilized_light_pink"
 /// Given by the multiple_lives component to the previous body of the mob upon death.
 #define EXPIRED_LIFE_TRAIT "expired_life"
-/// Trait given to a ghost when they orbit something.
-#define GHOST_ORBITING_TRAIT "ghost_orbiting"
+/// Trait given to an atom/movable when they orbit something.
+#define ORBITING_TRAIT "orbiting"
 
 /**
 * Trait granted by [/mob/living/carbon/Initialize] and

--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -69,6 +69,8 @@
 			orbiter.orbiting.end_orbit(orbiter)
 	orbiter_list[orbiter] = TRUE
 	orbiter.orbiting = src
+
+	ADD_TRAIT(orbiter, TRAIT_NO_FLOATING_ANIM, ORBITING_TRAIT)
 	RegisterSignal(orbiter, COMSIG_MOVABLE_MOVED, .proc/orbiter_move_react)
 
 	SEND_SIGNAL(parent, COMSIG_ATOM_ORBIT_BEGIN, orbiter)
@@ -117,6 +119,8 @@
 		var/mob/orbiter_mob = orbiter
 		orbiter_mob.updating_glide_size = TRUE
 		orbiter_mob.glide_size = 8
+
+	REMOVE_TRAIT(orbiter, TRAIT_NO_FLOATING_ANIM, ORBITING_TRAIT)
 
 	if(!refreshing && !length(orbiter_list) && !QDELING(src))
 		qdel(src)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -493,14 +493,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 /mob/dead/observer/orbit()
 	setDir(2)//reset dir so the right directional sprites show up
-	ADD_TRAIT(src, TRAIT_NO_FLOATING_ANIM, GHOST_ORBITING_TRAIT)
 	return ..()
 
 /mob/dead/observer/stop_orbit(datum/component/orbiter/orbits)
 	. = ..()
 	//restart our floating animation after orbit is done.
 	pixel_y = base_pixel_y
-	REMOVE_TRAIT(src, TRAIT_NO_FLOATING_ANIM, GHOST_ORBITING_TRAIT)
 
 /mob/dead/observer/verb/jumptomob() //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"


### PR DESCRIPTION
## About The Pull Request

Fixes #65011.

Basically, I didn't think that, when orbiting different things in a row without breaking the orbit by, like, moving around, it wouldn't call `orbit()` on the ghost. I thus moved all the logic of adding the `TRAIT_NO_FLOATING_ANIM` to the orbiter component instead, and that made it all work flawlessly.

## Why It's Good For The Game
No more weird orbit issues where you're stuck going around in a circle when you shouldn't be going around in a circle.

## Changelog

:cl: GoldenAlpharex
fix: Ghosts are 100% less afraid of bobbing up and down, and will no longer keep their orbit when they shouldn't be keeping it.
/:cl: