### PR TITLE
Changes rounding on cell power percentage

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -110,7 +110,7 @@
 	if(rigged)
 		. += span_danger("This power cell seems to be faulty!")
 	else
-		. += "The charge meter reads [CEILING(percent(), 0.1)]%" //so it doesn't say 0% charge when the overlay indicates it still has charge
+		. += "The charge meter reads [CEILING(percent(), 0.1)]%." //so it doesn't say 0% charge when the overlay indicates it still has charge
 
 /obj/item/stock_parts/cell/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is licking the electrodes of [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -110,7 +110,7 @@
 	if(rigged)
 		. += span_danger("This power cell seems to be faulty!")
 	else
-		. += "The charge meter reads [round(percent(), 0.01)]%."
+		. += "The charge meter reads [round(percent(), 0.01)]%"
 
 /obj/item/stock_parts/cell/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is licking the electrodes of [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -80,7 +80,7 @@
 	. += mutable_appearance('icons/obj/power.dmi', "cell-[charge_light_type]-o[(percent() >= 99.5) ? 2 : 1]")
 
 /obj/item/stock_parts/cell/proc/percent() // return % charge of cell
-	return 100*charge/maxcharge
+	return 100 * charge / maxcharge
 
 // use power from a cell
 /obj/item/stock_parts/cell/use(amount, force)
@@ -110,7 +110,7 @@
 	if(rigged)
 		. += span_danger("This power cell seems to be faulty!")
 	else
-		. += "The charge meter reads [round(percent(), 0.01)]%"
+		. += "The charge meter reads [CEILING(percent(), 0.1)]%" //so it doesn't say 0% charge when the overlay indicates it still has charge
 
 /obj/item/stock_parts/cell/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is licking the electrodes of [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -110,7 +110,7 @@
 	if(rigged)
 		. += span_danger("This power cell seems to be faulty!")
 	else
-		. += "The charge meter reads [round(src.percent() )]%."
+		. += "The charge meter reads [round(percent(), 0.01)]%."
 
 /obj/item/stock_parts/cell/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is licking the electrodes of [src]! It looks like [user.p_theyre()] trying to commit suicide!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so a cell with a yellow overlay won't say it has 0% charge when examined.

![dreamseeker_cuEfTMHScQ](https://user-images.githubusercontent.com/25089914/155272542-91806777-8c62-4947-b74f-11eb6431441e.png)

![dreamseeker_K0DBs8KdYv](https://user-images.githubusercontent.com/25089914/155272475-6fb87a15-a446-4d5f-82ea-8f750e514287.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It seems like a bug with the overlay, but it's not.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Examining cells won't say they have 0% charge when the overlay indicates they don't
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
