### PR TITLE
Summon items closes modsuits + code improvement

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -117,6 +117,8 @@
 ///called before marking an object for retrieval, checked in /obj/effect/proc_holder/spell/targeted/summonitem/cast() : (mob/user)
 #define COMSIG_ITEM_MARK_RETRIEVAL "item_mark_retrieval"
 	#define COMPONENT_BLOCK_MARK_RETRIEVAL (1<<0)
+///called when the item is summoned, checked in /obj/effect/proc_holder/spell/targeted/summonitem/cast() : (mob/user)
+#define COMSIG_ITEM_SUMMONED "item_summoned"
 ///from base of obj/item/hit_reaction(): (list/args)
 #define COMSIG_ITEM_HIT_REACT "item_hit_react"
 	#define COMPONENT_HIT_REACTION_BLOCK (1<<0)

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -23,6 +23,7 @@
 	air_contents.volume = volume
 	air_contents.temperature = T20C
 	SSair.start_processing_machine(src)
+	RegisterSignal(src, COMSIG_ITEM_SUMMONED, .proc/on_summon)
 
 /obj/machinery/portable_atmospherics/Destroy()
 	disconnect()
@@ -121,6 +122,12 @@
 	. += span_notice("\The [src] contains [holding]. Alt-click [src] to remove it.")+\
 		span_notice("Click [src] with another gas tank to hot swap [holding].")
 
+/obj/machinery/portable_atmospherics/proc/on_summon(datum/source, mob/living/thief)
+	SIGNAL_HANDLER
+
+	disconnect()
+	update_appearance()
+
 /**
  * Allow the player to place a tank inside the machine.
  * Arguments:
@@ -193,10 +200,10 @@
 	add_fingerprint(user)
 	return ..()
 
-/// Holding tanks can get to zero integrity and be destroyed without other warnings due to pressure change. 
+/// Holding tanks can get to zero integrity and be destroyed without other warnings due to pressure change.
 /// This checks for that case and removes our reference to it.
 /obj/machinery/portable_atmospherics/proc/unregister_holding()
 	SIGNAL_HANDLER
-	
+
 	UnregisterSignal(holding, COMSIG_PARENT_QDELETING)
 	holding = null

--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -241,4 +241,13 @@
 		seal_part(part, seal = TRUE)
 	finish_activation(on = TRUE)
 
+/// Quickly undeploys all the suit parts and if successful, unseals them and turns the suit off. Intended mostly for nodrop bypassing.
+/obj/item/mod/control/proc/quick_deactivation()
+	for(var/obj/item/part as anything in mod_parts)
+		seal_part(part, seal = FALSE)
+
+	for(var/obj/item/part as anything in mod_parts)
+		conceal(null, part)
+	finish_activation(on = FALSE)
+
 #undef MOD_ACTIVATION_STEP_FLAGS

--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -245,8 +245,6 @@
 /obj/item/mod/control/proc/quick_deactivation()
 	for(var/obj/item/part as anything in mod_parts)
 		seal_part(part, seal = FALSE)
-
-	for(var/obj/item/part as anything in mod_parts)
 		conceal(null, part)
 	finish_activation(on = FALSE)
 

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -142,6 +142,7 @@
 		install(module)
 	RegisterSignal(src, COMSIG_ATOM_EXITED, .proc/on_exit)
 	RegisterSignal(src, COMSIG_SPEED_POTION_APPLIED, .proc/on_potion)
+	RegisterSignal(src, COMSIG_ITEM_SUMMONED, .proc/on_summon)
 	movedelay = CONFIG_GET(number/movedelay/run_delay)
 
 /obj/item/mod/control/Destroy()
@@ -461,6 +462,11 @@
 	for(var/obj/item/part as anything in mod_parts)
 		if(part.loc != src)
 			return COMPONENT_ITEM_BLOCK_UNEQUIP
+
+/obj/item/mod/control/proc/on_summon(mob/living/thief)
+	SIGNAL_HANDLER
+
+	quick_deactivation()
 
 /obj/item/mod/control/proc/update_flags()
 	var/list/used_skin = theme.skins[skin]

--- a/code/modules/spells/spell_types/summonitem.dm
+++ b/code/modules/spells/spell_types/summonitem.dm
@@ -52,15 +52,8 @@
 		else //Getting previously marked item
 			var/obj/item_to_retrieve = marked_item
 			var/infinite_recursion = 0 //I don't want to know how someone could put something inside itself but these are wizards so let's be safe
-
-			if(!item_to_retrieve.loc)
-				if(isorgan(item_to_retrieve)) // Organs are usually stored in nullspace
-					var/obj/item/organ/organ = item_to_retrieve
-					if(organ.owner)
-						// If this code ever runs I will be happy
-						log_combat(L, organ.owner, "magically removed [organ.name] from", addition="COMBAT MODE: [uppertext(L.combat_mode)]")
-						organ.Remove(organ.owner)
-			else
+			SEND_SIGNAL(marked_item, COMSIG_ITEM_SUMMONED, L)
+			if(item_to_retrieve.loc)
 				while(!isturf(item_to_retrieve.loc) && infinite_recursion < 10) //if it's in something you get the whole thing.
 					if(isitem(item_to_retrieve.loc))
 						var/obj/item/I = item_to_retrieve.loc
@@ -81,10 +74,6 @@
 						var/obj/retrieved_item = item_to_retrieve.loc
 						if(retrieved_item.anchored)
 							return
-						if(istype(retrieved_item, /obj/machinery/portable_atmospherics)) //Edge cases for moved machinery
-							var/obj/machinery/portable_atmospherics/P = retrieved_item
-							P.disconnect()
-							P.update_appearance()
 
 						item_to_retrieve = retrieved_item
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -45,6 +45,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 /obj/item/organ/Initialize(mapload)
 	. = ..()
 	START_PROCESSING(SSobj, src)
+	RegisterSignal(src, COMSIG_ITEM_SUMMONED, .proc/on_summon)
 	if(organ_flags & ORGAN_EDIBLE)
 		AddComponent(/datum/component/edible,\
 			initial_reagents = food_reagents,\
@@ -172,6 +173,12 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	else
 		STOP_PROCESSING(SSobj, src)
 	return ..()
+
+/obj/item/organ/proc/on_summon(datum/source, mob/living/thief)
+	SIGNAL_HANDLER
+
+	log_combat(thief, owner, "magically removed [name] from", addition="COMBAT MODE: [uppertext(thief.combat_mode)]")
+	Remove(owner)
 
 /obj/item/organ/proc/OnEatFrom(eater, feeder)
 	useable = FALSE //You can't use it anymore after eating it you spaztic


### PR DESCRIPTION
## About The Pull Request

I didn't fix the WHOLE spell or anything but I made it send a signal so we wouldn't have to snowflake things like hearts/modsuits/pipes. I just thought it would be cool so did it.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/65226

## Changelog

:cl:
fix: Summon items spell no longer causes duplicate MODsuit parts.
/:cl: