### PR TITLE
Fixes Blank Space Area Turf Definition in TramStation Science

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -64465,8 +64465,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wbE" = (
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/science/mixing)
+/area/space/nearstation)
 "wbI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -116371,9 +116372,9 @@ cxb
 wAe
 tjk
 mSi
+jwD
 wbE
-wbE
-wbE
+jwD
 uKp
 aLN
 fhZ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm back! I saw this the other day in TramStation's Ordnance Division:

![image](https://user-images.githubusercontent.com/34697715/155467316-7c5f5db4-ba90-4bdc-ba6e-8d6b01e44c7f.png)

That's not supposed to be like that! Why does it own space? I like how Kilo handles this, so I just put the same solution it has, and gave it a NearStation area definition to boot.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/155467370-381a1a8c-73d3-4c46-b4f3-8cca39a75b65.png)

Much better.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: On TramStation, the Ordnance Burning Room (for your Tritium) no longer owns that bit of space where noxious gases are meant to vent out into.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
