### PR TITLE
Fixes Chili sin carne

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_moth.dm
@@ -484,3 +484,15 @@
 	)
 	result = /obj/item/food/soup/red_porridge
 	subcategory = CAT_MOTH
+
+/datum/crafting_recipe/food/chili_sin_carne
+	name = "Chili sin carne (vegetarian chili)"
+	reqs = list(
+		/obj/item/reagent_containers/glass/bowl = 1,
+		/datum/reagent/water = 10,
+		/datum/reagent/consumable/salt = 1,
+		/obj/item/food/grown/chili = 1,
+		/obj/item/food/grown/tomato = 1
+	)
+	result = /obj/item/food/soup/vegetarian_chili
+	subcategory = CAT_MOTH


### PR DESCRIPTION
Fixes Chili sin carne not having a recipe

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes Chili sin carne (vegetarian chili) not having a recipe. Adding this recipe will also make Loaded curds craftable again since they require chili sin carne as an ingredient.

## Why It's Good For The Game

Makes food craftable again instead of being literally impossible to make.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
Fix: fixes Chili sin carne being uncraftable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
