### PR TITLE
CE envirosuit crafting

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -1221,7 +1221,7 @@
 				)
 	category = CAT_MISC
 
-/datum/crafting_recipe/CE_envirosuit
+/datum/crafting_recipe/ce_envirosuit
 	name = "Chief Engineer Plasmaman Envirosuit"
 	result = /obj/item/clothing/under/plasmaman/chief_engineer
 	time = 5 SECONDS
@@ -1230,7 +1230,7 @@
 				)
 	category = CAT_MISC
 
-/datum/crafting_recipe/CE_envirosuit_helmet
+/datum/crafting_recipe/ce_envirosuit_helmet
 	name = "Chief Engineer Plasmaman Envirosuit Helmet"
 	result = /obj/item/clothing/head/helmet/space/plasmaman/chief_engineer
 	time = 5 SECONDS

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -1221,6 +1221,24 @@
 				)
 	category = CAT_MISC
 
+/datum/crafting_recipe/CE_envirosuit
+	name = "Chief Engineer Plasmaman Envirosuit"
+	result = /obj/item/clothing/under/plasmaman/chief_engineer
+	time = 5 SECONDS
+	reqs = list(/obj/item/stack/sheet/mineral/metal_hydrogen = 10,
+				/obj/item/clothing/under/plasmaman = 1,
+				)
+	category = CAT_MISC
+
+/datum/crafting_recipe/CE_envirosuit_helmet
+	name = "Chief Engineer Plasmaman Envirosuit Helmet"
+	result = /obj/item/clothing/head/helmet/space/plasmaman/chief_engineer
+	time = 5 SECONDS
+	reqs = list(/obj/item/stack/sheet/mineral/metal_hydrogen = 5,
+				/obj/item/clothing/head/helmet/space/plasmaman = 1,
+				)
+	category = CAT_MISC
+
 /datum/crafting_recipe/bluespace_vendor_mount
 	name = "Bluespace Vendor Wall Mount"
 	result = /obj/item/wallframe/bluespace_vendor_mount


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows the crafting of the CE envirosuit and helmet with the basic envirosuit + metallic hydrogen in the crafting menu
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We have beautiful command sprites that are never used, this might bring some interest in them
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: adds a way to craft the CE envirosuit  and helmet with the basic envirosuit (any department) + metallic hydrogen (10 for the suit, 5 for the helmet)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
