### PR TITLE
[No GBP] Fix opening an air alarm panel leaving overlays on

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -583,7 +583,7 @@
 /obj/machinery/airalarm/update_overlays()
 	. = ..()
 
-	if((machine_stat & (NOPOWER|BROKEN)) || shorted)
+	if(panel_open || (machine_stat & (NOPOWER|BROKEN)) || shorted)
 		return
 
 	var/area/our_area = get_area(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Oops. I literally wrote the correct condition 30 lines earlier.
Closes #65105

![image](https://user-images.githubusercontent.com/1185434/155455269-8474ae64-dd9e-4eac-86c4-4d432deb0459.png)
![image](https://user-images.githubusercontent.com/1185434/155455282-38356ea9-9fa2-4aff-b73f-9a0857dd88af.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

make game work gud

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
fix: Opening an air alarm panel now renders the overlays correctly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
