### PR TITLE
Add null check for status display circuitboard in case somehow is free of its prison

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -562,6 +562,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/ai, 32)
 	// Just use command handling built into status display.
 	// The option inputs thankfully sanitize command and picture for us.
 
+	if(!connected_display)
+		return
+
 	var/command_value = command_map[command.value]
 	var/datum/signal/status_signal = new(list("command" = command_value))
 	switch(command_value)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Per Mothblock's suggestion in #65127 adds null check in case status display circuit board is loose, such as if the christmas tree gives it out.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/1185434/155757106-e012d549-32ca-4100-a7cc-fdc2f0e514e9.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

not worth changelog or gbp

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
