### PR TITLE
Adds USB port to status display

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -296,6 +296,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 	. = ..()
 	// register for radio system
 	SSradio.add_object(src, frequency)
+	// Circuit USB
+	AddComponent(/datum/component/usb_port, list(
+		/obj/item/circuit_component/status_display,
+	))
 
 /obj/machinery/status_display/evac/Destroy()
 	SSradio.remove_object(src,frequency)
@@ -496,6 +500,78 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/ai, 32)
 
 	set_picture(emotion_map[emotion])
 	return PROCESS_KILL
+
+/obj/item/circuit_component/status_display
+	display_name = "Status Display"
+	desc = "Output text and pictures to a status display."
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
+
+	var/datum/port/input/option/command
+	var/datum/port/input/option/picture
+	var/datum/port/input/message1
+	var/datum/port/input/message2
+
+	var/obj/machinery/status_display/connected_display
+
+	var/list/command_map
+	var/list/picture_map
+
+/obj/item/circuit_component/status_display/populate_ports()
+	message1 = add_input_port("Message 1", PORT_TYPE_STRING)
+	message2 = add_input_port("Message 2", PORT_TYPE_STRING)
+
+/obj/item/circuit_component/status_display/populate_options()
+	var/static/list/command_options = list(
+		"Blank" = "blank",
+		"Shuttle" = "shuttle",
+		"Message" = "message",
+		"Alert" = "alert"
+	)
+
+	var/static/list/picture_options = list(
+		"Default" = "default",
+		"Red Alert" = "redalert",
+		"Biohazard" = "biohazard",
+		"Lockdown" = "lockdown",
+		"Happy" = "ai_happy",
+		"Neutral" = "ai_neutral",
+		"Very Happy" = "ai_veryhappy",
+		"Sad" = "ai_sad",
+		"Unsure" = "ai_unsure",
+		"Confused" = "ai_confused",
+		"Surprised" = "ai_surprised",
+		"BSOD" = "ai_bsod"
+	)
+
+	command = add_option_port("Command", command_options)
+	command_map = command_options
+
+	picture = add_option_port("Picture", picture_options)
+	picture_map = picture_options
+
+/obj/item/circuit_component/status_display/register_usb_parent(atom/movable/shell)
+	. = ..()
+	if(istype(shell, /obj/machinery/status_display))
+		connected_display = shell
+
+/obj/item/circuit_component/status_display/unregister_usb_parent(atom/movable/parent)
+	connected_display = null
+	return ..()
+
+/obj/item/circuit_component/status_display/input_received(datum/port/input/port)
+	// Just use command handling built into status display,
+	// but do checks in case user is doing something weird
+
+	var/command_value = command_map[command.value]
+	var/datum/signal/status_signal = new(list("command" = command_value))
+	switch(command_value)
+		if("message")
+			status_signal.data["msg1"] = message1.value
+			status_signal.data["msg2"] = message2.value
+		if("alert")
+			status_signal.data["picture_state"] = picture_map[picture.value]
+
+	connected_display.receive_signal(status_signal)
 
 #undef CHARS_PER_LINE
 #undef FONT_SIZE

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -559,8 +559,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/ai, 32)
 	return ..()
 
 /obj/item/circuit_component/status_display/input_received(datum/port/input/port)
-	// Just use command handling built into status display,
-	// but do checks in case user is doing something weird
+	// Just use command handling built into status display.
+	// The option inputs thankfully sanitize command and picture for us.
 
 	var/command_value = command_map[command.value]
 	var/datum/signal/status_signal = new(list("command" = command_value))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It occurred to me that the status displays make for an amazing output device, so I added USB support to them.
* Only the `status_display/evac` ones have USB ports, as the other types take over their own state constantly.
* Note that if a department head uses their PDA or comms console, it will change the status display still, so circuits shouldn't rely on the display being correct passively forever.
* Alert (picture) mode supports the 4 PDA/comm console pictures, the AI faces, and BSOD.

### Example with classic voice activator -> output device converter
![image](https://user-images.githubusercontent.com/1185434/155430445-aeedf7eb-7748-4d4e-844b-f4a1c4647b73.png)
![image](https://user-images.githubusercontent.com/1185434/155430502-56275149-8d2b-4744-98d7-2321bffcf81a.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is an obvious use case for the USB connection system, that probably never previously was used because the message mode used to be terrible.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
add: Most status displays now have USB support for circuits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
