### PR TITLE
[update tgs:DMAPI] Fix git commit detection, fix runtimes when starting tgs on a fresh repo reclone

### DIFF
--- a/code/modules/tgs/v3210/api.dm
+++ b/code/modules/tgs/v3210/api.dm
@@ -68,11 +68,19 @@
 
 	var/list/logs = file2list(".git/logs/HEAD")
 	if(logs.len)
-		logs = splittext(logs[logs.len - 1], " ")
-		commit = logs[2]
+		logs = splittext(logs[logs.len], " ")
+		if (logs.len >= 2)
+			commit = logs[2]
+		else
+			TGS_ERROR_LOG("Error parsing commit logs")
+
 	logs = file2list(".git/logs/refs/remotes/origin/master")
 	if(logs.len)
-		originmastercommit = splittext(logs[logs.len - 1], " ")[2]
+		logs = splittext(logs[logs.len], " ")
+		if (logs.len >= 2)
+			originmastercommit = logs[2]
+		else
+			TGS_ERROR_LOG("Error parsing origin commmit logs")
 
 	if(world.system_type != MS_WINDOWS)
 		TGS_ERROR_LOG("This API version is only supported on Windows. Not running on Windows. Aborting initialization!")

--- a/code/modules/tgs/v3210/api.dm
+++ b/code/modules/tgs/v3210/api.dm
@@ -28,6 +28,8 @@
 
 #define SERVICE_RETURN_SUCCESS "SUCCESS"
 
+#define TGS_FILE2LIST(filename) (splittext(trim_left(trim_right(file2text(filename))), "\n"))
+
 /datum/tgs_api/v3210
 	var/reboot_mode = REBOOT_MODE_NORMAL
 	var/comms_key
@@ -53,11 +55,6 @@
 			return copytext(text, 1, i + 1)
 	return ""
 
-/datum/tgs_api/v3210/proc/file2list(filename)
-	if(IsAdminAdvancedProcCall())
-		CRASH("Attempted to read file via admin call")
-	return splittext(trim_left(trim_right(file2text(filename))), "\n")
-
 /datum/tgs_api/v3210/OnWorldNew(minimum_required_security_level)
 	. = FALSE
 
@@ -66,15 +63,15 @@
 	if(!instance_name)
 		instance_name = "TG Station Server" //maybe just upgraded
 
-	var/list/logs = file2list(".git/logs/HEAD")
+	var/list/logs = TGS_FILE2LIST(".git/logs/HEAD")
 	if(logs.len)
 		logs = splittext(logs[logs.len], " ")
 		if (logs.len >= 2)
 			commit = logs[2]
 		else
 			TGS_ERROR_LOG("Error parsing commit logs")
-
-	logs = file2list(".git/logs/refs/remotes/origin/master")
+	
+	logs = TGS_FILE2LIST(".git/logs/refs/remotes/origin/master")
 	if(logs.len)
 		logs = splittext(logs[logs.len], " ")
 		if (logs.len >= 2)
@@ -236,3 +233,5 @@
 #undef SERVICE_REQUEST_API_VERSION
 
 #undef SERVICE_RETURN_SUCCESS
+
+#undef TGS_FILE2LIST


### PR DESCRIPTION
`file2list` already trims the trailing blank line, skipping the last line like this was unnecessary and runtiming on fresh reclones

Upstream PR https://github.com/tgstation/tgstation-server/pull/1360