### PR TITLE
DNA console no longer lists reinforcement chromosome

### DIFF
--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -186,8 +186,6 @@
 		valid_chrom_list += "none"
 		return
 
-	valid_chrom_list += "Reinforcement"
-
 	if(stabilizer_coeff != -1)
 		valid_chrom_list += "Stabilizer"
 	if(synchronizer_coeff != -1)


### PR DESCRIPTION
## About The Pull Request
Reinforcement chromosome got removed back in 2020 for being all around shit.

Despite this, every mutation in the game lists reinforcement as a compatible chromosome in the DNA console.
## Why It's Good For The Game
DNA console no longer lies, huge geneticist buffs.
## Changelog
:cl:
fix: DNA console no longer lists reinforcement as a usable chromosome
:cl: