### PR TITLE
Moves Floor Light in MetaStation Atmospherics

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -23014,6 +23014,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"fTX" = (
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fUk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -120048,7 +120052,7 @@ uuF
 elN
 wia
 pik
-wLr
+mCT
 pik
 uzC
 gcA
@@ -120305,7 +120309,7 @@ uuF
 elN
 qaf
 cOb
-mCT
+wLr
 pik
 qah
 lOu
@@ -120818,7 +120822,7 @@ qmX
 uuF
 elN
 pDE
-dtQ
+fTX
 bzg
 lye
 uzC
@@ -121075,7 +121079,7 @@ tYt
 tuk
 jYd
 wCh
-lye
+dtQ
 dSC
 lye
 kHI


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there,

I was playing (WHAT, IMPOSSIBLE) and noticed this.

![image](https://user-images.githubusercontent.com/34697715/155670175-a0ea486f-401e-442c-8a28-f31e02659da1.png)

That's a floor light, and it really just doesn't work when the canister is right there. I moved it off to the side, that shouldn't affect visibility too bad.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/155670189-f4cde05f-69b5-4ac4-a985-ef1ce7fe9ad8.png)

Less visual contrast/clunkiness/oddity is better.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: In MetaStation Atmospherics, the floor light is no longer installed right on top of a canister.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
