### PR TITLE
Fixes being able to insert hand emote items (kisses, slappers, etc) into storage

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -77,7 +77,7 @@
 #define COMSIG_LIVING_POST_FULLY_HEAL "living_post_fully_heal"
 /// from start of /mob/living/handle_breathing(): (delta_time, times_fired)
 #define COMSIG_LIVING_HANDLE_BREATHING "living_handle_breathing"
-///from /obj/item/slapper/attack_atom(): (source=mob/living/slammer, obj/structure/table/slammed_table)
+///from /obj/item/hand_item/slapper/attack_atom(): (source=mob/living/slammer, obj/structure/table/slammed_table)
 #define COMSIG_LIVING_SLAM_TABLE "living_slam_table"
 ///(NOT on humans) from mob/living/*/UnarmedAttack(): (atom/target, proximity, modifiers)
 #define COMSIG_LIVING_UNARMED_ATTACK "living_unarmed_attack"

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -112,7 +112,7 @@
 #define COMSIG_MOB_CREAMED "mob_creamed"
 ///From /obj/item/gun/proc/check_botched()
 #define COMSIG_MOB_CLUMSY_SHOOT_FOOT "mob_clumsy_shoot_foot"
-///from /obj/item/slapper/attack_atom(): (source=obj/structure/table/slammed_table, mob/living/slammer)
+///from /obj/item/hand_item/slapper/attack_atom(): (source=obj/structure/table/slammed_table, mob/living/slammer)
 #define COMSIG_TABLE_SLAMMED "table_slammed"
 ///from base of atom/attack_hand(): (mob/user, modifiers)
 #define COMSIG_MOB_ATTACK_HAND "mob_attack_hand"

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -7,6 +7,7 @@
 	force = 0
 	throwforce = 0
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
+	w_class = WEIGHT_CLASS_HUGE
 	attack_verb_continuous = list("bops")
 	attack_verb_simple = list("bop")
 
@@ -207,6 +208,7 @@
 	force = 0
 	throwforce = 0
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
+	w_class = WEIGHT_CLASS_HUGE
 	attack_verb_continuous = list("slaps")
 	attack_verb_simple = list("slap")
 	hitsound = 'sound/effects/snap.ogg'

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -112,6 +112,7 @@
 	force = 0
 	throwforce = 0
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
+	w_class = WEIGHT_CLASS_HUGE
 
 /obj/item/noogie/attack(mob/living/carbon/target, mob/living/carbon/human/user)
 	if(!istype(target))
@@ -427,6 +428,7 @@
 	force = 0
 	throwforce = 0
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
+	w_class = WEIGHT_CLASS_HUGE
 	/// The kind of projectile this version of the kiss blower fires
 	var/kiss_type = /obj/projectile/kiss
 	/// TRUE if the user was aiming anywhere but the mouth when they offer the kiss, if it's offered

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -421,7 +421,6 @@
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "heart"
 	inhand_icon_state = "nothing"
-	w_class = WEIGHT_CLASS_HUGE
 	/// The kind of projectile this version of the kiss blower fires
 	var/kiss_type = /obj/projectile/kiss
 	/// TRUE if the user was aiming anywhere but the mouth when they offer the kiss, if it's offered

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -1,36 +1,40 @@
-// For all of the items that are really just the user's hand used in different ways, mostly (all, really) from emotes
-
-/obj/item/circlegame
-	name = "circled hand"
-	desc = "If somebody looks at this while it's below your waist, you get to bop them."
-	icon_state = "madeyoulook"
+/// For all of the items that are really just the user's hand used in different ways, mostly (all, really) from emotes
+/obj/item/hand_item
 	force = 0
 	throwforce = 0
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
-	w_class = WEIGHT_CLASS_HUGE
+
+/obj/item/hand_item/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NO_STORAGE_INSERT, TRAIT_GENERIC)
+
+/obj/item/hand_item/circlegame
+	name = "circled hand"
+	desc = "If somebody looks at this while it's below your waist, you get to bop them."
+	icon_state = "madeyoulook"
 	attack_verb_continuous = list("bops")
 	attack_verb_simple = list("bop")
 
-/obj/item/circlegame/Initialize(mapload)
+/obj/item/hand_item/circlegame/Initialize(mapload)
 	. = ..()
 	var/mob/living/owner = loc
 	if(!istype(owner))
 		return
 	RegisterSignal(owner, COMSIG_PARENT_EXAMINE, .proc/ownerExamined)
 
-/obj/item/circlegame/Destroy()
+/obj/item/hand_item/circlegame/Destroy()
 	var/mob/owner = loc
 	if(istype(owner))
 		UnregisterSignal(owner, COMSIG_PARENT_EXAMINE)
 	return ..()
 
-/obj/item/circlegame/dropped(mob/user)
+/obj/item/hand_item/circlegame/dropped(mob/user)
 	UnregisterSignal(user, COMSIG_PARENT_EXAMINE) //loc will have changed by the time this is called, so Destroy() can't catch it
 	// this is a dropdel item.
 	return ..()
 
 /// Stage 1: The mistake is made
-/obj/item/circlegame/proc/ownerExamined(mob/living/owner, mob/living/sucker)
+/obj/item/hand_item/circlegame/proc/ownerExamined(mob/living/owner, mob/living/sucker)
 	SIGNAL_HANDLER
 
 	if(!istype(sucker) || !in_range(owner, sucker))
@@ -38,7 +42,7 @@
 	addtimer(CALLBACK(src, .proc/waitASecond, owner, sucker), 4)
 
 /// Stage 2: Fear sets in
-/obj/item/circlegame/proc/waitASecond(mob/living/owner, mob/living/sucker)
+/obj/item/hand_item/circlegame/proc/waitASecond(mob/living/owner, mob/living/sucker)
 	if(QDELETED(sucker) || QDELETED(src) || QDELETED(owner))
 		return
 
@@ -50,7 +54,7 @@
 		addtimer(CALLBACK(src, .proc/GOTTEM, owner, sucker), 6)
 
 /// Stage 3A: We face our own failures
-/obj/item/circlegame/proc/selfGottem(mob/living/owner)
+/obj/item/hand_item/circlegame/proc/selfGottem(mob/living/owner)
 	if(QDELETED(src) || QDELETED(owner))
 		return
 
@@ -64,7 +68,7 @@
 	qdel(src)
 
 /// Stage 3B: We face our reckoning (unless we moved away or they're incapacitated)
-/obj/item/circlegame/proc/GOTTEM(mob/living/owner, mob/living/sucker)
+/obj/item/hand_item/circlegame/proc/GOTTEM(mob/living/owner, mob/living/sucker)
 	if(QDELETED(sucker))
 		return
 
@@ -104,17 +108,13 @@
 	qdel(src)
 
 
-/obj/item/noogie
+/obj/item/hand_item/noogie
 	name = "noogie"
 	desc = "Get someone in an aggressive grab then use this on them to ruin their day."
 	icon_state = "latexballon"
 	inhand_icon_state = "nothing"
-	force = 0
-	throwforce = 0
-	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
-	w_class = WEIGHT_CLASS_HUGE
 
-/obj/item/noogie/attack(mob/living/carbon/target, mob/living/carbon/human/user)
+/obj/item/hand_item/noogie/attack(mob/living/carbon/target, mob/living/carbon/human/user)
 	if(!istype(target))
 		to_chat(user, span_warning("You don't think you can give this a noogie!"))
 		return
@@ -165,7 +165,7 @@
 	noogie_loop(user, target, 0)
 
 /// The actual meat and bones of the noogie'ing
-/obj/item/noogie/proc/noogie_loop(mob/living/carbon/human/user, mob/living/carbon/target, iteration)
+/obj/item/hand_item/noogie/proc/noogie_loop(mob/living/carbon/human/user, mob/living/carbon/target, iteration)
 	if(!(target?.get_bodypart(BODY_ZONE_HEAD)) || user.pulling != target)
 		return FALSE
 
@@ -201,22 +201,18 @@
 	noogie_loop(user, target, iteration)
 
 
-/obj/item/slapper
+/obj/item/hand_item/slapper
 	name = "slapper"
 	desc = "This is how real men fight."
 	icon_state = "latexballon"
 	inhand_icon_state = "nothing"
-	force = 0
-	throwforce = 0
-	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
-	w_class = WEIGHT_CLASS_HUGE
 	attack_verb_continuous = list("slaps")
 	attack_verb_simple = list("slap")
 	hitsound = 'sound/effects/snap.ogg'
 	/// How many smaller table smacks we can do before we're out
 	var/table_smacks_left = 3
 
-/obj/item/slapper/attack(mob/living/slapped, mob/living/carbon/human/user)
+/obj/item/hand_item/slapper/attack(mob/living/slapped, mob/living/carbon/human/user)
 	if(ishuman(slapped))
 		var/mob/living/carbon/human/human_slapped = slapped
 		human_slapped.dna?.species?.stop_wagging_tail(slapped)
@@ -224,7 +220,7 @@
 
 	var/slap_volume = 50
 	var/datum/status_effect/offering/kiss_check = slapped.has_status_effect(/datum/status_effect/offering)
-	if(kiss_check && istype(kiss_check.offered_item, /obj/item/kisser) && (user in kiss_check.possible_takers))
+	if(kiss_check && istype(kiss_check.offered_item, /obj/item/hand_item/kisser) && (user in kiss_check.possible_takers))
 		user.visible_message(
 			span_danger("[user] scoffs at [slapped]'s advance, winds up, and smacks [slapped.p_them()] hard to the ground!"),
 			span_notice("The nerve! You wind back your hand and smack [slapped] hard enough to knock [slapped.p_them()] over!"),
@@ -273,7 +269,7 @@
 	playsound(slapped, 'sound/weapons/slap.ogg', slap_volume, TRUE, -1)
 	return
 
-/obj/item/slapper/attack_atom(obj/O, mob/living/user, params)
+/obj/item/hand_item/slapper/attack_atom(obj/O, mob/living/user, params)
 	if(!istype(O, /obj/structure/table))
 		return ..()
 
@@ -299,7 +295,7 @@
 		if(table_smacks_left <= 0)
 			qdel(src)
 
-/obj/item/slapper/on_offered(mob/living/carbon/offerer)
+/obj/item/hand_item/slapper/on_offered(mob/living/carbon/offerer)
 	. = TRUE
 
 	if(!(locate(/mob/living/carbon) in orange(1, offerer)))
@@ -312,7 +308,7 @@
 	offerer.apply_status_effect(/datum/status_effect/offering, src, /atom/movable/screen/alert/give/highfive)
 
 /// Yeah broh! This is where we do the high-fiving (or high-tenning :o)
-/obj/item/slapper/on_offer_taken(mob/living/carbon/offerer, mob/living/carbon/taker)
+/obj/item/hand_item/slapper/on_offer_taken(mob/living/carbon/offerer, mob/living/carbon/taker)
 	. = TRUE
 
 	var/open_hands_taker
@@ -327,7 +323,7 @@
 		return
 
 	for(var/i in offerer.held_items)
-		var/obj/item/slapper/slap_check = i
+		var/obj/item/hand_item/slapper/slap_check = i
 		if(istype(slap_check))
 			slappers_giver++
 
@@ -350,7 +346,7 @@
 	qdel(src)
 
 /// Gangster secret handshakes.
-/obj/item/slapper/secret_handshake
+/obj/item/hand_item/slapper/secret_handshake
 	name = "Secret Handshake"
 	icon_state = "recruit"
 	icon = 'icons/obj/gang/actions.dmi'
@@ -363,7 +359,7 @@
 
 
 /// Adds the user to the family that this package corresponds to, dispenses the free_clothes of that family, and adds them to the handler if it exists.
-/obj/item/slapper/secret_handshake/proc/add_to_gang(mob/living/user, original_name)
+/obj/item/hand_item/slapper/secret_handshake/proc/add_to_gang(mob/living/user, original_name)
 	var/datum/antagonist/gang/swappin_sides = new gang_to_use()
 	swappin_sides.original_name = original_name
 	swappin_sides.handler = handler
@@ -377,7 +373,7 @@
 		handler.gangbangers += user.mind
 
 /// Checks if the user is trying to use the package of the family they are in, and if not, adds them to the family, with some differing processing depending on whether the user is already a family member.
-/obj/item/slapper/secret_handshake/proc/attempt_join_gang(mob/living/user)
+/obj/item/hand_item/slapper/secret_handshake/proc/attempt_join_gang(mob/living/user)
 	if(!user?.mind)
 		return
 	var/datum/antagonist/gang/is_gangster = user.mind.has_antag_datum(/datum/antagonist/gang)
@@ -390,7 +386,7 @@
 		user.mind.remove_antag_datum(/datum/antagonist/gang)
 	add_to_gang(user, real_name_backup)
 
-/obj/item/slapper/secret_handshake/on_offer_taken(mob/living/carbon/offerer, mob/living/carbon/taker)
+/obj/item/hand_item/slapper/secret_handshake/on_offer_taken(mob/living/carbon/offerer, mob/living/carbon/taker)
 	. = TRUE
 	if (!(null in taker.held_items))
 		to_chat(taker, span_warning("You can't get taught the secret handshake if [offerer] has no free hands!"))
@@ -419,22 +415,19 @@
 
 
 
-/obj/item/kisser
+/obj/item/hand_item/kisser
 	name = "kiss"
 	desc = "I want you all to know, everyone and anyone, to seal it with a kiss."
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "heart"
 	inhand_icon_state = "nothing"
-	force = 0
-	throwforce = 0
-	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
 	w_class = WEIGHT_CLASS_HUGE
 	/// The kind of projectile this version of the kiss blower fires
 	var/kiss_type = /obj/projectile/kiss
 	/// TRUE if the user was aiming anywhere but the mouth when they offer the kiss, if it's offered
 	var/cheek_kiss
 
-/obj/item/kisser/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/hand_item/kisser/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_GARLIC_BREATH))
 		kiss_type = /obj/projectile/kiss/french
@@ -450,7 +443,7 @@
 	blown_kiss.fire()
 	qdel(src)
 
-/obj/item/kisser/on_offered(mob/living/carbon/offerer)
+/obj/item/hand_item/kisser/on_offered(mob/living/carbon/offerer)
 	if(!(locate(/mob/living/carbon) in orange(1, offerer)))
 		return TRUE
 
@@ -460,7 +453,7 @@
 	offerer.apply_status_effect(/datum/status_effect/offering, src)
 	return TRUE
 
-/obj/item/kisser/on_offer_taken(mob/living/carbon/offerer, mob/living/carbon/taker)
+/obj/item/hand_item/kisser/on_offer_taken(mob/living/carbon/offerer, mob/living/carbon/taker)
 	var/obj/projectile/blown_kiss = new kiss_type(get_turf(offerer))
 	offerer.visible_message("<b>[offerer]</b> gives [taker] \a [blown_kiss][cheek_kiss ? " on the cheek" : ""]!!", span_notice("You give [taker] \a [blown_kiss][cheek_kiss ? " on the cheek" : ""]!"), ignored_mobs = taker)
 	to_chat(taker, span_nicegreen("[offerer] gives you \a [blown_kiss][cheek_kiss ? " on the cheek" : ""]!"))
@@ -478,7 +471,7 @@
 	qdel(src)
 	return TRUE // so the core offering code knows to halt
 
-/obj/item/kisser/death
+/obj/item/hand_item/kisser/death
 	name = "kiss of death"
 	desc = "If looks could kill, they'd be this."
 	color = COLOR_BLACK

--- a/code/modules/antagonists/gang/gang.dm
+++ b/code/modules/antagonists/gang/gang.dm
@@ -239,7 +239,7 @@
 	if(human_owner.stat != CONSCIOUS || human_owner.incapacitated())
 		return FALSE
 
-	var/obj/item/slapper/secret_handshake/secret_handshake_item = new(owner)
+	var/obj/item/hand_item/slapper/secret_handshake/secret_handshake_item = new(owner)
 	if(owner.put_in_hands(secret_handshake_item))
 		to_chat(owner, span_notice("You ready your secret handshake."))
 	else

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -32,6 +32,10 @@
 		to_chat(user, span_warning("No matter what way you try, you can't get [I] to fit inside [src]."))
 		return TRUE //begone infinite storage ghosts, begone from me
 
+	if(HAS_TRAIT(I, TRAIT_NO_STORAGE_INSERT))
+		to_chat(user, span_warning("No matter what way you try, you can't get [I] to fit inside [src]."))
+		return TRUE
+
 	if(istype(I, /obj/item/evidencebag))
 		to_chat(user, span_warning("You find putting an evidence bag in another evidence bag to be slightly absurd."))
 		return TRUE //now this is podracing

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -662,7 +662,7 @@
 		to_chat(src, span_danger("You fail to grasp your [grasped_part.name]."))
 		return
 
-	var/obj/item/self_grasp/grasp = new
+	var/obj/item/hand_item/self_grasp/grasp = new
 	if(starting_hand_index != active_hand_index || !put_in_active_hand(grasp))
 		to_chat(src, span_danger("You fail to grasp your [grasped_part.name]."))
 		QDEL_NULL(grasp)
@@ -670,13 +670,11 @@
 	grasp.grasp_limb(grasped_part)
 
 /// an abstract item representing you holding your own limb to staunch the bleeding, see [/mob/living/carbon/proc/grabbedby] will probably need to find somewhere else to put this.
-/obj/item/self_grasp
+/obj/item/hand_item/self_grasp
 	name = "self-grasp"
 	desc = "Sometimes all you can do is slow the bleeding."
 	icon_state = "latexballon"
 	inhand_icon_state = "nothing"
-	force = 0
-	throwforce = 0
 	slowdown = 1
 	item_flags = DROPDEL | ABSTRACT | NOBLUDGEON | SLOWS_WHILE_IN_HAND | HAND_ITEM
 	/// The bodypart we're staunching bleeding on, which also has a reference to us in [/obj/item/bodypart/var/grasped_by]
@@ -684,7 +682,7 @@
 	/// The carbon who owns all of this mess
 	var/mob/living/carbon/user
 
-/obj/item/self_grasp/Destroy()
+/obj/item/hand_item/self_grasp/Destroy()
 	if(user)
 		to_chat(user, span_warning("You stop holding onto your[grasped_part ? " [grasped_part.name]" : "self"]."))
 		UnregisterSignal(user, COMSIG_PARENT_QDELETING)
@@ -696,12 +694,12 @@
 	return ..()
 
 /// The limb or the whole damn person we were grasping got deleted or dismembered, so we don't care anymore
-/obj/item/self_grasp/proc/qdel_void()
+/obj/item/hand_item/self_grasp/proc/qdel_void()
 	SIGNAL_HANDLER
 	qdel(src)
 
 /// We've already cleared that the bodypart in question is bleeding in [the place we create this][/mob/living/carbon/proc/grabbedby], so set up the connections
-/obj/item/self_grasp/proc/grasp_limb(obj/item/bodypart/grasping_part)
+/obj/item/hand_item/self_grasp/proc/grasp_limb(obj/item/bodypart/grasping_part)
 	user = grasping_part.owner
 	if(!istype(user))
 		stack_trace("[src] attempted to try_grasp() with [istype(user, /datum) ? user.type : isnull(user) ? "null" : user] user")

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -46,18 +46,18 @@
 	if(!iscarbon(user) || user.usable_hands < 2)
 		return FALSE
 	return ..()
-	
+
 /datum/emote/living/carbon/circle
 	key = "circle"
 	key_third_person = "circles"
 	hands_use_check = TRUE
-	
+
 /datum/emote/living/carbon/circle/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
 	if(!length(user.get_empty_held_indexes()))
 		to_chat(user, span_warning("You don't have any free hands to make a circle with."))
 		return
-	var/obj/item/circlegame/N = new(user)
+	var/obj/item/hand_item/circlegame/N = new(user)
 	if(user.put_in_hands(N))
 		to_chat(user, span_notice("You make a circle with your hand."))
 
@@ -67,7 +67,7 @@
 	message = "moans!"
 	message_mime = "appears to moan!"
 	emote_type = EMOTE_AUDIBLE
-	
+
 /datum/emote/living/carbon/noogie
 	key = "noogie"
 	key_third_person = "noogies"
@@ -77,7 +77,7 @@
 	. = ..()
 	if(!.)
 		return
-	var/obj/item/noogie/noogie = new(user)
+	var/obj/item/hand_item/noogie/noogie = new(user)
 	if(user.put_in_hands(noogie))
 		to_chat(user, span_notice("You ready your noogie'ing hand."))
 	else
@@ -104,7 +104,7 @@
 	message_param = "signs the number %t."
 	mob_type_allowed_typecache = list(/mob/living/carbon/alien)
 	hands_use_check = TRUE
-	
+
 /datum/emote/living/carbon/sign/select_param(mob/user, params)
 	. = ..()
 	if(!isnum(text2num(params)))
@@ -116,18 +116,18 @@
 	message_param = "raises %t fingers."
 	mob_type_allowed_typecache = list(/mob/living/carbon/human)
 	hands_use_check = TRUE
-	
+
 /datum/emote/living/carbon/slap
 	key = "slap"
 	key_third_person = "slaps"
 	hands_use_check = TRUE
 	cooldown = 3 SECONDS // to prevent endless table slamming
-	
+
 /datum/emote/living/carbon/slap/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
 	if(!.)
 		return
-	var/obj/item/slapper/N = new(user)
+	var/obj/item/hand_item/slapper/N = new(user)
 	if(user.put_in_hands(N))
 		to_chat(user, span_notice("You ready your slapping hand."))
 	else

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -202,10 +202,10 @@
 	. = ..()
 	if(!.)
 		return
-	var/kiss_type = /obj/item/kisser
+	var/kiss_type = /obj/item/hand_item/kisser
 
 	if(HAS_TRAIT(user, TRAIT_KISS_OF_DEATH))
-		kiss_type = /obj/item/kisser/death
+		kiss_type = /obj/item/hand_item/kisser/death
 
 	var/obj/item/kiss_blower = new kiss_type(user)
 	if(user.put_in_hands(kiss_blower))

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -107,8 +107,8 @@
 	var/generic_bleedstacks
 	/// If we have a gauze wrapping currently applied (not including splints)
 	var/obj/item/stack/current_gauze
-	/// If something is currently grasping this bodypart and trying to staunch bleeding (see [/obj/item/self_grasp])
-	var/obj/item/self_grasp/grasped_by
+	/// If something is currently grasping this bodypart and trying to staunch bleeding (see [/obj/item/hand_item/self_grasp])
+	var/obj/item/hand_item/self_grasp/grasped_by
 
 	///A list of all the external organs we've got stored to draw horns, wings and stuff with (special because we are actually in the limbs unlike normal organs :/ )
 	var/list/obj/item/organ/external/external_organs = list()


### PR DESCRIPTION
## About The Pull Request

Makes circlehands and slappers huge, just like offhand is.
I dunno if it is worth adding a check to evidence bag for dropdel to not fit, because I don't know how much the flag is used, but I thought changing the hand's weights would be better in the long run for those specific items since this problem might not be limited to just evidence bags.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/65168 and possibly more edgecases.

## Changelog

:cl:
fix: Slappers and circlehands don't fit in storage bags anymore.
/:cl: