### PR TITLE
Fire door screentip fixes and additions

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -119,25 +119,20 @@
 		if(density)
 			if(isalienadult(living_user) || issilicon(living_user))
 				context[SCREENTIP_CONTEXT_LMB] = "Open"
-				context[SCREENTIP_CONTEXT_RMB] = "Open"
 				return CONTEXTUAL_SCREENTIP_SET
 			if(!living_user.combat_mode)
 				if(ishuman(living_user))
 					context[SCREENTIP_CONTEXT_LMB] = "Knock"
-					context[SCREENTIP_CONTEXT_RMB] = "Knock"
 					return CONTEXTUAL_SCREENTIP_SET
 			else
 				if(ismonkey(living_user))
 					context[SCREENTIP_CONTEXT_LMB] = "Attack"
-					context[SCREENTIP_CONTEXT_RMB] = "Attack"
 					return CONTEXTUAL_SCREENTIP_SET
 				if(ishuman(living_user))
 					context[SCREENTIP_CONTEXT_LMB] = "Bash"
-					context[SCREENTIP_CONTEXT_RMB] = "Bash"
 					return CONTEXTUAL_SCREENTIP_SET
 		else if(issilicon(living_user))
 			context[SCREENTIP_CONTEXT_LMB] = "Close"
-			context[SCREENTIP_CONTEXT_RMB] = "Close"
 			return CONTEXTUAL_SCREENTIP_SET
 		return .
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -116,25 +116,41 @@
 	var/mob/living/living_user = user
 
 	if (isnull(held_item))
-		if (density)
-			// This should be LMB/RMB one day
-			if (living_user.combat_mode)
-				context[SCREENTIP_CONTEXT_LMB] = "Knock"
+		if(density)
+			if(isalienadult(living_user) || issilicon(living_user))
+				context[SCREENTIP_CONTEXT_LMB] = "Open"
+				context[SCREENTIP_CONTEXT_RMB] = "Open"
+				return CONTEXTUAL_SCREENTIP_SET
+			if(!living_user.combat_mode)
+				if(ishuman(living_user))
+					context[SCREENTIP_CONTEXT_LMB] = "Knock"
+					context[SCREENTIP_CONTEXT_RMB] = "Knock"
+					return CONTEXTUAL_SCREENTIP_SET
 			else
-				context[SCREENTIP_CONTEXT_LMB] = "Bash"
-
+				if(ismonkey(living_user))
+					context[SCREENTIP_CONTEXT_LMB] = "Attack"
+					context[SCREENTIP_CONTEXT_RMB] = "Attack"
+					return CONTEXTUAL_SCREENTIP_SET
+				if(ishuman(living_user))
+					context[SCREENTIP_CONTEXT_LMB] = "Bash"
+					context[SCREENTIP_CONTEXT_RMB] = "Bash"
+					return CONTEXTUAL_SCREENTIP_SET
+		else if(issilicon(living_user))
+			context[SCREENTIP_CONTEXT_LMB] = "Close"
+			context[SCREENTIP_CONTEXT_RMB] = "Close"
 			return CONTEXTUAL_SCREENTIP_SET
-		else
-			return .
+		return .
+
+	if(!Adjacent(src, living_user))
+		return .
 
 	switch (held_item.tool_behaviour)
 		if (TOOL_CROWBAR)
-			if (density)
+			if (!density)
 				context[SCREENTIP_CONTEXT_LMB] = "Close"
 			else if (!welded)
 				context[SCREENTIP_CONTEXT_LMB] = "Hold open"
 				context[SCREENTIP_CONTEXT_RMB] = "Open permanently"
-
 			return CONTEXTUAL_SCREENTIP_SET
 		if (TOOL_WELDER)
 			context[SCREENTIP_CONTEXT_LMB] = welded ? "Unweld shut" : "Weld shut"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Fixed firelock screentips telling silicons they could knock or bash them
- Fixed firelock screentips saying bash with combat mode off and knock with it on (it's the opposite)
- Adds firelock screentips for silicons, monkeys and xenos
- Firelock tool screentips only show when adjacent

Fixes #64961
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It's self-evident, probably


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed firelock screentips telling silicons they could knock or bash them
fix: Fixed firelock screentips saying bash with combat mode off and knock with it on (it's the opposite)
qol: Adds firelock screentips for silicons, monkeys and xenos
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
