### PR TITLE
Screentips for anomaly neutralizer / null rod (and other effect removers)

### DIFF
--- a/code/datums/components/effect_remover.dm
+++ b/code/datums/components/effect_remover.dm
@@ -8,6 +8,8 @@
 	var/success_feedback
 	/// Line forcesaid by the user on successful removal.
 	var/success_forcesay
+	/// The text used in the screentip when our parent is hovering over an item we can clear. Ex "Destroy rune"
+	var/tip_text
 	/// Callback invoked with removal is done.
 	var/datum/callback/on_clear_callback
 	/// A typecache of all effects we can clear with our item.
@@ -16,6 +18,7 @@
 /datum/component/effect_remover/Initialize(
 	success_forcesay,
 	success_feedback,
+	tip_text,
 	on_clear_callback,
 	effects_we_clear,
 	)
@@ -30,14 +33,24 @@
 
 	src.success_feedback = success_feedback
 	src.success_forcesay = success_forcesay
+	src.tip_text = tip_text
 	src.on_clear_callback = on_clear_callback
 	src.effects_we_clear = typecacheof(effects_we_clear)
+
+/datum/component/effect_remover/Destroy(force, silent)
+	QDEL_NULL(on_clear_callback)
+	return ..()
 
 /datum/component/effect_remover/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_EFFECT, .proc/try_remove_effect)
 
+	if(tip_text)
+		var/obj/item/item_parent = parent
+		item_parent.item_flags |= ITEM_HAS_CONTEXTUAL_SCREENTIPS
+		RegisterSignal(parent, COMSIG_ITEM_REQUESTING_CONTEXT_FOR_TARGET, .proc/add_item_context)
+
 /datum/component/effect_remover/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_EFFECT)
+	UnregisterSignal(parent, list(COMSIG_ITEM_ATTACK_EFFECT, COMSIG_ITEM_REQUESTING_CONTEXT_FOR_TARGET))
 
 /*
  * Signal proc for [COMSIG_ITEM_ATTACK_EFFECT].
@@ -67,3 +80,19 @@
 
 	if(!QDELETED(target))
 		qdel(target)
+
+/*
+ * Signal proc for [COMSIG_ITEM_REQUESTING_CONTEXT_FOR_TARGET].
+ *
+ * Adds some context for the target, if we have one set and it's a valid target.
+ */
+/datum/component/effect_remover/proc/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
+	SIGNAL_HANDLER
+
+	context[SCREENTIP_CONTEXT_RMB] = "[tip_text]"
+
+	if(effects_we_clear[target.type])
+		context[SCREENTIP_CONTEXT_LMB] = "[tip_text]"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	return CONTEXTUAL_SCREENTIP_SET

--- a/code/datums/components/effect_remover.dm
+++ b/code/datums/components/effect_remover.dm
@@ -89,10 +89,8 @@
 /datum/component/effect_remover/proc/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
 	SIGNAL_HANDLER
 
-	context[SCREENTIP_CONTEXT_RMB] = "[tip_text]"
-
 	if(effects_we_clear[target.type])
-		context[SCREENTIP_CONTEXT_LMB] = "[tip_text]"
+		context[SCREENTIP_CONTEXT_LMB] = tip_text
 		return CONTEXTUAL_SCREENTIP_SET
 
-	return CONTEXTUAL_SCREENTIP_SET
+	return NONE

--- a/code/game/objects/items/devices/anomaly_neutralizer.dm
+++ b/code/game/objects/items/devices/anomaly_neutralizer.dm
@@ -17,12 +17,14 @@
 	// Primarily used to delete and neutralize anomalies.
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You neutralize %THEEFFECT with %THEWEAPON, frying its circuitry in the process.", \
+		tip_text = "Neutralize anomaly", \
 		on_clear_callback = CALLBACK(src, .proc/on_anomaly_neutralized), \
 		effects_we_clear = list(/obj/effect/anomaly))
 
 	// Can also be used to delete drained heretic influences, to stop fools from losing arms.
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You close %THEEFFECT with %THEWEAPON, frying its circuitry in the process.", \
+		tip_text = "Close rift", \
 		on_clear_callback = CALLBACK(src, .proc/on_use), \
 		effects_we_clear = list(/obj/effect/visible_heretic_influence))
 

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -154,6 +154,7 @@
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You disrupt the magic of %THEEFFECT with %THEWEAPON.", \
 		success_forcesay = "BEGONE FOUL MAGIKS!!", \
+		tip_text = "Clear rune", \
 		on_clear_callback = CALLBACK(src, .proc/on_cult_rune_removed), \
 		effects_we_clear = list(/obj/effect/rune, /obj/effect/heretic_rune))
 

--- a/code/modules/antagonists/heretic/items/forbidden_book.dm
+++ b/code/modules/antagonists/heretic/items/forbidden_book.dm
@@ -12,6 +12,7 @@
 	. = ..()
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You remove %THEEFFECT.", \
+		tip_text = "Clear rune", \
 		effects_we_clear = list(/obj/effect/heretic_rune))
 
 /obj/item/codex_cicatrix/examine(mob/user)

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -21,6 +21,7 @@
 	. = ..()
 	AddComponent(/datum/component/effect_remover, \
 		success_feedback = "You remove %THEEFFECT.", \
+		tip_text = "Clear rune", \
 		on_clear_callback = CALLBACK(src, .proc/after_clear_rune), \
 		effects_we_clear = list(/obj/effect/heretic_rune))
 


### PR DESCRIPTION
## About The Pull Request

Adds screentips for the following users of the effect remover component:
- Null Rod, on heretic and cult runes
- Anomaly Neutralizer, on anomalies and heretic realities
- Codex Cicatrix, for heretic runes
- Mansus Grasp, for heretic runes

Also ceans up the effect remover's clear callback on deleting properly. 

## Why It's Good For The Game

More screentips for vague interactions.

## Changelog

:cl: Melbert
qol: Screen tips for the Null Rod, Anomaly Neutralizer, Codex Cicatrix, and Mansus Grasp for removing runes / anomalies / drained heretic influences
/:cl:

