### PR TITLE
Buffs The Ecto-Sniffer Again

### DIFF
--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -32,6 +32,7 @@
 	flick("ecto_sniffer_flick", src)
 	playsound(loc, 'sound/machines/ectoscope_beep.ogg', 75)
 	use_power(10)
+	say("Registering [pick(world.file2list("strings/spook_levels.txt"))] levels of paranormal activity!!")
 	if(activator?.ckey)
 		ectoplasmic_residues += activator.ckey
 		addtimer(CALLBACK(src, .proc/clear_residue, activator.ckey), 15 SECONDS)

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -32,7 +32,7 @@
 	flick("ecto_sniffer_flick", src)
 	playsound(loc, 'sound/machines/ectoscope_beep.ogg', 75)
 	use_power(10)
-	say("Registering [pick(world.file2list("strings/spook_levels.txt"))] levels of paranormal activity!!")
+	say("Reporting [pick(world.file2list("strings/spook_levels.txt"))] levels of paranormal activity!")
 	if(activator?.ckey)
 		ectoplasmic_residues += activator.ckey
 		addtimer(CALLBACK(src, .proc/clear_residue, activator.ckey), 15 SECONDS)

--- a/strings/spook_levels.txt
+++ b/strings/spook_levels.txt
@@ -1,0 +1,14 @@
+low
+medium
+high
+medium rare
+golem
+cheesy horror flick
+SKELLY TONE
+minimum wage employment
+chair-moving
+hair-raising
+nearby welding tool
+distant explosion
+gasmask assistant
+unpaid student loan

--- a/strings/spook_levels.txt
+++ b/strings/spook_levels.txt
@@ -1,3 +1,19 @@
+moderate
+regular
+okay
+somewhat irregular
+weird
+offputting
+ungodly
+off the charts
+earth-shattering
+station-shaking
+REDACTED
+annoying
+nuisance heavy
+intern
+clown
+Poly
 low
 medium
 high
@@ -5,10 +21,10 @@ medium rare
 golem
 cheesy horror flick
 SKELLY TONE
-minimum wage employment
 chair-moving
 hair-raising
-nearby welding tool
-distant explosion
-gasmask assistant
-unpaid student loan
+RUNTIME ERROR
+help
+IT COMES
+NAR
+hi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Not even a louder sound got roboticists to pay attention to this machine, so I've done it.
This adds a a 'say()' to the ecto sniffer, along with a handful of silly (and spooky) phrases for it to say. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Roboticists please just make cyborgs, I'm begging you. It's the whole point of your job. I don't want to make this even more absurd.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
accessibility: Ectoscopic Sniffers now shout a handful of silly phrases to remind robotics to not ignore them, and to accommodate deaf players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
