### PR TITLE
Fixes two typos in heretic logging

### DIFF
--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -378,7 +378,7 @@
 		total_points += knowledge.cost
 
 	log_heretic_knowledge("[key_name(user)] gained knowledge of their final ritual at [worldtime2text()]. \
-		They have [length(heretic_datum)] knowledge nodes researched, totalling [total_points] points \
+		They have [length(heretic_datum.researched_knowledge)] knowledge nodes researched, totalling [total_points] points \
 		and have sacrificed [heretic_datum.total_sacrifices] people ([heretic_datum.high_value_sacrifices] of which were high value)")
 
 /datum/heretic_knowledge/final/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -106,7 +106,7 @@
 
 	LAZYADD(created_items, WEAKREF(human_target))
 	log_game("[key_name(source)] created a ghoul, controlled by [key_name(human_target)].")
-	message_admins("[ADMIN_LOOKUPFLW(source)] created a ghuol, [ADMIN_LOOKUPFLW(human_target)].")
+	message_admins("[ADMIN_LOOKUPFLW(source)] created a ghoul, [ADMIN_LOOKUPFLW(human_target)].")
 
 	RegisterSignal(human_target, COMSIG_LIVING_DEATH, .proc/remove_ghoul)
 	human_target.revive(full_heal = TRUE, admin_revive = TRUE)


### PR DESCRIPTION
## About The Pull Request

- Final knowledge log was intended to print all knowledge know, only printed 0. Oops.
- Ghuol -> ghoul

## Why It's Good For The Game

Clear logs!

## Changelog

:cl: Melbert
admin: Fixes some heretic logs. Final knowledge uplink log should be clearer, and ghoul admin message no longer has a typo. 
/:cl:
