### PR TITLE
Getting electrically shocked now helps against heart attacks

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -365,6 +365,8 @@
 		return
 	//Propagation through pulling, fireman carry
 	if(!(flags & SHOCK_ILLUSION))
+		if(undergoing_cardiac_arrest())
+			set_heartattack(FALSE)
 		var/list/shocking_queue = list()
 		if(iscarbon(pulling) && source != pulling)
 			shocking_queue += pulling


### PR DESCRIPTION
## About The Pull Request

I don't know if this was intended or not, but this is the current text for heart attacks
![image](https://user-images.githubusercontent.com/53777086/156905603-b3b6fe21-f9ee-4d25-83dd-212e305498a6.png)

Despite this, there's only 2 ways to stop a heart attack: defibrilators and ahealing, which means the second part of that sentence isn't true.

I'm not sure if it was ever the case, but the text does say it should be, so I'm making it work as intended.

## Why It's Good For The Game

The text isn't misleading anymore.

## Changelog

:cl:
fix: Electric shocks now help against heart attacks.
/:cl: