### PR TITLE
Allows more than two assemblies to be connected together

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -106,8 +106,8 @@
 		return
 	if(istype(W,/obj/item/assembly_holder))
 		if(!secured)
-			var/obj/item/assembly_holder/w_holder = W
-			w_holder.add_assembly(src,user)
+			var/obj/item/assembly_holder/added_to_holder = W
+			added_to_holder.add_assembly(src,user)
 	..()
 
 /obj/item/assembly/screwdriver_act(mob/living/user, obj/item/I)

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -104,6 +104,10 @@
 		else
 			to_chat(user, span_warning("Both devices must be in attachable mode to be attached together."))
 		return
+	if(istype(W,/obj/item/assembly_holder))
+		if((!secured)
+			var/obj/item/assembly_holder/W_holder = W
+			W_holder.add_assembly(src,user)
 	..()
 
 /obj/item/assembly/screwdriver_act(mob/living/user, obj/item/I)

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -104,10 +104,10 @@
 		else
 			to_chat(user, span_warning("Both devices must be in attachable mode to be attached together."))
 		return
-	if(istype(W,/obj/item/assembly_holder))
+	if(istype(W, /obj/item/assembly_holder))
 		if(!secured)
 			var/obj/item/assembly_holder/added_to_holder = W
-			added_to_holder.add_assembly(src,user)
+			added_to_holder.add_assembly(src, user)
 	..()
 
 /obj/item/assembly/screwdriver_act(mob/living/user, obj/item/I)

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -105,9 +105,9 @@
 			to_chat(user, span_warning("Both devices must be in attachable mode to be attached together."))
 		return
 	if(istype(W,/obj/item/assembly_holder))
-		if((!secured)
-			var/obj/item/assembly_holder/W_holder = W
-			W_holder.add_assembly(src,user)
+		if(!secured)
+			var/obj/item/assembly_holder/w_holder = W
+			w_holder.add_assembly(src,user)
 	..()
 
 /obj/item/assembly/screwdriver_act(mob/living/user, obj/item/I)

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -115,7 +115,11 @@
 //Bomb assembly proc. This turns assembly+tank into a bomb
 /obj/item/tank/proc/bomb_assemble(obj/item/assembly_holder/assembly, mob/living/user)
 	//Check if either part of the assembly has an igniter, but if both parts are igniters, then fuck it
-	if(isigniter(assembly.a_left) == isigniter(assembly.a_right))
+	var/igniter_count = 0
+	for(var/obj/item/assembly/A in assembly.assemblies)
+		if(isigniter(A))
+			igniter_count +=1
+	if(LAZYLEN(assembly.assemblies) == igniter_count)
 		return
 
 	if((src in user.get_equipped_items(TRUE)) && !user.canUnEquip(src))

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -118,7 +118,7 @@
 	var/igniter_count = 0
 	for(var/obj/item/assembly/attached_assembly as anything in assembly.assemblies)
 		if(isigniter(attached_assembly))
-			igniter_count +=1
+			igniter_count += 1
 	if(LAZYLEN(assembly.assemblies) == igniter_count)
 		return
 

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -116,8 +116,8 @@
 /obj/item/tank/proc/bomb_assemble(obj/item/assembly_holder/assembly, mob/living/user)
 	//Check if either part of the assembly has an igniter, but if both parts are igniters, then fuck it
 	var/igniter_count = 0
-	for(var/obj/item/assembly/A in assembly.assemblies)
-		if(isigniter(A))
+	for(var/obj/item/assembly/attached_assembly as anything in assembly.assemblies)
+		if(isigniter(attached_assembly))
 			igniter_count +=1
 	if(LAZYLEN(assembly.assemblies) == igniter_count)
 		return

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -111,7 +111,7 @@
 		var/obj/item/assembly/attached_assembly = weapon
 		if(!attached_assembly.secured)
 			add_assembly(attached_assembly, user)
-			balloon_alert(user, span_notice("You add the part to the assembly."))
+			balloon_alert(user, "part added")
 		return
 	return ..()
 /obj/item/assembly_holder/AltClick(mob/user)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -130,7 +130,7 @@
 /obj/item/assembly_holder/proc/process_activation(obj/D, normal = 1, special = 1)
 	if(!D)
 		return FALSE
-	if((normal) && LAZYLEN(assemblies) >= 2)
+	if(normal && LAZYLEN(assemblies) >= 2)
 		for(var/obj/item/assembly/assembly in assemblies)
 			if(LAZYACCESS(assemblies,assembly) != D)
 				assembly.pulsed(FALSE)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -120,7 +120,7 @@
 /obj/item/assembly_holder/screwdriver_act(mob/user, obj/item/tool)
 	if(..())
 		return TRUE
-	balloon_alert(user, span_notice("You disassemble [src]!"))
+	balloon_alert(user, "disassembled")
 	for(var/obj/item/assembly/assembly as anything in assemblies)
 		assembly.on_detach()
 		LAZYREMOVE(assemblies, assembly)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -11,7 +11,7 @@
 	throw_speed = 2
 	throw_range = 7
 
-	var/list/assemblies
+	var/list/obj/item/assembly/assemblies
 
 /obj/item/assembly_holder/Initialize(mapload)
 	. = ..()

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -24,7 +24,7 @@
 
 /obj/item/assembly_holder/Exited(atom/movable/gone, direction)
 	. = ..()
-	LAZYREMOVE(assemblies,gone)
+	LAZYREMOVE(assemblies, gone)
 
 /obj/item/assembly_holder/IsAssemblyHolder()
 	return TRUE

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -119,7 +119,7 @@
 
 /obj/item/assembly_holder/attack_self(mob/user)
 	src.add_fingerprint(user)
-	if(LAZYLEN(assemblies)==1)
+	if(LAZYLEN(assemblies) == 1)
 		to_chat(user, span_danger("Assembly part missing!"))
 		return
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -54,7 +54,7 @@
 			A.forceMove(src)
 	A.holder = src
 	A.toggle_secure()
-	LAZYADD(assemblies,A)
+	LAZYADD(assemblies, A)
 	A.holder_movement()
 	A.on_attach()
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -11,24 +11,20 @@
 	throw_speed = 2
 	throw_range = 7
 
-	var/obj/item/assembly/a_left = null
-	var/obj/item/assembly/a_right = null
+	var/list/assemblies
 
 /obj/item/assembly_holder/Initialize(mapload)
 	. = ..()
+	LAZYINITLIST(assemblies)
 	AddComponent(/datum/component/simple_rotation)
 
 /obj/item/assembly_holder/Destroy()
-	QDEL_NULL(a_left)
-	QDEL_NULL(a_right)
+	QDEL_NULL(assemblies)
 	return ..()
 
 /obj/item/assembly_holder/Exited(atom/movable/gone, direction)
 	. = ..()
-	if(gone == a_left)
-		a_left = null
-	else if(gone == a_right)
-		a_right = null
+	LAZYREMOVE(assemblies,gone)
 
 /obj/item/assembly_holder/IsAssemblyHolder()
 	return TRUE
@@ -41,6 +37,15 @@
 	update_appearance()
 	SSblackbox.record_feedback("tally", "assembly_made", 1, "[initial(A.name)]-[initial(A2.name)]")
 
+/obj/item/assembly_holder/proc/add_assembly(obj/item/assembly/A, mob/user)
+	attach(A,user)
+	name = ""
+	for(var/obj/item/assembly/assembly in assemblies)
+		name += "[assembly.name]-"
+	name = splicetext(name,length(name),length(name)+1, "")
+	name += " assembly"
+	update_appearance()
+
 /obj/item/assembly_holder/proc/attach(obj/item/assembly/A, mob/user)
 	if(!A.remove_item_from_storage(src))
 		if(user)
@@ -49,10 +54,7 @@
 			A.forceMove(src)
 	A.holder = src
 	A.toggle_secure()
-	if(!a_left)
-		a_left = A
-	else
-		a_right = A
+	LAZYADD(assemblies,A)
 	A.holder_movement()
 	A.on_attach()
 
@@ -62,54 +64,49 @@
 
 /obj/item/assembly_holder/update_overlays()
 	. = ..()
-	if(a_left)
-		. += "[a_left.icon_state]_left"
-		for(var/left_overlay in a_left.attached_overlays)
+	for(var/obj/item/assembly/assembly in assemblies)
+		. += "[assembly.icon_state]_left"
+		for(var/left_overlay in assembly.attached_overlays)
 			. += "[left_overlay]_l"
 
-	if(!a_right)
-		return
+		if(assembly.is_position_sensitive)
+			. += "[assembly.icon_state]_right"
+			for(var/right_overlay in assembly.attached_overlays)
+				. += "[right_overlay]_r"
+			return
 
-	if(a_right.is_position_sensitive)
-		. += "[a_right.icon_state]_right"
-		for(var/right_overlay in a_right.attached_overlays)
-			. += "[right_overlay]_r"
-		return
-
-	var/mutable_appearance/right = mutable_appearance(icon, "[a_right.icon_state]_left")
-	right.transform = matrix(-1, 0, 0, 0, 1, 0)
-	for(var/right_overlay in a_right.attached_overlays)
-		right.add_overlay("[right_overlay]_l")
-	. += right
+		var/mutable_appearance/right = mutable_appearance(icon, "[assembly.icon_state]_left")
+		right.transform = matrix(-1, 0, 0, 0, 1, 0)
+		for(var/right_overlay in assembly.attached_overlays)
+			right.add_overlay("[right_overlay]_l")
+		. += right
 
 /obj/item/assembly_holder/on_found(mob/finder)
-	if(a_left)
-		a_left.on_found(finder)
-	if(a_right)
-		a_right.on_found(finder)
+	for(var/obj/item/assembly/assembly in assemblies)
+		assembly.on_found(finder)
 
 /obj/item/assembly_holder/setDir()
 	. = ..()
-	if(a_left)
-		a_left.holder_movement()
-	if(a_right)
-		a_right.holder_movement()
+	for(var/obj/item/assembly/assembly in assemblies)
+		assembly.holder_movement()
 
 /obj/item/assembly_holder/dropped(mob/user)
 	. = ..()
-	if(a_left)
-		a_left.dropped()
-	if(a_right)
-		a_right.dropped()
+	for(var/obj/item/assembly/assembly in assemblies)
+		assembly.dropped()
 
 /obj/item/assembly_holder/attack_hand(mob/living/user, list/modifiers)//Perhapse this should be a holder_pickup proc instead, can add if needbe I guess
 	. = ..()
 	if(.)
 		return
-	if(a_left)
-		a_left.attack_hand()
-	if(a_right)
-		a_right.attack_hand()
+	for(var/obj/item/assembly/assembly in assemblies)
+		assembly.attack_hand()
+
+/obj/item/assembly_holder/attackby(obj/item/W, mob/user, params)
+	if(isassembly(W))
+		var/obj/item/assembly/A = W
+		if((!A.secured)
+			add_assembly(A,user)
 
 /obj/item/assembly_holder/AltClick(mob/user)
 	return ..() // This hotkey is BLACKLISTED since it's used by /datum/component/simple_rotation
@@ -118,40 +115,29 @@
 	if(..())
 		return TRUE
 	to_chat(user, span_notice("You disassemble [src]!"))
-	if(a_left)
-		a_left.on_detach()
-		a_left = null
-	if(a_right)
-		a_right.on_detach()
-		a_right = null
+	for(var/obj/item/assembly/assembly in assemblies)
+		assembly.on_detach()
+		LAZYREMOVE(assemblies,assembly)
 	qdel(src)
 	return TRUE
 
 /obj/item/assembly_holder/attack_self(mob/user)
 	src.add_fingerprint(user)
-	if(!a_left || !a_right)
+	if(LAZYLEN(assemblies)==1)
 		to_chat(user, span_danger("Assembly part missing!"))
 		return
-	if(istype(a_left,a_right.type))//If they are the same type it causes issues due to window code
-		switch(tgui_alert(usr,"Which side would you like to use?",,list("Left","Right")))
-			if("Left")
-				a_left.attack_self(user)
-			if("Right")
-				a_right.attack_self(user)
-		return
-	else
-		a_left.attack_self(user)
-		a_right.attack_self(user)
+
+	for(var/obj/item/assembly/assembly in assemblies)
+		assembly.attack_self(user)
 
 
 /obj/item/assembly_holder/proc/process_activation(obj/D, normal = 1, special = 1)
 	if(!D)
 		return FALSE
-	if((normal) && (a_right) && (a_left))
-		if(a_right != D)
-			a_right.pulsed(FALSE)
-		if(a_left != D)
-			a_left.pulsed(FALSE)
+	if((normal) && LAZYLEN(assemblies) >= 2)
+		for(var/obj/item/assembly/assembly in assemblies)
+			if(LAZYACCESS(assemblies,assembly) != D)
+				assembly.pulsed(FALSE)
 	if(master)
 		master.receive_signal()
 	return TRUE

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -111,14 +111,16 @@
 		var/obj/item/assembly/attached_assembly = weapon
 		if(!attached_assembly.secured)
 			add_assembly(attached_assembly, user)
-
+			balloon_alert(user, span_notice("You add the part to the assembly."))
+		return
+	return ..()
 /obj/item/assembly_holder/AltClick(mob/user)
 	return ..() // This hotkey is BLACKLISTED since it's used by /datum/component/simple_rotation
 
 /obj/item/assembly_holder/screwdriver_act(mob/user, obj/item/tool)
 	if(..())
 		return TRUE
-	to_chat(user, span_notice("You disassemble [src]!"))
+	balloon_alert(user, span_notice("You disassemble [src]!"))
 	for(var/obj/item/assembly/assembly as anything in assemblies)
 		assembly.on_detach()
 		LAZYREMOVE(assemblies, assembly)
@@ -128,7 +130,7 @@
 /obj/item/assembly_holder/attack_self(mob/user)
 	src.add_fingerprint(user)
 	if(LAZYLEN(assemblies) == 1)
-		to_chat(user, span_danger("Assembly part missing!"))
+		balloon_alert(user, span_danger("Assembly part missing!"))
 		return
 
 	for(var/obj/item/assembly/assembly as anything in assemblies)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -42,7 +42,7 @@
 	name = ""
 	for(var/obj/item/assembly/assembly in assemblies)
 		name += "[assembly.name]-"
-	name = splicetext(name,length(name),length(name)+1, "")
+	name = splicetext(name, length(name), length(name) + 1, "")
 	name += " assembly"
 	update_appearance()
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -149,7 +149,7 @@
 		return FALSE
 	if(normal && LAZYLEN(assemblies) >= 2)
 		for(var/obj/item/assembly/assembly as anything in assemblies)
-			if(LAZYACCESS(assemblies,assembly) != device)
+			if(LAZYACCESS(assemblies, assembly) != device)
 				assembly.pulsed(FALSE)
 	if(master)
 		master.receive_signal()

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -121,7 +121,7 @@
 	to_chat(user, span_notice("You disassemble [src]!"))
 	for(var/obj/item/assembly/assembly as anything in assemblies)
 		assembly.on_detach()
-		LAZYREMOVE(assemblies,assembly)
+		LAZYREMOVE(assemblies, assembly)
 	qdel(src)
 	return TRUE
 

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -130,7 +130,7 @@
 /obj/item/assembly_holder/attack_self(mob/user)
 	src.add_fingerprint(user)
 	if(LAZYLEN(assemblies) == 1)
-		balloon_alert(user, span_danger("Assembly part missing!"))
+		balloon_alert(user, "part missing!")
 		return
 
 	for(var/obj/item/assembly/assembly as anything in assemblies)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -15,7 +15,6 @@
 
 /obj/item/assembly_holder/Initialize(mapload)
 	. = ..()
-	LAZYINITLIST(assemblies)
 	AddComponent(/datum/component/simple_rotation)
 
 /obj/item/assembly_holder/Destroy()
@@ -40,7 +39,7 @@
 /obj/item/assembly_holder/proc/add_assembly(obj/item/assembly/A, mob/user)
 	attach(A, user)
 	name = ""
-	for(var/obj/item/assembly/assembly in assemblies)
+	for(var/obj/item/assembly/assembly as anything in assemblies)
 		name += "[assembly.name]-"
 	name = splicetext(name, length(name), length(name) + 1, "")
 	name += " assembly"
@@ -64,45 +63,46 @@
 
 /obj/item/assembly_holder/update_overlays()
 	. = ..()
-	for(var/i in 1 to LAZYLEN(assemblies) step 2)
-		var/obj/item/assembly/assembly = assemblies[i]
-		. += "[assembly.icon_state]_left"
-		for(var/left_overlay in assembly.attached_overlays)
-			. += "[left_overlay]_l"
-	for(var/i in 2 to LAZYLEN(assemblies) step 2)
-		var/obj/item/assembly/assembly = assemblies[i]
-		var/mutable_appearance/right = mutable_appearance(icon, "[assembly.icon_state]_left")
-		right.transform = matrix(-1, 0, 0, 0, 1, 0)
-		for(var/right_overlay in assembly.attached_overlays)
-			right.add_overlay("[right_overlay]_l")
-		. += right
+	for(var/i in 1 to LAZYLEN(assemblies))
+		if(i % 2 == 1)
+			var/obj/item/assembly/assembly = assemblies[i]
+			. += "[assembly.icon_state]_left"
+			for(var/left_overlay in assembly.attached_overlays)
+				. += "[left_overlay]_l"
+		if(i % 2 == 0)
+			var/obj/item/assembly/assembly = assemblies[i]
+			var/mutable_appearance/right = mutable_appearance(icon, "[assembly.icon_state]_left")
+			right.transform = matrix(-1, 0, 0, 0, 1, 0)
+			for(var/right_overlay in assembly.attached_overlays)
+				right.add_overlay("[right_overlay]_l")
+			. += right
 
 /obj/item/assembly_holder/on_found(mob/finder)
-	for(var/obj/item/assembly/assembly in assemblies)
+	for(var/obj/item/assembly/assembly as anything in assemblies)
 		assembly.on_found(finder)
 
 /obj/item/assembly_holder/setDir()
 	. = ..()
-	for(var/obj/item/assembly/assembly in assemblies)
+	for(var/obj/item/assembly/assembly as anything in assemblies)
 		assembly.holder_movement()
 
 /obj/item/assembly_holder/dropped(mob/user)
 	. = ..()
-	for(var/obj/item/assembly/assembly in assemblies)
+	for(var/obj/item/assembly/assembly as anything in assemblies)
 		assembly.dropped()
 
 /obj/item/assembly_holder/attack_hand(mob/living/user, list/modifiers)//Perhapse this should be a holder_pickup proc instead, can add if needbe I guess
 	. = ..()
 	if(.)
 		return
-	for(var/obj/item/assembly/assembly in assemblies)
+	for(var/obj/item/assembly/assembly as anything in assemblies)
 		assembly.attack_hand()
 
-/obj/item/assembly_holder/attackby(obj/item/W, mob/user, params)
-	if(isassembly(W))
-		var/obj/item/assembly/A = W
-		if(!A.secured)
-			add_assembly(A,user)
+/obj/item/assembly_holder/attackby(obj/item/weapon, mob/user, params)
+	if(isassembly(weapon))
+		var/obj/item/assembly/attached_assembly = weapon
+		if(!attached_assembly.secured)
+			add_assembly(attached_assembly,user)
 
 /obj/item/assembly_holder/AltClick(mob/user)
 	return ..() // This hotkey is BLACKLISTED since it's used by /datum/component/simple_rotation
@@ -111,7 +111,7 @@
 	if(..())
 		return TRUE
 	to_chat(user, span_notice("You disassemble [src]!"))
-	for(var/obj/item/assembly/assembly in assemblies)
+	for(var/obj/item/assembly/assembly as anything in assemblies)
 		assembly.on_detach()
 		LAZYREMOVE(assemblies,assembly)
 	qdel(src)
@@ -123,7 +123,7 @@
 		to_chat(user, span_danger("Assembly part missing!"))
 		return
 
-	for(var/obj/item/assembly/assembly in assemblies)
+	for(var/obj/item/assembly/assembly as anything in assemblies)
 		assembly.attack_self(user)
 
 
@@ -131,7 +131,7 @@
 	if(!D)
 		return FALSE
 	if(normal && LAZYLEN(assemblies) >= 2)
-		for(var/obj/item/assembly/assembly in assemblies)
+		for(var/obj/item/assembly/assembly as anything in assemblies)
 			if(LAZYACCESS(assemblies,assembly) != D)
 				assembly.pulsed(FALSE)
 	if(master)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -38,7 +38,7 @@
 	SSblackbox.record_feedback("tally", "assembly_made", 1, "[initial(A.name)]-[initial(A2.name)]")
 
 /obj/item/assembly_holder/proc/add_assembly(obj/item/assembly/A, mob/user)
-	attach(A,user)
+	attach(A, user)
 	name = ""
 	for(var/obj/item/assembly/assembly in assemblies)
 		name += "[assembly.name]-"

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -110,7 +110,7 @@
 	if(isassembly(weapon))
 		var/obj/item/assembly/attached_assembly = weapon
 		if(!attached_assembly.secured)
-			add_assembly(attached_assembly,user)
+			add_assembly(attached_assembly, user)
 
 /obj/item/assembly_holder/AltClick(mob/user)
 	return ..() // This hotkey is BLACKLISTED since it's used by /datum/component/simple_rotation

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -10,7 +10,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 2
 	throw_range = 7
-
+	/// used to store the list of assemblies making up our assembly holder
 	var/list/obj/item/assembly/assemblies
 
 /obj/item/assembly_holder/Initialize(mapload)
@@ -36,8 +36,16 @@
 	update_appearance()
 	SSblackbox.record_feedback("tally", "assembly_made", 1, "[initial(A.name)]-[initial(A2.name)]")
 
-/obj/item/assembly_holder/proc/add_assembly(obj/item/assembly/A, mob/user)
-	attach(A, user)
+/**
+ * Adds an assembly to the assembly holder
+ *
+ * This proc is used to add an assembly to the assembly holder, update the appearance, and the name of it.
+ * Arguments:
+ * * attached_assembly - assembly we are adding to the assembly holder
+ * * user - user we pass into attach()
+ */
+/obj/item/assembly_holder/proc/add_assembly(obj/item/assembly/attached_assembly, mob/user)
+	attach(attached_assembly, user)
 	name = ""
 	for(var/obj/item/assembly/assembly as anything in assemblies)
 		name += "[assembly.name]-"
@@ -126,13 +134,22 @@
 	for(var/obj/item/assembly/assembly as anything in assemblies)
 		assembly.attack_self(user)
 
-
-/obj/item/assembly_holder/proc/process_activation(obj/D, normal = 1, special = 1)
-	if(!D)
+/**
+ * this proc is used to process the activation of the assembly holder
+ *
+ * This proc is usually called by signalers, timers, or anything that can trigger and
+ * send a pulse to the assembly holder, which then calls this proc that actually activates the assemblies
+ * Arguments:
+ * * /obj/device - the device we sent the pulse from which called this proc
+ * * normal - 	if this is a normal activation
+ * * special - if this is a special activation
+ */
+/obj/item/assembly_holder/proc/process_activation(obj/device, normal = TRUE, special = TRUE)
+	if(!device)
 		return FALSE
 	if(normal && LAZYLEN(assemblies) >= 2)
 		for(var/obj/item/assembly/assembly as anything in assemblies)
-			if(LAZYACCESS(assemblies,assembly) != D)
+			if(LAZYACCESS(assemblies,assembly) != device)
 				assembly.pulsed(FALSE)
 	if(master)
 		master.receive_signal()

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -64,17 +64,13 @@
 
 /obj/item/assembly_holder/update_overlays()
 	. = ..()
-	for(var/obj/item/assembly/assembly in assemblies)
+	for(var/i in 1 to LAZYLEN(assemblies) step 2)
+		var/obj/item/assembly/assembly = assemblies[i]
 		. += "[assembly.icon_state]_left"
 		for(var/left_overlay in assembly.attached_overlays)
 			. += "[left_overlay]_l"
-
-		if(assembly.is_position_sensitive)
-			. += "[assembly.icon_state]_right"
-			for(var/right_overlay in assembly.attached_overlays)
-				. += "[right_overlay]_r"
-			return
-
+	for(var/i in 2 to LAZYLEN(assemblies) step 2)
+		var/obj/item/assembly/assembly = assemblies[i]
 		var/mutable_appearance/right = mutable_appearance(icon, "[assembly.icon_state]_left")
 		right.transform = matrix(-1, 0, 0, 0, 1, 0)
 		for(var/right_overlay in assembly.attached_overlays)
@@ -105,7 +101,7 @@
 /obj/item/assembly_holder/attackby(obj/item/W, mob/user, params)
 	if(isassembly(W))
 		var/obj/item/assembly/A = W
-		if((!A.secured)
+		if(!A.secured)
 			add_assembly(A,user)
 
 /obj/item/assembly_holder/AltClick(mob/user)

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -19,7 +19,7 @@
 	AddComponent(/datum/component/simple_rotation)
 
 /obj/item/assembly_holder/Destroy()
-	QDEL_NULL(assemblies)
+	QDEL_LAZYLIST(assemblies)
 	return ..()
 
 /obj/item/assembly_holder/Exited(atom/movable/gone, direction)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -101,8 +101,7 @@
 		for(var/i in 1 to maxlength)
 			var/obj/effect/beam/i_beam/I = new(T)
 			if(istype(holder, /obj/item/assembly_holder))
-				var/obj/item/assembly_holder/assembly_holder = holder
-				I.icon_state = "[initial(I.icon_state)]_[(assembly_holder.a_left == src) ? "l":"r"]" //Sync the offset of the beam with the position of the sensor.
+				I.icon_state = "[initial(I.icon_state)]_l" //Sync the offset of the beam with the position of the sensor.
 			else if(istype(holder, /obj/item/transfer_valve))
 				I.icon_state = "[initial(I.icon_state)]_ttv"
 			I.set_density(TRUE)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -123,8 +123,18 @@
 			to_chat(user, "You transfer the frequency and code of \the [signaler2.name] to \the [name]")
 	..()
 
-/obj/item/assembly/signaler/AltClick(mob/user)
-	activate()
+/obj/item/assembly/signaler/attack_self_secondary(mob/user, modifiers)
+	. = ..()
+	if(!can_interact(user))
+		return
+	if(!ishuman(user))
+		return
+	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_SIGNALLER_SEND))
+		to_chat(usr, span_warning("[src] is still recharging..."))
+		return
+	TIMER_COOLDOWN_START(src, COOLDOWN_SIGNALLER_SEND, 1 SECONDS)
+	INVOKE_ASYNC(src, .proc/signal)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/assembly/signaler/proc/signal()
 	if(!radio_connection)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -123,6 +123,9 @@
 			to_chat(user, "You transfer the frequency and code of \the [signaler2.name] to \the [name]")
 	..()
 
+/obj/item/assembly/signaler/attack_self(mob/user)
+	activate()
+
 /obj/item/assembly/signaler/proc/signal()
 	if(!radio_connection)
 		return

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -130,7 +130,7 @@
 	if(!ishuman(user))
 		return
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_SIGNALLER_SEND))
-		balloon_alert(user, span_warning("[src] is still recharging..."))
+		balloon_alert(user, "still recharging...")
 		return
 	TIMER_COOLDOWN_START(src, COOLDOWN_SIGNALLER_SEND, 1 SECONDS)
 	INVOKE_ASYNC(src, .proc/signal)

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -123,7 +123,7 @@
 			to_chat(user, "You transfer the frequency and code of \the [signaler2.name] to \the [name]")
 	..()
 
-/obj/item/assembly/signaler/attack_self(mob/user)
+/obj/item/assembly/signaler/AltClick(mob/user)
 	activate()
 
 /obj/item/assembly/signaler/proc/signal()

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -130,7 +130,7 @@
 	if(!ishuman(user))
 		return
 	if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_SIGNALLER_SEND))
-		to_chat(usr, span_warning("[src] is still recharging..."))
+		balloon_alert(user, span_warning("[src] is still recharging..."))
 		return
 	TIMER_COOLDOWN_START(src, COOLDOWN_SIGNALLER_SEND, 1 SECONDS)
 	INVOKE_ASYNC(src, .proc/signal)


### PR DESCRIPTION
## About The Pull Request

This PR changes how assemblies and assembly holders work, and allows you to connect more than just a signaler and an igniter together. You could have a signaler, a repeating timer, and an igniter together to constantly produce sparks. Making the assembly holder is the same as before, but now you can add assemblies to it. This also allows signalers to be triggered via right clicking them while holding them in your active hand.

## Why It's Good For The Game

This would allow increasingly complex use of assemblies, give them more utility as well as enabling greater player freedom.

## Changelog

:cl:
expansion: More than two assemblies can now be combined for use in bombs, grenades, or anything else assembly holders are used in.
qol: signalers can now be triggered through right click
/:cl:
