### PR TITLE
Lower thieves cost from 6 to 4, disable midround thieves

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -982,7 +982,7 @@
 		ROLE_POSITRONIC_BRAIN,
 	)
 	required_candidates = 1
-	weight = 5
+	weight = 0 // Disabled until Dynamic midround rolling handles minor threats better
 	cost = 3 //Worth less than obsessed, but there's more of them.
 	requirements = list(10,10,10,10,10,10,10,10,10,10)
 	repeatable = TRUE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -723,7 +723,7 @@
 	)
 	required_candidates = 1
 	weight = 3
-	cost = 6 //very cheap cost for the round
+	cost = 4 //very cheap cost for the round
 	scaling_cost = 0
 	requirements = list(8,8,8,8,8,8,8,8,8,8)
 	antag_cap = list("denominator" = 24, "offset" = 2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game
Even though thieves can now only run once, there still just often isn't a lot of threat left in order to spend on antags that impact the round more.

Disables midround thieves, as Dynamic midround rolling currently creates scenarios where you wait a long amount of time (30-45 minutes), just to get one antagonist, which ends up being a bad use of threat. Dynamic midround problems are something I'm acutely aware of and am investigation solutions for. I intend to re-enable this when I write a design doc on how I intend to redo midround rolling.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Lowered thieves cost from 6 to 4.
balance: Disabled midround thieves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
