### PR TITLE
Improve ornament, barricade, grille, and girder random spawners

### DIFF
--- a/code/game/objects/effects/spawners/random/decoration.dm
+++ b/code/game/objects/effects/spawners/random/decoration.dm
@@ -32,12 +32,12 @@
 	name = "ornament spawner"
 	icon_state = "lamp"
 	loot = list(
-		/obj/item/sign = 10,
-		/obj/item/flashlight/lamp/green = 10,
-		/obj/item/plaque = 5,
+		/obj/item/flashlight/lamp = 35,
+		/obj/item/flashlight/lamp/green = 35,
+		/obj/item/flashlight/lantern = 10,
+		/obj/item/phone = 10,
 		/obj/item/flashlight/lantern/jade = 5,
-		/obj/item/phone = 5,
-		/obj/item/flashlight/lamp/bananalamp = 3,
+		/obj/item/flashlight/lamp/bananalamp = 5,
 	)
 
 /obj/effect/spawner/random/decoration/generic

--- a/code/game/objects/effects/spawners/random/structure.dm
+++ b/code/game/objects/effects/spawners/random/structure.dm
@@ -25,17 +25,19 @@
 /obj/effect/spawner/random/structure/girder
 	name = "girder spawner"
 	icon_state = "girder"
+	spawn_loot_chance = 90                   // 10% chance of nothing
 	loot = list(
-		/obj/structure/girder = 4,
-		/obj/structure/girder/displaced = 1,
+		/obj/structure/girder = 8,           // 80% chance
+		/obj/structure/girder/displaced = 1, // 10% chance
 	)
 
 /obj/effect/spawner/random/structure/grille
 	name = "grille spawner"
 	icon_state = "grille"
+	spawn_loot_chance = 90                   // 10% chance of nothing
 	loot = list(
-		/obj/structure/grille = 4,
-		/obj/structure/grille/broken = 1,
+		/obj/structure/grille = 8,           // 80% chance
+		/obj/structure/grille/broken = 1,    // 10% chance
 	)
 
 /obj/effect/spawner/random/structure/furniture_parts
@@ -173,6 +175,7 @@
 /obj/effect/spawner/random/structure/barricade
 	name = "barricade spawner"
 	icon_state = "barricade"
+	spawn_loot_chance = 80
 	loot = list(
 		/obj/structure/barricade/wooden,
 		/obj/structure/barricade/wooden/crude,

--- a/code/game/objects/effects/spawners/random/structure.dm
+++ b/code/game/objects/effects/spawners/random/structure.dm
@@ -25,19 +25,19 @@
 /obj/effect/spawner/random/structure/girder
 	name = "girder spawner"
 	icon_state = "girder"
-	spawn_loot_chance = 90                   // 10% chance of nothing
-	loot = list(
-		/obj/structure/girder = 8,           // 80% chance
-		/obj/structure/girder/displaced = 1, // 10% chance
+	spawn_loot_chance = 90
+	loot = list( // 80% chance normal girder, 10% chance of displaced, 10% chance of nothing
+		/obj/structure/girder = 8,
+		/obj/structure/girder/displaced = 1,
 	)
 
 /obj/effect/spawner/random/structure/grille
 	name = "grille spawner"
 	icon_state = "grille"
-	spawn_loot_chance = 90                   // 10% chance of nothing
-	loot = list(
-		/obj/structure/grille = 8,           // 80% chance
-		/obj/structure/grille/broken = 1,    // 10% chance
+	spawn_loot_chance = 90
+	loot = list( // 80% chance normal grille, 10% chance of broken, 10% chance of nothing
+		/obj/structure/grille = 8,
+		/obj/structure/grille/broken = 1,
 	)
 
 /obj/effect/spawner/random/structure/furniture_parts


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This is a small QoL to make a few random spawners more consistent with mapping:

- Ornament spawner was meant to be lamp decoration for tables.  The sign and plaques were removed since it didn't fit the theme.  The red phone is the only non-lamp object in the spawner and it should compliment table decorations. (and it's rare)
- Grilles and Girder spawners have a 10% chance to not spawn, and a 10% chance to spawn a broken grille or displaced girder.  This is to keep it consistent with old maps were there would be complete gaps in outside grilles and the same with girders.
- Barricades have a 20% to not spawn at the location. Same logic as grilles and girders.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

More randomization is good flavor for the game.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Change barricade, grille, and girder mapping spawners to have a ~20% not to spawn.
qol: Change ornament mapping spawner to only spawn lamps and red phones.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
