### PR TITLE
Rebalances kudzu

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -274,5 +274,3 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 // Spacevine-related flags
 /// Is the spacevine / flower bud heat resistant
 #define SPACEVINE_HEAT_RESISTANT (1 << 0)
-/// Is the spacevine / flower bud cold resistant
-#define SPACEVINE_COLD_RESISTANT (1 << 1)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -67,8 +67,6 @@
 	var/mob/living/simple_animal/hostile/venus_human_trap/spawned_human_trap = new(get_turf(src))
 	if(trait_flags & SPACEVINE_HEAT_RESISTANT)
 		spawned_human_trap.unsuitable_heat_damage = 0
-	if(trait_flags & SPACEVINE_COLD_RESISTANT)
-		spawned_human_trap.unsuitable_cold_damage = 0
 	qdel(src)
 
 /obj/structure/alien/resin/flower_bud/proc/progress_growth()
@@ -126,15 +124,13 @@
 	obj_damage = 60
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-	minbodytemp = 100
 	combat_mode = TRUE
 	del_on_death = TRUE
 	deathmessage = "collapses into bits of plant matter."
 	attacked_sound = 'sound/creatures/venus_trap_hurt.ogg'
 	deathsound = 'sound/creatures/venus_trap_death.ogg'
 	attack_sound = 'sound/creatures/venus_trap_hit.ogg'
-	unsuitable_heat_damage = 5 // heat damage is different from cold damage since coldmos is significantly more common than plasmafires
-	unsuitable_cold_damage = 2 // they now do take cold damage, but this should be sufficiently small that it does not cause major issues
+	unsuitable_heat_damage = 5 //note that venus human traps do not take cold damage, only heat damage- this is because space vines can cause hull breaches
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 0
 	/// copied over from the code from eyeballs (the mob) to make it easier for venus human traps to see in kudzu that doesn't have the transparency mutation
@@ -187,7 +183,6 @@
 	vines += newVine
 	if(isliving(the_target))
 		var/mob/living/L = the_target
-		L.apply_damage(85, STAMINA, BODY_ZONE_CHEST)
 		L.Knockdown(1 SECONDS)
 	ranged_cooldown = world.time + ranged_cooldown_time
 


### PR DESCRIPTION
## About The Pull Request

Further rebalances kudzu following https://github.com/tgstation/tgstation/pull/64675.
Increases maximum possible severity cap from 20 to 40.
Removes cold vulnerability from kudzu for both vines and maneaters.
Nerfs explosive kudzu by increasing it's severity rating from above average to severe.
Nerfs stamina damage caused by maneater vine throw.

## Why It's Good For The Game

https://github.com/tgstation/tgstation/pull/64675 nerfed many aspects of the kudzu.  Some of these were warranted, but at present it seems drastically overdone.

The severity system acts as a limiter on the max number of mutations, but a budget of 20 doesn't allow for more than a handful of them, going against kudzu's entire premise.  A budget of 40 still provides a limit, while not completely crippling the vine.

The cold vulnerability was an extreme impairment to both vine spreading and maneaters.  In my experiments, a single window breaking would very rapidly prevent all vine growth in a small to mid sized area.  Larger areas would just take longer for the same effect.  The entire effectiveness of the vine is completely dependent on an rng based cold resist trait that might not ever naturally appear as a mutation.  Additionally, it doesn't make sense for space vines to not be able to deal with being exposed to space.

In the previous PR, the reasoning for the cold vulnerability was to disincentivize hull breaches.  Making the explosive mutation more costly and thus less likely should help mitigate this somewhat.

A lot of the umbrage towards kudzu seems to be less about the vines and more about the player controlled maneaters.  The previous pull replaced their vine whip stun with a knockdown + stamina damage.  This pull further nerfs the vine whip by also removing the stamina damage component in order to prevent easy stunlocks.

## Changelog

:cl:
balance: Space vines max possible severity cap increased.
balance: Space vines have returned to their previous comfort level when exposed to the cold of space.
balance: Exploding space vines are now classified more severely.
balance: Maneaters vine whip no longer causes stamina damage to the victim.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
