### PR TITLE
Some Mining Station Area Redefines, Renaming, and Redrawing

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -10767,7 +10767,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/mine/living_quarters)
+/area/mine/production)
 "Iu" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Service Hall Exit";
@@ -14435,12 +14435,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft/lesser)
-"TR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/mine/living_quarters)
 "TS" = (
 /turf/open/floor/iron/dark,
 /area/mine/eva)
@@ -32019,9 +32013,9 @@ mO
 mO
 Rj
 mO
-cR
+br
 It
-cR
+br
 mO
 Rj
 mO
@@ -32276,9 +32270,9 @@ mO
 mO
 Rj
 mO
-cR
-TR
-cR
+br
+NR
+br
 mO
 Rj
 mO
@@ -32533,9 +32527,9 @@ mO
 mO
 Rj
 mO
-cR
-TR
-cR
+br
+NR
+br
 mO
 Rj
 mO
@@ -32790,9 +32784,9 @@ mO
 mO
 Rj
 mO
-cR
-TR
-cR
+br
+NR
+br
 mO
 Rj
 mO
@@ -33047,9 +33041,9 @@ mO
 mO
 Rj
 mO
-cR
-TR
-cR
+br
+NR
+br
 mO
 Rj
 mO

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1707,18 +1707,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"iO" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/mine/living_quarters)
 "iX" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -4545,6 +4533,11 @@
 	},
 /turf/open/floor/carpet,
 /area/mine/living_quarters)
+"Yc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/mine/production)
 "Yd" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningbathroom";
@@ -17192,9 +17185,9 @@ ab
 ab
 aj
 ab
-cR
-iO
-cR
+br
+oK
+br
 ab
 ab
 aj
@@ -17449,9 +17442,9 @@ ab
 aj
 aj
 aj
-cR
-eq
-cR
+br
+eC
+br
 ab
 aj
 aj
@@ -17706,9 +17699,9 @@ ab
 aj
 aj
 aj
-cR
-eq
-cR
+br
+eC
+br
 aj
 aj
 aj
@@ -17963,9 +17956,9 @@ ab
 ab
 aj
 aj
-cR
-eq
-cR
+br
+eC
+br
 aj
 aj
 aj
@@ -18220,7 +18213,7 @@ ab
 ab
 aj
 aj
-br
+Yc
 eC
 br
 aj

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -46,14 +46,14 @@
 	icon_state = "mining_storage"
 
 /area/mine/production
-	name = "Mining Station Starboard Wing"
+	name = "Mining Station Production Wing"
 	icon_state = "mining_production"
 
 /area/mine/abandoned
 	name = "Abandoned Mining Station"
 
 /area/mine/living_quarters
-	name = "Mining Station Port Wing"
+	name = "Mining Station Living Quarters"
 	icon_state = "mining_living"
 
 /area/mine/eva


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there, I saw this the other day:

![image](https://user-images.githubusercontent.com/34697715/156476343-d08c3e57-3ff0-4a12-9da2-f9d8b54f2884.png)

Why is it so arbitrarily split down the middle? It's not IceBox's fault, this was present on the base Lavaland version.

I then took another look, and saw this:

![image](https://user-images.githubusercontent.com/34697715/156476355-1738ee8c-9cc8-405e-93dd-da7cb5dd931c.png)

The "Mining Living" you see is also named the "Port Wing". I get that they're starboard and port to each other, but it's a really weird complication to say "Starboard Wing" when it's not on the starboard side of the station. I updated the areas so that they are now named to reflect their intention (as stated in the names put in the area turf icons). Hopefully, that makes it easier. I changed 11 years of soul in this one PR (as far as Lavaland is concerned).

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's a few changes but I think it's a good step on lessening "Why is it called THAT?!" in regards to weird directionally named areas, and maybe changing these names will let people be more creative that having "living" be port and "production" be starboard? Just maybe?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Nanotrasen has decided to re-name the areas found on the mining station bases of Lavaland and IceBox Station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
