### PR TITLE
Introduces 3 new permenant banner rolls for fish! 

### DIFF
--- a/code/modules/aquarium/aquarium_kit.dm
+++ b/code/modules/aquarium/aquarium_kit.dm
@@ -39,12 +39,22 @@
 /obj/item/storage/fish_case/random/freshwater/select_fish_type()
 	return random_fish_type(required_fluid=AQUARIUM_FLUID_FRESHWATER)
 
+/obj/item/storage/fish_case/random/saltwater/select_fish_type()
+	return random_fish_type(required_fluid=AQUARIUM_FLUID_SALTWATER)
+
 /obj/item/storage/fish_case/syndicate
 	name = "ominous fish case"
 
 /obj/item/storage/fish_case/syndicate/PopulateContents()
 	. = ..()
 	generate_fish(src, pick(/datum/aquarium_behaviour/fish/donkfish, /datum/aquarium_behaviour/fish/emulsijack))
+
+/obj/item/storage/fish_case/tirizan
+	name = "imported fish case"
+
+/obj/item/storage/fish_case/tirizan/PopulateContents()
+	. = ..()
+	generate_fish(src, pick(/datum/aquarium_behaviour/fish/dwarf_moonfish, /datum/aquarium_behaviour/fish/gunner_jellyfish, /datum/aquarium_behaviour/fish/needlefish, /datum/aquarium_behaviour/fish/armorfish))
 
 ///Book detailing where to get the fish and their properties.
 /obj/item/book/fish_catalog

--- a/code/modules/aquarium/aquarium_kit.dm
+++ b/code/modules/aquarium/aquarium_kit.dm
@@ -49,10 +49,10 @@
 	. = ..()
 	generate_fish(src, pick(/datum/aquarium_behaviour/fish/donkfish, /datum/aquarium_behaviour/fish/emulsijack))
 
-/obj/item/storage/fish_case/tirizan
+/obj/item/storage/fish_case/tiziran
 	name = "imported fish case"
 
-/obj/item/storage/fish_case/tirizan/PopulateContents()
+/obj/item/storage/fish_case/tiziran/PopulateContents()
 	. = ..()
 	generate_fish(src, pick(/datum/aquarium_behaviour/fish/dwarf_moonfish, /datum/aquarium_behaviour/fish/gunner_jellyfish, /datum/aquarium_behaviour/fish/needlefish, /datum/aquarium_behaviour/fish/armorfish))
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2509,7 +2509,7 @@
 
 /datum/supply_pack/misc/aquarium_fish
 	name = "Aquarium Fish Case"
-	desc = "An aquarium fish collection handpicked by monkeys from our collection."
+	desc = "An aquarium fish bundle handpicked by monkeys from our collection."
 	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/storage/fish_case/random,
 					/obj/item/storage/fish_case/random,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2532,13 +2532,13 @@
 					/obj/item/storage/fish_case/random/saltwater)
 	crate_name = "saltwater fish crate"
 
-/datum/supply_pack/misc/tirizan_fish
+/datum/supply_pack/misc/tiziran_fish
 	name = "Tirizan Fish Case"
-	desc = "Tirizian fish caught by the finest tirizan indentured servant."
+	desc = "Tiziran saltwater fish imported from the Zagos Sea."
 	cost = CARGO_CRATE_VALUE * 2
-	contains = list(/obj/item/storage/fish_case/tirizan,
-					/obj/item/storage/fish_case/tirizan)
-	crate_name = "tirizan fish crate"
+	contains = list(/obj/item/storage/fish_case/tiziran,
+					/obj/item/storage/fish_case/tiziran)
+	crate_name = "tiziran fish crate"
 
 /datum/supply_pack/misc/bicycle
 	name = "Bicycle"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2532,7 +2532,7 @@
 					/obj/item/storage/fish_case/random/saltwater)
 	crate_name = "saltwater fish crate"
 
-/datum/supply_pack/misc/aquarium_fish
+/datum/supply_pack/misc/tirizan_fish
 	name = "Tirizan Fish Case"
 	desc = "Tirizian fish caught by the finest tirizan indentured servant."
 	cost = CARGO_CRATE_VALUE * 2

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2509,11 +2509,36 @@
 
 /datum/supply_pack/misc/aquarium_fish
 	name = "Aquarium Fish Case"
-	desc = "An aquarium fish handpicked by monkeys from our collection."
+	desc = "An aquarium fish collection handpicked by monkeys from our collection."
 	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/storage/fish_case/random,
+					/obj/item/storage/fish_case/random,
 					/obj/item/storage/fish_case/random)
 	crate_name = "aquarium fish crate"
+
+/datum/supply_pack/misc/freshwater_fish
+	name = "Freshwater Fish Case"
+	desc = "Aquarium fish that have had most of their mud cleaned off."
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/storage/fish_case/random/freshwater,
+					/obj/item/storage/fish_case/random/freshwater)
+	crate_name = "freshwater fish crate"
+
+/datum/supply_pack/misc/saltwater_fish
+	name = "Saltwater Fish Case"
+	desc = "Aquarium fish that fill the room with the smell of salt."
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/storage/fish_case/random/saltwater,
+					/obj/item/storage/fish_case/random/saltwater)
+	crate_name = "saltwater fish crate"
+
+/datum/supply_pack/misc/aquarium_fish
+	name = "Tirizan Fish Case"
+	desc = "Tirizian fish caught by the finest tirizan indentured servant."
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/storage/fish_case/tirizan,
+					/obj/item/storage/fish_case/tirizan)
+	crate_name = "tirizan fish crate"
 
 /datum/supply_pack/misc/bicycle
 	name = "Bicycle"


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/16896032/156344094-8f605ed0-c186-4aab-8c8d-7fc3bdf5c3f5.png)

Tired of spending all of your hard-earned station gacha gemmies on fish, only to receive a fish you DO NOT want? 

![image](https://user-images.githubusercontent.com/16896032/156341498-0dd356f3-f2f6-42f9-b58a-48f41aae43bb.png)

You will now be able to roll specifically for fish of the "Salt Water, Fresh Water and Tirizan" Classes separately, allowing players a much greater chance to build their fish tank parties accordingly. However, we understand some players wish to catch EVERY fish, so we have chosen to increase the summons from the regular fish pack from 2 fish to 3. 

We hope that our players enjoy this update and look forward to our yearly anniversary, where we will be allowing 100 free summons.

_Attempts at rolling for the rare lanternfish will never be modified. Keep pumping more funds into us whales._

## Why It's Good For The Game

I attempted to try and increase incentives to buy aquariums and fish a few months back by reducing costs. While one may be purchased occasionally after this change, they are still extraordinarily underutilized and quite rare. I've seen quite a few people order two fish tanks in order to utilize both types of fish, which is a big reason why I decided to go with the salt/freshwater split. 

It's a pain to keep receiving fish you have no interest in having; many tirizan recipes focus on specific fish and trying to roll for that fish. To get a particular tirizian fish, for example, you would have an 11% chance that the fish you desired is in one of the crates that were ordered. With this change, there will be a 50% chance that one fish in the crate you ordered will be that specific fish. 

A part of me hopes more people purchasing these crates will incentivize people to work on the aquarium and fish system more,  it has a lot of room for fun ideas (I want to steal electric eels from /vg/ someday). 

## Changelog


:cl:
qol: Adds three new orderable fish crates to split rates of fish one gets.
/:cl: