### PR TITLE
Improves spelling for Wheelys' procs to take into account its subtypes

### DIFF
--- a/code/modules/clothing/shoes/wheelys.dm
+++ b/code/modules/clothing/shoes/wheelys.dm
@@ -26,7 +26,7 @@
 	if(!isliving(user))
 		return
 	if(!istype(user.get_item_by_slot(ITEM_SLOT_FEET), /obj/item/clothing/shoes/wheelys))
-		balloon_alert(user, "You must be wearing [src] to use [p_them()]!")
+		balloon_alert(user, "must be worn!")
 		return
 	if(!(wheels.is_occupant(user)))
 		wheelToggle = FALSE

--- a/code/modules/clothing/shoes/wheelys.dm
+++ b/code/modules/clothing/shoes/wheelys.dm
@@ -26,7 +26,7 @@
 	if(!isliving(user))
 		return
 	if(!istype(user.get_item_by_slot(ITEM_SLOT_FEET), /obj/item/clothing/shoes/wheelys))
-		to_chat(user, span_warning("You must be wearing \the [src] to use [src.p_them()]!"))
+		to_chat(user, span_warning("You must be wearing [src] to use [p_them()]!"))
 		return
 	if(!(wheels.is_occupant(user)))
 		wheelToggle = FALSE

--- a/code/modules/clothing/shoes/wheelys.dm
+++ b/code/modules/clothing/shoes/wheelys.dm
@@ -26,7 +26,7 @@
 	if(!isliving(user))
 		return
 	if(!istype(user.get_item_by_slot(ITEM_SLOT_FEET), /obj/item/clothing/shoes/wheelys))
-		to_chat(user, span_warning("You must be wearing \the [src] to use [src.p_them]!"))
+		to_chat(user, span_warning("You must be wearing \the [src] to use [src.p_them()]!"))
 		return
 	if(!(wheels.is_occupant(user)))
 		wheelToggle = FALSE

--- a/code/modules/clothing/shoes/wheelys.dm
+++ b/code/modules/clothing/shoes/wheelys.dm
@@ -26,7 +26,7 @@
 	if(!isliving(user))
 		return
 	if(!istype(user.get_item_by_slot(ITEM_SLOT_FEET), /obj/item/clothing/shoes/wheelys))
-		to_chat(user, span_warning("You must be wearing \the [src] to use [src.p_them()]!"))
+		balloon_alert(user, "You must be wearing [src] to use [p_them()]!")
 		return
 	if(!(wheels.is_occupant(user)))
 		wheelToggle = FALSE

--- a/code/modules/clothing/shoes/wheelys.dm
+++ b/code/modules/clothing/shoes/wheelys.dm
@@ -26,7 +26,7 @@
 	if(!isliving(user))
 		return
 	if(!istype(user.get_item_by_slot(ITEM_SLOT_FEET), /obj/item/clothing/shoes/wheelys))
-		to_chat(user, span_warning("You must be wearing the wheely-heels to use them!"))
+		to_chat(user, span_warning("You must be wearing \the [src] to use [src.p_them]!"))
 		return
 	if(!(wheels.is_occupant(user)))
 		wheelToggle = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hold ski shoes in your hand, try to deploy them, game tells you you must be wearing Wheelys to do that. This PR fixes that and replaces the span warning with a balloon alert.

## Why It's Good For The Game

More consistency, the proc is shared with its subtypes, roller skates and ski shoes, and as such shouldn't be hardcoded to state something specifically about Wheelys.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: you will no longer be asked to be wearing Wheelys when trying to activate ski shoes and rollerskates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
