### PR TITLE
Makes plumbing IV drips rotatable with alt-click, removes alt-clicking IV drips to max out transfer rate

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -342,7 +342,8 @@
 	. = ..()
 	AddComponent(/datum/component/plumbing/iv_drip, anchored)
 	AddComponent(/datum/component/simple_rotation)
-
+/obj/machinery/iv_drip/plumbing/AltClick(mob/user)
+	return ..() // This hotkey is BLACKLISTED since it's used by /datum/component/simple_rotation
 /obj/machinery/iv_drip/plumbing/wrench_act(mob/living/user, obj/item/I)
 	..()
 	default_unfasten_wrench(user, I)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -7,7 +7,7 @@
 ///Universal IV that can drain blood or feed reagents over a period of time from or to a replaceable container
 /obj/machinery/iv_drip
 	name = "\improper IV drip"
-	desc = "An IV drip with an advanced infusion pump that can both drain blood into and inject liquids from attached containers. Blood packs are injected at twice the displayed rate. Right-Click to detach the IV or the attached container. Alt-Click to change the transfer rate to the maximum possible."
+	desc = "An IV drip with an advanced infusion pump that can both drain blood into and inject liquids from attached containers. Blood packs are injected at twice the displayed rate. Right-Click to detach the IV or the attached container."
 	icon = 'icons/obj/iv_drip.dmi'
 	icon_state = "iv_drip"
 	base_icon_state = "iv_drip"
@@ -225,15 +225,6 @@
 		toggle_mode()
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-/obj/machinery/iv_drip/AltClick(mob/user)
-	if(can_interact(user))
-		set_transfer_rate_max()
-	return ..()
-
-/obj/machinery/iv_drip/proc/set_transfer_rate_max()
-	transfer_rate = MAX_IV_TRANSFER_RATE
-	to_chat(usr, span_notice("You set the transfer rate to [transfer_rate] units per metabolism cycle to speed up the [src]."))
-
 ///called when an IV is attached
 /obj/machinery/iv_drip/proc/attach_iv(mob/living/target, mob/user)
 	user.visible_message(span_warning("[usr] begins attaching [src] to [target]..."), span_warning("You begin attaching [src] to [target]."))
@@ -351,9 +342,6 @@
 	. = ..()
 	AddComponent(/datum/component/plumbing/iv_drip, anchored)
 	AddComponent(/datum/component/simple_rotation)
-
-/obj/machinery/iv_drip/plumbing/set_transfer_rate_max()
-	return //alt clicking this shouldn't do anything special as it's reserved for rotation
 
 /obj/machinery/iv_drip/plumbing/wrench_act(mob/living/user, obj/item/I)
 	..()

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -342,8 +342,7 @@
 	. = ..()
 	AddComponent(/datum/component/plumbing/iv_drip, anchored)
 	AddComponent(/datum/component/simple_rotation)
-/obj/machinery/iv_drip/plumbing/AltClick(mob/user)
-	return ..() // This hotkey is BLACKLISTED since it's used by /datum/component/simple_rotation
+	
 /obj/machinery/iv_drip/plumbing/wrench_act(mob/living/user, obj/item/I)
 	..()
 	default_unfasten_wrench(user, I)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -227,9 +227,12 @@
 
 /obj/machinery/iv_drip/AltClick(mob/user)
 	if(can_interact(user))
-		transfer_rate = MAX_IV_TRANSFER_RATE
-		to_chat(usr, span_notice("You set the transfer rate to [transfer_rate] units per metabolism cycle to speed up the [src]."))
+		set_transfer_rate_max()
 	return ..()
+
+/obj/machinery/iv_drip/proc/set_transfer_rate_max()
+	transfer_rate = MAX_IV_TRANSFER_RATE
+	to_chat(usr, span_notice("You set the transfer rate to [transfer_rate] units per metabolism cycle to speed up the [src]."))
 
 ///called when an IV is attached
 /obj/machinery/iv_drip/proc/attach_iv(mob/living/target, mob/user)
@@ -347,6 +350,10 @@
 /obj/machinery/iv_drip/plumbing/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/plumbing/iv_drip, anchored)
+	AddComponent(/datum/component/simple_rotation)
+
+/obj/machinery/iv_drip/plumbing/set_transfer_rate_max()
+	return //alt clicking this shouldn't do anything special as it's reserved for rotation
 
 /obj/machinery/iv_drip/plumbing/wrench_act(mob/living/user, obj/item/I)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes alt-clicking plumbing IV drips rotate them.
Removes alt-clicking IV drips to max out their transfer rate.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Trying to rotate them by pushing them around is really awkward, every other plumbing device can be rotated with alt-click.

Removes alt-clicking IV drips to max out their transfer rate as it's almost entirely useless. It gets in the way of using alt-click for rotations, they start at max by default, and it's very rare that you'd ever even want to change their transfer rate from the default anyway.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Alt-clicking plumbing IV drips now rotates them like other plumbing components.
del: Alt-clicking IV drips no longer sets the transfer rate to max.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
