### PR TITLE
Hitting someone in melee with the explosive lance now moves you to the same tile as them before it sets off the grenade.

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -139,6 +139,7 @@
 	if(iseffect(AM)) //and no accidentally wasting your moment of glory on graffiti
 		return
 	user.say("[war_cry]", forced="spear warcry")
+	user.forceMove(get_turf(AM))
 	explosive.forceMove(AM)
 	explosive.detonate(lanced_by=user)
 	qdel(src)

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -139,8 +139,9 @@
 	if(iseffect(AM)) //and no accidentally wasting your moment of glory on graffiti
 		return
 	user.say("[war_cry]", forced="spear warcry")
-	user.forceMove(get_turf(AM))
-	explosive.forceMove(AM)
+	if(ismob(AM))
+		user.forceMove(get_turf(AM))
+	explosive.forceMove(get_turf(AM))
 	explosive.detonate(lanced_by=user)
 	qdel(src)
 


### PR DESCRIPTION
From @Iamgoofball PR in https://github.com/tgstation/tgstation/pull/65112

> Closes #65090
> 
> ## About The Pull Request
> Alternative to #65090 Hitting someone in melee with the explosive lance now moves you to the same tile as them before it sets off the spear.
> 
> ## Why It's Good For The Game
> It's possible to make an explosive mix that completely vaporizes the target while leaving all the tiles next to it relatively unharmed or at least in a revivable state. This is working as intended for explosion code. However, when applied to the concept for the explosive lance, it doesn't really mesh with the concept as Kor envisioned it when adding them:
> 
> ![chrome_Vq5APFuVq9](https://user-images.githubusercontent.com/4081722/155187536-cd7f174f-cb58-4d00-a18d-0dffb97b0fa5.png)
> 
> As you can see, Kor very much intended for this to be a "if I'm dying you're coming with me" style weapon. It used to be this in the past, and the natural content churn of the game means it isn't anymore. This change should restore the weapon to it's former intended (non-meta) functionality rather than being a powergame weapon.

## Changelog
🆑 Iamgoofball
balance: Hitting someone in melee with the explosive lance now moves you to the same tile as them before it sets off the grenade. 
/🆑
