### PR TITLE
Fixes Icebox and Meta's medbay door controls button not working

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -49651,7 +49651,9 @@
 /obj/machinery/holopad,
 /obj/effect/landmark/start/depsec/medical,
 /obj/machinery/button/door/directional/west{
-	id_tag = "MedbayFoyer";
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
 	pixel_x = -35;
 	pixel_y = -56
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -39488,7 +39488,9 @@
 	dir = 8
 	},
 /obj/machinery/button/door/directional/west{
-	id_tag = "MedbayFoyer";
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
 	pixel_y = -9
 	},
 /turf/open/floor/iron/dark,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**Icebox and meta's medbay door control buttons were broken and have no name. This PR fixes that.**

They now open medbay doors as they should, and they have correct names now instead of just being "door button"
![image](https://user-images.githubusercontent.com/64306407/156888771-4c096315-880c-47cc-b88b-ec294b65bce7.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Things working as indented is good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes Icebox and Meta's medbay door controls button not working
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
