### PR TITLE
Lets cayenne use the nuke

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -415,8 +415,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 
 /// This mob can strip other mobs.
 #define TRAIT_CAN_STRIP "can_strip"
-/// Can use machine UI's regardless of lacking hands
-#define TRAIT_CAN_USE_MACHINES "can_use_machines"
+/// Can use the nuclear device's UI, regardless of a lack of hands
+#define TRAIT_CAN_USE_NUKE "can_use_nuke"
 
 // If present on a mob or mobmind, allows them to "suplex" an immovable rod
 // turning it into a glorified potted plant, and giving them an

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -415,6 +415,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 
 /// This mob can strip other mobs.
 #define TRAIT_CAN_STRIP "can_strip"
+/// Can use machine UI's regardless of lacking hands
+#define TRAIT_CAN_USE_MACHINES "can_use_machines"
 
 // If present on a mob or mobmind, allows them to "suplex" an immovable rod
 // turning it into a glorified potted plant, and giving them an

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -517,7 +517,7 @@
 	var/is_dextrous = FALSE
 	if(isanimal(user))
 		var/mob/living/simple_animal/user_as_animal = user
-		if (user_as_animal.dextrous)
+		if (ISADVANCEDTOOLUSER(user_as_animal))
 			is_dextrous = TRUE
 
 	if(!issilicon(user) && !is_dextrous && !user.can_hold_items())

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -517,7 +517,7 @@
 	var/is_dextrous = FALSE
 	if(isanimal(user))
 		var/mob/living/simple_animal/user_as_animal = user
-		if (user_as_animal.dextrous || HAS_TRAIT(user_as_animal, TRAIT_CAN_USE_MACHINES))
+		if (user_as_animal.dextrous)
 			is_dextrous = TRUE
 
 	if(!issilicon(user) && !is_dextrous && !user.can_hold_items())

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -517,7 +517,7 @@
 	var/is_dextrous = FALSE
 	if(isanimal(user))
 		var/mob/living/simple_animal/user_as_animal = user
-		if (ISADVANCEDTOOLUSER(user_as_animal))
+		if (user_as_animal.dextrous || HAS_TRAIT(user_as_animal, TRAIT_CAN_USE_MACHINES))
 			is_dextrous = TRUE
 
 	if(!issilicon(user) && !is_dextrous && !user.can_hold_items())

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -174,6 +174,11 @@ GLOBAL_VAR(station_nuke_source)
 		return TRUE
 	return ..()
 
+/obj/machinery/nuclearbomb/ui_state(mob/user)
+	if(HAS_TRAIT(user, TRAIT_CAN_USE_NUKE))
+		return GLOB.conscious_state
+	return ..()
+
 /obj/machinery/nuclearbomb/proc/get_nuke_state()
 	if(exploding)
 		return NUKE_ON_EXPLODING

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -169,6 +169,11 @@ GLOBAL_VAR(station_nuke_source)
 				START_PROCESSING(SSobj, core)
 			return TRUE
 
+/obj/machinery/nuclearbomb/can_interact(mob/user)
+	if(HAS_TRAIT(user, TRAIT_CAN_USE_NUKE))
+		return TRUE
+	return ..()
+
 /obj/machinery/nuclearbomb/proc/get_nuke_state()
 	if(exploding)
 		return NUKE_ON_EXPLODING

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -247,7 +247,7 @@
 	colored_disk_mouth = mutable_appearance(SSgreyscale.GetColoredIconByType(/datum/greyscale_config/carp/disk_mouth, greyscale_colors), "disk_mouth")
 	ADD_TRAIT(src, TRAIT_DISK_VERIFIER, INNATE_TRAIT) //carp can verify disky
 	ADD_TRAIT(src, TRAIT_CAN_STRIP, INNATE_TRAIT) //carp can take the disk off the captain
-	ADD_TRAIT(src, TRAIT_CAN_USE_MACHINES, INNATE_TRAIT) //carp SMART
+	ADD_TRAIT(src, TRAIT_CAN_USE_NUKE, INNATE_TRAIT) //carp SMART
 
 /mob/living/simple_animal/hostile/carp/cayenne/death(gibbed)
 	if(disky)

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -247,6 +247,7 @@
 	colored_disk_mouth = mutable_appearance(SSgreyscale.GetColoredIconByType(/datum/greyscale_config/carp/disk_mouth, greyscale_colors), "disk_mouth")
 	ADD_TRAIT(src, TRAIT_DISK_VERIFIER, INNATE_TRAIT) //carp can verify disky
 	ADD_TRAIT(src, TRAIT_CAN_STRIP, INNATE_TRAIT) //carp can take the disk off the captain
+	ADD_TRAIT(src, TRAIT_ADVANCEDTOOLUSER, INNATE_TRAIT) //carp SMART
 
 /mob/living/simple_animal/hostile/carp/cayenne/death(gibbed)
 	if(disky)
@@ -283,6 +284,11 @@
 			update_icon()
 		else
 			disky.melee_attack_chain(src, attacked_target)
+		return
+
+	if(istype(attacked_target, /obj/machinery/nuclearbomb))
+		var/obj/machinery/nuclearbomb/nuke = attacked_target
+		nuke.ui_interact(src)
 		return
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -247,7 +247,7 @@
 	colored_disk_mouth = mutable_appearance(SSgreyscale.GetColoredIconByType(/datum/greyscale_config/carp/disk_mouth, greyscale_colors), "disk_mouth")
 	ADD_TRAIT(src, TRAIT_DISK_VERIFIER, INNATE_TRAIT) //carp can verify disky
 	ADD_TRAIT(src, TRAIT_CAN_STRIP, INNATE_TRAIT) //carp can take the disk off the captain
-	ADD_TRAIT(src, TRAIT_ADVANCEDTOOLUSER, INNATE_TRAIT) //carp SMART
+	ADD_TRAIT(src, TRAIT_CAN_USE_MACHINES, INNATE_TRAIT) //carp SMART
 
 /mob/living/simple_animal/hostile/carp/cayenne/death(gibbed)
 	if(disky)


### PR DESCRIPTION
## About The Pull Request

Cayenne was given the ability to pick up the nuke disk, and even insert the nuke disk into the nuke. This is great and all, but it is useless if they cannot actually use the nuke.
There is a simple solution to this that would greatly improve the quality of cayenne lives everywhere, finally a way for Cayenne to finally carry nukies and not be weighed down by the humans.

I got the idea to make this PR a long time ago as I would play cayenne frequently and on several ocassions was the last operative alive and had the disk. I re-gained motivation to work on it because of  a round earlier today where I died with the disk, and cayenne (the last op) found my body, took the disk, but couldn't finish the job.

This is how they do it (i sadly cannot draw stick figure carps):
![carp](https://user-images.githubusercontent.com/53777086/156524552-0f47eaf1-e84d-4bb4-9966-0bec826411de.png)

## Why It's Good For The Game

https://user-images.githubusercontent.com/53777086/156531578-943668a9-84d2-48c2-8b89-4c27940d65b9.mp4

Mostly explained in the about section, cayenne can pick up the disk and insert it in the nuke, but can't use the nuke. This means cayenne can do a lot of work alone except actually finish the job without admins, which I think sucks. I see no reason why cayenne should be limited to the last stretch of the round.

Just as a note: all dextrous mobs get advancedtooluser, and cayenne is the only mob (now) that has advancedtooluser outside of dextrous mobs, so it wouldn't break anything. Cayenne also can't open any other UI's except the nuke so that should also be good. If there's any other suggestions on how to do it I can try to implement them, but I thought this would be best to not make this a balance PR.

## Changelog

:cl:
qol: Cayenne can now use the nuke with their head or something.
/:cl: