### PR TITLE
Reset Poly's death streak upon surviving a round

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -965,7 +965,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 		else
 			file_data["longestdeathstreak"] = longest_deathstreak
 	else
-		file_data["roundssurvived"] = rounds_survived + 1
+		file_data["roundssurvived"] = max(rounds_survived, 0) + 1
 		if(rounds_survived + 1 > longest_survival)
 			file_data["longestsurvival"] = rounds_survived + 1
 		else


### PR DESCRIPTION
## About The Pull Request

Fixes saving Poly's death streak so it resets back to 1 when Poly survives a round.

## Why It's Good For The Game

Gotta earn those death streak records.

## Changelog

:cl:
fix: Poly's death streak resets upon surviving
/:cl: