### PR TITLE
Makes lock access on tablet researching a var

### DIFF
--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -11,6 +11,8 @@
 	transfer_access = ACCESS_RD
 	/// Reference to global science techweb
 	var/datum/techweb/stored_research
+	///Access needed to lock/unlock the console
+	var/lock_access = ACCESS_RND
 	/// Determines if the console is locked, and consequently if actions can be performed with it
 	var/locked = FALSE
 	/// Used for compressing data sent to the UI via static_data as payload size is of concern
@@ -93,7 +95,7 @@
 			if(computer.obj_flags & EMAGGED)
 				to_chat(usr, span_boldwarning("Security protocol error: Unable to access locking protocols."))
 				return TRUE
-			if(ACCESS_RND in user_id_card?.access)
+			if(lock_access in user_id_card?.access)
 				locked = !locked
 			else
 				to_chat(usr, span_boldwarning("Unauthorized Access. Please insert research ID card."))

--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -11,7 +11,7 @@
 	transfer_access = ACCESS_RD
 	/// Reference to global science techweb
 	var/datum/techweb/stored_research
-	///Access needed to lock/unlock the console
+	/// Access needed to lock/unlock the console
 	var/lock_access = ACCESS_RND
 	/// Determines if the console is locked, and consequently if actions can be performed with it
 	var/locked = FALSE


### PR DESCRIPTION
## About The Pull Request

Makes access needed to lock/unlock an RnD tablet app, a var on the app itself, much like the RnD console itself does.
Making this PR is how I found out locking/unlocking consoles requires RND access, not RD office, which I find really dumb, but I don't want to spend the GBP to change it.

## Why It's Good For The Game

Consistent between the two apps.
Honestly I'm confused why we have this system where we just had two of every app, one for tablets and one for its own separate computer. I'm sure there's a better way to go about this, but I'm kinda lazy?

## Changelog

Not needed.