### PR TITLE
You can no longer survive nuke by being inside lockers, however, you are guaranteed to survive it while inside a fridge.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -606,7 +606,7 @@ GLOBAL_VAR(station_nuke_source)
 /proc/KillEveryoneOnStation()
 	for(var/mob/living/victim as anything in GLOB.mob_living_list)
 		var/turf/target_turf = get_turf(victim)
-		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer) && prob(10))
+		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer))
 			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
 			continue
 		if(victim.stat != DEAD && target_turf && is_station_level(target_turf.z))
@@ -619,7 +619,7 @@ GLOBAL_VAR(station_nuke_source)
 	for(var/_victim in GLOB.mob_living_list)
 		var/mob/living/victim = _victim
 		var/turf/target_turf = get_turf(victim)
-		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer) && prob(10))
+		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer))
 			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
 			continue
 		if(victim.stat != DEAD && target_turf && target_turf.z == z)

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -605,11 +605,11 @@ GLOBAL_VAR(station_nuke_source)
 
 /proc/KillEveryoneOnStation()
 	for(var/mob/living/victim as anything in GLOB.mob_living_list)
-		var/turf/mob = get_turf(victim)
+		var/turf/living_target = get_turf(victim)
 		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer) && prob(10))
 			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
 			continue
-		if(victim.stat != DEAD && mob && is_station_level(mob.z))
+		if(victim.stat != DEAD && living_target && is_station_level(living_target.z))
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()
 
@@ -618,11 +618,11 @@ GLOBAL_VAR(station_nuke_source)
 		return
 	for(var/_victim in GLOB.mob_living_list)
 		var/mob/living/victim = _victim
-		var/turf/mob = get_turf(victim)
+		var/turf/living_target = get_turf(victim)
 		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer) && prob(10))
 			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
 			continue
-		if(victim.stat != DEAD && mob && mob.z == z)
+		if(victim.stat != DEAD && living_target && living_target.z == z)
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -608,7 +608,10 @@ GLOBAL_VAR(station_nuke_source)
 		var/turf/target_turf = get_turf(victim)
 		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer))
 			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
-			continue
+			var/obj/structure/closet/secure_closet/freezer/freezer = victim.loc
+			if(!freezer.jones)
+				freezer.jones = TRUE
+				continue
 		if(victim.stat != DEAD && target_turf && is_station_level(target_turf.z))
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()
@@ -621,7 +624,10 @@ GLOBAL_VAR(station_nuke_source)
 		var/turf/target_turf = get_turf(victim)
 		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer))
 			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
-			continue
+			var/obj/structure/closet/secure_closet/freezer/freezer = victim.loc
+			if(!freezer.jones)
+				freezer.jones = TRUE
+				continue
 		if(victim.stat != DEAD && target_turf && target_turf.z == z)
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -605,7 +605,11 @@ GLOBAL_VAR(station_nuke_source)
 
 /proc/KillEveryoneOnStation()
 	for(var/mob/living/victim as anything in GLOB.mob_living_list)
-		if(victim.stat != DEAD && is_station_level(victim.z))
+		var/turf/M = get_turf(victim)
+		if(prob (10) && istype(victim.loc, /obj/structure/closet/secure_closet/freezer/))
+			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
+			continue
+		if(victim.stat != DEAD && M && is_station_level(M.z))
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()
 
@@ -614,7 +618,11 @@ GLOBAL_VAR(station_nuke_source)
 		return
 	for(var/_victim in GLOB.mob_living_list)
 		var/mob/living/victim = _victim
-		if(victim.stat != DEAD && victim.z == z)
+		var/turf/M = get_turf(victim)
+		if(prob (10) && istype(victim.loc, /obj/structure/closet/secure_closet/freezer/))
+			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
+			continue
+		if(victim.stat != DEAD && M && M.z == z)
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -605,11 +605,11 @@ GLOBAL_VAR(station_nuke_source)
 
 /proc/KillEveryoneOnStation()
 	for(var/mob/living/victim as anything in GLOB.mob_living_list)
-		var/turf/M = get_turf(victim)
-		if(prob (10) && istype(victim.loc, /obj/structure/closet/secure_closet/freezer/))
+		var/turf/mob = get_turf(victim)
+		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer) && prob(10))
 			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
 			continue
-		if(victim.stat != DEAD && M && is_station_level(M.z))
+		if(victim.stat != DEAD && mob && is_station_level(mob.z))
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()
 
@@ -618,11 +618,11 @@ GLOBAL_VAR(station_nuke_source)
 		return
 	for(var/_victim in GLOB.mob_living_list)
 		var/mob/living/victim = _victim
-		var/turf/M = get_turf(victim)
-		if(prob (10) && istype(victim.loc, /obj/structure/closet/secure_closet/freezer/))
+		var/turf/mob = get_turf(victim)
+		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer) && prob(10))
 			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
 			continue
-		if(victim.stat != DEAD && M && M.z == z)
+		if(victim.stat != DEAD && mob && mob.z == z)
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -607,9 +607,9 @@ GLOBAL_VAR(station_nuke_source)
 	for(var/mob/living/victim as anything in GLOB.mob_living_list)
 		var/turf/target_turf = get_turf(victim)
 		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer))
-			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
 			var/obj/structure/closet/secure_closet/freezer/freezer = victim.loc
 			if(!freezer.jones)
+				to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
 				freezer.jones = TRUE
 				continue
 		if(victim.stat != DEAD && target_turf && is_station_level(target_turf.z))

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -605,11 +605,11 @@ GLOBAL_VAR(station_nuke_source)
 
 /proc/KillEveryoneOnStation()
 	for(var/mob/living/victim as anything in GLOB.mob_living_list)
-		var/turf/living_target = get_turf(victim)
+		var/turf/target_turf = get_turf(victim)
 		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer) && prob(10))
 			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
 			continue
-		if(victim.stat != DEAD && living_target && is_station_level(living_target.z))
+		if(victim.stat != DEAD && target_turf && is_station_level(target_turf.z))
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()
 
@@ -618,11 +618,11 @@ GLOBAL_VAR(station_nuke_source)
 		return
 	for(var/_victim in GLOB.mob_living_list)
 		var/mob/living/victim = _victim
-		var/turf/living_target = get_turf(victim)
+		var/turf/target_turf = get_turf(victim)
 		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer) && prob(10))
 			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
 			continue
-		if(victim.stat != DEAD && living_target && living_target.z == z)
+		if(victim.stat != DEAD && target_turf && target_turf.z == z)
 			to_chat(victim, span_userdanger("You are shredded to atoms!"))
 			victim.gib()
 

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -623,9 +623,9 @@ GLOBAL_VAR(station_nuke_source)
 		var/mob/living/victim = _victim
 		var/turf/target_turf = get_turf(victim)
 		if(istype(victim.loc, /obj/structure/closet/secure_closet/freezer))
-			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
 			var/obj/structure/closet/secure_closet/freezer/freezer = victim.loc
 			if(!freezer.jones)
+				to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as the nuclear bomb goes off. Luckily as \the [victim.loc] is lead-lined, you survive."))
 				freezer.jones = TRUE
 				continue
 		if(victim.stat != DEAD && target_turf && target_turf.z == z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**Being inside closet no longer protects you from a nuke, but being inside fridge gives you 100% of chance of surviving.**
**Edit: You will guarantee to survive in fridge now**

Lockers or closets used to make you survive from nuclear bomb. This PR changes that it is no longer possible but gives a 100% chance of surviving while inside a fridge. 

(Check out this shit video I made for the PR): https://streamable.com/31nv7k 
I made the video in 20 minutes. Don't expect too much from it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't see how a person being able to guarantee to survive a nuke inside a metal locker is normal, and the pods lose their purposes as you can simply hide inside lockers. 
On the other hand, I thought it will be funny to keep it a 100% chance that you can survive a nuke in the fridge. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: being inside locker no longer protects you from a nuke
balance: being inside the fridge guarantees you to survive nuclear bomb
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
