### PR TITLE
Spacemen now are weak from living in a low-gravity environment and can't rapidly gesture their fingers at stuff without straining their arms.

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -268,6 +268,7 @@
 			else
 				message_param = "[span_userdanger("bumps [user.p_their()] head on the ground")] trying to motion towards %t."
 				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+		H.adjustStaminaLoss(25)
 	return ..()
 
 /datum/emote/living/pout


### PR DESCRIPTION
## About The Pull Request

Spacemen now are weak from living in a low-gravity environment and can't rapidly gesture their fingers at stuff without straining their arms.

## Why It's Good For The Game

Use your words, or long form emotes if you're a mime.

## Changelog

:cl:
balance: Spacemen now are weak from living in a low-gravity environment and can't rapidly gesture their fingers at stuff without straining their arms.
/:cl:
