### PR TITLE
Fixes Broken Texture Edge Case Oddity (Rock Meet Skull Edition)

### DIFF
--- a/_maps/map_files/tramstation/modular_pieces/maintenance_lowarrivals_attachment_3.dmm
+++ b/_maps/map_files/tramstation/modular_pieces/maintenance_lowarrivals_attachment_3.dmm
@@ -131,11 +131,7 @@
 	pixel_y = -7
 	},
 /obj/item/stack/ore/glass,
-/turf/open/floor/plating/asteroid{
-	base_icon_state = "asteroid_dug";
-	dug = 1;
-	icon_state = "asteroid_dug"
-	},
+/turf/open/floor/plating/asteroid/dug,
 /area/mine/explored)
 "Z" = (
 /obj/item/stack/ore/iron{

--- a/code/game/turfs/open/floor/plating/asteroid.dm
+++ b/code/game/turfs/open/floor/plating/asteroid.dm
@@ -89,6 +89,11 @@
 /turf/open/floor/plating/lavaland_baseturf
 	baseturfs = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 
+/turf/open/floor/plating/asteroid/dug //When you want one of these to be already dug.
+	dug = TRUE
+	base_icon_state = "asteroid_dug"
+	icon_state = "asteroid_dug"
+
 /// Used by ashstorms to replenish basalt tiles that have been dug up without going through all of them.
 GLOBAL_LIST_EMPTY(dug_up_basalt)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is... interesting.

So, you know-

Fixes #65136

Sorry, had to get that in. So basically, it has to do with the var_edited asteroid_sand. Like such:

![image](https://user-images.githubusercontent.com/34697715/156992964-a7656e29-4bba-4a72-866f-765d5310f50f.png)

Now, here's the interesting thing. _This does not happen outside of modular map pieces!_ Let's set up a test case (outside of modular maints, the situation may change a bit since I was lazy but it illustrates the point):

![image](https://user-images.githubusercontent.com/34697715/156993019-3a1aef35-767f-4941-bc76-6e9e79208901.png)

On your right (OLD) we have the var_edited asteroid plating. On your left (NEW), I made a new object with the var_edits baked in. Now look what happens when it's not in a modular maintenance scenario:

![image](https://user-images.githubusercontent.com/34697715/156993067-8500c0d9-fb8f-4f99-be4f-e25ad8817af8.png)

What? My hypothesis was that there's an initialize proc which has something along the lines of

`icon_state = "[base_icon_state]_dug"`
or something and my hypothesis was that this always broke (since it would be something nonsensical like `asteroid_dug_dug`, which does not exist as a valid sprite). However, this isn't the case as evidented in our test example outside of a modular maintenance situation. I chalk it up to weird Initialize proc timing. I kept the turf I created and replaced it in the modular maintenance section.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/156993169-df16cf92-303d-4e63-b892-84a737ee43d5.png)

CS:Source has now been installed.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The reality-correctioneers have removed the purple and black square that shows up like 33% of the time in TramStation's Maintenance Tunnels.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

![image](https://user-images.githubusercontent.com/34697715/156994114-01247514-0294-4dc0-b1e7-788cf09ab76d.jpeg)