### PR TITLE
Restores old monkey knockdowns (monkey nerf)

### DIFF
--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -75,7 +75,6 @@ have ways of interacting with a specific mob and control it.
 		COMSIG_ATOM_ATTACK_ANIMAL,
 		COMSIG_MOB_ATTACK_ALIEN,
 	))
-	qdel(GetComponent(/datum/component/connect_loc_behalf))
 
 	return ..() //Run parent at end
 

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -183,7 +183,7 @@ have ways of interacting with a specific mob and control it.
 /datum/ai_controller/monkey/proc/on_crossed(datum/source, atom/movable/crossed)
 	SIGNAL_HANDLER
 	var/mob/living/living_pawn = pawn
-	if(!IS_DEAD_OR_INCAP(living_pawn) && isliving(crossed) && crossed.density)
+	if(!IS_DEAD_OR_INCAP(living_pawn) && isliving(crossed))
 		var/mob/living/in_the_way_mob = crossed
 		in_the_way_mob.knockOver(living_pawn)
 		return

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -27,9 +27,6 @@ have ways of interacting with a specific mob and control it.
 		BB_MONKEY_GUN_WORKED = TRUE,
 		BB_SONG_LINES = MONKEY_SONG,
 	)
-	var/static/list/loc_connections = list(
-		COMSIG_ATOM_ENTERED = .proc/on_entered,
-	)
 	idle_behavior = /datum/idle_behavior/idle_monkey
 
 /datum/ai_controller/monkey/angry
@@ -45,6 +42,7 @@ have ways of interacting with a specific mob and control it.
 		return AI_CONTROLLER_INCOMPATIBLE
 
 	var/mob/living/living_pawn = new_pawn
+	RegisterSignal(new_pawn, COMSIG_MOVABLE_CROSS, .proc/on_crossed)
 	RegisterSignal(new_pawn, COMSIG_PARENT_ATTACKBY, .proc/on_attackby)
 	RegisterSignal(new_pawn, COMSIG_ATOM_ATTACK_HAND, .proc/on_attack_hand)
 	RegisterSignal(new_pawn, COMSIG_ATOM_ATTACK_PAW, .proc/on_attack_paw)
@@ -58,13 +56,25 @@ have ways of interacting with a specific mob and control it.
 	RegisterSignal(new_pawn, COMSIG_CARBON_CUFF_ATTEMPTED, .proc/on_attempt_cuff)
 	RegisterSignal(new_pawn, COMSIG_MOB_MOVESPEED_UPDATED, .proc/update_movespeed)
 
-	AddComponent(/datum/component/connect_loc_behalf, new_pawn, loc_connections)
 	movement_delay = living_pawn.cached_multiplicative_slowdown
 	return ..() //Run parent at end
 
 /datum/ai_controller/monkey/UnpossessPawn(destroy)
-	UnregisterSignal(pawn, list(COMSIG_PARENT_ATTACKBY, COMSIG_ATOM_ATTACK_HAND, COMSIG_ATOM_ATTACK_PAW, COMSIG_ATOM_BULLET_ACT, COMSIG_ATOM_HITBY, COMSIG_LIVING_START_PULL,\
-	COMSIG_LIVING_TRY_SYRINGE, COMSIG_ATOM_HULK_ATTACK, COMSIG_CARBON_CUFF_ATTEMPTED, COMSIG_MOB_MOVESPEED_UPDATED, COMSIG_ATOM_ATTACK_ANIMAL, COMSIG_MOB_ATTACK_ALIEN))
+	UnregisterSignal(pawn, list(
+		COMSIG_MOVABLE_CROSS,
+		COMSIG_PARENT_ATTACKBY,
+		COMSIG_ATOM_ATTACK_HAND,
+		COMSIG_ATOM_ATTACK_PAW,
+		COMSIG_ATOM_BULLET_ACT,
+		COMSIG_ATOM_HITBY,
+		COMSIG_LIVING_START_PULL,
+		COMSIG_LIVING_TRY_SYRINGE,
+		COMSIG_ATOM_HULK_ATTACK,
+		COMSIG_CARBON_CUFF_ATTEMPTED,
+		COMSIG_MOB_MOVESPEED_UPDATED,
+		COMSIG_ATOM_ATTACK_ANIMAL,
+		COMSIG_MOB_ATTACK_ALIEN,
+	))
 	qdel(GetComponent(/datum/component/connect_loc_behalf))
 
 	return ..() //Run parent at end
@@ -72,11 +82,11 @@ have ways of interacting with a specific mob and control it.
 // Stops sentient monkeys from being knocked over like weak dunces.
 /datum/ai_controller/monkey/on_sentience_gained()
 	. = ..()
-	qdel(GetComponent(/datum/component/connect_loc_behalf))
+	UnregisterSignal(pawn, COMSIG_MOVABLE_CROSS)
 
 /datum/ai_controller/monkey/on_sentience_lost()
 	. = ..()
-	AddComponent(/datum/component/connect_loc_behalf, pawn, loc_connections)
+	RegisterSignal(pawn, COMSIG_MOVABLE_CROSS, .proc/on_crossed)
 
 /datum/ai_controller/monkey/able_to_run()
 	. = ..()
@@ -170,11 +180,11 @@ have ways of interacting with a specific mob and control it.
 			var/mob/living/carbon/human/H = thrown_by
 			retaliate(H)
 
-/datum/ai_controller/monkey/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+/datum/ai_controller/monkey/proc/on_crossed(datum/source, atom/movable/crossed)
 	SIGNAL_HANDLER
 	var/mob/living/living_pawn = pawn
-	if(!IS_DEAD_OR_INCAP(living_pawn) && isliving(arrived) && arrived.density)
-		var/mob/living/in_the_way_mob = arrived
+	if(!IS_DEAD_OR_INCAP(living_pawn) && isliving(crossed) && crossed.density)
+		var/mob/living/in_the_way_mob = crossed
 		in_the_way_mob.knockOver(living_pawn)
 		return
 

--- a/code/game/objects/structures/industrial_lift.dm
+++ b/code/game/objects/structures/industrial_lift.dm
@@ -190,7 +190,7 @@ GLOBAL_LIST_EMPTY(lifts)
 	if(!(potential_rider in lift_load))
 		return
 	if(isliving(potential_rider) && HAS_TRAIT(potential_rider, TRAIT_CANNOT_BE_UNBUCKLED))
-		REMOVE_TRAIT(potential_rider, TRAIT_CANNOT_BE_UNBUCKLED, BUCKLED_TRAIT)		
+		REMOVE_TRAIT(potential_rider, TRAIT_CANNOT_BE_UNBUCKLED, BUCKLED_TRAIT)
 	LAZYREMOVE(lift_load, potential_rider)
 	UnregisterSignal(potential_rider, COMSIG_PARENT_QDELETING)
 
@@ -201,7 +201,7 @@ GLOBAL_LIST_EMPTY(lifts)
 	if(AM in lift_load)
 		return
 	if(isliving(AM) && !HAS_TRAIT(AM, TRAIT_CANNOT_BE_UNBUCKLED))
-		ADD_TRAIT(AM, TRAIT_CANNOT_BE_UNBUCKLED, BUCKLED_TRAIT)		
+		ADD_TRAIT(AM, TRAIT_CANNOT_BE_UNBUCKLED, BUCKLED_TRAIT)
 	LAZYADD(lift_load, AM)
 	RegisterSignal(AM, COMSIG_PARENT_QDELETING, .proc/RemoveItemFromLift)
 
@@ -240,7 +240,7 @@ GLOBAL_LIST_EMPTY(lifts)
 		destination = get_step_multiz(src, going)
 	else
 		destination = going
-	///handles any special interactions objects could have with the lift/tram, handled on the item itself	
+	///handles any special interactions objects could have with the lift/tram, handled on the item itself
 	SEND_SIGNAL(destination, COMSIG_TURF_INDUSTRIAL_LIFT_ENTER, things_to_move)
 
 	if(istype(destination, /turf/closed/wall))


### PR DESCRIPTION
## About The Pull Request

Monkey knockdown used to be on Crossed until it was made an AI here: https://github.com/tgstation/tgstation/pull/55238

Now it instead uses COMSIG_ATOM_ENTERED, which only takes into account walking over the monkey. Something that you can't do unless you are non-dense or they are lying on the floor, in which case you aren't even knocking them down?
Now it uses COMSIG_MOVABLE_CROSS instead so it's how it used to be, actually functional and useful.

## Why It's Good For The Game

Restores a lost feature to counter monkeys, knocking them over.

## Changelog

:cl:
fix: you can knock monkeys over by crossing them again.
/:cl: