### PR TITLE
Fixes Sentient Diseases INSTANTLY FUCKING DYING if someone with a different disease walks on the same screen as you right after you pick your host and spawn. Fuck virology code, holy shit.

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -99,6 +99,8 @@
 			if(totalTransmittable() > competition.totalResistance())
 				if(!istype(competition, /datum/disease/advance/sentient_disease)) // I FUCKING SPAWNED, 30 SECONDS LATER IT WAS OVER, BECAUSE OF THIS FUCKING CODE
 					competition.cure(FALSE)
+				else
+					return FALSE // FUCK THIS MECHANIC
 			else
 				return FALSE //we are not strong enough to bully our way in
 	infect(infectee, make_copy)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -97,7 +97,8 @@
 		for(var/i in 1 to replace_num)
 			var/datum/disease/advance/competition = advance_diseases[i]
 			if(totalTransmittable() > competition.totalResistance())
-				competition.cure(FALSE)
+				if(!istype(competition, /datum/disease/advance/sentient_disease)) // I FUCKING SPAWNED, 30 SECONDS LATER IT WAS OVER, BECAUSE OF THIS FUCKING CODE
+					competition.cure(FALSE)
 			else
 				return FALSE //we are not strong enough to bully our way in
 	infect(infectee, make_copy)


### PR DESCRIPTION
## About The Pull Request

Sentient Diseases no longer INSTANTLY FUCKING DIE if someone with a different disease walks on the same screen as you right after you pick your host and spawn. Fuck virology code, holy shit.

I hope whoever thought this was a good idea never gets a job in the games industry.

## Why It's Good For The Game

If you don't understand why this is good you haven't had a once in a year antag roll killed 30 seconds after spawn by fucking virology code.

## Changelog

:cl:
fix: Sentient Diseases no longer INSTANTLY FUCKING DIE if someone with a different disease walks on the same screen as you right after you pick your host and spawn. Fuck virology code, holy shit.
/:cl:
