### PR TITLE
Removes The Firelocks From Kilo's External Airlocks

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -21657,7 +21657,6 @@
 	},
 /area/maintenance/port/lesser)
 "cqN" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Ferry Shuttle Airlock"
 	},
@@ -29348,7 +29347,6 @@
 	},
 /area/commons/locker)
 "esc" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Departure Shuttle Airlock"
 	},
@@ -32897,7 +32895,6 @@
 	},
 /area/maintenance/port/fore)
 "fEH" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/warning/xeno_mining{
 	pixel_y = 32
@@ -33303,7 +33300,6 @@
 /turf/open/floor/iron,
 /area/cargo/drone_bay)
 "fMz" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "External Freight Airlock"
 	},
@@ -38540,7 +38536,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "hPm" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "External Freight Airlock"
 	},
@@ -38929,7 +38924,6 @@
 	},
 /area/maintenance/port/greater)
 "hVI" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "External Freight Airlock"
 	},
@@ -42245,7 +42239,6 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "jaA" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Ferry Shuttle Airlock"
 	},
@@ -44441,7 +44434,6 @@
 /turf/open/floor/iron/dark,
 /area/medical/paramedic)
 "jTH" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "External Freight Airlock"
 	},
@@ -73157,7 +73149,6 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "ufN" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "External Freight Airlock"
 	},
@@ -77988,7 +77979,6 @@
 /turf/open/floor/iron/dark,
 /area/commons/fitness/recreation)
 "waQ" = (
-/obj/machinery/door/firedoor,
 /obj/structure/door_assembly/door_assembly_ext{
 	anchored = 1
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -31829,7 +31829,6 @@
 /turf/closed/wall/rust,
 /area/service/chapel)
 "flZ" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Brig Shuttle Airlock";
 	req_access = null;
@@ -33031,7 +33030,6 @@
 	},
 /area/maintenance/central)
 "fGU" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Departure Shuttle Airlock"
 	},
@@ -39828,7 +39826,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "inB" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Departure Shuttle Airlock";
 	space_dir = 4
@@ -56103,7 +56100,6 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "obh" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Brig Shuttle Airlock";
 	req_access = null;
@@ -75669,7 +75665,6 @@
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "vgP" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	name = "Departure Shuttle Airlock"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the redundant, stupid, pain-inducing firelocks from /all/ of Kilo's external airlocks. That's it. That's the PR.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These were okay if annoying pre smart-firelocks - but now that firelocks are smart, these are more an issue than they're worth. Let the cyclelink handle atmosloss.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The AI no longer can start a full OSI investigation when the tips of your combat boots hit Kilostation, thanks to the fact the firedoors that formerly automatically triggered the fire alarm whenever you use the external airlocks are gone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
