### PR TITLE
Fix mother of god experiment being unobtainable on kilo

### DIFF
--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -72,9 +72,18 @@
 	required_light = 6
 
 /datum/experiment/explosion/maxcap/New()
-	required_devastation = GLOB.MAX_EX_DEVESTATION_RANGE
-	required_heavy = GLOB.MAX_EX_HEAVY_RANGE
-	required_light = GLOB.MAX_EX_LIGHT_RANGE
+	var/cap_multiplier
+	for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION)) // if for some reason someone designs a map with multiple station levels with different maxcap limits for each, take the smallest one
+		var/z_cap_multiplier = SSmapping.level_trait(z, ZTRAIT_BOMBCAP_MULTIPLIER)
+		if(cap_multiplier)
+			cap_multiplier = min(cap_multiplier, z_cap_multiplier)
+		else
+			cap_multiplier = z_cap_multiplier
+	if(isnull(cap_multiplier))
+		cap_multiplier = 1
+	required_devastation = GLOB.MAX_EX_DEVESTATION_RANGE * cap_multiplier
+	required_heavy = GLOB.MAX_EX_HEAVY_RANGE * cap_multiplier
+	required_light = GLOB.MAX_EX_LIGHT_RANGE * cap_multiplier
 
 /datum/experiment/scanning/random/material/meat
 	name = "Biological Material Scanning Experiment"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
See title, made the mother of god experiment respect cap_multiplier values (for station z-levels)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes #65255 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The mother of god experiment can now actually be completed on kilostation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
