### PR TITLE
Windoors can cycle like airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -101,18 +101,25 @@
 	blocks_emissive = NONE // Custom emissive blocker. We don't want the normal behavior.
 	uses_electronics = TRUE
 
-	var/security_level = 0 //How much are wires secured
-	var/aiControlDisabled = AI_WIRE_NORMAL //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
-	var/hackProof = FALSE // if true, this door can't be hacked by the AI
-	var/secondsMainPowerLost = 0 //The number of seconds until power is restored.
-	var/secondsBackupPowerLost = 0 //The number of seconds until power is restored.
+	///How much are wires secured
+	var/security_level = 0
+	///If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
+	var/aiControlDisabled = AI_WIRE_NORMAL
+	/// if true, this door can't be hacked by the AI
+	var/hackProof = FALSE
+	///The number of seconds until power is restored.
+	var/secondsMainPowerLost = 0
+	///The number of seconds until power is restored.
+	var/secondsBackupPowerLost = 0
 	var/spawnPowerRestoreRunning = FALSE
-	var/lights = TRUE // bolt lights show by default
+	/// bolt lights show by default
+	var/lights = TRUE
 	var/aiDisabledIdScanner = FALSE
 	var/aiHacking = FALSE
 	var/obj/machinery/door/airlock/closeOther
 	COOLDOWN_DECLARE(shockCooldown)
-	var/obj/item/note //Any papers pinned to the airlock
+	///Any papers pinned to the airlock
+	var/obj/item/note
 	/// The seal on the airlock
 	var/obj/item/seal
 	var/detonated = FALSE
@@ -124,12 +131,16 @@
 	var/boltUp = 'sound/machines/boltsup.ogg'
 	var/boltDown = 'sound/machines/boltsdown.ogg'
 	var/noPower = 'sound/machines/doorclick.ogg'
-	var/previous_airlock = /obj/structure/door_assembly //what airlock assembly mineral plating was applied to
-	var/airlock_material //material of inner filling; if its an airlock with glass, this should be set to "glass"
+	///what airlock assembly mineral plating was applied to
+	var/previous_airlock = /obj/structure/door_assembly
+	///material of inner filling; if its an airlock with glass, this should be set to "glass"
+	var/airlock_material
 	var/overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
-	var/note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi' //Used for papers and photos pinned to the airlock
+	///Used for papers and photos pinned to the airlock
+	var/note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 
-	var/air_tight = FALSE //TRUE means density will be set as soon as the door begins to close
+	/// TRUE means density will be set as soon as the door begins to close.
+	var/air_tight = FALSE
 	var/prying_so_hard = FALSE
 
 	flags_1 = HTML_USE_INITAL_ICON_1

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -99,3 +99,12 @@
 	if(holder)
 		return holder
 	return src
+
+/obj/item/electronics/airlock/proc/Clone()
+	var/obj/item/electronics/airlock/new_electronics = new()
+	new_electronics.accesses = accesses.Copy()
+	new_electronics.one_access = one_access
+	new_electronics.unres_sides = unres_sides
+	new_electronics.passed_name = passed_name
+	new_electronics.passed_cycle_id = passed_cycle_id
+	return new_electronics

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -356,9 +356,9 @@
 	if(space_dir)
 		. += span_notice("It has labels indicating that it has an emergency mechanism to open from the [dir2text(space_dir)] side with <b>just your hands</b> even if there's no power.")
 
-/obj/machinery/door/airlock/external/setup_cycle_link()
+/obj/machinery/door/airlock/external/find_close_other()
 	. = ..()
-	var/obj/machinery/door/airlock/external/cycle_linked_external_airlock = cyclelinkeddoor
+	var/obj/machinery/door/airlock/external/cycle_linked_external_airlock = close_other
 	if(istype(cycle_linked_external_airlock))
 		cycle_linked_external_airlock.space_dir |= space_dir
 		space_dir |= cycle_linked_external_airlock.space_dir
@@ -373,7 +373,7 @@
 		else
 			// always open from the space side
 			// get_dir(src, user) & space_dir, checked in unresricted_sides
-			var/should_safety_open = shuttledocked || cyclelinkeddoor?.shuttledocked || is_safe_turf(get_step(src, space_dir), TRUE, FALSE)
+			var/should_safety_open = shuttledocked || close_other?.shuttledocked || is_safe_turf(get_step(src, space_dir), TRUE, FALSE)
 			return try_to_activate_door(user, should_safety_open)
 
 	return ..()

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -356,9 +356,9 @@
 	if(space_dir)
 		. += span_notice("It has labels indicating that it has an emergency mechanism to open from the [dir2text(space_dir)] side with <b>just your hands</b> even if there's no power.")
 
-/obj/machinery/door/airlock/external/cyclelinkairlock()
+/obj/machinery/door/airlock/external/setup_cycle_link()
 	. = ..()
-	var/obj/machinery/door/airlock/external/cycle_linked_external_airlock = cyclelinkedairlock
+	var/obj/machinery/door/airlock/external/cycle_linked_external_airlock = cyclelinkeddoor
 	if(istype(cycle_linked_external_airlock))
 		cycle_linked_external_airlock.space_dir |= space_dir
 		space_dir |= cycle_linked_external_airlock.space_dir
@@ -373,7 +373,7 @@
 		else
 			// always open from the space side
 			// get_dir(src, user) & space_dir, checked in unresricted_sides
-			var/should_safety_open = shuttledocked || cyclelinkedairlock?.shuttledocked || is_safe_turf(get_step(src, space_dir), TRUE, FALSE)
+			var/should_safety_open = shuttledocked || cyclelinkeddoor?.shuttledocked || is_safe_turf(get_step(src, space_dir), TRUE, FALSE)
 			return try_to_activate_door(user, should_safety_open)
 
 	return ..()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -127,7 +127,6 @@
 		update_other_id()
 
 /obj/machinery/door/proc/update_other_id()
-	message_admins("update_other_id() called!")
 	for(var/obj/machinery/door/door in GLOB.airlocks)
 		if(door == src)
 			continue

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -18,13 +18,14 @@
 	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_REQUIRES_SILICON | INTERACT_MACHINE_OPEN
 	network_id = NETWORK_DOOR_AIRLOCKS
 	set_dir_on_move = FALSE
+	uses_electronics = TRUE
 	var/reinf = 0
 	var/shards = 2
 	var/rods = 2
 	var/cable = 1
 	var/list/debris = list()
 
-/obj/machinery/door/window/Initialize(mapload, set_dir)
+/obj/machinery/door/window/Initialize(mapload, constructed = FALSE, set_dir)
 	. = ..()
 	flags_1 &= ~PREVENT_CLICK_UNDER_1
 	if(set_dir)
@@ -58,7 +59,7 @@
 	QDEL_LIST(debris)
 	if(atom_integrity == 0)
 		playsound(src, "shatter", 70, TRUE)
-	electronics = null
+	QDEL_NULL(electronics)
 	var/turf/floor = get_turf(src)
 	floor.air_update_turf(TRUE, FALSE)
 	return ..()
@@ -208,7 +209,6 @@
 		if(obj_flags & EMAGGED)
 			return 0
 	try_close_others()
-	try_close_linked_airlock()
 	if(!operating) //in case of emag
 		operating = TRUE
 	do_animate("opening")
@@ -223,7 +223,7 @@
 	if(delayed_close_requested)
 		delayed_close_requested = FALSE
 		addtimer(CALLBACK(src, .proc/close), 1)
-	return 1
+	return TRUE
 
 /obj/machinery/door/window/close(forced=FALSE)
 	if(density)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -208,6 +208,7 @@
 		if(obj_flags & EMAGGED)
 			return 0
 	try_close_others()
+	try_close_linked_airlock()
 	if(!operating) //in case of emag
 		operating = TRUE
 	do_animate("opening")

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -244,11 +244,11 @@
 				to_chat(user, span_notice("You finish the airlock."))
 				var/obj/machinery/door/airlock/door
 				if(glass)
-					door = new glass_type(loc)
+					door = new glass_type(loc,/* constructed =*/ TRUE)
 				else
-					door = new airlock_type(loc)
+					door = new airlock_type(loc,/* constructed =*/ TRUE)
 				door.setDir(dir)
-				door.set_up_access(electronics, move_to_door = TRUE)
+				door.set_access_from_electronics(electronics, move_to_door = TRUE)
 				door.heat_proof = heat_proof_finished
 				door.security_level = 0
 				if(created_name)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -244,30 +244,18 @@
 				to_chat(user, span_notice("You finish the airlock."))
 				var/obj/machinery/door/airlock/door
 				if(glass)
-					door = new glass_type( loc )
+					door = new glass_type(loc)
 				else
-					door = new airlock_type( loc )
+					door = new airlock_type(loc)
 				door.setDir(dir)
-				door.unres_sides = electronics.unres_sides
-				//door.req_access = req_access
-				door.electronics = electronics
+				door.set_up_access(electronics, move_to_door = TRUE)
 				door.heat_proof = heat_proof_finished
 				door.security_level = 0
-				if(electronics.one_access)
-					door.req_one_access = electronics.accesses
-				else
-					door.req_access = electronics.accesses
 				if(created_name)
 					door.name = created_name
-				else if(electronics.passed_name)
-					door.name = sanitize(electronics.passed_name)
-				else
+				else if(!electronics.passed_name)
 					door.name = base_name
-				if(electronics.passed_cycle_id)
-					door.closeOtherId = electronics.passed_cycle_id
-					door.update_other_id()
 				door.previous_airlock = previous_assembly
-				electronics.forceMove(door)
 				door.update_appearance()
 				qdel(src)
 	else

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -12,7 +12,7 @@
 /obj/structure/windoor_assembly
 	icon = 'icons/obj/doors/windoor.dmi'
 
-	name = "windoor Assembly"
+	name = "windoor assembly"
 	icon_state = "l_windoor_assembly01"
 	desc = "A small glass and wire assembly for windoors."
 	anchored = FALSE
@@ -270,51 +270,28 @@
 					set_density(TRUE) //Shouldn't matter but just incase
 					to_chat(user, span_notice("You finish the windoor."))
 
+					var/obj/machinery/door/window/windoor
 					if(secure)
-						var/obj/machinery/door/window/brigdoor/windoor = new /obj/machinery/door/window/brigdoor(loc)
+						windoor = new /obj/machinery/door/window/brigdoor(loc, dir)
 						if(facing == "l")
 							windoor.icon_state = "leftsecureopen"
 							windoor.base_state = "leftsecure"
 						else
 							windoor.icon_state = "rightsecureopen"
 							windoor.base_state = "rightsecure"
-						windoor.setDir(dir)
-						windoor.set_density(FALSE)
-
-						if(electronics.one_access)
-							windoor.req_one_access = electronics.accesses
-						else
-							windoor.req_access = electronics.accesses
-						windoor.electronics = electronics
-						electronics.forceMove(windoor)
-						if(created_name)
-							windoor.name = created_name
-						qdel(src)
-						windoor.close()
-
-
 					else
-						var/obj/machinery/door/window/windoor = new /obj/machinery/door/window(loc)
+						windoor = new /obj/machinery/door/window(loc, dir)
 						if(facing == "l")
 							windoor.icon_state = "leftopen"
 							windoor.base_state = "left"
 						else
 							windoor.icon_state = "rightopen"
 							windoor.base_state = "right"
-						windoor.setDir(dir)
-						windoor.set_density(FALSE)
 
-						if(electronics.one_access)
-							windoor.req_one_access = electronics.accesses
-						else
-							windoor.req_access = electronics.accesses
-						windoor.electronics = electronics
-						electronics.forceMove(windoor)
-						if(created_name)
-							windoor.name = created_name
-						qdel(src)
-						windoor.close()
-
+					windoor.set_up_access(electronics, TRUE)
+					windoor.set_density(FALSE)
+					qdel(src)
+					windoor.close()
 
 			else
 				return ..()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -272,7 +272,7 @@
 
 					var/obj/machinery/door/window/windoor
 					if(secure)
-						windoor = new /obj/machinery/door/window/brigdoor(loc, dir)
+						windoor = new /obj/machinery/door/window/brigdoor(loc,/* constructed =*/ TRUE, dir)
 						if(facing == "l")
 							windoor.icon_state = "leftsecureopen"
 							windoor.base_state = "leftsecure"
@@ -280,7 +280,7 @@
 							windoor.icon_state = "rightsecureopen"
 							windoor.base_state = "rightsecure"
 					else
-						windoor = new /obj/machinery/door/window(loc, dir)
+						windoor = new /obj/machinery/door/window(loc,/* constructed =*/ TRUE, dir)
 						if(facing == "l")
 							windoor.icon_state = "leftopen"
 							windoor.base_state = "left"
@@ -288,7 +288,7 @@
 							windoor.icon_state = "rightopen"
 							windoor.base_state = "right"
 
-					windoor.set_up_access(electronics, TRUE)
+					windoor.set_access_from_electronics(electronics, move_to_door = TRUE)
 					windoor.set_density(FALSE)
 					qdel(src)
 					windoor.close()

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -284,36 +284,14 @@
 				return FALSE
 			if(ispath(the_rcd.airlock_type, /obj/machinery/door/window))
 				to_chat(user, span_notice("You build a windoor."))
-				var/obj/machinery/door/window/new_window = new the_rcd.airlock_type(src, user.dir, the_rcd.airlock_electronics?.unres_sides)
-				if(the_rcd.airlock_electronics)
-					new_window.name = the_rcd.airlock_electronics.passed_name || initial(new_window.name)
-					if(the_rcd.airlock_electronics.one_access)
-						new_window.req_one_access = the_rcd.airlock_electronics.accesses.Copy()
-					else
-						new_window.req_access = the_rcd.airlock_electronics.accesses.Copy()
+				var/obj/machinery/door/window/new_window = new the_rcd.airlock_type(src, user.dir)
+				new_window.set_up_access(the_rcd.airlock_electronics, FALSE)
 				new_window.autoclose = TRUE
 				new_window.update_appearance()
 				return TRUE
 			to_chat(user, span_notice("You build an airlock."))
 			var/obj/machinery/door/airlock/new_airlock = new the_rcd.airlock_type(src)
-			new_airlock.electronics = new /obj/item/electronics/airlock(new_airlock)
-			if(the_rcd.airlock_electronics)
-				new_airlock.electronics.accesses = the_rcd.airlock_electronics.accesses.Copy()
-				new_airlock.electronics.one_access = the_rcd.airlock_electronics.one_access
-				new_airlock.electronics.unres_sides = the_rcd.airlock_electronics.unres_sides
-				new_airlock.electronics.passed_name = the_rcd.airlock_electronics.passed_name
-				new_airlock.electronics.passed_cycle_id = the_rcd.airlock_electronics.passed_cycle_id
-			if(new_airlock.electronics.one_access)
-				new_airlock.req_one_access = new_airlock.electronics.accesses
-			else
-				new_airlock.req_access = new_airlock.electronics.accesses
-			if(new_airlock.electronics.unres_sides)
-				new_airlock.unres_sides = new_airlock.electronics.unres_sides
-			if(new_airlock.electronics.passed_name)
-				new_airlock.name = sanitize(new_airlock.electronics.passed_name)
-			if(new_airlock.electronics.passed_cycle_id)
-				new_airlock.closeOtherId = new_airlock.electronics.passed_cycle_id
-				new_airlock.update_other_id()
+			new_airlock.set_up_access(the_rcd.airlock_electronics, FALSE)
 			new_airlock.autoclose = TRUE
 			new_airlock.update_appearance()
 			return TRUE

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -284,14 +284,14 @@
 				return FALSE
 			if(ispath(the_rcd.airlock_type, /obj/machinery/door/window))
 				to_chat(user, span_notice("You build a windoor."))
-				var/obj/machinery/door/window/new_window = new the_rcd.airlock_type(src, user.dir)
-				new_window.set_up_access(the_rcd.airlock_electronics, FALSE)
+				var/obj/machinery/door/window/new_window = new the_rcd.airlock_type(src,/* constructed =*/ TRUE, user.dir)
+				new_window.set_access_from_electronics(the_rcd.airlock_electronics, FALSE)
 				new_window.autoclose = TRUE
 				new_window.update_appearance()
 				return TRUE
 			to_chat(user, span_notice("You build an airlock."))
-			var/obj/machinery/door/airlock/new_airlock = new the_rcd.airlock_type(src)
-			new_airlock.set_up_access(the_rcd.airlock_electronics, FALSE)
+			var/obj/machinery/door/airlock/new_airlock = new the_rcd.airlock_type(src,/* constructed =*/ TRUE)
+			new_airlock.set_access_from_electronics(the_rcd.airlock_electronics, FALSE)
 			new_airlock.autoclose = TRUE
 			new_airlock.update_appearance()
 			return TRUE

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -107,35 +107,37 @@
 	if(!mapload)
 		log_mapping("[src] spawned outside of mapload!")
 		return
-	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in loc
-	if(!airlock)
-		log_mapping("[src] failed to find an airlock at [AREACOORD(src)]")
-	else
-		payload(airlock)
+	var/obj/machinery/door/door = locate(/obj/machinery/door/airlock) in loc
+	if(!door)
+		door = locate(/obj/machinery/door/window) in loc
+	if(!door)
+		log_mapping("[src] failed to find an airlock or windoor at [AREACOORD(src)].")
+		return
+	payload(door)
 
-/obj/effect/mapping_helpers/airlock/proc/payload(obj/machinery/door/airlock/payload)
+/obj/effect/mapping_helpers/airlock/proc/payload(obj/machinery/door/payload)
 	return
 
 /obj/effect/mapping_helpers/airlock/cyclelink_helper
-	name = "airlock cyclelink helper"
+	name = "airlock/windoor cyclelink helper"
 	icon_state = "airlock_cyclelink_helper"
 
-/obj/effect/mapping_helpers/airlock/cyclelink_helper/payload(obj/machinery/door/airlock/airlock)
-	if(airlock.cyclelinkeddir)
-		log_mapping("[src] at [AREACOORD(src)] tried to set [airlock] cyclelinkeddir, but it's already set!")
+/obj/effect/mapping_helpers/airlock/cyclelink_helper/payload(obj/machinery/door/door)
+	if(door.cyclelinkeddir)
+		log_mapping("[src] at [AREACOORD(src)] tried to set [door] cyclelinkeddir, but it's already set!")
 	else
-		airlock.cyclelinkeddir = dir
+		door.cyclelinkeddir = dir
 
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi
-	name = "airlock multi-cyclelink helper"
+	name = "airlock/windoor multi-cyclelink helper"
 	icon_state = "airlock_multicyclelink_helper"
 	var/cycle_id
 
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi/payload(obj/machinery/door/airlock/airlock)
-	if(airlock.closeOtherId)
-		log_mapping("[src] at [AREACOORD(src)] tried to set [airlock] closeOtherId, but it's already set!")
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi/payload(obj/machinery/door/door)
+	if(door.closeOtherId)
+		log_mapping("[src] at [AREACOORD(src)] tried to set [door] closeOtherId, but it's already set!")
 	else
-		airlock.closeOtherId = cycle_id
+		door.closeOtherId = cycle_id
 
 /obj/effect/mapping_helpers/airlock/locked
 	name = "airlock lock helper"
@@ -149,11 +151,11 @@
 
 
 /obj/effect/mapping_helpers/airlock/unres
-	name = "airlock unresctricted side helper"
+	name = "airlock/windoor unrestricted side helper"
 	icon_state = "airlock_unres_helper"
 
-/obj/effect/mapping_helpers/airlock/unres/payload(obj/machinery/door/airlock/airlock)
-	airlock.unres_sides ^= dir
+/obj/effect/mapping_helpers/airlock/unres/payload(obj/machinery/door/door)
+	door.unres_sides ^= dir
 
 /obj/effect/mapping_helpers/airlock/abandoned
 	name = "airlock abandoned helper"

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -119,25 +119,27 @@
 	return
 
 /obj/effect/mapping_helpers/airlock/cyclelink_helper
-	name = "airlock/windoor cyclelink helper"
+	name = "airlock/windoor close other helper"
+	desc = "Uses facing directions to find another airlock or windoor to close when this one opens. Needs the same X or Y coordinate and to be within range."
 	icon_state = "airlock_cyclelink_helper"
 
 /obj/effect/mapping_helpers/airlock/cyclelink_helper/payload(obj/machinery/door/door)
-	if(door.cyclelinkeddir)
-		log_mapping("[src] at [AREACOORD(src)] tried to set [door] cyclelinkeddir, but it's already set!")
+	if(door.close_other_dir)
+		log_mapping("[src] at [AREACOORD(src)] tried to set [door] close_other_dir, but it's already set!")
 	else
-		door.cyclelinkeddir = dir
+		door.close_other_dir = dir
 
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi
-	name = "airlock/windoor multi-cyclelink helper"
+	name = "airlock/windoor multi-close others helper"
+	desc = "Uses an ID string to find multiple airlocks or windoors to close when this one opens. Doesn't need the same X or Y coordinate or to be within range."
 	icon_state = "airlock_multicyclelink_helper"
 	var/cycle_id
 
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi/payload(obj/machinery/door/door)
-	if(door.closeOtherId)
-		log_mapping("[src] at [AREACOORD(src)] tried to set [door] closeOtherId, but it's already set!")
+	if(door.close_others_ID)
+		log_mapping("[src] at [AREACOORD(src)] tried to set [door] close_others_ID, but it's already set!")
 	else
-		door.closeOtherId = cycle_id
+		door.close_others_ID = cycle_id
 
 /obj/effect/mapping_helpers/airlock/locked
 	name = "airlock lock helper"

--- a/code/modules/shuttle/shuttle_rotate.dm
+++ b/code/modules/shuttle/shuttle_rotate.dm
@@ -105,8 +105,8 @@ If ever any of these procs are useful for non-shuttles, rename it to proc/rotate
 
 /obj/machinery/door/airlock/shuttleRotate(rotation, params)
 	. = ..()
-	if(cyclelinkeddir && (params & ROTATE_DIR))
-		cyclelinkeddir = angle2dir(rotation+dir2angle(cyclelinkeddir))
+	if(close_other_dir && (params & ROTATE_DIR))
+		close_other_dir = angle2dir(rotation+dir2angle(close_other_dir))
 		// If we update the linked airlock here, the partner airlock might
 		// not be present yet, so don't do that. Just assume we're still
 		// partnered with the same airlock as before.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Can set cycle ID in airlock electronics or with mapping multi-cyclelink helper to make windoors cycle with windoors and airlocks
- Can use mapping cyclelink helper on windoors to make them cycle with another windoor or airlock (including windoors on the same tile, e.g. HoP desk)
- Windoors created by the RCD no longer produce electronics with blank settings when deconstructed
- Windoors and airlocks that are spawned rather than built no longer produce electronics with blank settings when deconstructed
- Cuts down on duplicated code for setting up door access in windoor_assembly.dm, door_assembly.dm and floor.dm
- Moves comments in door.dm to be autodoc comments, adds new comments, clarifies old ones
- Moves comments in airlock.dm to be autodoc comments
- Renames a bunch of var and proc names around airlock cycling to be more intuitive
- Adds descriptions to airlock cycle helpers to help mappers understand how they work

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

- Setting the cycle ID in airlock electronics for windoors will actually do something
- Mappers can make windoors cycle like and with airlocks
- Windoors created by the RCD will have their settings preserved in their electronics
- Windoors and airlocks that are spawned rather than built will have their settings preserved in their electronics
- Cuts down on a lot of lines of needlessly duplicated code

I've tested everything this touches and it works fine.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Windoors can cycle like and with airlocks now
fix: Windoors created by RCDs no longer produce airlock electronics with blank settings when deconstructed
fix: Spawned airlocks no longer produce blank airlock electronics when deconstructed
code: Removes a lot of needlessly duplicated code for setting airlock access related stuff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
