### PR TITLE
Vampires cannot become bats(Spellcheck)

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/vampire.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/vampire.ts
@@ -15,15 +15,7 @@ const Vampire: Species = {
       description: "Minor undead enjoy some of the perks of being dead, like \
         not needing to breathe or eat, but do not get many of the \
         environmental immunities involved with being fully undead.",
-    }, {
-      icon: "recycle",
-      name: "Bat Form",
-      description: "Vampires can become bats. Bats are very weak, but \
-        are great for escaping bad situations. They can also travel through \
-        vents, giving Vampires a lot of access. Just remember that access \
-        doesn't equal permission, and people may be unhappy with you showing \
-        up uninvited!",
-    }],
+    }
     neutral: [],
     bad: [{
       icon: "tint",

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/vampire.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/vampire.ts
@@ -35,7 +35,6 @@ const Vampire: Species = {
   },
   lore: [
     "Vampires are unholy beings blessed and cursed with The Thirst. The Thirst requires them to feast on blood to stay alive, and in return it gives them many bonuses. Because of this, Vampires have split into two clans, one that embraces their powers as a blessing and one that rejects it.",
-    "\"I'm not doing the bat trick. It's self deprecating. Okay, fine, but I'm not doing it again!\" - Count Baz, before venting into security for the third time this week.",
   ],
 };
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/vampire.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/species/vampire.ts
@@ -15,7 +15,7 @@ const Vampire: Species = {
       description: "Minor undead enjoy some of the perks of being dead, like \
         not needing to breathe or eat, but do not get many of the \
         environmental immunities involved with being fully undead.",
-    }
+    }],
     neutral: [],
     bad: [{
       icon: "tint",


### PR DESCRIPTION
## About The Pull Request

Vampires cant become bats. fixes issue #65009

## Why It's Good For The Game

Removes misleading info

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: fixes false info with vampires becoming bats
/:cl:

