### PR TITLE
Adds Some Lattices to KiloStation Atmospherics

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -30185,6 +30185,7 @@
 /area/medical/chemistry)
 "eHf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "eHz" = (
@@ -57506,6 +57507,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 9
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "ozA" = (
@@ -83937,6 +83939,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "yhd" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there. Interesting PR today. I was doing some work on some active branches (making sure mapmerge didn't shit the bed), and I noticed the following:

![image](https://user-images.githubusercontent.com/34697715/156094790-76554181-683f-4464-b6a1-941570c9dff6.png)

I don't really think having solitary pipes just there should grant it having nearstation lighting+gravity, and I looked at other maps, and the way that something like Delta handles it is that it just puts lattices under the pipes. Like so:

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/156094804-da611d46-bff5-42d9-b7d6-9e2a90a88c32.png)

I think it makes a bit more sense, and I hope you think it makes more sense too.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: There are now some lattices under some pipes in KiloStation Atmospherics. If you want to see history unravel in front of your eyes, it's south to the "Atmospherics Pump Room" under the orange Atmos-to-SM pipeline, right above the SM cooling loops. How nice.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
