### PR TITLE
lavaland elite fix + code improvement

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -129,54 +129,62 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	var/times_won = 0
 	var/mob/living/carbon/human/activator
 	var/mob/living/simple_animal/hostile/asteroid/elite/mychild = null
-	var/potentialspawns = list(/mob/living/simple_animal/hostile/asteroid/elite/broodmother,
-								/mob/living/simple_animal/hostile/asteroid/elite/pandora,
-								/mob/living/simple_animal/hostile/asteroid/elite/legionnaire,
-								/mob/living/simple_animal/hostile/asteroid/elite/herald)
+	///List of all potentially spawned elites
+	var/potentialspawns = list(
+		/mob/living/simple_animal/hostile/asteroid/elite/broodmother,
+		/mob/living/simple_animal/hostile/asteroid/elite/pandora,
+		/mob/living/simple_animal/hostile/asteroid/elite/legionnaire,
+		/mob/living/simple_animal/hostile/asteroid/elite/herald,
+	)
 
 /obj/structure/elite_tumor/attack_hand(mob/user, list/modifiers)
 	. = ..()
-	if(ishuman(user))
-		switch(activity)
-			if(TUMOR_PASSIVE)
-				// Prevents the user from being forcemoved back and forth between two elite arenas.
-				if(HAS_TRAIT(user, TRAIT_ELITE_CHALLENGER))
-					user.visible_message(span_warning("[user] reaches for [src] with [user.p_their()] arm, but nothing happens."),
-						span_warning("You reach for [src] with your arm... but nothing happens."))
-					return
-				activity = TUMOR_ACTIVE
-				user.visible_message(span_boldwarning("[src] convulses as [user]'s arm enters its radius.  Uh-oh..."),
-					span_boldwarning("[src] convulses as your arm enters its radius.  Your instincts tell you to step back."))
-				make_activator(user)
-				if(boosted)
-					mychild.playsound_local(get_turf(mychild), 'sound/effects/magic.ogg', 40, 0)
-					to_chat(mychild, "<b>Someone has activated your tumor.  You will be returned to fight shortly, get ready!</b>")
-				addtimer(CALLBACK(src, .proc/return_elite), 30)
-				INVOKE_ASYNC(src, .proc/arena_checks)
-			if(TUMOR_INACTIVE)
-				if(HAS_TRAIT(user, TRAIT_ELITE_CHALLENGER))
-					user.visible_message(span_warning("[user] reaches for [src] with [user.p_their()] arm, but nothing happens."),
-						span_warning("You reach for [src] with your arm... but nothing happens."))
-					return
-				activity = TUMOR_ACTIVE
-				var/mob/dead/observer/elitemind = null
-				visible_message(span_boldwarning("[src] begins to convulse.  Your instincts tell you to step back."))
-				make_activator(user)
-				if(!boosted)
-					addtimer(CALLBACK(src, .proc/spawn_elite), 30)
-					return
-				visible_message(span_boldwarning("Something within [src] stirs..."))
-				var/list/candidates = poll_candidates_for_mob("Do you want to play as a lavaland elite?", ROLE_SENTIENCE, ROLE_SENTIENCE, 5 SECONDS, src, POLL_IGNORE_SENTIENCE_POTION)
-				if(candidates.len)
-					audible_message(span_boldwarning("The stirring sounds increase in volume!"))
-					elitemind = pick(candidates)
-					elitemind.playsound_local(get_turf(elitemind), 'sound/effects/magic.ogg', 40, 0)
-					to_chat(elitemind, "<b>You have been chosen to play as a Lavaland Elite.\nIn a few seconds, you will be summoned on Lavaland as a monster to fight your activator, in a fight to the death.\nYour attacks can be switched using the buttons on the top left of the HUD, and used by clicking on targets or tiles similar to a gun.\nWhile the opponent might have an upper hand with  powerful mining equipment and tools, you have great power normally limited by AI mobs.\nIf you want to win, you'll have to use your powers in creative ways to ensure the kill.  It's suggested you try using them all as soon as possible.\nShould you win, you'll receive extra information regarding what to do after.  Good luck!</b>")
-					addtimer(CALLBACK(src, .proc/spawn_elite, elitemind), 100)
-				else
-					visible_message(span_boldwarning("The stirring stops, and nothing emerges.  Perhaps try again later."))
-					activity = TUMOR_INACTIVE
-					clear_activator(user)
+	if(!ishuman(user))
+		return
+	switch(activity)
+		if(TUMOR_PASSIVE)
+			// Prevents the user from being forcemoved back and forth between two elite arenas.
+			if(HAS_TRAIT(user, TRAIT_ELITE_CHALLENGER))
+				user.visible_message(span_warning("[user] reaches for [src] with [user.p_their()] arm, but nothing happens."),
+					span_warning("You reach for [src] with your arm... but nothing happens."))
+				return
+			activity = TUMOR_ACTIVE
+			user.visible_message(span_boldwarning("[src] convulses as [user]'s arm enters its radius.  Uh-oh..."),
+				span_boldwarning("[src] convulses as your arm enters its radius.  Your instincts tell you to step back."))
+			make_activator(user)
+			if(boosted)
+				mychild.playsound_local(get_turf(mychild), 'sound/effects/magic.ogg', 40, 0)
+				to_chat(mychild, "<b>Someone has activated your tumor.  You will be returned to fight shortly, get ready!</b>")
+			addtimer(CALLBACK(src, .proc/return_elite), 30)
+			INVOKE_ASYNC(src, .proc/arena_checks)
+		if(TUMOR_INACTIVE)
+			if(HAS_TRAIT(user, TRAIT_ELITE_CHALLENGER))
+				user.visible_message(span_warning("[user] reaches for [src] with [user.p_their()] arm, but nothing happens."),
+					span_warning("You reach for [src] with your arm... but nothing happens."))
+				return
+			activity = TUMOR_ACTIVE
+			var/mob/dead/observer/elitemind = null
+			visible_message(span_boldwarning("[src] begins to convulse.  Your instincts tell you to step back."))
+			make_activator(user)
+			if(!boosted)
+				addtimer(CALLBACK(src, .proc/spawn_elite), 30)
+				return
+			visible_message(span_boldwarning("Something within [src] stirs..."))
+			var/list/candidates = poll_candidates_for_mob("Do you want to play as a lavaland elite?", ROLE_SENTIENCE, ROLE_SENTIENCE, 5 SECONDS, src, POLL_IGNORE_SENTIENCE_POTION)
+			if(candidates.len)
+				audible_message(span_boldwarning("The stirring sounds increase in volume!"))
+				elitemind = pick(candidates)
+				elitemind.playsound_local(get_turf(elitemind), 'sound/effects/magic.ogg', 40, 0)
+				to_chat(elitemind, "<b>You have been chosen to play as a Lavaland Elite.\nIn a few seconds, you will be summoned on Lavaland as a monster to fight your activator, in a fight to the death.\n\
+					Your attacks can be switched using the buttons on the top left of the HUD, and used by clicking on targets or tiles similar to a gun.\n\
+					While the opponent might have an upper hand with  powerful mining equipment and tools, you have great power normally limited by AI mobs.\n\
+					If you want to win, you'll have to use your powers in creative ways to ensure the kill. It's suggested you try using them all as soon as possible.\n\
+					Should you win, you'll receive extra information regarding what to do after. Good luck!</b>")
+				addtimer(CALLBACK(src, .proc/spawn_elite, elitemind), 100)
+			else
+				visible_message(span_boldwarning("The stirring stops, and nothing emerges.  Perhaps try again later."))
+				activity = TUMOR_INACTIVE
+				clear_activator(user)
 
 /obj/structure/elite_tumor/proc/spawn_elite(mob/dead/observer/elitemind)
 	var/selectedspawn = pick(potentialspawns)
@@ -188,12 +196,8 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		mychild.sentience_act()
 		notify_ghosts("\A [mychild] has been awakened in \the [get_area(src)]!", source = mychild, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Lavaland Elite awakened")
 	icon_state = "tumor_popped"
-	RegisterSignal(mychild, COMSIG_PARENT_QDELETING, .proc/mychild_gone_missing)
+	RegisterSignal(mychild, COMSIG_PARENT_QDELETING, .proc/onEliteLoss)
 	INVOKE_ASYNC(src, .proc/arena_checks)
-
-/obj/structure/elite_tumor/proc/mychild_gone_missing()
-	SIGNAL_HANDLER
-	mychild = null
 
 /obj/structure/elite_tumor/proc/return_elite()
 	mychild.forceMove(loc)
@@ -232,17 +236,19 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	UnregisterSignal(source, COMSIG_PARENT_QDELETING)
 
 /obj/structure/elite_tumor/process(delta_time)
-	if(isturf(loc))
-		for(var/mob/living/simple_animal/hostile/asteroid/elite/elitehere in loc)
-			if(elitehere == mychild && activity == TUMOR_PASSIVE)
-				mychild.adjustHealth(-mychild.maxHealth*0.025*delta_time)
-				var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(mychild))
-				H.color = "#FF0000"
+	if(!isturf(loc))
+		return
 
-/obj/structure/elite_tumor/attackby(obj/item/I, mob/user, params)
+	for(var/mob/living/simple_animal/hostile/asteroid/elite/elitehere in loc)
+		if(elitehere == mychild && activity == TUMOR_PASSIVE)
+			mychild.adjustHealth(-mychild.maxHealth * 0.025*delta_time)
+			var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal(get_turf(mychild))
+			H.color = "#FF0000"
+
+/obj/structure/elite_tumor/attackby(obj/item/attacking_item, mob/user, params)
 	. = ..()
-	if(istype(I, /obj/item/organ/regenerative_core) && activity == TUMOR_INACTIVE && !boosted)
-		var/obj/item/organ/regenerative_core/core = I
+	if(istype(attacking_item, /obj/item/organ/regenerative_core) && activity == TUMOR_INACTIVE && !boosted)
+		var/obj/item/organ/regenerative_core/core = attacking_item
 		visible_message(span_boldwarning("As [user] drops the core into [src], [src] appears to swell."))
 		icon_state = "advanced_tumor"
 		boosted = TRUE
@@ -270,15 +276,15 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		onEliteWon()
 
 /obj/structure/elite_tumor/proc/arena_trap()
-	var/turf/T = get_turf(src)
+	var/turf/tumor_turf = get_turf(src)
 	if(loc == null)
 		return
 	var/datum/weakref/activator_ref = WEAKREF(activator)
 	var/datum/weakref/mychild_ref = WEAKREF(mychild)
-	for(var/t in RANGE_TURFS(12, T))
-		if(get_dist(t, T) == 12)
+	for(var/tumor_range_turfs in RANGE_TURFS(12, tumor_turf))
+		if(get_dist(tumor_range_turfs, tumor_turf) == 12)
 			var/obj/effect/temp_visual/elite_tumor_wall/newwall
-			newwall = new /obj/effect/temp_visual/elite_tumor_wall(t, src)
+			newwall = new /obj/effect/temp_visual/elite_tumor_wall(tumor_range_turfs, src)
 			newwall.activator_ref = activator_ref
 			newwall.ourelite_ref = mychild_ref
 
@@ -314,9 +320,13 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		mychild.health = mychild.maxHealth
 	if(times_won == 1)
 		mychild.playsound_local(get_turf(mychild), 'sound/effects/magic.ogg', 40, 0)
-		to_chat(mychild, span_boldwarning("As the life in the activator's eyes fade, the forcefield around you dies out and you feel your power subside.\nDespite this inferno being your home, you feel as if you aren't welcome here anymore.\nWithout any guidance, your purpose is now for you to decide."))
-		to_chat(mychild, "<b>Your max health has been halved, but can now heal by standing on your tumor.  Note, it's your only way to heal.\nBear in mind, if anyone interacts with your tumor, you'll be resummoned here to carry out another fight.  In such a case, you will regain your full max health.\nAlso, be weary of your fellow inhabitants, they likely won't be happy to see you!</b>")
-		to_chat(mychild, "<span class='big bold'>Note that you are a lavaland monster, and thus not allied to the station.  You should not cooperate or act friendly with any station crew unless under extreme circumstances!</span>")
+		to_chat(mychild, span_boldwarning("As the life in the activator's eyes fade, the forcefield around you dies out and you feel your power subside.\n\
+			Despite this inferno being your home, you feel as if you aren't welcome here anymore.\n\
+			Without any guidance, your purpose is now for you to decide."))
+		to_chat(mychild, "<b>Your max health has been halved, but can now heal by standing on your tumor. Note, it's your only way to heal.\n\
+			Bear in mind, if anyone interacts with your tumor, you'll be resummoned here to carry out another fight. In such a case, you will regain your full max health.\n\
+			Also, be weary of your fellow inhabitants, they likely won't be happy to see you!</b>")
+		to_chat(mychild, "<span class='big bold'>Note that you are a lavaland monster, and thus not allied to the station. You should not cooperate or act friendly with any station crew unless under extreme circumstances!</span>")
 
 /obj/item/tumor_shard
 	name = "tumor shard"


### PR DESCRIPTION
## About The Pull Request

Boosted (Sentient) Lavaland elites had a bit of code where they would spawn certain items
![image](https://user-images.githubusercontent.com/53777086/155422657-73697005-fffe-428e-bdb3-c228f8c54603.png)

Except if they fall in a chasm first, then mychild would null, causing the code above, spawning the chest, to runtime, and not qdel the elite tumor
![image](https://user-images.githubusercontent.com/53777086/155422734-9c0ce777-8036-43fd-b4ff-5847a8a7ba41.png)

This was likely caused by https://github.com/tgstation/tgstation/pull/62540

The fix was easy, I just made it falling in a chasm, call the fight over;
![image](https://user-images.githubusercontent.com/53777086/155423298-a664bdb0-0545-47d0-a549-2c6d1c33475f.png)

Runtime in question
![image](https://user-images.githubusercontent.com/53777086/155422612-07f48887-fefd-488a-bee4-557a90b075af.png)

and proof it works in game
![image](https://user-images.githubusercontent.com/53777086/155423018-85ef327f-9d73-4207-ae54-8880613e84fe.png)
![image](https://user-images.githubusercontent.com/53777086/155423104-fe95d887-ff42-4500-85cb-ca1c9681c6b0.png)


## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/65048
No infinite chests

## Changelog

:cl:
fix: Sentient elites falling in chasms will no longer spam chests.
/:cl: