### PR TITLE
Thieves can no longer scale and take more than 6 threat, increases number of thieves ran by 2

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -724,9 +724,9 @@
 	required_candidates = 1
 	weight = 3
 	cost = 6 //very cheap cost for the round
-	scaling_cost = 9
+	scaling_cost = 0
 	requirements = list(8,8,8,8,8,8,8,8,8,8)
-	antag_cap = list("denominator" = 24)
+	antag_cap = list("denominator" = 24, "offset" = 2)
 
 /datum/dynamic_ruleset/roundstart/thieves/pre_execute(population)
 	. = ..()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -727,6 +727,7 @@
 	scaling_cost = 0
 	requirements = list(8,8,8,8,8,8,8,8,8,8)
 	antag_cap = list("denominator" = 24, "offset" = 2)
+	flags = LONE_RULESET
 
 /datum/dynamic_ruleset/roundstart/thieves/pre_execute(population)
 	. = ..()


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Thieves can no longer scale, and can only run once.

Number of thieves increased by 2, such that:

<24 pop: 3 thieves (previously 1)
25-48 pop: 4 thieves (previously 2)
...etc...

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Thieves are good for increasing shenanigans in the round, but because of their low cost are too infrequently sucking up the rest of the threat in the round.

Increasing number of thieves helps preserve shenanigans considering individual thiefs don't do much.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Thieves can no longer scale, and can only run once.
balance: Increased the number of thieves by 2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
