### PR TITLE
Adds some electrified grilles to the IceBox Labor Camp

### DIFF
--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -498,6 +498,7 @@
 "bA" = (
 /obj/structure/rack,
 /obj/item/wirecutters,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
 "bC" = (
@@ -4019,6 +4020,7 @@
 	c_tag = "Labor Camp Mud Room";
 	network = list("labor")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
 "mX" = (
@@ -6637,6 +6639,7 @@
 "uT" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
 "uU" = (
@@ -50422,7 +50425,7 @@ oU
 Hd
 iz
 bh
-bh
+vM
 Hd
 Hd
 Hd
@@ -50679,7 +50682,7 @@ Fd
 Hd
 uN
 bh
-bh
+vM
 mu
 bh
 ce

--- a/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
+++ b/_maps/map_files/IceBoxStation/IcemoonUnderground_Above.dmm
@@ -2778,10 +2778,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron,
 /area/service/theater)
-"iT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/mine/laborcamp/security)
 "iU" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -8617,6 +8613,7 @@
 "BL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
 "BM" = (
@@ -51199,7 +51196,7 @@ tc
 tc
 tc
 bA
-iT
+FF
 Fp
 Fp
 ak
@@ -51456,7 +51453,7 @@ ni
 bh
 tc
 VB
-iT
+FF
 Fp
 Fp
 ak


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey there, it's on the tin. These windows:

![image](https://user-images.githubusercontent.com/34697715/156476791-fd5984ab-056e-461f-9335-5b7d70d6e17e.png)

are missing their electrified grilles. The other windows on this room are electrified, so I think it was an oversight to not have included these since they are also present like this in the Lavaland version.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/156476805-4bb9887a-44d8-4276-aa23-378f022112a1.png)

_You_ wouldn't want those pesky nobodies that wander the wastes getting into a secure area to facilitate a jailbreak, now would you?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: IceBoxStation's Labor Camp now has some electrified windows to help deter potential jailbreakers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
