### PR TITLE
Deletes useless/wrong info about esniffer's desc

### DIFF
--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -75,9 +75,8 @@
 
 /obj/machinery/ecto_sniffer/examine(mob/user)
 	. = ..()
-	. += span_notice("Any active ghost can leave a layer of ectoplasm on the ectoscopic sniffer, causing a small, audible blip. They may use this \
-	to communicate that they wish to enter the world as a positronic personality, to trigger a signaller assembly attached to the device, or a myraid \
-	of other possible use cases.")
+	. += span_notice("Any active ghost can leave a layer of ectoplasm on the ectoscopic sniffer, causing a small, audible blip, \
+	indicating they wish to enter the world as a positronic personality.")
 
 ///Removes the ghost from the ectoplasmic_residues list and lets them know they are free to activate the sniffer again.
 /obj/machinery/ecto_sniffer/proc/clear_residue(ghost_ckey)


### PR DESCRIPTION
## About The Pull Request

Just states that the esniffer is used to show that ghosts want posibrains.

## Why It's Good For The Game

Ghosts don't send the signal in the sniffer, and what are such "possible use cases"? We want this to be used to make borgs, not metagame (I hope), so trying to encourage that is... eh...

## Changelog

:cl:
spellcheck: Removed wrong text in esniffers saying ghosts using them sends the signaller inside of it's, frequency.
/:cl:
