### PR TITLE
Fixes lavaland survival pod ruin decals

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_survivalpod.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_survivalpod.dmm
@@ -6,21 +6,16 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "c" = (
-/obj/effect/turf_decal/mining/survival{
-	pixel_y = -32
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/effect/turf_decal/mining,
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/ruin/powered)
 "d" = (
 /turf/closed/wall/mineral/titanium/survival/pod,
 /area/ruin/powered)
 "e" = (
-/obj/effect/turf_decal/mining/survival{
-	dir = 4;
-	pixel_x = 32
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/effect/turf_decal/mining/survival,
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/ruin/powered)
 "f" = (
 /obj/structure/fans,
 /turf/open/floor/pod/dark,
@@ -39,11 +34,10 @@
 /area/ruin/powered)
 "i" = (
 /obj/effect/turf_decal/mining/survival{
-	dir = 8;
-	pixel_x = -32
+	dir = 8
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/ruin/powered)
 "j" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -125,10 +119,10 @@
 /area/lavaland/surface/outdoors)
 "w" = (
 /obj/effect/turf_decal/mining/survival{
-	pixel_y = 32
+	dir = 4
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/ruin/powered)
 "x" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/footprints{
@@ -137,14 +131,11 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "y" = (
-/obj/effect/turf_decal/mining{
-	pixel_y = 32
+/obj/effect/turf_decal/mining/survival{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/ruin/powered)
 "z" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8
@@ -175,9 +166,9 @@ a
 a
 b
 b
-e
 b
-e
+b
+b
 b
 b
 a
@@ -189,7 +180,7 @@ a
 b
 d
 d
-d
+i
 d
 d
 b
@@ -199,13 +190,13 @@ a
 (4,1,1) = {"
 a
 b
-c
+b
 d
 f
 k
 p
-d
-w
+e
+b
 b
 b
 "}
@@ -213,7 +204,7 @@ b
 a
 b
 b
-d
+y
 g
 l
 q
@@ -225,13 +216,13 @@ b
 (6,1,1) = {"
 b
 b
-c
+b
 d
 h
 m
 r
-d
-y
+c
+z
 b
 b
 "}
@@ -241,7 +232,7 @@ b
 b
 d
 d
-d
+w
 d
 d
 z
@@ -253,9 +244,9 @@ a
 a
 b
 b
-i
 b
-i
+b
+b
 u
 A
 b


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes: #65118

the decals now match the current standard pod configuration

## Why It's Good For The Game

wall decals on floor bad

## Changelog

:cl:
fix: wall decals on survival pod ruin should be on the pod walls now
/:cl:
