### PR TITLE
Fixes Kilostation's space ruin z-linkages and level count

### DIFF
--- a/_maps/kilostation.json
+++ b/_maps/kilostation.json
@@ -3,7 +3,6 @@
     "map_name": "Kilo Station",
     "map_path": "map_files/KiloStation",
     "map_file": "KiloStation.dmm",
-    "space_ruin_levels": 4,
     "shuttles": {
 	    "emergency": "emergency_kilo",
 	    "ferry": "ferry_kilo",
@@ -12,6 +11,7 @@
     },
 	"traits": [
 		{
+			"Linkage": "Cross",
 			"Bombcap Multiplier": 0.7
 		}
 	],

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -23455,7 +23455,6 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "cBf" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

#49457 reduced the number of space z-levels on Kilostation in an attempt to tackle the old OOM issue that cropped up on the map. Since the OOM issue was a turf duplication bug in shuttle code, this did not actually work, but never got reverted.

In addition Kilo is not picking up the linkage trait needed to connect with the space ruin z-levels. This applies the trait in the map's json file, which results in normal behavior.

Also removes a duplicate APC I found.

## Why It's Good For The Game

It's rather annoying to go space exploring when you can't cross the edges of the station map.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Kilostation will now generate a normal number of space ruin z-levels
fix: Kilostation will now have the correct linkage between its space z-levels - you can now easily go space exploring again.
fix: Removed duplicate APC from Kilostation security office.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
