### PR TITLE
Show "important" messages in created chat tabs (#5501)

### DIFF
--- a/tgui/packages/tgui-panel/chat/model.js
+++ b/tgui/packages/tgui-panel/chat/model.js
@@ -11,14 +11,24 @@ export const canPageAcceptType = (page, type) => (
   type.startsWith(MESSAGE_TYPE_INTERNAL) || page.acceptedTypes[type]
 );
 
-export const createPage = obj => ({
-  id: createUuid(),
-  name: 'New Tab',
-  acceptedTypes: {},
-  unreadCount: 0,
-  createdAt: Date.now(),
-  ...obj,
-});
+export const createPage = obj => {
+  let acceptedTypes = {};
+
+  for (let typeDef of MESSAGE_TYPES) {
+    if (typeDef.important) {
+      acceptedTypes[typeDef.type] = true;
+    }
+  }
+
+  return {
+    id: createUuid(),
+    name: 'New Tab',
+    acceptedTypes: acceptedTypes,
+    unreadCount: 0,
+    createdAt: Date.now(),
+    ...obj,
+  };
+};
 
 export const createMainPage = () => {
   const acceptedTypes = {};

--- a/tgui/packages/tgui-panel/chat/model.js
+++ b/tgui/packages/tgui-panel/chat/model.js
@@ -15,9 +15,7 @@ export const createPage = obj => {
   let acceptedTypes = {};
 
   for (let typeDef of MESSAGE_TYPES) {
-    if (typeDef.important) {
-      acceptedTypes[typeDef.type] = true;
-    }
+    acceptedTypes[typeDef.type] = !!typeDef.important;
   }
 
   return {

--- a/tgui/packages/tgui-panel/chat/reducer.js
+++ b/tgui/packages/tgui-panel/chat/reducer.js
@@ -30,6 +30,7 @@ export const chatReducer = (state = initialState, action) => {
     }
     // Enable any filters that are not explicitly set, that are
     // enabled by default on the main page.
+    // NOTE: This mutates acceptedTypes on the state.
     for (let id of Object.keys(payload.pageById)) {
       const page = payload.pageById[id];
       const filters = page.acceptedTypes;

--- a/tgui/packages/tgui-panel/chat/reducer.js
+++ b/tgui/packages/tgui-panel/chat/reducer.js
@@ -28,6 +28,18 @@ export const chatReducer = (state = initialState, action) => {
     if (payload?.version !== state.version) {
       return state;
     }
+    // Enable any filters that are not explicitly set, that are
+    // enabled by default on the main page.
+    for (let id of Object.keys(payload.pageById)) {
+      const page = payload.pageById[id];
+      const filters = page.acceptedTypes;
+      const defaultFilters = mainPage.acceptedTypes;
+      for (let type of Object.keys(defaultFilters)) {
+        if (filters[type] === undefined) {
+          filters[type] = defaultFilters[type];
+        }
+      }
+    }
     // Reset page message counts
     // NOTE: We are mutably changing the payload on the assumption
     // that it is a copy that comes straight from the web storage.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports the following PRs:
- https://github.com/BeeStation/BeeStation-Hornet/pull/5501
- https://github.com/BeeStation/BeeStation-Hornet/pull/6415

Code-wise, it does the following things:
- Newly created chat tabs will have system messages enabled.
- Disabled message types in newly created chat tabs will be initialised to `false`, as opposed to leaving them uninitialised.
- Previously created chat tabs will have any uninitialised message types set to the defaults of the main tab.

From the user's point of view:
- Custom chat tabs will now have system messages enabled. This is done to prevent a situation where a user removes the main tab, which leaves them unable to read system messages, since those cannot be toggled by the user.
- Newly added message types (in the future) will be enabled by default in all tabs. This is done to prevent a situation where most users are unaware of the message types and left unable to read those messages.
- **All** message types in custom tabs, that were created before this PR, that weren't manually toggled on and off, will be enabled. This is because there is currently no way to distinguish between message types that were newly added and message types that weren't configured by the user.

Also note, that this is not a destructive or irreversible process in any way. No changes are made to the format of the saved data, only to the defaults and the semantics of `undefined` vs `false` entries in the filters.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Chat tab filter behavior has been tweaked: System messages will now be enabled in custom tabs and any new message types will be enabled by default. NOTE: This will mess up your custom chat tab filters after the first time you join. You will need to disable any message types that were automatically enabled with this change.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
