### PR TITLE
Fixes explosive compressor breaking after refining a core

### DIFF
--- a/code/modules/research/anomaly/explosive_compressor.dm
+++ b/code/modules/research/anomaly/explosive_compressor.dm
@@ -93,6 +93,10 @@
  * * anomaly_type - anomaly type define
  */
 /obj/machinery/research/explosive_compressor/proc/get_required_radius(anomaly_type)
+	if(ispath(anomaly_type, /obj/effect/anomaly))
+		var/obj/effect/anomaly/anomaly = anomaly_type
+		anomaly_type = initial(anomaly.aSignal)
+		
 	var/already_made = SSresearch.created_anomaly_types[anomaly_type]
 	var/hard_limit = SSresearch.anomaly_hard_limit_by_type[anomaly_type]
 	if(already_made >= hard_limit)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Someone did an oopsie, time to fix it

## Changelog

:cl:
fix: Explosive compressor no longer yells at you that the limit was reached after refining a core
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
