### PR TITLE
Blocks Proto-Nitrade/BZ Reactions from occuring inside pipes.

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -825,8 +825,7 @@
 	var/temperature = air.temperature
 	var/turf/open/location
 	if(istype(holder,/datum/pipeline)) //Find the tile the reaction is occuring on, or a random part of the network if it's a pipenet.
-		var/datum/pipeline/pipenet = holder
-		location = get_turf(pick(pipenet.members))
+		return NO_REACTION // We don't want to irradiate from the pipeline.
 	else
 		location = get_turf(holder)
 	var consumed_amount = min(air.temperature / 2240 * cached_gases[/datum/gas/bz][MOLES] * cached_gases[/datum/gas/proto_nitrate][MOLES] / (cached_gases[/datum/gas/bz][MOLES] + cached_gases[/datum/gas/proto_nitrate][MOLES]), cached_gases[/datum/gas/bz][MOLES], cached_gases[/datum/gas/proto_nitrate][MOLES])


### PR DESCRIPTION
Closes #65212

## About The Pull Request

Fixes being able to irradiate the station via pipes, the other PR kicks the can down the road while this PR definitively stops the issue.

## Why It's Good For The Game

It's like being back in old radiation all over again

## Changelog

:cl:
fix: Fixes irradiating the entire station via pipes.
/:cl: