### PR TITLE
Lets geese actually retaliate / attack

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -50,12 +50,16 @@
 		Retaliate()
 
 /mob/living/simple_animal/hostile/retaliate/goose/handle_automated_action()
+	. = ..()
+	feed_random()
+
+/mob/living/simple_animal/hostile/retaliate/goose/proc/feed_random()
 	var/obj/item/eat_it_motherfucker = pick(locate(/obj/item) in loc)
 	if(!eat_it_motherfucker)
 		return
 	feed(eat_it_motherfucker)
 
-/mob/living/simple_animal/hostile/retaliate/goose/vomit/handle_automated_action()
+/mob/living/simple_animal/hostile/retaliate/goose/vomit/feed_random()
 	for(var/obj/item/eat_it_motherfucker in loc)
 		if(!eat_it_motherfucker.has_material_type(/datum/material/plastic))
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Geese haven't actually been able to retaliate for years, despite having a custom retaliation cause, because `handle_automated_action()` didn't call the parent behavior.

Now Birdboat can defend himself if some sod punches him.

Or, one of his pals can get amgry if you dare exist near them, as God intended. (Birdboat is too lazy/full of plastic to do this).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/1185434/156405647-c4efdbcb-f797-4874-ab3a-7b37433ca86a.png)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: tastyfish
fix: Geese now act like geese if provoked again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
