### PR TITLE
Adds proper item stack support to heretic transmutation + gives some generally better feedback for certain failed transmutations

### DIFF
--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -124,7 +124,7 @@
 		if(isliving(sacrificed))
 			continue
 
-		if(istype(sacrificed, /obj/item/stack))
+		if(isstack(sacrificed))
 			var/obj/item/stack/sac_stack = sacrificed
 			var/how_much_to_use = 0
 			for(var/requirement in required_atoms)

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -124,6 +124,17 @@
 		if(isliving(sacrificed))
 			continue
 
+		if(istype(sacrificed, /obj/item/stack))
+			var/obj/item/stack/sac_stack = sacrificed
+			var/how_much_to_use = 0
+			for(var/requirement in required_atoms)
+				if(istype(sacrificed, requirement))
+					how_much_to_use = required_atoms[requirement]
+					break
+
+			sac_stack.use(how_much_to_use)
+			continue
+
 		selected_atoms -= sacrificed
 		qdel(sacrificed)
 
@@ -205,7 +216,7 @@
 			compiled_list[human_to_check.real_name] = human_to_check
 
 	if(!length(compiled_list))
-		loc.balloon_alert(user, "no fingerprints!")
+		loc.balloon_alert(user, "ritual failed, no fingerprints!")
 		return FALSE
 
 	var/chosen_mob = tgui_input_list(user, "Select the person you wish to curse", "Eldritch Curse", sort_list(compiled_list, /proc/cmp_mob_realname_dsc))
@@ -214,7 +225,7 @@
 
 	var/mob/living/carbon/human/to_curse = compiled_list[chosen_mob]
 	if(QDELETED(to_curse))
-		loc.balloon_alert(user, "invalid choice!")
+		loc.balloon_alert(user, "ritual failed, invalid choice!")
 		return FALSE
 
 	log_combat(user, to_curse, "cursed via heretic ritual", addition = "([name])")

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -164,6 +164,7 @@
 /datum/heretic_knowledge/limited_amount/flesh_ghoul/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	var/mob/living/carbon/human/soon_to_be_ghoul = locate() in selected_atoms
 	if(QDELETED(soon_to_be_ghoul)) // No body? No ritual
+		stack_trace("[type] reached on_finished_recipe without a human in selected_atoms to make a ghoul out of.")
 		return FALSE
 
 	soon_to_be_ghoul.grab_ghost()

--- a/code/modules/antagonists/heretic/knowledge/general_side.dm
+++ b/code/modules/antagonists/heretic/knowledge/general_side.dm
@@ -36,6 +36,7 @@
 		CRASH("Heretic datum didn't have a hunt_and_sacrifice knowledge learned, what?")
 
 	if(!target_finder.obtain_targets(user))
+		loc.balloon_alert("ritual failed, no targets!")
 		return FALSE
 
 	return TRUE
@@ -55,10 +56,3 @@
 	result_atoms = list(/obj/item/codex_cicatrix)
 	cost = 1
 	route = PATH_SIDE
-
-/datum/heretic_knowledge/codex_cicatrix/cleanup_atoms(list/selected_atoms)
-	var/obj/item/stack/sheet/animalhide/hide = locate() in selected_atoms
-	if(hide)
-		selected_atoms -= hide
-		hide.use(1)
-	return ..()

--- a/code/modules/antagonists/heretic/knowledge/general_side.dm
+++ b/code/modules/antagonists/heretic/knowledge/general_side.dm
@@ -36,7 +36,7 @@
 		CRASH("Heretic datum didn't have a hunt_and_sacrifice knowledge learned, what?")
 
 	if(!target_finder.obtain_targets(user))
-		loc.balloon_alert("ritual failed, no targets!")
+		loc.balloon_alert(user, "ritual failed, no targets!")
 		return FALSE
 
 	return TRUE

--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -155,10 +155,3 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	result_atoms = list(/obj/item/clothing/neck/heretic_focus)
 	cost = 0
 	route = PATH_START
-
-/datum/heretic_knowledge/amber_focus/cleanup_atoms(list/selected_atoms)
-	var/obj/item/stack/sheet/glass/sheets = locate() in selected_atoms
-	if(sheets)
-		selected_atoms -= sheets
-		sheets.use(1)
-	return ..()

--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -1,9 +1,9 @@
-
+/// The heretic's rune, which they use to complete transmutation rituals.
 /obj/effect/heretic_rune
-	name = "Generic rune"
+	name = "transmutation rune"
 	desc = "A flowing circle of shapes and runes is etched into the floor, filled with a thick black tar-like fluid."
-	anchored = TRUE
 	icon_state = ""
+	anchored = TRUE
 	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	layer = SIGIL_LAYER
@@ -64,8 +64,8 @@
 	if(!length(knowledge_list))
 		CRASH("[type] do_rituals called without any passed knowledge!")
 
+	// Collect all nearby valid atoms over the rune for processing in rituals.
 	var/list/atom/movable/atoms_in_range = list()
-
 	for(var/atom/close_atom as anything in range(1, src))
 		if(!ismovable(close_atom))
 			continue
@@ -76,6 +76,7 @@
 
 		atoms_in_range += close_atom
 
+	// Now let's go through all of our knowledge and try to do some magic.
 	for(var/datum/heretic_knowledge/knowledge as anything in knowledge_list)
 
 		// It's not a ritual, we don't care.
@@ -103,11 +104,17 @@
 				if(!istype(nearby_atom, req_type))
 					continue
 
-				// This item is a valid type.
-				// Add it to our selected atoms list
-				// and decrement the value of our requirements list
+				// This item is a valid type. Add it to our selected atoms list.
 				selected_atoms |= nearby_atom
-				requirements_list[req_type]--
+				// If it's a stack, we gotta see if it has more than one inside,
+				// as our requirements may want more than one item of a stack
+				if(istype(nearby_atom, /obj/item/stack))
+					var/obj/item/stack/picked_stack = nearby_atom
+					requirements_list[req_type] -= picked_stack.amount // Can go negative, but doesn't matter. Negative = fulfilled
+
+				// Otherwise, just add the mark down the item as fulfilled x1
+				else
+					requirements_list[req_type]--
 
 		// All of the atoms have been checked, let's see if the ritual was successful
 		var/requirements_fulfilled = TRUE
@@ -120,36 +127,53 @@
 			requirements_fulfilled = FALSE
 			break
 
+		// We didn't find enough for this ritual. Move onto the next one
 		if(!requirements_fulfilled)
 			continue
 
-		// If we made it here, the ritual succeeded
-		// Do the animations and feedback
+		// If we made it here, the ritual had all necessary components, and we can try to cast it.
+		// This doesn't necessarily mean the ritual will succeed, but it's valid!
+		// Do the animations and associated feedback.
 		flick("[icon_state]_active", src)
 		playsound(user, 'sound/magic/castsummon.ogg', 75, TRUE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_exponent = 10)
 
-		// We temporarily make all of our chosen atoms invisible,
-		// as some rituals may sleep, and we don't want people
-		// to be able to run off with ritual items.
+		// - We temporarily make all of our chosen atoms invisible, as some rituals may sleep,
+		// and we don't want people to be able to run off with ritual items.
+		// - We make a duplicate list here to ensure that all atoms are correctly un-invisibled by the end.
+		// Some rituals may remove atoms from the selected_atoms list, and not consume them.
+		var/list/initial_selected_atoms = selected_atoms.Copy()
 		for(var/atom/to_disappear as anything in selected_atoms)
 			to_disappear.invisibility = INVISIBILITY_ABSTRACT
 
-		// on_finished_recipe may sleep in the case of some rituals like summons.
-		if(knowledge.on_finished_recipe(user, selected_atoms, loc))
+		// All the components have been invisibled, time to actually do the ritual. Call on_finished_recipe
+		// (Note: on_finished_recipe may sleep in the case of some rituals like summons, which expect ghost candidates.)
+		// - If the ritual was success (Returned TRUE), proceede to clean up the atoms involved in the ritual. The result has already been spawned by this point.
+		// - If the ritual failed for some reason (Returned FALSE), likely due to no ghosts taking a role or an error, we shouldn't clean up anything, and reset.
+		var/ritual_result = knowledge.on_finished_recipe(user, selected_atoms, loc)
+		if(ritual_result)
 			knowledge.cleanup_atoms(selected_atoms)
 
-		// Re-appear anything left in the list
-		for(var/atom/to_appear as anything in selected_atoms)
+		// Clean up done, re-appear anything that hasn't been deleted.
+		for(var/atom/to_appear as anything in initial_selected_atoms)
+			if(QDELETED(to_appear))
+				continue
 			to_appear.invisibility = initial(to_appear.invisibility)
 
-		loc.balloon_alert(user, "ritual complete")
-		return TRUE
+		// And finally, give some user feedback
+		// No feedback is given on failure here -
+		// the ritual itself should handle it (providing specifics as to why it failed)
+		if(ritual_result)
+			loc.balloon_alert(user, "ritual complete")
 
+		return ritual_result
+
+	// General "fail" case. Only reached if we looped through all knowledges researched and not a single one had all components necessary.
+	// (Note: if a ritual fails despite having all components necessary, it will not be handled here - instead, it will above, see "ritual_result".)
 	loc.balloon_alert(user, "ritual failed!")
 	return FALSE
 
+/// A 3x3 heretic rune. The kind heretics actually draw in game.
 /obj/effect/heretic_rune/big
-	name = "transmutation rune"
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "eldritch_rune1"
 	pixel_x = -32 //So the big ol' 96x96 sprite shows up right

--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -108,7 +108,7 @@
 				selected_atoms |= nearby_atom
 				// If it's a stack, we gotta see if it has more than one inside,
 				// as our requirements may want more than one item of a stack
-				if(istype(nearby_atom, /obj/item/stack))
+				if(isstack(nearby_atom))
 					var/obj/item/stack/picked_stack = nearby_atom
 					requirements_list[req_type] -= picked_stack.amount // Can go negative, but doesn't matter. Negative = fulfilled
 


### PR DESCRIPTION
## About The Pull Request

- Adds proper stack support to heretic items instead of hard-coding it in two spots. 
- Adds some generally better feedback for some failed heretic rituals
- Fixes some weird bugs with heretic rituals vanishing stuff. 
- Adds some better documentation to the ritual and rune stuff, and moves some of the ritual vars up a level. 

## Why It's Good For The Game

I wanted to clean up the rituals a bit post-merge, so yeah, here. 
Also fixes some bugs in the process and improves documentation. 

## Changelog

:cl: Melbert
fix: Fixes a few potential issues with heretic rituals.
code: Adds proper stack support to heretic rituals. Also allows for more specific "ritual failure" feedback. 
/:cl:

