### PR TITLE
Fixes an oversight with heretic influence generation

### DIFF
--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -98,7 +98,7 @@
 	tracked_heretics |= heretic
 
 	// If our heretic's on station, generate some new influences
-	if(ishuman(heretic.current) && is_station_level(heretic.current.z))
+	if(ishuman(heretic.current) && !is_centcom_level(heretic.current.z))
 		generate_new_influences()
 
 	add_to_smashes(heretic)


### PR DESCRIPTION
## About The Pull Request

I initially limited influence generation to station z so admins can mess with heretics in the thunderdome or for events.
Prior, admins risk messing with the round by giving themselves heretic, as it generated influences on the station itself. 

Unfortunately, latejoins don't gain antag datums on the station z. They gain it in hyperspace. 

Replaces the station check with a not-centcom check. 

Closes #64955

## Why It's Good For The Game

Latetejoin heretics actually spawn influences

## Changelog

:cl: Melbert
fix: Heretic Smugglers (latejoin heretics) actually spawn influences
/:cl:

