### PR TITLE
AIs can now send messages to borgs using Siliconnect.

### DIFF
--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -132,8 +132,6 @@
 				if(!isAI(usr))
 					return //We got an AI action from a non-AI user, abandon ship
 				sendername = "[usr.name], Station AI"
-			else
-				sendername = checkID()
 
 			if(!sendername)
 				return

--- a/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
@@ -89,12 +89,12 @@ export const NtosCyborgRemoteMonitorContent = (props, context) => {
                     <Fragment>
                       {!!ai_user && (
                         <Button
-                        icon="terminal"
-                        content={"Send Message As AI"}
-                        color="blue"
-                        onClick={() => act('messagebot_ai', {
-                          ref: cyborg.ref,
-                        })} /> 
+                          icon="terminal"
+                          content={"Send Message As AI"}
+                          color="blue"
+                          onClick={() => act('messagebot_ai', {
+                            ref: cyborg.ref,
+                          })} /> 
                       )}
                       <Button
                         icon="terminal"

--- a/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
@@ -1,5 +1,5 @@
 import { useBackend, useSharedState } from '../backend';
-import { Box, Button, LabeledList, NoticeBox, ProgressBar, Section, Stack, Tabs } from '../components';
+import { Box, Button, Fragment, LabeledList, NoticeBox, ProgressBar, Section, Stack, Tabs } from '../components';
 import { NtosWindow } from '../layouts';
 
 export const NtosCyborgRemoteMonitor = (props, context) => {
@@ -36,6 +36,7 @@ export const NtosCyborgRemoteMonitorContent = (props, context) => {
   const [tab_main, setTab_main] = useSharedState(context, 'tab_main', 1);
   const {
     card,
+    ai_user,
     cyborgs = [],
     DL_progress,
   } = data;
@@ -85,6 +86,16 @@ export const NtosCyborgRemoteMonitorContent = (props, context) => {
                   key={cyborg.ref}
                   title={cyborg.name}
                   buttons={(
+                  <Fragment>
+                    {!!ai_user && (
+                      <Button
+                      icon="terminal"
+                      content={"Send Message As AI"}
+                      color="blue"
+                      onClick={() => act('messagebot_ai', {
+                        ref: cyborg.ref,
+                      })} /> 
+                    )}
                     <Button
                       icon="terminal"
                       content="Send Message"
@@ -93,6 +104,7 @@ export const NtosCyborgRemoteMonitorContent = (props, context) => {
                       onClick={() => act('messagebot', {
                         ref: cyborg.ref,
                       })} />
+                  </Fragment>
                   )}>
                   <LabeledList>
                     <LabeledList.Item label="Status">

--- a/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
@@ -86,25 +86,25 @@ export const NtosCyborgRemoteMonitorContent = (props, context) => {
                   key={cyborg.ref}
                   title={cyborg.name}
                   buttons={(
-                  <Fragment>
-                    {!!ai_user && (
+                    <Fragment>
+                      {!!ai_user && (
+                        <Button
+                        icon="terminal"
+                        content={"Send Message As AI"}
+                        color="blue"
+                        onClick={() => act('messagebot_ai', {
+                          ref: cyborg.ref,
+                        })} /> 
+                      )}
                       <Button
-                      icon="terminal"
-                      content={"Send Message As AI"}
-                      color="blue"
-                      onClick={() => act('messagebot_ai', {
-                        ref: cyborg.ref,
-                      })} /> 
-                    )}
-                    <Button
-                      icon="terminal"
-                      content="Send Message"
-                      color="blue"
-                      disabled={!card}
-                      onClick={() => act('messagebot', {
-                        ref: cyborg.ref,
-                      })} />
-                  </Fragment>
+                        icon="terminal"
+                        content="Send Message"
+                        color="blue"
+                        disabled={!card}
+                        onClick={() => act('messagebot', {
+                          ref: cyborg.ref,
+                        })} />
+                    </Fragment>
                   )}>
                   <LabeledList>
                     <LabeledList.Item label="Status">


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
AIs get a button to send a message "as AI" when viewing any modular computer running Siliconnect. This indicates it is done using the AI's own login rather than any existing ID card.

Also cleaned up the ui_data proc for Siliconnect a bit, and fixed what was probably an occasional runtime if a message box was opened and then the borg became deleted.

Finally, Siliconnect messages now send the user's job title, if it exists on the ID card.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives AIs a way to reach out to borgs without using binary. This does not take into account borg/AI connectivity on purpose.  Thus, they can also reach other AIs by proxy, as all messages sent still alert the connected AI as well.

If binary is compromised, alternative tools can be used to work around it. Holopads are a great option for two-way communication, while SiliConnect will work for one-way orders.

This option is not without risks; messages are saved to the borg's IC logs, meaning a human with siliconnect on a tablet and a way to make a borg hold still can read everything you (or anyone else) has sent it.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: AIs can now use any modular computer or console with SiliConnect running to send messages to cyborgs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

As an aside, if someone has left an ID in a console, the AI can send a message under their name. This can make a borg believe a law 2 order has been sent by a human, which may be useful to a malfunctioning AI if the stars align. This is the current behavior, and is intentionally left as a possible option.

Siliconnect messages are logged, bad players will not get to use this to fake getting grief orders.