### PR TITLE
Dehardcodes SSmapping

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -166,7 +166,7 @@ require only minor tweaks.
 #define BIOME_HIGH_HUMIDITY "high_humidity"
 
 // Bluespace shelter deploy checks for survival capsules
-/// Shelter spot is allowed 
+/// Shelter spot is allowed
 #define SHELTER_DEPLOY_ALLOWED "allowed"
 /// Shelter spot has turfs that restrict deployment
 #define SHELTER_DEPLOY_BAD_TURFS "bad turfs"
@@ -174,5 +174,15 @@ require only minor tweaks.
 #define SHELTER_DEPLOY_BAD_AREA "bad area"
 /// Shelter spot has anchored objects that restrict deployment
 #define SHELTER_DEPLOY_ANCHORED_OBJECTS "anchored objects"
-/// Shelter spot is out of bounds from the maps x/y coordinates 
+/// Shelter spot is out of bounds from the maps x/y coordinates
 #define SHELTER_DEPLOY_OUTSIDE_MAP "outside map"
+
+//Ruin types
+///Space ruin
+#define RUIN_TYPE_SPACE "space_ruin"
+///Lava ruin
+#define RUIN_TYPE_LAVA "lava_ruin"
+///Ice ruin
+#define RUIN_TYPE_ICE "ice_ruin"
+///Underground ice ruin
+#define RUIN_TYPE_ICE_UNDERGROUND "underground_ice_ruin"

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -176,13 +176,3 @@ require only minor tweaks.
 #define SHELTER_DEPLOY_ANCHORED_OBJECTS "anchored objects"
 /// Shelter spot is out of bounds from the maps x/y coordinates
 #define SHELTER_DEPLOY_OUTSIDE_MAP "outside map"
-
-//Ruin types
-///Space ruin
-#define RUIN_TYPE_SPACE "space_ruin"
-///Lava ruin
-#define RUIN_TYPE_LAVA "lava_ruin"
-///Ice ruin
-#define RUIN_TYPE_ICE "ice_ruin"
-///Underground ice ruin
-#define RUIN_TYPE_ICE_UNDERGROUND "underground_ice_ruin"

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -14,10 +14,9 @@ SUBSYSTEM_DEF(mapping)
 	var/list/map_templates = list()
 
 	var/list/ruins_templates = list()
-	var/list/space_ruins_templates = list()
-	var/list/lava_ruins_templates = list()
-	var/list/ice_ruins_templates = list()
-	var/list/ice_ruins_underground_templates = list()
+
+	///List of ruins, separated by their theme
+	var/list/themed_ruins = list()
 
 	var/datum/space_level/isolated_ruins_z //Created on demand during ruin loading.
 
@@ -91,32 +90,10 @@ SUBSYSTEM_DEF(mapping)
 		load_new_z_level("_maps/RandomZLevels/VR/vrhub.dmm", "Virtual Reality Hub")
 		to_chat(world, span_boldannounce("Virtual reality loaded."))
 
-	// Generate mining ruins
 	loading_ruins = TRUE
-	var/list/lava_ruins = levels_by_trait(ZTRAIT_LAVA_RUINS)
-	if (lava_ruins.len)
-		seedRuins(lava_ruins, CONFIG_GET(number/lavaland_budget), list(/area/lavaland/surface/outdoors/unexplored), lava_ruins_templates)
-		for (var/lava_z in lava_ruins)
-			spawn_rivers(lava_z)
-
-	var/list/ice_ruins = levels_by_trait(ZTRAIT_ICE_RUINS)
-	if (ice_ruins.len)
-		// needs to be whitelisted for underground too so place_below ruins work
-		seedRuins(ice_ruins, CONFIG_GET(number/icemoon_budget), list(/area/icemoon/surface/outdoors/unexplored, /area/icemoon/underground/unexplored), ice_ruins_templates)
-		for (var/ice_z in ice_ruins)
-			spawn_rivers(ice_z, 4, /turf/open/openspace/icemoon, /area/icemoon/surface/outdoors/unexplored/rivers)
-
-	var/list/ice_ruins_underground = levels_by_trait(ZTRAIT_ICE_RUINS_UNDERGROUND)
-	if (ice_ruins_underground.len)
-		seedRuins(ice_ruins_underground, CONFIG_GET(number/icemoon_budget), list(/area/icemoon/underground/unexplored), ice_ruins_underground_templates)
-		for (var/ice_z in ice_ruins_underground)
-			spawn_rivers(ice_z, 4, level_trait(ice_z, ZTRAIT_BASETURF), /area/icemoon/underground/unexplored/rivers)
-
-	// Generate deep space ruins
-	var/list/space_ruins = levels_by_trait(ZTRAIT_SPACE_RUINS)
-	if (space_ruins.len)
-		seedRuins(space_ruins, CONFIG_GET(number/space_budget), list(/area/space), space_ruins_templates)
+	setup_ruins()
 	loading_ruins = FALSE
+
 #endif
 	// Run map generation after ruin generation to prevent issues
 	run_map_generation()
@@ -129,6 +106,37 @@ SUBSYSTEM_DEF(mapping)
 	initialize_reserved_level(transit.z_value)
 	SSticker.OnRoundstart(CALLBACK(src, .proc/spawn_maintenance_loot))
 	return ..()
+
+/**
+ * ##setup_ruins
+ *
+ * Sets up all of the ruins to be spawned
+ */
+/datum/controller/subsystem/mapping/proc/setup_ruins()
+	// Generate mining ruins
+	var/list/lava_ruins = levels_by_trait(ZTRAIT_LAVA_RUINS)
+	if (lava_ruins.len)
+		seedRuins(lava_ruins, CONFIG_GET(number/lavaland_budget), list(/area/lavaland/surface/outdoors/unexplored), themed_ruins[RUIN_TYPE_LAVA])
+		for (var/lava_z in lava_ruins)
+			spawn_rivers(lava_z)
+
+	var/list/ice_ruins = levels_by_trait(ZTRAIT_ICE_RUINS)
+	if (ice_ruins.len)
+		// needs to be whitelisted for underground too so place_below ruins work
+		seedRuins(ice_ruins, CONFIG_GET(number/icemoon_budget), list(/area/icemoon/surface/outdoors/unexplored, /area/icemoon/underground/unexplored), themed_ruins[RUIN_TYPE_ICE])
+		for (var/ice_z in ice_ruins)
+			spawn_rivers(ice_z, 4, /turf/open/openspace/icemoon, /area/icemoon/surface/outdoors/unexplored/rivers)
+
+	var/list/ice_ruins_underground = levels_by_trait(ZTRAIT_ICE_RUINS_UNDERGROUND)
+	if (ice_ruins_underground.len)
+		seedRuins(ice_ruins_underground, CONFIG_GET(number/icemoon_budget), list(/area/icemoon/underground/unexplored), themed_ruins[RUIN_TYPE_ICE_UNDERGROUND])
+		for (var/ice_z in ice_ruins_underground)
+			spawn_rivers(ice_z, 4, level_trait(ice_z, ZTRAIT_BASETURF), /area/icemoon/underground/unexplored/rivers)
+
+	// Generate deep space ruins
+	var/list/space_ruins = levels_by_trait(ZTRAIT_SPACE_RUINS)
+	if (space_ruins.len)
+		seedRuins(space_ruins, CONFIG_GET(number/space_budget), list(/area/space), themed_ruins[RUIN_TYPE_SPACE])
 
 /datum/controller/subsystem/mapping/proc/wipe_reservations(wipe_safety_delay = 100)
 	if(clearing_reserved_turfs || !initialized) //in either case this is just not needed.
@@ -185,10 +193,10 @@ Used by the AI doomsday and the self-destruct nuke.
 	initialized = SSmapping.initialized
 	map_templates = SSmapping.map_templates
 	ruins_templates = SSmapping.ruins_templates
-	space_ruins_templates = SSmapping.space_ruins_templates
-	lava_ruins_templates = SSmapping.lava_ruins_templates
-	ice_ruins_templates = SSmapping.ice_ruins_templates
-	ice_ruins_underground_templates = SSmapping.ice_ruins_underground_templates
+	themed_ruins[RUIN_TYPE_SPACE] = SSmapping.themed_ruins[RUIN_TYPE_SPACE]
+	themed_ruins[RUIN_TYPE_LAVA] = SSmapping.themed_ruins[RUIN_TYPE_LAVA]
+	themed_ruins[RUIN_TYPE_ICE] = SSmapping.themed_ruins[RUIN_TYPE_ICE]
+	themed_ruins[RUIN_TYPE_ICE_UNDERGROUND] = SSmapping.themed_ruins[RUIN_TYPE_ICE_UNDERGROUND]
 	shuttle_templates = SSmapping.shuttle_templates
 	shelter_templates = SSmapping.shelter_templates
 	unused_turfs = SSmapping.unused_turfs
@@ -428,14 +436,9 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		map_templates[R.name] = R
 		ruins_templates[R.name] = R
 
-		if(istype(R, /datum/map_template/ruin/lavaland))
-			lava_ruins_templates[R.name] = R
-		else if(istype(R, /datum/map_template/ruin/icemoon/underground))
-			ice_ruins_underground_templates[R.name] = R
-		else if(istype(R, /datum/map_template/ruin/icemoon))
-			ice_ruins_templates[R.name] = R
-		else if(istype(R, /datum/map_template/ruin/space))
-			space_ruins_templates[R.name] = R
+		if (!(R.ruin_type in themed_ruins))
+			themed_ruins[R.ruin_type] = list()
+		themed_ruins[R.ruin_type] |= list(R.name = R)
 
 /datum/controller/subsystem/mapping/proc/preloadShuttleTemplates()
 	var/list/unbuyable = generateMapList("unbuyableshuttles.txt")

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -438,7 +438,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 
 		if (!(R.ruin_type in themed_ruins))
 			themed_ruins[R.ruin_type] = list()
-		themed_ruins[R.ruin_type] |= list(R.name = R)
+		themed_ruins[R.ruin_type][R.name] = R
 
 /datum/controller/subsystem/mapping/proc/preloadShuttleTemplates()
 	var/list/unbuyable = generateMapList("unbuyableshuttles.txt")

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -116,27 +116,27 @@ SUBSYSTEM_DEF(mapping)
 	// Generate mining ruins
 	var/list/lava_ruins = levels_by_trait(ZTRAIT_LAVA_RUINS)
 	if (lava_ruins.len)
-		seedRuins(lava_ruins, CONFIG_GET(number/lavaland_budget), list(/area/lavaland/surface/outdoors/unexplored), themed_ruins[RUIN_TYPE_LAVA])
+		seedRuins(lava_ruins, CONFIG_GET(number/lavaland_budget), list(/area/lavaland/surface/outdoors/unexplored), themed_ruins[ZTRAIT_LAVA_RUINS])
 		for (var/lava_z in lava_ruins)
 			spawn_rivers(lava_z)
 
 	var/list/ice_ruins = levels_by_trait(ZTRAIT_ICE_RUINS)
 	if (ice_ruins.len)
 		// needs to be whitelisted for underground too so place_below ruins work
-		seedRuins(ice_ruins, CONFIG_GET(number/icemoon_budget), list(/area/icemoon/surface/outdoors/unexplored, /area/icemoon/underground/unexplored), themed_ruins[RUIN_TYPE_ICE])
+		seedRuins(ice_ruins, CONFIG_GET(number/icemoon_budget), list(/area/icemoon/surface/outdoors/unexplored, /area/icemoon/underground/unexplored), themed_ruins[ZTRAIT_ICE_RUINS])
 		for (var/ice_z in ice_ruins)
 			spawn_rivers(ice_z, 4, /turf/open/openspace/icemoon, /area/icemoon/surface/outdoors/unexplored/rivers)
 
 	var/list/ice_ruins_underground = levels_by_trait(ZTRAIT_ICE_RUINS_UNDERGROUND)
 	if (ice_ruins_underground.len)
-		seedRuins(ice_ruins_underground, CONFIG_GET(number/icemoon_budget), list(/area/icemoon/underground/unexplored), themed_ruins[RUIN_TYPE_ICE_UNDERGROUND])
+		seedRuins(ice_ruins_underground, CONFIG_GET(number/icemoon_budget), list(/area/icemoon/underground/unexplored), themed_ruins[ZTRAIT_ICE_RUINS_UNDERGROUND])
 		for (var/ice_z in ice_ruins_underground)
 			spawn_rivers(ice_z, 4, level_trait(ice_z, ZTRAIT_BASETURF), /area/icemoon/underground/unexplored/rivers)
 
 	// Generate deep space ruins
 	var/list/space_ruins = levels_by_trait(ZTRAIT_SPACE_RUINS)
 	if (space_ruins.len)
-		seedRuins(space_ruins, CONFIG_GET(number/space_budget), list(/area/space), themed_ruins[RUIN_TYPE_SPACE])
+		seedRuins(space_ruins, CONFIG_GET(number/space_budget), list(/area/space), themed_ruins[ZTRAIT_SPACE_RUINS])
 
 /datum/controller/subsystem/mapping/proc/wipe_reservations(wipe_safety_delay = 100)
 	if(clearing_reserved_turfs || !initialized) //in either case this is just not needed.

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -193,10 +193,10 @@ Used by the AI doomsday and the self-destruct nuke.
 	initialized = SSmapping.initialized
 	map_templates = SSmapping.map_templates
 	ruins_templates = SSmapping.ruins_templates
-	themed_ruins[RUIN_TYPE_SPACE] = SSmapping.themed_ruins[RUIN_TYPE_SPACE]
-	themed_ruins[RUIN_TYPE_LAVA] = SSmapping.themed_ruins[RUIN_TYPE_LAVA]
-	themed_ruins[RUIN_TYPE_ICE] = SSmapping.themed_ruins[RUIN_TYPE_ICE]
-	themed_ruins[RUIN_TYPE_ICE_UNDERGROUND] = SSmapping.themed_ruins[RUIN_TYPE_ICE_UNDERGROUND]
+
+	for (var/theme in SSmapping.themed_ruins)
+		themed_ruins[theme] = SSmapping.themed_ruins[theme]
+
 	shuttle_templates = SSmapping.shuttle_templates
 	shelter_templates = SSmapping.shelter_templates
 	unused_turfs = SSmapping.unused_turfs

--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -17,6 +17,8 @@
 	var/prefix = null
 	var/suffix = null
 
+	var/ruin_type = null
+
 /datum/map_template/ruin/New()
 	if(!name && id)
 		name = id

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -4,7 +4,8 @@
 	prefix = "_maps/RandomRuins/IceRuins/"
 	allow_duplicates = FALSE
 	cost = 5
-	ruin_type = RUIN_TYPE_ICE
+	ruin_type = ZTRAIT_ICE_RUINS
+	default_area = /area/icemoon/surface/outdoors/unexplored
 
 // above ground only
 
@@ -72,7 +73,8 @@
 
 /datum/map_template/ruin/icemoon/underground
 	name = "underground ruin"
-	ruin_type = RUIN_TYPE_ICE_UNDERGROUND
+	ruin_type = ZTRAIT_ICE_RUINS_UNDERGROUND
+	default_area = /area/icemoon/underground/unexplored
 
 /datum/map_template/ruin/icemoon/underground/abandonedvillage
 	name = "Abandoned Village"

--- a/code/datums/ruins/icemoon.dm
+++ b/code/datums/ruins/icemoon.dm
@@ -4,6 +4,7 @@
 	prefix = "_maps/RandomRuins/IceRuins/"
 	allow_duplicates = FALSE
 	cost = 5
+	ruin_type = RUIN_TYPE_ICE
 
 // above ground only
 
@@ -71,6 +72,7 @@
 
 /datum/map_template/ruin/icemoon/underground
 	name = "underground ruin"
+	ruin_type = RUIN_TYPE_ICE_UNDERGROUND
 
 /datum/map_template/ruin/icemoon/underground/abandonedvillage
 	name = "Abandoned Village"

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -1,6 +1,7 @@
 // Hey! Listen! Update \config\lavaruinblacklist.txt with your new ruins!
 
 /datum/map_template/ruin/lavaland
+	ruin_type = RUIN_TYPE_LAVA
 	prefix = "_maps/RandomRuins/LavaRuins/"
 
 /datum/map_template/ruin/lavaland/biodome

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -1,8 +1,9 @@
 // Hey! Listen! Update \config\lavaruinblacklist.txt with your new ruins!
 
 /datum/map_template/ruin/lavaland
-	ruin_type = RUIN_TYPE_LAVA
+	ruin_type = ZTRAIT_LAVA_RUINS
 	prefix = "_maps/RandomRuins/LavaRuins/"
+	default_area = /area/lavaland/surface/outdoors/unexplored
 
 /datum/map_template/ruin/lavaland/biodome
 	cost = 5

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -4,7 +4,8 @@
 	prefix = "_maps/RandomRuins/SpaceRuins/"
 	cost = 1
 	allow_duplicates = FALSE
-	ruin_type = RUIN_TYPE_SPACE
+	ruin_type = ZTRAIT_SPACE_RUINS
+	default_area = /area/space
 
 /datum/map_template/ruin/space/zoo
 	id = "zoo"

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -4,6 +4,7 @@
 	prefix = "_maps/RandomRuins/SpaceRuins/"
 	cost = 1
 	allow_duplicates = FALSE
+	ruin_type = RUIN_TYPE_SPACE
 
 /datum/map_template/ruin/space/zoo
 	id = "zoo"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -655,17 +655,17 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 
 	var/list/names = list()
 	names += "---- Space Ruins ----"
-	for(var/name in SSmapping.space_ruins_templates)
-		names[name] = list(SSmapping.space_ruins_templates[name], ZTRAIT_SPACE_RUINS, list(/area/space))
+	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_SPACE])
+		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_SPACE][name], ZTRAIT_SPACE_RUINS, list(/area/space))
 	names += "---- Lava Ruins ----"
-	for(var/name in SSmapping.lava_ruins_templates)
-		names[name] = list(SSmapping.lava_ruins_templates[name], ZTRAIT_LAVA_RUINS, list(/area/lavaland/surface/outdoors/unexplored))
+	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_SPACE])
+		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_LAVA][name], ZTRAIT_LAVA_RUINS, list(/area/lavaland/surface/outdoors/unexplored))
 	names += "---- Ice Ruins ----"
-	for(var/name in SSmapping.ice_ruins_templates)
-		names[name] = list(SSmapping.ice_ruins_templates[name], ZTRAIT_ICE_RUINS, list(/area/icemoon/surface/outdoors/unexplored, /area/icemoon/underground/unexplored))
+	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_ICE])
+		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_ICE][name], ZTRAIT_ICE_RUINS, list(/area/icemoon/surface/outdoors/unexplored, /area/icemoon/underground/unexplored))
 	names += "---- Ice Underground Ruins ----"
-	for(var/name in SSmapping.ice_ruins_underground_templates)
-		names[name] = list(SSmapping.ice_ruins_underground_templates[name], ZTRAIT_ICE_RUINS_UNDERGROUND, list(/area/icemoon/underground/unexplored))
+	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_ICE_UNDERGROUND])
+		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_ICE_UNDERGROUND][name], ZTRAIT_ICE_RUINS_UNDERGROUND, list(/area/icemoon/underground/unexplored))
 
 	var/ruinname = input("Select ruin", "Spawn Ruin") as null|anything in sort_list(names)
 	var/data = names[ruinname]

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -654,18 +654,12 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		exists[L.ruin_template] = landmark
 
 	var/list/names = list()
-	names += "---- Space Ruins ----"
-	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_SPACE])
-		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_SPACE][name], ZTRAIT_SPACE_RUINS, list(/area/space))
-	names += "---- Lava Ruins ----"
-	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_SPACE])
-		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_LAVA][name], ZTRAIT_LAVA_RUINS, list(/area/lavaland/surface/outdoors/unexplored))
-	names += "---- Ice Ruins ----"
-	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_ICE])
-		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_ICE][name], ZTRAIT_ICE_RUINS, list(/area/icemoon/surface/outdoors/unexplored, /area/icemoon/underground/unexplored))
-	names += "---- Ice Underground Ruins ----"
-	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_ICE_UNDERGROUND])
-		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_ICE_UNDERGROUND][name], ZTRAIT_ICE_RUINS_UNDERGROUND, list(/area/icemoon/underground/unexplored))
+	for (var/theme in SSmapping.themed_ruins)
+		names += "---- [theme] ----"
+		for (var/name in SSmapping.themed_ruins[theme])
+			var/datum/map_template/ruin/ruin = SSmapping.themed_ruins[theme][name]
+			names[name] = list(ruin, theme, list(ruin.default_area))
+
 
 	var/ruinname = input("Select ruin", "Spawn Ruin") as null|anything in sort_list(names)
 	var/data = names[ruinname]

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -654,10 +654,18 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		exists[L.ruin_template] = landmark
 
 	var/list/names = list()
-	for(var/theme in SSmapping.themed_ruins)
-		names += "---- [theme] ----"
-		for(var/name in SSmapping.themed_ruins[theme])
-			names[name] = list(SSmapping.themed_ruins[theme][name], ZTRAIT_SPACE_RUINS, list(/area/space))
+	names += "---- Space Ruins ----"
+	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_SPACE])
+		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_SPACE][name], ZTRAIT_SPACE_RUINS, list(/area/space))
+	names += "---- Lava Ruins ----"
+	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_SPACE])
+		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_LAVA][name], ZTRAIT_LAVA_RUINS, list(/area/lavaland/surface/outdoors/unexplored))
+	names += "---- Ice Ruins ----"
+	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_ICE])
+		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_ICE][name], ZTRAIT_ICE_RUINS, list(/area/icemoon/surface/outdoors/unexplored, /area/icemoon/underground/unexplored))
+	names += "---- Ice Underground Ruins ----"
+	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_ICE_UNDERGROUND])
+		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_ICE_UNDERGROUND][name], ZTRAIT_ICE_RUINS_UNDERGROUND, list(/area/icemoon/underground/unexplored))
 
 	var/ruinname = input("Select ruin", "Spawn Ruin") as null|anything in sort_list(names)
 	var/data = names[ruinname]

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -654,18 +654,10 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		exists[L.ruin_template] = landmark
 
 	var/list/names = list()
-	names += "---- Space Ruins ----"
-	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_SPACE])
-		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_SPACE][name], ZTRAIT_SPACE_RUINS, list(/area/space))
-	names += "---- Lava Ruins ----"
-	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_SPACE])
-		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_LAVA][name], ZTRAIT_LAVA_RUINS, list(/area/lavaland/surface/outdoors/unexplored))
-	names += "---- Ice Ruins ----"
-	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_ICE])
-		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_ICE][name], ZTRAIT_ICE_RUINS, list(/area/icemoon/surface/outdoors/unexplored, /area/icemoon/underground/unexplored))
-	names += "---- Ice Underground Ruins ----"
-	for(var/name in SSmapping.themed_ruins[RUIN_TYPE_ICE_UNDERGROUND])
-		names[name] = list(SSmapping.themed_ruins[RUIN_TYPE_ICE_UNDERGROUND][name], ZTRAIT_ICE_RUINS_UNDERGROUND, list(/area/icemoon/underground/unexplored))
+	for(var/theme in SSmapping.themed_ruins)
+		names += "---- [theme] ----"
+		for(var/name in SSmapping.themed_ruins[theme])
+			names[name] = list(SSmapping.themed_ruins[theme][name], ZTRAIT_SPACE_RUINS, list(/area/space))
 
 	var/ruinname = input("Select ruin", "Spawn Ruin") as null|anything in sort_list(names)
 	var/data = names[ruinname]

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -8,6 +8,9 @@
 	var/keep_cached_map = FALSE
 	var/station_id = null // used to override the root id when generating
 
+	///Default area associated with the map template
+	var/default_area
+
 	///if true, turfs loaded from this template are placed on top of the turfs already there, defaults to TRUE
 	var/should_place_on_top = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Essentially SSmapping had a list for each theme of ruin (space, lava,
ice, ice underground). These were all filled with an if statement
checking the ruin templates type. Now, i've given ruins a `ruin_type` var, which is then used to dynamically add to a single list of ruins, which separates lists of ruins by ruin type.
Good for downstreams who may have more ruin types

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Dehardcoded SSmapping ruin types.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
