### PR TITLE
Adds a seperate pick proc to work on lists

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -123,6 +123,16 @@
 /proc/_pick(...)
 	return pick(arglist(args))
 
+/// Allow me to explain
+/// for some reason, if pick() is passed arglist(args) directly and args contains only one list
+/// it considers it to be a list of lists
+/// this means something like _pick(list) would fail
+/// need to do this instead
+///
+/// I hate this timeline
+/proc/_pick_list(list/pick_from)
+	return pick(pick_from)
+
 /proc/_prob(P)
 	return prob(P)
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Because of how arglist() works, _pick was only working on args matching
the format pick(1, 2 ,3)

Because this is logic that happens inside pick itself, and I can't
figure out the proper way to actually pass things in, I've created
_pick_list so admins have a sane way to pick from lists.

## Why It's Good For The Game

Admins can use sdql better. If we satiate them maybe they'll stop asking for harder things

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
admin: Since _pick doesn't accept lists, I've added _pick_list for you to use in sdql. Please table everyone on the station kthnx
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
