### PR TITLE
Fixes floor lights by setting their plane.

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -596,6 +596,7 @@
 	base_state = "floor" // base description and icon_state
 	icon_state = "floor"
 	brightness = 4
-	layer = 2.5
+	layer = LOW_OBJ_LAYER
+	plane = FLOOR_PLANE
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"


### PR DESCRIPTION
## About The Pull Request

Floor lights are missing "plane" and the default is -4, which makes them appear on top of tables and players.

## Why It's Good For The Game

Fixes the layering of floor lights.

## Changelog

:cl:
fix: Added the missing variable "plane" to floor lights.
/:cl:
