### PR TITLE
conveyor belt and switch changes

### DIFF
--- a/code/datums/wires/conveyor.dm
+++ b/code/datums/wires/conveyor.dm
@@ -2,7 +2,7 @@
 	holder_type = /obj/machinery/conveyor_switch
 	proper_name = "Conveyor"
 	/// var holder that logs who put the assembly inside and gets transfered to the switch on pulse
-	var/mob/fingerman
+	var/datum/weakref/fingerman
 
 /datum/wires/conveyor/New(atom/holder)
 	add_duds(1)
@@ -15,5 +15,5 @@
 /datum/wires/conveyor/interactable(mob/user)
 	if(!..())
 		return FALSE
-	fingerman = user
+	fingerman = WEAKREF(user)
 	return TRUE

--- a/code/datums/wires/conveyor.dm
+++ b/code/datums/wires/conveyor.dm
@@ -2,7 +2,7 @@
 	holder_type = /obj/machinery/conveyor_switch
 	proper_name = "Conveyor"
 	/// var holder that logs who put the assembly inside and gets transfered to the switch on pulse
-	var/datum/weakref/fingerman
+	var/datum/weakref/fingerman_ref
 
 /datum/wires/conveyor/New(atom/holder)
 	add_duds(1)
@@ -10,10 +10,11 @@
 
 /datum/wires/conveyor/on_pulse(wire)
 	var/obj/machinery/conveyor_switch/C = holder
+	var/mob/living/carbon/human/fingerman = fingerman_ref?.resolve()
 	C.interact(fingerman)
 
 /datum/wires/conveyor/interactable(mob/user)
 	if(!..())
 		return FALSE
-	fingerman = WEAKREF(user)
+	fingerman_ref = WEAKREF(user)
 	return TRUE

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -396,10 +396,10 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	update_linked_conveyors()
 	update_linked_switches()
 
-
-/obj/machinery/conveyor_switch/wirecutter_act(mob/living/user, obj/item/I)
-	wires.interact(user)
-	return TRUE
+/obj/machinery/conveyor_switch/attackby(obj/item/attacking_item, mob/user, params)
+	if(is_wire_tool(attacking_item))
+		wires.interact(user)
+		return TRUE
 
 /obj/machinery/conveyor_switch/multitool_act(mob/living/user, obj/item/I)
 	var/input_speed = tgui_input_number(user, "Set the speed of the conveyor belts in seconds", "Speed", conveyor_speed, 20, 0.2)

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -222,7 +222,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	var/datum/move_loop/move/moving_loop = SSmove_manager.processing_on(convayable, SSconveyors)
 	if(moving_loop)
 		moving_loop.direction = movedir
-		moving_loop.delay = 10 * speed
+		moving_loop.delay = speed SECONDS
 		return
 	start_conveying(convayable)
 

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -204,10 +204,6 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 		for(var/atom/movable/movable in get_turf(src))
 			stop_conveying(movable)
 
-/obj/machinery/conveyor/proc/set_speed(new_value)
-	if(new_value)
-		speed = new_value
-
 /obj/machinery/conveyor/proc/update()
 	. = TRUE
 	if(machine_stat & NOPOWER)
@@ -226,6 +222,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	var/datum/move_loop/move/moving_loop = SSmove_manager.processing_on(convayable, SSconveyors)
 	if(moving_loop)
 		moving_loop.direction = movedir
+		moving_loop.delay = 10 * speed
 		return
 	start_conveying(convayable)
 
@@ -363,7 +360,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 /obj/machinery/conveyor_switch/proc/update_linked_conveyors()
 	for(var/obj/machinery/conveyor/belt in GLOB.conveyors_by_id[id])
 		belt.set_operating(position)
-		belt.set_speed(conveyor_speed)
+		belt.speed = conveyor_speed
 		CHECK_TICK
 
 /// Finds any switches with same `id` as this one, and set their position and icon to match us.
@@ -405,11 +402,11 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	return TRUE
 
 /obj/machinery/conveyor_switch/multitool_act(mob/living/user, obj/item/I)
-	var/speed = tgui_input_number(user, "Set the speed of the conveyor belts", "Speed", id, 20, 0.2)
-	if(!speed || QDELETED(user) || QDELETED(src) || !usr.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+	var/input_speed = tgui_input_number(user, "Set the speed of the conveyor belts in seconds", "Speed", conveyor_speed, 20, 0.2)
+	if(!input_speed || QDELETED(user) || QDELETED(src) || !usr.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		return
-	conveyor_speed = speed
-	to_chat(user, span_notice("You change the time between moves to [speed] seconds."))
+	conveyor_speed = input_speed
+	to_chat(user, span_notice("You change the time between moves to [input_speed] seconds."))
 	update_linked_conveyors()
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

This pull request allows conveyor belt speeds to be set, from the base of 0.2 seconds, to a maximum of 20 seconds between moves. This can be done by using a multitool on a placed switch. Now only wirecutters now allow you to interact with wires.

## Why It's Good For The Game

This makes conveyor belts more useful to players by allowing different speeds, as well as adding functionality. These two things are always good.

## Changelog

:cl:
expansion: Allows multitools to change the speed of linked conveyor belts by clicking on a placed conveyor switch.
code: Because of the above, multitools can no longer be used to interact with switches. Not like they did much, but well, so you know
/:cl: