### PR TITLE
Explosive Lances now detonate on the tile the person is standing on rather than the person hit with the lance

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -139,7 +139,6 @@
 	if(iseffect(AM)) //and no accidentally wasting your moment of glory on graffiti
 		return
 	user.say("[war_cry]", forced="spear warcry")
-	explosive.forceMove(AM)
 	explosive.detonate(lanced_by=user)
 	qdel(src)
 

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -139,6 +139,7 @@
 	if(iseffect(AM)) //and no accidentally wasting your moment of glory on graffiti
 		return
 	user.say("[war_cry]", forced="spear warcry")
+	explosive.forceMove(get_turf(user))
 	explosive.detonate(lanced_by=user)
 	qdel(src)
 


### PR DESCRIPTION
From @Iamgoofball PR in #65090

> Closes #65089
> 
> ## About The Pull Request
> Alternative to #65089 Explosive Lances now detonate on the tile the person is standing on rather than the person hit with the lance.
> 
> ## Why It's Good For The Game
> It's possible to make an explosive mix that completely vaporizes the target while leaving all the tiles next to it relatively unharmed or at least in a revivable state. This is working as intended for explosion code. However, when applied to the concept for the explosive lance, it doesn't really mesh with the concept as Kor envisioned it when adding them: ![chrome_Vq5APFuVq9](https://user-images.githubusercontent.com/4081722/155193342-22b57523-9aac-4f56-951c-1ee95a06d258.png) As you can see, Kor very much intended for this to be a "if I'm dying you're coming with me" style weapon. It used to be this in the past, and the natural content churn of the game means it isn't anymore. This change should restore the weapon to it's former intended (non-meta) functionality rather than being a powergame weapon.
> 
> @MrMelbert suggested this change to the functionality over the forcemove of the user.
> 

Say bye bye to the #56289 meme @Mothblocks

## Changelog
🆑 Iamgoofball
balance: Explosive Lances now detonate on the tile the person is standing on rather than the person hit with the lance. 
/🆑