### PR TITLE
Makes snow walls consistent with other walls

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -342,11 +342,11 @@ GLOBAL_LIST_INIT(plastitanium_recipes, list ( \
 	material_type = /datum/material/snow
 
 GLOBAL_LIST_INIT(snow_recipes, list ( \
-	new/datum/stack_recipe("Snow wall", /turf/closed/wall/mineral/snow, 5, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("Snowman", /obj/structure/statue/snow/snowman, 5, one_per_turf = 1, on_floor = 1), \
-	new/datum/stack_recipe("Snowball", /obj/item/toy/snowball, 1), \
-	new/datum/stack_recipe("Snow tile", /obj/item/stack/tile/mineral/snow, 1, 4, 20), \
-	))
+	new/datum/stack_recipe("snow wall", /turf/closed/wall/mineral/snow, 5, time = 40, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("snowman", /obj/structure/statue/snow/snowman, 5, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("snowball", /obj/item/toy/snowball, 1), \
+	new/datum/stack_recipe("snow tile", /obj/item/stack/tile/mineral/snow, 1, 4, 20), \
+))
 
 /obj/item/stack/sheet/mineral/snow/get_main_recipes()
 	. = ..()

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -342,7 +342,7 @@ GLOBAL_LIST_INIT(plastitanium_recipes, list ( \
 	material_type = /datum/material/snow
 
 GLOBAL_LIST_INIT(snow_recipes, list ( \
-	new/datum/stack_recipe("snow wall", /turf/closed/wall/mineral/snow, 5, time = 40, one_per_turf = TRUE, on_floor = TRUE), \
+	new/datum/stack_recipe("snow wall", /turf/closed/wall/mineral/snow, 5, time = 4 SECONDS, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("snowman", /obj/structure/statue/snow/snowman, 5, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("snowball", /obj/item/toy/snowball, 1), \
 	new/datum/stack_recipe("snow tile", /obj/item/stack/tile/mineral/snow, 1, 4, 20), \


### PR DESCRIPTION
## About The Pull Request

Makes snow walls take time to build, like all other types of walls.
Also since I was already there, made them use TRUE/FALSE instead of 1/0

## Why It's Good For The Game

I assume will close https://github.com/tgstation/tgstation/issues/32739 - it is weirdly worded, but I assume this was the problem they were trying to talk about, every other possible bug seems to already have been fixed (question mark)

## Changelog

:cl:
fix: Building walls with snow now take time to do, like every other type.
/:cl: