### PR TITLE
Makes discoordinated a status effect

### DIFF
--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -230,12 +230,12 @@
 	lose_text = "<span class='notice'>You feel in control of your hands again.</span>"
 
 /datum/brain_trauma/severe/discoordination/on_gain()
-	ADD_TRAIT(owner, TRAIT_DISCOORDINATED_TOOL_USER, TRAUMA_TRAIT)
-	..()
+	. = ..()
+	owner.apply_status_effect(/datum/status_effect/discoordinated)
 
 /datum/brain_trauma/severe/discoordination/on_lose()
-	REMOVE_TRAIT(owner, TRAIT_DISCOORDINATED_TOOL_USER, TRAUMA_TRAIT)
-	..()
+	owner.remove_status_effect(/datum/status_effect/discoordinated)
+	return ..()
 
 /datum/brain_trauma/severe/pacifism
 	name = "Traumatic Non-Violence"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1168,3 +1168,21 @@
 
 /datum/movespeed_modifier/freezing_blast
 	multiplicative_slowdown = 1
+
+/datum/status_effect/discoordinated
+	id = "discoordinated"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = /atom/movable/screen/alert/status_effect/discoordinated
+
+/atom/movable/screen/alert/status_effect/discoordinated
+	name = "Discoordinated"
+	desc = "You can't seem to properly use anything..."
+	icon_state = "convulsing"
+
+/datum/status_effect/discoordinated/on_apply()
+	ADD_TRAIT(owner, TRAIT_DISCOORDINATED_TOOL_USER, TRAUMA_TRAIT)
+	return ..()
+
+/datum/status_effect/discoordinated/on_remove()
+	REMOVE_TRAIT(owner, TRAIT_DISCOORDINATED_TOOL_USER, TRAUMA_TRAIT)
+	return ..()

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1184,5 +1184,5 @@
 	return ..()
 
 /datum/status_effect/discoordinated/on_remove()
-	REMOVE_TRAIT(owner, TRAIT_DISCOORDINATED_TOOL_USER, TRAUMA_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_DISCOORDINATED_TOOL_USER, "[type]")
 	return ..()

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1180,7 +1180,7 @@
 	icon_state = "convulsing"
 
 /datum/status_effect/discoordinated/on_apply()
-	ADD_TRAIT(owner, TRAIT_DISCOORDINATED_TOOL_USER, TRAUMA_TRAIT)
+	ADD_TRAIT(owner, TRAIT_DISCOORDINATED_TOOL_USER, "[type]")
 	return ..()
 
 /datum/status_effect/discoordinated/on_remove()


### PR DESCRIPTION
## About The Pull Request

Was requested by oranges and I had time to spare.

## Why It's Good For The Game

Discoordinatedtooluser makes you unable to do many things, and the trauma gives no indication on what the problem is, which is very annoying.

## Changelog

:cl:
qol: Discoordinated tool user trauma now gives a status effect to let you know you have it.
/:cl:
