### PR TITLE
De-hardcodes the decomposition examine proc, and makes the decompose time editable

### DIFF
--- a/code/datums/components/food/decomposition.dm
+++ b/code/datums/components/food/decomposition.dm
@@ -4,9 +4,6 @@
 #define DECOMPOSITION_TIME_RAW 5 MINUTES
 #define DECOMPOSITION_TIME_GROSS 7 MINUTES
 
-#define DECOMP_EXAM_NORMAL 0
-#define DECOMP_EXAM_GROSS 1
-#define DECOMP_EXAM_RAW 2
 
 /datum/component/decomposition
 	dupe_mode = COMPONENT_DUPE_UNIQUE
@@ -16,6 +13,8 @@
 	var/protected = FALSE
 	/// Used to stop the timer & check for the examine proc
 	var/timerid
+	/// The total time that this takes to decompose
+	var/original_time = DECOMPOSITION_TIME
 	/// Used so the timer won't reset.
 	var/time_remaining = DECOMPOSITION_TIME
 	/// Used to give raw/gross food lower timers
@@ -24,10 +23,8 @@
 	var/decomp_result
 	/// Does our food attract ants?
 	var/produce_ants = TRUE
-	/// Used for examining
-	var/examine_type = DECOMP_EXAM_NORMAL
 
-/datum/component/decomposition/Initialize(mapload, decomp_req_handle, decomp_flags = NONE, decomp_result, ant_attracting = TRUE)
+/datum/component/decomposition/Initialize(mapload, decomp_req_handle, decomp_flags = NONE, decomp_result, ant_attracting = TRUE, custom_time = 0)
 	if(!isobj(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -49,12 +46,14 @@
 		.proc/dropped)
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/examine)
 
-	if(decomp_flags & RAW) // Raw food overrides gross
-		time_remaining = DECOMPOSITION_TIME_RAW
-		examine_type = DECOMP_EXAM_RAW
+	if(custom_time) // We have a custom decomposition time, set it to that
+		original_time = custom_time
+	else if(decomp_flags & RAW) // Raw food overrides gross
+		original_time = DECOMPOSITION_TIME_RAW
 	else if(decomp_flags & GROSS)
-		time_remaining = DECOMPOSITION_TIME_GROSS
-		examine_type = DECOMP_EXAM_GROSS
+		original_time = DECOMPOSITION_TIME_GROSS
+
+	time_remaining = original_time
 
 	handle_movement()
 
@@ -125,36 +124,14 @@
 		time_d = timeleft(timerid)
 	else
 		time_d = time_remaining
-	switch(examine_type)
-		if(DECOMP_EXAM_NORMAL)// All other types
-			switch(time_d) // Deciseconds used so there's no gaps between examine times.
-				if(3001 to 4500) // 7.5 to 5 Minutes left
-					examine_list += "[parent] looks kinda stale."
-				if(1501 to 3000) // 5 to 2.5 Minutes left
-					examine_list += "[parent] is starting to look pretty gross."
-				if(1 to 1500) // 2.5 Minutes to 1 Decisecond left
-					examine_list += "[parent] looks barely edible."
-		if(DECOMP_EXAM_GROSS) // Gross food
-			switch(time_d)
-				if(2101 to 3150) // 5.25 to 3.5 Minutes
-					examine_list += "[parent] looks kinda stale."
-				if(1050 to 2100) // 3.5 to 1.75 Minutes left
-					examine_list += "[parent] is starting to look pretty gross."
-				if(1 to 1051) // 1.75 Minutes to 1 Decisecond left
-					examine_list += "[parent] looks barely edible."
-		if(DECOMP_EXAM_RAW) // Raw food
-			switch(time_d)
-				if(1501 to 2250) // 3.75 to 2.5 Minutes left
-					examine_list += "[parent] looks kinda stale."
-				if(751 to 1500) // 2.5 to 1.25 Minutes left
-					examine_list += "[parent] is starting to look pretty gross."
-				if(1 to 750) // 1.25 Minutes to 1 Decisecond left
-					examine_list += "[parent] looks barely edible."
+	switch(time_d)
+		if((original_time * 0.5) to (original_time * 0.75)) // 25% rotten
+			examine_list += "[parent] looks kinda stale."
+		if((original_time * 0.25) to (original_time * 0.5)) // 50% rotten
+			examine_list += "[parent] is starting to look pretty gross."
+		if(1 to (original_time * 0.25)) // 75% rotten
+			examine_list += "[parent] looks barely edible."
 
 #undef DECOMPOSITION_TIME
 #undef DECOMPOSITION_TIME_GROSS
 #undef DECOMPOSITION_TIME_RAW
-
-#undef DECOMP_EXAM_NORMAL
-#undef DECOMP_EXAM_GROSS
-#undef DECOMP_EXAM_RAW

--- a/code/datums/components/food/decomposition.dm
+++ b/code/datums/components/food/decomposition.dm
@@ -4,7 +4,6 @@
 #define DECOMPOSITION_TIME_RAW 5 MINUTES
 #define DECOMPOSITION_TIME_GROSS 7 MINUTES
 
-
 /datum/component/decomposition
 	dupe_mode = COMPONENT_DUPE_UNIQUE
 	/// Makes sure maploaded food only starts decomposing if a player's EVER picked it up before
@@ -124,13 +123,13 @@
 		time_d = timeleft(timerid)
 	else
 		time_d = time_remaining
-	switch(time_d)
-		if((original_time * 0.5) to (original_time * 0.75)) // 25% rotten
-			examine_list += "[parent] looks kinda stale."
-		if((original_time * 0.25) to (original_time * 0.5)) // 50% rotten
-			examine_list += "[parent] is starting to look pretty gross."
-		if(1 to (original_time * 0.25)) // 75% rotten
-			examine_list += "[parent] looks barely edible."
+	switch(time_d / original_time)
+		if(0.5 to 0.75) // 25% rotten
+			examine_list += span_notice("[parent] looks kinda stale.")
+		if(0.25 to 0.5) // 50% rotten
+			examine_list += span_notice("[parent] is starting to look pretty gross.")
+		if(0 to 0.25) // 75% rotten
+			examine_list += span_danger("[parent] barely looks edible.")
 
 #undef DECOMPOSITION_TIME
 #undef DECOMPOSITION_TIME_GROSS

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -46,6 +46,8 @@
 	var/decomp_type = /obj/item/food/badrecipe/moldy
 	///Food that needs to be picked up in order to decompose.
 	var/decomp_req_handle = FALSE
+	///Used to set custom decomposition times for food. Set to 0 to have it automatically set via the food's flags.
+	var/decomposition_time = 0
 
 /obj/item/food/Initialize(mapload)
 	. = ..()
@@ -106,4 +108,4 @@
 ///Set decomp_req_handle to TRUE to only make it decompose when someone picks it up.
 /obj/item/food/proc/MakeDecompose(mapload)
 	if(!preserved_food)
-		AddComponent(/datum/component/decomposition, mapload, decomp_req_handle, decomp_flags = foodtypes, decomp_result = decomp_type, ant_attracting = ant_attracting)
+		AddComponent(/datum/component/decomposition, mapload, decomp_req_handle, decomp_flags = foodtypes, decomp_result = decomp_type, ant_attracting = ant_attracting, custom_time = decomposition_time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Makes the decomposition examine proc, which handles the little examine warning telling you how close to decomposing a piece of food is, not hardcoded anymore. Doing this allowed me to also...
- Adds a variable to food that lets them edit the decomposition timer. By default it's set to 0, which makes food automatically get its timer based off its flags. By setting the `decomposition_time` variable in a `/obj/item/food` to anything other than 0 (using SECONDS or MINUTES), it will take that amount of time to decompose instead.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Clean code good.
Lets people coding food set their own decompose times if they want to.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Wallem
refactor: De-Hardcodes decomposition timers. The decomposition time can now either be custom or use the existing automatic food flag system.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
