### PR TITLE
Fixes pathing mistakes for a few food things

### DIFF
--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -142,8 +142,8 @@
 
 /obj/item/trash/can/food/pine_nuts
 	name = "canned pine nuts"
-	icon = 'icons/obj/food/food.dmi'
-	icon_state = "pine_nuts_empty"
+	icon = 'icons/obj/food/canned.dmi'
+	icon_state = "pinenutscan_empty"
 
 /obj/item/trash/spacers_sidekick
 	name = "\improper Spacer's Sidekick packet"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
@@ -146,7 +146,7 @@
 	name = "Mozzarella sticks"
 	reqs = list(
 		/obj/item/food/mozzarella = 1,
-		/obj/item/food/breadslice = 2,
+		/obj/item/food/breadslice/plain = 2,
 		/obj/item/food/tomato_sauce = 1
 	)
 	result = /obj/item/food/mozzarella_sticks
@@ -321,7 +321,7 @@
 	reqs = list(
 		/obj/item/food/soup/cheesy_porridge = 1,
 		/obj/item/food/grown/eggplant = 1,
-		/obj/item/food/breadslice = 2,
+		/obj/item/food/breadslice/plain = 2,
 		/obj/item/food/tomato_sauce = 1,
 		/obj/item/food/mozzarella = 1
 	)
@@ -345,7 +345,7 @@
 	reqs = list(
 		/obj/item/food/mothic_salad = 1,
 		/obj/item/food/grilled_cheese = 1,
-		/obj/item/food/breadslice = 1,
+		/obj/item/food/breadslice/plain = 1,
 		/obj/item/food/grown/carrot = 1,
 		/datum/reagent/consumable/quality_oil = 2,
 		/datum/reagent/consumable/vinegar = 2

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_spaghetti.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_spaghetti.dm
@@ -75,7 +75,7 @@
 		/obj/item/food/spaghetti/boiledspaghetti = 1,
 		/obj/item/food/bechamel_sauce = 1,
 		/obj/item/food/cheese = 2,
-		/obj/item/food/breadslice = 1,
+		/obj/item/food/breadslice/plain = 1,
 		/datum/reagent/consumable/blackpepper = 2
 	)
 	result = /obj/item/food/spaghetti/mac_n_cheese


### PR DESCRIPTION
## About The Pull Request
fixes https://github.com/tgstation/tgstation/issues/65096
Also fixes a food related icon path error

## Why It's Good For The Game
Lets people know they're supposed to use plain bread slices rather than a parent item
Also avoids an error sprite showing up

## Changelog
:cl:
fix: Various cooking recipes that simply said they required 'food' now properly use plain bread slices.
fix: Fully eating a can of pine nuts no longer creates an error sprite.
/:cl:
