### PR TITLE
Atmos volume pumps and meters are now compatible with circuits

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -64,11 +64,8 @@
 /// from /obj/machinery/atmospherics/components/binary/valve/toggle(): (on)
 #define COMSIG_VALVE_SET_OPEN "valve_toggled"
 
-/// from /obj/machinery/atmospherics/components/binary/pump/set_on(active): (on)
-#define COMSIG_PUMP_SET_ON "pump_set_on"
-
-/// from /obj/machinery/atmospherics/components/binary/volume_pump/set_on(active): (on)
-#define COMSIG_VOLUME_PUMP_SET_ON "volume_pump_set_on"
+/// from /obj/machinery/atmospherics/set_on(active): (on)
+#define COMSIG_ATMOS_MACHINE_SET_ON "atmos_machine_set_on"
 
 /// from /obj/machinery/light_switch/set_lights(), sent to every switch in the area: (status)
 #define COMSIG_LIGHT_SWITCH_SET "light_switch_set"

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -67,6 +67,9 @@
 /// from /obj/machinery/atmospherics/components/binary/pump/set_on(active): (on)
 #define COMSIG_PUMP_SET_ON "pump_set_on"
 
+/// from /obj/machinery/atmospherics/components/binary/volume_pump/set_on(active): (on)
+#define COMSIG_VOLUME_PUMP_SET_ON "volume_pump_set_on"
+
 /// from /obj/machinery/light_switch/set_lights(), sent to every switch in the area: (status)
 #define COMSIG_LIGHT_SWITCH_SET "light_switch_set"
 

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -110,6 +110,10 @@
 /obj/machinery/atmospherics/proc/destroy_network()
 	return
 
+/obj/machinery/atmospherics/proc/set_on(active)
+	on = active
+	SEND_SIGNAL(src, COMSIG_ATMOS_MACHINE_SET_ON, on)
+
 /// This should only be called by SSair as part of the rebuild queue.
 /// Handles rebuilding pipelines after init or they've been changed.
 /obj/machinery/atmospherics/proc/rebuild_pipes()

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -270,12 +270,14 @@
 	if(!connected_pump)
 		return
 	connected_pump.set_on(TRUE)
+	connected_pump.update_appearance()
 
 /obj/item/circuit_component/atmos_pump/proc/set_pump_off()
 	CIRCUIT_TRIGGER
 	if(!connected_pump)
 		return
 	connected_pump.set_on(FALSE)
+	connected_pump.update_appearance()
 
 /obj/item/circuit_component/atmos_pump/proc/request_pump_data()
 	CIRCUIT_TRIGGER

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -68,10 +68,6 @@
 	if(air1.pump_gas_to(air2, target_pressure))
 		update_parents()
 
-/obj/machinery/atmospherics/components/binary/pump/proc/set_on(active)
-	on = active
-	SEND_SIGNAL(src, COMSIG_PUMP_SET_ON, on)
-
 /**
  * Called in atmos_init(), used to change or remove the radio frequency from the component
  * Arguments:
@@ -241,10 +237,10 @@
 	. = ..()
 	if(istype(shell, /obj/machinery/atmospherics/components/binary/pump))
 		connected_pump = shell
-		RegisterSignal(connected_pump, COMSIG_PUMP_SET_ON, .proc/handle_pump_activation)
+		RegisterSignal(connected_pump, COMSIG_ATMOS_MACHINE_SET_ON, .proc/handle_pump_activation)
 
 /obj/item/circuit_component/atmos_pump/unregister_usb_parent(atom/movable/shell)
-	UnregisterSignal(connected_pump, COMSIG_PUMP_SET_ON)
+	UnregisterSignal(connected_pump, COMSIG_ATMOS_MACHINE_SET_ON)
 	connected_pump = null
 	return ..()
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -57,7 +57,7 @@
 
 /obj/machinery/atmospherics/components/binary/volume_pump/proc/set_on(active)
 	on = active
-	SEND_SIGNAL(src, COMSIG_PUMP_SET_ON, on)
+	SEND_SIGNAL(src, COMSIG_VOLUME_PUMP_SET_ON, on)
 
 /obj/machinery/atmospherics/components/binary/volume_pump/update_icon_nopipes()
 	icon_state = on && is_operational ? "volpump_on-[set_overlay_offset(piping_layer)]" : "volpump_off-[set_overlay_offset(piping_layer)]"
@@ -284,10 +284,10 @@
 	. = ..()
 	if(istype(shell, /obj/machinery/atmospherics/components/binary/volume_pump))
 		connected_pump = shell
-		RegisterSignal(connected_pump, COMSIG_PUMP_SET_ON, .proc/handle_pump_activation)
+		RegisterSignal(connected_pump, COMSIG_VOLUME_PUMP_SET_ON, .proc/handle_pump_activation)
 
 /obj/item/circuit_component/atmos_volume_pump/unregister_usb_parent(atom/movable/shell)
-	UnregisterSignal(connected_pump, COMSIG_PUMP_SET_ON)
+	UnregisterSignal(connected_pump, COMSIG_VOLUME_PUMP_SET_ON)
 	connected_pump = null
 	return ..()
 

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -30,9 +30,15 @@
 	///Connection to the radio processing
 	var/datum/radio_frequency/radio_connection
 
+/obj/machinery/atmospherics/components/binary/volume_pump/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/usb_port, list(
+		/obj/item/circuit_component/atmos_volume_pump,
+	))
+
 /obj/machinery/atmospherics/components/binary/volume_pump/CtrlClick(mob/user)
 	if(can_interact(user))
-		on = !on
+		set_on(!on)
 		investigate_log("was turned [on ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
 		update_appearance()
 	return ..()
@@ -48,6 +54,10 @@
 /obj/machinery/atmospherics/components/binary/volume_pump/Destroy()
 	SSradio.remove_object(src,frequency)
 	return ..()
+
+/obj/machinery/atmospherics/components/binary/volume_pump/proc/set_on(active)
+	on = active
+	SEND_SIGNAL(src, COMSIG_PUMP_SET_ON, on)
 
 /obj/machinery/atmospherics/components/binary/volume_pump/update_icon_nopipes()
 	icon_state = on && is_operational ? "volpump_on-[set_overlay_offset(piping_layer)]" : "volpump_off-[set_overlay_offset(piping_layer)]"
@@ -144,7 +154,7 @@
 		return
 	switch(action)
 		if("power")
-			on = !on
+			set_on(!on)
 			investigate_log("was turned [on ? "on" : "off"] by [key_name(usr)]", INVESTIGATE_ATMOS)
 			. = TRUE
 		if("rate")
@@ -167,10 +177,10 @@
 	var/old_on = on //for logging
 
 	if("power" in signal.data)
-		on = text2num(signal.data["power"])
+		set_on(text2num(signal.data["power"]))
 
 	if("power_toggle" in signal.data)
-		on = !on
+		set_on(!on)
 
 	if("set_transfer_rate" in signal.data)
 		var/datum/gas_mixture/air1 = airs[1]
@@ -222,3 +232,103 @@
 /obj/machinery/atmospherics/components/binary/volume_pump/on/layer4
 	piping_layer = 4
 	icon_state = "volpump_map-4"
+
+/obj/item/circuit_component/atmos_volume_pump
+	display_name = "Atmospheric Volume Pump"
+	desc = "The interface for communicating with a volume pump."
+
+	///Set the transfer rate of the pump
+	var/datum/port/input/transfer_rate
+	///Activate the pump
+	var/datum/port/input/on
+	///Deactivate the pump
+	var/datum/port/input/off
+	///Signals the circuit to retrieve the pump's current pressure and temperature
+	var/datum/port/input/request_data
+
+	///Pressure of the input port
+	var/datum/port/output/input_pressure
+	///Pressure of the output port
+	var/datum/port/output/output_pressure
+	///Temperature of the input port
+	var/datum/port/output/input_temperature
+	///Temperature of the output port
+	var/datum/port/output/output_temperature
+
+	///Whether the pump is currently active
+	var/datum/port/output/is_active
+	///Send a signal when the pump is turned on
+	var/datum/port/output/turned_on
+	///Send a signal when the pump is turned off
+	var/datum/port/output/turned_off
+
+	///The component parent object
+	var/obj/machinery/atmospherics/components/binary/volume_pump/connected_pump
+
+/obj/item/circuit_component/atmos_volume_pump/populate_ports()
+	transfer_rate = add_input_port("New Transfer Rate", PORT_TYPE_NUMBER, trigger = .proc/set_transfer_rate)
+	on = add_input_port("Turn On", PORT_TYPE_SIGNAL, trigger = .proc/set_pump_on)
+	off = add_input_port("Turn Off", PORT_TYPE_SIGNAL, trigger = .proc/set_pump_off)
+	request_data = add_input_port("Request Port Data", PORT_TYPE_SIGNAL, trigger = .proc/request_pump_data)
+
+	input_pressure = add_output_port("Input Pressure", PORT_TYPE_NUMBER)
+	output_pressure = add_output_port("Output Pressure", PORT_TYPE_NUMBER)
+	input_temperature = add_output_port("Input Temperature", PORT_TYPE_NUMBER)
+	output_temperature = add_output_port("Output Temperature", PORT_TYPE_NUMBER)
+
+	is_active = add_output_port("Active", PORT_TYPE_NUMBER)
+	turned_on = add_output_port("Turned On", PORT_TYPE_SIGNAL)
+	turned_off = add_output_port("Turned Off", PORT_TYPE_SIGNAL)
+
+/obj/item/circuit_component/atmos_volume_pump/register_usb_parent(atom/movable/shell)
+	. = ..()
+	if(istype(shell, /obj/machinery/atmospherics/components/binary/volume_pump))
+		connected_pump = shell
+		RegisterSignal(connected_pump, COMSIG_PUMP_SET_ON, .proc/handle_pump_activation)
+
+/obj/item/circuit_component/atmos_volume_pump/unregister_usb_parent(atom/movable/shell)
+	UnregisterSignal(connected_pump, COMSIG_PUMP_SET_ON)
+	connected_pump = null
+	return ..()
+
+/obj/item/circuit_component/atmos_volume_pump/pre_input_received(datum/port/input/port)
+	transfer_rate.set_value(clamp(transfer_rate.value, 0, MAX_TRANSFER_RATE))
+
+/obj/item/circuit_component/atmos_volume_pump/proc/handle_pump_activation(datum/source, active)
+	SIGNAL_HANDLER
+	is_active.set_output(active)
+	if(active)
+		turned_on.set_output(COMPONENT_SIGNAL)
+	else
+		turned_off.set_output(COMPONENT_SIGNAL)
+
+/obj/item/circuit_component/atmos_volume_pump/proc/set_transfer_rate()
+	CIRCUIT_TRIGGER
+	if(!connected_pump)
+		return
+	connected_pump.transfer_rate = transfer_rate.value
+
+/obj/item/circuit_component/atmos_volume_pump/proc/set_pump_on()
+	CIRCUIT_TRIGGER
+	if(!connected_pump)
+		return
+	connected_pump.set_on(TRUE)
+	connected_pump.update_appearance()
+
+/obj/item/circuit_component/atmos_volume_pump/proc/set_pump_off()
+	CIRCUIT_TRIGGER
+	if(!connected_pump)
+		return
+	connected_pump.set_on(FALSE)
+	connected_pump.update_appearance()
+
+/obj/item/circuit_component/atmos_volume_pump/proc/request_pump_data()
+	CIRCUIT_TRIGGER
+	if(!connected_pump)
+		return
+	var/datum/gas_mixture/air_input = connected_pump.airs[1]
+	var/datum/gas_mixture/air_output = connected_pump.airs[2]
+	input_pressure.set_output(air_input.return_pressure())
+	output_pressure.set_output(air_output.return_pressure())
+	input_temperature.set_output(air_input.return_temperature())
+	output_temperature.set_output(air_output.return_temperature())

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -55,10 +55,6 @@
 	SSradio.remove_object(src,frequency)
 	return ..()
 
-/obj/machinery/atmospherics/components/binary/volume_pump/proc/set_on(active)
-	on = active
-	SEND_SIGNAL(src, COMSIG_VOLUME_PUMP_SET_ON, on)
-
 /obj/machinery/atmospherics/components/binary/volume_pump/update_icon_nopipes()
 	icon_state = on && is_operational ? "volpump_on-[set_overlay_offset(piping_layer)]" : "volpump_off-[set_overlay_offset(piping_layer)]"
 
@@ -284,10 +280,10 @@
 	. = ..()
 	if(istype(shell, /obj/machinery/atmospherics/components/binary/volume_pump))
 		connected_pump = shell
-		RegisterSignal(connected_pump, COMSIG_VOLUME_PUMP_SET_ON, .proc/handle_pump_activation)
+		RegisterSignal(connected_pump, COMSIG_ATMOS_MACHINE_SET_ON, .proc/handle_pump_activation)
 
 /obj/item/circuit_component/atmos_volume_pump/unregister_usb_parent(atom/movable/shell)
-	UnregisterSignal(connected_pump, COMSIG_VOLUME_PUMP_SET_ON)
+	UnregisterSignal(connected_pump, COMSIG_ATMOS_MACHINE_SET_ON)
 	connected_pump = null
 	return ..()
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -207,12 +207,12 @@ GLOBAL_VAR_INIT(cryo_overlay_cover_off, mutable_appearance('icons/obj/cryogenics
 	open_machine()
 
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/proc/set_on(new_value)
-	if(on == new_value)
+/obj/machinery/atmospherics/components/unary/cryo_cell/set_on(active)
+	if(on == active)
 		return
-	SEND_SIGNAL(src, COMSIG_CRYO_SET_ON, new_value)
+	SEND_SIGNAL(src, COMSIG_CRYO_SET_ON, active)
 	. = on
-	on = new_value
+	on = active
 	update_appearance()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/on_set_is_operational(old_value)

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -47,6 +47,9 @@
 	SSair.start_processing_machine(src)
 	if(!target)
 		reattach_to_layer()
+	AddComponent(/datum/component/usb_port, list(
+		/obj/item/circuit_component/atmos_meter,
+	))
 	return ..()
 
 /obj/machinery/meter/proc/reattach_to_layer()
@@ -168,6 +171,44 @@
 	..()
 	if(current_size >= STAGE_FIVE)
 		deconstruct()
+
+/obj/item/circuit_component/atmos_meter
+	display_name = "Atmospheric Meter"
+	desc = "Allows to read the pressure and temperature of the pipenet."
+
+	///Signals the circuit to retrieve the pipenet's current pressure and temperature
+	var/datum/port/input/request_data
+
+	///Pressure of the pipenet
+	var/datum/port/output/pressure
+	///Temperature of the pipenet
+	var/datum/port/output/temperature
+
+	///The component parent object
+	var/obj/machinery/meter/connected_meter
+
+/obj/item/circuit_component/atmos_meter/populate_ports()
+	request_data = add_input_port("Request Meter Data", PORT_TYPE_SIGNAL, trigger = .proc/request_meter_data)
+
+	pressure = add_output_port("Pressure", PORT_TYPE_NUMBER)
+	temperature = add_output_port("Temperature", PORT_TYPE_NUMBER)
+
+/obj/item/circuit_component/atmos_meter/register_usb_parent(atom/movable/shell)
+	. = ..()
+	if(istype(shell, /obj/machinery/meter))
+		connected_meter = shell
+
+/obj/item/circuit_component/atmos_meter/unregister_usb_parent(atom/movable/shell)
+	connected_meter = null
+	return ..()
+
+/obj/item/circuit_component/atmos_meter/proc/request_meter_data()
+	CIRCUIT_TRIGGER
+	if(!connected_meter)
+		return
+	var/datum/gas_mixture/environment = connected_meter.target.return_air()
+	pressure.set_output(environment.return_pressure())
+	temperature.set_output(environment.temperature)
 
 // TURF METER - REPORTS A TILE'S AIR CONTENTS
 // why are you yelling?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a USB port to volume pumps and meters. Also fixes a bug where the gas pumps icon wasn't changing when getting turned on/off with circuits.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows atmos techs to be more creative with their setups using circuits.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Volume pumps and meters are now compatible with circuits.
fix: Fix the gas pump's icon not updating when turned on/off with circuits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
