### PR TITLE
Removes lattices from our walls, adds CI to help find them and prevent them from occurring again

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -588,10 +588,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/ancientstation/medbay)
-"bG" = (
-/obj/structure/lattice,
-/turf/closed/wall/rust,
-/area/ruin/space/has_grav/ancientstation/betastorage)
 "bH" = (
 /obj/machinery/door/firedoor/closed,
 /obj/effect/decal/cleanable/dirt,
@@ -7952,7 +7948,7 @@ mf
 DF
 DF
 br
-bG
+DF
 GU
 DF
 GU

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -67517,10 +67517,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"ndj" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/service/kitchen/abandoned)
 "ndp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
@@ -156122,7 +156118,7 @@ aaa
 aad
 aaa
 aad
-ndj
+cqr
 cqr
 wom
 wom

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -9694,11 +9694,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"Fz" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall,
-/area/icemoon/underground/explored)
 "FD" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -36774,7 +36769,7 @@ ak
 Fp
 Fp
 Fp
-Fz
+Xo
 Rj
 qs
 mO

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -21161,7 +21161,6 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cow" = (
-/obj/structure/lattice,
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -35504,6 +35503,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
+"gGF" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gGG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -53630,7 +53634,6 @@
 /turf/open/floor/engine,
 /area/engineering/gravity_generator)
 "mZT" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/closed/wall/rust,
 /area/space/nearstation)
@@ -59358,6 +59361,11 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/disposal/incinerator)
+"pjr" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pjy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -112304,7 +112312,7 @@ aGc
 cFX
 dKD
 aaa
-aeo
+pjr
 aaa
 aaa
 aaa
@@ -113583,9 +113591,9 @@ rko
 idD
 alm
 acm
-aaQ
+gGF
 acm
-aaQ
+gGF
 aaa
 aaa
 aaa
@@ -114098,7 +114106,7 @@ idD
 acK
 aaa
 cow
-aaQ
+gGF
 cow
 aaa
 aaa
@@ -115382,7 +115390,7 @@ oNT
 idD
 acm
 aaa
-aaQ
+gGF
 aaa
 aeU
 aeU

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1218,7 +1218,6 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "ajy" = (
-/obj/structure/lattice,
 /turf/closed/wall/mineral/plastitanium,
 /area/hallway/secondary/entry)
 "ajz" = (
@@ -54576,7 +54575,6 @@
 /turf/open/floor/plating,
 /area/service/chapel)
 "rch" = (
-/obj/structure/lattice,
 /turf/closed/wall/mineral/plastitanium,
 /area/security/prison)
 "rcl" = (
@@ -54836,10 +54834,6 @@
 /obj/item/target/alien,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"rgD" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/medical/virology)
 "rgE" = (
 /obj/item/radio/intercom/directional/south,
 /obj/structure/rack,
@@ -88575,7 +88569,7 @@ dBN
 dBN
 dBN
 cBR
-rgD
+cBR
 dBN
 dBN
 hRK

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -26,10 +26,6 @@
 "ah" = (
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
-"ai" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/engineering/main)
 "aj" = (
 /turf/closed/wall/r_wall,
 /area/engineering/main)
@@ -1810,10 +1806,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science)
-"ge" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/hallway/secondary/entry)
 "gf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5865,7 +5857,7 @@ eh
 rn
 eh
 eh
-ge
+dY
 aa
 aa
 aa
@@ -5957,7 +5949,7 @@ cN
 LH
 en
 dY
-ge
+dY
 dY
 aa
 aa
@@ -7120,7 +7112,7 @@ aa
 aa
 aa
 aa
-ai
+aj
 aj
 aj
 aj

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -57,6 +57,11 @@ if grep -Pzo '/obj/machinery/power/apc[/\w]*?\{\n[^}]*?pixel_[xy] = -?[013-9]\d*
     echo "ERROR: found an APC with a manually set pixel_x or pixel_y that is not +-25."
     st=1
 fi;
+if grep -Pzo '"\w+" = \(\n[^)]*?/obj/structure/lattice[/\w]*?,\n[^)]*?/turf/closed/wall[/\w]*?,\n[^)]*?/area/.+?\)' _maps/**/*.dmm;	then
+	echo
+    echo "ERROR: found lattice stacked with a wall, please remove them."
+    st=1
+fi;
 if grep -P '^/area/.+[\{]' _maps/**/*.dmm;	then
     echo "ERROR: Vareditted /area path use detected in maps, please replace with proper paths."
     st=1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Since lattices render below walls in DM and StrongDMM, it has become a trend that they end up unnoticed when mistakenly placed under walls and at least each one of our station which the exception of Tram is guilty of it. This PR aims to fix that with the addition of a CI to make it easier in the future to find them.
I thought of having it check for all lattices in all closed turfs and not just specifically walls, but I didn't really have an issue with lattices being placed under mineral turfs and as I am not a mapping expert, I'd be more than happy to hear your opinions on what we should be looking for.

![help2](https://user-images.githubusercontent.com/25415050/155621297-2bc6790a-0333-43e9-9bc9-055b91af417b.png)
![help](https://user-images.githubusercontent.com/25415050/155621265-c4d99eec-7fca-4f12-bb63-5968b848134a.png)
Deltastation, with walls filtered out of the preview.

![kilo3](https://user-images.githubusercontent.com/25415050/155621397-725b09cb-35ce-4e83-8cd8-7eb49e5181d9.png)
![kilo](https://user-images.githubusercontent.com/25415050/155621365-d7a21719-f888-4b96-b783-d2581fb42c31.png)
Kilostation

## Why It's Good For The Game

Helps fix mistakes that were previously hard to look out for, as they were invisible unless you specifically investigated each tile for it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Lattices removed from inside the walls of Icebox, Meta, Delta and Kilo.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
