### PR TITLE
Removes AI shells from being printable.

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -886,16 +886,6 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
-/datum/design/boris_ai_controller
-	name = "B.O.R.I.S. AI-Cyborg Remote Control"
-	id = "borg_ai_control"
-	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/ai
-	materials = list(/datum/material/iron = 1200, /datum/material/glass = 1500, /datum/material/gold = 200)
-	construction_time = 50
-	category = list("Control Interfaces")
-	search_metadata = "boris"
-
 /datum/design/borg_upgrade_rped
 	name = "Cyborg Upgrade (RPED)"
 	id = "borg_upgrade_rped"


### PR DESCRIPTION
What fucking genius decided the AI needs to be able to corpse rush people with cyborgs? I thought we didn't let AI mains make PRs anymore. Jesus christ, this is the stupidest fucking garbage. Rogue AIs can now bolt you down and then personally murder you with a circular saw medical borg/stun arm engineering borg.

# WHY ITS GOOD FOR THE GAME

ai corpserush bad
require actual players to corpserush cyborgs at people

:cl:
del: Removes AI shells from being printable.
/:cl: