### PR TITLE
[COOL BUG READ FOR MORE INFO] Fix vaccines not working in chem masters by giving Fungal TB's vaccine (and others) a name + Add unit test for duplicate chem names + Rename fake beer + Ratio

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/energized_jelly.dm
+++ b/code/modules/antagonists/blob/blobstrains/energized_jelly.dm
@@ -22,7 +22,7 @@
 	B.take_damage(damage, BURN, ENERGY)
 
 /datum/reagent/blob/energized_jelly
-	name = "Energized Jelly"
+	name = "Energized Blob Jelly"
 	taste_description = "gelatin"
 	color = "#EFD65A"
 

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 /// A single reagent
 /datum/reagent
 	/// datums don't have names by default
-	var/name = "Reagent"
+	var/name = ""
 	/// nor do they have descriptions
 	var/description = ""
 	///J/(K*mol)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -431,7 +431,7 @@
 /datum/reagent/consumable/roy_rogers
 	name = "Roy Rogers"
 	description = "A sweet fizzy drink."
-	color = "#53090B" 
+	color = "#53090B"
 	quality = DRINK_GOOD
 	taste_description = "fruity overlysweet cola"
 	glass_icon_state = "royrogers"
@@ -439,7 +439,7 @@
 	glass_desc = "90% sugar in a glass."
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/consumable/roy_roger/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+/datum/reagent/consumable/roy_rogers/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	M.Jitter(6 * REM * delta_time) //not as strong as coffe, still this is a lot of sugar
 	M.adjust_drowsyness(-5 * REM * delta_time)
 	M.adjust_bodytemperature(-5 * REM * TEMPERATURE_DAMAGE_COEFFICIENT * delta_time, M.get_body_temp_normal())
@@ -805,7 +805,7 @@
 /datum/reagent/consumable/cinderella
 	name = "Cinderella"
 	description = "Most definitely a fruity alcohol cocktail to have while partying with your friends."
-	color = "#FF6A50" 
+	color = "#FF6A50"
 	quality = DRINK_VERYGOOD
 	taste_description = "sweet tangy fruit"
 	glass_icon_state = "cinderella"
@@ -1171,7 +1171,7 @@
 /datum/reagent/consumable/agua_fresca
 	name = "Agua Fresca"
 	description = "A refreshing watermelon agua fresca. Perfect on a day at the holodeck."
-	color = "#D25B66" 
+	color = "#D25B66"
 	quality = DRINK_VERYGOOD
 	taste_description = "cool refreshing watermelon"
 	glass_icon_state = "aguafresca"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -7,7 +7,6 @@
 // where all the reagents related to medicine go.
 
 /datum/reagent/medicine
-	name = "Medicine"
 	taste_description = "bitterness"
 	failed_chem = /datum/reagent/impurity/healing/medicine_failure
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -135,6 +135,7 @@
 		src.data |= data.Copy()
 
 /datum/reagent/vaccine/fungal_tb
+	name = "Vaccine (Fungal Tuberculosis)"
 
 /datum/reagent/vaccine/fungal_tb/New(data)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -456,7 +456,7 @@
 	..()
 
 /datum/reagent/toxin/fakebeer //disguised as normal beer for use by emagged brobots
-	name = "Beer"
+	name = "Beer...?"
 	description = "A specially-engineered sedative disguised as beer. It induces instant sleep in its target."
 	color = "#664300" // rgb: 102, 67, 0
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -790,11 +790,11 @@
 	toxpwr = 0
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
 
-/datum/reagent/medicine/sodium_thiopental/on_mob_add(mob/living/L, amount)
+/datum/reagent/toxin/sodium_thiopental/on_mob_add(mob/living/L, amount)
 	. = ..()
 	ADD_TRAIT(L, TRAIT_ANTICONVULSANT, name)
 
-/datum/reagent/medicine/sodium_thiopental/on_mob_delete(mob/living/L)
+/datum/reagent/toxin/sodium_thiopental/on_mob_delete(mob/living/L)
 	. = ..()
 	REMOVE_TRAIT(L, TRAIT_ANTICONVULSANT, name)
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -97,6 +97,7 @@
 #include "reagent_id_typos.dm"
 #include "reagent_mod_expose.dm"
 #include "reagent_mod_procs.dm"
+#include "reagent_names.dm"
 #include "reagent_recipe_collisions.dm"
 #include "resist.dm"
 #include "say.dm"

--- a/code/modules/unit_tests/reagent_names.dm
+++ b/code/modules/unit_tests/reagent_names.dm
@@ -1,8 +1,6 @@
 /// Test that all reagent names are different in order to prevent #65231
 /datum/unit_test/reagent_names
 
-TEST_FOCUS(/datum/unit_test/reagent_names)
-
 /datum/unit_test/reagent_names/Run()
 	var/used_names = list()
 

--- a/code/modules/unit_tests/reagent_names.dm
+++ b/code/modules/unit_tests/reagent_names.dm
@@ -1,0 +1,17 @@
+/// Test that all reagent names are different in order to prevent #65231
+/datum/unit_test/reagent_names
+
+TEST_FOCUS(/datum/unit_test/reagent_names)
+
+/datum/unit_test/reagent_names/Run()
+	var/used_names = list()
+
+	for (var/datum/reagent/reagent as anything in subtypesof(/datum/reagent))
+		var/name = initial(reagent.name)
+		if (!name)
+			continue
+
+		if (name in used_names)
+			Fail("[used_names[name]] shares a name with [reagent] ([name])")
+		else
+			used_names[name] = reagent


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #65231.
Fixes #64569.

Reagents work based off their name. Vaccines and fungal TB's vaccine had the same name. 

Renames fake beer from "Beer" to "Beer...?", because it's been used 10 times this entire year and it's obvious it doesn't matter.

Fixes some typos in some other chemical names, where typepaths were not correct.

![image](https://user-images.githubusercontent.com/35135081/156292740-12c72a8c-acd1-4eb8-a93c-25e8fb07d83b.png)

This means:

![image](https://user-images.githubusercontent.com/35135081/156292754-2a87a894-6cd3-46f9-b1cb-857339250711.png)

But wait, why didn't this happen before? Here's the cool part: **the order of `typesof` has changed, and we were relying on it**.

```dm
/datum/reagent
/datum/reagent/vaccine
/datum/reagent/vaccine/fungal_tb

/proc/main()
 for (var/t in typesof(/datum/reagent))
  world.log << "[t]"
```

BYOND 514.1571:
![dreamseeker_2022-03-01T19-59-32](https://user-images.githubusercontent.com/35135081/156292817-2647bcc6-42cb-47aa-994d-5c7668f56a5d.png)

BYOND 514.1580:

![image](https://user-images.githubusercontent.com/35135081/156292837-fcfd591f-5529-4e09-ba5f-cc23c2710782.png)

Because:

![image](https://user-images.githubusercontent.com/35135081/156292851-f5f2a2ab-6733-4c7a-a544-0688a47df148.png)

What else did this break? Who knows 👻

The fun part to me is I technically caused this by suggesting the O(1) change to begin with 💃 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed vaccines not being able to be moved through chem buffers.
fix: Fixed Roy Rogers and Sodium Thiopental not applying their effects.
balance: Fake beer has been renamed from "Beer" to "Beer...?"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
